### PR TITLE
chore: Add cpu-template-helper to release artifacts

### DIFF
--- a/src/cpu-template-helper/Cargo.toml
+++ b/src/cpu-template-helper/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.2.3", features = ["derive"] }
+clap = { version = "4.2.3", features = ["derive", "string"] }
 serde_json = "1.0.78"
 thiserror = "1.0.32"
 

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -33,7 +33,7 @@ enum Error {
 type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Parser)]
-#[command(version)]
+#[command(version = format!("v{}", crate::utils::CPU_TEMPLATE_HELPER_VERSION))]
 struct Cli {
     #[command(subcommand)]
     command: Command,

--- a/src/cpu-template-helper/src/utils/mod.rs
+++ b/src/cpu-template-helper/src/utils/mod.rs
@@ -19,7 +19,7 @@ pub mod aarch64;
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
-const CPU_TEMPLATE_HELPER_VERSION: &str = env!("FIRECRACKER_VERSION");
+pub const CPU_TEMPLATE_HELPER_VERSION: &str = env!("FIRECRACKER_VERSION");
 
 /// Trait for key of `HashMap`-based modifier.
 ///

--- a/tools/devtool
+++ b/tools/devtool
@@ -1041,7 +1041,7 @@ cmd_install() {
     profile="release"
     target="$TARGET_PREFIX""musl"
     install_path="/usr/local/bin"
-    binaries=("firecracker" "jailer" "seccompiler-bin" "rebase-snap")
+    binaries=("firecracker" "jailer" "seccompiler-bin" "rebase-snap" "cpu-template-helper")
 
     # Parse any command line args.
     while [ $# -gt 0 ]; do

--- a/tools/devtool
+++ b/tools/devtool
@@ -109,12 +109,6 @@ CARGO_GIT_REGISTRY_DIR="${FC_BUILD_DIR}/cargo_git_registry"
 # Full path to the cargo target dir on the host.
 CARGO_TARGET_DIR="${FC_BUILD_DIR}/cargo_target"
 
-# Full path to the seccompiler cargo target dir on the host.
-CARGO_SECCOMPILER_TARGET_DIR="${FC_BUILD_DIR}/seccompiler"
-
-# Full path to the rebase-snap cargo target dir on the host.
-CARGO_REBASE_SNAP_TARGET_DIR="${FC_BUILD_DIR}/rebase-snap"
-
 # Full path to the Firecracker sources dir, as bind-mounted in the container.
 CTR_FC_ROOT_DIR="/firecracker"
 
@@ -123,12 +117,6 @@ CTR_FC_BUILD_DIR="${CTR_FC_ROOT_DIR}/build"
 
 # Full path to the cargo target dir, as bind-mounted in the container.
 CTR_CARGO_TARGET_DIR="$CTR_FC_BUILD_DIR/cargo_target"
-
-# Full path to the seccompiler cargo target dir, as bind-mounted in the container.
-CTR_CARGO_SECCOMPILER_TARGET_DIR="$CTR_FC_BUILD_DIR/seccompiler"
-
-# Full path to the rebase-snap cargo target dir, as bind-mounted in the container.
-CTR_CARGO_REBASE_SNAP_TARGET_DIR="$CTR_FC_BUILD_DIR/rebase-snap"
 
 # Full path to the microVM images cache dir
 CTR_MICROVM_IMAGES_DIR="$CTR_FC_BUILD_DIR/img"
@@ -246,13 +234,13 @@ build_jailer_bin_path() {
 build_seccomp_bin_path() {
     target="$1"
     profile="$2"
-    echo "$CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler-bin"
+    echo "$CARGO_TARGET_DIR/$target/$profile/seccompiler-bin"
 }
 
 build_rebase_snap_bin_path() {
     target="$1"
     profile="$2"
-    echo "$CARGO_REBASE_SNAP_TARGET_DIR/$target/$profile/rebase-snap"
+    echo "$CARGO_TARGET_DIR/$target/$profile/rebase-snap"
 }
 
 ensure_release_binaries_exist() {

--- a/tools/devtool
+++ b/tools/devtool
@@ -219,46 +219,11 @@ ensure_build_dir() {
     done
 }
 
-build_fc_bin_path() {
+build_bin_path() {
     target="$1"
     profile="$2"
-    echo "$CARGO_TARGET_DIR/$target/$profile/firecracker"
-}
-
-build_jailer_bin_path() {
-    target="$1"
-    profile="$2"
-    echo "$CARGO_TARGET_DIR/$target/$profile/jailer"
-}
-
-build_seccomp_bin_path() {
-    target="$1"
-    profile="$2"
-    echo "$CARGO_TARGET_DIR/$target/$profile/seccompiler-bin"
-}
-
-build_rebase_snap_bin_path() {
-    target="$1"
-    profile="$2"
-    echo "$CARGO_TARGET_DIR/$target/$profile/rebase-snap"
-}
-
-ensure_release_binaries_exist() {
-    target=$1
-    profile=$2
-    firecracker_bin_path=$( build_fc_bin_path "$target" "$profile")
-    jailer_bin_path=$( build_jailer_bin_path "$target" "$profile")
-    seccompiler_bin_path=$( build_seccomp_bin_path "$target" "$profile")
-    rebase_snap_bin_path=$( build_rebase_snap_bin_path "$target" "$profile")
-
-    { [ -f "$firecracker_bin_path" ] && [ -f "$jailer_bin_path" ] && [ -f "$seccompiler_bin_path" ] && \
-    [ -f "$rebase_snap_bin_path" ]; } || \
-    die "Missing release binaries. Needed files:\n" \
-    "* $firecracker_bin_path\n" \
-    "* $jailer_bin_path\n" \
-    "* $seccompiler_bin_path\n" \
-    "* $rebase_snap_bin_path\n" \
-    "To build the binaries, run:\n\t$0 build --$profile"
+    binary="$3"
+    echo "$CARGO_TARGET_DIR/$target/$profile/$binary"
 }
 
 # Fix build/ dir permissions after a privileged container run.
@@ -1076,6 +1041,7 @@ cmd_install() {
     profile="release"
     target="$TARGET_PREFIX""musl"
     install_path="/usr/local/bin"
+    binaries=("firecracker" "jailer" "seccompiler-bin" "rebase-snap")
 
     # Parse any command line args.
     while [ $# -gt 0 ]; do
@@ -1095,19 +1061,19 @@ cmd_install() {
     done
 
     # Check that the binaries exist first
-    ensure_release_binaries_exist $target $profile
+    for binary in "${binaries[@]}"; do
+        bin_path=$( build_bin_path "$target" "$profile" "$binary" )
+        if [ ! -f "$bin_path" ]; then
+            die "Missing release binary. Needed file: $bin_path\n"\
+            "To build the binaries, run:\n\t$0 build --$profile"
+        fi
+    done
 
-    say "Installing firecracker in $install_path"
-    install -m 755 "$( build_fc_bin_path "$target" "$profile")" "$install_path"
-
-    say "Installing jailer in $install_path"
-    install -m 755 "$( build_jailer_bin_path "$target" "$profile")" "$install_path"
-
-    say "Installing seccomp in $install_path"
-    install -m 755 "$( build_seccomp_bin_path "$target" "$profile")" "$install_path"
-
-    say "Installing rebase-snap in $install_path"
-    install -m 755 "$( build_rebase_snap_bin_path "$target" "$profile")" "$install_path"
+    # Install the binaries
+    for binary in "${binaries[@]}"; do
+        say "Installing $binary in $install_path"
+        install -m 755 "$( build_bin_path "$target" "$profile" "$binary" )" "$install_path"
+    done
 }
 
 # Build a Firecracker CI compatible kernel image.

--- a/tools/release-prepare.sh
+++ b/tools/release-prepare.sh
@@ -62,6 +62,7 @@ say "Updating from $prev_ver to $version ..."
 # Update version in files.
 files_to_change=(
     "$FC_ROOT_DIR/src/api_server/swagger/firecracker.yaml"
+    "$FC_ROOT_DIR/src/cpu-template-helper/Cargo.toml"
     "$FC_ROOT_DIR/src/firecracker/Cargo.toml"
     "$FC_ROOT_DIR/src/jailer/Cargo.toml"
     "$FC_ROOT_DIR/src/rebase-snap/Cargo.toml"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -121,13 +121,13 @@ fi
 # to make sure that `firecracker --version` reports the latest changes.
 touch build.rs
 
-ARTIFACTS=(firecracker jailer seccompiler-bin rebase-snap)
+ARTIFACTS=(firecracker jailer seccompiler-bin rebase-snap cpu-template-helper)
 
 if [ "$LIBC" == "gnu" ]; then
     # Don't build jailer. See commit 3bf285c8f
     echo "Not building jailer because glibc selected instead of musl"
     CARGO_OPTS+=" --exclude jailer"
-    ARTIFACTS=(firecracker seccompiler-bin rebase-snap)
+    ARTIFACTS=(firecracker seccompiler-bin rebase-snap cpu-template-helper)
 fi
 
 say "Building version=$VERSION, profile=$PROFILE, target=$CARGO_TARGET..."


### PR DESCRIPTION
## Changes

- Add cpu-template-helper to release artifacts
- Fix `tools/devtool install` and add cpu-template-helper to it.

## Reason

The CPU template helper tool is delivered as a new separate binary from firecracker.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
