### PR TITLE
feat: Static CPU templates in JSON format and `CpuTemplate` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_templates"
+version = "0.1.0"
+dependencies = [
+ "kvm-bindings",
+ "serde_json",
+ "vmm",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["src/firecracker", "src/jailer", "src/seccompiler", "src/rebase-snap"]
+members = ["src/firecracker", "src/jailer", "src/seccompiler", "src/rebase-snap", "src/static_templates"]
 default-members = ["src/firecracker"]
 
 [profile.dev]

--- a/src/static_templates/Cargo.toml
+++ b/src/static_templates/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "static_templates"
+version = "0.1.0"
+authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+vmm = { path = "../vmm" }
+
+[dev-dependencies]
+kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
+serde_json = "1.0.78"

--- a/src/static_templates/src/c3.rs
+++ b/src/static_templates/src/c3.rs
@@ -1,0 +1,117 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterValueFilter,
+};
+use vmm::guest_config::templates::CpuTemplate;
+
+pub fn c3() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            CpuidLeafModifier {
+                leaf: 0x1,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Eax,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00001111111111110011111111111111,
+                            value: 0b00000000000000110000011011100100,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000010000001101110100111100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b10101000011001000001000010000000,
+                            value: 0b00000000000000000001000010000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0x7,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ebx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b11111111101011111101110101111100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b01000000010000010100100000011110,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000000000000000000001100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000001011111000,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x1,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000000000001110,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0x80000001,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000000000000000100100000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000100000000000000000000000000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+        ],
+        msr_modifiers: vec![],
+    }
+}

--- a/src/static_templates/src/lib.rs
+++ b/src/static_templates/src/lib.rs
@@ -1,0 +1,31 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Definition of static CPU templates using `struct CpuTemplate`.
+//
+// This crate is temporary until merging this into `vmm` crate.
+
+#[cfg(target_arch = "x86_64")]
+pub mod c3;
+#[cfg(target_arch = "x86_64")]
+pub use c3::c3;
+
+#[cfg(target_arch = "x86_64")]
+pub mod t2;
+#[cfg(target_arch = "x86_64")]
+pub use t2::t2;
+
+#[cfg(target_arch = "x86_64")]
+pub mod t2a;
+#[cfg(target_arch = "x86_64")]
+pub use t2a::t2a;
+
+#[cfg(target_arch = "x86_64")]
+pub mod t2cl;
+#[cfg(target_arch = "x86_64")]
+pub use t2cl::t2cl;
+
+#[cfg(target_arch = "x86_64")]
+pub mod t2s;
+#[cfg(target_arch = "x86_64")]
+pub use t2s::t2s;

--- a/src/static_templates/src/t2.rs
+++ b/src/static_templates/src/t2.rs
@@ -1,0 +1,129 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterValueFilter,
+};
+use vmm::guest_config::templates::CpuTemplate;
+
+pub fn t2() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            CpuidLeafModifier {
+                leaf: 0x1,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Eax,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00001111111111110011111111111111,
+                            value: 0b00000000000000110000011011110010,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000001001100110111111100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b11101000011001000001000010000000,
+                            value: 0b00000000000000000001000010000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0x7,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ebx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b11111111111011111111101001010100,
+                            value: 0b00000000000000000000001000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b01000000010000010101111101011110,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000000000000000100011100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000001011111000,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x1,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000000000001110,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0x80000001,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00100000000000000000000100000000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000100000000000000000000000000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0x80000008,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Ebx,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000001000000000,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+        ],
+        msr_modifiers: vec![],
+    }
+}

--- a/src/static_templates/src/t2a.rs
+++ b/src/static_templates/src/t2a.rs
@@ -1,0 +1,129 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterValueFilter,
+};
+use vmm::guest_config::templates::CpuTemplate;
+
+pub fn t2a() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            CpuidLeafModifier {
+                leaf: 0x1,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Eax,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00001111111111110011111111111111,
+                            value: 0b00000000000000110000011011110010,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000001001100110111111100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b11101000011001000001000010000000,
+                            value: 0b00000000000000000001000010000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0x7,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ebx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b11111111111011111111101001010100,
+                            value: 0b00000000000000000000001000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b01000000010000010101111101011110,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000000000000000100011100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000001011111000,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x1,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000000000001110,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0x80000001,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00100000000000000000000111000000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000111110000000000000000000000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0x80000008,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Ebx,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000011000000001000000101,
+                        value: 0b00000000000011000000000000000000,
+                    },
+                }],
+            },
+        ],
+        msr_modifiers: vec![],
+    }
+}

--- a/src/static_templates/src/t2cl.rs
+++ b/src/static_templates/src/t2cl.rs
@@ -1,0 +1,135 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterModifier, RegisterValueFilter,
+};
+use vmm::guest_config::templates::CpuTemplate;
+
+pub fn t2cl() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            CpuidLeafModifier {
+                leaf: 0x1,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Eax,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00001111111111110011111111111111,
+                            value: 0b00000000000000110000011011110010,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000001001100110111111100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b11101000011001000001000010000000,
+                            value: 0b00000000000000000001000010000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0x7,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ebx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b11111111111011111111101001010100,
+                            value: 0b00000000000000000000001000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b01000000010000010101111101011110,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000000000000000100011100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000001011111000,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x1,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000000000001110,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0x80000001,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00100000000000000000000111000000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000111110000000000000000000000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0x80000008,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Ebx,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000001000000000,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+        ],
+        msr_modifiers: vec![RegisterModifier {
+            addr: 0x10a,
+            bitmap: RegisterValueFilter {
+                filter: 0b1111111111111111111111111111111111111111111111111111111111111111,
+                value: 0b0000000000000000000000000000000000000000000000000000000011101011,
+            },
+        }],
+    }
+}

--- a/src/static_templates/src/t2s.rs
+++ b/src/static_templates/src/t2s.rs
@@ -1,0 +1,135 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterModifier, RegisterValueFilter,
+};
+use vmm::guest_config::templates::CpuTemplate;
+
+pub fn t2s() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            CpuidLeafModifier {
+                leaf: 0x1,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Eax,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00001111111111110011111111111111,
+                            value: 0b00000000000000110000011011110010,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000001001100110111111100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b11101000011001000001000010000000,
+                            value: 0b00000000000000000001000010000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0x7,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ebx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b11111111111011111111101001010100,
+                            value: 0b00000000000000000000001000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b01000000010000010101111101011110,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000000000000000000000100011100,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000001011111000,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0xd,
+                subleaf: 0x1,
+                flags: KvmCpuidFlags(1),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000000000001110,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+            CpuidLeafModifier {
+                leaf: 0x80000001,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Ecx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00100000000000000000000100000000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                    CpuidRegisterModifier {
+                        register: CpuidRegister::Edx,
+                        bitmap: RegisterValueFilter {
+                            filter: 0b00000100000000000000000000000000,
+                            value: 0b00000000000000000000000000000000,
+                        },
+                    },
+                ],
+            },
+            CpuidLeafModifier {
+                leaf: 0x80000008,
+                subleaf: 0x0,
+                flags: KvmCpuidFlags(0),
+                modifiers: vec![CpuidRegisterModifier {
+                    register: CpuidRegister::Ebx,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b00000000000000000000001000000000,
+                        value: 0b00000000000000000000000000000000,
+                    },
+                }],
+            },
+        ],
+        msr_modifiers: vec![RegisterModifier {
+            addr: 0x10a,
+            bitmap: RegisterValueFilter {
+                filter: 0b1111111111111111111111111111111111111111111111111111111111111111,
+                value: 0b0000000000000000000000000000000000000000000000000000110001001100,
+            },
+        }],
+    }
+}

--- a/src/static_templates/tests/integration_tests.rs
+++ b/src/static_templates/tests/integration_tests.rs
@@ -1,0 +1,82 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(target_arch = "x86_64")]
+mod main_branch;
+
+#[cfg(target_arch = "x86_64")]
+mod x86_64 {
+    use static_templates::{c3, t2, t2a, t2cl, t2s};
+    use vmm::guest_config::templates::CpuTemplate;
+
+    fn load_json_template(template_type: &str) -> CpuTemplate {
+        use std::fs::read_to_string;
+        use std::path::PathBuf;
+
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push(format!("tests/json/{template_type}.json"));
+
+        let json_string = read_to_string(path).unwrap();
+        serde_json::from_str(&json_string).unwrap()
+    }
+
+    #[test]
+    fn test_c3_json() {
+        let json_template = load_json_template("c3");
+        assert_eq!(json_template, c3::c3());
+    }
+
+    #[test]
+    fn test_t2_json() {
+        let json_template = load_json_template("t2");
+        assert_eq!(json_template, t2::t2());
+    }
+
+    #[test]
+    fn test_t2a_json() {
+        let json_template = load_json_template("t2a");
+        assert_eq!(json_template, t2a::t2a());
+    }
+
+    #[test]
+    fn test_t2cl_json() {
+        let json_template = load_json_template("t2cl");
+        assert_eq!(json_template, t2cl::t2cl());
+    }
+
+    #[test]
+    fn test_t2s_json() {
+        let json_template = load_json_template("t2s");
+        assert_eq!(json_template, t2s::t2s());
+    }
+
+    #[test]
+    fn test_c3_main_branch() {
+        let main_template = crate::main_branch::intel::c3::c3();
+        assert_eq!(main_template, c3::c3());
+    }
+
+    #[test]
+    fn test_t2_main_branch() {
+        let main_template = crate::main_branch::intel::t2::t2();
+        assert_eq!(main_template, t2::t2());
+    }
+
+    #[test]
+    fn test_t2s_main_branch() {
+        let main_template = crate::main_branch::intel::t2s::t2s();
+        assert_eq!(main_template, t2s::t2s());
+    }
+
+    #[test]
+    fn test_t2cl_main_branch() {
+        let main_template = crate::main_branch::intel::t2cl::t2cl();
+        assert_eq!(main_template, t2cl::t2cl());
+    }
+
+    #[test]
+    fn test_t2a_main_branch() {
+        let main_template = crate::main_branch::amd::t2a::t2a();
+        assert_eq!(main_template, t2a::t2a());
+    }
+}

