### PR TITLE
feat: upgrade of deserialization of RVF.

### DIFF
--- a/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs
+++ b/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs
@@ -185,16 +185,15 @@ mod tests {
                     "reg_modifiers":  [
                         {
                             "addr": "200",
-                            "bitmap": "0bx0?100x?x1xxxx00xxx1xxxxxxxxxxx1"
+                            "bitmap": "0bx0?1_0_0x_?x1xxxx00xxx1xxxxxxxxxxx1"
                         },
                     ]
                 }"#,
         );
         assert!(cpu_config_result.is_err());
-        assert!(cpu_config_result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse string [x0?100x?x1xxxx00xxx1xxxxxxxxxxx1] as a bitmap"));
+        assert!(cpu_config_result.unwrap_err().to_string().contains(
+            "Failed to parse string [0bx0?1_0_0x_?x1xxxx00xxx1xxxxxxxxxxx1] as a bitmap"
+        ));
 
         // Malformed 64-bit bitmap - value failed
         let cpu_config_result = serde_json::from_str::<CustomCpuTemplate>(
@@ -211,7 +210,7 @@ mod tests {
         assert!(cpu_config_result
             .unwrap_err()
             .to_string()
-            .contains("Failed to parse string [x00100x0x1xxxx05xxx1xxxxxxxxxxx1] as a bitmap"));
+            .contains("Failed to parse string [0bx00100x0x1xxxx05xxx1xxxxxxxxxxx1] as a bitmap"));
     }
 
     #[test]

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -27,7 +27,6 @@ mod common_types {
 }
 
 use std::borrow::Cow;
-use std::num::ParseIntError;
 use std::result::Result;
 
 pub use common_types::*;
@@ -112,24 +111,39 @@ where
 }
 
 /// Trait for numeric types
