### PR TITLE
test: fix performance baseline definitions for c7g.metal

### DIFF
--- a/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
@@ -103,30 +103,6 @@
                                             }
                                         }
                                     }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 595811
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 378346
-                                                },
-                                                "read-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 885161
-                                                },
-                                                "readwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 428937
-                                                }
-                                            }
-                                        }
-                                    }
                                 }
                             },
                             "bw_write": {
@@ -181,22 +157,6 @@
                                                 "readwrite-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 885459
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 378329
-                                                },
-                                                "readwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 428919
                                                 }
                                             }
                                         }
@@ -291,30 +251,6 @@
                                             }
                                         }
                                     }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 85
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 93
-                                                },
-                                                "read-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 94
-                                                },
-                                                "readwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 92
-                                                }
-                                            }
-                                        }
-                                    }
                                 }
                             },
                             "cpu_utilization_vmm": {
@@ -401,30 +337,6 @@
                                                 "readwrite-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 74
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 40
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 56
-                                                },
-                                                "read-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 51
-                                                },
-                                                "readwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 53
                                                 }
                                             }
                                         }
@@ -519,30 +431,6 @@
                                             }
                                         }
                                     }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 148953
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 94587
-                                                },
-                                                "read-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 221291
-                                                },
-                                                "readwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 107235
-                                                }
-                                            }
-                                        }
-                                    }
                                 }
                             },
                             "iops_write": {
@@ -597,22 +485,6 @@
                                                 "readwrite-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 221365
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 94583
-                                                },
-                                                "readwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 107230
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
@@ -11,8 +11,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 10.1,
-                                                    "target": 0.024
+                                                    "delta_percentage": 24.1,
+                                                    "target": 0.025
                                                 }
                                             }
                                         }
@@ -23,8 +23,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 12.1,
-                                                    "target": 0.036
+                                                    "delta_percentage": 13.1,
+                                                    "target": 0.031
                                                 }
                                             }
                                         }
@@ -50,7 +50,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "delta_percentage": 0.1,
-                                                    "target": 0
+                                                    "target": 0.0
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
@@ -18,7 +18,7 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
+                                "vmlinux-5.10-no-sve.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
@@ -44,7 +44,7 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
+                                "vmlinux-5.10-no-sve.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
@@ -138,7 +138,7 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
+                                "vmlinux-5.10-no-sve.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
@@ -404,7 +404,7 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
+                                "vmlinux-5.10-no-sve.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
@@ -670,7 +670,7 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
+                                "vmlinux-5.10-no-sve.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_1024mb.json": {
                                             "total": {

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
@@ -87,12 +87,12 @@
                                                     "target": 200
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 200
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 15,
-                                                    "target": 158
+                                                    "target": 155
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -195,76 +195,76 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 154
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 145
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 143
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 152
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 149
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 171
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 153
+                                                    "delta_percentage": 5,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 139
+                                                    "delta_percentage": 11,
+                                                    "target": 158
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 157
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 153
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 146
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 143
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 154
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 149
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 142
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 152
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 148
+                                                    "delta_percentage": 7,
+                                                    "target": 188
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 151
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 }
                                             }
                                         }
@@ -281,35 +281,35 @@
                                                     "target": 62
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 52
+                                                    "delta_percentage": 8,
+                                                    "target": 53
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 86
+                                                    "delta_percentage": 9,
+                                                    "target": 87
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 59
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 94
+                                                    "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 97
+                                                    "target": 98
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 12,
                                                     "target": 62
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 52
+                                                    "delta_percentage": 8,
+                                                    "target": 53
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 84
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
@@ -317,11 +317,11 @@
                                                     "target": 80
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 91
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 98
                                                 }
                                             }