--- a/src/static_templates/tests/json/c3.json
+++ b/src/static_templates/tests/json/c3.json
@@ -1,0 +1,80 @@
+{
+  "cpuid_modifiers": [
+    {
+      "leaf": "0x1",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxx000000000011xx00011011100100"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bxxxxxxxxx0xxxxxx00x000x0xx0000xx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0b0x0x0xxxx00xx0xxxxx1xxxx1xxxxxxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0x7",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "ebx",
+          "bitmap": "0b000000000x0x000000x000x0x00000xx"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bx0xxxxxxx0xxxxx0x0xx0xxxxxx0000x"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxxx00xx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxx0x00000xxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x1",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxxx000x"
+        }
+      ]
+    },
+    {
+      "leaf": "0x80000001",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ecx",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxx0xx0xxxxx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxx0xxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    }
+  ],
+  "msr_modifiers": []
+}

--- a/src/static_templates/tests/json/t2.json
+++ b/src/static_templates/tests/json/t2.json
@@ -1,0 +1,91 @@
+{
+  "cpuid_modifiers": [
+    {
+      "leaf": "0x1",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxx000000000011xx00011011110010"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bxxxxxxxxxxxxx0xx00xx00x0000000xx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0b000x0xxxx00xx0xxxxx1xxxx1xxxxxxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0x7",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "ebx",
+          "bitmap": "0b00000000000x000000000x1xx0x0x0xx"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bx0xxxxxxx0xxxxx0x0x00000x0x0000x"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxx0xxx000xx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxx0x00000xxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x1",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxxx000x"
+        }
+      ]
+    },
+    {
+      "leaf": "0x80000001",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ecx",
+          "bitmap": "0bxx0xxxxxxxxxxxxxxxxxxxx0xxxxxxxx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxx0xxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0x80000008",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ebx",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxx0xxxxxxxxx"
+        }
+      ]
+    }
+  ],
+  "msr_modifiers": []
+}

--- a/src/static_templates/tests/json/t2a.json
+++ b/src/static_templates/tests/json/t2a.json
@@ -1,0 +1,91 @@
+{
+  "cpuid_modifiers": [
+    {
+      "leaf": "0x1",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxx000000000011xx00011011110010"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bxxxxxxxxxxxxx0xx00xx00x0000000xx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0b000x0xxxx00xx0xxxxx1xxxx1xxxxxxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0x7",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "ebx",
+          "bitmap": "0b00000000000x000000000x1xx0x0x0xx"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bx0xxxxxxx0xxxxx0x0x00000x0x0000x"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxx0xxx000xx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxx0x00000xxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x1",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxxx000x"
+        }
+      ]
+    },
+    {
+      "leaf": "0x80000001",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ecx",
+          "bitmap": "0bxx0xxxxxxxxxxxxxxxxxxxx000xxxxxx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxx00000xxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0x80000008",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ebx",
+          "bitmap": "0bxxxxxxxxxxxx11xxxxxxxx0xxxxxx0x0"
+        }
+      ]
+    }
+  ],
+  "msr_modifiers": []
+}

--- a/src/static_templates/tests/json/t2cl.json
+++ b/src/static_templates/tests/json/t2cl.json
@@ -1,0 +1,96 @@
+{
+  "cpuid_modifiers": [
+    {
+      "leaf": "0x1",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxx000000000011xx00011011110010"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bxxxxxxxxxxxxx0xx00xx00x0000000xx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0b000x0xxxx00xx0xxxxx1xxxx1xxxxxxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0x7",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "ebx",
+          "bitmap": "0b00000000000x000000000x1xx0x0x0xx"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bx0xxxxxxx0xxxxx0x0x00000x0x0000x"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxx0xxx000xx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxx0x00000xxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x1",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxxx000x"
+        }
+      ]
+    },
+    {
+      "leaf": "0x80000001",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ecx",
+          "bitmap": "0bxx0xxxxxxxxxxxxxxxxxxxx000xxxxxx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxx00000xxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0x80000008",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ebx",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxx0xxxxxxxxx"
+        }
+      ]
+    }
+  ],
+  "msr_modifiers": [
+    {
+      "addr": "0x10a",
+      "bitmap": "0b0000000000000000000000000000000000000000000000000000000011101011"
+    }
+  ]
+}

--- a/src/static_templates/tests/json/t2s.json
+++ b/src/static_templates/tests/json/t2s.json
@@ -1,0 +1,96 @@
+{
+  "cpuid_modifiers": [
+    {
+      "leaf": "0x1",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxx000000000011xx00011011110010"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bxxxxxxxxxxxxx0xx00xx00x0000000xx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0b000x0xxxx00xx0xxxxx1xxxx1xxxxxxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0x7",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "ebx",
+          "bitmap": "0b00000000000x000000000x1xx0x0x0xx"
+        },
+        {
+          "register": "ecx",
+          "bitmap": "0bx0xxxxxxx0xxxxx0x0x00000x0x0000x"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxx0xxx000xx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x0",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxx0x00000xxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0xd",
+      "subleaf": "0x1",
+      "flags": 1,
+      "modifiers": [
+        {
+          "register": "eax",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxxx000x"
+        }
+      ]
+    },
+    {
+      "leaf": "0x80000001",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ecx",
+          "bitmap": "0bxx0xxxxxxxxxxxxxxxxxxxx0xxxxxxxx"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0bxxxxx0xxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    },
+    {
+      "leaf": "0x80000008",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ebx",
+          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxx0xxxxxxxxx"
+        }
+      ]
+    }
+  ],
+  "msr_modifiers": [
+    {
+      "addr": "0x10a",
+      "bitmap": "0b0000000000000000000000000000000000000000000000000000110001001100"
+    }
+  ]
+}

--- a/src/static_templates/tests/main_branch/amd/mod.rs
+++ b/src/static_templates/tests/main_branch/amd/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Follows the T2 template for setting up the CPUID.
+/// Also disables AMD-specific features.
+pub mod t2a;

--- a/src/static_templates/tests/main_branch/amd/t2a.rs
+++ b/src/static_templates/tests/main_branch/amd/t2a.rs
@@ -1,0 +1,115 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterValueFilter,
+};
+use vmm::guest_config::templates::CpuTemplate;
+
+use crate::main_branch::bit_helper::{BitHelper, BitRangeExt};
+
+pub fn t2a() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            super::super::intel::t2::leaf_0x1_subleaf_0x0(),
+            super::super::intel::t2::leaf_0x7_subleaf_0x0(),
+            super::super::intel::t2::leaf_0xd_subleaf_0x0(),
+            super::super::intel::t2::leaf_0xd_subleaf_0x1(),
+            leaf_0x80000001_subleaf_0x0(),
+            leaf_0x80000008_subleaf_0x0(),
+        ],
+        msr_modifiers: vec![],
+    }
+}
+
+pub fn leaf_0x80000001_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x80000001::*;
+
+    // ECX
+    let mut ecx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ecx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    ecx_modifier
+        .bitmap
+        .value
+        .write_bit(ecx::SSE4A_BITINDEX, false)
+        .write_bit(ecx::MISALIGN_SSE_BITINDEX, false)
+        .write_bit(ecx::PREFETCH_BITINDEX, false)
+        .write_bit(ecx::MWAIT_EXTENDED_BITINDEX, false);
+
+    ecx_modifier.bitmap.filter = ecx::SSE4A_BITINDEX.get_mask()
+        | ecx::MISALIGN_SSE_BITINDEX.get_mask()
+        | ecx::PREFETCH_BITINDEX.get_mask()
+        | ecx::MWAIT_EXTENDED_BITINDEX.get_mask();
+
+    // EDX
+    let mut edx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Edx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    edx_modifier
+        .bitmap
+        .value
+        .write_bit(edx::MMX_EXT_BITINDEX, false)
+        .write_bit(edx::MMX_BITINDEX, false)
+        .write_bit(edx::FXSR_BITINDEX, false)
+        .write_bit(edx::FFXSR_BITINDEX, false)
+        .write_bit(edx::PDPE1GB_BITINDEX, false);
+
+    edx_modifier.bitmap.filter = edx::MMX_EXT_BITINDEX.get_mask()
+        | edx::MMX_BITINDEX.get_mask()
+        | edx::FXSR_BITINDEX.get_mask()
+        | edx::FFXSR_BITINDEX.get_mask()
+        | edx::PDPE1GB_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(0),
+        modifiers: vec![ecx_modifier, edx_modifier],
+    }
+}
+
+pub fn leaf_0x80000008_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x80000008::*;
+
+    let mut ebx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ebx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    ebx_modifier
+        .bitmap
+        .value
+        .write_bit(ebx::CLZERO_BITINDEX, false)
+        .write_bit(ebx::RSTR_FP_ERR_PTRS_BITINDEX, false)
+        .write_bit(ebx::WBNOINVD_BITINDEX, false)
+        .write_bit(ebx::IBRS_PREFERRED_BITINDEX, true)
+        .write_bit(ebx::IBRS_PROVIDES_SAME_MODE_PROTECTION_BITINDEX, true);
+
+    ebx_modifier.bitmap.filter = ebx::CLZERO_BITINDEX.get_mask()
+        | ebx::RSTR_FP_ERR_PTRS_BITINDEX.get_mask()
+        | ebx::WBNOINVD_BITINDEX.get_mask()
+        | ebx::IBRS_PREFERRED_BITINDEX.get_mask()
+        | ebx::IBRS_PROVIDES_SAME_MODE_PROTECTION_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(0),
+        modifiers: vec![ebx_modifier],
+    }
+}

