### PR TITLE
Send notification on new release

### DIFF
--- a/.github/workflows/send_release_notification.yml
+++ b/.github/workflows/send_release_notification.yml
@@ -1,0 +1,16 @@
+name: Send notification on release created
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  send_notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: notify
+        run: |
+          curl -X POST ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK }} \
+               -H 'Content-Type: application/json' \
+               -d '{ "GITHUB_RELEASE_URL": "${{ github.event.release.url }}",
+                     "GITHUB_RELEASE_TAG": "${{ github.event.release.tag_name }}"}'


### PR DESCRIPTION
Set up a GitHub action that triggers a webhook when a new GitHub release is published.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
