### PR TITLE
feat(tool): Add strip feature

### DIFF
--- a/src/cpu-template-helper/src/dump/aarch64.rs
+++ b/src/cpu-template-helper/src/dump/aarch64.rs
@@ -4,17 +4,13 @@
 use vmm::guest_config::templates::aarch64::{RegisterModifier, RegisterValueFilter};
 use vmm::guest_config::templates::{CpuConfiguration, CustomCpuTemplate};
 
+use crate::utils::aarch64::reg_modifier;
+
 pub fn config_to_template(cpu_config: &CpuConfiguration) -> CustomCpuTemplate {
     let mut reg_modifiers: Vec<RegisterModifier> = cpu_config
         .regs
         .iter()
-        .map(|reg| RegisterModifier {
-            addr: reg.id,
-            bitmap: RegisterValueFilter {
-                filter: u128::MAX,
-                value: reg.value,
-            },
-        })
+        .map(|reg| reg_modifier!(reg.id, reg.value))
         .collect();
     reg_modifiers.sort_by_key(|modifier| modifier.addr);
 
@@ -46,27 +42,18 @@ mod tests {
 
     fn build_expected_reg_modifiers() -> Vec<RegisterModifier> {
         vec![
-            RegisterModifier {
-                addr: 0x0000_0000_0000_0000,
-                bitmap: RegisterValueFilter {
-                    filter: 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
-                    value: 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
-                },
-            },
-            RegisterModifier {
-                addr: 0x0000_0000_0000_0001,
-                bitmap: RegisterValueFilter {
-                    filter: 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
-                    value: 0x0000_ffff_0000_ffff_0000_ffff_0000_ffff,
-                },
-            },
-            RegisterModifier {
-                addr: 0xffff_ffff_ffff_ffff,
-                bitmap: RegisterValueFilter {
-                    filter: 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
-                    value: 0x0000_ffff_0000_ffff_0000_ffff_0000_ffff,
-                },
-            },
+            reg_modifier!(
+                0x0000_0000_0000_0000,
+                0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff
+            ),
+            reg_modifier!(
+                0x0000_0000_0000_0001,
+                0x0000_ffff_0000_ffff_0000_ffff_0000_ffff
+            ),
+            reg_modifier!(
+                0xffff_ffff_ffff_ffff,
+                0x0000_ffff_0000_ffff_0000_ffff_0000_ffff
+            ),
         ]
     }
 

--- a/src/cpu-template-helper/src/dump/mod.rs
+++ b/src/cpu-template-helper/src/dump/mod.rs
@@ -72,25 +72,7 @@ mod tests {
     use vmm::utilities::mock_resources::kernel_image_path;
 
     use super::*;
-
-    fn generate_config(kernel_image_path: &str, rootfs_path: &str) -> String {
-        format!(
-            r#"{{
-                "boot-source": {{
-                    "kernel_image_path": "{}"
-                }},
-                "drives": [
-                    {{
-                        "drive_id": "rootfs",
-                        "path_on_host": "{}",
-                        "is_root_device": true,
-                        "is_read_only": false
-                    }}
-                ]
-            }}"#,
-            kernel_image_path, rootfs_path,
-        )
-    }
+    use crate::tests::generate_config;
 
     #[test]
     fn test_valid_config() {

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -145,4 +145,113 @@ mod tests {
 
         run(cli).unwrap();
     }
+
+    #[cfg(target_arch = "x86_64")]
+    fn build_sample_cpu_config_files() -> Vec<TempFile> {
+        let files = vec![TempFile::new().unwrap(), TempFile::new().unwrap()];
+        files[0]
+            .as_file()
+            .write_all(
+                r#"{
+                    "cpuid_modifiers": [
+                        {
+                            "leaf": "0x0",
+                            "subleaf": "0x0",
+                            "flags": 0,
+                            "modifiers": [
+                                {
+                                    "register": "eax",
+                                    "bitmap": "0b00000000000000000000000000000000"
+                                }
+                            ]
+                        }
+                    ],
+                    "msr_modifiers": [
+                        {
+                            "addr": "0x0",
+                            "bitmap": "0b0000000000000000000000000000000000000000000000000000000000000000"
+                        }
+                    ]
+                }"#
+                .as_bytes(),
+            )
+            .unwrap();
+        files[1]
+            .as_file()
+            .write_all(
+                r#"{
+                    "cpuid_modifiers": [
+                        {
+                            "leaf": "0x0",
+                            "subleaf": "0x0",
+                            "flags": 0,
+                            "modifiers": [
+                                {
+                                    "register": "eax",
+                                    "bitmap": "0b00000000000000000000000000000000"
+                                }
+                            ]
+                        }
+                    ],
+                    "msr_modifiers": [
+                        {
+                            "addr": "0x0",
+                            "bitmap": "0b0000000000000000000000000000000000000000000000000000000000000000"
+                        }
+                    ]
+                }"#
+                .as_bytes(),
+            )
+            .unwrap();
+        files
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn build_sample_cpu_config_files() -> Vec<TempFile> {
+        let files = vec![TempFile::new().unwrap(), TempFile::new().unwrap()];
+        files[0]
+            .as_file()
+            .write_all(
+                r#"{
+                    "reg_modifiers": [
+                        {
+                            "addr": "0x0",
+                            "bitmap": "0b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                        }
+                    ]
+                }"#
+                .as_bytes(),
+            )
+            .unwrap();
+        files[1]
+            .as_file()
+            .write_all(
+                r#"{
+                    "reg_modifiers": [
+                        {
+                            "addr": "0x0",
+                            "bitmap": "0b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                        }
+                    ]
+                }"#
+                .as_bytes(),
+            )
+            .unwrap();
+        files
+    }
+
+    #[test]
+    fn test_strip_command() {
+        let files = build_sample_cpu_config_files();
+
+        let mut args = vec!["cpu-template-helper", "strip", "-p"];
+        let paths = files
+            .iter()
+            .map(|file| file.as_path().to_str().unwrap())
+            .collect::<Vec<_>>();
+        args.extend(paths);
+        let cli = Cli::parse_from(args);
+
+        run(cli).unwrap();
+    }
 }

