### PR TITLE
test: fix baseline provider dict structure

### DIFF
--- a/tests/framework/stats/baseline.py
+++ b/tests/framework/stats/baseline.py
@@ -34,4 +34,7 @@ class Provider(ABC):
                 cpu_model = cpu["model"]
                 for baseline, val in cpu["baselines"].items():
                     baselines[instance, cpu_model][baseline] = val
-        return baselines.get((global_props.instance, global_props.cpu_model))
+        return {
+            "baselines": baselines.get((global_props.instance, global_props.cpu_model)),
+            "model": global_props.cpu_model,
+        }


### PR DESCRIPTION
734696ffd93d2cce2201aacf45e67551f1f548e2 slightly changed the structure of the dictionary containing the baselines against which performance test results are compared, causing failures of the tests. I verified this commit by comparing the return value to the what was returned before the above commit.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
