### PR TITLE
virtio-rng integration tests

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -42,6 +42,7 @@ from framework.resources import (
     BootSource,
     DescribeInstance,
     Drive,
+    Entropy,
     FullConfig,
     InstanceVersion,
     Logger,
@@ -142,6 +143,7 @@ class Microvm:
         self.vm = None
         self.vsock = None
         self.snapshot = None
+        self.entropy = None
 
         # Initialize the logging subsystem.
         self.logging_thread = None
@@ -440,6 +442,7 @@ class Microvm:
         self.drive = Drive(self._api_socket, self._api_session)
         self.vm = Vm(self._api_socket, self._api_session)
         self.vsock = Vsock(self._api_socket, self._api_session)
+        self.entropy = Entropy(self._api_socket, self._api_session)
 
         if create_logger:
             log_fifo_path = os.path.join(self.path, log_file)

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -726,3 +726,30 @@ class Vsock:
             datax["vsock_id"] = vsock_id
 
         return datax
+
+
+class Entropy:
+    """Facility for handling virtio-rng configuration for a microvm."""
+
+    ENTROPY_CFG_RESOURCE = "entropy"
+
+    def __init__(self, api_usocket_full_name, api_session):
+        """Specify the information needed for sending API requests"""
+        url_encoded_path = urllib.parse.quote_plus(api_usocket_full_name)
+        api_url = API_USOCKET_URL_PREFIX + url_encoded_path + "/"
+
+        self._entropy_cfg_url = api_url + self.ENTROPY_CFG_RESOURCE
+        self._api_session = api_session
+
+    def put(self, **args):
+        """Attach a new rng device."""
+        datax = self.create_json(**args)
+
+        return self._api_session.put(self._entropy_cfg_url, json=datax)
+
+    @staticmethod
+    def create_json(rate_limiter=None):
+        """Create the json object for entropy specific API requests."""
+        datax = {"rate_limiter": rate_limiter}
+
+        return datax

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -827,6 +827,13 @@ def check_filesystem(ssh_connection, disk_fmt, disk):
     assert exit_code == 0, stderr.read()
 
 
+def check_entropy(ssh_connection):
+    """Check that we can get random numbers from /dev/hwrng"""
+    cmd = "dd if=/dev/hwrng of=/dev/null bs=4096 count=1"
+    exit_code, _, stderr = ssh_connection.execute_command(cmd)
+    assert exit_code == 0, stderr.read()
+
+
 @retry(delay=0.5, tries=5)
 def wait_process_running(process):
     """Wait for a process to run.

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -669,6 +669,15 @@ def test_rate_limiters_api_config(test_microvm_with_api):
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
+    # Test entropy device bw and ops rate-limiting.
+    response = test_microvm.entropy.put(
+        rate_limiter={
+            "bandwidth": {"size": 1000000, "refill_time": 100},
+            "ops": {"size": 1, "refill_time": 100},
+        },
+    )
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
 
 def test_api_patch_pre_boot(test_microvm_with_api):
     """
@@ -1053,6 +1062,31 @@ def _test_vsock(vm):
     # Updating an existing vsock should not be fine at this point.
     response = vm.vsock.put(guest_cid=17, uds_path="vsock.sock")
     assert vm.api_session.is_status_bad_request(response.status_code)
+
+
+def test_api_entropy(test_microvm_with_api):
+    """
+    Test entropy related API commands.
+
+    @type: functional
+    """
+    test_microvm = test_microvm_with_api
+    test_microvm.spawn()
+    test_microvm.basic_config()
+
+    # Create a new entropy device should be OK.
+    response = test_microvm.entropy.put()
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Overwriting an existing should be OK.
+    response = test_microvm.entropy.put()
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Start the microvm
+    test_microvm.start()
+
+    response = test_microvm.entropy.put()
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
 
 
 def test_api_balloon(test_microvm_with_api):

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -1,0 +1,78 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the virtio-rng device"""
+
+import pytest
+
+from framework.artifacts import NetIfaceConfig
+from framework.properties import get_kernel_version
+from framework.utils import check_entropy
+from framework.utils_cpuid import get_instance_type
+
+INSTANCE_TYPE = get_instance_type()
+HOST_KERNEL = get_kernel_version(level=2)
+
+
+def _microvm_basic_config(microvm):
+    microvm.spawn()
+    microvm.basic_config()
+    iface = NetIfaceConfig()
+    microvm.add_net_iface(iface)
+
+
+def _microvm_rng_config(microvm):
+    _microvm_basic_config(microvm)
+    microvm.entropy.put()
+
+
+def _start_vm_with_rng(microvm):
+    _microvm_rng_config(microvm)
+    microvm.start()
+
+
+def _start_vm_without_rng(microvm):
+    _microvm_basic_config(microvm)
+    microvm.start()
+
+
+@pytest.mark.skipif(
+    INSTANCE_TYPE == "c7g.metal" and HOST_KERNEL == "4.14",
+    reason="c7g requires no SVE 5.10 kernel",
+)
+def test_rng_not_present(test_microvm_with_rng):
+    """
+    Test a guest microVM *without* an entropy device and ensure that
+    we cannot get data from /dev/hwrng
+    """
+
+    vm = test_microvm_with_rng
+    _start_vm_without_rng(vm)
+
+    # If the guest kernel has been built with the virtio-rng module
+    # the device should exist in the guest filesystem but we should
+    # not be able to get random numbers out of it.
+    cmd = "test -e /dev/hwrng"
+    ecode, _, _ = vm.ssh.execute_command(cmd)
+    assert ecode == 0
+
+    cmd = "dd if=/dev/hwrng of=/dev/null bs=10 count=1"
+    ecode, _, _ = vm.ssh.execute_command(cmd)
+    assert ecode == 1
+
+
+@pytest.mark.skipif(
+    INSTANCE_TYPE == "c7g.metal" and HOST_KERNEL == "4.14",
+    reason="c7g requires no SVE 5.10 kernel",
+)
+def test_rng_present(test_microvm_with_rng):
+    """
+    Test a guest microVM with an entropy defined configured and ensure
+    that we can access `/dev/hwrng`
+
+    @type: functional
+    """
+
+    vm = test_microvm_with_rng
+    _start_vm_with_rng(vm)
+
+    check_entropy(vm.ssh)

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -22,13 +22,14 @@ def _microvm_basic_config(microvm):
     microvm.add_net_iface(iface)
 
 
-def _microvm_rng_config(microvm):
+def _microvm_rng_config(microvm, rate_limiter=None):
     _microvm_basic_config(microvm)
-    microvm.entropy.put()
+    response = microvm.entropy.put(rate_limiter=rate_limiter)
+    assert microvm.api_session.is_status_no_content(response.status_code), response.text
 
 
-def _start_vm_with_rng(microvm):
-    _microvm_rng_config(microvm)
+def _start_vm_with_rng(microvm, rate_limiter=None):
+    _microvm_rng_config(microvm, rate_limiter)
     microvm.start()
 
 
@@ -122,3 +123,126 @@ def test_rng_snapshot(test_microvm_with_rng, microvm_factory):
     )
 
     check_entropy(new_vm.ssh)
+
+
+def _get_percentage_difference(measured, base):
+    """Return the percentage delta between the arguments."""
+    if measured == base:
+        return 0
+    try:
+        return (abs(measured - base) / base) * 100.0
+    except ZeroDivisionError:
+        # It means base and only base is 0.
+        return 100.0
+
+
+def _throughput_units_multiplier(units):
+    """
+    Parse the throughput units and return the multiplier that would
+    translate the corresponding value to Bytes/sec
+    """
+    if units == "kB/s":
+        return 1000
+
+    if units == "MB/s":
+        return 1000 * 1000
+
+    if units == "GB/s":
+        return 1000 * 1000 * 1000
+
+    raise Exception("Unknown units")
+
+
+def _process_dd_output(out):
+    """
+    Parse the output of `dd` and return the achieved throughput in
+    KB/sec.
+    """
+
+    # Example `dd` output:
+    #
+    # $ dd if=/dev/hwrng of=/dev/null bs=100 count=1
+    # 1+0 records in
+    # 1+0 records out
+    # 100 bytes (100 B) copied, 0.000749912 s, 133 kB/s
+
+    # So we split the lines of the output and keep the last line.
+    report = out.splitlines()[-1].split(" ")
+
+    # Last two items in the line are value and units
+    (value, units) = (report[-2], report[-1])
+
+    return float(value) * _throughput_units_multiplier(units) / 1000
+
+
+def _get_throughput(ssh, random_bytes):
+    """
+    Request `random_bytes` from `/dev/hwrng` and return the achieved
+    throughput in KB/sec
+    """
+
+    # Issue a `dd` command to request 100 times `random_bytes` from the device.
+    # 100 here is used to get enough confidence on the achieved throughput.
+    cmd = "dd if=/dev/hwrng of=/dev/null bs={} count=100".format(random_bytes)
+    exit_code, _, stderr = ssh.execute_command(cmd)
+    assert exit_code == 0, stderr.read()
+
+    # dd gives its output on stderr
+    return _process_dd_output(stderr.read())
+
+
+def _check_entropy_rate_limited(ssh, random_bytes, expected_kbps):
+    """
+    Ask for `random_bytes` from `/dev/hwrng` in the guest and check
+    that achieved throughput is within a 10% of the expected throughput.
+
+    NOTE: 10% is an arbitrarily selected limit which should be safe enough,
+    so that we don't run into many intermittent CI failures.
+    """
+    measured_kbps = _get_throughput(ssh, random_bytes)
+    assert (
+        _get_percentage_difference(measured_kbps, expected_kbps) <= 10
+    ), "Expected {} KB/s, measured {} KB/s".format(expected_kbps, measured_kbps)
+
+
+def _rate_limiter_id(rate_limiter):
+    """
+    Helper function to return a name for the rate_limiter to be
+    used as an id for parametrized tests.
+    """
+    size = rate_limiter["bandwidth"]["size"]
+    refill_time = rate_limiter["bandwidth"]["refill_time"]
+
+    return "{} KB/sec".format(float(size) / float(refill_time))
+
+
+@pytest.mark.skipif(
+    INSTANCE_TYPE == "c7g.metal" and HOST_KERNEL == "4.14",
+    reason="c7g requires no SVE 5.10 kernel",
+)
+@pytest.mark.parametrize(
+    "rate_limiter",
+    [
+        {"bandwidth": {"size": 1000, "refill_time": 100}},
+        {"bandwidth": {"size": 10000, "refill_time": 100}},
+        {"bandwidth": {"size": 100000, "refill_time": 100}},
+    ],
+    ids=_rate_limiter_id,
+)
+def test_rng_bw_rate_limiter(test_microvm_with_rng, rate_limiter):
+    """
+    Test that rate limiter without initial burst budget works
+
+    @type: functional
+    """
+    vm = test_microvm_with_rng
+    _start_vm_with_rng(vm, rate_limiter)
+
+    size = rate_limiter["bandwidth"]["size"]
+    refill_time = rate_limiter["bandwidth"]["refill_time"]
+
+    expected_kbps = size / refill_time
+
+    # Check the rate limiter using a request size equal to the size
+    # of the token bucket.
+    _check_entropy_rate_limited(vm.ssh, size, expected_kbps)


### PR DESCRIPTION
## Changes

Add integration tests for `virtio-rng` device.

## Reason

Test end-to-end that virtio-rng is working. Also test rate limiting and functionality after resuming from a snapshot

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
