### PR TITLE
fix: removed check for cpu templates for aarch64

### DIFF
--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -52,11 +52,7 @@ pub struct MachineConfig {
     #[serde(default, deserialize_with = "deserialize_smt")]
     pub smt: bool,
     /// A CPU template that it is used to filter the CPU features exposed to the guest.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_cpu_template",
-        skip_serializing_if = "StaticCpuTemplate::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "StaticCpuTemplate::is_none")]
     pub cpu_template: StaticCpuTemplate,
     /// Enables or disables dirty page tracking. Enabling allows incremental snapshots.
     #[serde(default)]
@@ -107,11 +103,7 @@ pub struct MachineConfigUpdate {
     )]
     pub smt: Option<bool>,
     /// A CPU template that it is used to filter the CPU features exposed to the guest.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_cpu_template"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpu_template: Option<StaticCpuTemplate>,
     /// Enables or disables dirty page tracking. Enabling allows incremental snapshots.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -286,24 +278,4 @@ where
     }
 
     Ok(val)
-}
-
-/// Deserialization function for the `cpu_template` field in `MachineConfig` and
-/// `MachineConfigUpdate`. This is called only when `cpu_template` is present in the JSON
-/// configuration.
-fn deserialize_cpu_template<'de, D, T>(_d: D) -> std::result::Result<T, D::Error>
-where
-    D: de::Deserializer<'de>,
-    T: Deserialize<'de>,
-{
-    // If this function was called it means that `cpu_template` was specified in
-    // the JSON. Return an error since `cpu_template` is not supported on aarch64.
-    #[cfg(target_arch = "aarch64")]
-    return Err(de::Error::invalid_value(
-        de::Unexpected::Enum,
-        &"CPU templates are not supported on aarch64",
-    ));
-
-    #[cfg(target_arch = "x86_64")]
-    T::deserialize(_d)
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -26,7 +26,7 @@ def is_on_skylake():
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {
         "Intel": 81.77 if is_on_skylake() else 82.28,
-        "AMD": 80.86,
+        "AMD": 80.8,
         "ARM": 82.68,
     }
 else:

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -410,14 +410,6 @@ def test_api_machine_config(test_microvm_with_api):
             in response.text
         )
 
-    # Test that CPU template errors on ARM.
-    response = test_microvm.machine_cfg.patch(cpu_template="C3")
-    if platform.machine() == "x86_64":
-        assert test_microvm.api_session.is_status_no_content(response.status_code)
-    else:
-        assert test_microvm.api_session.is_status_bad_request(response.status_code)
-        assert "CPU templates are not supported on aarch64" in response.text
-
     # Test invalid mem_size_mib < 0.
     response = test_microvm.machine_cfg.put(mem_size_mib="-2")
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
@@ -465,13 +457,16 @@ def test_api_machine_config(test_microvm_with_api):
 
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
-    # Set the cpu template again
-    response = test_microvm.machine_cfg.patch(cpu_template="C3")
+    # Set the cpu template
     if platform.machine() == "x86_64":
+        response = test_microvm.machine_cfg.patch(cpu_template="C3")
         assert test_microvm.api_session.is_status_no_content(response.status_code)
     else:
-        assert test_microvm.api_session.is_status_bad_request(response.status_code)
-        assert "CPU templates are not supported on aarch64" in response.text
+        # We test with "None" because this is the only option supported on
+        # all aarch64 instances. It still tests setting `cpu_template`,
+        # even though the values we set is "None".
+        response = test_microvm.machine_cfg.patch(cpu_template="None")
+        assert test_microvm.api_session.is_status_no_content(response.status_code)
 
     response = test_microvm.actions.put(action_type="InstanceStart")
     if utils.get_cpu_vendor() == utils.CpuVendor.AMD:


### PR DESCRIPTION
## Changes

Removed check for cpu templates for aarch64.
This is done, because now we have static templates for aarch64 and we forgot to remove this restriction earlier.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
