### PR TITLE
fix: Make sure memory written to by virtio-rng is marked as dirty

### DIFF
--- a/src/devices/src/virtio/iovec.rs
+++ b/src/devices/src/virtio/iovec.rs
@@ -4,7 +4,7 @@
 use std::marker::PhantomData;
 
 use libc::{c_void, iovec, size_t};
-use vm_memory::{GuestMemory, GuestMemoryMmap};
+use vm_memory::{Bitmap, GuestMemory, GuestMemoryMmap};
 
 use crate::virtio::DescriptorChain;
 
@@ -238,10 +238,14 @@ impl IoVecBufferMut {
             // We use get_slice instead of `get_host_address` here in order to have the whole
             // range of the descriptor chain checked, i.e. [addr, addr + len) is a valid memory
             // region in the GuestMemoryMmap.
-            let iov_base = mem
-                .get_slice(desc.addr, desc.len as usize)?
-                .as_ptr()
-                .cast::<c_void>();
+            let slice = mem.get_slice(desc.addr, desc.len as usize)?;
+
+            // We need to mark the area of guest memory that will be mutated through this
+            // IoVecBufferMut as dirty ahead of time, as we loose access to all
+            // vm-memory related information after converting down to iovecs.
+            slice.bitmap().mark_dirty(0, desc.len as usize);
+
+            let iov_base = slice.as_ptr().cast::<c_void>();
             vecs.push(iovec {
                 iov_base,
                 iov_len: desc.len as size_t,


### PR DESCRIPTION
This is needed for diff snapshots to work correctly.

## Changes

Mark the memory that will be written to via IoVecBufferMut as dirty.

## Reason

The memory needs to be marked as dirty for diff snapshots to work correctly.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
