### PR TITLE
handle 0 size buffers from guest

### DIFF
--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -103,6 +103,11 @@ impl Entropy {
     }
 
     fn handle_one(&self, iovec: &mut IoVecBufferMut) -> Result<u32> {
+        // If guest provided us with an empty buffer just return directly
+        if iovec.len() == 0 {
+            return Ok(0);
+        }
+
         let mut rand_bytes = vec![0; iovec.len()];
         rand::fill(&mut rand_bytes).map_err(|err| {
             METRICS.entropy.host_rng_fails.inc();
@@ -411,6 +416,9 @@ mod tests {
 
         // Add a write-only descriptor with 10 bytes
         th.add_desc_chain(RNG_QUEUE, 0, &[(1, 10, VIRTQ_DESC_F_WRITE)]);
+
+        // Add a write-only descriptor with 0 bytes. This should not fail.
+        th.add_desc_chain(RNG_QUEUE, 0, &[(2, 0, VIRTQ_DESC_F_WRITE)]);
 
         let mut entropy_dev = th.device();
 


### PR DESCRIPTION
## Changes

In theory guests should not pass us 0 size buffers, but if they do right now we crash. Instead handle the case by adding back the buffer as used, having touched 0 bytes. Also add a unit-test for this case.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