--- a/src/static_templates/tests/main_branch/bit_helper.rs
+++ b/src/static_templates/tests/main_branch/bit_helper.rs
@@ -1,0 +1,185 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![macro_use]
+
+/// Structure representing a range of bits in a number.
+///
+/// # Example
+///
+/// ```
+/// use vmm::cpuid::bit_helper::*;
+///
+/// let range = BitRange {
+///     msb_index: 7,
+///     lsb_index: 3,
+/// };
+/// ```
+/// The BitRange specified above will represent the following part of the number 72:
+/// +-------------------------------------+---+---+---+---+---+---+---+---+---+---+
+/// | Base 2 Representation of the number | 0 | 0 | 0 | 1 | 0 | 0 | 1 | 0 | 0 | 0 |
+/// +-------------------------------------+---+---+---+---+---+---+---+---+---+---+
+/// | bits indexes                        | 9 | 8 | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+/// +-------------------------------------+---+---+---+---+---+---+---+---+---+---+
+/// | BitRange                            |   |   | * | * | * | * | * |   |   |   |
+/// +-------------------------------------+---+---+---+---+---+---+---+---+---+---+
+pub struct BitRange {
+    /// most significant bit index
+    pub msb_index: u32,
+    /// least significant bit index
+    pub lsb_index: u32,
+}
+
+/// Trait containing helper methods for [`BitRange`](struct.BitRange.html)
+///
+/// The methods are needed for:
+/// - checking if the `BitRange` is valid for a type `T`
+/// - creating masks for a type `T`
+pub trait BitRangeExt<T> {
+    /// Returns a value of type `T` that has all the bits in the specified bit range set to 1.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use vmm::cpuid::bit_helper::*;
+    ///
+    /// let range = BitRange {
+    ///     msb_index: 7,
+    ///     lsb_index: 3,
+    /// };
+    /// println!("binary value: {:b}", range.get_mask());
+    /// ```
+    /// The code above will print:
+    /// ```bash
+    /// binary value: 11111000
+    /// ```
+    fn get_mask(&self) -> T;
+
+    /// Checks if the current BitRange is valid for type `T`.
+    fn is_valid(&self) -> bool;
+
+    /// Asserts if `self.is_valid()` returns true.
+    fn check(&self) {
+        assert!(self.is_valid(), "Invalid BitRange");
+    }
+}
+
+const MAX_U64_BIT_INDEX: u32 = 63;
+
+impl BitRangeExt<u64> for BitRange {
+    fn get_mask(&self) -> u64 {
+        self.check();
+
+        ((((1_u128) << (self.msb_index - self.lsb_index + 1)) - 1) << self.lsb_index) as u64
+    }
+
+    fn is_valid(&self) -> bool {
+        self.msb_index >= self.lsb_index && self.msb_index <= MAX_U64_BIT_INDEX
+    }
+}
+
+impl BitRangeExt<u64> for u32 {
+    fn get_mask(&self) -> u64 {
+        self.check();
+
+        1u64 << *self
+    }
+
+    fn is_valid(&self) -> bool {
+        *self <= MAX_U64_BIT_INDEX
+    }
+}
+
+macro_rules! bit_range {
+    ($msb_index:expr, $lsb_index:expr) => {
+        BitRange {
+            msb_index: $msb_index,
+            lsb_index: $lsb_index,
+        }
+    };
+}
+
+/// Trait containing helper methods for bit operations.
+pub trait BitHelper {
+    /// Reads the value of the bit at position `pos`
+    fn read_bit(&self, pos: u32) -> bool;
+
+    /// Changes the value of the bit at position `pos` to `val`
+    fn write_bit(&mut self, pos: u32, val: bool) -> &mut Self;
+
+    /// Reads the value stored within the specified range of bits
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use vmm::cpuid::bit_helper::*;
+    ///
+    /// let val: u32 = 0b000010001000;
+    /// let range = BitRange {
+    ///     msb_index: 7,
+    ///     lsb_index: 3,
+    /// };
+    /// println!("binary value: {:b}", val.read_bits_in_range(&range));
+    /// ```
+    /// The code above will print:
+    /// ```bash
+    /// binary value: 10001
+    /// ```
+    fn read_bits_in_range(&self, bit_range: &BitRange) -> Self;
+
+    /// Stores a value within the specified range of bits
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use vmm::cpuid::bit_helper::*;
+    ///
+    /// let mut val: u32 = 0;
+    /// let range = BitRange {
+    ///     msb_index: 7,
+    ///     lsb_index: 3,
+    /// };
+    /// val.write_bits_in_range(&range, 0b10001 as u32);
+    /// println!("binary value: {:b}", val);
+    /// ```
+    /// The code above will print:
+    /// ```bash
+    /// binary value: 10001000
+    /// ```
+    fn write_bits_in_range(&mut self, bit_range: &BitRange, val: Self) -> &mut Self;
+}
+
+impl BitHelper for u64 {
+    fn read_bit(&self, pos: u32) -> bool {
+        assert!(pos <= MAX_U64_BIT_INDEX, "Invalid pos");
+
+        (*self & (1u64 << pos)) > 0
+    }
+
+    fn write_bit(&mut self, pos: u32, val: bool) -> &mut Self {
+        assert!(pos <= MAX_U64_BIT_INDEX, "Invalid pos");
+
+        *self &= !(1u64 << pos);
+        *self |= (u64::from(val)) << pos;
+        self
+    }
+
+    fn read_bits_in_range(&self, range: &BitRange) -> Self {
+        range.check();
+
+        (self & range.get_mask()) >> range.lsb_index
+    }
+
+    fn write_bits_in_range(&mut self, range: &BitRange, val: Self) -> &mut Self {
+        range.check();
+        let mask: u64 = range.get_mask();
+        let max_val: u64 = mask >> range.lsb_index;
+        assert!(val <= max_val, "Invalid val");
+
+        *self &= !mask;
+        *self |= val << range.lsb_index;
+        self
+    }
+}

