### PR TITLE
Add CPU template benchmarking for JSON ops

### DIFF
--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -315,7 +315,7 @@ pub mod tests {
 
     use micro_http::HttpConnection;
     use vmm::builder::StartMicrovmError;
-    use vmm::guest_config::templates::CustomCpuTemplate;
+    use vmm::guest_config::templates::test_utils::build_test_template;
     use vmm::resources::VmmConfig;
     use vmm::rpc_interface::VmmActionError;
     use vmm::vmm_config::balloon::{BalloonDeviceConfig, BalloonStats};
@@ -961,7 +961,7 @@ pub mod tests {
         let (mut sender, receiver) = UnixStream::pair().unwrap();
         let mut connection = HttpConnection::new(receiver);
 
-        let cpu_template = CustomCpuTemplate::build_test_template();
+        let cpu_template = build_test_template();
         let cpu_config_json_result = serde_json::to_string(&cpu_template);
         assert!(
             cpu_config_json_result.is_ok(),

--- a/src/api_server/src/request/cpu_configuration.rs
+++ b/src/api_server/src/request/cpu_configuration.rs
@@ -24,6 +24,9 @@ pub(crate) fn parse_put_cpu_config(body: &Body) -> Result<ParsedRequest, Error> 
 mod tests {
     use logger::{IncMetric, METRICS};
     use micro_http::Body;
+    use vmm::guest_config::templates::test_utils::{
+        build_test_template, TEST_INVALID_TEMPLATE_JSON,
+    };
     use vmm::rpc_interface::VmmAction;
 
     use super::*;
@@ -31,7 +34,7 @@ mod tests {
 
     #[test]
     fn test_parse_put_cpu_config_request() {
-        let cpu_template = CustomCpuTemplate::build_test_template();
+        let cpu_template = build_test_template();
         let cpu_config_json_result = serde_json::to_string(&cpu_template);
         assert!(
             &cpu_config_json_result.is_ok(),
@@ -78,8 +81,7 @@ mod tests {
         );
 
         // Test request with invalid fields
-        let invalid_put_result =
-            parse_put_cpu_config(&Body::new(CustomCpuTemplate::TEST_INVALID_TEMPLATE_JSON));
+        let invalid_put_result = parse_put_cpu_config(&Body::new(TEST_INVALID_TEMPLATE_JSON));
         expected_err_count += 1;
 
         assert!(invalid_put_result.is_err());

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -40,5 +40,9 @@ criterion = { version = "0.4.0", default-features = false }
 device_tree = "1.1.0"
 
 [[bench]]
-name = "main"
+name = "cpu_templates"
+harness = false
+
+[[bench]]
+name = "snapshots"
 harness = false

--- a/src/vmm/benches/cpu_templates.rs
+++ b/src/vmm/benches/cpu_templates.rs
@@ -1,0 +1,37 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Benchmarking cases:
+//   * `CustomCpuTemplate` Deserialization
+
+use std::path::Path;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use vmm::guest_config::templates::test_utils::TEST_TEMPLATE_JSON;
+use vmm::guest_config::templates::CustomCpuTemplate;
+
+#[inline]
+pub fn bench_deserialize_cpu_template(cpu_template_str: &str) {
+    serde_json::from_str::<CustomCpuTemplate>(cpu_template_str);
+}
+
+pub fn cpu_template_benchmark(c: &mut Criterion) {
+    println!(
+        "Template size (JSON string): [{}] bytes.",
+        TEST_TEMPLATE_JSON.len()
+    );
+
+    c.bench_function("Deserialize custom CPU Template", |b| {
+        b.iter(|| bench_deserialize_cpu_template(TEST_TEMPLATE_JSON))
+    });
+}
+
+criterion_group! {
+    name = cpu_template_benches;
+    config = Criterion::default().sample_size(200).output_directory(Path::new("../../build/vmm_benchmark/cpu_templates"));
+    targets = cpu_template_benchmark
+}
+
+criterion_main! {
+    cpu_template_benches
+}

--- a/src/vmm/benches/cpu_templates.rs
+++ b/src/vmm/benches/cpu_templates.rs
@@ -2,13 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Benchmarking cases:
-//   * `CustomCpuTemplate` Deserialization
+//   * `CustomCpuTemplate` JSON deserialization
+//   * `CustomCpuTemplate` JSON serialization
 
+use std::mem::size_of_val;
 use std::path::Path;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use vmm::guest_config::templates::test_utils::TEST_TEMPLATE_JSON;
+use vmm::guest_config::templates::test_utils::{build_test_template, TEST_TEMPLATE_JSON};
 use vmm::guest_config::templates::CustomCpuTemplate;
+
+#[inline]
+pub fn bench_serialize_cpu_template(cpu_template: &CustomCpuTemplate) {
+    serde_json::to_string(cpu_template);
+}
 
 #[inline]
 pub fn bench_deserialize_cpu_template(cpu_template_str: &str) {
@@ -17,12 +24,22 @@ pub fn bench_deserialize_cpu_template(cpu_template_str: &str) {
 
 pub fn cpu_template_benchmark(c: &mut Criterion) {
     println!(
-        "Template size (JSON string): [{}] bytes.",
+        "Deserialization test - Template size (JSON string): [{}] bytes.",
         TEST_TEMPLATE_JSON.len()
     );
 
-    c.bench_function("Deserialize custom CPU Template", |b| {
+    let test_cpu_template = build_test_template();
+    println!(
+        "Serialization test - Template size: [{}] bytes.",
+        size_of_val(&test_cpu_template)
+    );
+
+    c.bench_function("deserialize_cpu_template", |b| {
         b.iter(|| bench_deserialize_cpu_template(TEST_TEMPLATE_JSON))
+    });
+
+    c.bench_function("serialize_cpu_template", |b| {
+        b.iter(|| bench_serialize_cpu_template(&test_cpu_template))
     });
 }
 

--- a/src/vmm/benches/snapshots.rs
+++ b/src/vmm/benches/snapshots.rs
@@ -110,7 +110,7 @@ fn create_microvm_state(is_diff: bool) -> MicrovmState {
     microvm_state
 }
 
-pub fn criterion_benchmark(c: &mut Criterion) {
+pub fn snapshot_benchmark(c: &mut Criterion) {
     let version_map = VERSION_MAP.clone();
 
     // Create the microvm state
@@ -178,11 +178,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 }
 
 criterion_group! {
-    name = benches;
-    config = Criterion::default().sample_size(200).output_directory(Path::new("../../build/vmm_benchmark"));
-    targets = criterion_benchmark
+    name = snapshot_benches;
+    config = Criterion::default().sample_size(200).output_directory(Path::new("../../build/vmm_benchmark/snapshots"));
+    targets = snapshot_benchmark
 }
 
 criterion_main! {
-    benches
+    snapshot_benches
 }

--- a/src/vmm/src/guest_config/templates/aarch64.rs
+++ b/src/vmm/src/guest_config/templates/aarch64.rs
@@ -179,63 +179,12 @@ impl CustomCpuTemplate {
     }
 }
 
-// TODO mark with #[cfg(test)] when we combine all crates into
-// one firecracker crate
-impl CustomCpuTemplate {
-    /// Test CPU template in JSON format
-    pub const TEST_TEMPLATE_JSON: &str = r#"{
-        "reg_modifiers":  [
-            {
-                "addr": "0x0AAC",
-                "bitmap": "0b1xx1"
-            },
-            {
-                "addr": "0x0AAB",
-                "bitmap": "0b1x00"
-            }
-        ]
-    }"#;
-
-    /// Test CPU template in JSON format but has an invalid field for the architecture.
-    /// "msr_modifiers" is the field name for the model specific registers for
-    /// defined by x86 CPUs.
-    pub const TEST_INVALID_TEMPLATE_JSON: &str = r#"{
-        "msr_modifiers":  [
-            {
-                "addr": "0x0AAC",
-                "bitmap": "0b1xx1"
-            }
-        ]
-    }"#;
-
-    /// Builds a sample custom CPU template
-    pub fn build_test_template() -> CustomCpuTemplate {
-        CustomCpuTemplate {
-            reg_modifiers: vec![
-                RegisterModifier {
-                    addr: 0x9999,
-                    bitmap: RegisterValueFilter {
-                        filter: 0b100010001,
-                        value: 0b100000001,
-                    },
-                },
-                RegisterModifier {
-                    addr: 0x8000,
-                    bitmap: RegisterValueFilter {
-                        filter: 0b1110,
-                        value: 0b0110,
-                    },
-                },
-            ],
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::Value;
 
     use super::*;
+    use crate::guest_config::templates::test_utils::{build_test_template, TEST_TEMPLATE_JSON};
 
     #[test]
     fn test_get_cpu_template_with_no_template() {
@@ -382,15 +331,14 @@ mod tests {
 
     #[test]
     fn test_deserialization_lifecycle() {
-        let cpu_config =
-            serde_json::from_str::<CustomCpuTemplate>(CustomCpuTemplate::TEST_TEMPLATE_JSON)
-                .expect("Failed to deserialize custom CPU template.");
+        let cpu_config = serde_json::from_str::<CustomCpuTemplate>(TEST_TEMPLATE_JSON)
+            .expect("Failed to deserialize custom CPU template.");
         assert_eq!(2, cpu_config.reg_modifiers.len());
     }
 
     #[test]
     fn test_serialization_lifecycle() {
-        let template = CustomCpuTemplate::build_test_template();
+        let template = build_test_template();
         let template_json_str_result = serde_json::to_string_pretty(&template);
         assert!(&template_json_str_result.is_ok());
         let template_json = template_json_str_result.unwrap();
@@ -406,7 +354,7 @@ mod tests {
     fn test_bitmap_width() {
         let mut checked = false;
 
-        let template = CustomCpuTemplate::build_test_template();
+        let template = build_test_template();
 
         let aarch64_template_str =
             serde_json::to_string(&template).expect("Error serializing aarch64 template");

--- a/src/vmm/src/guest_config/templates/mod.rs
+++ b/src/vmm/src/guest_config/templates/mod.rs
@@ -8,6 +8,9 @@
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
+/// Utility module for testing guest_configuration.
+pub mod test_utils;
+
 #[cfg(target_arch = "x86_64")]
 mod common_types {
     pub use crate::guest_config::templates::x86_64::CustomCpuTemplate;

--- a/src/vmm/src/guest_config/templates/test_utils/aarch64.rs
+++ b/src/vmm/src/guest_config/templates/test_utils/aarch64.rs
@@ -1,0 +1,57 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(target_arch = "aarch64")]
+use crate::guest_config::templates::aarch64::{RegisterModifier, RegisterValueFilter};
+use crate::guest_config::templates::CustomCpuTemplate;
+
+/// Test CPU template in JSON format
+#[cfg(target_arch = "aarch64")]
+pub const TEST_TEMPLATE_JSON: &str = r#"{
+    "reg_modifiers":  [
+        {
+            "addr": "0x0AAC",
+            "bitmap": "0b1xx1"
+        },
+        {
+            "addr": "0x0AAB",
+            "bitmap": "0b1x00"
+        }
+    ]
+}"#;
+
+/// Test CPU template in JSON format but has an invalid field for the architecture.
+/// "msr_modifiers" is the field name for the model specific registers for
+/// defined by x86 CPUs.
+#[cfg(target_arch = "aarch64")]
+pub const TEST_INVALID_TEMPLATE_JSON: &str = r#"{
+    "msr_modifiers":  [
+        {
+            "addr": "0x0AAC",
+            "bitmap": "0b1xx1"
+        }
+    ]
+}"#;
+
+/// Builds a sample custom CPU template
+#[cfg(target_arch = "aarch64")]
+pub fn build_test_template() -> CustomCpuTemplate {
+    CustomCpuTemplate {
+        reg_modifiers: vec![
+            RegisterModifier {
+                addr: 0x9999,
+                bitmap: RegisterValueFilter {
+                    filter: 0b100010001,
+                    value: 0b100000001,
+                },
+            },
+            RegisterModifier {
+                addr: 0x8000,
+                bitmap: RegisterValueFilter {
+                    filter: 0b1110,
+                    value: 0b0110,
+                },
+            },
+        ],
+    }
+}

--- a/src/vmm/src/guest_config/templates/test_utils/mod.rs
+++ b/src/vmm/src/guest_config/templates/test_utils/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Aarch64 sub-module reference for "use" statements
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+/// x86_64 sub-module reference for "use" statements
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64;
+
+/// The following wildcard imports enables consumers of the test_utils module
+/// to not be concerned with the architecture in question.
+
+/// Test data unique to aarch64 platforms
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;
+/// Test data unique to x86_64 platforms
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::*;

--- a/src/vmm/src/guest_config/templates/test_utils/x86_64.rs
+++ b/src/vmm/src/guest_config/templates/test_utils/x86_64.rs
@@ -1,0 +1,172 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(target_arch = "x86_64")]
+use crate::guest_config::cpuid::KvmCpuidFlags;
+#[cfg(target_arch = "x86_64")]
+use crate::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterModifier, RegisterValueFilter,
+};
+use crate::guest_config::templates::CustomCpuTemplate;
+
+/// Test CPU template in JSON format
+#[cfg(target_arch = "x86_64")]
+pub const TEST_TEMPLATE_JSON: &str = r#"{
+    "cpuid_modifiers": [
+        {
+            "leaf": "0x80000001",
+            "subleaf": "0x0007",
+            "flags": 0,
+            "modifiers": [
+                {
+                    "register": "eax",
+                    "bitmap": "0bx00100xxx1xxxxxxxxxxxxxxxxxxxxx1"
+                }
+            ]
+        },
+        {
+            "leaf": "0x80000002",
+            "subleaf": "0x0004",
+            "flags": 0,
+            "modifiers": [
+                {
+                    "register": "ebx",
+                    "bitmap": "0bxxx1xxxxxxxxxxxxxxxxxxxxx1"
+                },
+                {
+                    "register": "ecx",
+                    "bitmap": "0bx00100xxx1xxxxxxxxxxx0xxxxx0xxx1"
+                }
+            ]
+        },
+        {
+            "leaf": "0x80000003",
+            "subleaf": "0x0004",
+            "flags": 0,
+            "modifiers": [
+                {
+                    "register": "edx",
+                    "bitmap": "0bx00100xxx1xxxxxxxxxxx0xxxxx0xxx1"
+                }
+            ]
+        },
+        {
+            "leaf": "0x80000004",
+            "subleaf": "0x0004",
+            "flags": 0,
+            "modifiers": [
+                {
+                    "register": "edx",
+                    "bitmap": "0b00100xxx1xxxxxx1xxxxxxxxxxxxxx1"
+                },
+                {
+                    "register": "ecx",
+                    "bitmap": "0bx00100xxx1xxxxxxxxxxxxx111xxxxx1"
+                }
+            ]
+        },
+        {
+            "leaf": "0x80000005",
+            "subleaf": "0x0004",
+            "flags": 0,
+            "modifiers": [
+                {
+                    "register": "eax",
+                    "bitmap": "0bx00100xxx1xxxxx00xxxxxx000xxxxx1"
+                },
+                {
+                    "register": "edx",
+                    "bitmap": "0bx10100xxx1xxxxxxxxxxxxx000xxxxx1"
+                }
+            ]
+        }
+    ],
+    "msr_modifiers":  [
+        {
+            "addr": "0x0",
+            "bitmap": "0bx00100xxx1xxxx00xxx1xxxxxxxxxxx1"
+        },
+        {
+            "addr": "0x1",
+            "bitmap": "0bx00111xxx1xxxx111xxxxx101xxxxxx1"
+        },
+        {
+            "addr": "2",
+            "bitmap": "0bx00100xxx1xxxxxx0000000xxxxxxxx1"
+        },
+        {
+            "addr": "0xbbca",
+            "bitmap": "0bx00100xxx1xxxxxxxxx1"
+        }
+    ]
+}"#;
+
+/// Test CPU template in JSON format but has an invalid field for the architecture.
+/// "reg_modifiers" is the field name for the registers for aarch64"
+#[cfg(target_arch = "x86_64")]
+pub const TEST_INVALID_TEMPLATE_JSON: &str = r#"{
+    "reg_modifiers":  [
+        {
+            "addr": "0x0AAC",
+            "bitmap": "0b1xx1"
+        }
+    ]
+}"#;
+
+/// Builds a sample custom CPU template
+#[cfg(target_arch = "x86_64")]
+pub fn build_test_template() -> CustomCpuTemplate {
+    CustomCpuTemplate {
+        cpuid_modifiers: vec![CpuidLeafModifier {
+            leaf: 0x3,
+            subleaf: 0x0,
+            flags: KvmCpuidFlags(kvm_bindings::KVM_CPUID_FLAG_STATEFUL_FUNC),
+            modifiers: vec![
+                CpuidRegisterModifier {
+                    register: CpuidRegister::Eax,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b0111,
+                        value: 0b0101,
+                    },
+                },
+                CpuidRegisterModifier {
+                    register: CpuidRegister::Ebx,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b0111,
+                        value: 0b0100,
+                    },
+                },
+                CpuidRegisterModifier {
+                    register: CpuidRegister::Ecx,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b0111,
+                        value: 0b0111,
+                    },
+                },
+                CpuidRegisterModifier {
+                    register: CpuidRegister::Edx,
+                    bitmap: RegisterValueFilter {
+                        filter: 0b0111,
+                        value: 0b0001,
+                    },
+                },
+            ],
+        }],
+        msr_modifiers: vec![
+            RegisterModifier {
+                addr: 0x9999,
+                bitmap: RegisterValueFilter {
+                    filter: 0,
+                    value: 0,
+                },
+            },
+            RegisterModifier {
+                addr: 0x8000,
+                bitmap: RegisterValueFilter {
+                    filter: 0,
+                    value: 0,
+                },
+            },
+        ],
+    }
+}

--- a/src/vmm/src/guest_config/templates/x86_64.rs
+++ b/src/vmm/src/guest_config/templates/x86_64.rs
@@ -340,174 +340,12 @@ impl CustomCpuTemplate {
     }
 }
 
-// TODO mark with #[cfg(test)] when we combine all crates into
-// one firecracker crate
-impl CustomCpuTemplate {
-    /// Test CPU template in JSON format
-    pub const TEST_TEMPLATE_JSON: &str = r#"{
-        "cpuid_modifiers": [
-            {
-                "leaf": "0x80000001",
-                "subleaf": "0x0007",
-                "flags": 0,
-                "modifiers": [
-                    {
-                        "register": "eax",
-                        "bitmap": "0bx00100xxx1xxxxxxxxxxxxxxxxxxxxx1"
-                    }
-                ]
-            },
-            {
-                "leaf": "0x80000002",
-                "subleaf": "0x0004",
-                "flags": 0,
-                "modifiers": [
-                    {
-                        "register": "ebx",
-                        "bitmap": "0bxxx1xxxxxxxxxxxxxxxxxxxxx1"
-                    },
-                    {
-                        "register": "ecx",
-                        "bitmap": "0bx00100xxx1xxxxxxxxxxx0xxxxx0xxx1"
-                    }
-                ]
-            },
-            {
-                "leaf": "0x80000003",
-                "subleaf": "0x0004",
-                "flags": 0,
-                "modifiers": [
-                    {
-                        "register": "edx",
-                        "bitmap": "0bx00100xxx1xxxxxxxxxxx0xxxxx0xxx1"
-                    }
-                ]
-            },
-            {
-                "leaf": "0x80000004",
-                "subleaf": "0x0004",
-                "flags": 0,
-                "modifiers": [
-                    {
-                        "register": "edx",
-                        "bitmap": "0b00100xxx1xxxxxx1xxxxxxxxxxxxxx1"
-                    },
-                    {
-                        "register": "ecx",
-                        "bitmap": "0bx00100xxx1xxxxxxxxxxxxx111xxxxx1"
-                    }
-                ]
-            },
-            {
-                "leaf": "0x80000005",
-                "subleaf": "0x0004",
-                "flags": 0,
-                "modifiers": [
-                    {
-                        "register": "eax",
-                        "bitmap": "0bx00100xxx1xxxxx00xxxxxx000xxxxx1"
-                    },
-                    {
-                        "register": "edx",
-                        "bitmap": "0bx10100xxx1xxxxxxxxxxxxx000xxxxx1"
-                    }
-                ]
-            }
-        ],
-        "msr_modifiers":  [
-            {
-                "addr": "0x0",
-                "bitmap": "0bx00100xxx1xxxx00xxx1xxxxxxxxxxx1"
-            },
-            {
-                "addr": "0x1",
-                "bitmap": "0bx00111xxx1xxxx111xxxxx101xxxxxx1"
-            },
-            {
-                "addr": "2",
-                "bitmap": "0bx00100xxx1xxxxxx0000000xxxxxxxx1"
-            },
-            {
-                "addr": "0xbbca",
-                "bitmap": "0bx00100xxx1xxxxxxxxx1"
-            }
-        ]
-    }"#;
-
-    /// Test CPU template in JSON format but has an invalid field for the architecture.
-    /// "reg_modifiers" is the field name for the registers for aarch64"
-    pub const TEST_INVALID_TEMPLATE_JSON: &str = r#"{
-        "reg_modifiers":  [
-            {
-                "addr": "0x0AAC",
-                "bitmap": "0b1xx1"
-            }
-        ]
-    }"#;
-
-    /// Builds a sample custom CPU template
-    pub fn build_test_template() -> CustomCpuTemplate {
-        CustomCpuTemplate {
-            cpuid_modifiers: vec![CpuidLeafModifier {
-                leaf: 0x3,
-                subleaf: 0x0,
-                flags: KvmCpuidFlags(kvm_bindings::KVM_CPUID_FLAG_STATEFUL_FUNC),
-                modifiers: vec![
-                    CpuidRegisterModifier {
-                        register: CpuidRegister::Eax,
-                        bitmap: RegisterValueFilter {
-                            filter: 0b0111,
-                            value: 0b0101,
-                        },
-                    },
-                    CpuidRegisterModifier {
-                        register: CpuidRegister::Ebx,
-                        bitmap: RegisterValueFilter {
-                            filter: 0b0111,
-                            value: 0b0100,
-                        },
-                    },
-                    CpuidRegisterModifier {
-                        register: CpuidRegister::Ecx,
-                        bitmap: RegisterValueFilter {
-                            filter: 0b0111,
-                            value: 0b0111,
-                        },
-                    },
-                    CpuidRegisterModifier {
-                        register: CpuidRegister::Edx,
-                        bitmap: RegisterValueFilter {
-                            filter: 0b0111,
-                            value: 0b0001,
-                        },
-                    },
-                ],
-            }],
-            msr_modifiers: vec![
-                RegisterModifier {
-                    addr: 0x9999,
-                    bitmap: RegisterValueFilter {
-                        filter: 0,
-                        value: 0,
-                    },
-                },
-                RegisterModifier {
-                    addr: 0x8000,
-                    bitmap: RegisterValueFilter {
-                        filter: 0,
-                        value: 0,
-                    },
-                },
-            ],
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::Value;
 
     use super::*;
+    use crate::guest_config::templates::test_utils::{build_test_template, TEST_TEMPLATE_JSON};
 
     #[test]
     fn test_get_cpu_template_with_no_template() {
@@ -744,16 +582,15 @@ mod tests {
 
     #[test]
     fn test_deserialization_lifecycle() {
-        let cpu_template =
-            serde_json::from_str::<CustomCpuTemplate>(CustomCpuTemplate::TEST_TEMPLATE_JSON)
-                .expect("Failed to deserialize custom CPU template.");
+        let cpu_template = serde_json::from_str::<CustomCpuTemplate>(TEST_TEMPLATE_JSON)
+            .expect("Failed to deserialize custom CPU template.");
         assert_eq!(5, cpu_template.cpuid_modifiers.len());
         assert_eq!(4, cpu_template.msr_modifiers.len());
     }
 
     #[test]
     fn test_serialization_lifecycle() {
-        let template = CustomCpuTemplate::build_test_template();
+        let template = build_test_template();
         let template_json_str_result = serde_json::to_string_pretty(&template);
         assert!(&template_json_str_result.is_ok());
         let template_json = template_json_str_result.unwrap();
@@ -770,7 +607,7 @@ mod tests {
         let mut cpuid_checked = false;
         let mut msr_checked = false;
 
-        let template = CustomCpuTemplate::build_test_template();
+        let template = build_test_template();
 
         let x86_template_str =
             serde_json::to_string(&template).expect("Error serializing x86 template");

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -844,6 +844,7 @@ mod tests {
     use seccompiler::BpfThreadMap;
 
     use super::*;
+    use crate::guest_config::templates::test_utils::build_test_template;
     use crate::guest_config::templates::{CpuTemplateType, StaticCpuTemplate};
     use crate::vmm_config::balloon::BalloonBuilder;
     use crate::vmm_config::drive::{CacheType, FileEngineType};
@@ -1296,14 +1297,12 @@ mod tests {
     #[test]
     fn test_preboot_put_cpu_config() {
         // Start testing - Provide VMM vCPU configuration in preparation for `InstanceStart`
-        let req = VmmAction::PutCpuConfiguration(CustomCpuTemplate::build_test_template());
+        let req = VmmAction::PutCpuConfiguration(build_test_template());
         check_preboot_request(req, |result, vm_res| {
             assert_eq!(result, Ok(VmmData::Empty));
             assert_eq!(
                 vm_res.vm_config.cpu_template,
-                Some(CpuTemplateType::Custom(
-                    CustomCpuTemplate::build_test_template()
-                ))
+                Some(CpuTemplateType::Custom(build_test_template()))
             );
         });
     }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,15 +25,15 @@ def is_on_skylake():
 # differences may appear.
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {
-        "Intel": 81.71 if is_on_skylake() else 82.23,
-        "AMD": 80.81,
-        "ARM": 82.69,
+        "Intel": 81.67 if is_on_skylake() else 82.18,
+        "AMD": 80.77,
+        "ARM": 82.68,
     }
 else:
     COVERAGE_DICT = {
-        "Intel": 78.95 if is_on_skylake() else 79.46,
-        "AMD": 78.04,
-        "ARM": 79.61,
+        "Intel": 78.9 if is_on_skylake() else 79.41,
+        "AMD": 77.99,
+        "ARM": 79.59,
     }
 
 PROC_MODEL = proc.proc_type()

--- a/tests/integration_tests/performance/test_cpu_template_benchmark.py
+++ b/tests/integration_tests/performance/test_cpu_template_benchmark.py
@@ -1,0 +1,95 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A benchmark that checks for regression of CPU template operations."""
+
+import json
+import logging
+import os
+import platform
+import shutil
+from pathlib import Path
+
+import pytest
+
+from framework import utils
+from framework.defs import FC_WORKSPACE_DIR
+from host_tools import proc
+
+BENCHMARK_DIRECTORY = "{}/src/vmm".format(FC_WORKSPACE_DIR)
+DEFAULT_BUILD_TARGET = "{}-unknown-linux-musl".format(platform.machine())
+
+PROC_MODEL = proc.proc_type()
+
+NSEC_IN_MSEC = 1000000
+
+BASELINES = {
+    "Intel": {
+        "deserialize": {"target": 0.025, "delta": 0.02}  # milliseconds
+    },
+    "AMD": {
+        "deserialize": {"target": 0.025, "delta": 0.02}  # milliseconds
+    },
+    "ARM": {
+        "deserialize": {"target": 0.0015, "delta": 0.001}  # milliseconds
+    },
+}
+
+
+def _check_statistics(directory, mean):
+    proc_model = [item for item in BASELINES if item in PROC_MODEL]
+    assert len(proc_model) == 1, "Could not get processor model!"
+
+    measure = BASELINES[proc_model[0]]["deserialize"]
+    target, delta = measure["target"], measure["delta"]
+
+    # When using multiple data sets where the delta can
+    # vary substantially, consider making use of the
+    # 'rel' parameter for more flexibility.
+    assert target == pytest.approx(
+        mean,
+        abs=delta,
+    ), f"Benchmark result {directory} has changed!"
+
+    return f"{target - delta} <= result <= {target + delta}"
+
+
+def test_cpu_template_benchmark(monkeypatch, record_property):
+    """
+    Benchmark test for CpuTemplate deserialization.
+
+    @type: performance
+    """
+    logger = logging.getLogger("cpu_template_benchmark")
+
+    # Move into the benchmark directory
+    monkeypatch.chdir(BENCHMARK_DIRECTORY)
+
+    # Run benchmark test
+    cmd = "cargo bench --bench cpu_templates --target {}".format(DEFAULT_BUILD_TARGET)
+    result = utils.run_cmd_sync(cmd)
+    assert result.returncode == 0
+
+    # Parse each Criterion benchmark from the result folder and
+    # check the results against a baseline
+    results_dir = Path(FC_WORKSPACE_DIR) / "build/vmm_benchmark/cpu_templates"
+    for directory in os.listdir(results_dir):
+        # Ignore the 'report' directory as it is of no use to us
+        if directory == "report":
+            continue
+
+        logger.info("Benchmark: %s", directory)
+
+        # Retrieve the 'estimates.json' file content
+        json_file = results_dir / directory / "base/estimates.json"
+        estimates = json.loads(json_file.read_text())
+
+        # Save the Mean measurement(nanoseconds) and transform it(milliseconds)
+        mean = estimates["mean"]["point_estimate"] / NSEC_IN_MSEC
+        logger.info("Mean: %f", mean)
+
+        criteria = _check_statistics(directory, mean)
+        record_property(f"{directory}_ms", mean)
+        record_property(f"{directory}_criteria", criteria)
+
+    # Cleanup the Target directory
+    shutil.rmtree(results_dir)

--- a/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
+++ b/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
@@ -91,13 +91,13 @@ def test_serialization_benchmark(monkeypatch, record_property):
     monkeypatch.chdir(BENCHMARK_DIRECTORY)
 
     # Run benchmark test
-    cmd = "cargo bench --target {}".format(DEFAULT_BUILD_TARGET)
+    cmd = "cargo bench --bench snapshots --target {}".format(DEFAULT_BUILD_TARGET)
     result = utils.run_cmd_sync(cmd)
     assert result.returncode == 0
 
     # Parse each Criterion benchmark from the result folder and
     # check the results against a baseline
-    results_dir = Path(FC_WORKSPACE_DIR) / "build/vmm_benchmark"
+    results_dir = Path(FC_WORKSPACE_DIR) / "build/vmm_benchmark/snapshots"
     for directory in os.listdir(results_dir):
         # Ignore the 'report' directory as it is of no use to us
         if directory == "report":


### PR DESCRIPTION
## Changes

Add criterion benchmarks for the to/from string JSON operations for the `CustomCpuTemplate` type.

## Reason

To keep a handle on the performance of serializing and deserializing CPU templates in JSON format.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].
