### PR TITLE
feat: Add nested virt comments for ARM64

### DIFF
--- a/src/vmm/src/arch/aarch64/regs.rs
+++ b/src/vmm/src/arch/aarch64/regs.rs
@@ -173,6 +173,12 @@ arm64_sys_reg!(ID_AA64ISAR0_EL1, 3, 0, 0, 6, 0);
 arm64_sys_reg!(ID_AA64ISAR1_EL1, 3, 0, 0, 6, 1);
 arm64_sys_reg!(ID_AA64MMFR2_EL1, 3, 0, 0, 7, 2);
 
+// TODO: When kernel versions that support ARM's nested virtualization become supported we will need
+// to disable NV forcefully in vended templates. See the static template v1n1 for use of the HCR
+// register. See Linux kernel def for the hypervisor control register:
+// https://elixir.bootlin.com/linux/v5.10.179/source/arch/arm64/include/asm/sysreg.h
+// arm64_sys_reg!(SYS_ICH_HCR_EL2, 3, 4, 12, 11, 0);
+
 // EL0 Virtual Timer Registers
 arm64_sys_reg!(KVM_REG_ARM_TIMER_CNT, 3, 3, 14, 3, 2);
 

--- a/src/vmm/src/cpu_config/aarch64/static_cpu_templates/v1n1.rs
+++ b/src/vmm/src/cpu_config/aarch64/static_cpu_templates/v1n1.rs
@@ -96,6 +96,18 @@ pub fn v1n1() -> CustomCpuTemplate {
                     value: 0x0000000000000000,
                 },
             },
+            // TODO: Uncomment this modifier once kernel version 6.3+ is supported by Firecracker.
+            // RegisterModifier {
+            // Disable nested virtualization (NV) CPU feature. Setting to 0b0000.
+            // NV enabled/disabled with zeroth bit in SYS_ICH_HCR_EL2.
+            // Occupies bits aarch32 system register ICH_HCR[31:0].
+            // https://developer.arm.com/documentation/ddi0601/2020-12/AArch64-Registers/ICH-HCR-EL2--Interrupt-Controller-Hyp-Control-Register
+            // addr: SYS_ICH_HCR_EL2,
+            // bitmap: RegisterValueFilter {
+            //     filter: 0x000000000000000F,
+            //     value: 0x0000000000000000,
+            // },
+            // },
         ],
     }
 }


### PR DESCRIPTION
## Changes

Add comments with TODOs and references on disabling nested virtualization on ARM CPUs on the v1n1 template.

## Reason

Upcoming versions of ARM CPUs will support nested virtualization(NV). This could perceivably create an inconsistency between older and newer versions of ARM when using Firecracker.

Once Firecracker moves to support Linux Kernel 6.3+, v1n1 should be tested and updated to disable NV.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

