### PR TITLE
jailer: fix perf regression when closing open FDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Fixed feature flags in T2S CPU template on Intel Ice Lake.
 - Fixed CPUID leaf 0xb to be exposed to guests running on AMD host.
+- Fixed a performance regression in the jailer logic for closing open file
+  descriptors. Related to:
+  [#3542](https://github.com/firecracker-microvm/firecracker/issues/3542).
 
 ## [1.3.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ name = "jailer"
 version = "1.3.0"
 dependencies = [
  "libc",
+ "nix 0.26.2",
  "regex",
  "thiserror",
  "utils",
@@ -679,6 +680,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -953,6 +966,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,7 +1073,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "nix",
+ "nix 0.23.1",
  "thiserror",
  "userfaultfd-sys",
 ]

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 
 [dependencies]
 libc = "0.2.117"
+nix = { version = "0.26.2", default-features = false, features = ["dir"] }
 regex = { version = "1.5.5", default-features = false, features = ["std"] }
 thiserror = "1.0.32"
 

--- a/tests/framework/dependencies.txt
+++ b/tests/framework/dependencies.txt
@@ -65,6 +65,7 @@
  'serde_json',
  'shlex',
  'snapshot',
+ 'static_assertions',
  'subtle',
  'syn',
  'thiserror',

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -19,7 +19,7 @@ SIZES_DICT = {
     },
     "aarch64": {
         "FC_BINARY_SIZE_TARGET": 2322392,
-        "JAILER_BINARY_SIZE_TARGET": 851152,
+        "JAILER_BINARY_SIZE_TARGET": 898656,
     },
 }
 


### PR DESCRIPTION
## Changes

Fixes the mechanism for closing open FDs in jailer which was
based on the SC_OPEN_MAX system constant. Such an approach can lead
to bad performance when this value is very high.

The method for closing file descriptors is now chosen based on the environment:
 1. we try to call into the close_range syscall (available on kernels >=5.9)
 2. we fallback to reading from /proc/self/fd (for kernels <5.9)
    
 ## Reason

Fixes #3542 - a bug where firecracker would end up spending minutes starting which arises when running on systems with OPEN_MAX set to a very high number.

Thanks @gorbak25 for reporting the issue and proposing the fix!

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
