### PR TITLE
Add CHANGELOG entry for `virtio-rng`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for the virtio-rng entropy device. The device is optional and
+  only one device is allowed per VM. Users can configure the device with a PUT
+  API call at the `/entropy` endpoint. Users can optionally configure a rate
+  limiter.
+
 ### Fixed
 
 - Fixed feature flags in T2S CPU template on Intel Ice Lake.


### PR DESCRIPTION
## Changes

Briefly mention what design choices and information about the API endpoint and the parameters users can pass.

## Reason

Prepare for merging to `main`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