@@ -337,19 +337,19 @@
                                                     "target": 73
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 59
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 90
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 90
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 96
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
@@ -357,7 +357,7 @@
                                                     "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 92
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
@@ -369,11 +369,11 @@
                                                     "target": 68
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 73
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 59
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
@@ -382,7 +382,7 @@
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 89
+                                                    "target": 88
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "delta_percentage": 6,
@@ -409,128 +409,128 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 58
+                                                    "delta_percentage": 9,
+                                                    "target": 59
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 51
+                                                    "delta_percentage": 10,
+                                                    "target": 53
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 79
+                                                    "target": 80
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 51
+                                                    "delta_percentage": 8,
+                                                    "target": 58
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 11,
-                                                    "target": 85
+                                                    "target": 87
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 94
+                                                    "target": 97
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 59
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 51
+                                                    "delta_percentage": 9,
+                                                    "target": 53
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 70
+                                                    "delta_percentage": 9,
+                                                    "target": 74
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 66
+                                                    "delta_percentage": 10,
+                                                    "target": 67
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 88
+                                                    "delta_percentage": 6,
+                                                    "target": 89
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 93
+                                                    "target": 98
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "delta_percentage": 67,
-                                                    "target": 27
+                                                    "delta_percentage": 9,
+                                                    "target": 69
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 37
+                                                    "delta_percentage": 8,
+                                                    "target": 69
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 133,
-                                                    "target": 20
+                                                    "delta_percentage": 9,
+                                                    "target": 61
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 129,
-                                                    "target": 37
+                                                    "delta_percentage": 7,
+                                                    "target": 91
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 32
+                                                    "delta_percentage": 7,
+                                                    "target": 86
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 16,
-                                                    "target": 72
+                                                    "delta_percentage": 13,
+                                                    "target": 67
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 54,
-                                                    "target": 72
+                                                    "delta_percentage": 7,
+                                                    "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 16,
-                                                    "target": 31
+                                                    "delta_percentage": 6,
+                                                    "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 42,
-                                                    "target": 52
+                                                    "delta_percentage": 7,
+                                                    "target": 98
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "delta_percentage": 74,
-                                                    "target": 35
+                                                    "delta_percentage": 10,
+                                                    "target": 69
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 49
+                                                    "delta_percentage": 9,
+                                                    "target": 69
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 77,
-                                                    "target": 14
+                                                    "delta_percentage": 9,
+                                                    "target": 62
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "delta_percentage": 91,
-                                                    "target": 35
+                                                    "delta_percentage": 7,
+                                                    "target": 92
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 21,
-                                                    "target": 42
+                                                    "delta_percentage": 9,
+                                                    "target": 84
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 76,
-                                                    "target": 58
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "delta_percentage": 119,
-                                                    "target": 54
+                                                    "delta_percentage": 7,
+                                                    "target": 95
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 40,
-                                                    "target": 36
+                                                    "delta_percentage": 6,
+                                                    "target": 94
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 46,
-                                                    "target": 69
+                                                    "delta_percentage": 6,
+                                                    "target": 98
                                                 }
                                             }
                                         }
@@ -543,52 +543,52 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 4773
+                                                    "delta_percentage": 7,
+                                                    "target": 4780
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 4553
+                                                    "target": 4544
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 38390
+                                                    "delta_percentage": 6,
+                                                    "target": 38637
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 21129
+                                                    "delta_percentage": 6,
+                                                    "target": 21109
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 19,
-                                                    "target": 58234
+                                                    "delta_percentage": 16,
+                                                    "target": 55757
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 42356
+                                                    "delta_percentage": 5,
+                                                    "target": 42284
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 4757
+                                                    "target": 4763
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4545
+                                                    "target": 4536
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 35171
+                                                    "delta_percentage": 15,
+                                                    "target": 35018
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 25736
+                                                    "target": 25676
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 50441
+                                                    "delta_percentage": 8,
+                                                    "target": 49635
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 41299
+                                                    "delta_percentage": 5,
+                                                    "target": 41085
                                                 }
                                             }
                                         },
