### PR TITLE
doc: add documentation for CPU templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for custom CPU templates allowing users to adjust vCPU features
+  exposed to the guest via CPUID, MSRs and ARM registers.
+
 ### Fixed
 
 - Fixed feature flags in T2S CPU template on Intel Ice Lake.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Added support for custom CPU templates allowing users to adjust vCPU features
   exposed to the guest via CPUID, MSRs and ARM registers.
+- Introduced V1N1 static CPU template for ARM to represent Neoverse V1 CPU
+  as Neoverse N1.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The **API endpoint** can be used to:
 - Configure the microvm by:
   - Setting the number of vCPUs (the default is 1).
   - Setting the memory size (the default is 128 MiB).
-  - [x86_64 only] Choosing a CPU template (currently, C3, T2 and T2S are available).
+  - Configuring a [CPU template](docs/cpu_templates/cpu-templates.md).
 - Add one or more network interfaces to the microVM.
 - Add one or more read-write or read-only disks to the microVM, each represented
   by a file-backed block device.
@@ -150,7 +150,6 @@ plans, check out our [kernel support policy](docs/kernel-policy.md).
 
 - The [SendCtrlAltDel](docs/api_requests/actions.md#sendctrlaltdel) API request
   is not supported for aarch64 enabled microVMs.
-- Configuring CPU templates is only supported for Intel enabled microVMs.
 - If a CPU template is not used on x86_64, overwrites of `MSR_IA32_TSX_CTRL` MSR
   value will not be preserved after restoring from a snapshot.
 - The `pl031` RTC device on aarch64 does not support interrupts, so guest

--- a/docs/cpu_templates/boot-protocol.md
+++ b/docs/cpu_templates/boot-protocol.md
@@ -1,0 +1,33 @@
+# Boot protocol register settings
+
+Firecracker makes certain modifications to the guest's registers
+regardless of whether a CPU template is used to comply with the boot protocol.
+If a CPU template is used the boot protocol settings are performed _after_ the
+CPU template is applied. That means that if the CPU template configures CPUID
+bits used in the boot protocol settings, they will be overwritten.
+
+See also: [CPUID normalization](cpuid-normalization.md)
+
+## Boot protocol MSRs (x86_64 only)
+
+On x86_64, the following MSRs are set to `0`:
+
+- MSR_IA32_SYSENTER_CS
+- MSR_IA32_SYSENTER_ESP
+- MSR_IA32_SYSENTER_EIP
+- MSR_STAR
+- MSR_CSTAR
+- MSR_KERNEL_GS_BASE
+- MSR_SYSCALL_MASK
+- MSR_LSTAR
+- MSR_IA32_TSC
+
+and MSR_IA32_MISC_ENABLE is set to `1`.
+
+## Boot protocol ARM registers (aarch64 only)
+
+On aarch64, the following registers are set:
+
+- PSTATE to PSR_MODE_EL1h | PSR_A_BIT | PSR_F_BIT | PSR_I_BIT | PSR_D_BIT
+- PC to kernel load address (vCPU0 only)
+- X0 to DTB/FDT address (vCPU0 only)

--- a/docs/cpu_templates/cpu-templates.md
+++ b/docs/cpu_templates/cpu-templates.md
@@ -1,0 +1,217 @@
+# CPU templates
+
+Firecracker allows users to customise how the vCPUs are represented
+to the guest software by changing the following configuration:
+
+- CPUID (x86_64 only)
+- MSRs (Model Specific Registers, x86_64 only)
+- ARM registers (aarch64 only)
+
+A combination of the changes to the above entities is called a CPU template.
+
+The functionality can be used when a user wants to mask a feature from
+the guest. A real world use case for this is representing a heterogeneous
+fleet (a fleet consisting of multiple CPU models) as a homogeneous fleet,
+so the guests will experience a consistent feature set supported by the host.
+
+> **Note**
+Representing one CPU vendor as another CPU vendor is not supported.
+
+> **Note**
+CPU templates shall not be used as a security protection against malicious
+guests. Disabling a feature in a CPU template does not generally make it
+completely unavailable to the guest. For example, disabling a feature related
+to an instruction set will indicate to the guest that the feature
+is not supported, but the guest may still be able to execute corresponding
+instructions if it does not obey the feature bit.
+
+Firecracker supports two types of CPU templates:
+
+- Static CPU templates - a set of built-in CPU templates for users
+  to choose from
+- Custom CPU templates - users can create their own CPU templates in json
+  format and pass them to Firecracker
+
+> **Note**
+CPU templates for ARM (both static and custom) require the following patch
+to be available in the host kernel: [Support writable CPU ID registers from userspace](https://lore.kernel.org/kvm/20230212215830.2975485-1-jingzhangos@google.com/#t).
+Otherwise KVM will fail to write to the ARM registers.
+
+## Static CPU templates
+
+At the moment the following set of static CPU templates are supported:
+
+| CPU template | CPU vendor | CPU model             |
+|--------------|------------|-----------------------|
+| C3           | Intel      | any                   |
+| T2           | Intel      | any                   |
+| T2A          | AMD        | Milan                 |
+| T2CL         | Intel      | Cascade Lake or newer |
+| T2S          | Intel      | any                   |
+| V1N1         | ARM        | Neoverse V1           |
+
+T2 and C3 templates are mapped as close as possible to AWS T2 and C3 instances
+in terms of CPU features.
+
+The T2S template is designed to allow migrating [snapshots](../snapshotting/versioning.md)
+between hosts with Intel Skylake and Intel Cascade Lake securely by further
+restricting CPU features for the guest, however this comes with a performance
+penalty. Users are encouraged to carry out a performance assessment if they wish
+to use the T2S template.
+
+The T2CL template is mapped to be close to Intel Cascade Lake.
+It is not safe to use it on Intel CPUs older than Cascade Lake (such as Skylake).
+
+The only AMD template is T2A. It is considered safe to be used with AMD Milan.
+
+Intel T2CL and AMD T2A templates together aim to provide instruction set feature
+parity between CPUs running them, so they can form a heterogeneous fleet
+exposing the same instruction sets to the application.
+
+The V1N1 template is designed to represent ARM Neoverse V1 as ARM Neoverse N1.
+
+### Configuring static CPU templates
+
+Configuration of a static CPU template is performed via the `/machine-config`
+API endpoint:
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i  \
+  -X PUT 'http://localhost/machine-config' \
+  -H 'Accept: application/json'            \
+  -H 'Content-Type: application/json'      \
+  -d '{
+           "vcpu_count": 2,
+           "mem_size_mib": 1024,
+           "cpu_template": "T2CL"
+  }'
+```
+
+## Custom CPU templates
+
+Users can create their own CPU templates by creating a json file containing
+modifiers for CPUID, MSRs or ARM registers.
+
+> **Note**
+Creating custom CPU templates requires expert knowledge of
+CPU architectures. Custom CPU templates must be tested thoroughly before use
+in production. An inappropriate configuration may lead to guest crashes or
+making guests vulnerable to security attacks. For example, if a CPU template
+signals a hardware vulnerability mitigation to the guest while the mitigation
+is in fact not supported by the hardware, the guest may decide to disable
+corresponding software mitigations which will make the guest vulnerable.
+
+> **Note**
+Having MSRs or ARM registers in the custom CPU template does
+not affect access permissions that guests will have to those registers.
+The access control is handled by KVM and is not influenced by CPU templates.
+
+> **Note**
+When setting guest configuration, KVM may reject setting some bits quietly.
+This is user's responsibility to make sure that their custom CPU template
+is applied as expected even if Firecracker does not report an error.
+
+In order to assist with creation and usage of CPU templates, there exists
+a CPU template helper tool.
+TODO: add a link to the CPU template helper tool when it is available.
+
+### Configuring custom CPU templates
+
+Configuration of a custom CPU template is performed via the `/cpu-config`
+API endpoint.
+
+An example of configuring a custom CPU template on x86_64:
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i  \
+  -X PUT 'http://localhost/cpu-config' \
+  -H 'Accept: application/json'            \
+  -H 'Content-Type: application/json'      \
+  -d '{
+        "cpuid_modifiers": [
+          {
+            "leaf": "0x1",
+            "subleaf": "0x0",
+            "flags": 0,
+            "modifiers": [
+              {
+                "register": "eax",
+                "bitmap": "0bxxxx000000000011xx00011011110010"
+              }
+            ]
+          }
+        ],
+        "msr_modifiers": [
+          {
+            "addr": "0x10a",
+            "bitmap": "0b0000000000000000000000000000000000000000000000000000000000000000"
+          }
+        ]
+      }'
+```
+
+This CPU template will do the following:
+
+- in leaf `0x1`, subleaf `0x0`, register `eax`:
+  - will clear bits `0b00001111111111000011100100001101`
+  - will set bits `0b00000000000000110000011011110010`
+  - will leave bits `0b11110000000000001100000000000000` intact.
+- in MSR `0x10`, it will clear all bits.
+
+An example of configuring a custom CPU template on ARM:
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i  \
+  -X PUT 'http://localhost/cpu-config' \
+  -H 'Accept: application/json'            \
+  -H 'Content-Type: application/json'      \
+  -d '{
+        "reg_modifiers": [
+          {
+            "addr": "0x603000000013c020",
+            "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx0000xxxxxxxxxxxx0000xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          }
+        ]
+      }'
+```
+
+This CPU templates will do the following with the ARM register `0x603000000013c020`:
+
+- will clear bits `0b00000000000000000000000000000000000000000000000000000000000000000000000000001111000000000000111100000000000000000000000000000000`
+- will leave bits `0b11111111111111111111111111111111111111111111111111111111111111111111111111110000111111111111000011111111111111111111111111111111`
+  intact.
+
+### Custom CPU templates language schema
+
+The full description of the custom CPU templates language can be found
+[here](schema.json).
+
+#### Expansion of contracted bitmaps
+
+If a contracted version of a bitmap is given, for example, `0b101` where
+a 32-bit bitmap is expected, missing characters are implied to be `x`
+(`0bxxxxxxxxxxxxxxxxxxxxxxxxxxxxx101`).
+
+#### CPUID normalization and boot protocol register settings
+
+Some of the configuration set by a custom CPU template may be overwritten
+by Firecracker. More details can be found [here](cpuid-normalization.md) and
+[here](boot-protocol.md).
+
+#### Information about architecture-specific settings
+
+For detailed information when working with custom CPU templates, please
+refer to hardware specifications from CPU vendors, for example:
+
+- [Intel Software Developer Manual](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)
+- [AMD Architecture Programmer's Manual](https://www.amd.com/en/support/tech-docs?keyword=programmer%27s+manual)
+- [ARM Architecture Refernce Manual](https://developer.arm.com/documentation/ddi0487/latest)
+
+## A note about configuration of both static and custom CPU templates
+
+If a user configured both a static CPU template (via `/machine-config`) and
+a custom CPU template (via `/cpu-config`) in the same Firecracker process,
+only the configuration that was performed the _last_ is applied. This means
+that if a static CPU template was configured first and a custom CPU template
+was configured later, only the custom CPU template configuration will be
+applied when starting a microVM.

--- a/docs/cpu_templates/cpuid-normalization.md
+++ b/docs/cpu_templates/cpuid-normalization.md
@@ -1,0 +1,48 @@
+# CPUID normalization (x86_64 only)
+
+On x86_64, Firecracker makes certain modifications to the guest's CPUID
+regardless of whether a CPU template is used. This is referred to as
+`CPUID normalization`. If a CPU template is used the normalization is
+performed _after_ the CPU template is applied. That means that if the CPU
+template configures CPUID bits used in the normalization process, they will
+be overwritten.
+
+See also: [boot protocol settings](boot-protocol.md)
+
+## x86_64 common CPUID normalization
+
+| Description                                                                          | Leaf | Subleaf | Register | Bits  |
+|--------------------------------------------------------------------------------------|:----:|:-------:|:--------:|:-----:|
+| Set CLFLUSH line size                                                                | 0x1  | -       | EBX      | 15:8  |
+| Set maximum number of addressable IDs for logical processors in the physical package | 0x1  | -       | EBX      | 23:16 |
+| Set initial APIC ID                                                                  | 0x1  | -       | EBX      | 31:24 |
+| Enable TSC_DEADLINE                                                                  | 0x1  | -       | ECX      | 24    |
+| Enable HYPERVISOR                                                                    | 0x1  | -       | ECX      | 31    |
+| Set HTT value if the microVM's CPU count is greater than 1                           | 0x1  | -       | EDX      | 28    |
+| Insert leaf 0xb, subleaf 0x1 filled with `0` if it is not already present            | 0xb  | 0x1     | all      | all   |
+| Update extended topology enumeration                                                 | 0xb  | all     | EAX      | 4:0   |
+| Update extended topology enumeration                                                 | 0xb  | all     | EBX      | 15:0  |
+| Update extended topology enumeration                                                 | 0xb  | all     | ECX      | 15:8  |
+
+## Intel-specific CPUID normalization
+
+| Description                                                    | Leaf                               | Subleaf | Register           | Bits  |
+|----------------------------------------------------------------|:----------------------------------:|:-------:|:------------------:|:----:|
+| Update deterministic cache parameters                          | 0x4                                | all     | EAX                | 31:14 |
+| Disable Intel Turbo Boost technology                           | 0x6                                | -       | EAX                | 1     |
+| Disable frequency selection                                    | 0x6                                | -       | ECX                | 3     |
+| Disable performance monitoring                                 | 0xa                                | -       | EAX, EBX, ECX, EDX | all   |
+| Update brand string to use a default format and real frequency | 0x80000002, 0x80000003, 0x80000004 | -       | EAX, EBX, ECX, EDX | all   |
+
+## AMD-specifc CPUID normalization
+
+| Description                                          | Leaf                               | Subleaf | Register           | Bits  |
+|------------------------------------------------------|:----------------------------------:|:-------:|:------------------:|:-----:|
+| Set IA32_ARCH_CAPABILITIES MSR as not present        | 0x7                                | -       | EDX                | 29    |
+| Update largest extended function entry to 0x8000001f | 0x80000000                         | -       | EAX                | 31:0  |
+| Set topology extension bit                           | 0x80000001                         | -       | ECX                | 22    |
+| Update brand string with a default AMD value         | 0x80000002, 0x80000003, 0x80000004 | -       | EAX, EBX, ECX, EDX | all   |
+| Update number of physical threads                    | 0x80000008                         | -       | ECX                | 7:0   |
+| Update APIC ID size                                  | 0x80000008                         | -       | ECX                | 15:12 |
+| Update cache topology information                    | 0x8000001d                         | all     | all                | all   |
+| Update extended APIC ID                              | 0x8000001e                         | -       | EAX, EBX, ECX      | all   |

--- a/docs/cpu_templates/schema.json
+++ b/docs/cpu_templates/schema.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/firecracker-microvm/firecracker/tree/main/docs/cpu-templates/schema.json",
+    "title": "Custom CPU template",
+    "description": "Custom CPU template language description",
+    "type": "object",
+    "properties": {
+        "cpuid_modifiers": {
+            "type": "array",
+            "items": {
+                "description": "CPUID modifiers. Only for x86_64.",
+                "type": "object",
+                "properties": {
+                    "leaf": {
+                        "description": "CPUID leaf index (or function). Must be a string containing an integer.",
+                        "type": "string",
+                        "examples": ["0x1", "0x2"]
+                    },
+                    "subleaf": {
+                        "description": "CPUID subleaf index (or subfunction). Must be a string containing an integer.",
+                        "type": "string",
+                        "examples": ["0x1", "0x2"]
+                    },
+                    "flags": {
+                        "description": "KVM CPUID flags, see https://docs.kernel.org/virt/kvm/api.html#kvm-get-supported-cpuid",
+                        "type": "integer"
+                    },
+                    "modifiers": {
+                        "type": "array",
+                        "items": {
+                            "description": "CPUID register modifiers.",
+                            "type": "object",
+                            "properties": {
+                                "register": {
+                                    "description": "CPUID register name.",
+                                    "type": "string",
+                                    "enum": ["eax", "ebx", "ecx", "edx"]
+                                },
+                                "bitmap": {
+                                    "description": "CPUID register value bitmap. Must be in format `0b[01x]{32}`. Corresponding bits will be cleared (`0`), set (`1`) or left intact (`x`).",
+                                    "type": "string",
+                                    "examples": ["0bxxxx000000000011xx00011011110010", "0bxxxxxxxxxxxxx0xx00xx00x0000000xx"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "msr_modifiers": {
+            "type": "array",
+            "items": {
+                "description": "MSR modifiers. Only for x86_64.",
+                "type": "object",
+                "properties": {
+                    "addr": {
+                        "description": "MSR address/identifier. Must be a string containing an integer.",
+                        "type": "string",
+                        "examples": ["0x10a"]
+                    },
+                    "bitmap": {
+                        "description": "MSR value bitmap. Must be in format `0b[01x]{64}`. Corresponding bits will be cleared (`0`), set (`1`) or left intact (`x`).",
+                        "type": "string",
+                        "examples": ["0bxxxx000000000000000000000000000000000000000000000000000011101011"]
+                    }
+                }
+            }
+        },
+        "reg_modifiers": {
+            "type": "array",
+            "items": {
+                "description": "ARM register modifiers. Only for aarch64.",
+                "type": "object",
+                "properties": {
+                    "addr": {
+                        "description": "MSR address/identifier. Must be a string containing an integer.",
+                        "type": "string",
+                        "examples": ["0x603000000013c020"]
+                    },
+                    "bitmap": {
+                        "description": "ARM register value bitmap. Must be in format `0b[01x]{128}`. Corresponding bits will be cleared (`0`), set (`1`) or left intact (`x`).",
+                        "type": "string",
+                        "examples": ["0bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx0000xxxxxxxxxxxx0000xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -115,12 +115,10 @@ KVM supports.
 
 #### Exposing the CPU to the guest
 
-Firecracker allows the exposure of either the host processor information or any
-other family/model/stepping as a way to keep compatibility for services that
-were not running on top of it. In addition, Firecracker supports feature
-masking via CPUID. To simplify customer operation, CPU feature templates can be
-set via the Firecracker API. Currently, the available feature templates to
-choose from are EC2 C3 and EC2 T2 instance types.
+Firecracker allows control of what processor information is exposed
+to the guest by using [CPU templates](cpu_templates/cpu-templates.md).
+CPU templates can be set via the Firecracker API. Users can choose from
+existing static CPU templates and/or creating their own custom CPU templates.
 
 #### Clocksources available to guests
 

--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -17,6 +17,7 @@ a call to one of the [API Endpoints](#api-endpoints) will fail with a
 | Endpoint                  | keyboard | serial console | virtio-block | virtio-net | virtio-vsock |
 | ------------------------- | :------: | :------------: | :----------: |:----------:| :----------: |
 | `boot-source`             |    O     |       O        |      O       |     O      |      O       |
+| `cpu-config`              |    O     |       O        |      O       |     O      |      O       |
 | `drives/{id}`             |    O     |       O        |    **R**     |     O      |      O       |
 | `logger`                  |    O     |       O        |      O       |     O      |      O       |
 | `machine-config`          |    O     |       O        |      O       |     O      |      O       |
@@ -39,6 +40,9 @@ specification: [firecracker.yaml](./../src/api_server/swagger/firecracker.yaml).
 | `BootSource`               | boot_args             |    O     |       O        |      O       |       O       |      O       |
 |                            | initrd_path           |    O     |       O        |      O       |       O       |      O       |
 |                            | kernel_image_path     |    O     |       O        |      O       |       O       |      O       |
+| `CpuConfig`                | cpuid_modifiers       |    O     |       O        |      O       |       O       |      O       |
+|                            | msr_modifiers         |    O     |       O        |      O       |       O       |      O       |
+|                            | reg_modifiers         |    O     |       O        |      O       |       O       |      O       |
 | `CpuTemplate`              | enum                  |    O     |       O        |      O       |       O       |      O       |
 | `CreateSnapshotParams`     | mem_file_path         |    O     |       O        |      O       |       O       |      O       |
 |                            | snapshot_path         |    O     |       O        |      O       |       O       |      O       |

--- a/docs/snapshotting/versioning.md
+++ b/docs/snapshotting/versioning.md
@@ -185,34 +185,13 @@ architecture. They are only compatible if the CPU features exposed to the guest
 are an invariant when saving and restoring the snapshot. The trivial scenario
 is creating and restoring snapshots on hosts that have the same CPU model.
 
-To make snapshots more portable across Intel CPUs Firecracker provides an API to
-select an Intel CPU template: T2, T2CL, T2S or C3.
-Firecracker CPU templates mask CPUID and some MSR values (in case of T2CL and T2S)
-to restrict the exposed features to a common denominator of multiple CPU models.
-T2 and C3 templates are mapped as close as possible to AWS T2/C3 instances in terms
-of CPU features. The T2S template is designed to allow migrating snapshots
-between hosts with Intel Skylake and Cascade Lake securely by further
-restricting CPU features for the guest, however this comes with a performance
-penalty. Users are encouraged to carry out a performance assessment if they wish
-to use the T2S template.
-The T2CL template is mapped to be close to Intel Cascade Lake.
-It is not safe to use it on Intel CPUs older than Cascade Lake (such as Skylake).
-
-The only AMD template is T2A. It is considered safe to be used with AMD Milan.
-
-Intel T2CL and AMD T2A templates together aim to provide instruction set feature
-parity between CPUs running them, so they can form a heterogeneous fleet
-exposing the same instruction sets to the application.
-
 Restoring from an Intel snapshot on AMD (or vice-versa) is not supported.
 
-There are no templates available for ARM64.
-
 It is important to note that guest workloads can still execute instructions
-that are being masked by CPUID and restoring and saving of such workloads will
-lead to undefined result. Firecracker retrieves the state of a discrete list
-MSRs from KVM, more specifically the MSRs corresponding to the guest
-exposed features.
+that are being [masked](../cpu_templates/cpu-templates.md) by CPUID and
+restoring and saving of such workloads will lead to undefined result.
+Firecracker retrieves the state of a discrete list of MSRs from KVM, more
+specifically, the MSRs corresponding to the guest exposed features.
 
 ## Implementation
 

--- a/tests/host_tools/mdl_style.rb
+++ b/tests/host_tools/mdl_style.rb
@@ -2,6 +2,7 @@ all
 rule 'MD013', :tables => false
 rule 'MD007', :indent => 2
 
+exclude_rule 'MD028'
 exclude_rule 'MD033'
 exclude_rule 'MD041'
 exclude_rule 'MD024'


### PR DESCRIPTION
## Changes

Add doc pages for static and custom CPU templates.

## Reason

Static CPU templates are not sufficiently covered in the documentation. Custom CPU templates are not covered in the documentation.
The change contains a TODO without creating a Github issue. The TODO will be addressed by the Amazon team shortly.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
~~- [ ] All added/changed functionality is tested.~~
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
