### PR TITLE
refactor(test): Delete duplicate function definition

### DIFF
--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -13,6 +13,7 @@ import re
 import subprocess
 from pathlib import Path
 
+from framework.utils import get_kernel_version
 from framework.utils_cpuid import get_cpu_codename, get_cpu_model_name, get_cpu_vendor
 from framework.utils_imdsv2 import imdsv2_get
 
@@ -20,15 +21,6 @@ from framework.utils_imdsv2 import imdsv2_get
 def run_cmd(cmd):
     """Return the stdout of a command"""
     return subprocess.check_output(cmd, shell=True).decode().strip()
-
-
-def get_kernel_version(level):
-    """Return the current kernel version in format `major.minor.patch`."""
-    linux_version = platform.release()
-    # 5.15.0-56-generic
-    # major, minor, patch
-    mmp = linux_version.split("-")[0].split(".")
-    return ".".join(mmp[:level])
 
 
 def get_os_version():
@@ -56,9 +48,9 @@ class GlobalProps:
         )
         self.host_linux_full_version = platform.release()
         # major.minor
-        self.host_linux_version = get_kernel_version(2)
+        self.host_linux_version = get_kernel_version(1)
         # major.minor.patch
-        self.host_linux_patch = get_kernel_version(3)
+        self.host_linux_patch = get_kernel_version(2)
         self.os = get_os_version()
         self.libc_ver = "-".join(platform.libc_ver())
         self.git_commit_id = run_cmd("git rev-parse HEAD")

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -7,12 +7,11 @@ from pathlib import Path
 import pytest
 
 from framework.artifacts import NetIfaceConfig
-from framework.properties import get_kernel_version
-from framework.utils import check_entropy
+from framework.utils import check_entropy, get_kernel_version
 from framework.utils_cpuid import get_instance_type
 
 INSTANCE_TYPE = get_instance_type()
-HOST_KERNEL = get_kernel_version(level=2)
+HOST_KERNEL = get_kernel_version(level=1)
 
 
 def _microvm_basic_config(microvm):


### PR DESCRIPTION
## Changes

The function get_kernel_version used to get the host operating system  kernel version was duplicated.
I removed the duplication.

## Reason

this PR will close #3751

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
