### PR TITLE
fix: Remove decimal support for CPU templates

### DIFF
--- a/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs
+++ b/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs
@@ -157,10 +157,13 @@ mod tests {
                 }"#,
         );
         assert!(cpu_config_result.is_err());
-        assert!(cpu_config_result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse string [j] as a number for CPU template"));
+        let error_msg: String = cpu_config_result.unwrap_err().to_string();
+        // Formatted error expected clarifying the number system prefix is missing
+        assert!(
+            error_msg.contains("No supported number system prefix found in value"),
+            "{}",
+            error_msg
+        );
 
         // Malformed address as binary
         let cpu_config_result = serde_json::from_str::<CustomCpuTemplate>(
@@ -184,7 +187,7 @@ mod tests {
             r#"{
                     "reg_modifiers":  [
                         {
-                            "addr": "200",
+                            "addr": "0x200",
                             "bitmap": "0bx0?1_0_0x_?x1xxxx00xxx1xxxxxxxxxxx1"
                         },
                     ]
@@ -200,7 +203,7 @@ mod tests {
             r#"{
                     "reg_modifiers":  [
                         {
-                            "addr": "200",
+                            "addr": "0x200",
                             "bitmap": "0bx00100x0x1xxxx05xxx1xxxxxxxxxxx1"
                         },
                     ]

--- a/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
+++ b/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
@@ -390,10 +390,13 @@ mod tests {
                 }"#,
         );
         assert!(cpu_template_result.is_err());
-        assert!(cpu_template_result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse string [0jj0] as a number for CPU template -"));
+        let error_msg: String = cpu_template_result.unwrap_err().to_string();
+        // Formatted error expected clarifying the number system prefix is missing
+        assert!(
+            error_msg.contains("No supported number system prefix found in value"),
+            "{}",
+            error_msg
+        );
 
         // Malformed CPUID leaf address
         let cpu_template_result = serde_json::from_str::<CustomCpuTemplate>(
@@ -414,17 +417,19 @@ mod tests {
                 }"#,
         );
         assert!(cpu_template_result.is_err());
-        assert!(cpu_template_result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse string [k] as a number for CPU template"));
-
+        let error_msg: String = cpu_template_result.unwrap_err().to_string();
+        // Formatted error expected clarifying the number system prefix is missing
+        assert!(
+            error_msg.contains("No supported number system prefix found in value"),
+            "{}",
+            error_msg
+        );
         // Malformed 64-bit bitmap - filter failed
         let cpu_template_result = serde_json::from_str::<CustomCpuTemplate>(
             r#"{
                     "msr_modifiers":  [
                         {
-                            "addr": "200",
+                            "addr": "0x200",
                             "bitmap": "0bx0?1_0_0x_?x1xxxx00xxx1xxxxxxxxxxx1"
                         },
                     ]
@@ -439,7 +444,7 @@ mod tests {
             r#"{
                     "msr_modifiers":  [
                         {
-                            "addr": "200",
+                            "addr": "0x200",
                             "bitmap": "0bx00100x0x1xxxx05xxx1xxxxxxxxxxx1"
                         },
                     ]

--- a/src/vmm/src/cpu_config/x86_64/test_utils.rs
+++ b/src/vmm/src/cpu_config/x86_64/test_utils.rs
@@ -88,7 +88,7 @@ pub const TEST_TEMPLATE_JSON: &str = r#"{
             "bitmap": "0bx00111xxx1xxxx111xxxxx101xxxxxx1"
         },
         {
-            "addr": "2",
+            "addr": "0b11",
             "bitmap": "0bx00100xxx1xxxxxx0000000xxxxxxxx1"
         },
         {


### PR DESCRIPTION
## Changes

Removed JSON deserialization support for decimal numbers in CPU templates.

## Reason

Unnecessary feature that isn't useful or has a known benefit.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][1].

[1]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
