### PR TITLE
Update versionize on 1.3 release branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,9 +1284,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "versionize"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e2495726cf917e7ba7ec8bf0f0fceab543dd38d0a4195ed6bef331e38a290f"
+checksum = "dca4b7062e7e6d685901e815c35f9671e059de97c1c0905eeff8592f3fff442f"
 dependencies = [
  "bincode",
  "crc64",

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -703,11 +703,11 @@ def test_mmds_snapshot(bin_cloner_path, version):
     for firecracker in firecracker_artifacts:
         iface_cfg = NetIfaceConfig()
         vm_instance = vm_builder.build_vm_nano(net_ifaces=[iface_cfg])
-        firecracker.download()
+        firecracker.download(perms=0o555)
         jailer = firecracker.jailer()
-        jailer.download()
+        jailer.download(perms=0o555)
 
-        target_version = firecracker.base_name()[1:]
+        target_version = firecracker.snapshot_version
         # If the version is smaller or equal to 1.0.0, we expect that
         # MMDS will be initialised with V1 by default.
         if compare_versions(target_version, "1.0.0") <= 0:

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -273,6 +273,7 @@ def _test_snapshot_create_latency(context):
 
     # Test snapshot creation for every supported target version.
     for target_version in firecracker_versions:
+        target_version = ".".join(target_version.split(".")[:2] + ["0"])
         logger.info(
             """Measuring snapshot create({}) latency for target
         version: {} and microvm: \"{}\", kernel {}, disk {} """.format(


### PR DESCRIPTION
## Changes

Update versionize for 1.3  branch. Subsumes https://github.com/firecracker-microvm/firecracker/pull/3562

## Reason

backport

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
