### PR TITLE
Tweaks to improve overall test coverage

### DIFF
--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 bitflags = "2.0.2"
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
 event-manager = "0.3.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"

--- a/src/vmm/src/guest_config/cpuid/common.rs
+++ b/src/vmm/src/guest_config/cpuid/common.rs
@@ -83,7 +83,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn get_cpuid_invalid_leaf() {
+    fn get_cpuid_unsupported_leaf() {
         let max_leaf =
             // JUSTIFICATION: There is no safe alternative.
             // SAFETY: This is safe because the host supports the `cpuid` instruction

--- a/src/vmm/src/guest_config/cpuid/common.rs
+++ b/src/vmm/src/guest_config/cpuid/common.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::restriction)]
 
 use super::CpuidTrait;
+use crate::guest_config::cpuid::intel::intel_msrs_to_save_by_cpuid;
 
 /// Error type for [`get_cpuid`].
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -75,92 +76,6 @@ pub fn msrs_to_save_by_cpuid(
         // We don't have MSR-CPUID dependencies set for other vendors yet.
         _ => Ok(std::collections::HashSet::new()),
     }
-}
-
-/// Returns MSRs to be saved based on the Intel CPUID features that are enabled.
-#[must_use]
-pub fn intel_msrs_to_save_by_cpuid(cpuid: &kvm_bindings::CpuId) -> std::collections::HashSet<u32> {
-    /// Memory Protection Extensions
-    const MPX_BITINDEX: u32 = 14;
-
-    /// Memory Type Range Registers
-    const MTRR_BITINDEX: u32 = 12;
-
-    /// Memory Check Exception
-    const MCE_BITINDEX: u32 = 7;
-
-    /// Scans through the CPUID and determines if a feature bit is set.
-    // TODO: This currently involves a linear search which would be improved
-    //       when we'll refactor the cpuid crate.
-    macro_rules! cpuid_is_feature_set {
-        ($cpuid:ident, $leaf:expr, $index:expr, $reg:tt, $feature_bit:expr) => {{
-            let mut res = false;
-            for entry in $cpuid.as_slice().iter() {
-                if entry.function == $leaf && entry.index == $index {
-                    if entry.$reg & (1 << $feature_bit) != 0 {
-                        res = true;
-                        break;
-                    }
-                }
-            }
-            res
-        }};
-    }
-
-    let mut msrs = std::collections::HashSet::new();
-
-    // Macro used for easy definition of CPUID-MSR dependencies.
-    macro_rules! cpuid_msr_dep {
-        ($leaf:expr, $index:expr, $reg:tt, $feature_bit:expr, $msr:expr) => {
-            if cpuid_is_feature_set!(cpuid, $leaf, $index, $reg, $feature_bit) {
-                msrs.extend($msr)
-            }
-        };
-    }
-
-    // TODO: Add more dependencies.
-    cpuid_msr_dep!(
-        0x7,
-        0,
-        ebx,
-        MPX_BITINDEX,
-        [crate::arch_gen::x86::msr_index::MSR_IA32_BNDCFGS]
-    );
-
-    // IA32_MTRR_PHYSBASEn, IA32_MTRR_PHYSMASKn
-    cpuid_msr_dep!(0x1, 0, edx, MTRR_BITINDEX, 0x200..0x210);
-
-    // Other MTRR MSRs
-    cpuid_msr_dep!(
-        0x1,
-        0,
-        edx,
-        MTRR_BITINDEX,
-        [
-            0x250, // IA32_MTRR_FIX64K_00000
-            0x258, // IA32_MTRR_FIX16K_80000
-            0x259, // IA32_MTRR_FIX16K_A0000
-            0x268, // IA32_MTRR_FIX4K_C0000
-            0x269, // IA32_MTRR_FIX4K_C8000
-            0x26a, // IA32_MTRR_FIX4K_D0000
-            0x26b, // IA32_MTRR_FIX4K_D8000
-            0x26c, // IA32_MTRR_FIX4K_E0000
-            0x26d, // IA32_MTRR_FIX4K_E8000
-            0x26e, // IA32_MTRR_FIX4K_F0000
-            0x26f, // IA32_MTRR_FIX4K_F8000
-            0x277, // IA32_PAT
-            0x2ff  // IA32_MTRR_DEF_TYPE
-        ]
-    );
-
-    // MCE MSRs
-    // We are saving 32 MCE banks here as this is the maximum number supported by KVM
-    // and configured by default.
-    // The physical number of the MCE banks depends on the CPU.
-    // The number of emulated MCE banks can be configured via KVM_X86_SETUP_MCE.
-    cpuid_msr_dep!(0x1, 0, edx, MCE_BITINDEX, 0x400..0x480);
-
-    msrs
 }
 
 #[cfg(test)]