@@ -596,75 +596,75 @@
                                             "total": {
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 6351
+                                                    "target": 6377
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 7935
+                                                    "delta_percentage": 9,
+                                                    "target": 7990
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6422
+                                                    "target": 6424
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 36960
+                                                    "delta_percentage": 5,
+                                                    "target": 36957
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 43085
+                                                    "delta_percentage": 7,
+                                                    "target": 43025
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 34405
+                                                    "target": 34492
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 45086
+                                                    "delta_percentage": 7,
+                                                    "target": 44673
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 49155
+                                                    "target": 48835
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 41969
+                                                    "delta_percentage": 5,
+                                                    "target": 41883
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6333
+                                                    "delta_percentage": 7,
+                                                    "target": 6362
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 7923
+                                                    "delta_percentage": 8,
+                                                    "target": 7987
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6420
+                                                    "delta_percentage": 5,
+                                                    "target": 6416
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 34993
+                                                    "target": 34792
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 41585
+                                                    "delta_percentage": 10,
+                                                    "target": 40838
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 34203
+                                                    "target": 34261
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 41913
+                                                    "target": 41639
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 46427
+                                                    "target": 46090
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 40017
+                                                    "delta_percentage": 5,
+                                                    "target": 39825
                                                 }
                                             }
                                         }
@@ -675,128 +675,128 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 4434
+                                                    "delta_percentage": 7,
+                                                    "target": 4660
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4190
+                                                    "target": 4303
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 33341
+                                                    "delta_percentage": 11,
+                                                    "target": 33749
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 17111
+                                                    "target": 19780
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 52843
+                                                    "delta_percentage": 8,
+                                                    "target": 52586
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 40505
+                                                    "target": 41918
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 4481
+                                                    "target": 4671
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4181
+                                                    "target": 4290
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 31621
+                                                    "delta_percentage": 11,
+                                                    "target": 32524
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 19989
+                                                    "delta_percentage": 9,
+                                                    "target": 20309
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 18,
-                                                    "target": 49504
+                                                    "delta_percentage": 16,
+                                                    "target": 50534
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 39483
+                                                    "delta_percentage": 5,
+                                                    "target": 41113
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "delta_percentage": 90,
-                                                    "target": 2920
+                                                    "delta_percentage": 6,
+                                                    "target": 6142
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 4593
+                                                    "target": 6792
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 150,
-                                                    "target": 1795
+                                                    "delta_percentage": 7,
+                                                    "target": 6277
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 133,
-                                                    "target": 14394
+                                                    "delta_percentage": 6,
+                                                    "target": 36855
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 27,
-                                                    "target": 19393
+                                                    "delta_percentage": 8,
+                                                    "target": 41030
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 25444
+                                                    "delta_percentage": 12,
+                                                    "target": 24230
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 56,
-                                                    "target": 34710
+                                                    "delta_percentage": 8,
+                                                    "target": 45780
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 16088
+                                                    "delta_percentage": 9,
+                                                    "target": 52273
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 55,
-                                                    "target": 26636
+                                                    "delta_percentage": 5,
+                                                    "target": 41690
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "delta_percentage": 76,
-                                                    "target": 3756
+                                                    "delta_percentage": 6,
+                                                    "target": 6134
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 4580
+                                                    "delta_percentage": 6,
+                                                    "target": 6787
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 82,
-                                                    "target": 1598
+                                                    "delta_percentage": 7,
+                                                    "target": 6284
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "delta_percentage": 108,
-                                                    "target": 16580
+                                                    "delta_percentage": 5,
+                                                    "target": 37413
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 38,
-                                                    "target": 29974
+                                                    "delta_percentage": 10,
+                                                    "target": 39489
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 82,
-                                                    "target": 18739
+                                                    "delta_percentage": 6,
+                                                    "target": 29363
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "delta_percentage": 125,
-                                                    "target": 24726
+                                                    "delta_percentage": 7,
+                                                    "target": 43341
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 55,
-                                                    "target": 23017
+                                                    "delta_percentage": 8,
+                                                    "target": 48413
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 44,
-                                                    "target": 30813
+                                                    "delta_percentage": 5,
+                                                    "target": 39895
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -111,40 +111,40 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 160
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 168
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 166
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 162
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 164
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 161
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 161
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 166
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 162
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 }
                                             }
                                         }
@@ -161,23 +161,23 @@
                                                     "target": 59
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 56
+                                                    "delta_percentage": 8,
+                                                    "target": 55
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 9,
                                                     "target": 60
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 71
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 60
+                                                    "target": 59
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 72
                                                 }
                                             }