--- a/src/static_templates/tests/main_branch/cpu_leaf.rs
+++ b/src/static_templates/tests/main_branch/cpu_leaf.rs
@@ -1,0 +1,371 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+
+// Basic CPUID Information
+pub mod leaf_0x1 {
+    pub const LEAF_NUM: u32 = 0x1;
+
+    pub mod eax {
+        use crate::main_branch::bit_helper::*;
+        pub const EXTENDED_FAMILY_ID_BITRANGE: BitRange = bit_range!(27, 20);
+        pub const EXTENDED_PROCESSOR_MODEL_BITRANGE: BitRange = bit_range!(19, 16);
+        pub const PROCESSOR_TYPE_BITRANGE: BitRange = bit_range!(13, 12);
+        pub const PROCESSOR_FAMILY_BITRANGE: BitRange = bit_range!(11, 8);
+        pub const PROCESSOR_MODEL_BITRANGE: BitRange = bit_range!(7, 4);
+        pub const STEPPING_BITRANGE: BitRange = bit_range!(3, 0);
+    }
+
+    pub mod ebx {
+        use crate::main_branch::bit_helper::*;
+        // The bit-range containing the (fixed) default APIC ID.
+        pub const APICID_BITRANGE: BitRange = bit_range!(31, 24);
+        // The bit-range containing the logical processor count.
+        pub const CPU_COUNT_BITRANGE: BitRange = bit_range!(23, 16);
+        // The bit-range containing the number of bytes flushed when executing CLFLUSH.
+        pub const CLFLUSH_SIZE_BITRANGE: BitRange = bit_range!(15, 8);
+    }
+
+    pub mod ecx {
+        // DTES64 = 64-bit debug store
+        pub const DTES64_BITINDEX: u32 = 2;
+        // MONITOR = Monitor/MWAIT
+        pub const MONITOR_BITINDEX: u32 = 3;
+        // CPL Qualified Debug Store
+        pub const DS_CPL_SHIFT: u32 = 4;
+        // Virtual Machine Extensions
+        pub const VMX_BITINDEX: u32 = 5;
+        // 6 = SMX (Safer Mode Extensions)
+        pub const SMX_BITINDEX: u32 = 6;
+        // 7 = EIST (Enhanced Intel SpeedStep® technology)
+        pub const EIST_BITINDEX: u32 = 7;
+        // TM2 = Thermal Monitor 2
+        pub const TM2_BITINDEX: u32 = 8;
+        // CNXT_ID = L1 Context ID (L1 data cache can be set to adaptive/shared mode)
+        pub const CNXT_ID_BITINDEX: u32 = 10;
+        // SDBG (cpu supports IA32_DEBUG_INTERFACE MSR for silicon debug)
+        pub const SDBG_BITINDEX: u32 = 11;
+        pub const FMA_BITINDEX: u32 = 12;
+        // XTPR_UPDATE = xTPR Update Control
+        pub const XTPR_UPDATE_BITINDEX: u32 = 14;
+        // PDCM = Perfmon and Debug Capability
+        pub const PDCM_BITINDEX: u32 = 15;
+        // 18 = DCA Direct Cache Access (prefetch data from a memory mapped device)
+        pub const DCA_BITINDEX: u32 = 18;
+        pub const MOVBE_BITINDEX: u32 = 22;
+        pub const TSC_DEADLINE_TIMER_BITINDEX: u32 = 24;
+        // Cpu is running on a hypervisor.
+        pub const HYPERVISOR_BITINDEX: u32 = 31;
+    }
+
+    pub mod edx {
+        pub const MCE_BITINDEX: u32 = 7; // Memory Check Exception
+        pub const MTRR_BITINDEX: u32 = 12; // Memory Type Range Registers
+        pub const PSN_BITINDEX: u32 = 18; // Processor Serial Number
+        pub const DS_BITINDEX: u32 = 21; // Debug Store.
+        pub const ACPI_BITINDEX: u32 = 22; // Thermal Monitor and Software Controlled Clock Facilities.
+        pub const SS_BITINDEX: u32 = 27; // Self Snoop
+        pub const HTT_BITINDEX: u32 = 28; // Max APIC IDs reserved field is valid
+        pub const TM_BITINDEX: u32 = 29; // Thermal Monitor.
+        pub const IA64_BITINDEX: u32 = 30; // IA64 processor emulating x86
+        pub const PBE_BITINDEX: u32 = 31; // Pending Break Enable.
+    }
+}
+
+pub mod leaf_cache_parameters {
+    pub mod eax {
+        use crate::main_branch::bit_helper::*;
+        pub const CACHE_LEVEL_BITRANGE: BitRange = bit_range!(7, 5);
+        pub const MAX_CPUS_PER_CORE_BITRANGE: BitRange = bit_range!(25, 14);
+    }
+}
+
+// Deterministic Cache Parameters Leaf
+pub mod leaf_0x4 {
+    pub const LEAF_NUM: u32 = 0x4;
+
+    pub mod eax {
+        use crate::main_branch::bit_helper::*;
+        // inherit eax from leaf_cache_parameters
+        pub use crate::main_branch::cpu_leaf::leaf_cache_parameters::eax::*;
+
+        pub const MAX_CORES_PER_PACKAGE_BITRANGE: BitRange = bit_range!(31, 26);
+    }
+}
+
+// Thermal and Power Management Leaf
+pub mod leaf_0x6 {
+    pub const LEAF_NUM: u32 = 0x6;
+
+    pub mod eax {
+        pub const TURBO_BOOST_BITINDEX: u32 = 1;
+    }
+
+    pub mod ecx {
+        // "Energy Performance Bias" bit.
+        pub const EPB_BITINDEX: u32 = 3;
+    }
+}
+
+// Structured Extended Feature Flags Enumeration Leaf
+pub mod leaf_0x7 {
+    pub const LEAF_NUM: u32 = 0x7;
+
+    pub mod index0 {
+        pub mod ebx {
+            // 1 = TSC_ADJUST
+            pub const SGX_BITINDEX: u32 = 2;
+            pub const BMI1_BITINDEX: u32 = 3;
+            pub const HLE_BITINDEX: u32 = 4;
+            pub const AVX2_BITINDEX: u32 = 5;
+            // FPU Data Pointer updated only on x87 exceptions if 1.
+            pub const FPDP_BITINDEX: u32 = 6;
+            // 7 = SMEP (Supervisor-Mode Execution Prevention if 1)
+            pub const BMI2_BITINDEX: u32 = 8;
+            // ERMS = Enhanced REP MOVSB/STOSB if 1
+            pub const ERMS_BITINDEX: u32 = 9;
+            // 10 = INVPCID
+            pub const INVPCID_BITINDEX: u32 = 10;
+            pub const RTM_BITINDEX: u32 = 11;
+            // Intel® Resource Director Technology (Intel® RDT) Monitoring
+            pub const RDT_M_BITINDEX: u32 = 12;
+            // 13 = Deprecates FPU CS and FPU DS values if 1
+            pub const FPU_CS_DS_DEPRECATE_BITINDEX: u32 = 13;
+            // Memory Protection Extensions
+            pub const MPX_BITINDEX: u32 = 14;
+            // RDT = Intel® Resource Director Technology
+            pub const RDT_A_BITINDEX: u32 = 15;
+            // AVX-512 Foundation instructions
+            pub const AVX512F_BITINDEX: u32 = 16;
+            // AVX-512 Doubleword and Quadword Instructions
+            pub const AVX512DQ_BITINDEX: u32 = 17;
+            pub const RDSEED_BITINDEX: u32 = 18;
+            pub const ADX_BITINDEX: u32 = 19;
+            // 20 = SMAP (Supervisor-Mode Access Prevention)
+            // AVX512IFMA = AVX-512 Integer Fused Multiply-Add Instructions
+            pub const AVX512IFMA_BITINDEX: u32 = 21;
+            // 22 = PCOMMIT intruction
+            pub const PCOMMIT_BITINDEX: u32 = 22;
+            // CLFLUSHOPT (flushing multiple cache lines in parallel within a single logical
+            // processor)
+            pub const CLFLUSHOPT_BITINDEX: u32 = 23;
+            // CLWB = Cache Line Write Back
+            pub const CLWB_BITINDEX: u32 = 24;
+            // PT = Intel Processor Trace
+            pub const PT_BITINDEX: u32 = 25;
+            // AVX512PF = AVX512 Prefetch Instructions
+            pub const AVX512PF_BITINDEX: u32 = 26;
+            // AVX512ER = AVX-512 Exponential and Reciprocal Instructions
+            pub const AVX512ER_BITINDEX: u32 = 27;
+            // AVX512CD = AVX-512 Conflict Detection Instructions
+            pub const AVX512CD_BITINDEX: u32 = 28;
+            // Intel Secure Hash Algorithm Extensions
+            pub const SHA_BITINDEX: u32 = 29;
+            // AVX-512 Byte and Word Instructions
+            pub const AVX512BW_BITINDEX: u32 = 30;
+            // AVX-512 Vector Length Extensions
+            pub const AVX512VL_BITINDEX: u32 = 31;
+        }
+
+        pub mod ecx {
+            // 0 = PREFETCHWT1 (move data closer to the processor in anticipation of future use)
+            // AVX512_VBMI = AVX-512 Vector Byte Manipulation Instructions
+            pub const AVX512_VBMI_BITINDEX: u32 = 1;
+            // UMIP (User Mode Instruction Prevention)
+            pub const UMIP_BITINDEX: u32 = 2;
+            // PKU = Protection Keys for user-mode pages
+            pub const PKU_BITINDEX: u32 = 3;
+            // OSPKE = If 1, OS has set CR4.PKE to enable protection keys
+            pub const OSPKE_BITINDEX: u32 = 4;
+            // 5 = WAITPKG
+            // AVX512_VBMI2 = AVX-512 byte/word load, store and concatenation with shift
+            pub const AVX512_VBMI2_BITINDEX: u32 = 6;
+            // 7 reserved
+            // GFNI = Galois Field New Instructions
+            pub const GFNI_BITINDEX: u32 = 8;
+            // VAES = Vector AES
+            pub const VAES_BITINDEX: u32 = 9;
+            // VPCLMULQDQ = AVX-512 carry-less multiplication
+            pub const VPCLMULQDQ_BITINDEX: u32 = 10;
+            // AVX512_VNNI = Vector Neural Network Instructions
+            pub const AVX512_VNNI_BITINDEX: u32 = 11;
+            // AVX512_BITALG = byte/word bit manipulation instructions expanding VPOPCNTDQj
+            pub const AVX512_BITALG_BITINDEX: u32 = 12;
+            // 13 = TME
+            // AVX512_VPOPCNTDQ = Vector population count instruction (Intel® Xeon Phi™ only.)
+            pub const AVX512_VPOPCNTDQ_BITINDEX: u32 = 14;
+            // LA57 = 5-level page tables.
+            pub const LA57_BITINDEX: u32 = 16;
+            // 21 - 17 = The value of MAWAU used by the BNDLDX and BNDSTX instructions in 64-bit
+            // mode. Read Processor ID
+            pub const RDPID_BITINDEX: u32 = 22;
+            // 23 - 29 reserved
+            // SGX_LC = SGX Launch Configuration
+            pub const SGX_LC_BITINDEX: u32 = 30;
+            // 31 reserved
+        }
+
+        pub mod edx {
+            // AVX-512 4-register Neural Network Instructions
+            pub const AVX512_4VNNIW_BITINDEX: u32 = 2;
+            // AVX-512 4-register Multiply Accumulation Single precision
+            pub const AVX512_4FMAPS_BITINDEX: u32 = 3;
+            // Fast Short REP MOV
+            pub const FSRM_BITINDEX: u32 = 4;
+            // AVX-512 Compute Intersection Between DWORDS/QUADWORDS
+            pub const AVX512_VP2INTERSECT_BITINDEX: u32 = 8;
+            // Presence of IA32_ARCH_CAPABILITIES MSR
+            pub const ARCH_CAPABILITIES_BITINDEX: u32 = 29;
+        }
+    }
+}
+
+pub mod leaf_0xa {
+    pub const LEAF_NUM: u32 = 0xa;
+}
+
+// Extended Topology Leaf
+pub mod leaf_0xb {
+    pub const LEAF_NUM: u32 = 0xb;
+
+    pub const LEVEL_TYPE_THREAD: u32 = 1;
+    pub const LEVEL_TYPE_CORE: u32 = 2;
+
+    pub mod eax {
+        use crate::main_branch::bit_helper::*;
+        // The bit-range containing the number of bits to shift right the APIC ID in order to get
+        // the next level APIC ID
+        pub const APICID_BITRANGE: BitRange = bit_range!(4, 0);
+    }
+
+    pub mod ebx {
+        use crate::main_branch::bit_helper::*;
+        // The bit-range containing the number of factory-configured logical processors
+        // at the current cache level
+        pub const NUM_LOGICAL_PROCESSORS_BITRANGE: BitRange = bit_range!(15, 0);
+    }
+
+    pub mod ecx {
+        use crate::main_branch::bit_helper::*;
+        pub const LEVEL_TYPE_BITRANGE: BitRange = bit_range!(15, 8);
+        pub const LEVEL_NUMBER_BITRANGE: BitRange = bit_range!(7, 0);
+    }
+}
+
+// Processor Extended State Enumeration Sub-leaves
+pub mod leaf_0xd {
+    pub const LEAF_NUM: u32 = 0xd;
+
+    pub mod index0 {
+        pub mod eax {
+            use crate::main_branch::bit_helper::*;
+            pub const MPX_STATE_BITRANGE: BitRange = bit_range!(4, 3);
+            pub const AVX512_STATE_BITRANGE: BitRange = bit_range!(7, 5);
+            pub const PKRU_BITINDEX: u32 = 9;
+        }
+    }
+
+    pub mod index1 {
+        pub mod eax {
+            pub const XSAVEC_SHIFT: u32 = 1;
+            pub const XGETBV_SHIFT: u32 = 2;
+            pub const XSAVES_SHIFT: u32 = 3;
+        }
+    }
+}
+
+pub mod leaf_0x80000000 {
+    pub const LEAF_NUM: u32 = 0x8000_0000;
+
+    pub mod eax {
+        use crate::main_branch::bit_helper::*;
+        pub const LARGEST_EXTENDED_FN_BITRANGE: BitRange = bit_range!(31, 0);
+    }
+}
+
+pub mod leaf_0x80000001 {
+    pub const LEAF_NUM: u32 = 0x8000_0001;
+
+    pub mod ecx {
+        pub const LZCNT_BITINDEX: u32 = 5; // advanced bit manipulation
+        pub const SSE4A_BITINDEX: u32 = 6; // EXTRQ, INSERTQ, MOVNTSS, and MOVNTSD instruction support
+        pub const MISALIGN_SSE_BITINDEX: u32 = 7; // Misaligned SEE mode
+        pub const PREFETCH_BITINDEX: u32 = 8; // 3DNow! PREFETCH/PREFETCHW instructions
+        pub const TOPOEXT_BITINDEX: u32 = 22; // topology extensions support
+        pub const MWAIT_EXTENDED_BITINDEX: u32 = 29; // MWAITX and MONITORX capability supported
+    }
+
+    pub mod edx {
+        pub const MMX_EXT_BITINDEX: u32 = 22; // AMD extensions to MMX instructions
+        pub const MMX_BITINDEX: u32 = 23; // MMX instructions
+        pub const FXSR_BITINDEX: u32 = 24; // FXSAVE and FXRSTOR instructions
+        pub const FFXSR_BITINDEX: u32 = 25; // FXSAVE and FXRSTOR instruction optimizations
+        pub const PDPE1GB_BITINDEX: u32 = 26; // 1-GByte pages are available if 1.
+    }
+}
+
+pub mod leaf_0x80000008 {
+    pub const LEAF_NUM: u32 = 0x8000_0008;
+
+    pub mod ebx {
+        // Clear Zero Instruction
+        pub const CLZERO_BITINDEX: u32 = 0;
+        // FXSAVE, XSAVE, FXSAVEOPT, XSAVEC, XSAVES always save error pointers and
+        // FXRSTOR, XRSTOR, XRSTORS always restore error pointers is supported
+        pub const RSTR_FP_ERR_PTRS_BITINDEX: u32 = 2;
+        // Write Back and Do Not Invalidate Cache instruction
+        pub const WBNOINVD_BITINDEX: u32 = 9;
+        // IBRS is preferred over software solution
+        pub const IBRS_PREFERRED_BITINDEX: u32 = 18;
+        // IBRS provides Same Mode Protection
+        pub const IBRS_PROVIDES_SAME_MODE_PROTECTION_BITINDEX: u32 = 19;
+    }
+    pub mod ecx {
+        use crate::main_branch::bit_helper::*;
+        // The number of bits in the initial ApicId value that indicate thread ID within a package
+        // Possible values:
+        // 0-5 -> Reserved
+        // 6 -> up to 64 threads
+        // 7 -> up to 128 threads
+        pub const THREAD_ID_SIZE_BITRANGE: BitRange = bit_range!(15, 12);
+        // The number of threads in the package - 1
+        pub const NUM_THREADS_BITRANGE: BitRange = bit_range!(7, 0);
+    }
+}
+
+// Extended Cache Topology Leaf
+pub mod leaf_0x8000001d {
+    pub const LEAF_NUM: u32 = 0x8000_001d;
+
+    // inherit eax from leaf_cache_parameters
+    pub use crate::main_branch::cpu_leaf::leaf_cache_parameters::eax;
+}
+
+// Extended APIC ID Leaf
+pub mod leaf_0x8000001e {
+    pub const LEAF_NUM: u32 = 0x8000_001e;
+
+    pub mod eax {
+        use crate::main_branch::bit_helper::*;
+        pub const EXTENDED_APIC_ID_BITRANGE: BitRange = bit_range!(31, 0);
+    }
+
+    pub mod ebx {
+        use crate::main_branch::bit_helper::*;
+        // The number of threads per core - 1
+        pub const THREADS_PER_CORE_BITRANGE: BitRange = bit_range!(15, 8);
+        pub const CORE_ID_BITRANGE: BitRange = bit_range!(7, 0);
+    }
+
+    pub mod ecx {
+        use crate::main_branch::bit_helper::*;
+        // The number of nodes per processor. Possible values:
+        // 0 -> 1 node per processor
+        // 1 -> 2 nodes per processor
+        // 2 -> Reserved
+        // 3 -> 4 nodes per processor
+        pub const NODES_PER_PROCESSOR_BITRANGE: BitRange = bit_range!(10, 8);
+        pub const NODE_ID_BITRANGE: BitRange = bit_range!(7, 0);
+    }
+}