--- a/src/vmm/src/guest_config/cpuid/intel/mod.rs
+++ b/src/vmm/src/guest_config/cpuid/intel/mod.rs
@@ -34,6 +34,94 @@ impl CpuidTrait for IntelCpuid {
     }
 }
 
+/// Returns MSRs to be saved based on the Intel CPUID features that are enabled.
+#[must_use]
+pub(crate) fn intel_msrs_to_save_by_cpuid(
+    cpuid: &kvm_bindings::CpuId,
+) -> std::collections::HashSet<u32> {
+    /// Memory Protection Extensions
+    const MPX_BITINDEX: u32 = 14;
+
+    /// Memory Type Range Registers
+    const MTRR_BITINDEX: u32 = 12;
+
+    /// Memory Check Exception
+    const MCE_BITINDEX: u32 = 7;
+
+    /// Scans through the CPUID and determines if a feature bit is set.
+    // TODO: This currently involves a linear search which would be improved
+    //       when we'll refactor the cpuid crate.
+    macro_rules! cpuid_is_feature_set {
+        ($cpuid:ident, $leaf:expr, $index:expr, $reg:tt, $feature_bit:expr) => {{
+            let mut res = false;
+            for entry in $cpuid.as_slice().iter() {
+                if entry.function == $leaf && entry.index == $index {
+                    if entry.$reg & (1 << $feature_bit) != 0 {
+                        res = true;
+                        break;
+                    }
+                }
+            }
+            res
+        }};
+    }
+
+    let mut msrs = std::collections::HashSet::new();
+
+    // Macro used for easy definition of CPUID-MSR dependencies.
+    macro_rules! cpuid_msr_dep {
+        ($leaf:expr, $index:expr, $reg:tt, $feature_bit:expr, $msr:expr) => {
+            if cpuid_is_feature_set!(cpuid, $leaf, $index, $reg, $feature_bit) {
+                msrs.extend($msr)
+            }
+        };
+    }
+
+    // TODO: Add more dependencies.
+    cpuid_msr_dep!(
+        0x7,
+        0,
+        ebx,
+        MPX_BITINDEX,
+        [crate::arch_gen::x86::msr_index::MSR_IA32_BNDCFGS]
+    );
+
+    // IA32_MTRR_PHYSBASEn, IA32_MTRR_PHYSMASKn
+    cpuid_msr_dep!(0x1, 0, edx, MTRR_BITINDEX, 0x200..0x210);
+
+    // Other MTRR MSRs
+    cpuid_msr_dep!(
+        0x1,
+        0,
+        edx,
+        MTRR_BITINDEX,
+        [
+            0x250, // IA32_MTRR_FIX64K_00000
+            0x258, // IA32_MTRR_FIX16K_80000
+            0x259, // IA32_MTRR_FIX16K_A0000
+            0x268, // IA32_MTRR_FIX4K_C0000
+            0x269, // IA32_MTRR_FIX4K_C8000
+            0x26a, // IA32_MTRR_FIX4K_D0000
+            0x26b, // IA32_MTRR_FIX4K_D8000
+            0x26c, // IA32_MTRR_FIX4K_E0000
+            0x26d, // IA32_MTRR_FIX4K_E8000
+            0x26e, // IA32_MTRR_FIX4K_F0000
+            0x26f, // IA32_MTRR_FIX4K_F8000
+            0x277, // IA32_PAT
+            0x2ff  // IA32_MTRR_DEF_TYPE
+        ]
+    );
+
+    // MCE MSRs
+    // We are saving 32 MCE banks here as this is the maximum number supported by KVM
+    // and configured by default.
+    // The physical number of the MCE banks depends on the CPU.
+    // The number of emulated MCE banks can be configured via KVM_X86_SETUP_MCE.
+    cpuid_msr_dep!(0x1, 0, edx, MCE_BITINDEX, 0x400..0x480);
+
+    msrs
+}
+
 impl From<kvm_bindings::CpuId> for IntelCpuid {
     #[inline]
     fn from(kvm_cpuid: kvm_bindings::CpuId) -> Self {

--- a/src/vmm/src/guest_config/cpuid/mod.rs
+++ b/src/vmm/src/guest_config/cpuid/mod.rs
@@ -728,26 +728,38 @@ mod tests {
 
     #[test]
     fn get() {
-        let cpuid = Cpuid::Intel(IntelCpuid(BTreeMap::new()));
+        let cpuid = build_sample_intel_cpuid();
         assert_eq!(
             cpuid.get(&CpuidKey {
-                leaf: 0,
-                subleaf: 0
+                leaf: 0x8888,
+                subleaf: 0x0
             }),
             None
         );
+        assert!(cpuid
+            .get(&CpuidKey {
+                leaf: 0x0,
+                subleaf: 0x0,
+            })
+            .is_some());
     }
 
     #[test]
     fn get_mut() {
-        let mut cpuid = Cpuid::Intel(IntelCpuid(BTreeMap::new()));
+        let mut cpuid = build_sample_intel_cpuid();
         assert_eq!(
             cpuid.get_mut(&CpuidKey {
-                leaf: 0,
-                subleaf: 0
+                leaf: 0x888,
+                subleaf: 0x0,
             }),
             None
         );
+        assert!(cpuid
+            .get_mut(&CpuidKey {
+                leaf: 0x0,
+                subleaf: 0x0,
+            })
+            .is_some());
     }
 
     #[test]

--- a/src/vmm/src/guest_config/templates/mod.rs
+++ b/src/vmm/src/guest_config/templates/mod.rs
@@ -73,15 +73,6 @@ pub enum CpuTemplateType {
     Static(StaticCpuTemplate),
 }
 
-impl From<StaticCpuTemplate> for Option<CpuTemplateType> {
-    fn from(value: StaticCpuTemplate) -> Self {
-        match value {
-            StaticCpuTemplate::None => None,
-            other => Some(CpuTemplateType::Static(other)),
-        }
-    }
-}
-
 impl From<&Option<CpuTemplateType>> for StaticCpuTemplate {
     fn from(value: &Option<CpuTemplateType>) -> Self {
         match value {

--- a/src/vmm/src/guest_config/templates/x86_64.rs
+++ b/src/vmm/src/guest_config/templates/x86_64.rs
@@ -464,6 +464,9 @@ mod tests {
             cpu_template.get_cpu_template().unwrap_err(),
             GetCpuTemplateError::InvalidStaticCpuTemplate(StaticCpuTemplate::None)
         );
+
+        // Test the Display for StaticCpuTemplate
+        assert_eq!(format!("{}", StaticCpuTemplate::None), "None");
     }
 
     #[test]

--- a/src/vmm/src/guest_config/templates/x86_64.rs
+++ b/src/vmm/src/guest_config/templates/x86_64.rs
@@ -413,6 +413,21 @@ mod tests {
     }
 
     #[test]
+    fn test_t2cl_template_equality() {
+        // For coverage purposes, this test forces usage of T2CL and bypasses
+        // validation that is generally applied which usually enforces that T2CL
+        // can only be used on Cascade Lake (or newer) CPUs.
+        let t2cl_custom_template = CpuTemplateType::Custom(t2cl::t2cl());
+        // This test also demonstrates the difference in concept between custom and static
+        // templates, while practically T2CL is consistent for the user, in code
+        // the static template of T2CL, and the custom template of T2CL are not equivalent.
+        assert_ne!(
+            t2cl_custom_template,
+            CpuTemplateType::Static(StaticCpuTemplate::T2CL)
+        );
+    }
+
+    #[test]
     fn test_get_cpu_template_with_t2cl_static_template() {
         // Test `get_cpu_template()` when T2CL static CPU template is specified. The owned
         // `CustomCpuTemplate` should be returned if CPU vendor is Intel. Otherwise, it should fail.

--- a/src/vmm/src/guest_config/x86_64/static_cpu_templates/mod.rs
+++ b/src/vmm/src/guest_config/x86_64/static_cpu_templates/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;
@@ -18,20 +19,28 @@ pub mod t2s;
 
 /// Template types available for configuring the x86 CPU features that map
 /// to EC2 instances.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Versionize)]
+#[derive(
+    Debug, Default, Display, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Versionize,
+)]
 pub enum StaticCpuTemplate {
     /// C3 Template.
+    #[display(fmt = "C3")]
     C3,
     /// T2 Template.
+    #[display(fmt = "T2")]
     T2,
     /// T2S Template.
+    #[display(fmt = "T2S")]
     T2S,
     /// No CPU template is used.
     #[default]
+    #[display(fmt = "None")]
     None,
     /// T2CL Template.
+    #[display(fmt = "T2CL")]
     T2CL,
     /// T2A Template.
+    #[display(fmt = "T2A")]
     T2A,
 }
 
@@ -39,18 +48,5 @@ impl StaticCpuTemplate {
     /// Check if no template specified
     pub fn is_none(&self) -> bool {
         self == &StaticCpuTemplate::None
-    }
-}
-
-impl std::fmt::Display for StaticCpuTemplate {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            StaticCpuTemplate::C3 => write!(f, "C3"),
-            StaticCpuTemplate::T2 => write!(f, "T2"),
-            StaticCpuTemplate::T2S => write!(f, "T2S"),
-            StaticCpuTemplate::None => write!(f, "None"),
-            StaticCpuTemplate::T2CL => write!(f, "T2CL"),
-            StaticCpuTemplate::T2A => write!(f, "T2A"),
-        }
     }
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,17 +24,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {
-        "Intel": 82.75 if is_on_skylake() else 83.27,
-        "AMD": 82.83,
-        "ARM": 82.68,
-    }
+    COVERAGE_DICT = {"Intel": 83.27, "AMD": 82.83, "ARM": 82.68}
 else:
-    COVERAGE_DICT = {
-        "Intel": 79.94 if is_on_skylake() else 80.46,
-        "AMD": 79.96,
-        "ARM": 79.59,
-    }
+    COVERAGE_DICT = {"Intel": 80.46, "AMD": 79.96, "ARM": 79.59}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,9 +24,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 83.27, "AMD": 82.83, "ARM": 82.68}
+    COVERAGE_DICT = {"Intel": 83.40, "AMD": 82.94, "ARM": 82.79}
 else:
-    COVERAGE_DICT = {"Intel": 80.51, "AMD": 79.96, "ARM": 79.59}
+    COVERAGE_DICT = {"Intel": 80.60, "AMD": 80.08, "ARM": 79.73}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -26,13 +26,13 @@ def is_on_skylake():
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {
         "Intel": 82.75 if is_on_skylake() else 83.27,
-        "AMD": 82.64,
+        "AMD": 82.83,
         "ARM": 82.68,
     }
 else:
     COVERAGE_DICT = {
         "Intel": 79.94 if is_on_skylake() else 80.46,
-        "AMD": 79.77,
+        "AMD": 79.96,
         "ARM": 79.59,
     }
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -26,7 +26,7 @@ def is_on_skylake():
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {"Intel": 83.27, "AMD": 82.83, "ARM": 82.68}
 else:
-    COVERAGE_DICT = {"Intel": 80.46, "AMD": 79.96, "ARM": 79.59}
+    COVERAGE_DICT = {"Intel": 80.51, "AMD": 79.96, "ARM": 79.59}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -86,6 +86,7 @@ def test_coverage(monkeypatch, record_property, metrics):
             --ignore "build/*" \
             --ignore "**/tests/*" \
             --ignore "**/test_utils*" \
+            --ignore "**/mock_*" \
             -t html \
             --ignore-not-existing \
             -o ./build/cargo_target/{TARGET}/debug/coverage"""


### PR DESCRIPTION
## Changes

* Use derive_more::Display for a CPUID related error handling.
* Ignore AMD specific code when running checking test coverage on an Intel host.
* Ignore Intel specific code when running checking test coverage on an AMD host.

## Reason

Improves accuracy of the Firecracker coverage report and improves the coverage target.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].
