### PR TITLE
[v1.2] ci: teach devtool to run shell commands inside devctr

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -647,6 +647,9 @@ cmd_help() {
     echo "                            Running Firecracker via the jailer requires elevated"
     echo "                            privileges, though the build phase does not."
     echo ""
+    echo "    sh CMD..."
+    echo "        Launch the development container and run a command."
+    echo ""
     echo "    tag <version>"
     echo "        Create a git tag for the specified version. The tag message will contain "
     echo "        the contents of CHANGELOG.md enclosed between the header corresponding to "
@@ -1283,6 +1286,15 @@ cmd_shell() {
     return $ret
 }
 
+cmd_sh() {
+    run_devctr \
+        --privileged \
+        --ulimit nofile=4096:4096 \
+        --ulimit memlock=-1:-1 \
+        --workdir "$CTR_FC_ROOT_DIR" \
+        -- \
+        bash --norc -c "$*"
+}
 
 cmd_create_snapshot_artifacts() {
     privileged=true


### PR DESCRIPTION
Example:

    ./tools/devtool sh "cd src/firecracker; cargo pkgid"
    file:///firecracker/src/firecracker#1.5.0-dev

(cherry picked from commit 270819e697c058ae48a56a4d62df799e1bb7c178)

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
