### PR TITLE
Update vm-memory to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,9 +696,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "linux-loader"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9259ddbfbb52cc918f6bbc60390004ddd0228cf1d85f402009ff2b3d95de83f"
+checksum = "8d3adb7b28e189741eca3b1a4a27de0bf15e0907c9d4b0c74bd2d7d84ef72e08"
 dependencies = [
  "vm-memory",
 ]
@@ -1366,9 +1366,9 @@ checksum = "f43fb5a6bd1a7d423ad72802801036719b7546cf847a103f8fe4575f5b0d45a6"
 
 [[package]]
 name = "vm-memory"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
+checksum = "9d6ea57fe00f9086c59eeeb68e102dd611686bc3c28520fa465996d4d4bdce07"
 dependencies = [
  "libc",
  "winapi",

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = "1.0.32"
 versionize = "0.1.10"
 versionize_derive = "0.1.5"
 vmm-sys-util = "0.11.0"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-bitmap"] }
 
 net_gen = { path = "../net_gen" }
 

--- a/src/utils/src/vm_memory.rs
+++ b/src/utils/src/vm_memory.rs
@@ -8,8 +8,7 @@
 use std::io::{Error as IoError, ErrorKind};
 use std::os::unix::io::AsRawFd;
 
-use vm_memory::bitmap::AtomicBitmap;
-pub use vm_memory::bitmap::{Bitmap, BitmapSlice};
+pub use vm_memory::bitmap::{AtomicBitmap, Bitmap, BitmapSlice, BS};
 use vm_memory::mmap::{check_file_offset, NewBitmap};
 pub use vm_memory::mmap::{MmapRegionBuilder, MmapRegionError};
 pub use vm_memory::{

--- a/src/utils/src/vm_memory.rs
+++ b/src/utils/src/vm_memory.rs
@@ -5,17 +5,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::io::Error as IoError;
+use std::io::{Error as IoError, ErrorKind};
 use std::os::unix::io::AsRawFd;
 
 use vm_memory::bitmap::AtomicBitmap;
-pub use vm_memory::bitmap::Bitmap;
+pub use vm_memory::bitmap::{Bitmap, BitmapSlice};
 use vm_memory::mmap::{check_file_offset, NewBitmap};
 pub use vm_memory::mmap::{MmapRegionBuilder, MmapRegionError};
 pub use vm_memory::{
     address, Address, ByteValued, Bytes, Error, FileOffset, GuestAddress, GuestMemory,
     GuestMemoryError, GuestMemoryRegion, GuestUsize, MemoryRegionAddress, MmapRegion,
-    VolatileMemory, VolatileMemoryError,
+    VolatileMemory, VolatileMemoryError, VolatileSlice,
 };
 
 pub type GuestMemoryMmap = vm_memory::GuestMemoryMmap<Option<AtomicBitmap>>;
@@ -142,6 +142,260 @@ pub fn mark_dirty_mem(mem: &GuestMemoryMmap, addr: GuestAddress, len: usize) {
     });
 }
 
