### PR TITLE
test: m6a vsock throughput baselines

### DIFF
--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -1352,7 +1352,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -1360,7 +1360,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -1384,11 +1384,11 @@
                                                     "target": 196
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 173
+                                                    "delta_percentage": 15,
+                                                    "target": 165
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 112
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -1396,11 +1396,11 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 122
+                                                    "delta_percentage": 5,
+                                                    "target": 121
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 113
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -1408,7 +1408,7 @@
                                                     "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 123
                                                 }
                                             }
@@ -1424,7 +1424,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -1448,31 +1448,31 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 40,
-                                                    "target": 118
+                                                    "delta_percentage": 38,
+                                                    "target": 129
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 197
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 145
+                                                    "target": 143
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 105
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 118
+                                                    "delta_percentage": 6,
+                                                    "target": 119
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 105
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -1494,27 +1494,27 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 25,
-                                                    "target": 37
+                                                    "delta_percentage": 11,
+                                                    "target": 44
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 13,
-                                                    "target": 36
+                                                    "target": 40
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 46
+                                                    "delta_percentage": 11,
+                                                    "target": 47
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 11,
                                                     "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 46
+                                                    "delta_percentage": 12,
+                                                    "target": 48
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 59
                                                 }
                                             }
@@ -1522,39 +1522,39 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 63
+                                                    "delta_percentage": 9,
+                                                    "target": 66
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 64
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 16,
                                                     "target": 58
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 62
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 61
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 72
+                                                    "delta_percentage": 9,
+                                                    "target": 71
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 8,
                                                     "target": 62
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 61
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 8,
                                                     "target": 71
                                                 }
                                             }
@@ -1566,7 +1566,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 45
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -1574,15 +1574,15 @@
                                                     "target": 39
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 15,
+                                                    "delta_percentage": 10,
                                                     "target": 32
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 59
+                                                    "target": 60
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 15,
+                                                    "delta_percentage": 14,
                                                     "target": 32
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -1594,27 +1594,27 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 34,
-                                                    "target": 47
+                                                    "delta_percentage": 31,
+                                                    "target": 51
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 63
+                                                    "delta_percentage": 7,
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 56
+                                                    "delta_percentage": 11,
+                                                    "target": 57
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 59
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 37
+                                                    "delta_percentage": 11,
+                                                    "target": 36
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 71
                                                 },
                                                 "vsock-pDEFAULT-bd": {
@@ -1622,11 +1622,11 @@
                                                     "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 17,
+                                                    "delta_percentage": 13,
                                                     "target": 37
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 70
                                                 }
                                             }
@@ -1640,68 +1640,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 92,
-                                                    "target": 1923
+                                                    "delta_percentage": 15,
+                                                    "target": 2899
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 2068
+                                                    "target": 2495
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 9372
+                                                    "delta_percentage": 5,
+                                                    "target": 9560
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 6111
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 9432
+                                                    "delta_percentage": 8,
+                                                    "target": 9679
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 5991
+                                                    "target": 6016
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1886
+                                                    "delta_percentage": 10,
+                                                    "target": 2716
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 4362
+                                                    "delta_percentage": 7,
+                                                    "target": 4461
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 2750
+                                                    "delta_percentage": 11,
+                                                    "target": 2974
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 6996
+                                                    "delta_percentage": 7,
+                                                    "target": 7168
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 11526
+                                                    "delta_percentage": 9,
+                                                    "target": 11582
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7561
+                                                    "delta_percentage": 10,
+                                                    "target": 7720
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 6982
+                                                    "target": 7112
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 11438
+                                                    "delta_percentage": 10,
+                                                    "target": 11626
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 7487
+                                                    "delta_percentage": 7,
+                                                    "target": 7645
                                                 }
                                             }
                                         }
@@ -1712,68 +1712,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 3422
+                                                    "delta_percentage": 6,
+                                                    "target": 3400
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 2880
+                                                    "target": 2866
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 17364
+                                                    "delta_percentage": 8,
+                                                    "target": 17470
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 6179
+                                                    "target": 6103
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 17350
+                                                    "delta_percentage": 8,
+                                                    "target": 17500
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 6071
+                                                    "target": 5956
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 16,
-                                                    "target": 3425
+                                                    "delta_percentage": 17,
+                                                    "target": 3551
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 4576
+                                                    "target": 4467
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 4111
+                                                    "target": 4137
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 7331
+                                                    "target": 7336
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 24728
+                                                    "delta_percentage": 8,
+                                                    "target": 25013
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 8606
+                                                    "delta_percentage": 8,
+                                                    "target": 8698
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7274
+                                                    "delta_percentage": 9,
+                                                    "target": 7347
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 24974
+                                                    "delta_percentage": 9,
+                                                    "target": 25119
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 8221
+                                                    "target": 8365
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
@@ -1348,7 +1348,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -1380,12 +1380,12 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 18,
-                                                    "target": 140
+                                                    "delta_percentage": 19,
+                                                    "target": 145
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 172
+                                                    "target": 173
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
@@ -1401,7 +1401,7 @@
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 116
+                                                    "target": 115
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
@@ -1409,7 +1409,7 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 126
+                                                    "target": 128
                                                 }
                                             }
                                         }
