### PR TITLE
Release Firecracker v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.3.3]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [1.3.2]
 
+### Changed
+
+- Upgraded Rust toolchain from 1.64.0 to 1.68.2.
+
 ### Fixed
 
 - A race condition that has been identified between the API thread and the VMM

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "api_server",
  "cargo_toml",
@@ -566,7 +566,7 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jailer"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "libc",
  "regex",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "rebase-snap"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "libc",
  "utils",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "seccompiler"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "bincode",
  "libc",

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 1.3.2
+  version: 1.3.3
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "../../build.rs"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "../../build.rs"

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rebase-snap"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "../../build.rs"

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seccompiler"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "../../build.rs"

--- a/tests/integration_tests/security/demo_seccomp/Cargo.lock
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "seccompiler"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "bincode",
  "libc",


### PR DESCRIPTION
## Changes

Create v1.3.3 release.

## Reason

Release the following:
- Fixed passing through cache information from host in CPUID leaf 0x80000006.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