--- a/src/cpu-template-helper/src/strip/aarch64.rs
+++ b/src/cpu-template-helper/src/strip/aarch64.rs
@@ -34,18 +34,7 @@ mod tests {
     use vmm::guest_config::templates::aarch64::{RegisterModifier, RegisterValueFilter};
 
     use super::*;
-
-    macro_rules! reg_modifier {
-        ($addr:literal, $value:literal) => {
-            RegisterModifier {
-                addr: $addr,
-                bitmap: RegisterValueFilter {
-                    filter: u128::MAX,
-                    value: $value,
-                },
-            }
-        };
-    }
+    use crate::utils::aarch64::reg_modifier;
 
     // Summary of reg modifiers:
     // * As addr 0x0 modifier exists in all the templates but its values are different, it should be

--- a/src/cpu-template-helper/src/strip/aarch64.rs
+++ b/src/cpu-template-helper/src/strip/aarch64.rs
@@ -1,0 +1,110 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use vmm::guest_config::templates::CustomCpuTemplate;
+
+use crate::strip::remove_common;
+
+#[allow(dead_code)]
+pub fn strip(templates: Vec<CustomCpuTemplate>) -> Vec<CustomCpuTemplate> {
+    // Convert `Vec<CustomCpuTemplate>` to `Vec<HashSet<RegisterModifier>>`.
+    let mut reg_modifiers_sets = templates
+        .into_iter()
+        .map(|template| template.reg_modifiers.into_iter().collect::<HashSet<_>>())
+        .collect::<Vec<_>>();
+
+    // Remove common items.
+    remove_common(&mut reg_modifiers_sets);
+
+    // Convert back to `Vec<CustomCpuTemplate>`.
+    reg_modifiers_sets
+        .into_iter()
+        .map(|reg_modifiers_set| {
+            let mut reg_modifiers = reg_modifiers_set.into_iter().collect::<Vec<_>>();
+            reg_modifiers.sort_by_key(|modifier| modifier.addr);
+            CustomCpuTemplate { reg_modifiers }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use vmm::guest_config::templates::aarch64::{RegisterModifier, RegisterValueFilter};
+
+    use super::*;
+
+    macro_rules! reg_modifier {
+        ($addr:literal, $value:literal) => {
+            RegisterModifier {
+                addr: $addr,
+                bitmap: RegisterValueFilter {
+                    filter: u128::MAX,
+                    value: $value,
+                },
+            }
+        };
+    }
+
+    // Summary of reg modifiers:
+    // * As addr 0x0 modifier exists in all the templates but its values are different, it should be
+    //   preserved.
+    // * As addr 0x1 modifier exists in all the templates and its values are same, it should be
+    //   removed.
+    // * As addr 0x2 modifier only exist in the third template, it should be preserved.
+    #[rustfmt::skip]
+    fn build_input_templates() -> Vec<CustomCpuTemplate> {
+        vec![
+            CustomCpuTemplate {
+                reg_modifiers: vec![
+                    reg_modifier!(0x0, 0x0),
+                    reg_modifier!(0x1, 0x1),
+                ],
+            },
+            CustomCpuTemplate {
+                reg_modifiers: vec![
+                    reg_modifier!(0x0, 0x1),
+                    reg_modifier!(0x1, 0x1),
+                ],
+            },
+            CustomCpuTemplate {
+                reg_modifiers: vec![
+                    reg_modifier!(0x0, 0x2),
+                    reg_modifier!(0x1, 0x1),
+                    reg_modifier!(0x2, 0x1),
+                ],
+            },
+        ]
+    }
+
+    #[rustfmt::skip]
+    fn build_expected_templates() -> Vec<CustomCpuTemplate> {
+        vec![
+            CustomCpuTemplate {
+                reg_modifiers: vec![
+                    reg_modifier!(0x0, 0x0),
+                ],
+            },
+            CustomCpuTemplate {
+                reg_modifiers: vec![
+                    reg_modifier!(0x0, 0x1),
+                ],
+            },
+            CustomCpuTemplate {
+                reg_modifiers: vec![
+                    reg_modifier!(0x0, 0x2),
+                    reg_modifier!(0x2, 0x1),
+                ],
+            },
+        ]
+    }
+
+    #[test]
+    fn test_strip_reg_modifiers() {
+        let input = build_input_templates();
+        let result = strip(input);
+        let expected = build_expected_templates();
+        assert_eq!(result, expected);
+    }
+}

--- a/src/cpu-template-helper/src/strip/mod.rs
+++ b/src/cpu-template-helper/src/strip/mod.rs
@@ -6,6 +6,9 @@ use std::hash::Hash;
 
 use vmm::guest_config::templates::CustomCpuTemplate;
 
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Failed to serialize/deserialize.

--- a/src/cpu-template-helper/src/strip/mod.rs
+++ b/src/cpu-template-helper/src/strip/mod.rs
@@ -1,6 +1,9 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+use std::hash::Hash;
+
 use vmm::guest_config::templates::CustomCpuTemplate;
 
 #[derive(Debug, thiserror::Error)]
@@ -25,4 +28,42 @@ pub fn strip(input: Vec<String>) -> Result<Vec<String>, Error> {
         .map(serde_json::to_string_pretty)
         .collect::<Result<Vec<_>, serde_json::Error>>()?;
     Ok(result)
+}
+
+pub fn remove_common<T>(sets: &mut [HashSet<T>])
+where
+    T: Clone + Hash + Eq + PartialEq,
+{
+    // Get common items shared by all the sets.
+    let mut common = sets[0].clone();
+    common.retain(|item| sets[1..].iter().all(|set| set.contains(item)));
+
+    // Remove the common items from all the sets.
+    for item in common {
+        for set in sets.iter_mut() {
+            set.remove(&item);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remove_common() {
+        let mut input = vec![
+            HashSet::from([0, 1, 2, 3]),
+            HashSet::from([0, 2, 4]),
+            HashSet::from([0, 1, 2, 5, 6]),
+        ];
+        let expected = vec![
+            HashSet::from([1, 3]),
+            HashSet::from([4]),
+            HashSet::from([1, 5, 6]),
+        ];
+
+        remove_common(&mut input);
+        assert_eq!(input, expected);
+    }
 }

--- a/src/cpu-template-helper/src/strip/mod.rs
+++ b/src/cpu-template-helper/src/strip/mod.rs
@@ -1,0 +1,28 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm::guest_config::templates::CustomCpuTemplate;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failed to serialize/deserialize.
+    #[error("Failed to serialize/deserialize: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+pub fn strip(input: Vec<String>) -> Result<Vec<String>, Error> {
+    // Deserialize `Vec<String>` to `Vec<CustomCpuTemplate>`.
+    let input = input
+        .iter()
+        .map(|s| serde_json::from_str::<CustomCpuTemplate>(s))
+        .collect::<Result<Vec<_>, serde_json::Error>>()?;
+
+    // TODO: Add actual implementation to strip.
+
+    // Serialize `Vec<CustomCpuTemplate>` to `Vec<String>`.
+    let result = input
+        .iter()
+        .map(serde_json::to_string_pretty)
+        .collect::<Result<Vec<_>, serde_json::Error>>()?;
+    Ok(result)
+}

--- a/src/cpu-template-helper/src/strip/mod.rs
+++ b/src/cpu-template-helper/src/strip/mod.rs
@@ -8,8 +8,13 @@ use vmm::guest_config::templates::CustomCpuTemplate;
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
+#[cfg(target_arch = "aarch64")]
+use aarch64::strip as arch_strip;
+
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
+#[cfg(target_arch = "x86_64")]
+use x86_64::strip as arch_strip;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -25,10 +30,11 @@ pub fn strip(input: Vec<String>) -> Result<Vec<String>, Error> {
         .map(|s| serde_json::from_str::<CustomCpuTemplate>(s))
         .collect::<Result<Vec<_>, serde_json::Error>>()?;
 
-    // TODO: Add actual implementation to strip.
+    // Strip common items.
+    let stripped = arch_strip(input);
 
     // Serialize `Vec<CustomCpuTemplate>` to `Vec<String>`.
-    let result = input
+    let result = stripped
         .iter()
         .map(serde_json::to_string_pretty)
         .collect::<Result<Vec<_>, serde_json::Error>>()?;

--- a/src/cpu-template-helper/src/strip/mod.rs
+++ b/src/cpu-template-helper/src/strip/mod.rs
@@ -6,6 +6,8 @@ use std::hash::Hash;
 
 use vmm::guest_config::templates::CustomCpuTemplate;
 
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 

--- a/src/cpu-template-helper/src/strip/x86_64.rs
+++ b/src/cpu-template-helper/src/strip/x86_64.rs
@@ -122,41 +122,7 @@ mod tests {
     };
 
     use super::*;
-
-    macro_rules! cpuid_reg_modifier {
-        ($register:expr, $value:literal) => {
-            CpuidRegisterModifier {
-                register: $register,
-                bitmap: RegisterValueFilter {
-                    filter: u32::MAX.into(),
-                    value: $value,
-                },
-            }
-        };
-    }
-
-    macro_rules! cpuid_leaf_modifier {
-        ($leaf:literal, $subleaf:literal, $flags:expr, $reg_modifiers:expr) => {
-            CpuidLeafModifier {
-                leaf: $leaf,
-                subleaf: $subleaf,
-                flags: $flags,
-                modifiers: $reg_modifiers,
-            }
-        };
-    }
-
-    macro_rules! msr_modifier {
-        ($addr:literal, $value:literal) => {
-            RegisterModifier {
-                addr: $addr,
-                bitmap: RegisterValueFilter {
-                    filter: u64::MAX,
-                    value: $value,
-                },
-            }
-        };
-    }
+    use crate::utils::x86_64::{cpuid_leaf_modifier, cpuid_reg_modifier, msr_modifier};
 
     // Summary of CPUID modifiers:
     // * As CPUID leaf 0x0 / subleaf 0x0 modifier exists in all the templates and its values are

--- a/src/cpu-template-helper/src/strip/x86_64.rs
+++ b/src/cpu-template-helper/src/strip/x86_64.rs
@@ -3,9 +3,73 @@
 
 use std::collections::HashSet;
 
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier, RegisterValueFilter,
+};
 use vmm::guest_config::templates::CustomCpuTemplate;
 
 use crate::strip::remove_common;
+
+#[derive(Clone, Eq, PartialEq, Hash)]
+struct CpuidModifier {
+    leaf: u32,
+    subleaf: u32,
+    flags: KvmCpuidFlags,
+    register: CpuidRegister,
+    bitmap: RegisterValueFilter,
+}
+
+struct CpuidModifierSet(HashSet<CpuidModifier>);
+
+impl From<Vec<CpuidLeafModifier>> for CpuidModifierSet {
+    fn from(leaf_modifiers: Vec<CpuidLeafModifier>) -> Self {
+        let mut set = HashSet::new();
+        for leaf_modifier in leaf_modifiers {
+            for reg_modifier in leaf_modifier.modifiers {
+                set.insert(CpuidModifier {
+                    leaf: leaf_modifier.leaf,
+                    subleaf: leaf_modifier.subleaf,
+                    flags: leaf_modifier.flags,
+                    register: reg_modifier.register,
+                    bitmap: reg_modifier.bitmap,
+                });
+            }
+        }
+        CpuidModifierSet(set)
+    }
+}
+
+impl From<CpuidModifierSet> for Vec<CpuidLeafModifier> {
+    fn from(cpuid_modifiers: CpuidModifierSet) -> Self {
+        let mut leaf_modifiers = Vec::<CpuidLeafModifier>::new();
+        for modifier in cpuid_modifiers.0 {
+            let leaf_modifier = leaf_modifiers.iter_mut().find(|leaf_modifier| {
+                leaf_modifier.leaf == modifier.leaf
+                    && leaf_modifier.subleaf == modifier.subleaf
+                    && leaf_modifier.flags == modifier.flags
+            });
+
+            if let Some(leaf_modifier) = leaf_modifier {
+                leaf_modifier.modifiers.push(CpuidRegisterModifier {
+                    register: modifier.register,
+                    bitmap: modifier.bitmap,
+                });
+            } else {
+                leaf_modifiers.push(CpuidLeafModifier {
+                    leaf: modifier.leaf,
+                    subleaf: modifier.subleaf,
+                    flags: modifier.flags,
+                    modifiers: vec![CpuidRegisterModifier {
+                        register: modifier.register,
+                        bitmap: modifier.bitmap,
+                    }],
+                });
+            }
+        }
+        leaf_modifiers
+    }
+}
 
 #[allow(dead_code)]
 pub fn strip(templates: Vec<CustomCpuTemplate>) -> Vec<CustomCpuTemplate> {
@@ -14,7 +78,7 @@ pub fn strip(templates: Vec<CustomCpuTemplate>) -> Vec<CustomCpuTemplate> {
         .into_iter()
         .map(|template| {
             (
-                template.cpuid_modifiers.into_iter().collect::<HashSet<_>>(),
+                CpuidModifierSet::from(template.cpuid_modifiers).0,
                 template.msr_modifiers.into_iter().collect::<HashSet<_>>(),
             )
         })
@@ -29,10 +93,16 @@ pub fn strip(templates: Vec<CustomCpuTemplate>) -> Vec<CustomCpuTemplate> {
         .into_iter()
         .zip(msr_modifiers_sets.into_iter())
         .map(|(cpuid_modifiers_set, msr_modifiers_set)| {
-            let mut cpuid_modifiers = cpuid_modifiers_set.into_iter().collect::<Vec<_>>();
+            let mut cpuid_modifiers: Vec<CpuidLeafModifier> =
+                CpuidModifierSet(cpuid_modifiers_set).into();
             let mut msr_modifiers = msr_modifiers_set.into_iter().collect::<Vec<_>>();
 
             cpuid_modifiers.sort_by_key(|modifier| (modifier.leaf, modifier.subleaf));
+            cpuid_modifiers.iter_mut().for_each(|leaf_modifier| {
+                leaf_modifier
+                    .modifiers
+                    .sort_by_key(|modifier| modifier.register.clone())
+            });
             msr_modifiers.sort_by_key(|modifier| modifier.addr);
 
             CustomCpuTemplate {
@@ -93,8 +163,9 @@ mod tests {
     //   different, it should be removed.
     // * As CPUID leaf 0x1 / subleaf 0x0 modifier only exists in the second template, it should be
     //   preserved.
-    // * As CPUID leaf 0x2 / subleaf 0x1 modifier exists in all the templates but EBX values are
-    //   different, the leaf modifier (not only the register modifier EBX) should be preserved.
+    // * As CPUID leaf 0x2 / subleaf 0x1 modifier exists in all the templates, EAX values are same
+    //   but EBX values are different, the EAX register modifier should be removed and the EBX
+    //   register modifier should be preserved.
     #[rustfmt::skip]
     fn build_input_cpuid_templates() -> Vec<CustomCpuTemplate> {
         vec![
@@ -146,7 +217,6 @@ mod tests {
             CustomCpuTemplate {
                 cpuid_modifiers: vec![
                     cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
-                        cpuid_reg_modifier!(Eax, 0x0),
                         cpuid_reg_modifier!(Ebx, 0x0),
                     ]),
                 ],
@@ -158,7 +228,6 @@ mod tests {
                         cpuid_reg_modifier!(Eax, 0x0),
                     ]),
                     cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
-                        cpuid_reg_modifier!(Eax, 0x0),
                         cpuid_reg_modifier!(Ebx, 0x1),
                     ]),
                 ],
@@ -167,7 +236,6 @@ mod tests {
             CustomCpuTemplate {
                 cpuid_modifiers: vec![
                     cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
-                        cpuid_reg_modifier!(Eax, 0x0),
                         cpuid_reg_modifier!(Ebx, 0x2),
                     ]),
                 ],

--- a/src/cpu-template-helper/src/strip/x86_64.rs
+++ b/src/cpu-template-helper/src/strip/x86_64.rs
@@ -1,0 +1,253 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use vmm::guest_config::templates::CustomCpuTemplate;
+
+use crate::strip::remove_common;
+
+#[allow(dead_code)]
+pub fn strip(templates: Vec<CustomCpuTemplate>) -> Vec<CustomCpuTemplate> {
+    // Convert `Vec<CustomCpuTemplate>` to two `Vec<HashSet<_>>` of modifiers.
+    let (mut cpuid_modifiers_sets, mut msr_modifiers_sets): (Vec<_>, Vec<_>) = templates
+        .into_iter()
+        .map(|template| {
+            (
+                template.cpuid_modifiers.into_iter().collect::<HashSet<_>>(),
+                template.msr_modifiers.into_iter().collect::<HashSet<_>>(),
+            )
+        })
+        .unzip();
+
+    // Remove common items.
+    remove_common(&mut cpuid_modifiers_sets);
+    remove_common(&mut msr_modifiers_sets);
+
+    // Convert back to `Vec<CustomCpuTemplate>`.
+    cpuid_modifiers_sets
+        .into_iter()
+        .zip(msr_modifiers_sets.into_iter())
+        .map(|(cpuid_modifiers_set, msr_modifiers_set)| {
+            let mut cpuid_modifiers = cpuid_modifiers_set.into_iter().collect::<Vec<_>>();
+            let mut msr_modifiers = msr_modifiers_set.into_iter().collect::<Vec<_>>();
+
+            cpuid_modifiers.sort_by_key(|modifier| (modifier.leaf, modifier.subleaf));
+            msr_modifiers.sort_by_key(|modifier| modifier.addr);
+
+            CustomCpuTemplate {
+                cpuid_modifiers,
+                msr_modifiers,
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use vmm::guest_config::cpuid::KvmCpuidFlags;
+    use vmm::guest_config::templates::x86_64::CpuidRegister::*;
+    use vmm::guest_config::templates::x86_64::{
+        CpuidLeafModifier, CpuidRegisterModifier, RegisterModifier, RegisterValueFilter,
+    };
+
+    use super::*;
+
+    macro_rules! cpuid_reg_modifier {
+        ($register:expr, $value:literal) => {
+            CpuidRegisterModifier {
+                register: $register,
+                bitmap: RegisterValueFilter {
+                    filter: u32::MAX.into(),
+                    value: $value,
+                },
+            }
+        };
+    }
+
+    macro_rules! cpuid_leaf_modifier {
+        ($leaf:literal, $subleaf:literal, $flags:expr, $reg_modifiers:expr) => {
+            CpuidLeafModifier {
+                leaf: $leaf,
+                subleaf: $subleaf,
+                flags: $flags,
+                modifiers: $reg_modifiers,
+            }
+        };
+    }
+
+    macro_rules! msr_modifier {
+        ($addr:literal, $value:literal) => {
+            RegisterModifier {
+                addr: $addr,
+                bitmap: RegisterValueFilter {
+                    filter: u64::MAX,
+                    value: $value,
+                },
+            }
+        };
+    }
+
+    // Summary of CPUID modifiers:
+    // * As CPUID leaf 0x0 / subleaf 0x0 modifier exists in all the templates and its values are
+    //   different, it should be removed.
+    // * As CPUID leaf 0x1 / subleaf 0x0 modifier only exists in the second template, it should be
+    //   preserved.
+    // * As CPUID leaf 0x2 / subleaf 0x1 modifier exists in all the templates but EBX values are
+    //   different, the leaf modifier (not only the register modifier EBX) should be preserved.
+    #[rustfmt::skip]
+    fn build_input_cpuid_templates() -> Vec<CustomCpuTemplate> {
+        vec![
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![
+                    cpuid_leaf_modifier!(0x0, 0x0, KvmCpuidFlags::EMPTY, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                    ]),
+                    cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                        cpuid_reg_modifier!(Ebx, 0x0),
+                    ]),
+                ],
+                msr_modifiers: vec![],
+            },
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![
+                    cpuid_leaf_modifier!(0x0, 0x0, KvmCpuidFlags::EMPTY, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                    ]),
+                    cpuid_leaf_modifier!(0x1, 0x0, KvmCpuidFlags::EMPTY, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                    ]),
+                    cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                        cpuid_reg_modifier!(Ebx, 0x1),
+                    ]),
+                ],
+                msr_modifiers: vec![],
+            },
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![
+                    cpuid_leaf_modifier!(0x0, 0x0, KvmCpuidFlags::EMPTY, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                    ]),
+                    cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                        cpuid_reg_modifier!(Ebx, 0x2),
+                    ]),
+                ],
+                msr_modifiers: vec![],
+            },
+        ]
+    }
+
+    #[rustfmt::skip]
+    fn build_expected_cpuid_templates() -> Vec<CustomCpuTemplate> {
+        vec![
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![
+                    cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                        cpuid_reg_modifier!(Ebx, 0x0),
+                    ]),
+                ],
+                msr_modifiers: vec![],
+            },
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![
+                    cpuid_leaf_modifier!(0x1, 0x0, KvmCpuidFlags::EMPTY, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                    ]),
+                    cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                        cpuid_reg_modifier!(Ebx, 0x1),
+                    ]),
+                ],
+                msr_modifiers: vec![],
+            },
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![
+                    cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
+                        cpuid_reg_modifier!(Eax, 0x0),
+                        cpuid_reg_modifier!(Ebx, 0x2),
+                    ]),
+                ],
+                msr_modifiers: vec![],
+            },
+        ]
+    }
+
+    // Summary of MSR modifiers:
+    // * As addr 0x0 modifier exists in all the templates but its values are different, it should be
+    //   preserved.
+    // * As addr 0x1 modifier exists in all the templates and its values are same, it should be
+    //   removed.
+    // * As addr 0x2 modifier only exist in the third template, it should be preserved.
+    #[rustfmt::skip]
+    fn build_input_msr_templates() -> Vec<CustomCpuTemplate> {
+        vec![
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![],
+                msr_modifiers: vec![
+                    msr_modifier!(0x0, 0x0),
+                    msr_modifier!(0x1, 0x1),
+                ],
+            },
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![],
+                msr_modifiers: vec![
+                    msr_modifier!(0x0, 0x1),
+                    msr_modifier!(0x1, 0x1),
+                ],
+            },
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![],
+                msr_modifiers: vec![
+                    msr_modifier!(0x0, 0x2),
+                    msr_modifier!(0x1, 0x1),
+                    msr_modifier!(0x2, 0x1),
+                ],
+            },
+        ]
+    }
+
+    #[rustfmt::skip]
+    fn build_expected_msr_templates() -> Vec<CustomCpuTemplate> {
+        vec![
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![],
+                msr_modifiers: vec![
+                    msr_modifier!(0x0, 0x0),
+                ],
+            },
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![],
+                msr_modifiers: vec![
+                    msr_modifier!(0x0, 0x1),
+                ],
+            },
+            CustomCpuTemplate {
+                cpuid_modifiers: vec![],
+                msr_modifiers: vec![
+                    msr_modifier!(0x0, 0x2),
+                    msr_modifier!(0x2, 0x1),
+                ],
+            },
+        ]
+    }
+
+    #[test]
+    fn test_strip_cpuid_modifiers() {
+        let input = build_input_cpuid_templates();
+        let result = strip(input);
+        let expected = build_expected_cpuid_templates();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_strip_msr_modifiers() {
+        let input = build_input_msr_templates();
+        let result = strip(input);
+        let expected = build_expected_msr_templates();
+        assert_eq!(result, expected);
+    }
+}

