### PR TITLE
refactor: simplified aarch64 vcpu code 

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -836,9 +836,9 @@ pub fn configure_system_for_boot(
 
     #[cfg(target_arch = "aarch64")]
     let cpu_config = {
-        let regs = vcpus[0]
-            .kvm_vcpu
-            .get_regs(&cpu_template.reg_list())
+        use crate::arch::aarch64::regs::get_registers;
+        let mut regs = vec![];
+        get_registers(&vcpus[0].kvm_vcpu.fd, &cpu_template.reg_list(), &mut regs)
             .map_err(GuestConfigError)?;
         CpuConfiguration { regs }
     };

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -294,10 +294,11 @@ mod tests {
         );
         assert!(err.is_err());
         assert_eq!(
-            err.err().unwrap().to_string(),
-            "Error configuring the vcpu registers: Failed to set processor state register: Bad \
-             file descriptor (os error 9)"
-                .to_string()
+            err.unwrap_err(),
+            super::Error::ConfigureRegisters(ArchError::SetOneReg(
+                6931039826524241986,
+                kvm_ioctls::Error::new(9)
+            ))
         );
 
         let (_vm, mut vcpu, vm_mem) = setup_vcpu(0x10000);
@@ -307,12 +308,12 @@ mod tests {
             GuestAddress(crate::arch::get_kernel_start()),
             &vcpu_config,
         );
-        assert!(err.is_err());
         assert_eq!(
-            err.err().unwrap().to_string(),
-            "Error configuring the vcpu registers: Failed to set processor state register: Bad \
-             file descriptor (os error 9)"
-                .to_string()
+            err.unwrap_err(),
+            super::Error::ConfigureRegisters(ArchError::SetOneReg(
+                6931039826524241986,
+                kvm_ioctls::Error::new(9)
+            ))
         );
     }
 
@@ -352,7 +353,7 @@ mod tests {
         assert!(res.is_err());
         assert_eq!(
             res.unwrap_err(),
-            super::Error::RestoreState(ArchError::SetSysRegister(0, kvm_ioctls::Error::new(8)))
+            super::Error::RestoreState(ArchError::SetOneReg(0, kvm_ioctls::Error::new(8)))
         );
 
         init_vcpu(&vcpu.fd, vm.fd());

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,9 +25,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 83.66, "AMD": 83.24, "ARM": 83.11}
+    COVERAGE_DICT = {"Intel": 83.66, "AMD": 83.24, "ARM": 83.06}
 else:
-    COVERAGE_DICT = {"Intel": 80.90, "AMD": 80.45, "ARM": 80.13}
+    COVERAGE_DICT = {"Intel": 80.90, "AMD": 80.45, "ARM": 80.06}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes
General improvements of vcpu code for aarch64

## Reason
Before integrating updates from the `kvm-ioctls` crate which include update to how `get/set_one_reg` work, I thought to do some clean up to make integration easier.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
