### PR TITLE
chore(test): Update performance baseline

### DIFF
--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
@@ -3315,11 +3315,11 @@
                                                     "target": 197
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 135
+                                                    "delta_percentage": 6,
+                                                    "target": 134
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 196
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
@@ -3351,8 +3351,8 @@
                                                     "target": 200
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 124
+                                                    "delta_percentage": 6,
+                                                    "target": 123
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -3448,11 +3448,11 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 138
+                                                    "target": 137
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "delta_percentage": 4,
@@ -3483,8 +3483,8 @@
                                                     "target": 200
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 129
+                                                    "delta_percentage": 6,
+                                                    "target": 128
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -3505,19 +3505,19 @@
                                                     "target": 67
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 54
+                                                    "delta_percentage": 9,
+                                                    "target": 55
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 84
+                                                    "delta_percentage": 10,
+                                                    "target": 85
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 10,
                                                     "target": 59
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
@@ -3525,28 +3525,28 @@
                                                     "target": 95
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 67
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 54
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 88
+                                                    "delta_percentage": 9,
+                                                    "target": 89
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 78
+                                                    "target": 80
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 93
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 98
+                                                    "target": 99
                                                 }
                                             }
                                         },
@@ -3554,19 +3554,19 @@
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 71
+                                                    "target": 72
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 77
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 63
+                                                    "delta_percentage": 8,
+                                                    "target": 64
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 90
+                                                    "delta_percentage": 7,
+                                                    "target": 91
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
                                                     "delta_percentage": 6,
@@ -3578,7 +3578,7 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 95
+                                                    "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
@@ -3589,16 +3589,16 @@
                                                     "target": 98
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 71
+                                                    "delta_percentage": 8,
+                                                    "target": 72
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 76
+                                                    "delta_percentage": 9,
+                                                    "target": 77
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 63
+                                                    "delta_percentage": 8,
+                                                    "target": 64
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
                                                     "delta_percentage": 6,
@@ -3609,15 +3609,15 @@
                                                     "target": 93
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 98
+                                                    "delta_percentage": 6,
+                                                    "target": 99
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 95
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 93
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
@@ -3633,12 +3633,12 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 63
+                                                    "delta_percentage": 8,
+                                                    "target": 62
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 54
+                                                    "delta_percentage": 10,
+                                                    "target": 55
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
                                                     "delta_percentage": 8,
@@ -3646,22 +3646,22 @@
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 58
+                                                    "target": 59
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 84
+                                                    "target": 85
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 95
+                                                    "target": 96
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 62
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 54
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
@@ -3669,15 +3669,15 @@
                                                     "target": 81
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 68
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 95
+                                                    "delta_percentage": 6,
+                                                    "target": 94
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -3690,11 +3690,11 @@
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 72
+                                                    "target": 73
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 74
+                                                    "delta_percentage": 10,
+                                                    "target": 73
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
                                                     "delta_percentage": 7,
@@ -3705,35 +3705,35 @@
                                                     "target": 89
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 16,
-                                                    "target": 69
+                                                    "delta_percentage": 18,
+                                                    "target": 70
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 97
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 96
+                                                    "target": 97
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 98
+                                                    "delta_percentage": 6,
+                                                    "target": 99
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 72
+                                                    "target": 73
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "delta_percentage": 7,
                                                     "target": 73
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 74
+                                                    "delta_percentage": 10,
+                                                    "target": 73
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 94
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
@@ -3741,7 +3741,7 @@
                                                     "target": 91
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 95
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
@@ -3749,11 +3749,11 @@
                                                     "target": 97
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 97
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -3767,52 +3767,52 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3570
+                                                    "delta_percentage": 8,
+                                                    "target": 3418
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 3261
+                                                    "target": 3207
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 22440
+                                                    "target": 22039
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 14443
+                                                    "target": 14333
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 34354
+                                                    "target": 33545
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 29256
+                                                    "target": 29131
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3548
+                                                    "delta_percentage": 8,
+                                                    "target": 3386
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 3251
+                                                    "target": 3205
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 22147
+                                                    "target": 21734
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 16976
+                                                    "target": 17022
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 31978
+                                                    "delta_percentage": 7,
+                                                    "target": 31156
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 28074
+                                                    "target": 27987
                                                 }
                                             }
                                         },
