### PR TITLE
[1.2] chore(changelog): fix version of the upgraded rust in 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Changed
 
-- Upgraded Rust toolchain from 1.64.0 to 1.66.1.
+- Upgraded Rust toolchain from 1.64.0 to 1.68.2.
 
 ### Fixed
 


### PR DESCRIPTION
## Changes

Fix the upgraded Rust version to 1.68.2.

## Reason

1.2.1 mentions upgrade to Rust 1.66.1, while the actual version is 1.68.2.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
~~- [ ] All added/changed functionality is tested.~~
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
