### PR TITLE
fix: use thiserror::Error in vmm_config

### DIFF
--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -1,7 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::{Display, Formatter, Result};
 use std::fs::File;
 use std::io;
 
@@ -38,31 +37,17 @@ pub struct BootSourceConfig {
 }
 
 /// Errors associated with actions on `BootSourceConfig`.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum BootSourceConfigError {
     /// The kernel file cannot be opened.
+    #[error("The kernel file cannot be opened: {0}")]
     InvalidKernelPath(io::Error),
     /// The initrd file cannot be opened.
+    #[error("The initrd file cannot be opened due to invalid path or invalid permissions. {0}")]
     InvalidInitrdPath(io::Error),
     /// The kernel command line is invalid.
+    #[error("The kernel command line is invalid: {0}")]
     InvalidKernelCommandLine(String),
-}
-
-impl Display for BootSourceConfigError {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        use self::BootSourceConfigError::*;
-        match *self {
-            InvalidKernelPath(ref err) => write!(f, "The kernel file cannot be opened: {}", err),
-            InvalidInitrdPath(ref err) => write!(
-                f,
-                "The initrd file cannot be opened due to invalid path or invalid permissions. {}",
-                err,
-            ),
-            InvalidKernelCommandLine(ref err) => {
-                write!(f, "The kernel command line is invalid: {}", err.as_str())
-            }
-        }
-    }
 }
 
 /// Holds the kernel specification (both configuration as well as runtime details).

--- a/src/vmm/src/vmm_config/logger.rs
+++ b/src/vmm/src/vmm_config/logger.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Auxiliary module for configuring the logger.
-use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
 use logger::{LevelFilter, LOGGER};
@@ -106,19 +105,11 @@ impl LoggerConfig {
 }
 
 /// Errors associated with actions on the `LoggerConfig`.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum LoggerConfigError {
     /// Cannot initialize the logger due to bad user input.
+    #[error("{}", format!("{:?}", .0).replace('\"', ""))]
     InitializationFailure(String),
-}
-
-impl Display for LoggerConfigError {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        use self::LoggerConfigError::*;
-        match *self {
-            InitializationFailure(ref err_msg) => write!(f, "{}", err_msg.replace('\"', "")),
-        }
-    }
 }
 
 /// Configures the logger as described in `logger_cfg`.
@@ -213,19 +204,6 @@ mod tests {
                 assert!(line.contains("Guest-boot-time ="));
             }
         }
-    }
-
-    #[test]
-    fn test_error_display() {
-        assert_eq!(
-            format!(
-                "{}",
-                LoggerConfigError::InitializationFailure(String::from(
-                    "Failed to initialize logger"
-                ))
-            ),
-            "Failed to initialize logger"
-        );
     }
 
     #[test]

--- a/src/vmm/src/vmm_config/metrics.rs
+++ b/src/vmm/src/vmm_config/metrics.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Auxiliary module for configuring the metrics system.
-use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
 use logger::METRICS;
@@ -18,19 +17,11 @@ pub struct MetricsConfig {
 }
 
 /// Errors associated with actions on the `MetricsConfig`.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum MetricsConfigError {
     /// Cannot initialize the metrics system due to bad user input.
+    #[error("{}", format!("{:?}", .0).replace('\"', ""))]
     InitializationFailure(String),
-}
-
-impl Display for MetricsConfigError {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        use self::MetricsConfigError::*;
-        match *self {
-            InitializationFailure(ref err_msg) => write!(f, "{}", err_msg.replace('\"', "")),
-        }
-    }
 }
 
 /// Configures the metrics as described in `metrics_cfg`.
@@ -66,18 +57,5 @@ mod tests {
 
         assert!(init_metrics(desc.clone()).is_ok());
         assert!(init_metrics(desc).is_err());
-    }
-
-    #[test]
-    fn test_error_display() {
-        assert_eq!(
-            format!(
-                "{}",
-                MetricsConfigError::InitializationFailure(String::from(
-                    "Failed to initialize metrics"
-                ))
-            ),
-            "Failed to initialize metrics"
-        );
     }
 }

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -1,7 +1,5 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-use std::fmt::{Display, Formatter, Result};
 use std::net::Ipv4Addr;
 
 use mmds::data_store;
@@ -40,46 +38,22 @@ impl MmdsConfig {
 }
 
 /// MMDS configuration related errors.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum MmdsConfigError {
     /// The network interfaces list provided is empty.
+    #[error("The list of network interface IDs that allow forwarding MMDS requests is empty.")]
     EmptyNetworkIfaceList,
     /// The provided IPv4 address is not link-local valid.
+    #[error("The MMDS IPv4 address is not link local.")]
     InvalidIpv4Addr,
     /// The network interfaces list provided contains IDs that
     /// does not correspond to any existing network interface.
+    #[error(
+        "The list of network interface IDs provided contains at least one ID that does not \
+         correspond to any existing network interface."
+    )]
     InvalidNetworkInterfaceId,
     /// MMDS version could not be configured.
+    #[error("The MMDS could not be configured to version {0}: {1}")]
     MmdsVersion(MmdsVersion, data_store::Error),
-}
-
-impl Display for MmdsConfigError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        match self {
-            MmdsConfigError::EmptyNetworkIfaceList => {
-                write!(
-                    f,
-                    "The list of network interface IDs that allow forwarding MMDS requests is \
-                     empty."
-                )
-            }
-            MmdsConfigError::InvalidIpv4Addr => {
-                write!(f, "The MMDS IPv4 address is not link local.")
-            }
-            MmdsConfigError::InvalidNetworkInterfaceId => {
-                write!(
-                    f,
-                    "The list of network interface IDs provided contains at least one ID that \
-                     does not correspond to any existing network interface."
-                )
-            }
-            MmdsConfigError::MmdsVersion(version, err) => {
-                write!(
-                    f,
-                    "The MMDS could not be configured to version {}: {}",
-                    version, err
-                )
-            }
-        }
-    }
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,9 +25,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 83.66, "AMD": 83.24, "ARM": 83.06}
+    COVERAGE_DICT = {"Intel": 83.76, "AMD": 83.34, "ARM": 83.12}
 else:
-    COVERAGE_DICT = {"Intel": 80.90, "AMD": 80.45, "ARM": 80.06}
+    COVERAGE_DICT = {"Intel": 81.02, "AMD": 80.55, "ARM": 80.12}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes
changed `src/vmm/src/vmm_config/` packages implementation to use thiserror::Error instead implements fmt::Display.


## Reason
This PR will fix part of https://github.com/firecracker-microvm/firecracker/issues/3278

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
