### PR TITLE
Backport Fix spurious failure in api_server::tests::test_serve_vmm_action_request  to FC 1.3

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -336,7 +336,12 @@ mod tests {
         let response = api_server.serve_vmm_action_request(Box::new(VmmAction::StartMicroVm), 0);
         assert_eq!(response.status(), StatusCode::BadRequest);
 
-        let start_time_us = utils::time::get_time_us(ClockType::Monotonic);
+        // Since the vmm side is mocked out in this test, the call to serve_vmm_action_request can
+        // complete very fast (under 1us, the resolution of our metrics). In these cases, the
+        // latencies_us.pause_vm metric can be set to 0, failing the assertion below. By
+        // subtracting 1 we assure that the metric will always be set to at least 1 (if it gets set
+        // at all, which is what this test is trying to prove).
+        let start_time_us = utils::time::get_time_us(ClockType::Monotonic) - 1;
         assert_eq!(METRICS.latencies_us.pause_vm.fetch(), 0);
         to_api.send(Box::new(Ok(VmmData::Empty))).unwrap();
         let response =


### PR DESCRIPTION
Backport to FC 1.3 for commit d6f55d6ccdd9eb351400d4a7d523fa5ce46489a0
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
