### PR TITLE
Resolves TODO: log virtio descriptor address

### DIFF
--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -6,7 +6,6 @@
 // found in the THIRD-PARTY file.
 #![cfg(target_arch = "x86_64")]
 
-use std::fmt;
 use std::sync::{Arc, Mutex};
 
 use devices::legacy::{EventFdTrigger, SerialDevice, SerialEventsWrapper};
@@ -17,23 +16,14 @@ use utils::eventfd::EventFd;
 use vm_superio::Serial;
 
 /// Errors corresponding to the `PortIODeviceManager`.
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, derive_more::From, thiserror::Error)]
 pub enum Error {
     /// Cannot add legacy device to Bus.
+    #[error("Failed to add legacy device to Bus: {0}")]
     BusError(devices::BusError),
     /// Cannot create EventFd.
+    #[error("Failed to create EventFd: {0}")]
     EventFd(std::io::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-
-        match *self {
-            BusError(ref err) => write!(f, "Failed to add legacy device to Bus: {}", err),
-            EventFd(ref err) => write!(f, "Failed to create EventFd: {}", err),
-        }
-    }
 }
 
 type Result<T> = ::std::result::Result<T, Error>;

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,10 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.90, "AMD": 82.14, "ARM": 82.43}
+    COVERAGE_DICT = {"Intel": 83.19, "AMD": 82.38, "ARM": 82.54}
 else:
-    COVERAGE_DICT = {"Intel": 80.05, "AMD": 79.28, "ARM": 79.34}
+    COVERAGE_DICT = {"Intel": 80.32, "AMD": 79.5, "ARM": 79.44}
+
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

This change resolves the TODO: log address in error.
...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
