### PR TITLE
Backport PR #3523 to firecracker-v1.3

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -21,6 +21,7 @@ from retry.api import retry_call
 
 from framework.defs import MIN_KERNEL_VERSION_FOR_IO_URING
 
+FLUSH_CMD = 'screen -S {session} -X colon "logfile flush 0^M"'
 CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
 CMDLOG = logging.getLogger("commands")
 GET_CPU_LOAD = "top -bn1 -H -p {} -w512 | tail -n+8"
@@ -760,17 +761,22 @@ def start_screen_process(screen_log, session_name, binary_path, binary_params):
         delay=1,
     ).group(1)
 
-    binary_clone_pid = int(
-        open("/proc/{0}/task/{0}/children".format(screen_pid), encoding="utf-8")
-        .read()
-        .strip()
-    )
+    # Make sure the screen process launched successfully
+    # As the parent process for the binary.
+    screen_ps = psutil.Process(int(screen_pid))
+    wait_process_running(screen_ps)
 
     # Configure screen to flush stdout to file.
-    flush_cmd = 'screen -S {session} -X colon "logfile flush 0^M"'
-    run_cmd(flush_cmd.format(session=session_name))
+    run_cmd(FLUSH_CMD.format(session=session_name))
 
-    return screen_pid, binary_clone_pid
+    children_count = len(screen_ps.children())
+    if children_count != 1:
+        raise RuntimeError(
+            f"Failed to retrieve child process id for binary {binary_path}. "
+            f"screen session process had [{children_count}]"
+        )
+
+    return screen_pid, screen_ps.children()[0].pid
 
 
 def guest_run_fio_iteration(ssh_connection, iteration):
@@ -790,3 +796,13 @@ def check_filesystem(ssh_connection, disk_fmt, disk):
     cmd = "fsck.{} -n {}".format(disk_fmt, disk)
     exit_code, _, stderr = ssh_connection.execute_command(cmd)
     assert exit_code == 0, stderr.read()
+
+
+@retry(delay=0.5, tries=5)
+def wait_process_running(process):
+    """Wait for a process to run.
+
+    Will return successfully if the process is in
+    a running state and will otherwise raise an exception.
+    """
+    assert process.is_running()


### PR DESCRIPTION
## Changes

Backport PR #3523 to firecracker-v1.3

## Reason

To suppress nightly CI failures.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
