### PR TITLE
chore(tests): run test_cpu_config_change only for supported kernels

### DIFF
--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from framework import defs, utils
+from framework.defs import SUPPORTED_HOST_KERNELS
 from framework.properties import global_props
 from framework.utils_cpuid import get_guest_cpuid
 from host_tools import cargo_build
@@ -307,6 +308,10 @@ def test_cpu_config_dump_vs_actual(
         ), f"Mismatched MSR for {key:#010x}: {actual=:#066b} vs. {dump=:#066b}"
 
 
+@pytest.mark.skipif(
+    utils.get_kernel_version(level=1) not in SUPPORTED_HOST_KERNELS,
+    reason=f"Supported kernels are {SUPPORTED_HOST_KERNELS}",
+)
 def test_cpu_config_change(test_microvm_with_api, cpu_template_helper, tmp_path):
     """
     Verify that the current guest CPU config has not changed since the baseline


### PR DESCRIPTION
## Changes

Skip the test if the host kernel is not supported.

## Reason

We only keep guest CPU config baselines for the kernels that we support.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
~~- [ ] Any required documentation changes (code and docs) are included in this PR.~~
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
~~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