--- a/src/static_templates/tests/main_branch/intel/c3.rs
+++ b/src/static_templates/tests/main_branch/intel/c3.rs
@@ -1,0 +1,363 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterValueFilter,
+};
+use vmm::guest_config::templates::CpuTemplate;
+
+use crate::main_branch::bit_helper::{BitHelper, BitRangeExt};
+
+pub fn c3() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            leaf_0x1_subleaf_0x0(),
+            leaf_0x7_subleaf_0x0(),
+            leaf_0xd_subleaf_0x0(),
+            leaf_0xd_subleaf_0x1(),
+            leaf_0x80000001_subleaf_0x0(),
+        ],
+        msr_modifiers: vec![],
+    }
+}
+
+pub fn leaf_0x1_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x1::*;
+
+    // EAX
+    let mut eax_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Eax,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    eax_modifier
+        .bitmap
+        .value
+        // Extended Family ID = 0
+        .write_bits_in_range(&eax::EXTENDED_FAMILY_ID_BITRANGE, 0)
+        // Extended Processor Model ID = 3 (Haswell)
+        .write_bits_in_range(&eax::EXTENDED_PROCESSOR_MODEL_BITRANGE, 3)
+        // Processor Type = 0 (Primary processor)
+        .write_bits_in_range(&eax::PROCESSOR_TYPE_BITRANGE, 0)
+        // Processor Family = 6
+        .write_bits_in_range(&eax::PROCESSOR_FAMILY_BITRANGE, 6)
+        // Processor Model = 14
+        .write_bits_in_range(&eax::PROCESSOR_MODEL_BITRANGE, 14)
+        // Stepping = 4
+        .write_bits_in_range(&eax::STEPPING_BITRANGE, 4);
+
+    eax_modifier.bitmap.filter = eax::EXTENDED_FAMILY_ID_BITRANGE.get_mask()
+        | eax::EXTENDED_PROCESSOR_MODEL_BITRANGE.get_mask()
+        | eax::PROCESSOR_TYPE_BITRANGE.get_mask()
+        | eax::PROCESSOR_FAMILY_BITRANGE.get_mask()
+        | eax::PROCESSOR_MODEL_BITRANGE.get_mask()
+        | eax::STEPPING_BITRANGE.get_mask();
+
+    // ECX
+    let mut ecx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ecx,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    ecx_modifier
+        .bitmap
+        .value
+        .write_bit(ecx::DTES64_BITINDEX, false)
+        .write_bit(ecx::MONITOR_BITINDEX, false)
+        .write_bit(ecx::DS_CPL_SHIFT, false)
+        .write_bit(ecx::VMX_BITINDEX, false)
+        .write_bit(ecx::TM2_BITINDEX, false)
+        .write_bit(ecx::CNXT_ID_BITINDEX, false)
+        .write_bit(ecx::SDBG_BITINDEX, false)
+        .write_bit(ecx::FMA_BITINDEX, false)
+        .write_bit(ecx::XTPR_UPDATE_BITINDEX, false)
+        .write_bit(ecx::PDCM_BITINDEX, false)
+        .write_bit(ecx::MOVBE_BITINDEX, false);
+
+    ecx_modifier.bitmap.filter = ecx::DTES64_BITINDEX.get_mask()
+        | ecx::MONITOR_BITINDEX.get_mask()
+        | ecx::DS_CPL_SHIFT.get_mask()
+        | ecx::VMX_BITINDEX.get_mask()
+        | ecx::TM2_BITINDEX.get_mask()
+        | ecx::CNXT_ID_BITINDEX.get_mask()
+        | ecx::SDBG_BITINDEX.get_mask()
+        | ecx::FMA_BITINDEX.get_mask()
+        | ecx::XTPR_UPDATE_BITINDEX.get_mask()
+        | ecx::PDCM_BITINDEX.get_mask()
+        | ecx::MOVBE_BITINDEX.get_mask();
+
+    // EDX
+    let mut edx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Edx,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    edx_modifier
+        .bitmap
+        .value
+        .write_bit(edx::MCE_BITINDEX, true)
+        .write_bit(edx::MTRR_BITINDEX, true)
+        .write_bit(edx::PSN_BITINDEX, false)
+        .write_bit(edx::DS_BITINDEX, false)
+        .write_bit(edx::ACPI_BITINDEX, false)
+        .write_bit(edx::SS_BITINDEX, false)
+        .write_bit(edx::TM_BITINDEX, false)
+        .write_bit(edx::PBE_BITINDEX, false);
+
+    edx_modifier.bitmap.filter = edx::MCE_BITINDEX.get_mask()
+        | edx::MTRR_BITINDEX.get_mask()
+        | edx::PSN_BITINDEX.get_mask()
+        | edx::DS_BITINDEX.get_mask()
+        | edx::ACPI_BITINDEX.get_mask()
+        | edx::SS_BITINDEX.get_mask()
+        | edx::TM_BITINDEX.get_mask()
+        | edx::PBE_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(0),
+        modifiers: vec![eax_modifier, ecx_modifier, edx_modifier],
+    }
+}
+
+pub fn leaf_0x7_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x7::index0::*;
+    use crate::main_branch::cpu_leaf::leaf_0x7::*;
+
+    // EBX
+    let mut ebx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ebx,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    ebx_modifier
+        .bitmap
+        .value
+        .write_bit(ebx::SGX_BITINDEX, false)
+        .write_bit(ebx::BMI1_BITINDEX, false)
+        .write_bit(ebx::HLE_BITINDEX, false)
+        .write_bit(ebx::AVX2_BITINDEX, false)
+        .write_bit(ebx::FPDP_BITINDEX, false)
+        .write_bit(ebx::BMI2_BITINDEX, false)
+        .write_bit(ebx::INVPCID_BITINDEX, false)
+        .write_bit(ebx::RTM_BITINDEX, false)
+        .write_bit(ebx::RDT_M_BITINDEX, false)
+        .write_bit(ebx::MPX_BITINDEX, false)
+        .write_bit(ebx::RDT_A_BITINDEX, false)
+        .write_bit(ebx::AVX512F_BITINDEX, false)
+        .write_bit(ebx::AVX512DQ_BITINDEX, false)
+        .write_bit(ebx::RDSEED_BITINDEX, false)
+        .write_bit(ebx::ADX_BITINDEX, false)
+        .write_bit(ebx::AVX512IFMA_BITINDEX, false)
+        .write_bit(ebx::CLFLUSHOPT_BITINDEX, false)
+        .write_bit(ebx::CLWB_BITINDEX, false)
+        .write_bit(ebx::PT_BITINDEX, false)
+        .write_bit(ebx::AVX512PF_BITINDEX, false)
+        .write_bit(ebx::AVX512ER_BITINDEX, false)
+        .write_bit(ebx::AVX512CD_BITINDEX, false)
+        .write_bit(ebx::SHA_BITINDEX, false)
+        .write_bit(ebx::AVX512BW_BITINDEX, false)
+        .write_bit(ebx::AVX512VL_BITINDEX, false);
+
+    ebx_modifier.bitmap.filter = ebx::SGX_BITINDEX.get_mask()
+        | ebx::BMI1_BITINDEX.get_mask()
+        | ebx::HLE_BITINDEX.get_mask()
+        | ebx::AVX2_BITINDEX.get_mask()
+        | ebx::FPDP_BITINDEX.get_mask()
+        | ebx::BMI2_BITINDEX.get_mask()
+        | ebx::INVPCID_BITINDEX.get_mask()
+        | ebx::RTM_BITINDEX.get_mask()
+        | ebx::RDT_M_BITINDEX.get_mask()
+        | ebx::MPX_BITINDEX.get_mask()
+        | ebx::RDT_A_BITINDEX.get_mask()
+        | ebx::AVX512F_BITINDEX.get_mask()
+        | ebx::AVX512DQ_BITINDEX.get_mask()
+        | ebx::RDSEED_BITINDEX.get_mask()
+        | ebx::ADX_BITINDEX.get_mask()
+        | ebx::AVX512IFMA_BITINDEX.get_mask()
+        | ebx::CLFLUSHOPT_BITINDEX.get_mask()
+        | ebx::CLWB_BITINDEX.get_mask()
+        | ebx::PT_BITINDEX.get_mask()
+        | ebx::AVX512PF_BITINDEX.get_mask()
+        | ebx::AVX512ER_BITINDEX.get_mask()
+        | ebx::AVX512CD_BITINDEX.get_mask()
+        | ebx::SHA_BITINDEX.get_mask()
+        | ebx::AVX512BW_BITINDEX.get_mask()
+        | ebx::AVX512VL_BITINDEX.get_mask();
+
+    // ECX
+    let mut ecx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ecx,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    ecx_modifier
+        .bitmap
+        .value
+        .write_bit(ecx::AVX512_VBMI_BITINDEX, false)
+        .write_bit(ecx::UMIP_BITINDEX, false)
+        .write_bit(ecx::PKU_BITINDEX, false)
+        .write_bit(ecx::OSPKE_BITINDEX, false)
+        .write_bit(ecx::AVX512_VNNI_BITINDEX, false)
+        .write_bit(ecx::AVX512_VPOPCNTDQ_BITINDEX, false)
+        .write_bit(ecx::LA57_BITINDEX, false)
+        .write_bit(ecx::RDPID_BITINDEX, false)
+        .write_bit(ecx::SGX_LC_BITINDEX, false);
+
+    ecx_modifier.bitmap.filter = ecx::AVX512_VBMI_BITINDEX.get_mask()
+        | ecx::UMIP_BITINDEX.get_mask()
+        | ecx::PKU_BITINDEX.get_mask()
+        | ecx::OSPKE_BITINDEX.get_mask()
+        | ecx::AVX512_VNNI_BITINDEX.get_mask()
+        | ecx::AVX512_VPOPCNTDQ_BITINDEX.get_mask()
+        | ecx::LA57_BITINDEX.get_mask()
+        | ecx::RDPID_BITINDEX.get_mask()
+        | ecx::SGX_LC_BITINDEX.get_mask();
+
+    // EDX
+    let mut edx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Edx,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    edx_modifier
+        .bitmap
+        .value
+        .write_bit(edx::AVX512_4VNNIW_BITINDEX, false)
+        .write_bit(edx::AVX512_4FMAPS_BITINDEX, false);
+
+    edx_modifier.bitmap.filter =
+        edx::AVX512_4VNNIW_BITINDEX.get_mask() | edx::AVX512_4FMAPS_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(1),
+        modifiers: vec![ebx_modifier, ecx_modifier, edx_modifier],
+    }
+}
+
+pub fn leaf_0xd_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0xd::*;
+
+    let mut eax_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Eax,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    eax_modifier
+        .bitmap
+        .value
+        .write_bits_in_range(&index0::eax::MPX_STATE_BITRANGE, 0)
+        .write_bits_in_range(&index0::eax::AVX512_STATE_BITRANGE, 0)
+        .write_bit(index0::eax::PKRU_BITINDEX, false);
+
+    eax_modifier.bitmap.filter = index0::eax::MPX_STATE_BITRANGE.get_mask()
+        | index0::eax::AVX512_STATE_BITRANGE.get_mask()
+        | index0::eax::PKRU_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(1),
+        modifiers: vec![eax_modifier],
+    }
+}
+
+pub fn leaf_0xd_subleaf_0x1() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0xd::*;
+
+    // EAX
+    let mut eax_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Eax,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    eax_modifier
+        .bitmap
+        .value
+        .write_bit(index1::eax::XSAVEC_SHIFT, false)
+        .write_bit(index1::eax::XGETBV_SHIFT, false)
+        .write_bit(index1::eax::XSAVES_SHIFT, false);
+
+    eax_modifier.bitmap.filter = index1::eax::XSAVEC_SHIFT.get_mask()
+        | index1::eax::XGETBV_SHIFT.get_mask()
+        | index1::eax::XSAVES_SHIFT.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x1,
+        flags: KvmCpuidFlags(1),
+        modifiers: vec![eax_modifier],
+    }
+}
+
+pub fn leaf_0x80000001_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x80000001::*;
+
+    // ECX
+    let mut ecx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ecx,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    ecx_modifier
+        .bitmap
+        .value
+        .write_bit(ecx::PREFETCH_BITINDEX, false)
+        .write_bit(ecx::LZCNT_BITINDEX, false);
+
+    ecx_modifier.bitmap.filter = ecx::PREFETCH_BITINDEX.get_mask() | ecx::LZCNT_BITINDEX.get_mask();
+
+    // EDX
+    let mut edx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Edx,
+        bitmap: RegisterValueFilter {
+            value: 0,
+            filter: 0,
+        },
+    };
+
+    edx_modifier
+        .bitmap
+        .value
+        .write_bit(edx::PDPE1GB_BITINDEX, false);
+
+    edx_modifier.bitmap.filter = edx::PDPE1GB_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(0),
+        modifiers: vec![ecx_modifier, edx_modifier],
+    }
+}

