### PR TITLE
doc: cpu templates: add info about arm register ids

### DIFF
--- a/docs/cpu_templates/cpu-templates.md
+++ b/docs/cpu_templates/cpu-templates.md
@@ -181,6 +181,9 @@ This CPU templates will do the following with the ARM register `0x603000000013c0
 - will leave bits `0b11111111111111111111111111111111111111111111111111111111111111111111111111110000111111111111000011111111111111111111111111111111`
   intact.
 
+Information on how the ARM register addresses are constructed can be found
+in the [KVM API documentation](https://docs.kernel.org/virt/kvm/api.html#kvm-set-one-reg).
+
 ### Custom CPU templates language schema
 
 The full description of the custom CPU templates language can be found

--- a/docs/cpu_templates/schema.json
+++ b/docs/cpu_templates/schema.json
@@ -73,7 +73,7 @@
                 "type": "object",
                 "properties": {
                     "addr": {
-                        "description": "MSR address/identifier. Must be a string containing an integer.",
+                        "description": "ARM register address/identifier. Must be a string containing an integer. See https://docs.kernel.org/virt/kvm/api.html#kvm-set-one-reg .",
                         "type": "string",
                         "examples": ["0x603000000013c020"]
                     },


### PR DESCRIPTION
## Changes

The link to KVM API is provided to help users
find information on how to build register addresses in a custom CPU template for ARM.

## Reason

It may be difficult for users to know how to choose ARM register addresses.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
~~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
~~- [ ] All added/changed functionality is tested.~~
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
