### PR TITLE
Fixing target version for snapshot tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,10 +94,11 @@ import host_tools.network as net_tools
 from host_tools import proc
 from framework import utils
 from framework import defs
-from framework.artifacts import ArtifactCollection
+from framework.artifacts import ArtifactCollection, FirecrackerArtifact
 from framework.microvm import Microvm
 from framework.s3fetcher import MicrovmImageS3Fetcher
 from framework.scheduler import PytestScheduler
+from framework.utils import get_firecracker_version_from_toml
 
 # Tests root directory.
 SCRIPT_FOLDER = os.path.dirname(os.path.realpath(__file__))
@@ -501,6 +502,35 @@ def test_spectre_mitigations():
 
     mitigated = x86_64(body) if arch == "x86_64" else aarch64(body)
     assert mitigated, "SPECTREv2 not mitigated {}".format(body)
+
+
+def firecracker_id(fc):
+    """Render a nice ID for pytest parametrize."""
+    if isinstance(fc, FirecrackerArtifact):
+        return f"firecracker-{fc.version}"
+    return None
+
+
+def firecracker_artifacts(*args, **kwargs):
+    """Return all supported firecracker binaries."""
+    params = {
+        "min_version": "1.1.0",
+        "max_version": get_firecracker_version_from_toml(),
+    }
+    params.update(kwargs)
+    return ARTIFACTS_COLLECTION.firecrackers(
+        *args,
+        **params,
+    )
+
+
+@pytest.fixture(params=firecracker_artifacts(), ids=firecracker_id)
+def firecracker_release(request):
+    """Return all supported firecracker binaries."""
+    firecracker = request.param
+    firecracker.download()
+    firecracker.jailer().download()
+    return firecracker
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Define classes for interacting with CI artifacts in s3."""
 
+import functools
 import os
 import platform
 import tempfile
@@ -12,6 +13,7 @@ from stat import S_IREAD, S_IWRITE
 
 import boto3
 import botocore.client
+
 from framework.defs import DEFAULT_TEST_SESSION_ROOT_PATH, SUPPORTED_KERNELS
 from framework.utils import compare_versions
 from host_tools.snapshot_helper import merge_memory_bitmaps
@@ -93,7 +95,7 @@ class Artifact:
         Path(self.local_dir()).mkdir(parents=True, exist_ok=True)
         if force or not os.path.exists(self.local_path()):
             self._bucket.download_file(self._key, self.local_path())
-            # Artifacts are read only by design.
+            # Artifacts are read-only by design.
             os.chmod(self.local_path(), S_IREAD)
 
     def local_path(self):
@@ -276,11 +278,12 @@ class DiskArtifact(Artifact):
 class FirecrackerArtifact(Artifact):
     """Provides access to associated jailer artifact."""
 
+    @functools.lru_cache
     def jailer(self):
         """Return a jailer binary artifact."""
         # Jailer and FC binaries have different extensions and share
         # file name when stored in S3:
-        # Firecracker binary: v0.22.firecrcker
+        # Firecracker binary: v0.22.firecracker
         # Jailer binary: v0.23.0.jailer
         jailer_path = str(Path(self.key).with_suffix(".jailer"))
         return Artifact(self.bucket, jailer_path, artifact_type=ArtifactType.JAILER)
@@ -290,6 +293,25 @@ class FirecrackerArtifact(Artifact):
         """Return the artifact's version: `X.Y.Z`."""
         # Get the filename, remove the extension and trim the leading 'v'.
         return os.path.splitext(os.path.basename(self.key))[0][1:]
+
+    @property
+    def version_tuple(self):
+        """Return the artifact's version as a tuple `(X, Y, Z)`."""
+        return tuple(int(x) for x in self.version.split("."))
+
+    @property
+    def snapshot_version_tuple(self):
+        """Return the artifact's snapshot version as a tuple: `X.Y.0`."""
+        return self.version_tuple[:2] + (0,)
+
+    @property
+    def snapshot_version(self):
+        """Return the artifact's snapshot version: `X.Y.0`.
+
+        Due to how Firecracker maps release versions to snapshot versions, we
+        have to request the minor version instead of the actual version.
+        """
+        return ".".join(str(x) for x in self.snapshot_version_tuple)
 
 
 class ArtifactCollection:

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -705,6 +705,8 @@ def test_mmds_snapshot(bin_cloner_path, version):
         jailer.download()
 
         target_version = firecracker.base_name()[1:]