--- a/src/static_templates/tests/main_branch/intel/mod.rs
+++ b/src/static_templates/tests/main_branch/intel/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Follows a C3 template in setting up the CPUID.
+pub mod c3;
+/// Follows a T2 template in setting up the CPUID.
+pub mod t2;
+/// Follows a T2 template in setting up the CPUID.
+/// Also explicitly configures IA32_ARCH_CAPABILITIES MSR.
+pub mod t2cl;
+/// Follows a T2 template for setting up the CPUID with additional MSRs
+/// that are speciffic to an Intel Skylake CPU.
+pub mod t2s;

--- a/src/static_templates/tests/main_branch/intel/t2.rs
+++ b/src/static_templates/tests/main_branch/intel/t2.rs
@@ -1,0 +1,408 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterValueFilter,
+};
+use vmm::guest_config::templates::CpuTemplate;
+
+use crate::main_branch::bit_helper::{BitHelper, BitRangeExt};
+
+pub fn t2() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            leaf_0x1_subleaf_0x0(),
+            leaf_0x7_subleaf_0x0(),
+            leaf_0xd_subleaf_0x0(),
+            leaf_0xd_subleaf_0x1(),
+            leaf_0x80000001_subleaf_0x0(),
+            leaf_0x80000008_subleaf_0x0(),
+        ],
+        msr_modifiers: vec![],
+    }
+}
+
+pub fn leaf_0x1_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x1::*;
+
+    // EAX
+    let mut eax_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Eax,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    eax_modifier
+        .bitmap
+        .value
+        // Extended Family ID = 0
+        .write_bits_in_range(&eax::EXTENDED_FAMILY_ID_BITRANGE, 0)
+        // Extended Processor Model ID = 3 (Haswell)
+        .write_bits_in_range(&eax::EXTENDED_PROCESSOR_MODEL_BITRANGE, 3)
+        // Processor Type = 0 (Primary processor)
+        .write_bits_in_range(&eax::PROCESSOR_TYPE_BITRANGE, 0)
+        // Processor Family = 6
+        .write_bits_in_range(&eax::PROCESSOR_FAMILY_BITRANGE, 6)
+        // Processor Model = 15
+        .write_bits_in_range(&eax::PROCESSOR_MODEL_BITRANGE, 15)
+        // Stepping = 2
+        .write_bits_in_range(&eax::STEPPING_BITRANGE, 2);
+
+    eax_modifier.bitmap.filter = eax::EXTENDED_FAMILY_ID_BITRANGE.get_mask()
+        | eax::EXTENDED_PROCESSOR_MODEL_BITRANGE.get_mask()
+        | eax::PROCESSOR_TYPE_BITRANGE.get_mask()
+        | eax::PROCESSOR_FAMILY_BITRANGE.get_mask()
+        | eax::PROCESSOR_MODEL_BITRANGE.get_mask()
+        | eax::STEPPING_BITRANGE.get_mask();
+
+    // ECX
+    let mut ecx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ecx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    ecx_modifier
+        .bitmap
+        .value
+        .write_bit(ecx::DTES64_BITINDEX, false)
+        .write_bit(ecx::MONITOR_BITINDEX, false)
+        .write_bit(ecx::DS_CPL_SHIFT, false)
+        .write_bit(ecx::VMX_BITINDEX, false)
+        .write_bit(ecx::SMX_BITINDEX, false)
+        .write_bit(ecx::EIST_BITINDEX, false)
+        .write_bit(ecx::TM2_BITINDEX, false)
+        .write_bit(ecx::CNXT_ID_BITINDEX, false)
+        .write_bit(ecx::SDBG_BITINDEX, false)
+        .write_bit(ecx::XTPR_UPDATE_BITINDEX, false)
+        .write_bit(ecx::PDCM_BITINDEX, false)
+        .write_bit(ecx::DCA_BITINDEX, false);
+
+    ecx_modifier.bitmap.filter = ecx::DTES64_BITINDEX.get_mask()
+        | ecx::MONITOR_BITINDEX.get_mask()
+        | ecx::DS_CPL_SHIFT.get_mask()
+        | ecx::VMX_BITINDEX.get_mask()
+        | ecx::SMX_BITINDEX.get_mask()
+        | ecx::EIST_BITINDEX.get_mask()
+        | ecx::TM2_BITINDEX.get_mask()
+        | ecx::CNXT_ID_BITINDEX.get_mask()
+        | ecx::SDBG_BITINDEX.get_mask()
+        | ecx::XTPR_UPDATE_BITINDEX.get_mask()
+        | ecx::PDCM_BITINDEX.get_mask()
+        | ecx::DCA_BITINDEX.get_mask();
+
+    // EDX
+    let mut edx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Edx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    edx_modifier
+        .bitmap
+        .value
+        .write_bit(edx::MCE_BITINDEX, true)
+        .write_bit(edx::MTRR_BITINDEX, true)
+        .write_bit(edx::PSN_BITINDEX, false)
+        .write_bit(edx::DS_BITINDEX, false)
+        .write_bit(edx::ACPI_BITINDEX, false)
+        .write_bit(edx::SS_BITINDEX, false)
+        .write_bit(edx::TM_BITINDEX, false)
+        .write_bit(edx::IA64_BITINDEX, false)
+        .write_bit(edx::PBE_BITINDEX, false);
+
+    edx_modifier.bitmap.filter = edx::MCE_BITINDEX.get_mask()
+        | edx::MTRR_BITINDEX.get_mask()
+        | edx::PSN_BITINDEX.get_mask()
+        | edx::DS_BITINDEX.get_mask()
+        | edx::ACPI_BITINDEX.get_mask()
+        | edx::SS_BITINDEX.get_mask()
+        | edx::TM_BITINDEX.get_mask()
+        | edx::IA64_BITINDEX.get_mask()
+        | edx::PBE_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(0),
+        modifiers: vec![eax_modifier, ecx_modifier, edx_modifier],
+    }
+}
+
+pub fn leaf_0x7_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x7::index0::*;
+    use crate::main_branch::cpu_leaf::leaf_0x7::*;
+
+    // EBX
+    let mut ebx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ebx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    ebx_modifier
+        .bitmap
+        .value
+        .write_bit(ebx::SGX_BITINDEX, false)
+        .write_bit(ebx::HLE_BITINDEX, false)
+        .write_bit(ebx::FPDP_BITINDEX, false)
+        .write_bit(ebx::ERMS_BITINDEX, true)
+        .write_bit(ebx::RTM_BITINDEX, false)
+        .write_bit(ebx::RDT_M_BITINDEX, false)
+        .write_bit(ebx::FPU_CS_DS_DEPRECATE_BITINDEX, false)
+        .write_bit(ebx::MPX_BITINDEX, false)
+        .write_bit(ebx::RDT_A_BITINDEX, false)
+        .write_bit(ebx::AVX512F_BITINDEX, false)
+        .write_bit(ebx::AVX512DQ_BITINDEX, false)
+        .write_bit(ebx::RDSEED_BITINDEX, false)
+        .write_bit(ebx::ADX_BITINDEX, false)
+        .write_bit(ebx::AVX512IFMA_BITINDEX, false)
+        .write_bit(ebx::PCOMMIT_BITINDEX, false)
+        .write_bit(ebx::CLFLUSHOPT_BITINDEX, false)
+        .write_bit(ebx::CLWB_BITINDEX, false)
+        .write_bit(ebx::PT_BITINDEX, false)
+        .write_bit(ebx::AVX512PF_BITINDEX, false)
+        .write_bit(ebx::AVX512ER_BITINDEX, false)
+        .write_bit(ebx::AVX512CD_BITINDEX, false)
+        .write_bit(ebx::SHA_BITINDEX, false)
+        .write_bit(ebx::AVX512BW_BITINDEX, false)
+        .write_bit(ebx::AVX512VL_BITINDEX, false);
+
+    ebx_modifier.bitmap.filter = ebx::SGX_BITINDEX.get_mask()
+        | ebx::HLE_BITINDEX.get_mask()
+        | ebx::FPDP_BITINDEX.get_mask()
+        | ebx::ERMS_BITINDEX.get_mask()
+        | ebx::RTM_BITINDEX.get_mask()
+        | ebx::RDT_M_BITINDEX.get_mask()
+        | ebx::FPU_CS_DS_DEPRECATE_BITINDEX.get_mask()
+        | ebx::MPX_BITINDEX.get_mask()
+        | ebx::RDT_A_BITINDEX.get_mask()
+        | ebx::AVX512F_BITINDEX.get_mask()
+        | ebx::AVX512DQ_BITINDEX.get_mask()
+        | ebx::RDSEED_BITINDEX.get_mask()
+        | ebx::ADX_BITINDEX.get_mask()
+        | ebx::AVX512IFMA_BITINDEX.get_mask()
+        | ebx::PCOMMIT_BITINDEX.get_mask()
+        | ebx::CLFLUSHOPT_BITINDEX.get_mask()
+        | ebx::CLWB_BITINDEX.get_mask()
+        | ebx::PT_BITINDEX.get_mask()
+        | ebx::AVX512PF_BITINDEX.get_mask()
+        | ebx::AVX512ER_BITINDEX.get_mask()
+        | ebx::AVX512CD_BITINDEX.get_mask()
+        | ebx::SHA_BITINDEX.get_mask()
+        | ebx::AVX512BW_BITINDEX.get_mask()
+        | ebx::AVX512VL_BITINDEX.get_mask();
+
+    // ECX
+    let mut ecx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ecx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    ecx_modifier
+        .bitmap
+        .value
+        .write_bit(ecx::AVX512_VBMI_BITINDEX, false)
+        .write_bit(ecx::UMIP_BITINDEX, false)
+        .write_bit(ecx::PKU_BITINDEX, false)
+        .write_bit(ecx::OSPKE_BITINDEX, false)
+        .write_bit(ecx::AVX512_VBMI2_BITINDEX, false)
+        .write_bit(ecx::GFNI_BITINDEX, false)
+        .write_bit(ecx::VAES_BITINDEX, false)
+        .write_bit(ecx::VPCLMULQDQ_BITINDEX, false)
+        .write_bit(ecx::AVX512_VNNI_BITINDEX, false)
+        .write_bit(ecx::AVX512_BITALG_BITINDEX, false)
+        .write_bit(ecx::AVX512_VPOPCNTDQ_BITINDEX, false)
+        .write_bit(ecx::LA57_BITINDEX, false)
+        .write_bit(ecx::RDPID_BITINDEX, false)
+        .write_bit(ecx::SGX_LC_BITINDEX, false);
+
+    ecx_modifier.bitmap.filter = ecx::AVX512_VBMI_BITINDEX.get_mask()
+        | ecx::UMIP_BITINDEX.get_mask()
+        | ecx::PKU_BITINDEX.get_mask()
+        | ecx::OSPKE_BITINDEX.get_mask()
+        | ecx::AVX512_VBMI2_BITINDEX.get_mask()
+        | ecx::GFNI_BITINDEX.get_mask()
+        | ecx::VAES_BITINDEX.get_mask()
+        | ecx::VPCLMULQDQ_BITINDEX.get_mask()
+        | ecx::AVX512_VNNI_BITINDEX.get_mask()
+        | ecx::AVX512_BITALG_BITINDEX.get_mask()
+        | ecx::AVX512_VPOPCNTDQ_BITINDEX.get_mask()
+        | ecx::LA57_BITINDEX.get_mask()
+        | ecx::RDPID_BITINDEX.get_mask()
+        | ecx::SGX_LC_BITINDEX.get_mask();
+
+    // EDX
+    let mut edx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Edx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    edx_modifier
+        .bitmap
+        .value
+        .write_bit(edx::AVX512_4VNNIW_BITINDEX, false)
+        .write_bit(edx::AVX512_4FMAPS_BITINDEX, false)
+        .write_bit(edx::FSRM_BITINDEX, false)
+        .write_bit(edx::AVX512_VP2INTERSECT_BITINDEX, false);
+
+    edx_modifier.bitmap.filter = edx::AVX512_4VNNIW_BITINDEX.get_mask()
+        | edx::AVX512_4FMAPS_BITINDEX.get_mask()
+        | edx::FSRM_BITINDEX.get_mask()
+        | edx::AVX512_VP2INTERSECT_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(1),
+        modifiers: vec![ebx_modifier, ecx_modifier, edx_modifier],
+    }
+}
+
+pub fn leaf_0xd_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0xd::*;
+
+    // EAX
+    let mut eax_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Eax,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    eax_modifier
+        .bitmap
+        .value
+        .write_bits_in_range(&index0::eax::MPX_STATE_BITRANGE, 0)
+        .write_bits_in_range(&index0::eax::AVX512_STATE_BITRANGE, 0)
+        .write_bit(index0::eax::PKRU_BITINDEX, false);
+
+    eax_modifier.bitmap.filter = index0::eax::MPX_STATE_BITRANGE.get_mask()
+        | index0::eax::AVX512_STATE_BITRANGE.get_mask()
+        | index0::eax::PKRU_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(1),
+        modifiers: vec![eax_modifier],
+    }
+}
+
+pub fn leaf_0xd_subleaf_0x1() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0xd::*;
+
+    let mut eax_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Eax,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    eax_modifier
+        .bitmap
+        .value
+        .write_bit(index1::eax::XSAVEC_SHIFT, false)
+        .write_bit(index1::eax::XGETBV_SHIFT, false)
+        .write_bit(index1::eax::XSAVES_SHIFT, false);
+
+    eax_modifier.bitmap.filter = index1::eax::XSAVEC_SHIFT.get_mask()
+        | index1::eax::XGETBV_SHIFT.get_mask()
+        | index1::eax::XSAVES_SHIFT.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x1,
+        flags: KvmCpuidFlags(1),
+        modifiers: vec![eax_modifier],
+    }
+}
+
+pub fn leaf_0x80000001_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x80000001::*;
+
+    // ECX
+    let mut ecx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ecx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    ecx_modifier
+        .bitmap
+        .value
+        .write_bit(ecx::PREFETCH_BITINDEX, false)
+        .write_bit(ecx::MWAIT_EXTENDED_BITINDEX, false);
+
+    ecx_modifier.bitmap.filter =
+        ecx::PREFETCH_BITINDEX.get_mask() | ecx::MWAIT_EXTENDED_BITINDEX.get_mask();
+
+    // EDX
+    let mut edx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Edx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    edx_modifier
+        .bitmap
+        .value
+        .write_bit(edx::PDPE1GB_BITINDEX, false);
+
+    edx_modifier.bitmap.filter = edx::PDPE1GB_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(0),
+        modifiers: vec![ecx_modifier, edx_modifier],
+    }
+}
+
+pub fn leaf_0x80000008_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x80000008::*;
+
+    // EBX
+    let mut ebx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ebx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    ebx_modifier
+        .bitmap
+        .value
+        .write_bit(ebx::WBNOINVD_BITINDEX, false);
+
+    ebx_modifier.bitmap.filter = ebx::WBNOINVD_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(0),
+        modifiers: vec![ebx_modifier],
+    }
+}

