### PR TITLE
gitlint: Ignore dependabot commits

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -7,3 +7,12 @@ line-length=72
 [ignore-body-lines]
 # Ignore HTTP reference links
 regex=^\[.+\]: http.+
+
+[ignore-by-author-name]
+# Ignore certain rules for commits of which the author name matches a regex
+# E.g. Match commits made by dependabot
+regex=(.*)dependabot(.*)
+
+# Ignore certain rules, you can reference them by their id or by their full name
+# Use 'all' to ignore all rules
+ignore=all  # dependabot constructs commit bodies from changelogs


### PR DESCRIPTION
## Changes

Dependabot commit messages are constructed by including the changelog of the package for which dependabot PRs in an update. We have no control over how these packages write their commits messages, so just disable gitlint for them.

Dependabot does not seem to have an option for configuring the commit messages beyond the title line. However, even if there was such an option, the next problem would be that GitHub's security update PRs (which are separate from normal dependabot) ignore the `.github/dependabot.yml` configuration file.

See: https://jorisroovers.com/gitlint/configuration/

## Reason

Dependabot PRs fail the gitlint style test

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
