### PR TITLE
Add custom CPU template tests to test_vulnerabilities.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,10 @@ from framework.microvm import Microvm
 from framework.properties import global_props
 from framework.s3fetcher import MicrovmImageS3Fetcher
 from framework.utils import get_firecracker_version_from_toml, is_io_uring_supported
-from framework.utils_cpu_templates import SUPPORTED_CPU_TEMPLATES
+from framework.utils_cpu_templates import (
+    SUPPORTED_CPU_TEMPLATES,
+    SUPPORTED_CUSTOM_CPU_TEMPLATES,
+)
 from framework.with_filelock import with_filelock
 from host_tools.ip_generator import network_config, subnet_generator
 from host_tools.metrics import get_metrics_logger
@@ -521,6 +524,13 @@ def rootfs_msrtools(request, record_property):
 def cpu_template(request, record_property):
     """Return all CPU templates supported by the vendor."""
     record_property("cpu_template", request.param)
+    return request.param
+
+
+@pytest.fixture(params=SUPPORTED_CUSTOM_CPU_TEMPLATES)
+def custom_cpu_template(request, record_property):
+    """Return all dummy custom CPU templates supported by the vendor."""
+    record_property("custom_cpu_template", request.param)
     return request.param
 
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -38,6 +38,7 @@ from framework.resources import (
     Actions,
     Balloon,
     BootSource,
+    CpuConfigure,
     DescribeInstance,
     Drive,
     FullConfig,
@@ -424,6 +425,7 @@ class Microvm:
         self.actions = Actions(self._api_socket, self._api_session)
         self.balloon = Balloon(self._api_socket, self._api_session)
         self.boot = BootSource(self._api_socket, self._api_session)
+        self.cpu_cfg = CpuConfigure(self._api_socket, self._api_session)
         self.desc_inst = DescribeInstance(self._api_socket, self._api_session)
         self.full_cfg = FullConfig(self._api_socket, self._api_session)
         self.logger = Logger(self._api_socket, self._api_session)
@@ -604,6 +606,13 @@ class Microvm:
             assert self._api_session.is_status_no_content(
                 response.status_code
             ), response.text
+
+    def cpu_config(self, config):
+        """Set CPU configuration."""
+        response = self.cpu_cfg.put(config)
+        assert self._api_session.is_status_no_content(
+            response.status_code
+        ), response.text
 
     def daemonize_jailer(self, jailer_param_list):
         """Daemonize the jailer."""

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -143,6 +143,34 @@ class BootSource:
         return datax
 
 
+class CpuConfigure:
+    """Facility for configuring the CPU capabilities."""
+
+    CPU_CFG_RESOURCE = "cpu-config"
+
+    def __init__(self, api_usocket_full_name, api_session):
+        """Specify the information needed for sending API requests."""
+        url_encoded_path = urllib.parse.quote_plus(api_usocket_full_name)
+        api_url = API_USOCKET_URL_PREFIX + url_encoded_path + "/"
+
+        self._cpu_cfg_url = api_url + self.CPU_CFG_RESOURCE
+        self._api_session = api_session
+        self._datax = {}
+
+    def put(self, args):
+        """Specify the details of the CPU configuration."""
+        self._datax = self.create_json(args)
+        return self._api_session.put("{}".format(self._cpu_cfg_url), json=self._datax)
+
+    def get(self):
+        """Get CPU configuration."""
+        return self._api_session.get(self._cpu_cfg_url)
+
+    def create_json(self, config):
+        """Compose the json associated to this type of API request."""
+        return config
+
+
 # Too few public methods (1/2) (too-few-public-methods)
 # pylint: disable=R0903
 class DescribeInstance:


### PR DESCRIPTION
## Changes

Add custom CPU template tests to test_vulnerabilities.py. Dummy custom CPU templates are used for testing that are replicas of existing static templates.

## Reason

Similar to static CPU templates, custom CPU templates need to be tested via `spectre_meltdown_checker.sh` and inspecting vulnerabilities files.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
~~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