--- a/src/static_templates/tests/main_branch/intel/t2cl.rs
+++ b/src/static_templates/tests/main_branch/intel/t2cl.rs
@@ -1,0 +1,104 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::arch::x86_64::msr::{ArchCapaMSRFlags, MSR_IA32_ARCH_CAPABILITIES};
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterModifier, RegisterValueFilter,
+};
+use vmm::guest_config::templates::CpuTemplate;
+
+use crate::main_branch::bit_helper::{BitHelper, BitRangeExt};
+
+pub fn t2cl() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            super::t2::leaf_0x1_subleaf_0x0(),
+            super::t2::leaf_0x7_subleaf_0x0(),
+            super::t2::leaf_0xd_subleaf_0x0(),
+            super::t2::leaf_0xd_subleaf_0x1(),
+            leaf_0x80000001_subleaf_0x0(),
+            super::t2::leaf_0x80000008_subleaf_0x0(),
+        ],
+        msr_modifiers: vec![msr_0x10a()],
+    }
+}
+
+pub fn leaf_0x80000001_subleaf_0x0() -> CpuidLeafModifier {
+    use crate::main_branch::cpu_leaf::leaf_0x80000001::*;
+
+    // ECX
+    let mut ecx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Ecx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    ecx_modifier
+        .bitmap
+        .value
+        .write_bit(ecx::SSE4A_BITINDEX, false)
+        .write_bit(ecx::MISALIGN_SSE_BITINDEX, false)
+        .write_bit(ecx::PREFETCH_BITINDEX, false)
+        .write_bit(ecx::MWAIT_EXTENDED_BITINDEX, false);
+
+    ecx_modifier.bitmap.filter = ecx::SSE4A_BITINDEX.get_mask()
+        | ecx::MISALIGN_SSE_BITINDEX.get_mask()
+        | ecx::PREFETCH_BITINDEX.get_mask()
+        | ecx::MWAIT_EXTENDED_BITINDEX.get_mask();
+
+    // EDX
+    let mut edx_modifier = CpuidRegisterModifier {
+        register: CpuidRegister::Edx,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    edx_modifier
+        .bitmap
+        .value
+        .write_bit(edx::MMX_EXT_BITINDEX, false)
+        .write_bit(edx::MMX_BITINDEX, false)
+        .write_bit(edx::FXSR_BITINDEX, false)
+        .write_bit(edx::FFXSR_BITINDEX, false)
+        .write_bit(edx::PDPE1GB_BITINDEX, false);
+
+    edx_modifier.bitmap.filter = edx::MMX_EXT_BITINDEX.get_mask()
+        | edx::MMX_BITINDEX.get_mask()
+        | edx::FXSR_BITINDEX.get_mask()
+        | edx::FFXSR_BITINDEX.get_mask()
+        | edx::PDPE1GB_BITINDEX.get_mask();
+
+    CpuidLeafModifier {
+        leaf: LEAF_NUM,
+        subleaf: 0x0,
+        flags: KvmCpuidFlags(0),
+        modifiers: vec![ecx_modifier, edx_modifier],
+    }
+}
+
+fn msr_0x10a() -> RegisterModifier {
+    let mut modifier = RegisterModifier {
+        addr: MSR_IA32_ARCH_CAPABILITIES,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    modifier.bitmap.value = (ArchCapaMSRFlags::RDCL_NO
+        | ArchCapaMSRFlags::IBRS_ALL
+        | ArchCapaMSRFlags::SKIP_L1DFL_VMENTRY
+        | ArchCapaMSRFlags::MDS_NO
+        | ArchCapaMSRFlags::IF_PSCHANGE_MC_NO
+        | ArchCapaMSRFlags::TSX_CTRL)
+        .bits();
+
+    modifier.bitmap.filter = u64::MAX;
+
+    modifier
+}

--- a/src/static_templates/tests/main_branch/intel/t2s.rs
+++ b/src/static_templates/tests/main_branch/intel/t2s.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::arch::x86_64::msr::{ArchCapaMSRFlags, MSR_IA32_ARCH_CAPABILITIES};
+use vmm::guest_config::templates::x86_64::{RegisterModifier, RegisterValueFilter};
+use vmm::guest_config::templates::CpuTemplate;
+
+pub fn t2s() -> CpuTemplate {
+    CpuTemplate {
+        cpuid_modifiers: vec![
+            super::t2::leaf_0x1_subleaf_0x0(),
+            super::t2::leaf_0x7_subleaf_0x0(),
+            super::t2::leaf_0xd_subleaf_0x0(),
+            super::t2::leaf_0xd_subleaf_0x1(),
+            super::t2::leaf_0x80000001_subleaf_0x0(),
+            super::t2::leaf_0x80000008_subleaf_0x0(),
+        ],
+        msr_modifiers: vec![msr_0x10a()],
+    }
+}
+
+pub fn msr_0x10a() -> RegisterModifier {
+    let mut modifier = RegisterModifier {
+        addr: MSR_IA32_ARCH_CAPABILITIES,
+        bitmap: RegisterValueFilter {
+            filter: 0,
+            value: 0,
+        },
+    };
+
+    modifier.bitmap.value = (ArchCapaMSRFlags::RSBA
+        | ArchCapaMSRFlags::SKIP_L1DFL_VMENTRY
+        | ArchCapaMSRFlags::IF_PSCHANGE_MC_NO
+        | ArchCapaMSRFlags::MISC_PACKAGE_CTRLS
+        | ArchCapaMSRFlags::ENERGY_FILTERING_CTL)
+        .bits();
+
+    modifier.bitmap.filter = u64::MAX;
+
+    modifier
+}

--- a/src/static_templates/tests/main_branch/mod.rs
+++ b/src/static_templates/tests/main_branch/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copied from main branch.
+// https://github.com/firecracker-microvm/firecracker/tree/d79b7d456db28e8a34b174a48067da2376a63f14/src/vmm/src/cpuid/template
+
+// Contains Intel specific templates.
+pub mod intel;
+// Contains AMD specific templates.
+pub mod amd;
+
+mod bit_helper;
+mod cpu_leaf;

--- a/tests/framework/dependencies.txt
+++ b/tests/framework/dependencies.txt
@@ -65,6 +65,7 @@
  'serde_json',
  'shlex',
  'snapshot',
+ 'static_templates',
  'subtle',
  'syn',
  'thiserror',

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,14 +25,14 @@ def is_on_skylake():
 # differences may appear.
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {
-        "Intel": 81.93 if is_on_skylake() else 84.37,
-        "AMD": 84.68,
+        "Intel": 82.32 if is_on_skylake() else 84.71,
+        "AMD": 85.00,
         "ARM": 82.44,
     }
 else:
     COVERAGE_DICT = {
-        "Intel": 79.46 if is_on_skylake() else 81.88,
-        "AMD": 82.19,
+        "Intel": 79.9 if is_on_skylake() else 82.27,
+        "AMD": 82.56,
         "ARM": 79.37,
     }
 


### PR DESCRIPTION
## Changes

Add static CPU templates defined in JSON format and new `CpuTemplate` type.

## Reason

To test custom CPU template logic, we need some sample CPU templates in the JSON format. And, static CPU templates defined with the new `CpuTemplate` type is required to integrate static and custom CPU template handling into one logic.

The crate is added separately from vmm crate temporarily, because much changes are required to integrate static and custom CPU template on vmm crate as of now. The actual integration will be done in follow-up commits. To test that CPU templates defined in the JSON format and `CpuTemplate` type are consistent with the static CPU templates defined in main branch, some logics are put back here. But those should be removed when deleting this crate.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- ~~[ ] This functionality cannot be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
