### PR TITLE
Possible race condition between VMM thread and API thread

### DIFF
--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -71,6 +71,7 @@ impl MutEventSubscriber for ApiServerAdapter {
         let event_set = event.event_set();
 
         if source == self.api_event_fd.as_raw_fd() && event_set == EventSet::IN {
+            let _ = self.api_event_fd.read();
             match self.from_api.try_recv() {
                 Ok(api_request) => {
                     let request_is_pause = *api_request == VmmAction::Pause;
@@ -101,7 +102,6 @@ impl MutEventSubscriber for ApiServerAdapter {
                     panic!("The channel's sending half was disconnected. Cannot receive data.");
                 }
             };
-            let _ = self.api_event_fd.read();
         } else {
             error!("Spurious EventManager event for handler: ApiServerAdapter");
         }
@@ -129,7 +129,7 @@ pub(crate) fn run_with_api(
     // FD to notify of API events. This is a blocking eventfd by design.
     // It is used in the config/pre-boot loop which is a simple blocking loop
     // which only consumes API events.
-    let api_event_fd = EventFd::new(0).expect("Cannot create API Eventfd.");
+    let api_event_fd = EventFd::new(libc::EFD_SEMAPHORE).expect("Cannot create API Eventfd.");
 
     // Channels for both directions between Vmm and Api threads.
     let (to_vmm, from_api) = channel();


### PR DESCRIPTION
## Reason

A race condition has been identified between the API thread and the VMM thread due to a misconfiguration of the `api_event_fd`. What happens actually behind is like this:

The API thread receives API requests that needs to be handled one by one. Handling a request by the API thread means the following actions:
1. Write the request on the channel to the VMM thread
2. Notify the VMM thread that it has a new request to handle
3. Call a blocking read on the channel from the VMM in order to get the results

On the VMM thread side, handling such a request represents the opposite actions:
1. Wait until getting notified that a new request needs its attention
2. Handle the request
3. Write the result on the channel to the API thread
4. Clear out the notification done by the API thread about the request previously handled

Step 2 from the API thread side and step 4 from the VMM thread side are actually implemented using an EventFD (`api_event_fd`) that should work as a semaphore: everytime a new event arrives at the API thread, the internal counter of the EventFD should be incremented by 1 (by the API thread by calling write(1)). When the VMM thread finishes handling a request and sends results back to the API thread, the internal counter of the EventFD should be decremented by 1 (by the VMM thread by calling read()).

The actual race condition appears because the `api_event_fd` was initialized with the `initval` set to 0. According to the spec https://man7.org/linux/man-pages/man2/eventfd.2.html an EventFD behaves as we need only if it is initialized with the `initval` set to `EFD_SEMAPHORE` which has a value of 1 actually: https://elixir.bootlin.com/linux/v5.10.176/source/include/linux/eventfd.h#L25

Currently, we had it initialized with a `initval` of 0 which means that calling `read()` on it will reset the internal counter of the EventFD to 0. That means that in a situation when the API thread is very fast in comparison with the VMM thread and calls `write(1)` for a second request (after the moment it gets the results for the first request but before the VMM thread calls `read()` for the first request) then the `read()` done by the VMM thread to clear out the notification for the first request will actually clear out the notification for the second request as well. Thus, the VMM thread will not know that it has to process another request and the API thread gets blocks waiting for the resutls of the second request that will never get produced leading to a timeout of the second API request.

Fixing this by setting the appropiate `initval` for the `api_event_fd` which is the `EFD_SEMAPHORE`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