@@ -1440,7 +1440,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
@@ -1452,8 +1452,8 @@
                                                     "target": 107
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 22,
-                                                    "target": 137
+                                                    "delta_percentage": 25,
+                                                    "target": 145
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
@@ -1461,7 +1461,7 @@
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 104
+                                                    "target": 105
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
@@ -1469,10 +1469,10 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 122
+                                                    "target": 121
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 105
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -1480,7 +1480,7 @@
                                                     "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 118
                                                 }
                                             }
@@ -1494,28 +1494,28 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 12,
                                                     "target": 47
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 42
+                                                    "delta_percentage": 9,
+                                                    "target": 43
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 17,
-                                                    "target": 49
+                                                    "delta_percentage": 16,
+                                                    "target": 50
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 60
+                                                    "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 19,
+                                                    "delta_percentage": 16,
                                                     "target": 50
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 59
+                                                    "delta_percentage": 8,
+                                                    "target": 60
                                                 }
                                             }
                                         },
@@ -1530,31 +1530,31 @@
                                                     "target": 69
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 64
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 63
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 12,
                                                     "target": 62
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 74
+                                                    "delta_percentage": 8,
+                                                    "target": 73
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 63
+                                                    "delta_percentage": 9,
+                                                    "target": 64
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 63
+                                                    "delta_percentage": 11,
+                                                    "target": 62
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 74
                                                 }
                                             }
@@ -1566,67 +1566,67 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 49
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 11,
-                                                    "target": 41
+                                                    "target": 42
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 34
+                                                    "delta_percentage": 14,
+                                                    "target": 33
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 60
+                                                    "delta_percentage": 8,
+                                                    "target": 61
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 15,
+                                                    "delta_percentage": 16,
                                                     "target": 34
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 59
+                                                    "delta_percentage": 9,
+                                                    "target": 60
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 11,
                                                     "target": 46
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 68
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 60
+                                                    "delta_percentage": 10,
+                                                    "target": 61
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 60
+                                                    "target": 61
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 39
+                                                    "delta_percentage": 10,
+                                                    "target": 38
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 69
+                                                    "target": 70
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 59
+                                                    "delta_percentage": 8,
+                                                    "target": 60
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 10,
                                                     "target": 39
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 69
                                                 }
                                             }
@@ -1640,28 +1640,28 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 2811
+                                                    "delta_percentage": 17,
+                                                    "target": 2807
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 2484
+                                                    "target": 2483
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 15,
-                                                    "target": 9590
+                                                    "target": 9455
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 6774
+                                                    "delta_percentage": 8,
+                                                    "target": 6809
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 9616
+                                                    "delta_percentage": 14,
+                                                    "target": 9513
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 6659
+                                                    "delta_percentage": 8,
+                                                    "target": 6658
                                                 }
                                             }
                                         },
@@ -1669,39 +1669,39 @@
                                             "total": {
                                                 "vsock-p1024-bd": {
                                                     "delta_percentage": 13,
-                                                    "target": 2570
+                                                    "target": 2555
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 4036
+                                                    "target": 4047
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 2933
+                                                    "delta_percentage": 7,
+                                                    "target": 2934
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 7782
+                                                    "delta_percentage": 8,
+                                                    "target": 7775
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 19,
-                                                    "target": 11365
+                                                    "delta_percentage": 15,
+                                                    "target": 11398
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 8074
+                                                    "delta_percentage": 8,
+                                                    "target": 8107
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7678
+                                                    "delta_percentage": 8,
+                                                    "target": 7698
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 17,
-                                                    "target": 11455
+                                                    "delta_percentage": 15,
+                                                    "target": 11308
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7968
+                                                    "delta_percentage": 6,
+                                                    "target": 8006
                                                 }
                                             }
                                         }
@@ -1712,28 +1712,28 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3199
+                                                    "delta_percentage": 7,
+                                                    "target": 3192
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 2851
+                                                    "target": 2838
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 18043
+                                                    "target": 17921
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 6781
+                                                    "target": 6754
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 18144
+                                                    "delta_percentage": 9,
+                                                    "target": 18027
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 6570
+                                                    "target": 6544
                                                 }
                                             }
                                         },
@@ -1741,39 +1741,39 @@
                                             "total": {
                                                 "vsock-p1024-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 3257
+                                                    "target": 3248
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 4014
+                                                    "target": 4040
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 4003
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 10,
-                                                    "target": 8084
+                                                    "delta_percentage": 9,
+                                                    "target": 7990
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 25252
+                                                    "target": 25278
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 8325
+                                                    "delta_percentage": 9,
+                                                    "target": 8328
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 8090
+                                                    "target": 7998
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 25388
+                                                    "target": 25296
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 7989
+                                                    "delta_percentage": 9,
+                                                    "target": 7975
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes

Re-gathered m6a.metal vsock throughput performance test baselines to incorporate a performance improvement.

## Reason

Failing CI due to out of date performance numbers.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
