### PR TITLE
fix: removed filler values from arm templates enum

### DIFF
--- a/src/vmm/src/guest_config/aarch64/static_cpu_templates/mod.rs
+++ b/src/vmm/src/guest_config/aarch64/static_cpu_templates/mod.rs
@@ -11,17 +11,12 @@ pub mod v1n1;
 /// Templates available for configuring the supported ARM CPU types.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Versionize)]
 pub enum StaticCpuTemplate {
-    // Needed for compatibility
-    /// Empty0
-    Empty0,
-    // Needed for compatibility
-    /// Empty1
-    Empty1,
     /// Template to mask Neoverse-V1 as Neoverse-N1
     V1N1,
     /// No CPU template is used.
+    /// Value needs to be 3 for backward compatibility
     #[default]
-    None,
+    None = 3,
 }
 
 impl StaticCpuTemplate {
@@ -36,7 +31,6 @@ impl std::fmt::Display for StaticCpuTemplate {
         match self {
             StaticCpuTemplate::V1N1 => write!(f, "V1N1"),
             StaticCpuTemplate::None => write!(f, "None"),
-            _ => write!(f, "None"),
         }
     }
 }

--- a/src/vmm/src/guest_config/templates/aarch64.rs
+++ b/src/vmm/src/guest_config/templates/aarch64.rs
@@ -221,32 +221,6 @@ mod tests {
     }
 
     #[test]
-    fn test_get_cpu_template_with_empty0_static_template() {
-        // Test `get_cpu_template()` when `Empty0` static CPU template is provided.
-        // `InvalidStaticCpuTemplate` error should be returned, because `StaticCpuTemplate::Empty0`
-        // is invalid and is used as a placeholder to align the position of
-        // `StaticCpuTemplate::None` with x86_64.
-        let cpu_template = Some(CpuTemplateType::Static(StaticCpuTemplate::Empty0));
-        assert_eq!(
-            cpu_template.get_cpu_template().unwrap_err(),
-            GetCpuTemplateError::InvalidStaticCpuTemplate(StaticCpuTemplate::Empty0)
-        );
-    }
-
-    #[test]
-    fn test_get_cpu_template_with_empty1_static_template() {
-        // Test `get_cpu_template()` when `Empty1` static CPU template is provided.
-        // `InvalidStaticCpuTemplate` error should be returned, because `StaticCpuTemplate::Empty1`
-        // is invalid and is used as a placeholder to align the position of
-        // `StaticCpuTemplate::None` with x86_64.
-        let cpu_template = Some(CpuTemplateType::Static(StaticCpuTemplate::Empty1));
-        assert_eq!(
-            cpu_template.get_cpu_template().unwrap_err(),
-            GetCpuTemplateError::InvalidStaticCpuTemplate(StaticCpuTemplate::Empty1)
-        );
-    }
-
-    #[test]
     fn test_get_cpu_template_with_custom_template() {
         // Test `get_cpu_template()` when a custom CPU template is provided. The borrowed
         // `CustomCpuTemplate` should be returned.


### PR DESCRIPTION
## Changes
Removed unnecessary enum values from arm static templates enum. Set `None` value to be 3 for backward compatibility.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
