### PR TITLE
[WIP] Move custom CPU template to VM Config

### DIFF
--- a/src/vmm/src/guest_config/templates/mod.rs
+++ b/src/vmm/src/guest_config/templates/mod.rs
@@ -45,7 +45,7 @@ pub mod x86_64 {
 
     /// CPUID register enumeration
     #[allow(missing_docs)]
-    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
     pub enum CpuidRegister {
         Eax,
         Ebx,
@@ -54,7 +54,7 @@ pub mod x86_64 {
     }
 
     /// Target register to be modified by a bitmap.
-    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
     pub struct CpuidRegisterModifier {
         /// CPUID register to be modified by the bitmap.
         #[serde(
@@ -74,7 +74,7 @@ pub mod x86_64 {
     /// Composite type that holistically provides
     /// the location of a specific register being used
     /// in the context of a CPUID tree.
-    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
     pub struct CpuidLeafModifier {
         /// Leaf value.
         #[serde(
@@ -96,7 +96,7 @@ pub mod x86_64 {
     }
 
     /// Wrapper type to containing x86_64 CPU config modifiers.
-    #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+    #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
     pub struct X86_64CpuTemplate {
         /// Modifiers for CPUID configuration.
         #[serde(default)]
@@ -107,7 +107,7 @@ pub mod x86_64 {
     }
 
     /// Bit-mapped value to adjust targeted bits of a register.
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct RegisterValueFilter {
         /// Filter to be used when writing the value bits.
         pub filter: u64,
@@ -117,7 +117,7 @@ pub mod x86_64 {
 
     /// Wrapper of a mask defined as a bitmap to apply
     /// changes to a given register's value.
-    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
     pub struct RegisterModifier {
         /// Pointer of the location to be bit mapped.
         #[serde(
@@ -428,7 +428,7 @@ pub mod aarch64 {
     use crate::guest_config::templates::Error;
 
     /// Wrapper type to containing aarch64 CPU config modifiers.
-    #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+    #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
     pub struct Aarch64CpuTemplate {
         /// Modifiers for registers on Aarch64 CPUs.
         pub reg_modifiers: Vec<RegisterModifier>,
@@ -436,7 +436,7 @@ pub mod aarch64 {
 
     /// Wrapper of a mask defined as a bitmap to apply
     /// changes to a given register's value.
-    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
     pub struct RegisterModifier {
         /// Pointer of the location to be bit mapped.
         #[serde(
@@ -454,7 +454,7 @@ pub mod aarch64 {
     }
 
     /// Bit-mapped value to adjust targeted bits of a register.
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct RegisterValueFilter {
         /// Filter to be used when writing the value bits.
         pub filter: u128,

--- a/src/vmm/src/guest_config/templates/mod.rs
+++ b/src/vmm/src/guest_config/templates/mod.rs
@@ -4,6 +4,28 @@
 // TODO: Refactor code to merge deserialize_* functions for modules x86_64 and aarch64
 /// Templates module to contain sub-modules for aarch64 and x86_64 templates
 
+#[cfg(target_arch = "aarch64")]
+use crate::guest_config::aarch64::Aarch64CpuConfiguration;
+#[cfg(target_arch = "aarch64")]
+use crate::guest_config::templates::aarch64::Aarch64CpuTemplate;
+#[cfg(target_arch = "x86_64")]
+use crate::guest_config::templates::x86_64::X86_64CpuTemplate;
+#[cfg(target_arch = "x86_64")]
+use crate::guest_config::x86_64::X86_64CpuConfiguration;
+
+/// Type alias agnostic of CPU architecture for CPU configuration
+#[cfg(target_arch = "x86_64")]
+pub type CpuConfigType = X86_64CpuConfiguration;
+/// Type alias agnostic of CPU architecture for CPU configuration
+#[cfg(target_arch = "aarch64")]
+pub type CpuConfigType = Aarch64CpuConfiguration;
+/// Type alias agnostic of CPU architecture for custom CPU templates
+#[cfg(target_arch = "x86_64")]
+pub type CustomCpuTemplateType = X86_64CpuTemplate;
+/// Type alias agnostic of CPU architecture for custom CPU templates
+#[cfg(target_arch = "aarch64")]
+pub type CustomCpuTemplateType = Aarch64CpuTemplate;
+
 /// Guest config sub-module specifically useful for
 /// config templates.
 #[cfg(target_arch = "x86_64")]
@@ -588,138 +610,19 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_arch = "x86_64")]
-    use std::collections::BTreeMap;
-
-    #[cfg(target_arch = "x86_64")]
-    use kvm_bindings::KVM_CPUID_FLAG_STATEFUL_FUNC;
     use serde_json::Value;
 
+    use super::guest_config_test::{
+        build_supported_cpu_config, build_test_template, unsupported_cpu_config,
+    };
     #[cfg(target_arch = "aarch64")]
-    use crate::guest_config::aarch64::Aarch64CpuConfiguration;
-    #[cfg(target_arch = "x86_64")]
-    use crate::guest_config::cpuid::KvmCpuidFlags;
-    #[cfg(target_arch = "x86_64")]
-    use crate::guest_config::cpuid::{Cpuid, IntelCpuid};
-    #[cfg(target_arch = "aarch64")]
-    use crate::guest_config::templates::aarch64::{
-        create_guest_cpu_config, Aarch64CpuTemplate, RegisterModifier, RegisterValueFilter,
+    use crate::guest_config::templates::aarch64::{create_guest_cpu_config, Aarch64CpuTemplate};
+    use crate::guest_config::templates::guest_config_test::{
+        build_empty_config, TEST_TEMPLATE_JSON,
     };
     #[cfg(target_arch = "x86_64")]
-    use crate::guest_config::templates::x86_64::{
-        create_guest_cpu_config, CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier,
-        RegisterModifier, RegisterValueFilter, X86_64CpuTemplate,
-    };
-    use crate::guest_config::templates::Error;
-    #[cfg(target_arch = "x86_64")]
-    use crate::guest_config::x86_64::X86_64CpuConfiguration;
-    #[cfg(target_arch = "x86_64")]
-    use crate::vstate::vcpu::x86_64::cpuid_templates;
-
-    #[cfg(target_arch = "x86_64")]
-    const X86_64_TEMPLATE_JSON: &str = r#"{
-        "cpuid_modifiers": [
-            {
-                "leaf": "0x80000001",
-                "subleaf": "0b000111",
-                "flags": 0,
-                "modifiers": [
-                    {
-                        "register": "eax",
-                        "bitmap": "0bx00100xxx1xxxxxxxxxxxxxxxxxxxxx1"
-                    }
-                ]
-            },
-            {
-                "leaf": "0x80000002",
-                "subleaf": "0x0004",
-                "flags": 0,
-                "modifiers": [
-                    {
-                        "register": "ebx",
-                        "bitmap": "0bxxx1xxxxxxxxxxxxxxxxxxxxx1"
-                    },
-                    {
-                        "register": "ecx",
-                        "bitmap": "0bx00100xxx1xxxxxxxxxxx0xxxxx0xxx1"
-                    }
-                ]
-            },
-            {
-                "leaf": "0x80000003",
-                "subleaf": "0x0004",
-                "flags": 1,
-                "modifiers": [
-                    {
-                        "register": "edx",
-                        "bitmap": "0bx00100xxx1xxxxxxxxxxx0xxxxx0xxx1"
-                    }
-                ]
-            },
-            {
-                "leaf": "0x80000004",
-                "subleaf": "0x0004",
-                "flags": 0,
-                "modifiers": [
-                    {
-                        "register": "edx",
-                        "bitmap": "0b00100xxx1xxxxxx1xxxxxxxxxxxxxx1"
-                    },
-                    {
-                        "register": "ecx",
-                        "bitmap": "0bx00100xxx1xxxxxxxxxxxxx111xxxxx1"
-                    }
-                ]
-            },
-            {
-                "leaf": "0x80000005",
-                "subleaf": "0x0004",
-                "flags": 0,
-                "modifiers": [
-                    {
-                        "register": "eax",
-                        "bitmap": "0bx00100xxx1xxxxx00xxxxxx000xxxxx1"
-                    },
-                    {
-                        "register": "edx",
-                        "bitmap": "0bx10100xxx1xxxxxxxxxxxxx000xxxxx1"
-                    }
-                ]
-            }
-        ],
-        "msr_modifiers":  [
-            {
-                "addr": "0x0",
-                "bitmap": "0bx00100xxx1xxxx00xxx1xxxxxxxxxxx1"
-            },
-            {
-                "addr": "0b1",
-                "bitmap": "0bx00111xxx1xxxx111xxxxx101xxxxxx1"
-            },
-            {
-                "addr": "2",
-                "bitmap": "0bx00100xxx1xxxxxx0000000xxxxxxxx1"
-            },
-            {
-                "addr": "0xbbca",
-                "bitmap": "0bx00100xxx1xxxxxxxxx1"
-            }
-        ]
-    }"#;
-
-    #[cfg(target_arch = "aarch64")]
-    const AARCH64_TEMPLATE_JSON: &str = r#"{
-        "reg_modifiers":  [
-            {
-                "addr": "0x0AAC",
-                "bitmap": "0b1xx1"
-            },
-            {
-                "addr": "0x0AAB",
-                "bitmap": "0b1x00"
-            }
-        ]
-    }"#;
+    use crate::guest_config::templates::x86_64::{create_guest_cpu_config, X86_64CpuTemplate};
+    use crate::guest_config::templates::{CustomCpuTemplateType, Error};
 
     #[test]
     fn test_malformed_json() {
@@ -898,97 +801,56 @@ mod tests {
 
     #[test]
     fn test_deserialization_lifecycle() {
+        let cpu_config: CustomCpuTemplateType = serde_json::from_str(TEST_TEMPLATE_JSON)
+            .expect("Failed to deserialize custom CPU template.");
         #[cfg(target_arch = "x86_64")]
         {
-            let cpu_config: X86_64CpuTemplate = serde_json::from_str(X86_64_TEMPLATE_JSON)
-                .expect("Failed to deserialize x86_64 CPU template.");
-
             assert_eq!(5, cpu_config.cpuid_modifiers.len());
             assert_eq!(4, cpu_config.msr_modifiers.len());
         }
 
         #[cfg(target_arch = "aarch64")]
         {
-            let cpu_config: Aarch64CpuTemplate = serde_json::from_str(AARCH64_TEMPLATE_JSON)
-                .expect("Failed to deserialize aarch64 CPU template.");
-
             assert_eq!(2, cpu_config.reg_modifiers.len());
         }
     }
 
     #[test]
     fn test_empty_template() {
-        #[cfg(target_arch = "x86_64")]
-        {
-            let host_configuration = supported_cpu_config();
-            let guest_config_result =
-                create_guest_cpu_config(&X86_64CpuTemplate::default(), &host_configuration);
-            assert!(
-                guest_config_result.is_ok(),
-                "{}",
-                guest_config_result.unwrap_err()
-            );
-            // CPUID will be comparable, but not MSRs.
-            // The configuration will be configuration required by the template,
-            // not a holistic view of all registers.
-            assert_eq!(guest_config_result.unwrap().cpuid, host_configuration.cpuid);
-        }
-
-        #[cfg(target_arch = "aarch64")]
-        {
-            let host_configuration = supported_cpu_config();
-            let guest_config_result =
-                create_guest_cpu_config(&Aarch64CpuTemplate::default(), &host_configuration);
-            assert!(
-                guest_config_result.is_ok(),
-                "{}",
-                guest_config_result.unwrap_err()
-            );
-        }
+        let host_configuration = build_empty_config();
+        let guest_config_result =
+            create_guest_cpu_config(&CustomCpuTemplateType::default(), &host_configuration);
+        assert!(
+            guest_config_result.is_ok(),
+            "{}",
+            guest_config_result.unwrap_err()
+        );
+        assert_eq!(guest_config_result.unwrap(), host_configuration);
     }
 
     #[test]
     fn test_apply_template() {
-        #[cfg(target_arch = "x86_64")]
-        {
-            let host_configuration = supported_cpu_config();
-            let guest_config_result =
-                create_guest_cpu_config(&build_test_template(), &host_configuration);
-            assert!(
-                guest_config_result.is_ok(),
-                "{}",
-                guest_config_result.unwrap_err()
-            );
-            assert_ne!(guest_config_result.unwrap(), host_configuration);
-        }
-
-        #[cfg(target_arch = "aarch64")]
-        {
-            let host_configuration = supported_cpu_config();
-            let guest_config_result =
-                create_guest_cpu_config(&build_test_template(), &host_configuration);
-            assert!(
-                guest_config_result.is_ok(),
-                "{}",
-                guest_config_result.unwrap_err()
-            );
-            assert_ne!(guest_config_result.unwrap(), host_configuration);
-        }
+        let host_configuration = build_supported_cpu_config();
+        let guest_config_result =
+            create_guest_cpu_config(&build_test_template(), &host_configuration);
+        assert!(
+            guest_config_result.is_ok(),
+            "{}",
+            guest_config_result.unwrap_err()
+        );
+        assert_ne!(guest_config_result.unwrap(), host_configuration);
     }
 
     #[test]
     fn test_serialization_lifecycle() {
-        #[cfg(target_arch = "x86_64")]
-        {
-            let template = build_test_template();
-            let template_json_str_result = serde_json::to_string_pretty(&template);
-            assert!(&template_json_str_result.is_ok());
-            let template_json = template_json_str_result.unwrap();
+        let template = build_test_template();
+        let template_json_str_result = serde_json::to_string_pretty(&template);
+        assert!(&template_json_str_result.is_ok());
+        let template_json = template_json_str_result.unwrap();
 
-            let deserialization_result = serde_json::from_str::<X86_64CpuTemplate>(&template_json);
-            assert!(deserialization_result.is_ok());
-            assert_eq!(template, deserialization_result.unwrap());
-        }
+        let deserialization_result = serde_json::from_str::<CustomCpuTemplateType>(&template_json);
+        assert!(deserialization_result.is_ok());
+        assert_eq!(template, deserialization_result.unwrap());
     }
 
     /// Invalid test in this context is when the template
@@ -998,7 +860,7 @@ mod tests {
         #[cfg(target_arch = "x86_64")]
         {
             // Test CPUID validation
-            let host_configuration = build_empty_x86_config();
+            let host_configuration = build_empty_config();
             let guest_template = build_test_template();
             let guest_config_result = create_guest_cpu_config(&guest_template, &host_configuration);
             assert!(
@@ -1131,121 +993,299 @@ mod tests {
             );
         }
     }
+}
+
+/// Contains utility functions exclusively for testing purposes
+pub mod guest_config_test {
+    #[cfg(target_arch = "x86_64")]
+    use std::collections::BTreeMap;
 
     #[cfg(target_arch = "x86_64")]
-    fn build_test_template() -> X86_64CpuTemplate {
-        X86_64CpuTemplate {
-            cpuid_modifiers: Vec::from([CpuidLeafModifier {
-                leaf: 0x3,
-                subleaf: 0x0,
-                flags: KvmCpuidFlags(KVM_CPUID_FLAG_STATEFUL_FUNC),
-                modifiers: Vec::from([
-                    CpuidRegisterModifier {
-                        register: CpuidRegister::Eax,
+    use kvm_bindings::KVM_CPUID_FLAG_STATEFUL_FUNC;
+
+    #[cfg(target_arch = "aarch64")]
+    use crate::guest_config::aarch64::Aarch64CpuConfiguration;
+    #[cfg(target_arch = "x86_64")]
+    use crate::guest_config::cpuid::KvmCpuidFlags;
+    #[cfg(target_arch = "x86_64")]
+    use crate::guest_config::cpuid::{Cpuid, IntelCpuid};
+    #[cfg(target_arch = "aarch64")]
+    use crate::guest_config::templates::aarch64::{
+        Aarch64CpuTemplate, RegisterModifier, RegisterValueFilter,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use crate::guest_config::templates::x86_64::{
+        CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterModifier,
+        RegisterValueFilter, X86_64CpuTemplate,
+    };
+    use crate::guest_config::templates::{CpuConfigType, CustomCpuTemplateType};
+    #[cfg(target_arch = "x86_64")]
+    use crate::guest_config::x86_64::X86_64CpuConfiguration;
+    #[cfg(target_arch = "x86_64")]
+    use crate::vstate::vcpu::x86_64::cpuid_templates;
+
+    /// Test CPU template in JSON format
+    #[cfg(target_arch = "x86_64")]
+    pub const TEST_TEMPLATE_JSON: &str = r#"{
+        "cpuid_modifiers": [
+            {
+                "leaf": "0x80000001",
+                "subleaf": "0x0007",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "eax",
+                        "bitmap": "0bx00100xxx1xxxxxxxxxxxxxxxxxxxxx1"
+                    }
+                ]
+            },
+            {
+                "leaf": "0x80000002",
+                "subleaf": "0x0004",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "ebx",
+                        "bitmap": "0bxxx1xxxxxxxxxxxxxxxxxxxxx1"
+                    },
+                    {
+                        "register": "ecx",
+                        "bitmap": "0bx00100xxx1xxxxxxxxxxx0xxxxx0xxx1"
+                    }
+                ]
+            },
+            {
+                "leaf": "0x80000003",
+                "subleaf": "0x0004",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "edx",
+                        "bitmap": "0bx00100xxx1xxxxxxxxxxx0xxxxx0xxx1"
+                    }
+                ]
+            },
+            {
+                "leaf": "0x80000004",
+                "subleaf": "0x0004",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "edx",
+                        "bitmap": "0b00100xxx1xxxxxx1xxxxxxxxxxxxxx1"
+                    },
+                    {
+                        "register": "ecx",
+                        "bitmap": "0bx00100xxx1xxxxxxxxxxxxx111xxxxx1"
+                    }
+                ]
+            },
+            {
+                "leaf": "0x80000005",
+                "subleaf": "0x0004",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "eax",
+                        "bitmap": "0bx00100xxx1xxxxx00xxxxxx000xxxxx1"
+                    },
+                    {
+                        "register": "edx",
+                        "bitmap": "0bx10100xxx1xxxxxxxxxxxxx000xxxxx1"
+                    }
+                ]
+            }
+        ],
+        "msr_modifiers":  [
+            {
+                "addr": "0x0",
+                "bitmap": "0bx00100xxx1xxxx00xxx1xxxxxxxxxxx1"
+            },
+            {
+                "addr": "0x1",
+                "bitmap": "0bx00111xxx1xxxx111xxxxx101xxxxxx1"
+            },
+            {
+                "addr": "2",
+                "bitmap": "0bx00100xxx1xxxxxx0000000xxxxxxxx1"
+            },
+            {
+                "addr": "0xbbca",
+                "bitmap": "0bx00100xxx1xxxxxxxxx1"
+            }
+        ]
+    }"#;
+
+    /// Test CPU template in JSON format but has an invalid field for the architecture.
+    /// "reg_modifiers" is the field name for the registers for aarch64"
+    #[cfg(target_arch = "x86_64")]
+    pub const INVALID_TEMPLATE_JSON: &str = r#"{
+        "reg_modifiers":  [
+            {
+                "addr": "0x0AAC",
+                "bitmap": "0b1xx1"
+            },
+        ]
+    }"#;
+
+    /// Test CPU template in JSON format
+    #[cfg(target_arch = "aarch64")]
+    pub const TEST_TEMPLATE_JSON: &str = r#"{
+        "reg_modifiers":  [
+            {
+                "addr": "0x0AAC",
+                "bitmap": "0b1xx1"
+            },
+            {
+                "addr": "0x0AAB",
+                "bitmap": "0b1x00"
+            }
+        ]
+    }"#;
+
+    /// Test CPU template in JSON format but has an invalid field for the architecture.
+    /// "msr_modifiers" is the field name for the model specific registers for
+    /// defined by x86 CPUs.
+    #[cfg(target_arch = "aarch64")]
+    pub const INVALID_TEMPLATE_JSON: &str = r#"{
+        "msr_modifiers":  [
+        ]
+    }"#;
+
+    /// Builds a sample custom CPU template
+    pub fn build_test_template() -> CustomCpuTemplateType {
+        #[cfg(target_arch = "x86_64")]
+        {
+            X86_64CpuTemplate {
+                cpuid_modifiers: Vec::from([CpuidLeafModifier {
+                    leaf: 0x3,
+                    subleaf: 0x0,
+                    flags: KvmCpuidFlags(KVM_CPUID_FLAG_STATEFUL_FUNC),
+                    modifiers: Vec::from([
+                        CpuidRegisterModifier {
+                            register: CpuidRegister::Eax,
+                            bitmap: RegisterValueFilter {
+                                filter: 0b0111,
+                                value: 0b0101,
+                            },
+                        },
+                        CpuidRegisterModifier {
+                            register: CpuidRegister::Ebx,
+                            bitmap: RegisterValueFilter {
+                                filter: 0b0111,
+                                value: 0b0100,
+                            },
+                        },
+                        CpuidRegisterModifier {
+                            register: CpuidRegister::Ecx,
+                            bitmap: RegisterValueFilter {
+                                filter: 0b0111,
+                                value: 0b0111,
+                            },
+                        },
+                        CpuidRegisterModifier {
+                            register: CpuidRegister::Edx,
+                            bitmap: RegisterValueFilter {
+                                filter: 0b0111,
+                                value: 0b0001,
+                            },
+                        },
+                    ]),
+                }]),
+                msr_modifiers: Vec::from([
+                    RegisterModifier {
+                        addr: 0x9999,
                         bitmap: RegisterValueFilter {
-                            filter: 0b0111,
-                            value: 0b0101,
+                            filter: 0,
+                            value: 0,
                         },
                     },
-                    CpuidRegisterModifier {
-                        register: CpuidRegister::Ebx,
+                    RegisterModifier {
+                        addr: 0x8000,
                         bitmap: RegisterValueFilter {
-                            filter: 0b0111,
-                            value: 0b0100,
-                        },
-                    },
-                    CpuidRegisterModifier {
-                        register: CpuidRegister::Ecx,
-                        bitmap: RegisterValueFilter {
-                            filter: 0b0111,
-                            value: 0b0111,
-                        },
-                    },
-                    CpuidRegisterModifier {
-                        register: CpuidRegister::Edx,
-                        bitmap: RegisterValueFilter {
-                            filter: 0b0111,
-                            value: 0b0001,
+                            filter: 0b1110,
+                            value: 0b0110,
                         },
                     },
                 ]),
-            }]),
-            msr_modifiers: Vec::from([
-                RegisterModifier {
-                    addr: 0x9999,
-                    bitmap: RegisterValueFilter {
-                        filter: 0,
-                        value: 0,
+            }
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            Aarch64CpuTemplate {
+                reg_modifiers: Vec::from([
+                    RegisterModifier {
+                        addr: 0x9999,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b100010001,
+                            value: 0b100000001,
+                        },
                     },
-                },
-                RegisterModifier {
-                    addr: 0x8000,
-                    bitmap: RegisterValueFilter {
-                        filter: 0,
-                        value: 0,
+                    RegisterModifier {
+                        addr: 0x8000,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b1110,
+                            value: 0b0110,
+                        },
                     },
-                },
-            ]),
+                ]),
+            }
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
-    fn build_empty_x86_config() -> X86_64CpuConfiguration {
-        X86_64CpuConfiguration {
-            cpuid: Cpuid::Intel(IntelCpuid(BTreeMap::new())),
-            msrs: Default::default(),
+    /// Builds a sample CPU configuration
+    pub fn build_supported_cpu_config() -> CpuConfigType {
+        #[cfg(target_arch = "x86_64")]
+        {
+            X86_64CpuConfiguration {
+                cpuid: cpuid_templates::t2::template(),
+                msrs: std::collections::HashMap::from([(0x8000, 0b1000), (0x9999, 0b1010)]),
+            }
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            Aarch64CpuConfiguration {
+                regs: std::collections::HashMap::from([(0x8000, 0b1000), (0x9999, 0b1010)]),
+            }
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
-    fn build_test_template() -> Aarch64CpuTemplate {
-        Aarch64CpuTemplate {
-            reg_modifiers: Vec::from([
-                RegisterModifier {
-                    addr: 0x9999,
-                    bitmap: RegisterValueFilter {
-                        filter: 100010001,
-                        value: 10000001,
-                    },
-                },
-                RegisterModifier {
-                    addr: 0x8000,
-                    bitmap: RegisterValueFilter {
-                        filter: 0b1110,
-                        value: 0b0110,
-                    },
-                },
-            ]),
+    /// Builds a CPU config that conflicts with the CPU template that is
+    /// applied to it in the unit tests.
+    pub fn unsupported_cpu_config() -> CpuConfigType {
+        #[cfg(target_arch = "x86_64")]
+        {
+            X86_64CpuConfiguration {
+                cpuid: cpuid_templates::t2::template(),
+                msrs: std::collections::HashMap::from([(0x8000, 0b1000), (0x8001, 0b1010)]),
+            }
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            Aarch64CpuConfiguration {
+                regs: std::collections::HashMap::from([(0x8000, 0b1000), (0x8001, 0b1010)]),
+            }
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
-    fn supported_cpu_config() -> X86_64CpuConfiguration {
-        X86_64CpuConfiguration {
-            cpuid: cpuid_templates::t2::template(),
-            msrs: std::collections::HashMap::from([(0x8000, 0b1000), (0x9999, 0b1010)]),
+    /// Empty CPU config
+    pub fn build_empty_config() -> CpuConfigType {
+        #[cfg(target_arch = "x86_64")]
+        {
+            X86_64CpuConfiguration {
+                cpuid: Cpuid::Intel(IntelCpuid(BTreeMap::new())),
+                msrs: Default::default(),
+            }
         }
-    }
 
-    #[cfg(target_arch = "x86_64")]
-    fn unsupported_cpu_config() -> X86_64CpuConfiguration {
-        X86_64CpuConfiguration {
-            cpuid: cpuid_templates::t2::template(),
-            msrs: std::collections::HashMap::from([(0x8000, 0b1000), (0x8001, 0b1010)]),
-        }
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    fn supported_cpu_config() -> Aarch64CpuConfiguration {
-        Aarch64CpuConfiguration {
-            regs: std::collections::HashMap::from([(0x8000, 0b1000), (0x9999, 0b1010)]),
-        }
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    fn unsupported_cpu_config() -> Aarch64CpuConfiguration {
-        Aarch64CpuConfiguration {
-            regs: std::collections::HashMap::from([(0x8000, 0b1000), (0x8001, 0b1010)]),
+        #[cfg(target_arch = "aarch64")]
+        {
+            Aarch64CpuConfiguration {
+                regs: Default::default(),
+            }
         }
     }
 }

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -6,6 +6,8 @@ use serde::{de, Deserialize, Serialize};
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;
 
+use crate::guest_config::templates::CustomCpuTemplateType;
+
 /// The default memory size of the VM, in MiB.
 pub const DEFAULT_MEM_SIZE_MIB: usize = 128;
 /// Firecracker aims to support small scale workloads only, so limit the maximum
@@ -75,6 +77,9 @@ pub struct VmConfig {
     /// Enables or disables dirty page tracking. Enabling allows incremental snapshots.
     #[serde(default)]
     pub track_dirty_pages: bool,
+    /// Custom CPU template to be defined.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_cpu_template: Option<CustomCpuTemplateType>,
 }
 
 impl Default for VmConfig {
@@ -85,6 +90,7 @@ impl Default for VmConfig {
             smt: false,
             cpu_template: CpuFeaturesTemplate::None,
             track_dirty_pages: false,
+            custom_cpu_template: None,
         }
     }
 }

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -23,6 +23,7 @@ use utils::eventfd::EventFd;
 use utils::signal::{register_signal_handler, sigrtmin, Killable};
 use utils::sm::StateMachine;
 
+use crate::guest_config::templates::CpuConfigType;
 use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 use crate::vstate::vm::Vm;
 use crate::FcExitCode;
@@ -36,11 +37,6 @@ pub(crate) mod x86_64;
 pub(crate) use aarch64::{Error as VcpuError, *};
 #[cfg(target_arch = "x86_64")]
 pub(crate) use x86_64::{Error as VcpuError, *};
-
-#[cfg(target_arch = "aarch64")]
-use crate::guest_config::aarch64::Aarch64CpuConfiguration;
-#[cfg(target_arch = "x86_64")]
-use crate::guest_config::x86_64::X86_64CpuConfiguration;
 
 /// Signal number (SIGRTMIN) used to kick Vcpus.
 pub(crate) const VCPU_RTSIG_OFFSET: i32 = 0;
@@ -82,11 +78,8 @@ pub struct VcpuConfig {
     pub smt: bool,
     /// Hard-coded template to use.
     pub static_cpu_template: CpuFeaturesTemplate,
-    /// Custom configuration for vCPU,
-    #[cfg(target_arch = "x86_64")]
-    pub custom_cpu_config: Option<X86_64CpuConfiguration>,
-    #[cfg(target_arch = "aarch64")]
-    pub custom_cpu_config: Option<Aarch64CpuConfiguration>,
+    /// Custom configuration for vCPU.
+    pub custom_cpu_config: Option<CpuConfigType>,
 }
 
 // Using this for easier explicit type-casting to help IDEs interpret the code.

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -24,14 +24,7 @@ use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 
-#[cfg(target_arch = "aarch64")]
-use crate::guest_config::aarch64::Aarch64CpuConfiguration;
-#[cfg(target_arch = "aarch64")]
-use crate::guest_config::templates::aarch64::Aarch64CpuTemplate;
-#[cfg(target_arch = "x86_64")]
-use crate::guest_config::templates::x86_64::X86_64CpuTemplate;
-#[cfg(target_arch = "x86_64")]
-use crate::guest_config::x86_64::X86_64CpuConfiguration;
+use crate::guest_config::templates::CpuConfigType;
 
 /// Errors associated with the wrappers over KVM ioctls.
 #[derive(Debug)]
@@ -155,18 +148,14 @@ pub struct Vm {
     #[cfg(target_arch = "x86_64")]
     supported_msrs: MsrList,
     #[cfg(target_arch = "x86_64")]
-    pub(crate) guest_cpu_template: Option<X86_64CpuTemplate>,
-    #[cfg(target_arch = "x86_64")]
-    pub(crate) guest_cpu_config: Option<X86_64CpuConfiguration>,
+    pub(crate) guest_cpu_config: Option<CpuConfigType>,
 
     // Arm specific fields.
     // On aarch64 we need to keep around the fd obtained by creating the VGIC device.
     #[cfg(target_arch = "aarch64")]
     irqchip_handle: Option<Box<dyn GICDevice>>,
     #[cfg(target_arch = "aarch64")]
-    pub(crate) guest_cpu_template: Option<Aarch64CpuTemplate>,
-    #[cfg(target_arch = "aarch64")]
-    pub(crate) guest_cpu_config: Option<Aarch64CpuConfiguration>,
+    pub(crate) guest_cpu_config: Option<CpuConfigType>,
 }
 
 /// Contains Vm functions that are usable across CPU architectures
@@ -228,13 +217,12 @@ impl Vm {
 #[cfg(target_arch = "aarch64")]
 impl Vm {
     /// Constructs a new `Vm` using the given `Kvm` instance.
-    pub fn new(kvm: &Kvm, guest_cpu_template: Option<Aarch64CpuTemplate>) -> Result<Self> {
+    pub fn new(kvm: &Kvm) -> Result<Self> {
         // Create fd for interacting with kvm-vm specific functions.
         let vm_fd = kvm.create_vm().map_err(Error::VmFd)?;
 
         Ok(Vm {
             fd: vm_fd,
-            guest_cpu_template,
             guest_cpu_config: None,
             irqchip_handle: None,
         })
@@ -285,7 +273,7 @@ impl Vm {
 #[cfg(target_arch = "x86_64")]
 impl Vm {
     /// Constructs a new `Vm` using the given `Kvm` instance.
-    pub fn new(kvm: &Kvm, guest_cpu_template: Option<X86_64CpuTemplate>) -> Result<Self> {
+    pub fn new(kvm: &Kvm) -> Result<Self> {
         // Create fd for interacting with kvm-vm specific functions.
         let vm_fd = kvm.create_vm().map_err(Error::VmFd)?;
 
@@ -299,7 +287,6 @@ impl Vm {
             fd: vm_fd,
             supported_cpuid,
             supported_msrs,
-            guest_cpu_template,
             guest_cpu_config: None,
         })
     }
@@ -435,7 +422,7 @@ pub(crate) mod tests {
             vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), mem_size)], false)
                 .unwrap();
 
-        let mut vm = Vm::new(kvm.fd(), None).expect("Cannot create new vm");
+        let mut vm = Vm::new(kvm.fd()).expect("Cannot create new vm");
         assert!(vm.memory_init(&gm, kvm.max_memslots(), false).is_ok());
 
         (vm, gm)
@@ -447,22 +434,20 @@ pub(crate) mod tests {
 
         use utils::tempfile::TempFile;
         // Testing an error case.
-        let vm = Vm::new(
-            &unsafe { Kvm::from_raw_fd(TempFile::new().unwrap().as_file().as_raw_fd()) },
-            None,
-        );
+        let vm =
+            Vm::new(&unsafe { Kvm::from_raw_fd(TempFile::new().unwrap().as_file().as_raw_fd()) });
         assert!(vm.is_err());
 
         // Testing with a valid /dev/kvm descriptor.
         let kvm = KvmContext::new().unwrap();
-        assert!(Vm::new(kvm.fd(), None).is_ok());
+        assert!(Vm::new(kvm.fd()).is_ok());
     }
 
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn test_get_supported_cpuid() {
         let kvm = KvmContext::new().unwrap();
-        let vm = Vm::new(kvm.fd(), None).expect("Cannot create new vm");
+        let vm = Vm::new(kvm.fd()).expect("Cannot create new vm");
         let cpuid = kvm
             .fd()
             .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
@@ -473,7 +458,7 @@ pub(crate) mod tests {
     #[test]
     fn test_vm_memory_init() {
         let kvm_context = KvmContext::new().unwrap();
-        let mut vm = Vm::new(kvm_context.fd(), None).expect("Cannot create new vm");
+        let mut vm = Vm::new(kvm_context.fd()).expect("Cannot create new vm");
 
         // Create valid memory region and test that the initialization is successful.
         let gm =
@@ -488,7 +473,7 @@ pub(crate) mod tests {
     #[test]
     fn test_vm_save_restore_state() {
         let kvm_fd = Kvm::new().unwrap();
-        let vm = Vm::new(&kvm_fd, None).expect("new vm failed");
+        let vm = Vm::new(&kvm_fd).expect("new vm failed");
         // Irqchips, clock and pitstate are not configured so trying to save state should fail.
         assert!(vm.save_state().is_err());
 
@@ -543,7 +528,7 @@ pub(crate) mod tests {
     #[test]
     fn test_set_kvm_memory_regions() {
         let kvm_context = KvmContext::new().unwrap();
-        let vm = Vm::new(kvm_context.fd(), None).expect("Cannot create new vm");
+        let vm = Vm::new(kvm_context.fd()).expect("Cannot create new vm");
 
         let gm =
             vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x1000)], false)


### PR DESCRIPTION
## Changes

* Used type aliases to introduce names for template and config types that are usable in both aarch64 and x86_64.
* Made use of `VmConfig` as the parent structure for the CPU template instead of `VmResources`.

## Reason

* Architecture agnostic type aliases were introduced to help readability (fewer target platform cfg annotations primarily).
* `VmConfig` is a more appropriate home for configuration.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].