--- a/src/cpu-template-helper/src/utils.rs
+++ b/src/cpu-template-helper/src/utils.rs
@@ -19,6 +19,63 @@ pub fn add_suffix(path: &Path, suffix: &str) -> PathBuf {
     path.with_file_name(new_file_name)
 }
 
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64 {
+    macro_rules! reg_modifier {
+        ($addr:expr, $value:expr) => {
+            RegisterModifier {
+                addr: $addr,
+                bitmap: RegisterValueFilter {
+                    filter: u128::MAX,
+                    value: $value,
+                },
+            }
+        };
+    }
+
+    pub(crate) use reg_modifier;
+}
+
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64 {
+    macro_rules! cpuid_reg_modifier {
+        ($register:expr, $value:expr) => {
+            CpuidRegisterModifier {
+                register: $register,
+                bitmap: RegisterValueFilter {
+                    filter: u32::MAX.into(),
+                    value: $value,
+                },
+            }
+        };
+    }
+
+    macro_rules! cpuid_leaf_modifier {
+        ($leaf:expr, $subleaf:expr, $flags:expr, $reg_modifiers:expr) => {
+            CpuidLeafModifier {
+                leaf: $leaf,
+                subleaf: $subleaf,
+                flags: $flags,
+                modifiers: $reg_modifiers,
+            }
+        };
+    }
+
+    macro_rules! msr_modifier {
+        ($addr:expr, $value:expr) => {
+            RegisterModifier {
+                addr: $addr,
+                bitmap: RegisterValueFilter {
+                    filter: u64::MAX,
+                    value: $value,
+                },
+            }
+        };
+    }
+
+    pub(crate) use {cpuid_leaf_modifier, cpuid_reg_modifier, msr_modifier};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cpu-template-helper/src/utils.rs
+++ b/src/cpu-template-helper/src/utils.rs
@@ -1,0 +1,55 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+pub fn add_suffix(path: &Path, suffix: &str) -> PathBuf {
+    // Extract the part of the filename before the extension.
+    let mut new_file_name = OsString::from(path.file_stem().unwrap());
+
+    // Push the suffix and the extension.
+    new_file_name.push(suffix);
+    if let Some(ext) = path.extension() {
+        new_file_name.push(".");
+        new_file_name.push(ext);
+    }
+
+    // Swap the file name.
+    path.with_file_name(new_file_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SUFFIX: &str = "_suffix";
+
+    #[test]
+    fn test_add_suffix_filename_only() {
+        let path = PathBuf::from("file.ext");
+        let expected = PathBuf::from(format!("file{SUFFIX}.ext"));
+        assert_eq!(add_suffix(&path, SUFFIX), expected);
+    }
+
+    #[test]
+    fn test_add_suffix_filename_without_ext() {
+        let path = PathBuf::from("file_no_ext");
+        let expected = PathBuf::from(format!("file_no_ext{SUFFIX}"));
+        assert_eq!(add_suffix(&path, SUFFIX), expected);
+    }
+
+    #[test]
+    fn test_add_suffix_rel_path() {
+        let path = PathBuf::from("relative/path/to/file.ext");
+        let expected = PathBuf::from(format!("relative/path/to/file{SUFFIX}.ext"));
+        assert_eq!(add_suffix(&path, SUFFIX), expected);
+    }
+
+    #[test]
+    fn test_add_suffix_abs_path() {
+        let path = PathBuf::from("/absolute/path/to/file.ext");
+        let expected = PathBuf::from(format!("/absolute/path/to/file{SUFFIX}.ext"));
+        assert_eq!(add_suffix(&path, SUFFIX), expected);
+    }
+}

--- a/src/vmm/src/guest_config/cpuid/mod.rs
+++ b/src/vmm/src/guest_config/cpuid/mod.rs
@@ -491,7 +491,7 @@ impl std::cmp::Ord for CpuidKey {
 
 /// Definitions from `kvm/arch/x86/include/uapi/asm/kvm.h
 #[derive(
-    Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy,
+    Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash,
 )]
 pub struct KvmCpuidFlags(pub u32);
 impl KvmCpuidFlags {

--- a/src/vmm/src/guest_config/templates/aarch64.rs
+++ b/src/vmm/src/guest_config/templates/aarch64.rs
@@ -40,7 +40,7 @@ pub struct CustomCpuTemplate {
 
 /// Wrapper of a mask defined as a bitmap to apply
 /// changes to a given register's value.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct RegisterModifier {
     /// Pointer of the location to be bit mapped.
     #[serde(
@@ -58,7 +58,7 @@ pub struct RegisterModifier {
 }
 
 /// Bit-mapped value to adjust targeted bits of a register.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct RegisterValueFilter {
     /// Filter to be used when writing the value bits.
     pub filter: u128,

--- a/src/vmm/src/guest_config/templates/x86_64.rs
+++ b/src/vmm/src/guest_config/templates/x86_64.rs
@@ -71,7 +71,7 @@ impl GetCpuTemplate for Option<CpuTemplateType> {
 
 /// CPUID register enumeration
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Ord, PartialOrd)]
 pub enum CpuidRegister {
     Eax,
     Ebx,

--- a/src/vmm/src/guest_config/templates/x86_64.rs
+++ b/src/vmm/src/guest_config/templates/x86_64.rs
@@ -71,7 +71,7 @@ impl GetCpuTemplate for Option<CpuTemplateType> {
 
 /// CPUID register enumeration
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum CpuidRegister {
     Eax,
     Ebx,
@@ -80,7 +80,7 @@ pub enum CpuidRegister {
 }
 
 /// Target register to be modified by a bitmap.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct CpuidRegisterModifier {
     /// CPUID register to be modified by the bitmap.
     #[serde(
@@ -100,7 +100,7 @@ pub struct CpuidRegisterModifier {
 /// Composite type that holistically provides
 /// the location of a specific register being used
 /// in the context of a CPUID tree.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct CpuidLeafModifier {
     /// Leaf value.
     #[serde(
@@ -134,7 +134,7 @@ pub struct CustomCpuTemplate {
 }
 
 /// Bit-mapped value to adjust targeted bits of a register.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct RegisterValueFilter {
     /// Filter to be used when writing the value bits.
     pub filter: u64,
@@ -152,7 +152,7 @@ impl RegisterValueFilter {
 
 /// Wrapper of a mask defined as a bitmap to apply
 /// changes to a given register's value.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct RegisterModifier {
     /// Pointer of the location to be bit mapped.
     #[serde(

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,15 +25,15 @@ def is_on_skylake():
 # differences may appear.
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {
-        "Intel": 81.77 if is_on_skylake() else 82.28,
-        "AMD": 80.8,
-        "ARM": 82.68,
+        "Intel": 81.86 if is_on_skylake() else 82.37,
+        "AMD": 80.90,
+        "ARM": 82.76,
     }
 else:
     COVERAGE_DICT = {
-        "Intel": 78.99 if is_on_skylake() else 79.52,
-        "AMD": 78.06,
-        "ARM": 79.59,
+        "Intel": 79.09 if is_on_skylake() else 79.61,
+        "AMD": 78.13,
+        "ARM": 79.71,
     }
 
 PROC_MODEL = proc.proc_type()


### PR DESCRIPTION
## Changes

- Add a strip feature of CPU template helper tool.

## Reason

PR #3586 introduced the dump feature to dump CPU configuration in the custom CPU template JSON format. The dumped CPU configurations allow users to check what CPU configurations (CPUID and MSR for x86_64 and registers supported by `KVM_{GET/SET}_ONE_REG` for aarch64) are exposed to guests and use it as a draft custom CPU template.

As you can see in commit ee9d27fb981eb075caaf52113ad95157ad40e9a8, the dumped CPU configurations are ~1,000 lines of JSON files and it is quite difficult for humans to comprehend all the dumped information. Considering the main use case of CPU templates is to provide the feature parity between guests running on different CPU models, items that are shared between those CPU configurations and have same values can be ignored. The strip feature automates this removal of shared items.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
