### PR TITLE
Bump version to 1.5.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "cpu-template-helper"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 dependencies = [
  "clap 4.2.7",
  "libc",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 dependencies = [
  "api_server",
  "cargo_toml",
@@ -665,7 +665,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jailer"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 dependencies = [
  "libc",
  "nix",
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "linux-loader"
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "rebase-snap"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 dependencies = [
  "libc",
  "utils",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "seccompiler"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 dependencies = [
  "bincode",
  "libc",

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 1.4.0-dev
+  version: 1.5.0-dev
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/cpu-template-helper/Cargo.toml
+++ b/src/cpu-template-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpu-template-helper"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "../../build.rs"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "../../build.rs"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "../../build.rs"

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rebase-snap"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "../../build.rs"

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seccompiler"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "../../build.rs"

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -33,6 +33,8 @@ pub const FC_V1_2_SNAP_VERSION: u16 = 6;
 pub const FC_V1_3_SNAP_VERSION: u16 = 7;
 /// Snap version for Firecracker v1.4
 pub const FC_V1_4_SNAP_VERSION: u16 = 8;
+/// Snap version for Firecracker v1.5
+pub const FC_V1_5_SNAP_VERSION: u16 = 9;
 
 lazy_static! {
     // Note: until we have a better design, this needs to be updated when the version changes.
@@ -70,6 +72,11 @@ lazy_static! {
         // v1.4 state change mappings.
         version_map.new_version().set_type_version(DeviceStates::type_id(), 4);
 
+        // v1.5 - no changes introduced, but we need to bump as mapping
+        // between firecracker minor versions and snapshot versions needs
+        // to be 1-to-1 (see below)
+        version_map.new_version();
+
         version_map
     };
 
@@ -96,6 +103,7 @@ lazy_static! {
         mapping.insert(String::from("1.2.0"), FC_V1_2_SNAP_VERSION);
         mapping.insert(String::from("1.3.0"), FC_V1_3_SNAP_VERSION);
         mapping.insert(String::from("1.4.0"), FC_V1_4_SNAP_VERSION);
+        mapping.insert(String::from("1.5.0"), FC_V1_5_SNAP_VERSION);
 
         mapping
     };

--- a/tests/host_tools/uffd/Cargo.lock
+++ b/tests/host_tools/uffd/Cargo.lock
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
 dependencies = [
  "unicode-ident",
 ]

--- a/tests/integration_tests/security/demo_seccomp/Cargo.lock
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.lock
@@ -60,9 +60,9 @@ version = "0.1.0"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -84,7 +84,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "seccompiler"
-version = "1.4.0-dev"
+version = "1.5.0-dev"
 dependencies = [
  "bincode",
  "libc",


### PR DESCRIPTION
## Changes

Bumping version to 1.5.0-dev

## Reason

We already created the release branch for 1.4.0, so from now on we should be in 1.5.0-dev.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
