### PR TITLE
Backport "fix(tests): test_balloon_snapshot: add delay after inflate" to v1.2

### DIFF
--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -18,6 +18,7 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 
 
 MB_TO_PAGES = 256
+STATS_POLLING_INTERVAL_S = 1
 
 
 @retry(delay=0.5, tries=10)
@@ -480,7 +481,9 @@ def test_stats_update(test_microvm_with_api, network_config):
 
     # Add a memory balloon with stats enabled.
     response = test_microvm.balloon.put(
-        amount_mib=0, deflate_on_oom=True, stats_polling_interval_s=1
+        amount_mib=0,
+        deflate_on_oom=True,
+        stats_polling_interval_s=STATS_POLLING_INTERVAL_S,
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
@@ -505,7 +508,7 @@ def test_stats_update(test_microvm_with_api, network_config):
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
     # Wait out the polling interval, then get the updated stats.
-    time.sleep(1)
+    time.sleep(STATS_POLLING_INTERVAL_S)
     next_stats = test_microvm.balloon.get_stats().json()
     assert initial_stats["available_memory"] != next_stats["available_memory"]
 
@@ -568,7 +571,9 @@ def _test_balloon_snapshot(context):
 
     # Add a memory balloon with stats enabled.
     response = basevm.balloon.put(
-        amount_mib=0, deflate_on_oom=True, stats_polling_interval_s=1
+        amount_mib=0,
+        deflate_on_oom=True,
+        stats_polling_interval_s=STATS_POLLING_INTERVAL_S,
     )
     assert basevm.api_session.is_status_no_content(response.status_code)
 
@@ -615,7 +620,8 @@ def _test_balloon_snapshot(context):
     # Get the firecracker from snapshot pid, and open an ssh connection.
     firecracker_pid = microvm.jailer_clone_pid
 
-    # Get the stats right after we take a snapshot.
+    # Wait out the polling interval, then get the updated stats.
+    time.sleep(STATS_POLLING_INTERVAL_S)
     stats_after_snap = microvm.balloon.get_stats().json()
 
     # Check memory usage.


### PR DESCRIPTION
## Changes

Backports commit 4613131c53d4ee618419478d444ea4648d734af3.

Since the configured stats polling interval is 1 second, it may take up to 1 second for the `available_memory` stat to get updated.
In some cases, the VM is snapshotted, restored and the `available_memory` stat is queried before the 1 second has passed after an inflation had been requested.
To avoid this situation, a 1 second delay is added between sending an inflation request and reading stats.


## Reason

- To suppress nightly CI test failures on v1.2

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
