### PR TITLE
feat(tool): Add verify command

### DIFF
--- a/src/cpu-template-helper/src/dump/mod.rs
+++ b/src/cpu-template-helper/src/dump/mod.rs
@@ -51,7 +51,7 @@ mod tests {
         let tmp_file = TempFile::new().unwrap();
         let valid_config =
             generate_config(&kernel_image_path, tmp_file.as_path().to_str().unwrap());
-        let vmm = build_microvm_from_config(&valid_config).unwrap();
+        let (vmm, _) = build_microvm_from_config(&valid_config).unwrap();
 
         assert!(dump(vmm).is_ok());
     }

--- a/src/cpu-template-helper/src/dump/mod.rs
+++ b/src/cpu-template-helper/src/dump/mod.rs
@@ -8,6 +8,7 @@ mod x86_64;
 
 use std::sync::{Arc, Mutex};
 
+use vmm::guest_config::templates::CustomCpuTemplate;
 use vmm::{DumpCpuConfigError, Vmm};
 
 #[cfg(target_arch = "aarch64")]
@@ -20,20 +21,14 @@ pub enum Error {
     /// Failed to dump CPU configuration.
     #[error("Failed to dump CPU config: {0}")]
     DumpCpuConfig(#[from] DumpCpuConfigError),
-    /// Failed to serialize CPU configuration in custom CPU template format.
-    #[error("Failed to serialize CPU configuration in custom CPU template format: {0}")]
-    Serialize(#[from] serde_json::Error),
 }
 
-pub fn dump(vmm: Arc<Mutex<Vmm>>) -> Result<String, Error> {
+pub fn dump(vmm: Arc<Mutex<Vmm>>) -> Result<CustomCpuTemplate, Error> {
     // Get CPU configuration.
     let cpu_configs = vmm.lock().unwrap().dump_cpu_config()?;
 
     // Convert CPU config to CPU template.
-    let cpu_template = config_to_template(&cpu_configs[0]);
-
-    // Serialize it.
-    Ok(serde_json::to_string_pretty(&cpu_template)?)
+    Ok(config_to_template(&cpu_configs[0]))
 }
 
 #[cfg(test)]

--- a/src/cpu-template-helper/src/dump/mod.rs
+++ b/src/cpu-template-helper/src/dump/mod.rs
@@ -6,27 +6,17 @@ mod aarch64;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
-use vmm::builder::{build_microvm_for_boot, StartMicrovmError};
-use vmm::resources::VmResources;
-use vmm::seccomp_filters::{get_filters, SeccompConfig};
-use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
-use vmm::{DumpCpuConfigError, EventManager, HTTP_MAX_PAYLOAD_SIZE};
+use std::sync::{Arc, Mutex};
+
+use vmm::{DumpCpuConfigError, Vmm};
 
 #[cfg(target_arch = "aarch64")]
 use crate::dump::aarch64::config_to_template;
 #[cfg(target_arch = "x86_64")]
 use crate::dump::x86_64::config_to_template;
 
-const CPU_TEMPLATE_HELPER_VERSION: &str = env!("FIRECRACKER_VERSION");
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Failed to create VmResources.
-    #[error("Failed to create VmResources: {0}")]
-    CreateVmResources(vmm::resources::Error),
-    /// Failed to build microVM.
-    #[error("Failed to build microVM: {0}")]
-    BuildMicroVm(#[from] StartMicrovmError),
     /// Failed to dump CPU configuration.
     #[error("Failed to dump CPU config: {0}")]
     DumpCpuConfig(#[from] DumpCpuConfigError),
@@ -35,27 +25,7 @@ pub enum Error {
     Serialize(#[from] serde_json::Error),
 }
 
-pub fn dump(config: String) -> Result<String, Error> {
-    // Prepare resources from the given config file.
-    let instance_info = InstanceInfo {
-        id: "anonymous-instance".to_string(),
-        state: VmState::NotStarted,
-        vmm_version: CPU_TEMPLATE_HELPER_VERSION.to_string(),
-        app_name: "cpu-template-helper".to_string(),
-    };
-    let vm_resources = VmResources::from_json(&config, &instance_info, HTTP_MAX_PAYLOAD_SIZE, None)
-        .map_err(Error::CreateVmResources)?;
-    let mut event_manager = EventManager::new().unwrap();
-    let seccomp_filters = get_filters(SeccompConfig::None).unwrap();
-
-    // Build a microVM.
-    let vmm = build_microvm_for_boot(
-        &instance_info,
-        &vm_resources,
-        &mut event_manager,
-        &seccomp_filters,
-    )?;
-
+pub fn dump(vmm: Arc<Mutex<Vmm>>) -> Result<String, Error> {
     // Get CPU configuration.
     let cpu_configs = vmm.lock().unwrap().dump_cpu_config()?;
 
@@ -73,29 +43,16 @@ mod tests {
 
     use super::*;
     use crate::tests::generate_config;
+    use crate::utils::build_microvm_from_config;
 
     #[test]
-    fn test_valid_config() {
+    fn test_dump() {
         let kernel_image_path = kernel_image_path(None);
         let tmp_file = TempFile::new().unwrap();
         let valid_config =
             generate_config(&kernel_image_path, tmp_file.as_path().to_str().unwrap());
+        let vmm = build_microvm_from_config(&valid_config).unwrap();
 
-        assert!(dump(valid_config).is_ok());
-    }
-
-    #[test]
-    fn test_invalid_config() {
-        let tmp_file = TempFile::new().unwrap();
-        let invalid_kernel_path_config = generate_config(
-            "/invalid_kernel_image_path",
-            tmp_file.as_path().to_str().unwrap(),
-        );
-
-        match dump(invalid_kernel_path_config) {
-            Ok(_) => panic!("Should fail with `No such file or directory`."),
-            Err(Error::CreateVmResources(_)) => (),
-            Err(err) => panic!("Unexpected error: {err}"),
-        }
+        assert!(dump(vmm).is_ok());
     }
 }

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -59,7 +59,7 @@ fn run(cli: Cli) -> Result<()> {
     match cli.command {
         Command::Dump { config, output } => {
             let config = read_to_string(config)?;
-            let vmm = utils::build_microvm_from_config(&config)?;
+            let (vmm, _) = utils::build_microvm_from_config(&config)?;
             let dump_result = dump::dump(vmm)?;
             write(output, dump_result)?;
         }

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -26,8 +26,8 @@ enum Error {
     Serde(#[from] serde_json::Error),
     #[error("{0}")]
     Utils(#[from] utils::Error),
-    #[error("A modifier has not been applied as intended: {0}")]
-    VerifyCpuTemplate(String),
+    #[error("{0}")]
+    VerifyCpuTemplate(#[from] verify::Error),
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -105,7 +105,7 @@ fn run(cli: Cli) -> Result<()> {
                 .into_owned();
             let cpu_config = dump::dump(vmm)?;
 
-            verify::verify(cpu_template, cpu_config).map_err(Error::VerifyCpuTemplate)?;
+            verify::verify(cpu_template, cpu_config)?;
         }
     };
 

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -20,6 +20,8 @@ enum Error {
     DumpCpuConfig(#[from] dump::Error),
     #[error("Failed to strip CPU configuration: {0}")]
     StripCpuConfig(#[from] strip::Error),
+    #[error("{0}")]
+    Utils(#[from] utils::Error),
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -57,7 +59,8 @@ fn run(cli: Cli) -> Result<()> {
     match cli.command {
         Command::Dump { config, output } => {
             let config = read_to_string(config)?;
-            let dump_result = dump::dump(config)?;
+            let vmm = utils::build_microvm_from_config(&config)?;
+            let dump_result = dump::dump(vmm)?;
             write(output, dump_result)?;
         }
         Command::Strip { path, suffix } => {

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -16,7 +16,7 @@ const EXIT_CODE_ERROR: i32 = 1;
 enum Error {
     #[error("Failed to operate file: {0}")]
     FileIo(#[from] std::io::Error),
-    #[error("Failed to dump CPU configuration: {0}")]
+    #[error("{0}")]
     DumpCpuConfig(#[from] dump::Error),
     #[error("Failed to serialize/deserialize JSON file: {0}")]
     Serde(#[from] serde_json::Error),

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -118,7 +118,7 @@ mod tests {
         )
     }
 
-    fn generate_valid_config_file(kernel_image_path: &str, rootfs_path: &str) -> TempFile {
+    fn generate_config_file(kernel_image_path: &str, rootfs_path: &str) -> TempFile {
         let config = generate_config(kernel_image_path, rootfs_path);
         let config_file = TempFile::new().unwrap();
         config_file.as_file().write_all(config.as_bytes()).unwrap();
@@ -130,7 +130,7 @@ mod tests {
         let kernel_image_path = kernel_image_path(None);
         let rootfs_file = TempFile::new().unwrap();
         let config_file =
-            generate_valid_config_file(&kernel_image_path, rootfs_file.as_path().to_str().unwrap());
+            generate_config_file(&kernel_image_path, rootfs_file.as_path().to_str().unwrap());
         let output_file = TempFile::new().unwrap();
 
         let args = vec![

--- a/src/cpu-template-helper/src/strip/aarch64.rs
+++ b/src/cpu-template-helper/src/strip/aarch64.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use vmm::guest_config::templates::CustomCpuTemplate;
 
-use crate::strip::remove_common;
+use crate::strip::strip_common;
 
 #[allow(dead_code)]
 pub fn strip(templates: Vec<CustomCpuTemplate>) -> Vec<CustomCpuTemplate> {
@@ -16,7 +16,7 @@ pub fn strip(templates: Vec<CustomCpuTemplate>) -> Vec<CustomCpuTemplate> {
         .collect::<Vec<_>>();
 
     // Remove common items.
-    remove_common(&mut reg_modifiers_sets);
+    strip_common(&mut reg_modifiers_sets);
 
     // Convert back to `Vec<CustomCpuTemplate>`.
     reg_modifiers_sets

--- a/src/cpu-template-helper/src/strip/aarch64.rs
+++ b/src/cpu-template-helper/src/strip/aarch64.rs
@@ -1,29 +1,28 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
-
+use vmm::guest_config::templates::aarch64::RegisterModifier;
 use vmm::guest_config::templates::CustomCpuTemplate;
 
 use crate::strip::strip_common;
+use crate::utils::aarch64::RegModifierMap;
 
 #[allow(dead_code)]
 pub fn strip(templates: Vec<CustomCpuTemplate>) -> Vec<CustomCpuTemplate> {
-    // Convert `Vec<CustomCpuTemplate>` to `Vec<HashSet<RegisterModifier>>`.
-    let mut reg_modifiers_sets = templates
+    // Convert `Vec<CustomCpuTemplate>` to `Vec<HashMap<_>>`.
+    let mut reg_modifiers_maps = templates
         .into_iter()
-        .map(|template| template.reg_modifiers.into_iter().collect::<HashSet<_>>())
+        .map(|template| RegModifierMap::from(template.reg_modifiers).0)
         .collect::<Vec<_>>();
 
     // Remove common items.
-    strip_common(&mut reg_modifiers_sets);
+    strip_common(&mut reg_modifiers_maps);
 
     // Convert back to `Vec<CustomCpuTemplate>`.
-    reg_modifiers_sets
+    reg_modifiers_maps
         .into_iter()
-        .map(|reg_modifiers_set| {
-            let mut reg_modifiers = reg_modifiers_set.into_iter().collect::<Vec<_>>();
-            reg_modifiers.sort_by_key(|modifier| modifier.addr);
+        .map(|reg_modifiers_map| {
+            let reg_modifiers = Vec::<RegisterModifier>::from(RegModifierMap(reg_modifiers_map));
             CustomCpuTemplate { reg_modifiers }
         })
         .collect()

--- a/src/cpu-template-helper/src/strip/mod.rs
+++ b/src/cpu-template-helper/src/strip/mod.rs
@@ -4,42 +4,15 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 
-use vmm::guest_config::templates::CustomCpuTemplate;
-
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
 #[cfg(target_arch = "aarch64")]
-use aarch64::strip as arch_strip;
+pub use aarch64::strip;
 
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 #[cfg(target_arch = "x86_64")]
-use x86_64::strip as arch_strip;
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    /// Failed to serialize/deserialize.
-    #[error("Failed to serialize/deserialize: {0}")]
-    Serde(#[from] serde_json::Error),
-}
-
-pub fn strip(input: Vec<String>) -> Result<Vec<String>, Error> {
-    // Deserialize `Vec<String>` to `Vec<CustomCpuTemplate>`.
-    let input = input
-        .iter()
-        .map(|s| serde_json::from_str::<CustomCpuTemplate>(s))
-        .collect::<Result<Vec<_>, serde_json::Error>>()?;
-
-    // Strip common items.
-    let stripped = arch_strip(input);
-
-    // Serialize `Vec<CustomCpuTemplate>` to `Vec<String>`.
-    let result = stripped
-        .iter()
-        .map(serde_json::to_string_pretty)
-        .collect::<Result<Vec<_>, serde_json::Error>>()?;
-    Ok(result)
-}
+pub use x86_64::strip;
 
 pub fn strip_common<T>(sets: &mut [HashSet<T>])
 where

--- a/src/cpu-template-helper/src/strip/mod.rs
+++ b/src/cpu-template-helper/src/strip/mod.rs
@@ -41,7 +41,7 @@ pub fn strip(input: Vec<String>) -> Result<Vec<String>, Error> {
     Ok(result)
 }
 
-pub fn remove_common<T>(sets: &mut [HashSet<T>])
+pub fn strip_common<T>(sets: &mut [HashSet<T>])
 where
     T: Clone + Hash + Eq + PartialEq,
 {
@@ -62,7 +62,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_remove_common() {
+    fn test_strip_common() {
         let mut input = vec![
             HashSet::from([0, 1, 2, 3]),
             HashSet::from([0, 2, 4]),
@@ -74,7 +74,7 @@ mod tests {
             HashSet::from([1, 5, 6]),
         ];
 
-        remove_common(&mut input);
+        strip_common(&mut input);
         assert_eq!(input, expected);
     }
 }

--- a/src/cpu-template-helper/src/strip/x86_64.rs
+++ b/src/cpu-template-helper/src/strip/x86_64.rs
@@ -9,7 +9,7 @@ use vmm::guest_config::templates::x86_64::{
 };
 use vmm::guest_config::templates::CustomCpuTemplate;
 
-use crate::strip::remove_common;
+use crate::strip::strip_common;
 
 #[derive(Clone, Eq, PartialEq, Hash)]
 struct CpuidModifier {
@@ -85,8 +85,8 @@ pub fn strip(templates: Vec<CustomCpuTemplate>) -> Vec<CustomCpuTemplate> {
         .unzip();
 
     // Remove common items.
-    remove_common(&mut cpuid_modifiers_sets);
-    remove_common(&mut msr_modifiers_sets);
+    strip_common(&mut cpuid_modifiers_sets);
+    strip_common(&mut msr_modifiers_sets);
 
     // Convert back to `Vec<CustomCpuTemplate>`.
     cpuid_modifiers_sets

--- a/src/cpu-template-helper/src/utils.rs
+++ b/src/cpu-template-helper/src/utils.rs
@@ -3,6 +3,50 @@
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use vmm::builder::{build_microvm_for_boot, StartMicrovmError};
+use vmm::resources::VmResources;
+use vmm::seccomp_filters::{get_filters, SeccompConfig};
+use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
+use vmm::{EventManager, Vmm, HTTP_MAX_PAYLOAD_SIZE};
+
+const CPU_TEMPLATE_HELPER_VERSION: &str = env!("FIRECRACKER_VERSION");
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failed to create VmResources.
+    #[error("Failed to create VmResources: {0}")]
+    CreateVmResources(vmm::resources::Error),
+    /// Failed to build microVM.
+    #[error("Failed to build microVM: {0}")]
+    BuildMicroVm(#[from] StartMicrovmError),
+}
+
+#[allow(dead_code)]
+pub fn build_microvm_from_config(config: &str) -> Result<Arc<Mutex<Vmm>>, Error> {
+    // Prepare resources from the given config file.
+    let instance_info = InstanceInfo {
+        id: "anonymous-instance".to_string(),
+        state: VmState::NotStarted,
+        vmm_version: CPU_TEMPLATE_HELPER_VERSION.to_string(),
+        app_name: "cpu-template-helper".to_string(),
+    };
+    let vm_resources = VmResources::from_json(config, &instance_info, HTTP_MAX_PAYLOAD_SIZE, None)
+        .map_err(Error::CreateVmResources)?;
+    let mut event_manager = EventManager::new().unwrap();
+    let seccomp_filters = get_filters(SeccompConfig::None).unwrap();
+
+    // Build a microVM.
+    let vmm = build_microvm_for_boot(
+        &instance_info,
+        &vm_resources,
+        &mut event_manager,
+        &seccomp_filters,
+    )?;
+
+    Ok(vmm)
+}
 
 pub fn add_suffix(path: &Path, suffix: &str) -> PathBuf {
     // Extract the part of the filename before the extension.
@@ -78,9 +122,38 @@ pub mod x86_64 {
 
 #[cfg(test)]
 mod tests {
+    use utils::tempfile::TempFile;
+    use vmm::utilities::mock_resources::kernel_image_path;
+
     use super::*;
+    use crate::tests::generate_config;
 
     const SUFFIX: &str = "_suffix";
+
+    #[test]
+    fn test_build_microvm_from_valid_config() {
+        let kernel_image_path = kernel_image_path(None);
+        let rootfs_file = TempFile::new().unwrap();
+        let valid_config =
+            generate_config(&kernel_image_path, rootfs_file.as_path().to_str().unwrap());
+
+        build_microvm_from_config(&valid_config).unwrap();
+    }
+
+    #[test]
+    fn test_build_microvm_from_invalid_config() {
+        let rootfs_file = TempFile::new().unwrap();
+        let invalid_config = generate_config(
+            "/invalid_kernel_image_path",
+            rootfs_file.as_path().to_str().unwrap(),
+        );
+
+        match build_microvm_from_config(&invalid_config) {
+            Ok(_) => panic!("Should fail with `No such file or directory`."),
+            Err(Error::CreateVmResources(_)) => (),
+            Err(err) => panic!("Unexpected error: {err}"),
+        }
+    }
 
     #[test]
     fn test_add_suffix_filename_only() {

--- a/src/cpu-template-helper/src/utils.rs
+++ b/src/cpu-template-helper/src/utils.rs
@@ -75,6 +75,15 @@ pub mod aarch64 {
                 },
             }
         };
+        ($addr:expr, $value:expr, $filter:expr) => {
+            RegisterModifier {
+                addr: $addr,
+                bitmap: RegisterValueFilter {
+                    filter: $filter,
+                    value: $value,
+                },
+            }
+        };
     }
 
     pub(crate) use reg_modifier;
@@ -88,6 +97,15 @@ pub mod x86_64 {
                 register: $register,
                 bitmap: RegisterValueFilter {
                     filter: u32::MAX.into(),
+                    value: $value,
+                },
+            }
+        };
+        ($register:expr, $value:expr, $filter:expr) => {
+            CpuidRegisterModifier {
+                register: $register,
+                bitmap: RegisterValueFilter {
+                    filter: $filter,
                     value: $value,
                 },
             }
@@ -111,6 +129,15 @@ pub mod x86_64 {
                 addr: $addr,
                 bitmap: RegisterValueFilter {
                     filter: u64::MAX,
+                    value: $value,
+                },
+            }
+        };
+        ($addr:expr, $value:expr, $filter:expr) => {
+            RegisterModifier {
+                addr: $addr,
+                bitmap: RegisterValueFilter {
+                    filter: $filter,
                     value: $value,
                 },
             }

--- a/src/cpu-template-helper/src/utils.rs
+++ b/src/cpu-template-helper/src/utils.rs
@@ -24,7 +24,7 @@ pub enum Error {
 }
 
 #[allow(dead_code)]
-pub fn build_microvm_from_config(config: &str) -> Result<Arc<Mutex<Vmm>>, Error> {
+pub fn build_microvm_from_config(config: &str) -> Result<(Arc<Mutex<Vmm>>, VmResources), Error> {
     // Prepare resources from the given config file.
     let instance_info = InstanceInfo {
         id: "anonymous-instance".to_string(),
@@ -45,7 +45,7 @@ pub fn build_microvm_from_config(config: &str) -> Result<Arc<Mutex<Vmm>>, Error>
         &seccomp_filters,
     )?;
 
-    Ok(vmm)
+    Ok((vmm, vm_resources))
 }
 
 pub fn add_suffix(path: &Path, suffix: &str) -> PathBuf {

--- a/src/cpu-template-helper/src/utils/aarch64.rs
+++ b/src/cpu-template-helper/src/utils/aarch64.rs
@@ -49,6 +49,21 @@ impl From<Vec<RegisterModifier>> for RegModifierMap {
     }
 }
 
+impl From<RegModifierMap> for Vec<RegisterModifier> {
+    fn from(modifier_map: RegModifierMap) -> Self {
+        let mut modifier_vec = modifier_map
+            .0
+            .into_iter()
+            .map(|(modifier_key, modifier_value)| RegisterModifier {
+                addr: modifier_key.0,
+                bitmap: modifier_value.0,
+            })
+            .collect::<Vec<_>>();
+        modifier_vec.sort_by_key(|modifier| modifier.addr);
+        modifier_vec
+    }
+}
+
 macro_rules! reg_modifier {
     ($addr:expr, $value:expr) => {
         RegisterModifier {
@@ -94,21 +109,33 @@ mod tests {
         assert_eq!(key.to_string(), "ID=0x1234");
     }
 
-    #[test]
-    fn test_reg_modifier_from_vec_to_map() {
-        let modifier_vec = vec![
-            reg_modifier!(0x1, 0x2),
+    fn build_sample_reg_modifier_vec() -> Vec<RegisterModifier> {
+        vec![
             reg_modifier!(0x0, 0x0),
+            reg_modifier!(0x1, 0x2),
             reg_modifier!(0x3, 0x2),
-        ];
-        let modifier_map = HashMap::from([
+        ]
+    }
+
+    fn build_sample_reg_modifier_map() -> RegModifierMap {
+        RegModifierMap(HashMap::from([
             reg_modifier_map!(0x0, 0x0),
             reg_modifier_map!(0x1, 0x2),
             reg_modifier_map!(0x3, 0x2),
-        ]);
-        assert_eq!(
-            RegModifierMap::from(modifier_vec),
-            RegModifierMap(modifier_map),
-        );
+        ]))
+    }
+
+    #[test]
+    fn test_reg_modifier_from_vec_to_map() {
+        let modifier_vec = build_sample_reg_modifier_vec();
+        let modifier_map = build_sample_reg_modifier_map();
+        assert_eq!(RegModifierMap::from(modifier_vec), modifier_map);
+    }
+
+    #[test]
+    fn test_reg_modifier_from_map_to_vec() {
+        let modifier_map = build_sample_reg_modifier_map();
+        let modifier_vec = build_sample_reg_modifier_vec();
+        assert_eq!(Vec::<RegisterModifier>::from(modifier_map), modifier_vec);
     }
 }

--- a/src/cpu-template-helper/src/utils/aarch64.rs
+++ b/src/cpu-template-helper/src/utils/aarch64.rs
@@ -8,7 +8,7 @@ use vmm::guest_config::templates::aarch64::{RegisterModifier, RegisterValueFilte
 
 use super::{ModifierMapKey, ModifierMapValue};
 
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct RegModifierMapKey(pub u64);
 
 impl ModifierMapKey for RegModifierMapKey {}
@@ -18,7 +18,7 @@ impl Display for RegModifierMapKey {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct RegModifierMapValue(pub RegisterValueFilter);
 
 impl ModifierMapValue for RegModifierMapValue {

--- a/src/cpu-template-helper/src/utils/aarch64.rs
+++ b/src/cpu-template-helper/src/utils/aarch64.rs
@@ -1,0 +1,25 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+macro_rules! reg_modifier {
+    ($addr:expr, $value:expr) => {
+        RegisterModifier {
+            addr: $addr,
+            bitmap: RegisterValueFilter {
+                filter: u128::MAX,
+                value: $value,
+            },
+        }
+    };
+    ($addr:expr, $value:expr, $filter:expr) => {
+        RegisterModifier {
+            addr: $addr,
+            bitmap: RegisterValueFilter {
+                filter: $filter,
+                value: $value,
+            },
+        }
+    };
+}
+
+pub(crate) use reg_modifier;

--- a/src/cpu-template-helper/src/utils/aarch64.rs
+++ b/src/cpu-template-helper/src/utils/aarch64.rs
@@ -1,6 +1,54 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use vmm::guest_config::templates::aarch64::{RegisterModifier, RegisterValueFilter};
+
+use super::{ModifierMapKey, ModifierMapValue};
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct RegModifierMapKey(pub u64);
+
+impl ModifierMapKey for RegModifierMapKey {}
+impl Display for RegModifierMapKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ID={:#x}", self.0)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct RegModifierMapValue(pub RegisterValueFilter);
+
+impl ModifierMapValue for RegModifierMapValue {
+    type Type = u128;
+
+    fn filter(&self) -> Self::Type {
+        self.0.filter
+    }
+
+    fn value(&self) -> Self::Type {
+        self.0.value
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct RegModifierMap(pub HashMap<RegModifierMapKey, RegModifierMapValue>);
+
+impl From<Vec<RegisterModifier>> for RegModifierMap {
+    fn from(modifiers: Vec<RegisterModifier>) -> Self {
+        let mut map = HashMap::new();
+        for modifier in modifiers {
+            map.insert(
+                RegModifierMapKey(modifier.addr),
+                RegModifierMapValue(modifier.bitmap),
+            );
+        }
+        RegModifierMap(map)
+    }
+}
+
 macro_rules! reg_modifier {
     ($addr:expr, $value:expr) => {
         RegisterModifier {
@@ -23,3 +71,44 @@ macro_rules! reg_modifier {
 }
 
 pub(crate) use reg_modifier;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! reg_modifier_map {
+        ($id:expr, $value:expr) => {
+            (
+                RegModifierMapKey($id),
+                RegModifierMapValue(RegisterValueFilter {
+                    filter: u128::MAX,
+                    value: $value,
+                }),
+            )
+        };
+    }
+
+    #[test]
+    fn test_format_reg_modifier_map_key() {
+        let key = RegModifierMapKey(0x1234);
+        assert_eq!(key.to_string(), "ID=0x1234");
+    }
+
+    #[test]
+    fn test_reg_modifier_from_vec_to_map() {
+        let modifier_vec = vec![
+            reg_modifier!(0x1, 0x2),
+            reg_modifier!(0x0, 0x0),
+            reg_modifier!(0x3, 0x2),
+        ];
+        let modifier_map = HashMap::from([
+            reg_modifier_map!(0x0, 0x0),
+            reg_modifier_map!(0x1, 0x2),
+            reg_modifier_map!(0x3, 0x2),
+        ]);
+        assert_eq!(
+            RegModifierMap::from(modifier_vec),
+            RegModifierMap(modifier_map),
+        );
+    }
+}

--- a/src/cpu-template-helper/src/utils/mod.rs
+++ b/src/cpu-template-helper/src/utils/mod.rs
@@ -11,6 +11,11 @@ use vmm::seccomp_filters::{get_filters, SeccompConfig};
 use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
 use vmm::{EventManager, Vmm, HTTP_MAX_PAYLOAD_SIZE};
 
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64;
+
 const CPU_TEMPLATE_HELPER_VERSION: &str = env!("FIRECRACKER_VERSION");
 
 #[derive(Debug, thiserror::Error)]
@@ -61,90 +66,6 @@ pub fn add_suffix(path: &Path, suffix: &str) -> PathBuf {
 
     // Swap the file name.
     path.with_file_name(new_file_name)
-}
-
-#[cfg(target_arch = "aarch64")]
-pub mod aarch64 {
-    macro_rules! reg_modifier {
-        ($addr:expr, $value:expr) => {
-            RegisterModifier {
-                addr: $addr,
-                bitmap: RegisterValueFilter {
-                    filter: u128::MAX,
-                    value: $value,
-                },
-            }
-        };
-        ($addr:expr, $value:expr, $filter:expr) => {
-            RegisterModifier {
-                addr: $addr,
-                bitmap: RegisterValueFilter {
-                    filter: $filter,
-                    value: $value,
-                },
-            }
-        };
-    }
-
-    pub(crate) use reg_modifier;
-}
-
-#[cfg(target_arch = "x86_64")]
-pub mod x86_64 {
-    macro_rules! cpuid_reg_modifier {
-        ($register:expr, $value:expr) => {
-            CpuidRegisterModifier {
-                register: $register,
-                bitmap: RegisterValueFilter {
-                    filter: u32::MAX.into(),
-                    value: $value,
-                },
-            }
-        };
-        ($register:expr, $value:expr, $filter:expr) => {
-            CpuidRegisterModifier {
-                register: $register,
-                bitmap: RegisterValueFilter {
-                    filter: $filter,
-                    value: $value,
-                },
-            }
-        };
-    }
-
-    macro_rules! cpuid_leaf_modifier {
-        ($leaf:expr, $subleaf:expr, $flags:expr, $reg_modifiers:expr) => {
-            CpuidLeafModifier {
-                leaf: $leaf,
-                subleaf: $subleaf,
-                flags: $flags,
-                modifiers: $reg_modifiers,
-            }
-        };
-    }
-
-    macro_rules! msr_modifier {
-        ($addr:expr, $value:expr) => {
-            RegisterModifier {
-                addr: $addr,
-                bitmap: RegisterValueFilter {
-                    filter: u64::MAX,
-                    value: $value,
-                },
-            }
-        };
-        ($addr:expr, $value:expr, $filter:expr) => {
-            RegisterModifier {
-                addr: $addr,
-                bitmap: RegisterValueFilter {
-                    filter: $filter,
-                    value: $value,
-                },
-            }
-        };
-    }
-
-    pub(crate) use {cpuid_leaf_modifier, cpuid_reg_modifier, msr_modifier};
 }
 
 #[cfg(test)]

--- a/src/cpu-template-helper/src/utils/x86_64.rs
+++ b/src/cpu-template-helper/src/utils/x86_64.rs
@@ -1,0 +1,57 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+macro_rules! cpuid_reg_modifier {
+    ($register:expr, $value:expr) => {
+        CpuidRegisterModifier {
+            register: $register,
+            bitmap: RegisterValueFilter {
+                filter: u32::MAX.into(),
+                value: $value,
+            },
+        }
+    };
+    ($register:expr, $value:expr, $filter:expr) => {
+        CpuidRegisterModifier {
+            register: $register,
+            bitmap: RegisterValueFilter {
+                filter: $filter,
+                value: $value,
+            },
+        }
+    };
+}
+
+macro_rules! cpuid_leaf_modifier {
+    ($leaf:expr, $subleaf:expr, $flags:expr, $reg_modifiers:expr) => {
+        CpuidLeafModifier {
+            leaf: $leaf,
+            subleaf: $subleaf,
+            flags: $flags,
+            modifiers: $reg_modifiers,
+        }
+    };
+}
+
+macro_rules! msr_modifier {
+    ($addr:expr, $value:expr) => {
+        RegisterModifier {
+            addr: $addr,
+            bitmap: RegisterValueFilter {
+                filter: u64::MAX,
+                value: $value,
+            },
+        }
+    };
+    ($addr:expr, $value:expr, $filter:expr) => {
+        RegisterModifier {
+            addr: $addr,
+            bitmap: RegisterValueFilter {
+                filter: $filter,
+                value: $value,
+            },
+        }
+    };
+}
+
+pub(crate) use {cpuid_leaf_modifier, cpuid_reg_modifier, msr_modifier};

--- a/src/cpu-template-helper/src/utils/x86_64.rs
+++ b/src/cpu-template-helper/src/utils/x86_64.rs
@@ -11,7 +11,7 @@ use vmm::guest_config::templates::x86_64::{
 
 use super::{ModifierMapKey, ModifierMapValue};
 
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct CpuidModifierMapKey {
     pub leaf: u32,
     pub subleaf: u32,
@@ -33,7 +33,7 @@ impl Display for CpuidModifierMapKey {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct CpuidModifierMapValue(pub RegisterValueFilter);
 
 impl ModifierMapValue for CpuidModifierMapValue {
@@ -111,7 +111,7 @@ impl From<CpuidModifierMap> for Vec<CpuidLeafModifier> {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct MsrModifierMapKey(pub u32);
 
 impl ModifierMapKey for MsrModifierMapKey {}
@@ -121,7 +121,7 @@ impl Display for MsrModifierMapKey {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct MsrModifierMapValue(pub RegisterValueFilter);
 
 impl ModifierMapValue for MsrModifierMapValue {

--- a/src/cpu-template-helper/src/utils/x86_64.rs
+++ b/src/cpu-template-helper/src/utils/x86_64.rs
@@ -1,6 +1,119 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{
+    CpuidLeafModifier, CpuidRegister, RegisterModifier, RegisterValueFilter,
+};
+
+use super::{ModifierMapKey, ModifierMapValue};
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct CpuidModifierMapKey {
+    pub leaf: u32,
+    pub subleaf: u32,
+    pub flags: KvmCpuidFlags,
+    pub register: CpuidRegister,
+}
+
+impl ModifierMapKey for CpuidModifierMapKey {}
+impl Display for CpuidModifierMapKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "leaf={:#x}, subleaf={:#x}, flags={:#b}, register={}",
+            self.leaf,
+            self.subleaf,
+            self.flags.0,
+            format!("{:?}", self.register).to_lowercase()
+        )
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct CpuidModifierMapValue(pub RegisterValueFilter);
+
+impl ModifierMapValue for CpuidModifierMapValue {
+    type Type = u32;
+
+    fn filter(&self) -> Self::Type {
+        // Filters of CPUID modifiers should fit in `u32`.
+        self.0.filter.try_into().unwrap()
+    }
+
+    fn value(&self) -> Self::Type {
+        // Values of CPUID modifiers should fit in `u32`.
+        self.0.value.try_into().unwrap()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct CpuidModifierMap(pub HashMap<CpuidModifierMapKey, CpuidModifierMapValue>);
+
+impl From<Vec<CpuidLeafModifier>> for CpuidModifierMap {
+    fn from(leaf_modifiers: Vec<CpuidLeafModifier>) -> Self {
+        let mut map = HashMap::new();
+        for leaf_modifier in leaf_modifiers {
+            for reg_modifier in leaf_modifier.modifiers {
+                map.insert(
+                    CpuidModifierMapKey {
+                        leaf: leaf_modifier.leaf,
+                        subleaf: leaf_modifier.subleaf,
+                        flags: leaf_modifier.flags,
+                        register: reg_modifier.register,
+                    },
+                    CpuidModifierMapValue(reg_modifier.bitmap),
+                );
+            }
+        }
+        CpuidModifierMap(map)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct MsrModifierMapKey(pub u32);
+
+impl ModifierMapKey for MsrModifierMapKey {}
+impl Display for MsrModifierMapKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "index={:#x}", self.0)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct MsrModifierMapValue(pub RegisterValueFilter);
+
+impl ModifierMapValue for MsrModifierMapValue {
+    type Type = u64;
+
+    fn filter(&self) -> Self::Type {
+        self.0.filter
+    }
+
+    fn value(&self) -> Self::Type {
+        self.0.value
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct MsrModifierMap(pub HashMap<MsrModifierMapKey, MsrModifierMapValue>);
+
+impl From<Vec<RegisterModifier>> for MsrModifierMap {
+    fn from(modifiers: Vec<RegisterModifier>) -> Self {
+        let mut map = HashMap::new();
+        for modifier in modifiers {
+            map.insert(
+                MsrModifierMapKey(modifier.addr),
+                MsrModifierMapValue(modifier.bitmap),
+            );
+        }
+        MsrModifierMap(map)
+    }
+}
+
 macro_rules! cpuid_reg_modifier {
     ($register:expr, $value:expr) => {
         CpuidRegisterModifier {
@@ -55,3 +168,102 @@ macro_rules! msr_modifier {
 }
 
 pub(crate) use {cpuid_leaf_modifier, cpuid_reg_modifier, msr_modifier};
+
+#[cfg(test)]
+mod tests {
+    use vmm::guest_config::templates::x86_64::CpuidRegister::*;
+    use vmm::guest_config::templates::x86_64::CpuidRegisterModifier;
+
+    use super::*;
+    use crate::utils::x86_64::{cpuid_leaf_modifier, cpuid_reg_modifier, msr_modifier};
+
+    macro_rules! cpuid_modifier_map {
+        ($leaf:expr, $subleaf:expr, $flags:expr, $register:expr, $value:expr) => {
+            (
+                CpuidModifierMapKey {
+                    leaf: $leaf,
+                    subleaf: $subleaf,
+                    flags: $flags,
+                    register: $register,
+                },
+                CpuidModifierMapValue(RegisterValueFilter {
+                    filter: u32::MAX.into(),
+                    value: $value,
+                }),
+            )
+        };
+    }
+
+    macro_rules! msr_modifier_map {
+        ($addr:expr, $value:expr) => {
+            (
+                MsrModifierMapKey($addr),
+                MsrModifierMapValue(RegisterValueFilter {
+                    filter: u64::MAX.into(),
+                    value: $value,
+                }),
+            )
+        };
+    }
+
+    #[test]
+    fn test_format_cpuid_modifier_map_key() {
+        let key = CpuidModifierMapKey {
+            leaf: 0x0,
+            subleaf: 0x1,
+            flags: KvmCpuidFlags::STATEFUL_FUNC,
+            register: Edx,
+        };
+        assert_eq!(
+            key.to_string(),
+            "leaf=0x0, subleaf=0x1, flags=0b10, register=edx",
+        )
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_cpuid_modifier_from_vec_to_map() {
+        let modifier_vec = vec![
+            cpuid_leaf_modifier!(0x0, 0x0, KvmCpuidFlags::EMPTY, vec![
+                cpuid_reg_modifier!(Eax, 0x0),
+            ]),
+            cpuid_leaf_modifier!(0x1, 0x2, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
+                cpuid_reg_modifier!(Ecx, 0x4),
+                cpuid_reg_modifier!(Ebx, 0x3),
+            ]),
+        ];
+        let modifier_map = HashMap::from([
+            cpuid_modifier_map!(0x0, 0x0, KvmCpuidFlags::EMPTY, Eax, 0x0),
+            cpuid_modifier_map!(0x1, 0x2, KvmCpuidFlags::SIGNIFICANT_INDEX, Ebx, 0x3),
+            cpuid_modifier_map!(0x1, 0x2, KvmCpuidFlags::SIGNIFICANT_INDEX, Ecx, 0x4),
+        ]);
+        assert_eq!(
+            CpuidModifierMap::from(modifier_vec),
+            CpuidModifierMap(modifier_map),
+        );
+    }
+
+    #[test]
+    fn test_format_msr_modifier_map_key() {
+        let key = MsrModifierMapKey(0x1234);
+        assert_eq!(key.to_string(), "index=0x1234");
+    }
+
+    #[test]
+    fn test_msr_modifier_from_vec_to_map() {
+        let modifier_vec = vec![
+            msr_modifier!(0x1, 0x2),
+            msr_modifier!(0x0, 0x0),
+            msr_modifier!(0x3, 0x2),
+        ];
+        let modifier_map = HashMap::from([
+            msr_modifier_map!(0x0, 0x0),
+            msr_modifier_map!(0x1, 0x2),
+            msr_modifier_map!(0x3, 0x2),
+        ]);
+        assert_eq!(
+            MsrModifierMap::from(modifier_vec),
+            MsrModifierMap(modifier_map),
+        );
+    }
+}

--- a/src/cpu-template-helper/src/verify/aarch64.rs
+++ b/src/cpu-template-helper/src/verify/aarch64.rs
@@ -1,0 +1,92 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use vmm::guest_config::templates::aarch64::{RegisterModifier, RegisterValueFilter};
+
+use super::{ModifierMapKey, ModifierMapValue};
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+struct RegModifierMapKey(u64);
+
+impl ModifierMapKey for RegModifierMapKey {}
+impl Display for RegModifierMapKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ID={:#x}", self.0)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct RegModifierMapValue(RegisterValueFilter);
+
+impl ModifierMapValue for RegModifierMapValue {
+    type Type = u128;
+
+    fn filter(&self) -> Self::Type {
+        self.0.filter
+    }
+
+    fn value(&self) -> Self::Type {
+        self.0.value
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct RegModifierMap(HashMap<RegModifierMapKey, RegModifierMapValue>);
+
+impl From<Vec<RegisterModifier>> for RegModifierMap {
+    fn from(modifiers: Vec<RegisterModifier>) -> Self {
+        let mut map = HashMap::new();
+        for modifier in modifiers {
+            map.insert(
+                RegModifierMapKey(modifier.addr),
+                RegModifierMapValue(modifier.bitmap),
+            );
+        }
+        RegModifierMap(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::aarch64::reg_modifier;
+
+    macro_rules! reg_modifier_map {
+        ($id:expr, $value:expr) => {
+            (
+                RegModifierMapKey($id),
+                RegModifierMapValue(RegisterValueFilter {
+                    filter: u128::MAX,
+                    value: $value,
+                }),
+            )
+        };
+    }
+
+    #[test]
+    fn test_format_reg_modifier_map_key() {
+        let key = RegModifierMapKey(0x1234);
+        assert_eq!(key.to_string(), "ID=0x1234");
+    }
+
+    #[test]
+    fn test_reg_modifier_from_vec_to_map() {
+        let modifier_vec = vec![
+            reg_modifier!(0x1, 0x2),
+            reg_modifier!(0x0, 0x0),
+            reg_modifier!(0x3, 0x2),
+        ];
+        let modifier_map = HashMap::from([
+            reg_modifier_map!(0x0, 0x0),
+            reg_modifier_map!(0x1, 0x2),
+            reg_modifier_map!(0x3, 0x2),
+        ]);
+        assert_eq!(
+            RegModifierMap::from(modifier_vec),
+            RegModifierMap(modifier_map),
+        );
+    }
+}

--- a/src/cpu-template-helper/src/verify/aarch64.rs
+++ b/src/cpu-template-helper/src/verify/aarch64.rs
@@ -1,54 +1,10 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::fmt::Display;
-
-use vmm::guest_config::templates::aarch64::{RegisterModifier, RegisterValueFilter};
 use vmm::guest_config::templates::CustomCpuTemplate;
 
-use super::{verify_common, Error, ModifierMapKey, ModifierMapValue};
-
-#[derive(Debug, Eq, PartialEq, Hash)]
-struct RegModifierMapKey(u64);
-
-impl ModifierMapKey for RegModifierMapKey {}
-impl Display for RegModifierMapKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ID={:#x}", self.0)
-    }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-struct RegModifierMapValue(RegisterValueFilter);
-
-impl ModifierMapValue for RegModifierMapValue {
-    type Type = u128;
-
-    fn filter(&self) -> Self::Type {
-        self.0.filter
-    }
-
-    fn value(&self) -> Self::Type {
-        self.0.value
-    }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-struct RegModifierMap(HashMap<RegModifierMapKey, RegModifierMapValue>);
-
-impl From<Vec<RegisterModifier>> for RegModifierMap {
-    fn from(modifiers: Vec<RegisterModifier>) -> Self {
-        let mut map = HashMap::new();
-        for modifier in modifiers {
-            map.insert(
-                RegModifierMapKey(modifier.addr),
-                RegModifierMapValue(modifier.bitmap),
-            );
-        }
-        RegModifierMap(map)
-    }
-}
+use super::{verify_common, Error};
+use crate::utils::aarch64::RegModifierMap;
 
 pub fn verify(cpu_template: CustomCpuTemplate, cpu_config: CustomCpuTemplate) -> Result<(), Error> {
     let reg_template = RegModifierMap::from(cpu_template.reg_modifiers);
@@ -58,44 +14,10 @@ pub fn verify(cpu_template: CustomCpuTemplate, cpu_config: CustomCpuTemplate) ->
 
 #[cfg(test)]
 mod tests {
+    use vmm::guest_config::templates::aarch64::{RegisterModifier, RegisterValueFilter};
+
     use super::*;
     use crate::utils::aarch64::reg_modifier;
-
-    macro_rules! reg_modifier_map {
-        ($id:expr, $value:expr) => {
-            (
-                RegModifierMapKey($id),
-                RegModifierMapValue(RegisterValueFilter {
-                    filter: u128::MAX,
-                    value: $value,
-                }),
-            )
-        };
-    }
-
-    #[test]
-    fn test_format_reg_modifier_map_key() {
-        let key = RegModifierMapKey(0x1234);
-        assert_eq!(key.to_string(), "ID=0x1234");
-    }
-
-    #[test]
-    fn test_reg_modifier_from_vec_to_map() {
-        let modifier_vec = vec![
-            reg_modifier!(0x1, 0x2),
-            reg_modifier!(0x0, 0x0),
-            reg_modifier!(0x3, 0x2),
-        ];
-        let modifier_map = HashMap::from([
-            reg_modifier_map!(0x0, 0x0),
-            reg_modifier_map!(0x1, 0x2),
-            reg_modifier_map!(0x3, 0x2),
-        ]);
-        assert_eq!(
-            RegModifierMap::from(modifier_vec),
-            RegModifierMap(modifier_map),
-        );
-    }
 
     #[test]
     #[rustfmt::skip]

--- a/src/cpu-template-helper/src/verify/aarch64.rs
+++ b/src/cpu-template-helper/src/verify/aarch64.rs
@@ -49,6 +49,11 @@ impl From<Vec<RegisterModifier>> for RegModifierMap {
     }
 }
 
+pub fn verify(cpu_template: CustomCpuTemplate, cpu_config: CustomCpuTemplate) -> Result<(), Error> {
+    // TODO: Add implementation for aarch64.
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cpu-template-helper/src/verify/mod.rs
+++ b/src/cpu-template-helper/src/verify/mod.rs
@@ -6,6 +6,8 @@ use std::fmt::{Binary, Display};
 use std::hash::Hash;
 use std::ops::{BitAnd, Shl};
 
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 

--- a/src/cpu-template-helper/src/verify/mod.rs
+++ b/src/cpu-template-helper/src/verify/mod.rs
@@ -55,48 +55,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::Display;
-
     use super::*;
-
-    #[derive(PartialEq, Eq, Hash)]
-    struct MockModifierMapKey(u8);
-
-    impl ModifierMapKey for MockModifierMapKey {}
-    impl Display for MockModifierMapKey {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "ID={:#x}", self.0)
-        }
-    }
-
-    struct MockModifierMapValue {
-        filter: u8,
-        value: u8,
-    }
-
-    impl ModifierMapValue for MockModifierMapValue {
-        type Type = u8;
-
-        fn filter(&self) -> Self::Type {
-            self.filter
-        }
-
-        fn value(&self) -> Self::Type {
-            self.value
-        }
-    }
-
-    macro_rules! mock_modifier {
-        ($key:expr, ($filter:expr, $value:expr)) => {
-            (
-                MockModifierMapKey($key),
-                MockModifierMapValue {
-                    filter: $filter,
-                    value: $value,
-                },
-            )
-        };
-    }
+    use crate::utils::tests::{mock_modifier, MockModifierMapKey, MockModifierMapValue};
 
     #[test]
     fn test_verify_modifier_map_with_non_existing_key() {

--- a/src/cpu-template-helper/src/verify/mod.rs
+++ b/src/cpu-template-helper/src/verify/mod.rs
@@ -8,18 +8,12 @@ use std::ops::{BitAnd, Shl};
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::verify;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
-
-#[allow(unused_variables)]
-pub fn verify(
-    cpu_template: vmm::guest_config::templates::CustomCpuTemplate,
-    cpu_config: vmm::guest_config::templates::CustomCpuTemplate,
-) -> Result<(), Error> {
-    // This is a placeholder of `verify()`.
-    // TODO: Add arch-specific `verify()` under arch-specific module.
-    Ok(())
-}
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::verify;
 
 #[rustfmt::skip]
 #[derive(Debug, thiserror::Error)]

--- a/src/cpu-template-helper/src/verify/mod.rs
+++ b/src/cpu-template-helper/src/verify/mod.rs
@@ -1,0 +1,12 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(unused_variables)]
+pub fn verify(
+    cpu_template: vmm::guest_config::templates::CustomCpuTemplate,
+    cpu_config: vmm::guest_config::templates::CustomCpuTemplate,
+) -> Result<(), String> {
+    // This is a placeholder of `verify()`.
+    // TODO: Add arch-specific `verify()` under arch-specific module.
+    Ok(())
+}

--- a/src/cpu-template-helper/src/verify/mod.rs
+++ b/src/cpu-template-helper/src/verify/mod.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::fmt::{Binary, Display};
-use std::hash::Hash;
-use std::ops::{BitAnd, Shl};
+
+use crate::utils::{ModifierMapKey, ModifierMapValue};
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
@@ -22,64 +21,6 @@ pub enum Error {
     KeyNotFound(String),
     #[error("Value for {0} mismatched.\n{1}")]
     ValueMismatched(String, String),
-}
-
-/// Trait for key of `HashMap`-based modifier.
-///
-/// This is a wrapper trait of some traits required for a key of `HashMap` modifier.
-pub trait ModifierMapKey: Eq + PartialEq + Hash + Display {}
-
-/// Trait for value of `HashMap`-based modifier.
-pub trait ModifierMapValue {
-    // The data size of `Self::Type` varies depending on the target modifier.
-    // * x86_64 CPUID: `u32`
-    // * x86_64 MSR: `u64`
-    // * aarch64 registers: `u128`
-    //
-    // These trait bounds are required for the following reasons:
-    // * `PartialEq + Eq`: To compare `Self::Type` values (like `filter()` and `value()`).
-    // * `BitAnd<Output = Self::Type>`: To use AND operation (like `filter() & value()`).
-    // * `Binary`: To display in a bitwise format.
-    // * `From<bool> + Shl<usize, Output = Self::Type>`: To construct bit masks in
-    //   `to_diff_string()`.
-    type Type: PartialEq
-        + Eq
-        + Copy
-        + BitAnd<Output = Self::Type>
-        + Binary
-        + From<bool>
-        + Shl<usize, Output = Self::Type>;
-
-    // Return `filter` of arch-specific `RegisterValueFilter` in the size for the target.
-    fn filter(&self) -> Self::Type;
-
-    // Return `value` of arch-specific `RegisterValueFilter` in the size for the target.
-    fn value(&self) -> Self::Type;
-
-    // Generate a string to display difference of filtered values between CPU template and guest
-    // CPU config.
-    #[rustfmt::skip]
-    fn to_diff_string(template: Self::Type, config: Self::Type) -> String {
-        let nbits = std::mem::size_of::<Self::Type>() * 8;
-
-        let mut diff = String::new();
-        for i in (0..nbits).rev() {
-            let mask = Self::Type::from(true) << i;
-            let template_bit = template & mask;
-            let config_bit = config & mask;
-            diff.push(match template_bit == config_bit {
-                true => ' ',
-                false => '^',
-            });
-        }
-
-        format!(
-            "* CPU template     : 0b{template:0width$b}\n\
-             * CPU configuration: 0b{config:0width$b}\n\
-             * Diff             :   {diff}",
-            width = nbits,
-        )
-    }
 }
 
 /// Verify that the given CPU template is applied as intended.
@@ -114,6 +55,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Display;
+
     use super::*;
 
     #[derive(PartialEq, Eq, Hash)]

--- a/src/cpu-template-helper/src/verify/mod.rs
+++ b/src/cpu-template-helper/src/verify/mod.rs
@@ -1,12 +1,203 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+use std::fmt::{Binary, Display};
+use std::hash::Hash;
+use std::ops::{BitAnd, Shl};
+
 #[allow(unused_variables)]
 pub fn verify(
     cpu_template: vmm::guest_config::templates::CustomCpuTemplate,
     cpu_config: vmm::guest_config::templates::CustomCpuTemplate,
-) -> Result<(), String> {
+) -> Result<(), Error> {
     // This is a placeholder of `verify()`.
     // TODO: Add arch-specific `verify()` under arch-specific module.
     Ok(())
+}
+
+#[rustfmt::skip]
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0} not found in CPU configuration.")]
+    KeyNotFound(String),
+    #[error("Value for {0} mismatched.\n{1}")]
+    ValueMismatched(String, String),
+}
+
+/// Trait for key of `HashMap`-based modifier.
+///
+/// This is a wrapper trait of some traits required for a key of `HashMap` modifier.
+pub trait ModifierMapKey: Eq + PartialEq + Hash + Display {}
+
+/// Trait for value of `HashMap`-based modifier.
+pub trait ModifierMapValue {
+    // The data size of `Self::Type` varies depending on the target modifier.
+    // * x86_64 CPUID: `u32`
+    // * x86_64 MSR: `u64`
+    // * aarch64 registers: `u128`
+    //
+    // These trait bounds are required for the following reasons:
+    // * `PartialEq + Eq`: To compare `Self::Type` values (like `filter()` and `value()`).
+    // * `BitAnd<Output = Self::Type>`: To use AND operation (like `filter() & value()`).
+    // * `Binary`: To display in a bitwise format.
+    // * `From<bool> + Shl<usize, Output = Self::Type>`: To construct bit masks in
+    //   `to_diff_string()`.
+    type Type: PartialEq
+        + Eq
+        + Copy
+        + BitAnd<Output = Self::Type>
+        + Binary
+        + From<bool>
+        + Shl<usize, Output = Self::Type>;
+
+    // Return `filter` of arch-specific `RegisterValueFilter` in the size for the target.
+    fn filter(&self) -> Self::Type;
+
+    // Return `value` of arch-specific `RegisterValueFilter` in the size for the target.
+    fn value(&self) -> Self::Type;
+
+    // Generate a string to display difference of filtered values between CPU template and guest
+    // CPU config.
+    #[rustfmt::skip]
+    fn to_diff_string(template: Self::Type, config: Self::Type) -> String {
+        let nbits = std::mem::size_of::<Self::Type>() * 8;
+
+        let mut diff = String::new();
+        for i in (0..nbits).rev() {
+            let mask = Self::Type::from(true) << i;
+            let template_bit = template & mask;
+            let config_bit = config & mask;
+            diff.push(match template_bit == config_bit {
+                true => ' ',
+                false => '^',
+            });
+        }
+
+        format!(
+            "* CPU template     : 0b{template:0width$b}\n\
+             * CPU configuration: 0b{config:0width$b}\n\
+             * Diff             :   {diff}",
+            width = nbits,
+        )
+    }
+}
+
+/// Verify that the given CPU template is applied as intended.
+///
+/// This function is an arch-agnostic part of CPU template verification. As template formats differ
+/// between x86_64 and aarch64, the arch-specific part converts the structure to an arch-agnostic
+/// `HashMap` implementing `ModifierMapKey` and `ModifierMapValue` for its key and value
+/// respectively before calling this arch-agnostic function.
+pub fn verify_common<K, V>(template: HashMap<K, V>, config: HashMap<K, V>) -> Result<(), Error>
+where
+    K: ModifierMapKey,
+    V: ModifierMapValue,
+{
+    for (key, template_value_filter) in template {
+        let config_value_filter = config
+            .get(&key)
+            .ok_or(Error::KeyNotFound(key.to_string()))?;
+
+        let template_value = template_value_filter.value() & template_value_filter.filter();
+        let config_value = config_value_filter.value() & template_value_filter.filter();
+
+        if template_value != config_value {
+            return Err(Error::ValueMismatched(
+                key.to_string(),
+                V::to_diff_string(template_value, config_value),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(PartialEq, Eq, Hash)]
+    struct MockModifierMapKey(u8);
+
+    impl ModifierMapKey for MockModifierMapKey {}
+    impl Display for MockModifierMapKey {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ID={:#x}", self.0)
+        }
+    }
+
+    struct MockModifierMapValue {
+        filter: u8,
+        value: u8,
+    }
+
+    impl ModifierMapValue for MockModifierMapValue {
+        type Type = u8;
+
+        fn filter(&self) -> Self::Type {
+            self.filter
+        }
+
+        fn value(&self) -> Self::Type {
+            self.value
+        }
+    }
+
+    macro_rules! mock_modifier {
+        ($key:expr, ($filter:expr, $value:expr)) => {
+            (
+                MockModifierMapKey($key),
+                MockModifierMapValue {
+                    filter: $filter,
+                    value: $value,
+                },
+            )
+        };
+    }
+
+    #[test]
+    fn test_verify_modifier_map_with_non_existing_key() {
+        // Test with a sample whose key exists in CPU template but not in CPU config.
+        let cpu_template_map =
+            HashMap::from([mock_modifier!(0b0000_0000, (0b0000_0000, 0b0000_0000))]);
+        let cpu_config_map = HashMap::new();
+
+        assert_eq!(
+            verify_common(cpu_template_map, cpu_config_map)
+                .unwrap_err()
+                .to_string(),
+            "ID=0x0 not found in CPU configuration.".to_string()
+        );
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_verify_modifier_map_with_mismatched_value() {
+        // Test with a sample whose filtered value mismatches between CPU config and CPU template.
+        let cpu_template_map =
+            HashMap::from([mock_modifier!(0b0000_0000, (0b0000_1111, 0b0000_0101))]);
+        let cpu_config_map =
+            HashMap::from([mock_modifier!(0b0000_0000, (u8::MAX, 0b0000_0000))]);
+
+        assert_eq!(
+            verify_common(cpu_template_map, cpu_config_map)
+                .unwrap_err()
+                .to_string(),
+            "Value for ID=0x0 mismatched.\n\
+             * CPU template     : 0b00000101\n\
+             * CPU configuration: 0b00000000\n\
+             * Diff             :        ^ ^"
+        )
+    }
+
+    #[test]
+    fn test_verify_modifier_map_with_valid_value() {
+        // Test with valid CPU template and CPU config.
+        let cpu_template_map =
+            HashMap::from([mock_modifier!(0b0000_0000, (0b0000_1111, 0b0000_1010))]);
+        let cpu_config_map = HashMap::from([mock_modifier!(0b0000_0000, (u8::MAX, 0b1010_1010))]);
+
+        verify_common(cpu_template_map, cpu_config_map).unwrap();
+    }
 }

--- a/src/cpu-template-helper/src/verify/mod.rs
+++ b/src/cpu-template-helper/src/verify/mod.rs
@@ -6,6 +6,9 @@ use std::fmt::{Binary, Display};
 use std::hash::Hash;
 use std::ops::{BitAnd, Shl};
 
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
+
 #[allow(unused_variables)]
 pub fn verify(
     cpu_template: vmm::guest_config::templates::CustomCpuTemplate,

--- a/src/cpu-template-helper/src/verify/x86_64.rs
+++ b/src/cpu-template-helper/src/verify/x86_64.rs
@@ -1,0 +1,135 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use vmm::guest_config::cpuid::KvmCpuidFlags;
+use vmm::guest_config::templates::x86_64::{CpuidLeafModifier, CpuidRegister, RegisterValueFilter};
+
+use super::{ModifierMapKey, ModifierMapValue};
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+struct CpuidModifierMapKey {
+    leaf: u32,
+    subleaf: u32,
+    flags: KvmCpuidFlags,
+    register: CpuidRegister,
+}
+
+impl ModifierMapKey for CpuidModifierMapKey {}
+impl Display for CpuidModifierMapKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "leaf={:#x}, subleaf={:#x}, flags={:#b}, register={}",
+            self.leaf,
+            self.subleaf,
+            self.flags.0,
+            format!("{:?}", self.register).to_lowercase()
+        )
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct CpuidModifierMapValue(RegisterValueFilter);
+
+impl ModifierMapValue for CpuidModifierMapValue {
+    type Type = u32;
+
+    fn filter(&self) -> Self::Type {
+        // Filters of CPUID modifiers should fit in `u32`.
+        self.0.filter.try_into().unwrap()
+    }
+
+    fn value(&self) -> Self::Type {
+        // Values of CPUID modifiers should fit in `u32`.
+        self.0.value.try_into().unwrap()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct CpuidModifierMap(HashMap<CpuidModifierMapKey, CpuidModifierMapValue>);
+
+impl From<Vec<CpuidLeafModifier>> for CpuidModifierMap {
+    fn from(leaf_modifiers: Vec<CpuidLeafModifier>) -> Self {
+        let mut map = HashMap::new();
+        for leaf_modifier in leaf_modifiers {
+            for reg_modifier in leaf_modifier.modifiers {
+                map.insert(
+                    CpuidModifierMapKey {
+                        leaf: leaf_modifier.leaf,
+                        subleaf: leaf_modifier.subleaf,
+                        flags: leaf_modifier.flags,
+                        register: reg_modifier.register,
+                    },
+                    CpuidModifierMapValue(reg_modifier.bitmap),
+                );
+            }
+        }
+        CpuidModifierMap(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vmm::guest_config::templates::x86_64::CpuidRegister::*;
+    use vmm::guest_config::templates::x86_64::CpuidRegisterModifier;
+
+    use super::*;
+    use crate::utils::x86_64::{cpuid_leaf_modifier, cpuid_reg_modifier};
+
+    macro_rules! cpuid_modifier_map {
+        ($leaf:expr, $subleaf:expr, $flags:expr, $register:expr, $value:expr) => {
+            (
+                CpuidModifierMapKey {
+                    leaf: $leaf,
+                    subleaf: $subleaf,
+                    flags: $flags,
+                    register: $register,
+                },
+                CpuidModifierMapValue(RegisterValueFilter {
+                    filter: u32::MAX.into(),
+                    value: $value,
+                }),
+            )
+        };
+    }
+
+    #[test]
+    fn test_format_cpuid_modifier_map_key() {
+        let key = CpuidModifierMapKey {
+            leaf: 0x0,
+            subleaf: 0x1,
+            flags: KvmCpuidFlags::STATEFUL_FUNC,
+            register: Edx,
+        };
+        assert_eq!(
+            key.to_string(),
+            "leaf=0x0, subleaf=0x1, flags=0b10, register=edx",
+        )
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_cpuid_modifier_from_vec_to_map() {
+        let modifier_vec = vec![
+            cpuid_leaf_modifier!(0x0, 0x0, KvmCpuidFlags::EMPTY, vec![
+                cpuid_reg_modifier!(Eax, 0x0),
+            ]),
+            cpuid_leaf_modifier!(0x1, 0x2, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
+                cpuid_reg_modifier!(Ebx, 0x3),
+                cpuid_reg_modifier!(Ecx, 0x4),
+            ]),
+        ];
+        let modifier_map = HashMap::from([
+            cpuid_modifier_map!(0x0, 0x0, KvmCpuidFlags::EMPTY, Eax, 0x0),
+            cpuid_modifier_map!(0x1, 0x2, KvmCpuidFlags::SIGNIFICANT_INDEX, Ebx, 0x3),
+            cpuid_modifier_map!(0x1, 0x2, KvmCpuidFlags::SIGNIFICANT_INDEX, Ecx, 0x4),
+        ]);
+        assert_eq!(
+            CpuidModifierMap::from(modifier_vec),
+            CpuidModifierMap(modifier_map),
+        );
+    }
+}

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,9 +24,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 83.40, "AMD": 82.94, "ARM": 82.79}
+    COVERAGE_DICT = {"Intel": 83.47, "AMD": 83.02, "ARM": 82.88}
 else:
-    COVERAGE_DICT = {"Intel": 80.60, "AMD": 80.08, "ARM": 79.73}
+    COVERAGE_DICT = {"Intel": 80.68, "AMD": 80.22, "ARM": 79.83}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

- Add a new command to verify CPU template to the helper tool.
- Refactor the helper tool.

## Reason

As firecracker applies some modifications on the guest config after applying CPU template for some reasons (e.g. to boot linux kernel) and KVM ignores given values via SET APIs due to capabilities of KVM and host CPUs, a command to verify that the given custom CPU template is applied as intended is important for users in the loop of new custom CPU template creation and after KVM/firecracker/BIOS updates.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
