### PR TITLE
doc: Add guidance on disabling unprivileged BPF

### DIFF
--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -274,6 +274,34 @@ echo "Hyperthreading: ENABLED (Recommendation: DISABLED)"
 **Note** There are some newer aarch64 CPUs that also implement SMT, however AWS Graviton
 processors do not implement it.
 
+#### Disable Unprivileged BPF
+
+Disabling BPF for unprivileged users protects against various transient
+execution attacks. See ["Spectre revisits
+BPF"](https://lwn.net/Articles/860597/) for one synopsis.
+
+Ensure unprivileged BPF remains disabled by setting `unprivileged_bpf_disable`
+to `1` as documented in the [kernel admin
+guide](https://docs.kernel.org/admin-guide/sysctl/kernel.html#unprivileged-bpf-disabled):
+
+```console
+echo "kernel.unprivileged_bpf_disabled = 1" >> /etc/sysctl.conf
+```
+
+The default setting is determined by the Linux kernel config
+`BPF_UNPRIV_DEFAULT_OFF` which defaults to `Y` starting with [this
+commit](https://github.com/torvalds/linux/commit/8a03e56b253e9691c90bc52ca199323d71b96204)
+first picked up in version 5.16. Amazon Linux kernel configs all use
+`BPF_UNPRIV_DEFAULT_OFF=Y`.
+
+Verification can be done by running:
+
+```bash
+cat /proc/sys/kernel/unprivileged_bpf_disabled
+```
+
+The output should be `1`
+
 #### [Intel and ARM only] Check Kernel Page-Table Isolation (KPTI) support
 
 KPTI is used to prevent certain side-channel issues that allow access to


### PR DESCRIPTION
## Changes

Add instructions to disable unprivileged BPF.

## Reason

BPF is a useful tool in various transient execution attacks. While disabling is now a common default, it is worth ensuring unprivileged BPF is disabled.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md