### PR TITLE
[1.3] Pass through cache information to the guest (leaf 0x80000006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed passing through cache information from host in CPUID leaf 0x80000006.
+
 ## [1.3.2]
 
 ### Fixed

--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -319,7 +319,7 @@ pub mod leaf_0x80000006 {
     pub mod edx {
         use crate::bit_helper::BitRange;
 
-        pub const RESERVED_BITRANGE: BitRange = bit_range!(16, 17);
+        pub const RESERVED_BITRANGE: BitRange = bit_range!(17, 16);
     }
 }
 

--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -313,6 +313,16 @@ pub mod leaf_0x80000001 {
     }
 }
 
+pub mod leaf_0x80000006 {
+    pub const LEAF_NUM: u32 = 0x8000_0006;
+
+    pub mod edx {
+        use crate::bit_helper::BitRange;
+
+        pub const RESERVED_BITRANGE: BitRange = bit_range!(16, 17);
+    }
+}
+
 pub mod leaf_0x80000008 {
     pub const LEAF_NUM: u32 = 0x8000_0008;
 

--- a/src/cpuid/src/transformer/amd.rs
+++ b/src/cpuid/src/transformer/amd.rs
@@ -132,6 +132,7 @@ impl CpuidTransformer for AmdCpuidTransformer {
         // Some versions of kernel may return the 0xB leaf for AMD even if this is an
         // Intel-specific leaf. Remove it.
         cpuid.retain(|entry| entry.function != leaf_0xb::LEAF_NUM);
+        use_host_cpuid_function(cpuid, leaf_0x80000006::LEAF_NUM, false)?;
         use_host_cpuid_function(cpuid, leaf_0x8000001e::LEAF_NUM, false)?;
         use_host_cpuid_function(cpuid, leaf_0x8000001d::LEAF_NUM, true)?;
         self.process_entries(cpuid, vm_spec)
@@ -143,6 +144,7 @@ impl CpuidTransformer for AmdCpuidTransformer {
             leaf_0x7::LEAF_NUM => Some(amd::update_structured_extended_entry),
             leaf_0x80000000::LEAF_NUM => Some(amd::update_largest_extended_fn_entry),
             leaf_0x80000001::LEAF_NUM => Some(amd::update_extended_feature_info_entry),
+            leaf_0x80000006::LEAF_NUM => Some(common::update_extended_cache_features_entry),
             leaf_0x80000008::LEAF_NUM => Some(amd::update_amd_features_entry),
             leaf_0x8000001d::LEAF_NUM => Some(amd::update_extended_cache_topology_entry),
             leaf_0x8000001e::LEAF_NUM => Some(amd::update_extended_apic_id_entry),

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -98,6 +98,19 @@ pub fn update_cache_parameters_entry(
     Ok(())
 }
 
+pub fn update_extended_cache_features_entry(
+    entry: &mut kvm_cpuid_entry2,
+    _vm_spec: &VmSpec,
+) -> Result<(), Error> {
+    use crate::cpu_leaf::leaf_0x80000006::*;
+
+    // This only zeroes reserved bits [17:16].
+    // The actual pass through is done by the `use_host_cpuid_function()` call.
+    entry.edx.write_bits_in_range(&edx::RESERVED_BITRANGE, 0);
+
+    Ok(())
+}
+
 /// Replaces the `cpuid` entries corresponding to `function` with the entries from the host's cpuid.
 pub fn use_host_cpuid_function(
     cpuid: &mut CpuId,

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -105,7 +105,7 @@ pub fn update_extended_cache_features_entry(
     use crate::cpu_leaf::leaf_0x80000006::*;
 
     // This only zeroes reserved bits [17:16].
-    // The actual pass through is done by the `use_host_cpuid_function()` call.
+    // The actual passthrough is done by the `use_host_cpuid_function()` call.
     entry.edx.write_bits_in_range(&edx::RESERVED_BITRANGE, 0);
 
     Ok(())

--- a/src/cpuid/src/transformer/intel.rs
+++ b/src/cpuid/src/transformer/intel.rs
@@ -4,6 +4,7 @@
 use super::*;
 use crate::bit_helper::BitHelper;
 use crate::cpu_leaf::*;
+use crate::transformer::common::use_host_cpuid_function;
 
 // The APIC ID shift in leaf 0xBh specifies the number of bits to shit the x2APIC ID to get a
 // unique topology of the next level. This allows 128 logical processors/package.
@@ -139,6 +140,8 @@ impl CpuidTransformer for IntelCpuidTransformer {
                 .map_err(Error::Fam)?;
         }
 
+        use_host_cpuid_function(cpuid, leaf_0x80000006::LEAF_NUM, false)?;
+
         self.process_entries(cpuid, vm_spec)
     }
 
@@ -150,6 +153,7 @@ impl CpuidTransformer for IntelCpuidTransformer {
             leaf_0xa::LEAF_NUM => Some(intel::update_perf_mon_entry),
             leaf_0xb::LEAF_NUM => Some(intel::update_extended_topology_entry),
             0x8000_0002..=0x8000_0004 => Some(common::update_brand_string_entry),
+            leaf_0x80000006::LEAF_NUM => Some(common::update_cache_parameters_entry),
             _ => None,
         }
     }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ from host_tools import proc
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {"Intel": 82.92, "AMD": 82.14, "ARM": 82.43}
 else:
-    COVERAGE_DICT = {"Intel": 80.07, "AMD": 79.28, "ARM": 79.34}
+    COVERAGE_DICT = {"Intel": 80.13, "AMD": 79.28, "ARM": 79.34}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -40,6 +40,22 @@ def _check_cpuid_x86(test_microvm, expected_cpu_count, expected_htt):
     )
 
 
+def _check_extended_cache_features(vm):
+    l3_params = cpuid_utils.get_guest_cpuid(vm)[(0x80000006, 0, "edx")]
+
+    # fmt: off
+    line_size     = (l3_params >>  0) & 0xFF
+    lines_per_tag = (l3_params >>  8) & 0xF
+    assoc         = (l3_params >> 12) & 0xF
+    cache_size    = (l3_params >> 18) & 0x3FFF
+    # fmt: on
+
+    assert line_size > 0
+    assert lines_per_tag == 0x1  # This is hardcoded in the AMD spec
+    assert assoc == 0x9  # This is hardcoded in the AMD spec
+    assert cache_size > 0
+
+
 def _check_cpu_features_arm(test_microvm):
     if cpuid_utils.get_instance_type() == "m6g.metal":
         expected_cpu_features = {
@@ -110,6 +126,25 @@ def test_cpuid(test_microvm_with_api, network_config, num_vcpus, htt):
     _tap, _, _ = vm.ssh_network_config(network_config, "1")
     vm.start()
     _check_cpuid_x86(vm, num_vcpus, "true" if num_vcpus > 1 else "false")
+
+
+@pytest.mark.skipif(PLATFORM != "x86_64", reason="CPUID is only supported on x86_64.")
+@pytest.mark.skipif(
+    cpuid_utils.get_cpu_vendor() != cpuid_utils.CpuVendor.AMD,
+    reason="L3 cache info is only present in 0x80000006 for AMD",
+)
+def test_extended_cache_features(test_microvm_with_api, network_config):
+    """
+    Check extended cache features (leaf 0x80000006).
+
+    @type: functional
+    """
+    vm = test_microvm_with_api
+    vm.spawn()
+    vm.basic_config()
+    _tap, _, _ = vm.ssh_network_config(network_config, "1")
+    vm.start()
+    _check_extended_cache_features(vm)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Changes

Pass through the leaf 0x80000006 from the host to the guest.

## Reason

Backport from https://github.com/firecracker-microvm/firecracker/pull/3721

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
