### PR TITLE
Backport `aws-lc-rs` switch to v1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   exposed to the guest via CPUID, MSRs and ARM registers.
 - Introduced V1N1 static CPU template for ARM to represent Neoverse V1 CPU
   as Neoverse N1.
+- Added support for the `virtio-rng` entropy device. The device is optional. A
+  single device can be enabled per VM using the `/entropy` endpoint.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364b8fb78fef99940d521bd13a304c83d5518489b0fb2c4bb6f3d188bd33b002"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "untrusted",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9402560dc1c27689dd717a233a22d38082e2f57401bf519bb1eaf2de938d78"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "dunce",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +177,7 @@ dependencies = [
  "clang-sys",
  "lazy_static",
  "lazycell",
+ "log",
  "peeking_take_while",
  "prettyplease",
  "proc-macro2",
@@ -160,6 +186,7 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.16",
+ "which",
 ]
 
 [[package]]
@@ -170,9 +197,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 
 [[package]]
 name = "byteorder"
@@ -329,6 +356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +472,7 @@ checksum = "f18f717c5c7c2e3483feb64cccebd077245ad6d19007c2db0fd341d38595353c"
 name = "devices"
 version = "0.1.0"
 dependencies = [
+ "aws-lc-rs",
  "derive_more",
  "dumbo",
  "event-manager",
@@ -445,7 +482,6 @@ dependencies = [
  "mmds",
  "net_gen",
  "proptest",
- "rand",
  "rate_limiter",
  "serde",
  "snapshot",
@@ -469,6 +505,12 @@ dependencies = [
  "serde_json",
  "utils",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
@@ -725,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "linux-loader"
@@ -796,6 +838,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "mmds"
@@ -880,6 +928,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1259,6 +1313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "userfaultfd"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,7 +1439,7 @@ checksum = "6de3dc0146d78558327419fac388850fc6cbf197e924c4659a4863db20b5af64"
 name = "vmm"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.2.1",
+ "bitflags 2.3.1",
  "criterion",
  "derive_more",
  "device_tree",
@@ -1434,6 +1494,17 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "winapi"
@@ -1531,3 +1602,9 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/docs/entropy.md
+++ b/docs/entropy.md
@@ -53,10 +53,8 @@ be achieved by adding a section like this:
 }
 ```
 
-On the host side, firecracker uses [`OsRng`][2] to get random bytes from the
-host kernel. The [implementation][3] of `OsRng` on Linux uses the
-`getrandom(2)` system call when available, otherwise it falls back to
-`/dev/urandom` after successfully polling `/dev/random`.
+On the host side, Firecracker relies on [`aws-lc-rs`][2] to retrieve the random bytes.
+`aws-lc-rs` uses the [`AWS-LC` cryptographic library][3].
 
 ## Prerequisites
 
@@ -66,5 +64,5 @@ kernel configuration option is `CONFIG_HW_RANDOM_VIRTIO` (which depends on
 `CONFIG_HW_RANDOM` and `CONFIG_VIRTIO`).
 
 [1]: https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html#x1-3050004
-[2]: https://docs.rs/rand/latest/rand/rngs/struct.OsRng.html
-[3]: https://docs.rs/getrandom/latest/getrandom/
+[2]: https://docs.rs/aws-lc-rs/latest/aws_lc_rs/index.html
+[3]: https://github.com/aws/aws-lc

--- a/docs/snapshotting/random-for-clones.md
+++ b/docs/snapshotting/random-for-clones.md
@@ -18,9 +18,8 @@ The Linux kernel exposes three main `RNG` interfaces to userspace: the
 `/dev/random` and `/dev/urandom` special devices, and the `getrandom` syscall,
 which are described in the [random(7) man page][1]. Moreover, Firecracker
 supports the [`virtio-rng`](../entropy.md) device which can provide additional
-entropy to guest VMs. It draws its random bytes from the host kernel via
-`getrandom` or `/dev/urandom` after ensuring that the entropy pool has been
-initialized.
+entropy to guest VMs. It draws its random bytes from the [`aws-lc-rs`][8] crate
+which wraps the [`AWS-LC` cryptographic library][9].
 
 Traditionally, `/dev/random` has been considered a source of “true”
 randomness, with the downside that reads block when the pool of entropy
@@ -237,3 +236,5 @@ int main(int argc, char ** argv) {
 [5]: https://elixir.bootlin.com/linux/v4.14.295/source/drivers/char/random.c#L1355
 [6]: https://elixir.bootlin.com/linux/v5.10.147/source/drivers/char/random.c#L1360
 [7]: https://elixir.bootlin.com/linux/v4.14.295/source/drivers/char/random.c#L1351
+[8]: https://docs.rs/aws-lc-rs/latest/aws_lc_rs/index.html
+[9]: https://github.com/aws/aws-lc

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -104,7 +104,7 @@
             },
             {
               "syscall": "getrandom",
-              "comment": "getrandom is used by virtio-rng to initialize the rand crate"
+              "comment": "getrandom is used by aws-lc library which we consume in virtio-rng"
             },
             {
                 "syscall": "accept4",
@@ -206,16 +206,7 @@
             },
             {
                 "syscall": "madvise",
-                "comment": "Used by the VirtIO balloon device and by musl for some customer workloads",
-                "args": [
-                    {
-                        "index": 2,
-                        "type": "dword",
-                        "op": "eq",
-                        "val": 4,
-                        "comment": "libc::MADV_DONTNEED"
-                    }
-                ]
+                "comment": "Used by the VirtIO balloon device and by musl for some customer workloads. It is also used by aws-lc during random number generation. They setup a memory page that mark with MADV_WIPEONFORK to be able to detect forks. They also call it with -1 to see if madvise is supported in certain platforms." 
             },
             {
                 "syscall": "mmap",

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -104,7 +104,7 @@
             },
             {
               "syscall": "getrandom",
-              "comment": "getrandom is used by virtio-rng to initialize the rand crate"
+              "comment": "getrandom is used by aws-lc library which we consume in virtio-rng" 
             },
             {
                 "syscall": "accept4",
@@ -206,16 +206,7 @@
             },
             {
                 "syscall": "madvise",
-                "comment": "Used by the VirtIO balloon device and by musl for some customer workloads",
-                "args": [
-                    {
-                        "index": 2,
-                        "type": "dword",
-                        "op": "eq",
-                        "val": 4,
-                        "comment": "libc::MADV_DONTNEED"
-                    }
-                ]
+                "comment": "Used by the VirtIO balloon device and by musl for some customer workloads. It is also used by aws-lc during random number generation. They setup a memory page that mark with MADV_WIPEONFORK to be able to detect forks. They also call it with -1 to see if madvise is supported in certain platforms." 
             },
             {
                 "syscall": "mmap",

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+aws-lc-rs = "1.0.2"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 event-manager = "0.3.0"
 libc = "0.2.117"
@@ -14,7 +15,6 @@ timerfd = "1.2.0"
 versionize = "0.1.10"
 versionize_derive = "0.1.5"
 vm-superio = "0.7.0"
-rand = "0.8.5"
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.17"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 thiserror = "1.0.32"
-userfaultfd = "0.5.0"
+userfaultfd = "0.5.1"
 versionize = "0.1.10"
 versionize_derive = "0.1.5"
 vm-allocator = "0.1.0"

--- a/tests/host_tools/uffd/Cargo.toml
+++ b/tests/host_tools/uffd/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 libc = "0.2.117"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
-userfaultfd = "0.5.0"
+userfaultfd = "0.5.1"
 
 utils = { path = "../../../src/utils" }
 

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -14,7 +14,7 @@ MACHINE = platform.machine()
 
 SIZES_DICT = {
     "x86_64": {
-        "FC_BINARY_SIZE_TARGET": 2649920,
+        "FC_BINARY_SIZE_TARGET": 2808184,
         "JAILER_BINARY_SIZE_TARGET": 965840,
     },
     "aarch64": {

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -58,6 +58,8 @@ RUN apt-get update \
         # TODO: Remove `dmidecode` after the end of kernel 4.14 support.
         # https://github.com/firecracker-microvm/firecracker/issues/3677
         dmidecode \
+        # for aws-lc-rs
+        cmake \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --upgrade pip poetry \
     && gem install mdl

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v56}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v57}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
## Changes

Switch to using `aws-lc-rs` for getting random bytes for `virtio-rng`.

## Reason

Currently, we are using the `OsRng` type from the `rand` crate. `aws-lc-rs` is in the process of getting FIPS certification, so switching to this implementation might benefit us in the future for use-cases that require FIPS compliance.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