@@ -190,14 +190,14 @@
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 71
+                                                    "target": 72
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 8,
                                                     "target": 77
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 75
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -209,7 +209,7 @@
                                                     "target": 84
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 76
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -217,8 +217,8 @@
                                                     "target": 66
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 85
+                                                    "delta_percentage": 8,
+                                                    "target": 84
                                                 }
                                             }
                                         }
@@ -229,16 +229,16 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 53
+                                                    "delta_percentage": 8,
+                                                    "target": 56
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 53
+                                                    "target": 54
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 41
+                                                    "delta_percentage": 12,
+                                                    "target": 49
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
@@ -246,7 +246,7 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 11,
-                                                    "target": 40
+                                                    "target": 50
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 9,
@@ -257,40 +257,40 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 25,
-                                                    "target": 56
+                                                    "delta_percentage": 7,
+                                                    "target": 88
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 55
+                                                    "delta_percentage": 8,
+                                                    "target": 74
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 47,
-                                                    "target": 69
+                                                    "delta_percentage": 8,
+                                                    "target": 83
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 23,
-                                                    "target": 49
+                                                    "delta_percentage": 8,
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 17,
-                                                    "target": 28
+                                                    "delta_percentage": 12,
+                                                    "target": 54
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 14,
-                                                    "target": 71
+                                                    "delta_percentage": 8,
+                                                    "target": 74
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 151,
-                                                    "target": 35
+                                                    "delta_percentage": 8,
+                                                    "target": 65
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 20,
-                                                    "target": 23
+                                                    "delta_percentage": 10,
+                                                    "target": 52
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 128,
-                                                    "target": 61
+                                                    "delta_percentage": 8,
+                                                    "target": 75
                                                 }
                                             }
                                         }
@@ -304,27 +304,27 @@
                                             "total": {
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 2676
+                                                    "target": 2666
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 2003
+                                                    "delta_percentage": 11,
+                                                    "target": 1984
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9961
+                                                    "target": 9956
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
                                                     "target": 6503
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 9969
+                                                    "delta_percentage": 6,
+                                                    "target": 9934
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6399
+                                                    "target": 6413
                                                 }
                                             }
                                         },
@@ -332,39 +332,39 @@
                                             "total": {
                                                 "vsock-p1024-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 4267
+                                                    "target": 4257
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 3416
+                                                    "target": 3303
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 3789
+                                                    "target": 3775
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6691
+                                                    "delta_percentage": 8,
+                                                    "target": 6709
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 10162
+                                                    "delta_percentage": 7,
+                                                    "target": 10109
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 7630
+                                                    "target": 7635
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 6736
+                                                    "target": 6735
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 10185
+                                                    "target": 10134
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7755
+                                                    "delta_percentage": 9,
+                                                    "target": 7734
                                                 }
                                             }
                                         }