+        # make target version look like X.Y.0
+        target_version = ".".join(target_version.split(".")[:2] + ["0"])
         # If the version is smaller or equal to 1.0.0, we expect that
         # MMDS will be initialised with V1 by default.
         if compare_versions(target_version, "1.0.0") <= 0:
@@ -752,6 +754,8 @@ def test_mmds_older_snapshot(bin_cloner_path):
         )
 
         fc_version = firecracker.base_name()[1:]
+        # make fc version look like X.Y.0
+        fc_version = ".".join(fc_version.split(".")[:2] + ["0"])
         # If the version is smaller or equal to 1.0.0, we expect that
         # MMDS will be initialised with V1 by default.
         # Otherwise, we may configure V2.

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -7,14 +7,8 @@ import platform
 import tempfile
 import pytest
 from test_balloon import _test_rss_memory_lower
-from conftest import _test_images_s3_bucket
-from framework.artifacts import (
-    ArtifactCollection,
-    FirecrackerArtifact,
-    create_net_devices_configuration,
-)
+from framework.artifacts import create_net_devices_configuration
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
-from framework.utils import get_firecracker_version_from_toml
 import host_tools.network as net_tools  # pylint: disable=import-error
 import host_tools.drive as drive_tools
 
@@ -25,106 +19,67 @@ net_ifaces = create_net_devices_configuration(4)
 scratch_drives = ["vdb", "vdc", "vdd", "vde", "vdf"]
 
 
-def firecracker_artifacts(*args, **kwargs):
-    """Return all available firecracker binaries."""
-    artifacts = ArtifactCollection(_test_images_s3_bucket())
-    # Fetch all firecracker binaries.
-    return artifacts.firecrackers(*args, **kwargs)
-
-
-def firecracker_id(fc):
-    """Render a nice ID for pytest parametrize."""
-    if isinstance(fc, FirecrackerArtifact):
-        return f"firecracker-{fc.version}"
-    return None
-
-
-@pytest.mark.parametrize(
-    "firecracker",
-    firecracker_artifacts(
-        min_version="1.1.0",
-        max_version=get_firecracker_version_from_toml(),
-    ),
-    ids=firecracker_id,
-)
-def test_restore_old_snapshot(bin_cloner_path, firecracker):
+def test_restore_old_to_current(bin_cloner_path, firecracker_release):
     """
-    Restore from snapshots obtained with previous versions of Firecracker.
+    Restore snapshots from previous supported versions of Firecracker.
+
+    For each firecracker release:
+    1. Snapshot with the past release
+    2. Restore with the current build
 
     @type: functional
     """
     # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("old_snapshot_many_devices")
     builder = MicrovmBuilder(bin_cloner_path)
-
-    # With each binary create a snapshot and try to restore in current
-    # version.
-
-    firecracker.download()
-    jailer = firecracker.jailer()
-    jailer.download()
-
-    logger.info("Creating snapshot with Firecracker: %s", firecracker.local_path())
+    jailer = firecracker_release.jailer()
+    logger.info("Using Firecracker: %s", firecracker_release.local_path())
     logger.info("Using Jailer: %s", jailer.local_path())
-
-    target_version = firecracker.base_name()[1:]
-
-    # v0.23 does not support creating diff snapshots.
-    # v0.23 does not support balloon.
-    diff_snapshots = "0.23" not in target_version
-
-    # Create a snapshot.
+    diff_snapshots = True
+    logger.info("Create snapshot")
     snapshot = create_snapshot_helper(
         builder,
         logger,
         drives=scratch_drives,
         ifaces=net_ifaces,
-        fc_binary=firecracker.local_path(),
+        fc_binary=firecracker_release.local_path(),
         jailer_binary=jailer.local_path(),
         diff_snapshots=diff_snapshots,
         balloon=diff_snapshots,
     )
 
-    # Resume microvm using current build of FC/Jailer.
+    logger.info("Resume microvm using current build of FC/Jailer")
     microvm, _ = builder.build_from_snapshot(
         snapshot, resume=True, diff_snapshots=False
     )
