### PR TITLE
feat: Add "cpu-config" field to config file

### DIFF
--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -809,6 +809,7 @@ mod tests {
     "kernel_image_path": "",
     "initrd_path": null
   }},
+  "cpu-config": null,
   "logger": null,
   "machine-config": {{
     "vcpu_count": 1,

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -22,6 +22,7 @@
     "smt": false,
     "track_dirty_pages": false
   },
+  "cpu-config": null,
   "balloon": null,
   "network-interfaces": [],
   "vsock": null,

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1167,6 +1167,8 @@ def test_get_full_config_after_restoring_snapshot(bin_cloner_path):
 
     test_microvm.machine_cfg.patch(**setup_cfg["machine-config"])
 
+    setup_cfg["cpu-config"] = None
+
     setup_cfg["drives"] = [
         {
             "drive_id": "rootfs",
@@ -1280,6 +1282,7 @@ def test_get_full_config(test_microvm_with_api):
         "smt": False,
         "track_dirty_pages": False,
     }
+    expected_cfg["cpu-config"] = None
     expected_cfg["boot-source"] = {
         "kernel_image_path": "/vmlinux.bin",
         "initrd_path": None,


### PR DESCRIPTION
## Changes

- Add a new "cpu-config" field into the existing fireracker config file.

## Reason

"cpu-config" PUT API was added in PR #3547 to set custom CPU template via API socket. Need to add the field to accept custom CPU template without API

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
