### PR TITLE
Remove CPU model validation from python tests

### DIFF
--- a/tests/framework/utils_cpuid.py
+++ b/tests/framework/utils_cpuid.py
@@ -57,21 +57,21 @@ def get_cpu_model_name():
     return CPU_DICT[CpuVendor.ARM].get(raw_cpu_model, "Unknown")
 
 
-def get_cpu_codename():
+def get_cpu_codename(default="Unknown"):
     """Return the CPU codename."""
     cpu_model = get_cpu_model_name()
     vendor = get_cpu_vendor()
     if vendor == CpuVendor.INTEL:
         result = re.match(r"^(.*) @.*$", cpu_model)
-        assert result, "CPU model name does not match the regex pattern."
-        return CPU_DICT[CpuVendor.INTEL].get(result.group(1), "Unknown")
+        if result:
+            return CPU_DICT[CpuVendor.INTEL].get(result.group(1), default)
     if vendor == CpuVendor.AMD:
         result = re.match(r"^(.*) [0-9]*-Core Processor$", cpu_model)
-        assert result, "CPU model name does not match the regex pattern."
-        return CPU_DICT[CpuVendor.AMD].get(result.group(1), "Unknown")
+        if result:
+            return CPU_DICT[CpuVendor.AMD].get(result.group(1), default)
     if vendor == CpuVendor.ARM:
         return cpu_model
-    return None
+    return default
 
 
 def get_instance_type():

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -31,7 +31,7 @@ if utils.is_io_uring_supported():
     }
 else:
     COVERAGE_DICT = {
-        "Intel": 78.90 if is_on_skylake() else 79.52,
+        "Intel": 78.99 if is_on_skylake() else 79.52,
         "AMD": 78.06,
         "ARM": 79.59,
     }


### PR DESCRIPTION
## Changes

* Removes asserts from `get_cpu_codename` utility function that checks that the host environment is a known CPU model.

## Reason

The asserts enforce that only known CPU models may run tests written in Pytest. This unfortunately prevents the Firecracker pytests from running on anything but specific CPU models currently defined by:
```
CPU_DICT = {
    CpuVendor.INTEL: {
        "Intel(R) Xeon(R) Platinum 8175M CPU": "INTEL_SKYLAKE",
        "Intel(R) Xeon(R) Platinum 8259CL CPU": "INTEL_CASCADELAKE",
        "Intel(R) Xeon(R) Platinum 8375C CPU": "INTEL_ICELAKE",
    },
    CpuVendor.AMD: {
        "AMD EPYC 7R13": "AMD_MILAN",
    },
    CpuVendor.ARM: {"0xd0c": "ARM_NEOVERSE_N1", "0xd40": "ARM_NEOVERSE_V1"},
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
