### PR TITLE
`virtio-rng` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The **API endpoint** can be used to:
 - `[BETA]` Configure the data tree of the guest-facing metadata service. The
   service is only available to the guest if this resource is configured.
 - Add a [vsock socket](docs/vsock.md) to the microVM.
+- Add a [entropy device](docs/entropy.md) to the microVM.
 - Start the microVM using a given kernel image, root file system, and boot
   arguments.
 - [x86_64 only] Stop the microVM.

--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -14,86 +14,88 @@ a call to one of the [API Endpoints](#api-endpoints) will fail with a
 
 ## API Endpoints
 
-| Endpoint                  | keyboard | serial console | virtio-block | virtio-net | virtio-vsock |
-| ------------------------- | :------: | :------------: | :----------: |:----------:| :----------: |
-| `boot-source`             |    O     |       O        |      O       |     O      |      O       |
-| `drives/{id}`             |    O     |       O        |    **R**     |     O      |      O       |
-| `logger`                  |    O     |       O        |      O       |     O      |      O       |
-| `machine-config`          |    O     |       O        |      O       |     O      |      O       |
-| `metrics`                 |    O     |       O        |      O       |     O      |      O       |
-| `mmds`                    |    O     |       O        |      O       |   **R**    |      O       |
-| `mmds/config`             |    O     |       O        |      O       |   **R**    |      O       |
-| `network-interfaces/{id}` |    O     |       O        |      O       |   **R**    |      O       |
-| `snapshot/create`         |    O     |       O        |      O       |     O      |      O       |
-| `snapshot/load`           |    O     |       O        |      O       |     O      |      O       |
-| `vm`                      |    O     |       O        |      O       |     O      |      O       |
-| `vsock`                   |    O     |       O        |      O       |     O      |      O       |
+| Endpoint                  | keyboard | serial console | virtio-block | virtio-net | virtio-vsock | virtio-rng |
+| ------------------------- | :------: | :------------: | :----------: |:----------:| :----------: | :--------: |
+| `boot-source`             |    O     |       O        |      O       |     O      |      O       |      O     |
+| `drives/{id}`             |    O     |       O        |    **R**     |     O      |      O       |      O     |
+| `logger`                  |    O     |       O        |      O       |     O      |      O       |      O     |
+| `machine-config`          |    O     |       O        |      O       |     O      |      O       |      O     |
+| `metrics`                 |    O     |       O        |      O       |     O      |      O       |      O     |
+| `mmds`                    |    O     |       O        |      O       |   **R**    |      O       |      O     |
+| `mmds/config`             |    O     |       O        |      O       |   **R**    |      O       |      O     |
+| `network-interfaces/{id}` |    O     |       O        |      O       |   **R**    |      O       |      O     |
+| `snapshot/create`         |    O     |       O        |      O       |     O      |      O       |      O     |
+| `snapshot/load`           |    O     |       O        |      O       |     O      |      O       |      O     |
+| `vm`                      |    O     |       O        |      O       |     O      |      O       |      O     |
+| `vsock`                   |    O     |       O        |      O       |     O      |      O       |      O     |
+| `entropy`                 |    O     |       O        |      O       |     O      |      O       |    **R**   |
 
 ## Input Schema
 
 All input schema fields can be found in the [Swagger](https://swagger.io)
 specification: [firecracker.yaml](./../src/api_server/swagger/firecracker.yaml).
 
-| Schema                     | Property              | keyboard | serial console | virtio-block |  virtio-net   | virtio-vsock |
-|----------------------------|-----------------------| :------: | :------------: | :----------: |:-------------:| :----------: |
-| `BootSource`               | boot_args             |    O     |       O        |      O       |       O       |      O       |
-|                            | initrd_path           |    O     |       O        |      O       |       O       |      O       |
-|                            | kernel_image_path     |    O     |       O        |      O       |       O       |      O       |
-| `CpuTemplate`              | enum                  |    O     |       O        |      O       |       O       |      O       |
-| `CreateSnapshotParams`     | mem_file_path         |    O     |       O        |      O       |       O       |      O       |
-|                            | snapshot_path         |    O     |       O        |      O       |       O       |      O       |
-|                            | snapshot_type         |    O     |       O        |      O       |       O       |      O       |
-|                            | version               |    O     |       O        |      O       |       O       |      O       |
-| `Drive`                    | drive_id              |    O     |       O        |    **R**     |       O       |      O       |
-|                            | is_read_only          |    O     |       O        |    **R**     |       O       |      O       |
-|                            | is_root_device        |    O     |       O        |    **R**     |       O       |      O       |
-|                            | partuuid              |    O     |       O        |    **R**     |       O       |      O       |
-|                            | path_on_host          |    O     |       O        |    **R**     |       O       |      O       |
-|                            | rate_limiter          |    O     |       O        |    **R**     |       O       |      O       |
-| `InstanceActionInfo`       | action_type           |    O     |       O        |      O       |       O       |      O       |
-| `LoadSnapshotParams`       | enable_diff_snapshots |    O     |       O        |      O       |       O       |      O       |
-|                            | mem_file_path         |    O     |       O        |      O       |       O       |      O       |
-|                            | mem_backend           |    O     |       O        |      O       |       O       |      O       |
-|                            | snapshot_path         |    O     |       O        |      O       |       O       |      O       |
-|                            | resume_vm             |    O     |       O        |      O       |       O       |      O       |
-| `Logger`                   | level                 |    O     |       O        |      O       |       O       |      O       |
-|                            | log_path              |    O     |       O        |      O       |       O       |      O       |
-|                            | show_level            |    O     |       O        |      O       |       O       |      O       |
-|                            | show_log_origin       |    O     |       O        |      O       |       O       |      O       |
-| `MachineConfiguration`     | cpu_template          |    O     |       O        |      O       |       O       |      O       |
-|                            | smt                   |    O     |       O        |      O       |       O       |      O       |
-|                            | mem_size_mib          |    O     |       O        |      O       |       O       |      O       |
-|                            | track_dirty_pages     |    O     |       O        |      O       |       O       |      O       |
-|                            | vcpu_count            |    O     |       O        |      O       |       O       |      O       |
-| `Metrics`                  | metrics_path          |    O     |       O        |      O       |       O       |      O       |
-| `MmdsConfig`               | network_interfaces    |    O     |       O        |      O       |     **R**     |      O       |
-|                            | version               |    O     |       O        |      O       |     **R**     |      O       |
-|                            | ipv4_address          |    O     |       O        |      O       |     **R**     |      O       |
-| `NetworkInterface`         | guest_mac             |    O     |       O        |      O       |     **R**     |      O       |
-|                            | host_dev_name         |    O     |       O        |      O       |     **R**     |      O       |
-|                            | iface_id              |    O     |       O        |      O       |     **R**     |      O       |
-|                            | rx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |
-|                            | tx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |
-| `PartialDrive`             | drive_id              |    O     |       O        |    **R**     |       O       |      O       |
-|                            | path_on_host          |    O     |       O        |    **R**     |       O       |      O       |
-| `PartialNetworkInterface`  | iface_id              |    O     |       O        |      O       |     **R**     |      O       |
-|                            | rx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |
-|                            | tx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |
-| `RateLimiter`              | bandwidth             |    O     |       O        |      O       |     **R**     |      O       |
-|                            | ops                   |    O     |       O        |    **R**     |       O       |      O       |
-| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |    **R**     |       O       |      O       |
-|                            | refill_time           |    O     |       O        |    **R**     |       O       |      O       |
-|                            | size                  |    O     |       O        |    **R**     |       O       |      O       |
-| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |      O       |     **R**     |      O       |
-|                            | refill_time           |    O     |       O        |      O       |     **R**     |      O       |
-|                            | size                  |    O     |       O        |      O       |     **R**     |      O       |
-| `Vm`                       | state                 |    O     |       O        |      O       |       O       |      O       |
-| `Vsock`                    | guest_cid             |    O     |       O        |      O       |       O       |    **R**     |
-|                            | uds_path              |    O     |       O        |      O       |       O       |    **R**     |
-|                            | vsock_id              |    O     |       O        |      O       |       O       |    **R**     |
+| Schema                     | Property              | keyboard | serial console | virtio-block |  virtio-net   | virtio-vsock | virtio-rng |
+|----------------------------|-----------------------| :------: | :------------: | :----------: |:-------------:| :----------: | :--------: |
+| `BootSource`               | boot_args             |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | initrd_path           |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | kernel_image_path     |    O     |       O        |      O       |       O       |      O       |      O     |
+| `CpuTemplate`              | enum                  |    O     |       O        |      O       |       O       |      O       |      O     |
+| `CreateSnapshotParams`     | mem_file_path         |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | snapshot_path         |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | snapshot_type         |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | version               |    O     |       O        |      O       |       O       |      O       |      O     |
+| `Drive`                    | drive_id              |    O     |       O        |    **R**     |       O       |      O       |      O     |
+|                            | is_read_only          |    O     |       O        |    **R**     |       O       |      O       |      O     |
+|                            | is_root_device        |    O     |       O        |    **R**     |       O       |      O       |      O     |
+|                            | partuuid              |    O     |       O        |    **R**     |       O       |      O       |      O     |
+|                            | path_on_host          |    O     |       O        |    **R**     |       O       |      O       |      O     |
+|                            | rate_limiter          |    O     |       O        |    **R**     |       O       |      O       |      O     |
+| `InstanceActionInfo`       | action_type           |    O     |       O        |      O       |       O       |      O       |      O     |
+| `LoadSnapshotParams`       | enable_diff_snapshots |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | mem_file_path         |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | mem_backend           |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | snapshot_path         |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | resume_vm             |    O     |       O        |      O       |       O       |      O       |      O     |
+| `Logger`                   | level                 |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | log_path              |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | show_level            |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | show_log_origin       |    O     |       O        |      O       |       O       |      O       |      O     |
+| `MachineConfiguration`     | cpu_template          |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | smt                   |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | mem_size_mib          |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | track_dirty_pages     |    O     |       O        |      O       |       O       |      O       |      O     |
+|                            | vcpu_count            |    O     |       O        |      O       |       O       |      O       |      O     |
+| `Metrics`                  | metrics_path          |    O     |       O        |      O       |       O       |      O       |      O     |
+| `MmdsConfig`               | network_interfaces    |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | version               |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | ipv4_address          |    O     |       O        |      O       |     **R**     |      O       |      O     |
+| `NetworkInterface`         | guest_mac             |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | host_dev_name         |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | iface_id              |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | rx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | tx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |      O     |
+| `PartialDrive`             | drive_id              |    O     |       O        |    **R**     |       O       |      O       |      O     |
+|                            | path_on_host          |    O     |       O        |    **R**     |       O       |      O       |      O     |
+| `PartialNetworkInterface`  | iface_id              |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | rx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | tx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |      O     |
+| `RateLimiter`              | bandwidth             |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | ops                   |    O     |       O        |    **R**     |       O       |      O       |      O     |
+| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |    **R**     |       O       |      O       |      O     |
+|                            | refill_time           |    O     |       O        |    **R**     |       O       |      O       |      O     |
+|                            | size                  |    O     |       O        |    **R**     |       O       |      O       |      O     |
+| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | refill_time           |    O     |       O        |      O       |     **R**     |      O       |      O     |
+|                            | size                  |    O     |       O        |      O       |     **R**     |      O       |      O     |
+| `Vm`                       | state                 |    O     |       O        |      O       |       O       |      O       |      O     |
+| `Vsock`                    | guest_cid             |    O     |       O        |      O       |       O       |    **R**     |      O     |
+|                            | uds_path              |    O     |       O        |      O       |       O       |    **R**     |      O     |
+|                            | vsock_id              |    O     |       O        |      O       |       O       |    **R**     |      O     |
+| `EntropyDevice`            | rate_limiter          |    O     |       O        |      O       |       O       |      O       |    **R**   |
 
-<sup>\*</sup>: The `TokenBucket` can be configured with either the virtio-net
-or virtio-block drivers, or both.
+<sup>\*</sup>: The `TokenBucket` can be configured with any combination of
+virtio-net, virtio-block and virtio-rng devices.
 
 ## Output Schema
 

--- a/docs/entropy.md
+++ b/docs/entropy.md
@@ -1,0 +1,70 @@
+# Using the Firecracker entropy device
+
+## What is the entropy device
+
+An entropy device is a [`virtio-rng` device][1] that provides guests with
+"high-quality randomness for guest use". Guests issue requests in the form of a
+buffer that will be filled with random bytes from the device. The source of
+random bytes that the device will use to fill the buffers is an implementation
+decision.
+
+On the guest side, the kernel uses random bytes received through the device
+as an extra source of entropy. Moreover, the guest VirtIO driver exposes the
+`/dev/hwrng` character device. User-space applications can use this device to
+request random bytes from the device.
+
+## Firecracker implementation
+
+Firecracker offers the option of attaching a single `virtio-rng` device. Users
+can configure it through the `/entropy` API endpoint. The request body includes
+a single (optional) parameter for configuring a rate limiter.
+
+For example, users can configure the entropy device with a bandwidth rate
+limiter of 10KB/sec like this:
+
+```console
+curl --unix-socket $socket_location -i \
+    -X PUT 'http://localhost/entropy' \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d "{
+        \"rate_limiter\": {
+            \"bandwidth\": {
+                \"size\": 1000,
+                \"one_time_burst\": 0,
+                \"refill_time\": 100
+            }
+        }
+    }"
+```
+
+If a configuration file is used for configuring a microVM, the same setup can
+be achieved by adding a section like this:
+
+```json
+"entropy": {
+    "rate_limiter": {
+        "bandwidth" {
+            "size": 1000,
+            "one_time_burst": 0,
+            "refill_time": 100
+        }
+    }
+}
+```
+
+On the host side, firecracker uses [`OsRng`][2] to get random bytes from the
+host kernel. The [implementation][3] of `OsRng` on Linux uses the
+`getrandom(2)` system call when available, otherwise it falls back to
+`/dev/urandom` after successfully polling `/dev/random`.
+
+## Prerequisites
+
+In order to use the entropy device, users must use a kernel with the
+`virtio-rng` front-end driver compiled in or loaded as a module. The relevant
+kernel configuration option is `CONFIG_HW_RANDOM_VIRTIO` (which depends on
+`CONFIG_HW_RANDOM` and `CONFIG_VIRTIO`).
+
+[1]: https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html#x1-3050004
+[2]: https://docs.rs/rand/latest/rand/rngs/struct.OsRng.html
+[3]: https://docs.rs/getrandom/latest/getrandom/


### PR DESCRIPTION
## Changes

Add documentation about `virtio-rng`

## Reason

Let the users know how they can use `virtio-rng` and add implementation details.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