-pub trait Numeric: Sized {
+pub trait Numeric:
+    Sized
+    + Copy
+    + PartialEq<Self>
+    + std::ops::Not<Output = Self>
+    + std::ops::BitAnd<Output = Self>
+    + std::ops::BitOr<Output = Self>
+    + std::ops::BitOrAssign<Self>
+    + std::ops::Shl<Output = Self>
+    + std::ops::AddAssign<Self>
+{
     /// Number of bits for type
     const BITS: u32;
-    /// Parse numeric type from string with given radix
-    fn from_str_radix(s: &str, radix: u32) -> Result<Self, ParseIntError>;
     /// Value of bit at pos
     fn bit(&self, pos: u32) -> bool;
+    /// Returns 0 of the type
+    fn zero() -> Self;
+    /// Returns 1 of the type
+    fn one() -> Self;
 }
 
 macro_rules! impl_numeric {
     ($type:tt) => {
         impl Numeric for $type {
             const BITS: u32 = $type::BITS;
-            fn from_str_radix(s: &str, radix: u32) -> Result<Self, ParseIntError> {
-                $type::from_str_radix(s, radix)
-            }
             fn bit(&self, pos: u32) -> bool {
                 (self & (1 << pos)) != 0
+            }
+            fn zero() -> Self {
+                0
+            }
+            fn one() -> Self {
+                1
             }
         }
     };
@@ -143,12 +157,7 @@ impl_numeric!(u128);
 
 impl<V> Serialize for RegisterValueFilter<V>
 where
-    V: Copy
-        + std::ops::Not<Output = V>
-        + std::ops::BitAnd<Output = V>
-        + std::ops::BitOr<Output = V>
-        + PartialEq<V>
-        + Numeric,
+    V: Numeric,
 {
     /// Serialize combination of value and filter into a single tri state string
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -179,11 +188,7 @@ where
 
 impl<'de, V> Deserialize<'de> for RegisterValueFilter<V>
 where
-    V: Copy
-        + std::ops::Not<Output = V>
-        + std::ops::BitAnd<Output = V>
-        + std::ops::BitOr<Output = V>
-        + Numeric,
+    V: Numeric,
 {
     /// Deserialize a composite bitmap string into a value pair
     /// input string: "010x"
@@ -195,29 +200,32 @@ where
     where
         D: Deserializer<'de>,
     {
-        let mut bitmap_str = String::deserialize(deserializer)?;
+        let original_str = String::deserialize(deserializer)?;
 
-        if bitmap_str.starts_with("0b") {
-            bitmap_str = bitmap_str[2..].to_string();
+        let stripped_str = original_str.strip_prefix("0b").unwrap_or(&original_str);
+
+        let (mut filter, mut value) = (V::zero(), V::zero());
+        let mut i = V::zero();
+        for s in stripped_str.as_bytes().iter().rev() {
+            match s {
+                b'_' => continue,
+                b'x' => {}
+                b'0' => {
+                    filter |= V::one() << i;
+                }
+                b'1' => {
+                    filter |= V::one() << i;
+                    value |= V::one() << i;
+                }
+                c => {
+                    return Err(D::Error::custom(format!(
+                        "Failed to parse string [{}] as a bitmap - unknown character: {}",
+                        original_str, c
+                    )))
+                }
+            }
+            i += V::one();
         }
-
-        let filter_str = bitmap_str.replace('0', "1");
-        let filter_str = filter_str.replace('x', "0");
-        let value_str = bitmap_str.replace('x', "0");
-
-        let filter = V::from_str_radix(filter_str.as_str(), 2).map_err(|err| {
-            D::Error::custom(format!(
-                "Failed to parse string [{}] as a bitmap - {:?}",
-                bitmap_str, err
-            ))
-        })?;
-        let value = V::from_str_radix(value_str.as_str(), 2).map_err(|err| {
-            D::Error::custom(format!(
-                "Failed to parse string [{}] as a bitmap - {:?}",
-                bitmap_str, err
-            ))
-        })?;
-
         Ok(RegisterValueFilter { filter, value })
     }
 }
@@ -243,5 +251,13 @@ mod tests {
         };
         let deserialized: RegisterValueFilter<u8> = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, expected_rvf);
+
+        let serialized = "\"0b0_101_xx_xx\"";
+        let deserialized: RegisterValueFilter<u8> = serde_json::from_str(serialized).unwrap();
+        assert_eq!(deserialized, expected_rvf);
+
+        let serialized = "\"0b0_xϽ1_xx_xx\"";
+        let deserialized: Result<RegisterValueFilter<u8>, _> = serde_json::from_str(serialized);
+        assert!(deserialized.is_err());
     }
 }

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -85,10 +85,7 @@ impl From<&Option<CpuTemplateType>> for StaticCpuTemplate {
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct RegisterValueFilter<V>
 where
-    V: Copy
-        + std::ops::Not<Output = V>
-        + std::ops::BitAnd<Output = V>
-        + std::ops::BitOr<Output = V>,
+    V: Numeric,
 {
     /// Filter to be used when writing the value bits.
     pub filter: V,
@@ -98,10 +95,7 @@ where
 
 impl<V> RegisterValueFilter<V>
 where
-    V: Copy
-        + std::ops::Not<Output = V>
-        + std::ops::BitAnd<Output = V>
-        + std::ops::BitOr<Output = V>,
+    V: Numeric,
 {
     /// Applies filter to the value
     #[inline]

--- a/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
+++ b/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
@@ -425,16 +425,15 @@ mod tests {
                     "msr_modifiers":  [
                         {
                             "addr": "200",
-                            "bitmap": "0bx0?100x?x1xxxx00xxx1xxxxxxxxxxx1"
+                            "bitmap": "0bx0?1_0_0x_?x1xxxx00xxx1xxxxxxxxxxx1"
                         },
                     ]
                 }"#,
         );
         assert!(cpu_template_result.is_err());
-        assert!(cpu_template_result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse string [x0?100x?x1xxxx00xxx1xxxxxxxxxxx1] as a bitmap"));
+        assert!(cpu_template_result.unwrap_err().to_string().contains(
+            "Failed to parse string [0bx0?1_0_0x_?x1xxxx00xxx1xxxxxxxxxxx1] as a bitmap"
+        ));
         // Malformed 64-bit bitmap - value failed
         let cpu_template_result = serde_json::from_str::<CustomCpuTemplate>(
             r#"{
@@ -450,7 +449,7 @@ mod tests {
         assert!(cpu_template_result
             .unwrap_err()
             .to_string()
-            .contains("Failed to parse string [x00100x0x1xxxx05xxx1xxxxxxxxxxx1] as a bitmap"));
+            .contains("Failed to parse string [0bx00100x0x1xxxx05xxx1xxxxxxxxxxx1] as a bitmap"));
     }
 
     #[test]

--- a/tests/integration_tests/performance/test_cpu_template_benchmark.py
+++ b/tests/integration_tests/performance/test_cpu_template_benchmark.py
@@ -28,11 +28,11 @@ BASELINES = {
         "serialize": {"target": 0.015, "delta": 0.02},  # milliseconds
     },
     "AMD": {
-        "deserialize": {"target": 0.025, "delta": 0.02},  # milliseconds
+        "deserialize": {"target": 0.0037, "delta": 0.002},  # milliseconds
         "serialize": {"target": 0.015, "delta": 0.02},  # milliseconds
     },
     "ARM": {
-        "deserialize": {"target": 0.0015, "delta": 0.001},  # milliseconds
+        "deserialize": {"target": 0.00037, "delta": 0.0006},  # milliseconds
         "serialize": {"target": 0.0015, "delta": 0.006},  # milliseconds
     },
 }


### PR DESCRIPTION
- Rewrote deserialization method for `RegisterValueFilter`.
- Improved performance by ~75%.
- Added ability to use `_` in string representation.

running: `cargo bench --bench cpu_templates`
```bash
deserialize_cpu_template
                        time:   [5.5389 µs 5.5402 µs 5.5419 µs]
                        change: [-77.543% -77.536% -77.530%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 200 measurements (5.50%)
  2 (1.00%) low mild
  4 (2.00%) high mild
  5 (2.50%) high severe
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