@@ -3820,75 +3820,75 @@
                                             "total": {
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 4404
+                                                    "target": 4352
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5275
+                                                    "delta_percentage": 11,
+                                                    "target": 5038
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 4625
+                                                    "target": 4569
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 23575
+                                                    "target": 23165
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 26151
+                                                    "delta_percentage": 5,
+                                                    "target": 25768
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 24537
+                                                    "target": 24183
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 29619
+                                                    "delta_percentage": 7,
+                                                    "target": 28943
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 31506
+                                                    "target": 30486
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 28501
+                                                    "target": 28399
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4395
+                                                    "delta_percentage": 6,
+                                                    "target": 4349
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5286
+                                                    "delta_percentage": 11,
+                                                    "target": 5043
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 4627
+                                                    "target": 4573
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 22005
+                                                    "target": 21646
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 25902
+                                                    "target": 25421
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 23048
+                                                    "delta_percentage": 5,
+                                                    "target": 23494
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 27495
+                                                    "delta_percentage": 6,
+                                                    "target": 27025
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 29755
+                                                    "target": 28917
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 26390
+                                                    "delta_percentage": 5,
+                                                    "target": 26246
                                                 }
                                             }
                                         }
@@ -3899,52 +3899,52 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3281
+                                                    "delta_percentage": 9,
+                                                    "target": 3097
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3041
+                                                    "delta_percentage": 7,
+                                                    "target": 2970
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 21587
+                                                    "delta_percentage": 7,
+                                                    "target": 21195
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 14009
+                                                    "target": 13800
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 31119
+                                                    "target": 30677
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 29189
+                                                    "target": 29048
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3269
+                                                    "delta_percentage": 9,
+                                                    "target": 3065
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 3023
+                                                    "delta_percentage": 6,
+                                                    "target": 2954
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 19831
+                                                    "target": 19520
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 13737
+                                                    "target": 13513
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 33386
+                                                    "delta_percentage": 9,
+                                                    "target": 32542
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 28172
+                                                    "target": 27891
                                                 }
                                             }
                                         },
@@ -3952,75 +3952,75 @@
                                             "total": {
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 4259
+                                                    "target": 4161
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4608
+                                                    "delta_percentage": 7,
+                                                    "target": 4463
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 4696
+                                                    "delta_percentage": 7,
+                                                    "target": 4532
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 24342
+                                                    "delta_percentage": 6,
+                                                    "target": 23959
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 25619
+                                                    "delta_percentage": 5,
+                                                    "target": 25060
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 15,
-                                                    "target": 17136
+                                                    "delta_percentage": 16,
+                                                    "target": 17058
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 31004
+                                                    "delta_percentage": 7,
+                                                    "target": 30464
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 33627
+                                                    "target": 32966
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 28921
+                                                    "target": 28792
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 4247
+                                                    "target": 4145
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4603
+                                                    "delta_percentage": 8,
+                                                    "target": 4457
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 4688
+                                                    "delta_percentage": 7,
+                                                    "target": 4538
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 23550
+                                                    "target": 23111
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 24983
+                                                    "target": 24423
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 20697
+                                                    "delta_percentage": 5,
+                                                    "target": 20532
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 29023
+                                                    "target": 28563
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 31245
+                                                    "delta_percentage": 8,
+                                                    "target": 30650
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 27108
+                                                    "target": 26942
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes

- Updates the performance baseline for network TCP throughput on kernel 5.10 + m6g.metal.

## Reason

- This regression was caused by virtio-rng feature introduced in PR #3691.

## Performance Diff
```
{
    "source": "9c7c47afc4fed69653b969549df6196db68436d3/tests/integration_tests/performance/configs/",
    "target": "tests/integration_tests/performance/configs/",
    "test_network_tcp_throughput_config_5.10.json": {
        "test": "network_tcp_throughput",
        "kernel": "5.10",
        "cpus": [
            {
                "instance": "m6g.metal",
                "model": "ARM_NEOVERSE_N1",
                "stats": {
                    "cpu_utilization_vmm": {
                        "target_diff_percentage": {
                            "mean": 0.38191623019355775,
                            "stdev": 0.8578222435586919
                        },
                        "delta_percentage_diff": {
                            "mean": 0.11666666666666667,
                            "stdev": 0.8653727846986955
                        }
                    },
                    "cpu_utilization_vcpus_total": {
                        "target_diff_percentage": {
                            "mean": -0.05920123897172521,
                            "stdev": 0.20041799768478533
                        },
                        "delta_percentage_diff": {
                            "mean": -0.03333333333333333,
                            "stdev": 0.2581988897471611
                        }
                    },
                    "throughput": {
                        "target_diff_percentage": {
                            "mean": -1.9337771884452069,
                            "stdev": 1.3948991640865926
                        },
                        "delta_percentage_diff": {
                            "mean": 0.55,
                            "stdev": 1.2544834847694577
                        }
                    }
                }
            }
        ]
    }
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
