### PR TITLE
Add spectre_meltdown_checker and vulnerabilities tests for restored guests

### DIFF
--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -4,7 +4,7 @@
 # N.B.: Although this repository is released under the Apache-2.0, part of its test requires a
 # script from the third party "Spectre & Meltdown Checker" project. This script is under the
 # GPL-3.0-only license.
-"""Tests spectre / meltdown mitigation."""
+"""Tests vulnerabilities mitigations."""
 
 from pathlib import Path
 


### PR DESCRIPTION
## Changes

- Add tests to check for reported vulnerabilities in `/sys/devices/system/cpu/vulnerabilities/*` files
- Add tests to run the `spectre_meltdown_checker.sh` script on restored guests
- Add tests to check the vulnerabilities files on restored guests.

## Reason

At the moment the `spectre_meltdown_checker.sh` script is only run on the launched guests. Guests restored from a snapshot are not exercised in a similar way.
Kernel's sysfs interfaces exposes vulnerabilities files that may report something other than Meltdown and Spectre.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
