### PR TITLE
test: stop CPU load monitoring at the end of a test

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -6,7 +6,8 @@ line-length=72
 
 [ignore-body-lines]
 # Ignore HTTP reference links
-regex=^\[.+\]: http.+
+# Ignore lines that start with 'Co-Authored-By' or with 'Signed-off-by'
+regex=(^\[.+\]: http.+)|(^Co-Authored-By)|(^Signed-off-by)
 
 [ignore-by-author-name]
 # Ignore certain rules for commits of which the author name matches a regex

--- a/tests/framework/gitlint_rules.py
+++ b/tests/framework/gitlint_rules.py
@@ -100,7 +100,7 @@ class EndsSigned(CommitRule):
         co_auth = "Co-authored-by:"
         sig = "Signed-off-by:"
 
-        message_iter = enumerate(commit.message.body)
+        message_iter = enumerate(commit.message.original.split("\n"))
 
         # Checks commit message contains a `sig` string
         found = False

--- a/tests/host_tools/cpu_load.py
+++ b/tests/host_tools/cpu_load.py
@@ -6,12 +6,6 @@ from threading import Thread
 
 from framework import utils
 
-# /proc/<pid>/stat output taken from
-# https://www.man7.org/linux/man-pages/man5/proc.5.html
-STAT_UTIME_IDX = 13
-STAT_STIME_IDX = 14
-STAT_STARTTIME_IDX = 21
-
 
 class CpuLoadExceededException(Exception):
     """A custom exception containing details on excessive cpu load."""
@@ -88,3 +82,18 @@ class CpuLoadMonitor(Thread):
         """Check that there are no samples above the threshold."""
         if len(self.cpu_load_samples) > 0:
             raise CpuLoadExceededException(self._cpu_load_samples, self._threshold)
+
+    def __enter__(self):
+        """Functions to use this CPU Load class as a Context Manager
+
+        >>> clm = CpuLoadMonitor(1000, 1000, 45)
+        >>> with clm:
+        >>>    # do stuff
+        """
+        self.start()
+
+    def __exit__(self, _type, _value, _traceback):
+        """Exit context"""
+        self.check_samples()
+        self.signal_stop()
+        self.join()

--- a/tests/integration_tests/functional/test_rate_limiter.py
+++ b/tests/integration_tests/functional/test_rate_limiter.py
@@ -4,6 +4,7 @@
 import time
 
 from framework import utils
+from host_tools import cpu_load
 
 # The iperf version to run this tests with
 IPERF_BINARY = "iperf3"
@@ -146,15 +147,7 @@ def test_rx_rate_limiting_cpu_load(test_microvm_with_api, network_config):
     """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
-
     test_microvm.basic_config()
-
-    # Enable monitor that checks if the cpu load is over the threshold.
-    # After multiple runs, the average value for the cpu load
-    # seems to be around 10%. Setting the threshold a little
-    # higher to skip false positives.
-    threshold = 20
-    test_microvm.enable_cpu_load_monitor(threshold)
 
     # Create interface with aggressive rate limiting enabled.
     rx_rate_limiter_no_burst = {
@@ -165,6 +158,7 @@ def test_rx_rate_limiting_cpu_load(test_microvm_with_api, network_config):
     )
 
     test_microvm.start()
+
     # Start iperf server on guest.
     _start_iperf_on_guest(test_microvm, guest_ip)
 
@@ -175,7 +169,21 @@ def test_rx_rate_limiting_cpu_load(test_microvm_with_api, network_config):
         guest_ip,
         IPERF_TRANSMIT_TIME * 5,
     )
-    _iperf_out = _run_local_iperf(iperf_cmd)
+
+    # Enable monitor that checks if the cpu load is over the threshold.
+    # After multiple runs, the average value for the cpu load
+    # seems to be around 10%. Setting the threshold a little
+    # higher to skip false positives.
+    # We want to monitor the emulation thread, which is currently
+    # the first one created.
+    # A possible improvement is to find it by name.
+    cpu_load_monitor = cpu_load.CpuLoadMonitor(
+        process_pid=test_microvm.jailer_clone_pid,
+        thread_pid=test_microvm.jailer_clone_pid,
+        threshold=20,
+    )
+    with cpu_load_monitor:
+        _run_local_iperf(iperf_cmd)
 
 
 def _check_tx_rate_limiting(test_microvm, guest_ips, host_ips):


### PR DESCRIPTION
Also remove the CPU load monitoring from Microvm, since this is the only user and it fits better as a Context Manager.

## Changes

...

## Reason

The assert/error belongs during the test call phase, and not teardown.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