+/// A version of the standard library's [`Read`] trait that operates on volatile memory instead of
+/// slices
+///
+/// This trait is needed as rust slices (`&[u8]` and `&mut [u8]`) cannot be used when operating on
+/// guest memory [1].
+///
+/// [1]: https://github.com/rust-vmm/vm-memory/pull/217
+pub trait ReadVolatile {
+    /// Tries to read some bytes into the given [`VolatileSlice`] buffer, returning how many bytes
+    /// were read.
+    ///
+    /// The behavior of implementations should be identical to [`Read::read`]
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError>;
+
+    /// Tries to fill the given [`VolatileSlice`] buffer by reading from `self` returning an error
+    /// if insufficient bytes could be read.
+    ///
+    /// The default implementation is identical to that of [`Read::read_exact`]
+    fn read_exact_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<(), VolatileMemoryError> {
+        // Implementation based on https://github.com/rust-lang/rust/blob/7e7483d26e3cec7a44ef00cf7ae6c9c8c918bec6/library/std/src/io/mod.rs#L465
+
+        let mut partial_buf = buf.offset(0)?;
+
+        while !partial_buf.is_empty() {
+            match self.read_volatile(&mut partial_buf) {
+                Err(VolatileMemoryError::IOError(err)) if err.kind() == ErrorKind::Interrupted => {
+                    continue
+                }
+                Ok(0) => {
+                    return Err(VolatileMemoryError::IOError(std::io::Error::new(
+                        ErrorKind::UnexpectedEof,
+                        "failed to fill whole buffer",
+                    )))
+                }
+                Ok(bytes_read) => partial_buf = partial_buf.offset(bytes_read)?,
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// A version of the standard library's [`Write`] trait that operates on volatile memory instead of
+/// slices
+///
+/// This trait is needed as rust slices (`&[u8]` and `&mut [u8]`) cannot be used when operating on
+/// guest memory [1].
+///
+/// [1]: https://github.com/rust-vmm/vm-memory/pull/217
+pub trait WriteVolatile {
+    /// Tries to write some bytes from the given [`VolatileSlice`] buffer, returning how many bytes
+    /// were written.
+    ///
+    /// The behavior of implementations should be identical to [`Write::write`]
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError>;
+
+    /// Tries write the entire content of the given [`VolatileSlice`] buffer to `self` returning an
+    /// error if not all bytes could be written.
+    ///
+    /// The default implementation is identical to that of [`Write::write_all`]
+    fn write_all_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<(), VolatileMemoryError> {
+        // Based on https://github.com/rust-lang/rust/blob/7e7483d26e3cec7a44ef00cf7ae6c9c8c918bec6/library/std/src/io/mod.rs#L1570
+
+        let mut partial_buf = buf.offset(0)?;
+
+        while !partial_buf.is_empty() {
+            match self.write_volatile(&partial_buf) {
+                Err(VolatileMemoryError::IOError(err)) if err.kind() == ErrorKind::Interrupted => {
+                    continue
+                }
+                Ok(0) => {
+                    return Err(VolatileMemoryError::IOError(std::io::Error::new(
+                        ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    )))
+                }
+                Ok(bytes_written) => partial_buf = partial_buf.offset(bytes_written)?,
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// We explicitly implement our traits for [`std::fs::File`] and [`std::os::unix::net::UnixStream`]
+// instead of providing blanket implementation for [`AsRawFd`] due to trait coherence limitations: A
+// blanket implementation would prevent us from providing implementations for `&mut [u8]` below, as
+// "an upstream crate could implement AsRawFd for &mut [u8]`.
+
+impl ReadVolatile for std::fs::File {
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        read_volatile_raw_fd(self, buf)
+    }
+}
+
+impl ReadVolatile for std::os::unix::net::UnixStream {
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        read_volatile_raw_fd(self, buf)
+    }
+}
+
+/// Tries to do a single `read` syscall on the provided file descriptor, storing the data raed in
+/// the given [`VolatileSlice`].
+///
+/// Returns the numbers of bytes read.
+fn read_volatile_raw_fd(
+    raw_fd: &mut impl AsRawFd,
+    buf: &mut VolatileSlice<impl BitmapSlice>,
+) -> Result<usize, VolatileMemoryError> {
+    let fd = raw_fd.as_raw_fd();
+    let dst = buf.as_ptr().cast::<libc::c_void>();
+
+    // SAFETY: We got a valid file descriptor from `AsRawFd`. The memory pointed to by `dst` is
+    // valid for writes of length `buf.len() by the invariants upheld by the constructor
+    // of `VolatileSlice`.
+    let bytes_read = unsafe { libc::read(fd, dst, buf.len()) };
+
+    if bytes_read < 0 {
+        // We don't know if a partial read might have happened, so mark everything as dirty
+        buf.bitmap().mark_dirty(0, buf.len());
+
+        Err(VolatileMemoryError::IOError(std::io::Error::last_os_error()))
+    } else {
+        let bytes_read = bytes_read.try_into().unwrap();
+        buf.bitmap().mark_dirty(0, bytes_read);
+        Ok(bytes_read)
+    }
+}
+
+impl WriteVolatile for std::fs::File {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        write_volatile_raw_fd(self, buf)
+    }
+}
+
+impl WriteVolatile for std::os::unix::net::UnixStream {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        write_volatile_raw_fd(self, buf)
+    }
+}
+
+/// Tries to do a single `write` syscall on the provided file descriptor, attempting to write the
+/// data stored in the given [`VolatileSlice`].
+///
+/// Returns the numbers of bytes written.
+fn write_volatile_raw_fd(
+    raw_fd: &mut impl AsRawFd,
+    buf: &VolatileSlice<impl BitmapSlice>,
+) -> Result<usize, VolatileMemoryError> {
+    let fd = raw_fd.as_raw_fd();
+    let src = buf.as_ptr().cast::<libc::c_void>();
+
+    // SAFETY: We got a valid file descriptor from `AsRawFd`. The memory pointed to by `src` is
+    // valid for reads of length `buf.len() by the invariants upheld by the constructor
+    // of `VolatileSlice`.
+    let bytes_written = unsafe { libc::write(fd, src, buf.len()) };
+
+    if bytes_written < 0 {
+        Err(VolatileMemoryError::IOError(std::io::Error::last_os_error()))
+    } else {
+        Ok(bytes_written.try_into().unwrap())
+    }
+}
+
+impl WriteVolatile for &mut [u8] {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        // NOTE: The duality of read <-> write here is correct. This is because we translate a call
+        // "slice.write(buf)" (e.g. write into slice from buf) into "buf.read(slice)" (e.g. read
+        // from buffer into slice). Both express data transfer from the buffer to the slice
+        let read = buf.read(self, 0)?;
+
+        // Advance the slice, just like the stdlib: https://doc.rust-lang.org/src/std/io/impls.rs.html#335
+        *self = std::mem::take(self).split_at_mut(read).1;
+
+        Ok(read)
+    }
+
+    fn write_all_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<(), VolatileMemoryError> {
+        // Based on https://github.com/rust-lang/rust/blob/f7b831ac8a897273f78b9f47165cf8e54066ce4b/library/std/src/io/impls.rs#L376-L382
+        if self.write_volatile(buf)? == buf.len() {
+            Ok(())
+        } else {
+            Err(VolatileMemoryError::IOError(std::io::Error::new(
+                ErrorKind::WriteZero,
+                "failed to write whole buffer",
+            )))
+        }
+    }
+}
+
+impl ReadVolatile for &[u8] {
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        // NOTE: the duality of read <-> write here is correct. This is because we translate a call
+        // "slice.read(buf)" (e.g. "read from slice into buf") into "buf.write(slice)" (e.g. write
+        // into buf from slice)
+        let written = buf.write(self, 0)?;
+
+        // Advance the slice, just like the stdlib: https://doc.rust-lang.org/src/std/io/impls.rs.html#232-310
+        *self = self.split_at(written).1;
+
+        Ok(written)
+    }
+
+    fn read_exact_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<(), VolatileMemoryError> {
+        // Based on https://github.com/rust-lang/rust/blob/f7b831ac8a897273f78b9f47165cf8e54066ce4b/library/std/src/io/impls.rs#L282-L302
+        if buf.len() > self.len() {
+            return Err(VolatileMemoryError::IOError(std::io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            )));
+        }
+
+        self.read_volatile(buf).map(|_| ())
+    }
+}
+
 pub mod test_utils {
     use super::*;
 
@@ -193,6 +447,8 @@ pub mod test_utils {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
+    use std::io::{Read, Seek, Write};
+
     use super::*;
     use crate::get_page_size;
     use crate::tempfile::TempFile;
@@ -442,6 +698,160 @@ mod tests {
                     },
                 )
                 .unwrap();
+        }
+    }
+
+    #[test]
+    fn test_read_volatile() {
+        let test_cases = [
+            (vec![1u8, 2], [1u8, 2, 0, 0, 0]),
+            (vec![1, 2, 3, 4], [1, 2, 3, 4, 0]),
+            // ensure we don't have a buffer overrun
+            (vec![5, 6, 7, 8, 9], [5, 6, 7, 8, 0]),
+        ];
+
+        for (input, output) in test_cases {
+            // ---- Test ReadVolatile for &[u8] ----
+            //
+            // Test read_volatile for &[u8] works
+            let mut memory = vec![0u8; 5];
+
+            assert_eq!(
+                (&input[..])
+                    .read_volatile(&mut VolatileSlice::from(&mut memory[..4]))
+                    .unwrap(),
+                input.len().min(4)
+            );
+            assert_eq!(&memory, &output);
+
+            // Test read_exact_volatile for &[u8] works
+            let mut memory = vec![0u8; 5];
+            let result =
+                (&input[..]).read_exact_volatile(&mut VolatileSlice::from(&mut memory[..4]));
+
+            // read_exact fails if there are not enough bytes in input to completely fill
+            // memory[..4]
+            if input.len() < 4 {
+                match result.unwrap_err() {
+                    VolatileMemoryError::IOError(ioe) => {
+                        assert_eq!(ioe.kind(), ErrorKind::UnexpectedEof)
+                    }
+                    err => panic!("{:?}", err),
+                }
+                assert_eq!(memory, vec![0u8; 5]);
+            } else {
+                result.unwrap();
+                assert_eq!(&memory, &output);
+            }
+
+            // ---- Test ReadVolatile for File ----
+
+            let mut temp_file = TempFile::new().unwrap().into_file();
+            temp_file.write_all(input.as_ref()).unwrap();
+            temp_file.rewind().unwrap();
+
+            // Test read_volatile for File works
+            let mut memory = vec![0u8; 5];
+
+            assert_eq!(
+                temp_file
+                    .read_volatile(&mut VolatileSlice::from(&mut memory[..4]))
+                    .unwrap(),
+                input.len().min(4)
+            );
+            assert_eq!(&memory, &output);
+
+            temp_file.rewind().unwrap();
+
+            // Test read_exact_volatile for File works
+            let mut memory = vec![0u8; 5];
+
+            let read_exact_result =
+                temp_file.read_exact_volatile(&mut VolatileSlice::from(&mut memory[..4]));
+
+            if input.len() < 4 {
+                read_exact_result.unwrap_err();
+            } else {
+                read_exact_result.unwrap();
+            }
+            assert_eq!(&memory, &output);
+        }
+    }
+
+    #[test]
+    fn test_write_volatile() {
+        let test_cases = [
+            (vec![1u8, 2], [1u8, 2, 0, 0, 0]),
+            (vec![1, 2, 3, 4], [1, 2, 3, 4, 0]),
+            // ensure we don't have a buffer overrun
+            (vec![5, 6, 7, 8, 9], [5, 6, 7, 8, 0]),
+        ];
+
+        for (mut input, output) in test_cases {
+            // ---- Test WriteVolatile for &mut [u8] ----
+            //
+            // Test write_volatile for &mut [u8] works
+            let mut memory = vec![0u8; 5];
+
+            assert_eq!(
+                (&mut memory[..4])
+                    .write_volatile(&VolatileSlice::from(input.as_mut_slice()))
+                    .unwrap(),
+                input.len().min(4)
+            );
+            assert_eq!(&memory, &output);
+
+            // Test write_all_volatile for &mut [u8] works
+            let mut memory = vec![0u8; 5];
+
+            let result =
+                (&mut memory[..4]).write_all_volatile(&VolatileSlice::from(input.as_mut_slice()));
+
+            if input.len() > 4 {
+                match result.unwrap_err() {
+                    VolatileMemoryError::IOError(ioe) => {
+                        assert_eq!(ioe.kind(), ErrorKind::WriteZero)
+                    }
+                    err => panic!("{:?}", err),
+                }
+                // This quirky behavior of writing to the slice even in the case of failure is also
+                // exhibited by the stdlib
+                assert_eq!(&memory, &output);
+            } else {
+                result.unwrap();
+                assert_eq!(&memory, &output);
+            }
+
+            // ---- Test ẂriteVolatile for File works
+            // Test write_volatile for File works
+            let mut temp_file = TempFile::new().unwrap().into_file();
+
+            temp_file
+                .write_volatile(&VolatileSlice::from(input.as_mut_slice()))
+                .unwrap();
+            temp_file.rewind().unwrap();
+
+            let mut written = vec![0u8; input.len()];
+            temp_file.read_exact(written.as_mut_slice()).unwrap();
+
+            assert_eq!(input, written);
+            // check no excess bytes were written to the file
+            assert_eq!(temp_file.read(&mut [0u8]).unwrap(), 0);
+
+            // Test write_all_volatile for File works
+            let mut temp_file = TempFile::new().unwrap().into_file();
+
+            temp_file
+                .write_all_volatile(&VolatileSlice::from(input.as_mut_slice()))
+                .unwrap();
+            temp_file.rewind().unwrap();
+
+            let mut written = vec![0u8; input.len()];
+            temp_file.read_exact(written.as_mut_slice()).unwrap();
+
+            assert_eq!(input, written);
+            // check no excess bytes were written to the file
+            assert_eq!(temp_file.read(&mut [0u8]).unwrap(), 0);
         }
     }
 }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -14,7 +14,7 @@ kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"
 lazy_static = "1.4.0"
 libc = "0.2.117"
