### PR TITLE
chore(devtool): build_kernel: fix info message

### DIFF
--- a/resources/tests/build_kernel.sh
+++ b/resources/tests/build_kernel.sh
@@ -90,7 +90,9 @@ build_kernel() {
     cp $binary_path $binary_name
 
     popd >/dev/null
-    echo "Kernel binary placed in build/kernel/$binary_name"
+
+    local full_binary_path="$KERNEL_DEST_DIR/$binary_name"
+    echo "Kernel binary placed in ${full_binary_path##$FC_ROOT_DIR/}"
 }
 
 


### PR DESCRIPTION
## Changes

Fix the path in the info message.

Was:
`Kernel binary placed in build/kernel/vmlinux-4.14-x86_64.bin`

Now:
`Kernel binary placed in build/kernel/linux-4.14/vmlinux-4.14-x86_64.bin`

## Reason

The info message says:
```Kernel binary placed in build/kernel/vmlinux-4.14-x86_64.bin```

However the binary is actually located at:
```build/kernel/linux-4.14/vmlinux-4.14-x86_64.bin```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
~~- [ ] Any required documentation changes (code and docs) are included in this PR.~~
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
~~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