+    logger.info("Validate all devices")
     validate_all_devices(logger, microvm, net_ifaces, scratch_drives, diff_snapshots)
     logger.debug("========== Firecracker restore snapshot log ==========")
     logger.debug(microvm.log_data)
 
 
-@pytest.mark.parametrize(
-    "firecracker",
-    firecracker_artifacts(
-        min_version="1.2.0",
-        max_version=get_firecracker_version_from_toml(),
-    ),
-    ids=firecracker_id,
-)
-def test_restore_old_version(bin_cloner_path, firecracker):
+def test_restore_current_to_old(bin_cloner_path, firecracker_release):
     """
     Restore current snapshot with previous versions of Firecracker.
 
-    Current snapshot (i.e a machine snapshotted with current build) is
-    incompatible with any past release due to notification suppression.
+    For each firecracker release:
+    1. Snapshot with the current build
+    2. Restore with the past release
 
     @type: functional
     """
+
+    # Current snapshot (i.e a machine snapshotted with current build) is
+    # incompatible with any past release due to notification suppression.
+    if firecracker_release.version_tuple < (1, 2, 0):
+        pytest.skip("incompatible with Firecracker <1.2.0")
+
     # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("old_snapshot_version_many_devices")
     builder = MicrovmBuilder(bin_cloner_path)
-
-    # Create a snapshot with current build and restore with each FC binary
-    # artifact.
-    firecracker.download()
-    jailer = firecracker.jailer()
-    jailer.download()
-
+    jailer = firecracker_release.jailer()
     logger.info("Creating snapshot with local build")
-
-    # Old version from artifact.
-    target_version = firecracker.base_name()[1:]
+    target_version = firecracker_release.snapshot_version
 
     # Create a snapshot with current FC version targeting the old version.
     snapshot = create_snapshot_helper(
@@ -137,7 +92,9 @@ def test_restore_old_version(bin_cloner_path, firecracker):
         diff_snapshots=True,
     )
 
-    logger.info("Restoring snapshot with Firecracker: %s", firecracker.local_path())
+    logger.info(
+        "Restoring snapshot with Firecracker: %s", firecracker_release.local_path()
+    )
     logger.info("Using Jailer: %s", jailer.local_path())
 
     # Resume microvm using FC/Jailer binary artifacts.
@@ -145,7 +102,7 @@ def test_restore_old_version(bin_cloner_path, firecracker):
         snapshot,
         resume=True,
         diff_snapshots=False,
-        fc_binary=firecracker.local_path(),
+        fc_binary=firecracker_release.local_path(),
         jailer_binary=jailer.local_path(),
     )
     validate_all_devices(logger, vm, net_ifaces, scratch_drives, True)

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -280,6 +280,7 @@ def _test_snapshot_create_latency(context):
 
     # Test snapshot creation for every supported target version.
     for target_version in firecracker_versions:
+        target_version = ".".join(target_version.split(".")[:2] + ["0"])
         logger.info(
             """Measuring snapshot create({}) latency for target
         version: {} and microvm: \"{}\", kernel {}, disk {} """.format(

--- a/tools/release-prepare.sh
+++ b/tools/release-prepare.sh
@@ -6,6 +6,14 @@
 set -eu -o pipefail
 set -x
 
+function check_snapshot_version {
+    local version=$1
+    local snap_version=$(echo $version |cut -f-2 -d. |tr . _)
+    if ! grep FC_V${snap_version}_SNAP_VERSION src/vmm/src/version_map.rs; then
+       die "I couldn't find FC_V${snap_version}_SNAP_VERSION in src/vmm/src/version_map.rs"
+    fi
+}
+
 FC_TOOLS_DIR=$(dirname $(realpath $0))
 source "$FC_TOOLS_DIR/functions"
 FC_ROOT_DIR=$FC_TOOLS_DIR/..
@@ -29,6 +37,7 @@ version=$1
 validate_version "$version"
 
 check_local_branch_is_release_branch
+check_snapshot_version "$version"
 
 # Create GitHub PR link
 ORIGIN_URL=$(git config --get remote.origin.url)


### PR DESCRIPTION
- split the tests so we can see which ones pass
- only test firecracker supported versions (drop 0.24, 0.25)
- make a new firecracker fixture so it is simple to use in tests
- give tests more descriptive names

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
