### PR TITLE
Add PUT /cpu-config API

### DIFF
--- a/src/api_server/src/request/cpu_configuration.rs
+++ b/src/api_server/src/request/cpu_configuration.rs
@@ -1,0 +1,93 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use logger::{IncMetric, METRICS};
+use vmm::guest_config::templates::CpuTemplate;
+
+use super::super::VmmAction;
+use crate::parsed_request::{Error, ParsedRequest};
+use crate::request::Body;
+
+pub(crate) fn parse_put_cpu_config(body: &Body) -> Result<ParsedRequest, Error> {
+    METRICS.put_api_requests.cpu_cfg_count.inc();
+
+    // Convert the API request into a a deserialized/binary format
+    Ok(ParsedRequest::new_sync(VmmAction::PutCpuConfiguration(
+        serde_json::from_slice::<CpuTemplate>(body.raw()).map_err(|err| {
+            METRICS.put_api_requests.cpu_cfg_fails.inc();
+            Error::SerdeJson(err)
+        })?,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use logger::{IncMetric, METRICS};
+    use micro_http::Body;
+    use vmm::guest_config::templates::guest_config_test;
+    use vmm::rpc_interface::VmmAction;
+
+    use super::*;
+    use crate::parsed_request::tests::vmm_action_from_request;
+
+    #[test]
+    fn test_parse_put_cpu_config_request() {
+        let cpu_template = vmm::guest_config::templates::guest_config_test::build_test_template();
+        let cpu_config_json_result = serde_json::to_string(&cpu_template);
+        assert!(
+            &cpu_config_json_result.is_ok(),
+            "Unable to serialize CPU template to JSON"
+        );
+        let cpu_template_json = cpu_config_json_result.unwrap();
+
+        {
+            match vmm_action_from_request(
+                parse_put_cpu_config(&Body::new(cpu_template_json.as_bytes())).unwrap(),
+            ) {
+                VmmAction::PutCpuConfiguration(received_cpu_template) => {
+                    // Test that the CPU config to be used for KVM config is the
+                    // the same that was read in from a test file.
+                    assert_eq!(cpu_template, received_cpu_template);
+                }
+                _ => panic!("Test failed - Expected VmmAction::PutCpuConfiguration() call"),
+            }
+        }
+
+        // Test empty request succeeds
+        let parse_cpu_config_result = parse_put_cpu_config(&Body::new(r#"{ }"#));
+        assert!(
+            parse_cpu_config_result.is_ok(),
+            "Failed to parse cpu-config: [{}]",
+            parse_cpu_config_result.unwrap_err()
+        );
+    }
+
+    /// Test basic API server validations like JSON sanity/legibility
+    /// Any testing or validation done involving KVM or OS specific context
+    /// need to be done in integration testing (api_cpu_configuration_integ_tests)
+    #[test]
+    fn test_parse_put_cpu_config_request_errors() {
+        let mut expected_err_count = METRICS.put_api_requests.cpu_cfg_fails.count() + 1;
+
+        // Test case for invalid payload
+        let unparsable_cpu_config_result =
+            parse_put_cpu_config(&Body::new("<unparseable_payload>"));
+        assert!(unparsable_cpu_config_result.is_err());
+        assert_eq!(
+            METRICS.put_api_requests.cpu_cfg_fails.count(),
+            expected_err_count
+        );
+
+        // Test request with invalid fields
+        let invalid_put_result =
+            parse_put_cpu_config(&Body::new(guest_config_test::INVALID_TEMPLATE_JSON));
+        expected_err_count += 1;
+
+        assert!(invalid_put_result.is_err());
+        assert_eq!(
+            METRICS.put_api_requests.cpu_cfg_fails.count(),
+            expected_err_count
+        );
+        assert!(matches!(invalid_put_result, Err(Error::SerdeJson(_))));
+    }
+}

--- a/src/api_server/src/request/mod.rs
+++ b/src/api_server/src/request/mod.rs
@@ -4,6 +4,7 @@
 pub mod actions;
 pub mod balloon;
 pub mod boot_source;
+pub mod cpu_configuration;
 pub mod drive;
 pub mod instance_info;
 pub mod logger;

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -195,6 +195,32 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /cpu-config:
+    put:
+      summary: Configures CPU features flags for the vCPUs of the guest VM. Pre-boot only.
+      description:
+        Provides configuration to the Firecracker process to specify vCPU resource configuration prior to
+        launching the guest machine.
+      operationId: putCpuConfiguration
+      parameters:
+        - name: body
+          in: body
+          description: CPU configuration request
+          schema:
+            $ref: "#/definitions/CpuConfig"
+      responses:
+        204:
+          description: CPU configuration set successfully
+        400:
+          description: CPU configuration cannot be updated due to invalid input format
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/Error"
+
+
   /drives/{drive_id}:
     put:
       summary: Creates or updates a drive. Pre-boot only.
@@ -787,6 +813,22 @@ definitions:
       - T2A
       - None
     default: "None"
+
+  CpuConfig:
+    type: string
+    description:
+      The CPU configuration template defines a set of bit maps as modifiers of flags accessed by register
+      to be disabled/enabled for the microvm.
+    properties:
+      cpuid_modifiers:
+        type: object
+        description: A collection of CPUIDs to be modified. (x86_64)
+      msr_modifiers:
+        type: object
+        description: A collection of model specific registers to be modified. (x86_64)
+      reg_modifiers:
+        type: object
+        description: A collection of registers to be modified. (aarch64)
 
   Drive:
     type: object

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -392,6 +392,10 @@ pub struct PutRequestsMetrics {
     pub machine_cfg_count: SharedIncMetric,
     /// Number of failures in configuring the machine.
     pub machine_cfg_fails: SharedIncMetric,
+    /// Number of PUTs for configuring a guest's vCPUs.
+    pub cpu_cfg_count: SharedIncMetric,
+    /// Number of failures in configuring a guest's vCPUs.
+    pub cpu_cfg_fails: SharedIncMetric,
     /// Number of PUTs for initializing the metrics system.
     pub metrics_count: SharedIncMetric,
     /// Number of failures in initializing the metrics system.

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -467,21 +467,21 @@ fn build_guest_cpu_config(
     vcpu: &Vcpu,
 ) -> Result<CpuConfigurationType, GuestConfigError> {
     let mut cpu_config: Option<CpuConfiguration> = None;
-    if let Some(custom_template) = &vm_resources.vm_config.custom_cpu_template {
+    if let Some(cpu_template) = &vm_resources.vm_config.custom_cpu_template {
         #[cfg(target_arch = "x86_64")]
         let cpu_config_result = create_guest_cpu_config(
-            custom_template,
+            cpu_template,
             &CpuConfiguration {
                 cpuid: Cpuid::try_from(RawCpuid::from(vm.supported_cpuid().clone())).unwrap(),
-                msrs: get_msr_values(vcpu, custom_template),
+                msrs: get_msr_values(vcpu, cpu_template),
             },
         );
 
         #[cfg(target_arch = "aarch64")]
         let cpu_config_result = create_guest_cpu_config(
-            custom_template,
+            cpu_template,
             &CpuConfiguration {
-                regs: get_reg_values(vcpu, custom_template),
+                regs: get_reg_values(vcpu, cpu_template),
             },
         );
 

--- a/src/vmm/src/guest_config/aarch64/mod.rs
+++ b/src/vmm/src/guest_config/aarch64/mod.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 /// CPU configuration for aarch64 CPUs
 #[derive(Clone, Default, Debug, Eq, PartialEq)]
-pub struct Aarch64CpuConfiguration {
+pub struct CpuConfiguration {
     /// Register values as a key pair
     /// Key: Register pointer
     /// Value: Register value

--- a/src/vmm/src/guest_config/templates/mod.rs
+++ b/src/vmm/src/guest_config/templates/mod.rs
@@ -153,6 +153,7 @@ pub mod x86_64 {
 
     /// Wrapper type to containing x86_64 CPU config modifiers.
     #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(deny_unknown_fields)]
     pub struct CpuTemplate {
         /// Modifiers for CPUID configuration.
         #[serde(default)]
@@ -486,8 +487,10 @@ pub mod aarch64 {
 
     /// Wrapper type to containing aarch64 CPU config modifiers.
     #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(deny_unknown_fields)]
     pub struct CpuTemplate {
         /// Modifiers for registers on Aarch64 CPUs.
+        #[serde(default)]
         pub reg_modifiers: Vec<RegisterModifier>,
     }
 
@@ -863,7 +866,6 @@ mod tests {
             assert_eq!(5, cpu_config.cpuid_modifiers.len());
             assert_eq!(4, cpu_config.msr_modifiers.len());
         }
-
         #[cfg(target_arch = "aarch64")]
         {
             assert_eq!(2, cpu_config.reg_modifiers.len());

--- a/src/vmm/src/guest_config/x86_64/mod.rs
+++ b/src/vmm/src/guest_config/x86_64/mod.rs
@@ -7,7 +7,7 @@ use crate::guest_config::cpuid::Cpuid;
 
 /// CPU configuration for x86_64 CPUs
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct X86_64CpuConfiguration {
+pub struct CpuConfiguration {
     /// CPUID configuration
     pub cpuid: Cpuid,
     /// Register values as a key pair for model specific registers

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use utils::net::ipv4addr::is_link_local_valid;
 
 use crate::device_manager::persist::SharedDeviceType;
-use crate::guest_config::templates::CpuConfigurationType;
+use crate::guest_config::templates::{CpuConfigurationType, CpuTemplate};
 use crate::vmm_config::balloon::*;
 use crate::vmm_config::boot_source::{
     BootConfig, BootSource, BootSourceConfig, BootSourceConfigError,
@@ -238,8 +238,14 @@ impl VmResources {
     }
 
     /// Returns the VmConfig.
-    pub fn vm_config(&self) -> &VmConfig {
-        &self.vm_config.config
+    pub fn vm_config(&self) -> VmConfig {
+        self.vm_config.build()
+    }
+
+    /// Add a custom CPU template to the VM resources
+    /// to configure vCPUs.
+    pub fn set_cpu_template(&mut self, cpu_template: CpuTemplate) {
+        self.vm_config.custom_cpu_template = Some(cpu_template);
     }
 
     /// Update the machine configuration of the microVM.
@@ -1272,7 +1278,7 @@ mod tests {
         let vm_resources = default_vm_resources();
         let expected_vm_cfg = VmConfig::default();
 
-        assert_eq!(vm_resources.vm_config(), &expected_vm_cfg);
+        assert_eq!(vm_resources.vm_config(), expected_vm_cfg);
     }
 
     #[test]

--- a/src/vmm/src/utilities/mock_resources/mod.rs
+++ b/src/vmm/src/utilities/mock_resources/mod.rs
@@ -4,6 +4,7 @@
 
 use std::path::PathBuf;
 
+use crate::guest_config::templates::CpuTemplate;
 use crate::resources::VmResources;
 use crate::vmm_config::boot_source::BootSourceConfig;
 use crate::vmm_config::machine_config::{VmConfig, VmUpdateConfig};
@@ -81,6 +82,10 @@ impl MockVmResources {
         let machine_config = VmUpdateConfig::from(vm_config);
         self.0.update_vm_config(&machine_config).unwrap();
         self
+    }
+
+    pub fn set_cpu_template(&mut self, cpu_template: CpuTemplate) {
+        self.0.vm_config.custom_cpu_template = Some(cpu_template);
     }
 }
 

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -241,8 +241,7 @@ mod tests {
         let vcpu_config = VcpuConfig {
             vcpu_count: 1,
             smt: false,
-            static_cpu_template: Default::default(),
-            custom_cpu_config: None,
+            cpu_config: Default::default(),
         };
         assert!(vcpu
             .configure(

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -23,7 +23,7 @@ use utils::eventfd::EventFd;
 use utils::signal::{register_signal_handler, sigrtmin, Killable};
 use utils::sm::StateMachine;
 
-use crate::vmm_config::machine_config::CpuFeaturesTemplate;
+use crate::guest_config::templates::CpuConfigurationType;
 use crate::vstate::vm::Vm;
 use crate::FcExitCode;
 
@@ -36,11 +36,6 @@ pub(crate) mod x86_64;
 pub(crate) use aarch64::{Error as VcpuError, *};
 #[cfg(target_arch = "x86_64")]
 pub(crate) use x86_64::{Error as VcpuError, *};
-
-#[cfg(target_arch = "aarch64")]
-use crate::guest_config::aarch64::Aarch64CpuConfiguration;
-#[cfg(target_arch = "x86_64")]
-use crate::guest_config::x86_64::X86_64CpuConfiguration;
 
 /// Signal number (SIGRTMIN) used to kick Vcpus.
 pub(crate) const VCPU_RTSIG_OFFSET: i32 = 0;
@@ -80,14 +75,8 @@ pub struct VcpuConfig {
     pub vcpu_count: u8,
     /// Enable simultaneous multithreading in the CPUID configuration.
     pub smt: bool,
-    /// Hard-coded template to use.
-    pub static_cpu_template: CpuFeaturesTemplate,
-    /// Custom configuration for vCPU.
-    #[cfg(target_arch = "x86_64")]
-    pub custom_cpu_config: Option<X86_64CpuConfiguration>,
-    /// Custom configuration for vCPU.
-    #[cfg(target_arch = "aarch64")]
-    pub custom_cpu_config: Option<Aarch64CpuConfiguration>,
+    /// Configuration to be applied to all guest vCPUs.
+    pub cpu_config: CpuConfigurationType,
 }
 
 // Using this for easier explicit type-casting to help IDEs interpret the code.
@@ -943,8 +932,7 @@ mod tests {
                 &VcpuConfig {
                     vcpu_count: 1,
                     smt: false,
-                    static_cpu_template: CpuFeaturesTemplate::None,
-                    custom_cpu_config: None,
+                    cpu_config: CpuConfigurationType::default(),
                 },
             )
             .expect("failed to configure vcpu");
@@ -957,8 +945,7 @@ mod tests {
                     &VcpuConfig {
                         vcpu_count: 1,
                         smt: false,
-                        static_cpu_template: CpuFeaturesTemplate::None,
-                        custom_cpu_config: None,
+                        cpu_config: CpuConfigurationType::default(),
                     },
                     _vm.supported_cpuid().clone(),
                 )

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -222,8 +222,8 @@ impl KvmVcpu {
         vcpu_config: &VcpuConfig,
         cpuid: CpuId,
     ) -> std::result::Result<(), KvmVcpuConfigureError> {
-        let cpuid = if let CpuConfigurationType::Custom(custom_template) = &vcpu_config.cpu_config {
-            custom_template.cpuid.clone()
+        let cpuid = if let CpuConfigurationType::Custom(cpu_template) = &vcpu_config.cpu_config {
+            cpu_template.cpuid.clone()
         } else {
             crate::guest_config::cpuid::Cpuid::try_from(crate::guest_config::cpuid::RawCpuid::from(
                 cpuid,

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -28,6 +28,7 @@ use crate::guest_config::static_templates::t2a::t2a;
 use crate::guest_config::static_templates::t2cl::{t2cl, update_t2cl_msr_entries};
 use crate::guest_config::static_templates::t2s::{t2s, update_t2s_msr_entries};
 use crate::guest_config::static_templates::{msr_entries_to_save, TSC_KHZ_TOL};
+use crate::guest_config::templates::CpuConfigurationType;
 use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 use crate::vstate::vcpu::{VcpuConfig, VcpuEmulation};
 use crate::vstate::vm::Vm;
@@ -221,16 +222,24 @@ impl KvmVcpu {
         vcpu_config: &VcpuConfig,
         cpuid: CpuId,
     ) -> std::result::Result<(), KvmVcpuConfigureError> {
-        let cpuid = match &vcpu_config.custom_cpu_config {
-            None => crate::guest_config::cpuid::Cpuid::try_from(
-                crate::guest_config::cpuid::RawCpuid::from(cpuid),
-            )
-            .map_err(KvmVcpuConfigureError::SnapshotCpuid)?,
-            Some(custom_config) => custom_config.cpuid.clone(),
+        let cpuid = if let CpuConfigurationType::Custom(custom_template) = &vcpu_config.cpu_config {
+            custom_template.cpuid.clone()
+        } else {
+            crate::guest_config::cpuid::Cpuid::try_from(crate::guest_config::cpuid::RawCpuid::from(
+                cpuid,
+            ))
+            .map_err(KvmVcpuConfigureError::SnapshotCpuid)?
         };
 
+        let static_cpu_template =
+            if let CpuConfigurationType::Static(static_template) = &vcpu_config.cpu_config {
+                static_template
+            } else {
+                &CpuFeaturesTemplate::None
+            };
+
         // If a template is specified, get the CPUID template, else use `cpuid`.
-        let mut config_cpuid = match vcpu_config.static_cpu_template {
+        let mut config_cpuid = match static_cpu_template {
             CpuFeaturesTemplate::T2 => t2(),
             CpuFeaturesTemplate::T2S => t2s(),
             CpuFeaturesTemplate::C3 => c3(),
@@ -290,7 +299,7 @@ impl KvmVcpu {
         // the previous comment, we get from the template a static list of MSRs we need
         // to save at snapshot as well.
         // C3, T2 and T2A currently don't have extra MSRs to save/set.
-        match vcpu_config.static_cpu_template {
+        match static_cpu_template {
             CpuFeaturesTemplate::T2S => {
                 self.msr_list.extend(msr_entries_to_save());
                 update_t2s_msr_entries(&mut msr_boot_entries);
@@ -661,8 +670,7 @@ mod tests {
         let mut vcpu_config = VcpuConfig {
             vcpu_count: 1,
             smt: false,
-            static_cpu_template: CpuFeaturesTemplate::None,
-            custom_cpu_config: None,
+            cpu_config: CpuConfigurationType::default(),
         };
 
         assert_eq!(
@@ -676,7 +684,7 @@ mod tests {
         );
 
         // Test configure while using the T2 template.
-        vcpu_config.static_cpu_template = CpuFeaturesTemplate::T2;
+        vcpu_config.cpu_config = CpuConfigurationType::Static(CpuFeaturesTemplate::T2);
         let t2_res = vcpu.configure(
             &vm_mem,
             GuestAddress(crate::arch::get_kernel_start()),
@@ -685,7 +693,7 @@ mod tests {
         );
 
         // Test configure while using the C3 template.
-        vcpu_config.static_cpu_template = CpuFeaturesTemplate::C3;
+        vcpu_config.cpu_config = CpuConfigurationType::Static(CpuFeaturesTemplate::C3);
         let c3_res = vcpu.configure(
             &vm_mem,
             GuestAddress(0),
@@ -694,7 +702,7 @@ mod tests {
         );
 
         // Test configure while using the T2S template.
-        vcpu_config.static_cpu_template = CpuFeaturesTemplate::T2S;
+        vcpu_config.cpu_config = CpuConfigurationType::Static(CpuFeaturesTemplate::T2S);
         let t2s_res = vcpu.configure(
             &vm_mem,
             GuestAddress(0),
@@ -705,7 +713,7 @@ mod tests {
         let mut t2cl_res = Ok(());
         if is_at_least_cascade_lake() {
             // Test configure while using the T2CL template.
-            vcpu_config.static_cpu_template = CpuFeaturesTemplate::T2CL;
+            vcpu_config.cpu_config = CpuConfigurationType::Static(CpuFeaturesTemplate::T2CL);
             t2cl_res = vcpu.configure(
                 &vm_mem,
                 GuestAddress(0),
@@ -715,7 +723,7 @@ mod tests {
         }
 
         // Test configure while using the T2S template.
-        vcpu_config.static_cpu_template = CpuFeaturesTemplate::T2A;
+        vcpu_config.cpu_config = CpuConfigurationType::Static(CpuFeaturesTemplate::T2A);
         let t2a_res = vcpu.configure(
             &vm_mem,
             GuestAddress(0),

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -5,8 +5,6 @@
 This module defines `Microvm`, which can be used to create, test drive, and
 destroy microvms.
 
-# TODO
-
 - Use the Firecracker Open API spec to populate Microvm API resource URLs.
 """
 
@@ -80,6 +78,7 @@ class Microvm:
         monitor_memory=True,
         bin_cloner_path=None,
     ):
+        # pylint: disable=too-many-statements
         """Set up microVM attributes, paths, and data structures."""
         # pylint: disable=too-many-statements
         # Unique identifier for this machine.
@@ -130,6 +129,7 @@ class Microvm:
         self.actions = None
         self.balloon = None
         self.boot = None
+        self.cpu_cfg = None
         self.desc_inst = None
         self.drive = None
         self.full_cfg = None

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,13 +25,13 @@ def is_on_skylake():
 # differences may appear.
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {
-        "Intel": 81.99 if is_on_skylake() else 84.43,
+        "Intel": 81.93 if is_on_skylake() else 84.37,
         "AMD": 84.68,
         "ARM": 82.44,
     }
 else:
     COVERAGE_DICT = {
-        "Intel": 79.51 if is_on_skylake() else 81.94,
+        "Intel": 79.46 if is_on_skylake() else 81.88,
         "AMD": 82.19,
         "ARM": 79.37,
     }


### PR DESCRIPTION
## Changes

Makes use of the `guest_config` module to provide an endpoint to configure vCPUs via an HTTP request using a JSON formatted payload. The means to change the configuration for the guest is a user-defined template that contains modifiers that will be applied to the default register values as they exist when KVM initializes them.

## Reason

Currently, all configuration of guest vCPU resources is derived from defaults of the environment (centered around KVM and microcode defaults),  and pre-defined templates that users can choose from. This API will provide an endpoint to configure user-defined templates in the form of modifiers.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