-linux-loader = "0.8.1"
+linux-loader = "0.9.0"
 log = "0.4.17"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"

--- a/src/vmm/src/devices/virtio/vsock/csm/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/mod.rs
@@ -6,7 +6,7 @@
 mod connection;
 mod txbuf;
 
-pub use connection::VsockConnection;
+pub use connection::{VsockConnection, VsockConnectionBackend};
 
 pub mod defs {
     /// Vsock connection TX buffer capacity.

--- a/src/vmm/src/devices/virtio/vsock/unix/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/mod.rs
@@ -13,6 +13,8 @@ mod muxer_rxq;
 
 pub use muxer::VsockMuxer as VsockUnixBackend;
 
+use crate::devices::virtio::vsock::csm::VsockConnectionBackend;
+
 mod defs {
     /// Maximum number of established connections that we can handle.
     pub const MAX_CONNECTIONS: usize = 1023;
@@ -46,3 +48,5 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 type MuxerConnection = super::csm::VsockConnection<std::os::unix::net::UnixStream>;
+
+impl VsockConnectionBackend for std::os::unix::net::UnixStream {}

--- a/tests/host_tools/uffd/Cargo.lock
+++ b/tests/host_tools/uffd/Cargo.lock
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "vm-memory"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
+checksum = "9d6ea57fe00f9086c59eeeb68e102dd611686bc3c28520fa465996d4d4bdce07"
 dependencies = [
  "libc",
  "winapi",

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,9 +25,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 83.59, "AMD": 83.18, "ARM": 83.04}
+    COVERAGE_DICT = {"Intel": 83.66, "AMD": 83.24, "ARM": 83.11}
 else:
-    COVERAGE_DICT = {"Intel": 80.90, "AMD": 80.39, "ARM": 80.05}
+    COVERAGE_DICT = {"Intel": 80.90, "AMD": 80.45, "ARM": 80.13}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/security/demo_seccomp/Cargo.lock
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.lock
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "vm-memory"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
+checksum = "9d6ea57fe00f9086c59eeeb68e102dd611686bc3c28520fa465996d4d4bdce07"
 dependencies = [
  "libc",
  "winapi",


### PR DESCRIPTION
## Changes

Update vm-memory 0.10.0 -> 0.11.0
Update linux-loader 0.8.1 -> 0.9.0

The update to vm-memory 0.11.0 brought with it a performance degradation in the `read_from` and `write_to` methods used for transferring data between guest memory and some `Read`/ `Write` implementation. This is due to an added copy-to-vmm-memory of all transferred data to avoid unsoundness concerns with taking rust-style slices to guest memory. This PR alleviates that performance impact by implementing `ReadVolatile` and `WriteVolatile` traits that work exactly like `Read`/`Write`, but operate on `VolatileSlice` instead of `&mut [u8]`. This means there is no unsoundness when transferring directly between guest memory and a file descriptor. 

These traits are used in three places where `read_from`/`write_to` were previously used:
- The vsock device, for transferring data between guest memory and the `UnixStream`/`TxBuf`,
- The block device, for transferring data between guest memory and the backing file
- Snapshotting, for transferring guest memory pages to the snapshot file

The first and third uses should yield identical behavior. The block device, however, has slightly changes in scenarios that the virtio spec considers undefined behavior (e.g. responses to when the guest does something it MUST NOT do according to the spec):
- Attempting to read file content to/write file content from (partially) outside the bounds of guest memory not fails (previously, a partial read/write up to the bounds of guest memory was performed)
- Attempting to read past the end of the backing file now reports 0 bytes being read (previously reported how many bytes could be read up to the end of the file) - note that the test case that attempted to verify the previous behavior is broken anyway: The only reason it even gets to the sync backends "read" function is because the block device is constructed in an invalid way (e.g. the backing file is trimmed after the device is constructed, believing the device to still have 8 sectors, while the file only has 2. Because of this, the request for reading past the end of the file is not rejected by the request validation logic)

## Reason

Keeping dependencies up-to-date

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

I think the `VolatileRead` and `VolatileWrite` traits would be valuable for rust-vmm/vm-memory. I also think part of @bchalios' work on iovec and `writev`/`readv` for guest memory is, and there these could be combined into an RFC about "volatile `Read`/`Write`" traits. 

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
