### PR TITLE
remove "push" target from GitHub actions

### DIFF
--- a/.github/workflows/deny_dirty_cargo_locks.yml
+++ b/.github/workflows/deny_dirty_cargo_locks.yml
@@ -1,7 +1,6 @@
 name: Check no Cargo.lock files are dirty
 
-on:
-  [push, pull_request]
+on: pull_request
 
 jobs:
   no_dirty_cargo_locks_check:

--- a/.github/workflows/dependency_modification_check.yml
+++ b/.github/workflows/dependency_modification_check.yml
@@ -1,7 +1,6 @@
 name: Check no dependencies were modified
 
-on:
-  [push, pull_request]
+on: pull_request
 
 jobs:
   dependency_changed_check:


### PR DESCRIPTION
It was causing them to trigger twice on every pull request, and also does not work since the checkout command in the action in specific to pull_request.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
