### PR TITLE
Fix .gitlint comment

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -14,5 +14,6 @@ regex=^\[.+\]: http.+
 regex=(.*)dependabot(.*)
 
 # Ignore certain rules, you can reference them by their id or by their full name
-# Use 'all' to ignore all rules
-ignore=all  # dependabot constructs commit bodies from changelogs
+# Use 'all' to ignore all rules. Dependabot constructs commit bodies from
+# changelogs, so disable all rules.
+ignore=all


### PR DESCRIPTION
## Changes

Comments need to be their own lines in the .gitlint file format.

## Reason

Dependabot PRs were still not passing CI

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
