### PR TITLE
fix: Warn on `clippy::exit`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -5,7 +5,8 @@ rustflags = [
   "-Dclippy::ptr_as_ptr",
   "-Dclippy::undocumented_unsafe_blocks",
   "-Dclippy::cast_lossless",
-  "-Dclippy::cast_sign_loss"
+  "-Dclippy::cast_sign_loss",
+  "-Dclippy::exit"
 ]
 
 [net]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "seccompiler",
  "serde_json",
  "snapshot",
+ "thiserror",
  "timerfd",
  "utils",
  "vmm",
@@ -978,6 +979,7 @@ name = "rebase-snap"
 version = "1.5.0-dev"
 dependencies = [
  "libc",
+ "thiserror",
  "utils",
 ]
 

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -17,6 +17,7 @@ event-manager = "0.3.0"
 libc = "0.2.117"
 serde_json = "1.0.78"
 timerfd = "1.3.0"
+thiserror = "1.0.32"
 
 api_server = { path = "../api_server" }
 logger = { path = "../logger" }

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -12,5 +12,6 @@ bench = false
 
 [dependencies]
 libc = "0.2.117"
+thiserror = "1.0.40"
 
 utils = { path = "../utils" }

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -32,28 +32,27 @@
 //!     collection of `BpfProgram` objects
 //! ```
 
-mod backend;
-mod common;
-mod compiler;
-mod syscall_table;
-
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::fs::File;
+use std::io;
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
-use std::{io, process};
 
 use backend::{TargetArch, TargetArchError};
 use bincode::Error as BincodeError;
 use common::BpfProgram;
 use compiler::{Compiler, Error as FilterFormatError, JsonFile};
 use serde_json::error::Error as JSONError;
-use utils::arg_parser::{ArgParser, Argument, Arguments as ArgumentsBag};
+use utils::arg_parser::{ArgParser, Argument, Arguments as ArgumentsBag, Error as ArgParserError};
+
+mod backend;
+mod common;
+mod compiler;
+mod syscall_table;
 
 const SECCOMPILER_VERSION: &str = env!("FIRECRACKER_VERSION");
 const DEFAULT_OUTPUT_FILENAME: &str = "seccomp_binary_filter.out";
-const EXIT_CODE_ERROR: i32 = 1;
 
 #[derive(Debug, thiserror::Error)]
 enum Error {
@@ -166,43 +165,46 @@ fn compile(args: &Arguments) -> Result<()> {
     Ok(())
 }
 
-fn main() {
+#[derive(Debug, thiserror::Error)]
+enum SeccompilerError {
+    #[error("Argument Parsing Error: {0}")]
+    ArgParsing(ArgParserError),
+    #[error("{0} \n\nFor more information try --help.")]
+    InvalidArgumentValue(Error),
+    #[error("{0}")]
+    Error(Error),
+}
+
+fn main() -> core::result::Result<(), SeccompilerError> {
     let mut arg_parser = build_arg_parser();
 
-    if let Err(err) = arg_parser.parse_from_cmdline() {
-        eprintln!(
-            "Arguments parsing error: {} \n\nFor more information try --help.",
-            err
-        );
-        process::exit(EXIT_CODE_ERROR);
-    }
+    arg_parser
+        .parse_from_cmdline()
+        .map_err(SeccompilerError::ArgParsing)?;
 
     if arg_parser.arguments().flag_present("help") {
         println!("Seccompiler-bin v{}\n", SECCOMPILER_VERSION);
         println!("{}", arg_parser.formatted_help());
-        return;
+        return Ok(());
     }
     if arg_parser.arguments().flag_present("version") {
         println!("Seccompiler-bin v{}\n", SECCOMPILER_VERSION);
-        return;
+        return Ok(());
     }
 
-    let args = get_argument_values(arg_parser.arguments()).unwrap_or_else(|err| {
-        eprintln!("{} \n\nFor more information try --help.", err);
-        process::exit(EXIT_CODE_ERROR);
-    });
+    let args = get_argument_values(arg_parser.arguments())
+        .map_err(SeccompilerError::InvalidArgumentValue)?;
 
-    if let Err(err) = compile(&args) {
-        eprintln!("Seccompiler error: {}", err);
-        process::exit(EXIT_CODE_ERROR);
-    }
+    compile(&args).map_err(SeccompilerError::Error)?;
 
     println!("Filter successfully compiled into: {}", args.output_file);
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
+
     use std::collections::HashMap;
     use std::io;
     use std::io::Write;


### PR DESCRIPTION
Sets clippy to warn on the lint `clippy::exit`. Introduces a new Error Type `FcExitError`, which implements the `Terminator` trait. Replaces uses of `Proccess::exit` by returning an error.

## Changes

Replaces `std::process::exit` with `Result::Err` propagated to the main function.

This PR currently uses multiple ExitError types, which could be combined into a single error Type.

## Reason

Enables the use of `clippy::exit`. Fixes #3233 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
