### PR TITLE
update of cpu_template doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 - Added support for the `virtio-rng` entropy device. The device is optional. A
   single device can be enabled per VM using the `/entropy` endpoint.
 
+### Changed
+
+- Updated deserialization of `bitmap` for custom CPU templates to allow usage
+  of '_' as a separator.
+
 ### Fixed
 
 - Fixed feature flags in T2S CPU template on Intel Ice Lake.

--- a/docs/cpu_templates/cpu-templates.md
+++ b/docs/cpu_templates/cpu-templates.md
@@ -186,6 +186,10 @@ This CPU templates will do the following with the ARM register `0x603000000013c0
 The full description of the custom CPU templates language can be found
 [here](schema.json).
 
+> **Note**
+You can also use `_` to visually separate parts of a bitmap.
+So instead of writing: `0b0000xxxx`, it can be `0b0000_xxxx`.
+
 #### Expansion of contracted bitmaps
 
 If a contracted version of a bitmap is given, for example, `0b101` where

--- a/docs/cpu_templates/schema.json
+++ b/docs/cpu_templates/schema.json
@@ -37,9 +37,9 @@
                                     "enum": ["eax", "ebx", "ecx", "edx"]
                                 },
                                 "bitmap": {
-                                    "description": "CPUID register value bitmap. Must be in format `0b[01x]{32}`. Corresponding bits will be cleared (`0`), set (`1`) or left intact (`x`).",
+                                    "description": "CPUID register value bitmap. Must be in format `0b[01x]{32}`. Corresponding bits will be cleared (`0`), set (`1`) or left intact (`x`). (`_`) can be used as a separator.",
                                     "type": "string",
-                                    "examples": ["0bxxxx000000000011xx00011011110010", "0bxxxxxxxxxxxxx0xx00xx00x0000000xx"]
+                                    "examples": ["0bxxxx000000000011xx00011011110010", "0bxxxxxxxxxxxxx0xx00xx00x0_0000_00xx"]
                                 }
                             }
                         }
@@ -59,9 +59,9 @@
                         "examples": ["0x10a"]
                     },
                     "bitmap": {
-                        "description": "MSR value bitmap. Must be in format `0b[01x]{64}`. Corresponding bits will be cleared (`0`), set (`1`) or left intact (`x`).",
+                        "description": "MSR value bitmap. Must be in format `0b[01x]{64}`. Corresponding bits will be cleared (`0`), set (`1`) or left intact (`x`). (`_`) can be used as a separator.",
                         "type": "string",
-                        "examples": ["0bxxxx000000000000000000000000000000000000000000000000000011101011"]
+                        "examples": ["0bxxxx0000000000000000000000000000000000000000000000000000_11101011"]
                     }
                 }
             }
@@ -78,9 +78,9 @@
                         "examples": ["0x603000000013c020"]
                     },
                     "bitmap": {
-                        "description": "ARM register value bitmap. Must be in format `0b[01x]{128}`. Corresponding bits will be cleared (`0`), set (`1`) or left intact (`x`).",
+                        "description": "ARM register value bitmap. Must be in format `0b[01x]{128}`. Corresponding bits will be cleared (`0`), set (`1`) or left intact (`x`). (`_`) can be used as a separator.",
                         "type": "string",
-                        "examples": ["0bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx0000xxxxxxxxxxxx0000xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]
+                        "examples": ["0bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_0000_xxxx_xxxx_xxxx_0000_xxxx_xxxx_xxxx_xxxx_xxxx_xxxx_xxxx_xxxx"]
                     }
                 }
             }


### PR DESCRIPTION
- Updated doc with info about `_` in bitmaps.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
