### PR TITLE
ci(gh_release.py): validate version parameter

### DIFF
--- a/tools/gh_release.py
+++ b/tools/gh_release.py
@@ -9,6 +9,7 @@ Assumes all the releases are in the current path.
 """
 
 import argparse
+import re
 import subprocess
 import tarfile
 from pathlib import Path
@@ -84,10 +85,21 @@ def github_release(tag_version, repo, github_token):
     print(f"Draft release created successful. Check it out at {release_url}")
 
 
+def version(version_str: str):
+    """Validate version parameter"""
+    if not re.fullmatch(r"v\d+\.\d+\.\d+", version_str):
+        raise ValueError("version does not match vX.Y.Z")
+    return version_str
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--version", required=True, help="Firecracker version. (v1.2.3)"
+        "--version",
+        required=True,
+        metavar="vX.Y.Z",
+        help="Firecracker version.",
+        type=version,
     )
     parser.add_argument(
         "--repository", required=False, default="firecracker-microvm/firecracker"


### PR DESCRIPTION
The version parameter is vulnerable to command injection. I.e.

    gh_release.py --version '**v1.2.4;id #**'

Validate the version parameter so it's not accepted.

    error: argument --version: invalid version value: '**v1.2.4;id #**'

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