@@ -375,68 +375,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 2741
+                                                    "delta_percentage": 8,
+                                                    "target": 2255
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 2749
+                                                    "delta_percentage": 6,
+                                                    "target": 2750
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 17584
+                                                    "delta_percentage": 9,
+                                                    "target": 20897
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6235
+                                                    "delta_percentage": 6,
+                                                    "target": 6293
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 16623
+                                                    "delta_percentage": 8,
+                                                    "target": 20883
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6110
+                                                    "delta_percentage": 6,
+                                                    "target": 6163
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 22,
-                                                    "target": 3037
+                                                    "delta_percentage": 6,
+                                                    "target": 4710
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 2637
+                                                    "target": 3528
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 20,
-                                                    "target": 3097
+                                                    "delta_percentage": 6,
+                                                    "target": 4763
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5698
+                                                    "delta_percentage": 7,
+                                                    "target": 7618
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 20365
+                                                    "target": 26589
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5307
+                                                    "target": 7231
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 11,
-                                                    "target": 3134
+                                                    "delta_percentage": 7,
+                                                    "target": 7819
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 11430
+                                                    "delta_percentage": 9,
+                                                    "target": 26167
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 63,
-                                                    "target": 3363
+                                                    "delta_percentage": 6,
+                                                    "target": 7227
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -78,7 +78,7 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
+                                "vmlinux-5.10-no-sve.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
@@ -224,7 +224,7 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
+                                "vmlinux-5.10-no-sve.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
@@ -370,7 +370,7 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
+                                "vmlinux-5.10-no-sve.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_1024mb.json": {
                                             "total": {


### PR DESCRIPTION
## Changes

- Removes unnecessary baselines.
- Renames vmlinux-5.10.bin to vmlinux-5.10-no-sve.bin on host kernel v4.14.
- Regather baselines for network latency, network TCP throughput, and vsock thoughput for c7g.metal.

## Reason

Thanks to PR #3539, some incorrect baseline definitions are detected.
Along with it, some performance improvements are found. Please see below for summary of performance changes.

```
{
    "source": "b32b1ed8f91954ced122d36259bf598ad66db929/tests/integration_tests/performance/configs/",
    "target": "f22cc5f29e37299dd2cd32d8bf7c904abbf5c25d/tests/integration_tests/performance/configs/",
    "test_network_latency_config_4.14.json": {
        "test": "network_latency",
        "kernel": "4.14",
        "cpus": [
            {
                "instance": "c7g.metal",
                "model": "ARM_NEOVERSE_V1",
                "stats": {
                    "pkt_loss": {
                        "target_diff_percentage": {
                            "mean": 0.0,
                            "stdev": 0.0
                        },
                        "delta_percentage_diff": {
                            "mean": 0.0,
                            "stdev": 0.0
                        }
                    },
                    "latency": {
                        "target_diff_percentage": {
                            "mean": -4.861111111111082,
                            "stdev": 12.767205771423681
                        },
                        "delta_percentage_diff": {
                            "mean": 7.500000000000001,
                            "stdev": 9.19238815542512
                        }
                    }
                }
            }
        ]
    },
    "test_network_tcp_throughput_config_4.14.json": {
        "test": "network_tcp_throughput",
        "kernel": "4.14",
        "cpus": [
            {
                "instance": "c7g.metal",
                "model": "ARM_NEOVERSE_V1",
                "stats": {
                    "throughput": {
                        "target_diff_percentage": {
                            "mean": 30.882877886125183,
                            "stdev": 64.12762671484461
                        },
                        "delta_percentage_diff": {
                            "mean": -17.416666666666668,
                            "stdev": 35.89452140183326
                        }
                    },
                    "cpu_utilization_vmm": {
                        "target_diff_percentage": {
                            "mean": 36.710766008004015,
                            "stdev": 70.68087528698601
                        },
                        "delta_percentage_diff": {
                            "mean": -15.05,
                            "stdev": 31.815370445905064
                        }
                    },
                    "cpu_utilization_vcpus_total": {
                        "target_diff_percentage": {
                            "mean": 9.397840214856169,
                            "stdev": 15.0561641552008
                        },
                        "delta_percentage_diff": {
                            "mean": -1.3166666666666667,
                            "stdev": 2.243572111435028
                        }
                    }
                }
            }
        ]
    },
    "test_vsock_throughput_config_4.14.json": {
        "test": "vsock_throughput",
        "kernel": "4.14",
        "cpus": [
            {
                "instance": "c7g.metal",
                "model": "ARM_NEOVERSE_V1",
                "stats": {
                    "throughput": {
                        "target_diff_percentage": {
                            "mean": 21.956096818857066,
                            "stdev": 41.31655312346459
                        },
                        "delta_percentage_diff": {
                            "mean": -3.2333333333333334,
                            "stdev": 10.871295114716757
                        }
                    },
                    "cpu_utilization_vmm": {
                        "target_diff_percentage": {
                            "mean": 17.442131087786358,
                            "stdev": 32.240051270688554
                        },
                        "delta_percentage_diff": {
                            "mean": -12.033333333333333,
                            "stdev": 33.605709011430186
                        }
                    },
                    "cpu_utilization_vcpus_total": {
                        "target_diff_percentage": {
                            "mean": 6.744115973245285,
                            "stdev": 10.534346759096946
                        },
                        "delta_percentage_diff": {
                            "mean": -1.1666666666666667,
                            "stdev": 1.8585001986832683
                        }
                    }
                }
            }
        ]
    }
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
