### PR TITLE
feat(aarch64): ability to work with wide registers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a321cabd827642499c77e27314f388dd83a717a5ca716b86476fb947f73ae4"
+checksum = "436246b230532c94ec619332e820e31518dac7943cf848b052e618467a7ede8a"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/src/cpu-template-helper/src/template/dump/aarch64.rs
+++ b/src/cpu-template-helper/src/template/dump/aarch64.rs
@@ -1,6 +1,7 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use vmm::arch::aarch64::regs::RegSize;
 use vmm::cpu_config::aarch64::custom_cpu_template::RegisterModifier;
 use vmm::cpu_config::templates::{CpuConfiguration, CustomCpuTemplate, RegisterValueFilter};
 
@@ -10,7 +11,18 @@ pub fn config_to_template(cpu_config: &CpuConfiguration) -> CustomCpuTemplate {
     let mut reg_modifiers: Vec<RegisterModifier> = cpu_config
         .regs
         .iter()
-        .map(|reg| reg_modifier!(reg.id, reg.value))
+        .map(|reg| match reg.size() {
+            RegSize::U32 => {
+                reg_modifier!(reg.id, u128::from(reg.value::<u32, 4>()))
+            }
+            RegSize::U64 => {
+                reg_modifier!(reg.id, u128::from(reg.value::<u64, 8>()))
+            }
+            RegSize::U128 => {
+                reg_modifier!(reg.id, reg.value::<u128, 16>())
+            }
+            _ => unreachable!("Only 32, 64 and 128 bit wide registers are supported"),
+        })
         .collect();
     reg_modifiers.sort_by_key(|modifier| modifier.addr);
 
@@ -19,41 +31,38 @@ pub fn config_to_template(cpu_config: &CpuConfiguration) -> CustomCpuTemplate {
 
 #[cfg(test)]
 mod tests {
-    use vmm::arch::aarch64::regs::Aarch64Register;
+    use vmm::arch::aarch64::regs::{Aarch64RegisterRef, Aarch64RegisterVec};
 
     use super::*;
 
-    fn build_sample_regs() -> Vec<Aarch64Register> {
-        vec![
-            Aarch64Register {
-                id: 0x0,
-                value: 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
-            },
-            Aarch64Register {
-                id: 0xffff_ffff_ffff_ffff,
-                value: 0x0000_ffff_0000_ffff_0000_ffff_0000_ffff,
-            },
-            Aarch64Register {
-                id: 0x1,
-                value: 0x0000_ffff_0000_ffff_0000_ffff_0000_ffff,
-            },
-        ]
+    // These are used as IDs to satisfy requirenments
+    // of `Aarch64RegisterRef::new`
+    const KVM_REG_SIZE_U32: u64 = 0x0020000000000000;
+    const KVM_REG_SIZE_U64: u64 = 0x0030000000000000;
+    const KVM_REG_SIZE_U128: u64 = 0x0040000000000000;
+
+    fn build_sample_regs() -> Aarch64RegisterVec {
+        let mut v = Aarch64RegisterVec::default();
+        v.push(Aarch64RegisterRef::new(
+            KVM_REG_SIZE_U128,
+            &0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_u128.to_le_bytes(),
+        ));
+        v.push(Aarch64RegisterRef::new(
+            KVM_REG_SIZE_U32,
+            &0x0000_ffff_u32.to_le_bytes(),
+        ));
+        v.push(Aarch64RegisterRef::new(
+            KVM_REG_SIZE_U64,
+            &0x0000_ffff_0000_ffff_u64.to_le_bytes(),
+        ));
+        v
     }
 
     fn build_expected_reg_modifiers() -> Vec<RegisterModifier> {
         vec![
-            reg_modifier!(
-                0x0000_0000_0000_0000,
-                0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff
-            ),
-            reg_modifier!(
-                0x0000_0000_0000_0001,
-                0x0000_ffff_0000_ffff_0000_ffff_0000_ffff
-            ),
-            reg_modifier!(
-                0xffff_ffff_ffff_ffff,
-                0x0000_ffff_0000_ffff_0000_ffff_0000_ffff
-            ),
+            reg_modifier!(KVM_REG_SIZE_U32, 0x0000_ffff),
+            reg_modifier!(KVM_REG_SIZE_U64, 0x0000_ffff_0000_ffff),
+            reg_modifier!(KVM_REG_SIZE_U128, 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff),
         ]
     }
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -14,7 +14,7 @@ bitflags = "2.0.2"
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
 event-manager = "0.3.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
-kvm-ioctls = "0.12.0"
+kvm-ioctls = "0.14.0"
 lazy_static = "1.4.0"
 libc = "0.2.117"
 linux-loader = "0.9.0"

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -9,6 +9,8 @@ pub mod gic;
 pub mod layout;
 /// Logic for configuring aarch64 registers.
 pub mod regs;
+/// Helper methods for VcpuFd.
+pub mod vcpu;
 
 use std::cmp::min;
 use std::collections::HashMap;

--- a/src/vmm/src/arch/aarch64/regs.rs
+++ b/src/vmm/src/arch/aarch64/regs.rs
@@ -5,76 +5,27 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::path::PathBuf;
-
 use kvm_bindings::*;
-use kvm_ioctls::VcpuFd;
-use utils::vm_memory::GuestMemoryMmap;
 use versionize::*;
 use versionize_derive::Versionize;
 
-use super::get_fdt_addr;
-
-/// Struct describing a saved aarch64 register.
-///
-/// Used for interacting with `KVM_GET/SET_ONE_REG`.
-#[derive(Debug, Clone, PartialEq, Eq, Versionize)]
-pub struct Aarch64Register {
-    /// The KVM register ID.
-    ///
-    /// See https://docs.kernel.org/virt/kvm/api.html?highlight=kvm_set_one_reg#kvm-set-one-reg
-    pub id: u64,
-
-    /// The value of the register.
-    ///
-    /// 128 bit wide, as we want to restore the V0-V31 FP SIMD registers,
-    /// which are this wide.
-    pub value: u128,
-}
-
-/// Errors thrown while setting aarch64 registers.
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-pub enum Error {
-    /// Failed to get a register value.
-    #[error("Failed to get register {0}: {1}")]
-    GetOneReg(u64, kvm_ioctls::Error),
-    /// Failed to set a register value.
-    #[error("Failed to set register {0}: {1}")]
-    SetOneReg(u64, kvm_ioctls::Error),
-    /// Failed to get the register list.
-    #[error("Failed to retrieve list of registers: {0}")]
-    GetRegList(kvm_ioctls::Error),
-    /// Failed to get multiprocessor state.
-    #[error("Failed to get multiprocessor state: {0}")]
-    GetMp(kvm_ioctls::Error),
-    /// Failed to Set multiprocessor state.
-    #[error("Failed to set multiprocessor state: {0}")]
-    SetMp(kvm_ioctls::Error),
-    /// A FamStructWrapper operation has failed.
-    #[error("Failed FamStructWrapper operation: {0:?}")]
-    Fam(utils::fam::Error),
-    /// Failed to get midr_el1 from host.
-    #[error("{0}")]
-    GetMidrEl1(String),
-}
-
 #[allow(non_upper_case_globals)]
-// PSR (Processor State Register) bits.
-// Taken from arch/arm64/include/uapi/asm/ptrace.h.
+/// PSR (Processor State Register) bits.
+/// Taken from arch/arm64/include/uapi/asm/ptrace.h.
 const PSR_MODE_EL1h: u64 = 0x0000_0005;
 const PSR_F_BIT: u64 = 0x0000_0040;
 const PSR_I_BIT: u64 = 0x0000_0080;
 const PSR_A_BIT: u64 = 0x0000_0100;
 const PSR_D_BIT: u64 = 0x0000_0200;
-// Taken from arch/arm64/kvm/inject_fault.c.
-const PSTATE_FAULT_BITS_64: u64 = PSR_MODE_EL1h | PSR_A_BIT | PSR_F_BIT | PSR_I_BIT | PSR_D_BIT;
+/// Taken from arch/arm64/kvm/inject_fault.c.
+pub const PSTATE_FAULT_BITS_64: u64 = PSR_MODE_EL1h | PSR_A_BIT | PSR_F_BIT | PSR_I_BIT | PSR_D_BIT;
 
 // Following are macros that help with getting the ID of a aarch64 core register.
 // The core register are represented by the user_pt_regs structure. Look for it in
 // arch/arm64/include/uapi/asm/ptrace.h.
 
-// Gets offset of a member (`field`) within a struct (`container`).
-// Same as bindgen offset tests.
+/// Gets offset of a member (`field`) within a struct (`container`).
+/// Same as bindgen offset tests.
 macro_rules! offset__of {
     ($container:ty, $field:ident) => {
         // SAFETY: The implementation closely matches that of the memoffset crate,
@@ -86,6 +37,7 @@ macro_rules! offset__of {
         }
     };
 }
+pub(crate) use offset__of;
 
 /// Gets a core id.
 macro_rules! arm64_core_reg_id {
@@ -119,10 +71,11 @@ macro_rules! arm64_core_reg_id {
             | (($offset / std::mem::size_of::<u32>()) as u64)
     };
 }
+pub(crate) use arm64_core_reg_id;
 
-// This macro computes the ID of a specific ARM64 system register similar to how
-// the kernel C macro does.
-// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/uapi/asm/kvm.h#L203
+/// This macro computes the ID of a specific ARM64 system register similar to how
+/// the kernel C macro does.
+/// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/uapi/asm/kvm.h#L203
 macro_rules! arm64_sys_reg {
     ($name: tt, $op0: tt, $op1: tt, $crn: tt, $crm: tt, $op2: tt) => {
         /// System register constant
@@ -157,265 +110,699 @@ arm64_sys_reg!(ID_AA64MMFR2_EL1, 3, 0, 0, 7, 2);
 // EL0 Virtual Timer Registers
 arm64_sys_reg!(KVM_REG_ARM_TIMER_CNT, 3, 3, 14, 3, 2);
 
-/// Extract the Manufacturer ID from a VCPU state's registers.
-/// The ID is found between bits 24-31 of MIDR_EL1 register.
-///
-/// # Arguments
-///
-/// * `state` - Array slice of [`Aarch64Register`] structures, representing the registers of a VCPU
-///   state.
-pub fn get_manufacturer_id_from_state(regs: &[Aarch64Register]) -> Result<u32, Error> {
-    let midr_el1 = regs.iter().find(|reg| reg.id == MIDR_EL1);
-    match midr_el1 {
-        Some(register) => Ok(register.value as u32 >> 24),
-        None => Err(Error::GetMidrEl1(
-            "Failed to find MIDR_EL1 in vCPU state!".to_string(),
-        )),
+/// Different aarch64 registers sizes
+pub enum RegSize {
+    /// 8 bit register
+    U8,
+    /// 16 bit register
+    U16,
+    /// 32 bit register
+    U32,
+    /// 64 bit register
+    U64,
+    /// 128 bit register
+    U128,
+    /// 256 bit register
+    U256,
+    /// 512 bit register
+    U512,
+    /// 1024 bit register
+    U1024,
+    /// 2048 bit register
+    U2048,
+}
+
+impl From<u64> for RegSize {
+    fn from(value: u64) -> Self {
+        match value {
+            1 => RegSize::U8,
+            2 => RegSize::U16,
+            4 => RegSize::U32,
+            8 => RegSize::U64,
+            16 => RegSize::U128,
+            32 => RegSize::U256,
+            64 => RegSize::U512,
+            128 => RegSize::U1024,
+            256 => RegSize::U2048,
+            _ => unreachable!("Registers bigger then 2048 bits are not supported"),
+        }
     }
 }
 
-/// Extract the Manufacturer ID from the host.
-/// The ID is found between bits 24-31 of MIDR_EL1 register.
-pub fn get_manufacturer_id_from_host() -> Result<u32, Error> {
-    let midr_el1_path =
-        &PathBuf::from("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1".to_string());
-
-    let midr_el1 = std::fs::read_to_string(midr_el1_path).map_err(|err| {
-        Error::GetMidrEl1(format!("Failed to get MIDR_EL1 from host path: {err}"))
-    })?;
-    let midr_el1_trimmed = midr_el1.trim_end().trim_start_matches("0x");
-    let manufacturer_id = u32::from_str_radix(midr_el1_trimmed, 16)
-        .map_err(|err| Error::GetMidrEl1(format!("Invalid MIDR_EL1 found on host: {err}",)))?;
-
-    Ok(manufacturer_id >> 24)
-}
-
-/// Configure relevant boot registers for a given vCPU.
-///
-/// # Arguments
-///
-/// * `cpu_id` - Index of current vcpu.
-/// * `boot_ip` - Starting instruction pointer.
-/// * `mem` - Reserved DRAM for current VM.
-pub fn setup_boot_regs(
-    vcpufd: &VcpuFd,
-    cpu_id: u8,
-    boot_ip: u64,
-    mem: &GuestMemoryMmap,
-) -> Result<(), Error> {
-    let kreg_off = offset__of!(kvm_regs, regs);
-
-    // Get the register index of the PSTATE (Processor State) register.
-    let pstate = offset__of!(user_pt_regs, pstate) + kreg_off;
-    let id = arm64_core_reg_id!(KVM_REG_SIZE_U64, pstate);
-    vcpufd
-        .set_one_reg(id, PSTATE_FAULT_BITS_64.into())
-        .map_err(|err| Error::SetOneReg(id, err))?;
-
-    // Other vCPUs are powered off initially awaiting PSCI wakeup.
-    if cpu_id == 0 {
-        // Setting the PC (Processor Counter) to the current program address (kernel address).
-        let pc = offset__of!(user_pt_regs, pc) + kreg_off;
-        let id = arm64_core_reg_id!(KVM_REG_SIZE_U64, pc);
-        vcpufd
-            .set_one_reg(id, boot_ip.into())
-            .map_err(|err| Error::SetOneReg(id, err))?;
-
-        // Last mandatory thing to set -> the address pointing to the FDT (also called DTB).
-        // "The device tree blob (dtb) must be placed on an 8-byte boundary and must
-        // not exceed 2 megabytes in size." -> https://www.kernel.org/doc/Documentation/arm64/booting.txt.
-        // We are choosing to place it the end of DRAM. See `get_fdt_addr`.
-        let regs0 = offset__of!(user_pt_regs, regs) + kreg_off;
-        let id = arm64_core_reg_id!(KVM_REG_SIZE_U64, regs0);
-        vcpufd
-            .set_one_reg(id, get_fdt_addr(mem).into())
-            .map_err(|err| Error::SetOneReg(id, err))?;
-    }
-    Ok(())
-}
-
-/// Read the MPIDR - Multiprocessor Affinity Register.
-pub fn get_mpidr(vcpufd: &VcpuFd) -> Result<u64, Error> {
-    match vcpufd.get_one_reg(MPIDR_EL1) {
-        Err(err) => Err(Error::GetOneReg(MPIDR_EL1, err)),
-        // MPIDR register is 64 bit wide on aarch64, this expect cannot fail
-        // on supported architectures
-        Ok(val) => Ok(val.try_into().expect("MPIDR register to be 64 bit")),
+impl From<RegSize> for u64 {
+    fn from(value: RegSize) -> Self {
+        match value {
+            RegSize::U8 => 1,
+            RegSize::U16 => 2,
+            RegSize::U32 => 4,
+            RegSize::U64 => 8,
+            RegSize::U128 => 16,
+            RegSize::U256 => 32,
+            RegSize::U512 => 64,
+            RegSize::U1024 => 128,
+            RegSize::U2048 => 256,
+        }
     }
 }
 
-/// Saves the states of the system registers into `state`.
-///
-/// # Arguments
-///
-/// * `regs` - Input/Output vector of registers.
-pub fn get_all_registers(vcpufd: &VcpuFd, state: &mut Vec<Aarch64Register>) -> Result<(), Error> {
-    get_registers(vcpufd, &get_all_registers_ids(vcpufd)?, state)
+/// Returns register size in bytes
+pub fn reg_size(reg_id: u64) -> u64 {
+    2_u64.pow(((reg_id & KVM_REG_SIZE_MASK) >> KVM_REG_SIZE_SHIFT) as u32)
 }
 
-/// Saves states of registers into `state`.
-///
-/// # Arguments
-///
-/// * `ids` - Slice of registers ids to save.
-/// * `regs` - Input/Output vector of registers.
-pub fn get_registers(
-    vcpufd: &VcpuFd,
-    ids: &[u64],
-    regs: &mut Vec<Aarch64Register>,
-) -> Result<(), Error> {
-    for id in ids.iter() {
-        regs.push(Aarch64Register {
-            id: *id,
-            value: vcpufd
-                .get_one_reg(*id)
-                .map_err(|e| Error::GetOneReg(*id, e))?,
-        });
+/// Storage for aarch64 registers with different sizes.
+/// For public usage it is wrapped into `Aarch64RegisterVec`
+/// which ensures correctness after deserialization.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Versionize)]
+struct Aarch64RegisterVecInner {
+    ids: Vec<u64>,
+    data: Vec<u8>,
+}
+
+impl Aarch64RegisterVecInner {
+    /// Returns the number of elements in the vector.
+    fn len(&self) -> usize {
+        self.ids.len()
     }
 
-    Ok(())
-}
-
-/// Returns all registers ids, including core and system
-pub fn get_all_registers_ids(vcpufd: &VcpuFd) -> Result<Vec<u64>, Error> {
-    // Call KVM_GET_REG_LIST to get all registers available to the guest. For ArmV8 there are
-    // less than 500 registers.
-    let mut reg_list = RegList::new(500).map_err(Error::Fam)?;
-    vcpufd
-        .get_reg_list(&mut reg_list)
-        .map_err(Error::GetRegList)?;
-    Ok(reg_list.as_slice().to_vec())
-}
-
-/// Set the state of the system registers.
-///
-/// # Arguments
-///
-/// * `regs` - Slice of registers to be set.
-pub fn set_registers(vcpufd: &VcpuFd, regs: &[Aarch64Register]) -> Result<(), Error> {
-    for reg in regs {
-        vcpufd
-            .set_one_reg(reg.id, reg.value)
-            .map_err(|e| Error::SetOneReg(reg.id, e))?;
+    /// Returns true if the vector contains no elements.
+    fn is_empty(&self) -> bool {
+        self.ids.is_empty()
     }
-    Ok(())
+
+    /// Appends a register to the vector, copying register data.
+    fn push(&mut self, reg: Aarch64RegisterRef<'_>) {
+        self.ids.push(reg.id);
+        self.data.extend_from_slice(reg.data);
+    }
+
+    /// Returns an iterator over stored registers.
+    fn iter(&self) -> impl Iterator<Item = Aarch64RegisterRef> {
+        Aarch64RegisterVecIterator {
+            index: 0,
+            offset: 0,
+            ids: &self.ids,
+            data: &self.data,
+        }
+    }
+
+    /// Returns an iterator over stored registers that allows register modifications.
+    fn iter_mut(&mut self) -> impl Iterator<Item = Aarch64RegisterRefMut> {
+        Aarch64RegisterVecIteratorMut {
+            index: 0,
+            offset: 0,
+            ids: &self.ids,
+            data: &mut self.data,
+        }
+    }
 }
 
-/// Get the multistate processor.
-///
-/// # Arguments
-///
-/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
-pub fn get_mpstate(vcpufd: &VcpuFd) -> Result<kvm_mp_state, Error> {
-    vcpufd.get_mp_state().map_err(Error::GetMp)
+/// Wrapper type around `Aarch64RegisterVecInner`.
+/// Needed to ensure correctness of inner state after
+/// deserialization.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct Aarch64RegisterVec {
+    inner: Aarch64RegisterVecInner,
 }
 
-/// Set the state of the system registers.
-///
-/// # Arguments
-///
-/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
-/// * `state` - Structure for returning the state of the system registers.
-pub fn set_mpstate(vcpufd: &VcpuFd, state: kvm_mp_state) -> Result<(), Error> {
-    vcpufd.set_mp_state(state).map_err(Error::SetMp)
+impl Aarch64RegisterVec {
+    /// Returns the number of elements in the vector.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns true if the vector contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Appends a register to the vector, copying register data.
+    pub fn push(&mut self, reg: Aarch64RegisterRef<'_>) {
+        self.inner.push(reg);
+    }
+
+    /// Returns an iterator over stored registers.
+    pub fn iter(&self) -> impl Iterator<Item = Aarch64RegisterRef> {
+        self.inner.iter()
+    }
+
+    /// Returns an iterator over stored registers that allows register modifications.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = Aarch64RegisterRefMut> {
+        self.inner.iter_mut()
+    }
 }
+
+impl Versionize for Aarch64RegisterVec {
+    fn serialize<W: std::io::Write>(
+        &self,
+        writer: &mut W,
+        version_map: &VersionMap,
+        target_version: u16,
+    ) -> VersionizeResult<()> {
+        self.inner.serialize(writer, version_map, target_version)
+    }
+
+    fn deserialize<R: std::io::Read>(
+        reader: &mut R,
+        version_map: &VersionMap,
+        source_version: u16,
+    ) -> VersionizeResult<Self>
+    where
+        Self: Sized,
+    {
+        let inner = Aarch64RegisterVecInner::deserialize(reader, version_map, source_version)?;
+        let total_size: u64 = inner.ids.iter().map(|id| reg_size(*id)).sum();
+        if total_size as usize != inner.data.len() {
+            Err(VersionizeError::Deserialize(
+                "Failed to deserialize aarch64 registers. Sum of registers sizes is not equal to \
+                 registers data length"
+                    .to_string(),
+            ))
+        } else {
+            Ok(Self { inner })
+        }
+    }
+
+    fn version() -> u16 {
+        Aarch64RegisterVecInner::version()
+    }
+}
+
+/// Iterator over `Aarch64RegisterVec`.
+#[derive(Debug)]
+pub struct Aarch64RegisterVecIterator<'a> {
+    index: usize,
+    offset: usize,
+    ids: &'a [u64],
+    data: &'a [u8],
+}
+
+impl<'a> Iterator for Aarch64RegisterVecIterator<'a> {
+    type Item = Aarch64RegisterRef<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.ids.len() {
+            let id = self.ids[self.index];
+            let reg_size = reg_size(id) as usize;
+            let reg_ref = Aarch64RegisterRef {
+                id,
+                data: &self.data[self.offset..self.offset + reg_size],
+            };
+            self.index += 1;
+            self.offset += reg_size;
+            Some(reg_ref)
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterator over `Aarch64RegisterVec` with mutable values.
+#[derive(Debug)]
+pub struct Aarch64RegisterVecIteratorMut<'a> {
+    index: usize,
+    offset: usize,
+    ids: &'a [u64],
+    data: &'a mut [u8],
+}
+
+impl<'a> Iterator for Aarch64RegisterVecIteratorMut<'a> {
+    type Item = Aarch64RegisterRefMut<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.ids.len() {
+            let id = self.ids[self.index];
+            let reg_size = reg_size(id) as usize;
+
+            let data = std::mem::take(&mut self.data);
+            let (head, tail) = data.split_at_mut(reg_size);
+
+            self.index += 1;
+            self.offset += reg_size;
+            self.data = tail;
+            Some(Aarch64RegisterRefMut { id, data: head })
+        } else {
+            None
+        }
+    }
+}
+
+/// Reference to the aarch64 register.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Aarch64RegisterRef<'a> {
+    /// ID of the register
+    pub id: u64,
+    data: &'a [u8],
+}
+
+impl<'a> Aarch64RegisterRef<'a> {
+    /// Creates new register reference with provided id and data.
+    /// Register size in `id` should be equal to the
+    /// length of the slice. Otherwise this method
+    /// will panic.
+    pub fn new(id: u64, data: &'a [u8]) -> Self {
+        assert_eq!(
+            reg_size(id) as usize,
+            data.len(),
+            "Attempt to create a register reference with incompatible id and data length"
+        );
+
+        Self { id, data }
+    }
+
+    /// Returns register size in bytes
+    pub fn size(&self) -> RegSize {
+        reg_size(self.id).into()
+    }
+
+    /// Returns a register value.
+    /// Type `T` must be of the same length as an
+    /// underlying data slice. Otherwise this method
+    /// will panic.
+    pub fn value<T: Aarch64RegisterData<N>, const N: usize>(&self) -> T {
+        T::from_slice(self.data)
+    }
+
+    /// Returns register data as a byte slice
+    pub fn as_slice(&self) -> &[u8] {
+        self.data
+    }
+}
+
+/// Reference to the aarch64 register.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Aarch64RegisterRefMut<'a> {
+    /// ID of the register
+    pub id: u64,
+    data: &'a mut [u8],
+}
+
+impl<'a> Aarch64RegisterRefMut<'a> {
+    /// Creates new register reference with provided id and data.
+    /// Register size in `id` should be equal to the
+    /// length of the slice. Otherwise this method
+    /// will panic.
+    pub fn new(id: u64, data: &'a mut [u8]) -> Self {
+        assert_eq!(
+            reg_size(id) as usize,
+            data.len(),
+            "Attempt to create a register reference with incompatible id and data length"
+        );
+
+        Self { id, data }
+    }
+
+    /// Returns register size in bytes
+    pub fn size(&self) -> RegSize {
+        reg_size(self.id).into()
+    }
+
+    /// Returns a register value.
+    /// Type `T` must be of the same length as an
+    /// underlying data slice. Otherwise this method
+    /// will panic.
+    pub fn value<T: Aarch64RegisterData<N>, const N: usize>(&self) -> T {
+        T::from_slice(self.data)
+    }
+
+    /// Sets the register value.
+    /// Type `T` must be of the same length as an
+    /// underlying data slice. Otherwise this method
+    /// will panic.
+    pub fn set_value<T: Aarch64RegisterData<N>, const N: usize>(&mut self, value: T) {
+        self.data.copy_from_slice(&value.to_bytes())
+    }
+}
+
+/// Old definition of a struct describing an aarch64 register.
+/// This type is only used to have a backward compatibility
+/// with old snapshot versions and should not be used anywhere
+/// else.
+#[derive(Debug, Clone, Copy, Versionize)]
+pub struct Aarch64RegisterOld {
+    /// ID of the register.
+    pub id: u64,
+    /// Register data.
+    pub data: u128,
+}
+
+impl<'a> TryFrom<Aarch64RegisterRef<'a>> for Aarch64RegisterOld {
+    type Error = &'static str;
+
+    fn try_from(value: Aarch64RegisterRef) -> Result<Self, Self::Error> {
+        let reg = match value.size() {
+            RegSize::U32 => Self {
+                id: value.id,
+                data: u128::from(value.value::<u32, 4>()),
+            },
+            RegSize::U64 => Self {
+                id: value.id,
+                data: u128::from(value.value::<u64, 8>()),
+            },
+            RegSize::U128 => Self {
+                id: value.id,
+                data: value.value::<u128, 16>(),
+            },
+            _ => return Err("Only 32, 64 and 128 bit wide registers are supported"),
+        };
+        Ok(reg)
+    }
+}
+
+impl<'a> TryFrom<&Aarch64RegisterOld> for Aarch64RegisterRef<'a> {
+    type Error = &'static str;
+
+    fn try_from(value: &Aarch64RegisterOld) -> Result<Self, Self::Error> {
+        // # Safety:
+        // `self.data` is a valid memory and slice size is valid for this type.
+        let data_ref = unsafe {
+            std::slice::from_raw_parts(
+                (&value.data as *const u128).cast::<u8>(),
+                std::mem::size_of::<u128>(),
+            )
+        };
+        match RegSize::from(reg_size(value.id)) {
+            RegSize::U32 => Ok(Self::new(value.id, &data_ref[..std::mem::size_of::<u32>()])),
+            RegSize::U64 => Ok(Self::new(value.id, &data_ref[..std::mem::size_of::<u64>()])),
+            RegSize::U128 => Ok(Self::new(value.id, data_ref)),
+            _ => Err("Only 32, 64 and 128 bit wide registers are supported"),
+        }
+    }
+}
+
+/// Trait for data types that can represent aarch64
+/// register data.
+pub trait Aarch64RegisterData<const N: usize> {
+    /// Create data type from slice
+    fn from_slice(slice: &[u8]) -> Self;
+    /// Convert data type to array of bytes
+    fn to_bytes(&self) -> [u8; N];
+}
+
+macro_rules! reg_data {
+    ($t:ty, $bytes: expr) => {
+        impl Aarch64RegisterData<$bytes> for $t {
+            fn from_slice(slice: &[u8]) -> Self {
+                let mut bytes = [0_u8; $bytes];
+                bytes.copy_from_slice(slice);
+                <$t>::from_le_bytes(bytes)
+            }
+
+            fn to_bytes(&self) -> [u8; $bytes] {
+                self.to_le_bytes()
+            }
+        }
+    };
+}
+
+macro_rules! reg_data_array {
+    ($t:ty, $bytes: expr) => {
+        impl Aarch64RegisterData<$bytes> for $t {
+            fn from_slice(slice: &[u8]) -> Self {
+                let mut bytes = [0_u8; $bytes];
+                bytes.copy_from_slice(slice);
+                bytes
+            }
+
+            fn to_bytes(&self) -> [u8; $bytes] {
+                *self
+            }
+        }
+    };
+}
+
+reg_data!(u8, 1);
+reg_data!(u16, 2);
+reg_data!(u32, 4);
+reg_data!(u64, 8);
+reg_data!(u128, 16);
+// 256
+reg_data_array!([u8; 32], 32);
+// 512
+reg_data_array!([u8; 64], 64);
+// 1024
+reg_data_array!([u8; 128], 128);
+// 2048
+reg_data_array!([u8; 256], 256);
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::undocumented_unsafe_blocks)]
-    use kvm_ioctls::Kvm;
-
     use super::*;
-    use crate::arch::aarch64::{arch_memory_regions, layout};
 
     #[test]
-    fn test_setup_regs() {
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
-        let vcpu = vm.create_vcpu(0).unwrap();
-        let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = utils::vm_memory::test_utils::create_anon_guest_memory(&regions, false)
-            .expect("Cannot initialize memory");
-
-        let res = setup_boot_regs(&vcpu, 0, 0x0, &mem);
-        assert_eq!(
-            res.unwrap_err(),
-            Error::SetOneReg(6931039826524241986, kvm_ioctls::Error::new(8))
-        );
-
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
-        vm.get_preferred_target(&mut kvi).unwrap();
-        vcpu.vcpu_init(&kvi).unwrap();
-
-        assert!(setup_boot_regs(&vcpu, 0, 0x0, &mem).is_ok());
-    }
-    #[test]
-    fn test_read_mpidr() {
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
-        let vcpu = vm.create_vcpu(0).unwrap();
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
-        vm.get_preferred_target(&mut kvi).unwrap();
-
-        // Must fail when vcpu is not initialized yet.
-        let res = get_mpidr(&vcpu);
-        assert_eq!(
-            res.unwrap_err(),
-            Error::GetOneReg(MPIDR_EL1, kvm_ioctls::Error::new(8))
-        );
-
-        vcpu.vcpu_init(&kvi).unwrap();
-        assert_eq!(get_mpidr(&vcpu).unwrap(), 0x8000_0000);
+    fn test_reg_size() {
+        assert_eq!(reg_size(KVM_REG_SIZE_U32), 4);
+        // ID_AA64PFR0_EL1 is 64 bit register
+        assert_eq!(reg_size(ID_AA64PFR0_EL1), 8);
     }
 
     #[test]
-    fn test_get_set_regs() {
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
-        let vcpu = vm.create_vcpu(0).unwrap();
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
-        vm.get_preferred_target(&mut kvi).unwrap();
+    fn test_aarch64_register_vec_serde() {
+        let mut v = Aarch64RegisterVec::default();
 
-        // Must fail when vcpu is not initialized yet.
-        let mut regs = Vec::new();
-        let res = get_all_registers(&vcpu, &mut regs);
-        assert_eq!(
-            res.unwrap_err(),
-            Error::GetRegList(kvm_ioctls::Error::new(8))
-        );
+        let reg1_bytes = 1_u8.to_le_bytes();
+        let reg1 = Aarch64RegisterRef::new(u64::from(KVM_REG_SIZE_U8), &reg1_bytes);
+        let reg2_bytes = 2_u16.to_le_bytes();
+        let reg2 = Aarch64RegisterRef::new(KVM_REG_SIZE_U16, &reg2_bytes);
 
-        vcpu.vcpu_init(&kvi).unwrap();
-        get_all_registers(&vcpu, &mut regs).unwrap();
+        v.push(reg1);
+        v.push(reg2);
 
-        set_registers(&vcpu, &regs).unwrap();
-        let off = offset__of!(user_pt_regs, pstate);
-        let id = arm64_core_reg_id!(KVM_REG_SIZE_U64, off);
-        let pstate = vcpu
-            .get_one_reg(id)
-            .expect("Failed to call kvm get one reg");
-        assert!(regs.contains(&Aarch64Register { id, value: pstate }));
+        let mut buf = vec![0; 10000];
+        let version_map = VersionMap::new();
+
+        assert!(v
+            .serialize(&mut buf.as_mut_slice(), &version_map, 1)
+            .is_ok());
+        let restored =
+            <Aarch64RegisterVec as Versionize>::deserialize(&mut buf.as_slice(), &version_map, 1)
+                .unwrap();
+
+        for (old, new) in v.iter().zip(restored.iter()) {
+            assert_eq!(old, new);
+        }
     }
 
     #[test]
-    fn test_mpstate() {
-        use std::os::unix::io::AsRawFd;
+    fn test_aarch64_register_vec_serde_invalid() {
+        let mut v = Aarch64RegisterVec::default();
 
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
-        let vcpu = vm.create_vcpu(0).unwrap();
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
-        vm.get_preferred_target(&mut kvi).unwrap();
+        let reg1_bytes = 1_u8.to_le_bytes();
+        // Creating invalid register with incompatible ID and reg size.
+        let reg1 = Aarch64RegisterRef {
+            id: KVM_REG_SIZE_U16,
+            data: &reg1_bytes,
+        };
+        let reg2_bytes = 2_u16.to_le_bytes();
+        let reg2 = Aarch64RegisterRef::new(KVM_REG_SIZE_U16, &reg2_bytes);
 
-        let res = get_mpstate(&vcpu);
-        assert!(res.is_ok());
-        assert!(set_mpstate(&vcpu, res.unwrap()).is_ok());
+        v.push(reg1);
+        v.push(reg2);
 
-        unsafe { libc::close(vcpu.as_raw_fd()) };
+        let mut buf = vec![0; 10000];
+        let version_map = VersionMap::new();
 
-        let res = get_mpstate(&vcpu);
-        assert_eq!(res.unwrap_err(), Error::GetMp(kvm_ioctls::Error::new(9)));
+        assert!(v
+            .serialize(&mut buf.as_mut_slice(), &version_map, 1)
+            .is_ok());
 
-        let res = set_mpstate(&vcpu, kvm_mp_state::default());
-        assert_eq!(res.unwrap_err(), Error::SetMp(kvm_ioctls::Error::new(9)));
+        // Total size of registers according IDs are 16 + 16 = 32,
+        // but actual data size is 8 + 16 = 24.
+        assert!(<Aarch64RegisterVec as Versionize>::deserialize(
+            &mut buf.as_slice(),
+            &version_map,
+            1
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_aarch64_register_vec_inner() {
+        let mut v = Aarch64RegisterVecInner::default();
+
+        let reg1_bytes = 1_u8.to_le_bytes();
+        let reg1 = Aarch64RegisterRef::new(u64::from(KVM_REG_SIZE_U8), &reg1_bytes);
+        let reg2_bytes = 2_u16.to_le_bytes();
+        let reg2 = Aarch64RegisterRef::new(KVM_REG_SIZE_U16, &reg2_bytes);
+        let reg3_bytes = 3_u32.to_le_bytes();
+        let reg3 = Aarch64RegisterRef::new(KVM_REG_SIZE_U32, &reg3_bytes);
+        let reg4_bytes = 4_u64.to_le_bytes();
+        let reg4 = Aarch64RegisterRef::new(KVM_REG_SIZE_U64, &reg4_bytes);
+        let reg5_bytes = 5_u128.to_le_bytes();
+        let reg5 = Aarch64RegisterRef::new(KVM_REG_SIZE_U128, &reg5_bytes);
+        let reg6 = Aarch64RegisterRef::new(KVM_REG_SIZE_U256, &[6; 32]);
+        let reg7 = Aarch64RegisterRef::new(KVM_REG_SIZE_U512, &[7; 64]);
+        let reg8 = Aarch64RegisterRef::new(KVM_REG_SIZE_U1024, &[8; 128]);
+        let reg9 = Aarch64RegisterRef::new(KVM_REG_SIZE_U2048, &[9; 256]);
+
+        v.push(reg1);
+        v.push(reg2);
+        v.push(reg3);
+        v.push(reg4);
+        v.push(reg5);
+        v.push(reg6);
+        v.push(reg7);
+        v.push(reg8);
+        v.push(reg9);
+
+        assert!(!v.is_empty());
+        assert_eq!(v.len(), 9);
+
+        // Test iter
+        {
+            macro_rules! test_iter {
+                ($iter:expr, $size: expr, $t:ty, $bytes:expr, $value:expr) => {
+                    let reg_ref = $iter.next().unwrap();
+                    assert_eq!(reg_ref.id, u64::from($size));
+                    assert_eq!(reg_ref.value::<$t, $bytes>(), $value);
+                };
+            }
+
+            let mut regs_iter = v.iter();
+
+            test_iter!(regs_iter, KVM_REG_SIZE_U8, u8, 1, 1);
+            test_iter!(regs_iter, KVM_REG_SIZE_U16, u16, 2, 2);
+            test_iter!(regs_iter, KVM_REG_SIZE_U32, u32, 4, 3);
+            test_iter!(regs_iter, KVM_REG_SIZE_U64, u64, 8, 4);
+            test_iter!(regs_iter, KVM_REG_SIZE_U128, u128, 16, 5);
+            test_iter!(regs_iter, KVM_REG_SIZE_U256, [u8; 32], 32, [6; 32]);
+            test_iter!(regs_iter, KVM_REG_SIZE_U512, [u8; 64], 64, [7; 64]);
+            test_iter!(regs_iter, KVM_REG_SIZE_U1024, [u8; 128], 128, [8; 128]);
+            test_iter!(regs_iter, KVM_REG_SIZE_U2048, [u8; 256], 256, [9; 256]);
+
+            assert!(regs_iter.next().is_none());
+        }
+
+        // Test iter mut
+        {
+            {
+                macro_rules! update_value {
+                    ($iter:expr, $t:ty, $bytes:expr) => {
+                        let mut reg_ref = $iter.next().unwrap();
+                        reg_ref.set_value(reg_ref.value::<$t, $bytes>() - 1);
+                    };
+                }
+
+                let mut regs_iter_mut = v.iter_mut();
+
+                update_value!(regs_iter_mut, u8, 1);
+                update_value!(regs_iter_mut, u16, 2);
+                update_value!(regs_iter_mut, u32, 4);
+                update_value!(regs_iter_mut, u64, 8);
+                update_value!(regs_iter_mut, u128, 16);
+            }
+
+            {
+                macro_rules! test_iter {
+                    ($iter:expr, $t:ty, $bytes:expr, $value:expr) => {
+                        let reg_ref = $iter.next().unwrap();
+                        assert_eq!(reg_ref.value::<$t, $bytes>(), $value);
+                    };
+                }
+
+                let mut regs_iter = v.iter();
+
+                test_iter!(regs_iter, u8, 1, 0);
+                test_iter!(regs_iter, u16, 2, 1);
+                test_iter!(regs_iter, u32, 4, 2);
+                test_iter!(regs_iter, u64, 8, 3);
+                test_iter!(regs_iter, u128, 16, 4);
+            }
+        }
+    }
+
+    #[test]
+    fn test_reg_ref() {
+        let bytes = 69_u64.to_le_bytes();
+        let reg_ref = Aarch64RegisterRef::new(KVM_REG_SIZE_U64, &bytes);
+
+        assert_eq!(u64::from(reg_ref.size()), 8);
+        assert_eq!(reg_ref.value::<u64, 8>(), 69);
+    }
+
+    /// Should panic because ID has different size from a slice length.
+    /// - Size in ID: 128
+    /// - Length of slice: 1
+    #[test]
+    #[should_panic]
+    fn test_reg_ref_new_must_panic() {
+        let _ = Aarch64RegisterRef::new(KVM_REG_SIZE_U128, &[0; 1]);
+    }
+
+    /// Should panic because of incorrect cast to value.
+    /// - Reference contains 64 bit register
+    /// - Casting to 128 bits.
+    #[test]
+    #[should_panic]
+    fn test_reg_ref_value_must_panic() {
+        let bytes = 69_u64.to_le_bytes();
+        let reg_ref = Aarch64RegisterRef::new(KVM_REG_SIZE_U64, &bytes);
+        assert_eq!(reg_ref.value::<u128, 16>(), 69);
+    }
+
+    #[test]
+    fn test_reg_ref_mut() {
+        let mut bytes = 69_u64.to_le_bytes();
+        let mut reg_ref = Aarch64RegisterRefMut::new(KVM_REG_SIZE_U64, &mut bytes);
+
+        assert_eq!(u64::from(reg_ref.size()), 8);
+        assert_eq!(reg_ref.value::<u64, 8>(), 69);
+        reg_ref.set_value(reg_ref.value::<u64, 8>() + 1);
+        assert_eq!(reg_ref.value::<u64, 8>(), 70);
+    }
+
+    /// Should panic because ID has different size from a slice length.
+    /// - Size in ID: 128
+    /// - Length of slice: 1
+    #[test]
+    #[should_panic]
+    fn test_reg_ref_mut_new_must_panic() {
+        let _ = Aarch64RegisterRefMut::new(KVM_REG_SIZE_U128, &mut [0; 1]);
+    }
+
+    /// Should panic because of incorrect cast to value.
+    /// - Reference contains 64 bit register
+    /// - Casting to 128 bits.
+    #[test]
+    #[should_panic]
+    fn test_reg_ref_mut_must_panic() {
+        let mut bytes = 69_u64.to_le_bytes();
+        let reg_ref = Aarch64RegisterRefMut::new(KVM_REG_SIZE_U64, &mut bytes);
+        assert_eq!(reg_ref.value::<u128, 16>(), 69);
+    }
+
+    #[test]
+    fn test_old_reg_to_reg_ref() {
+        let old_reg = Aarch64RegisterOld {
+            id: KVM_REG_SIZE_U64,
+            data: 69,
+        };
+
+        let reg_ref: Aarch64RegisterRef = (&old_reg).try_into().unwrap();
+        assert_eq!(old_reg.id, reg_ref.id);
+        assert_eq!(old_reg.data as u64, reg_ref.value::<u64, 8>());
+
+        let old_reg = Aarch64RegisterOld {
+            id: KVM_REG_SIZE_U256,
+            data: 69,
+        };
+
+        let reg_ref: Result<Aarch64RegisterRef, _> = (&old_reg).try_into();
+        assert!(reg_ref.is_err());
+    }
+
+    #[test]
+    fn test_reg_ref_to_old_reg() {
+        let reg_bytes = 69_u64.to_le_bytes();
+        let reg_ref = Aarch64RegisterRef::new(KVM_REG_SIZE_U64, &reg_bytes);
+
+        let reg: Aarch64RegisterOld = reg_ref.try_into().unwrap();
+        assert_eq!(reg.id, reg_ref.id);
+        assert_eq!(reg.data as u64, reg_ref.value::<u64, 8>());
+
+        let reg_ref = Aarch64RegisterRef::new(KVM_REG_SIZE_U256, &[0_u8; 32]);
+
+        let reg: Result<Aarch64RegisterOld, _> = reg_ref.try_into();
+        assert!(reg.is_err());
     }
 }

--- a/src/vmm/src/arch/aarch64/vcpu.rs
+++ b/src/vmm/src/arch/aarch64/vcpu.rs
@@ -1,0 +1,290 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::path::PathBuf;
+
+use kvm_bindings::*;
+use kvm_ioctls::VcpuFd;
+use utils::vm_memory::GuestMemoryMmap;
+
+use super::get_fdt_addr;
+use super::regs::*;
+
+/// Errors thrown while setting aarch64 registers.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum Error {
+    /// Failed to get a register value.
+    #[error("Failed to get register {0}: {1}")]
+    GetOneReg(u64, kvm_ioctls::Error),
+    /// Failed to set a register value.
+    #[error("Failed to set register {0}: {1}")]
+    SetOneReg(u64, kvm_ioctls::Error),
+    /// Failed to get the register list.
+    #[error("Failed to retrieve list of registers: {0}")]
+    GetRegList(kvm_ioctls::Error),
+    /// Failed to get multiprocessor state.
+    #[error("Failed to get multiprocessor state: {0}")]
+    GetMp(kvm_ioctls::Error),
+    /// Failed to Set multiprocessor state.
+    #[error("Failed to set multiprocessor state: {0}")]
+    SetMp(kvm_ioctls::Error),
+    /// A FamStructWrapper operation has failed.
+    #[error("Failed FamStructWrapper operation: {0:?}")]
+    Fam(utils::fam::Error),
+    /// Failed to get midr_el1 from host.
+    #[error("{0}")]
+    GetMidrEl1(String),
+}
+
+/// Extract the Manufacturer ID from a VCPU state's registers.
+/// The ID is found between bits 24-31 of MIDR_EL1 register.
+///
+/// # Arguments
+///
+/// * `regs` - reference [`Aarch64RegisterVec`] structure with all registers of a VCPU.
+pub fn get_manufacturer_id_from_state(regs: &Aarch64RegisterVec) -> Result<u32, Error> {
+    let midr_el1 = regs.iter().find(|reg| reg.id == MIDR_EL1);
+    match midr_el1 {
+        Some(register) => Ok(register.value::<u64, 8>() as u32 >> 24),
+        None => Err(Error::GetMidrEl1(
+            "Failed to find MIDR_EL1 in vCPU state!".to_string(),
+        )),
+    }
+}
+
+/// Extract the Manufacturer ID from the host.
+/// The ID is found between bits 24-31 of MIDR_EL1 register.
+pub fn get_manufacturer_id_from_host() -> Result<u32, Error> {
+    let midr_el1_path =
+        &PathBuf::from("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1".to_string());
+
+    let midr_el1 = std::fs::read_to_string(midr_el1_path).map_err(|err| {
+        Error::GetMidrEl1(format!("Failed to get MIDR_EL1 from host path: {err}"))
+    })?;
+    let midr_el1_trimmed = midr_el1.trim_end().trim_start_matches("0x");
+    let manufacturer_id = u32::from_str_radix(midr_el1_trimmed, 16)
+        .map_err(|err| Error::GetMidrEl1(format!("Invalid MIDR_EL1 found on host: {err}",)))?;
+
+    Ok(manufacturer_id >> 24)
+}
+
+/// Configure relevant boot registers for a given vCPU.
+///
+/// # Arguments
+///
+/// * `cpu_id` - Index of current vcpu.
+/// * `boot_ip` - Starting instruction pointer.
+/// * `mem` - Reserved DRAM for current VM.
+pub fn setup_boot_regs(
+    vcpufd: &VcpuFd,
+    cpu_id: u8,
+    boot_ip: u64,
+    mem: &GuestMemoryMmap,
+) -> Result<(), Error> {
+    let kreg_off = offset__of!(kvm_regs, regs);
+
+    // Get the register index of the PSTATE (Processor State) register.
+    let pstate = offset__of!(user_pt_regs, pstate) + kreg_off;
+    let id = arm64_core_reg_id!(KVM_REG_SIZE_U64, pstate);
+    vcpufd
+        .set_one_reg(id, &PSTATE_FAULT_BITS_64.to_le_bytes())
+        .map_err(|err| Error::SetOneReg(id, err))?;
+
+    // Other vCPUs are powered off initially awaiting PSCI wakeup.
+    if cpu_id == 0 {
+        // Setting the PC (Processor Counter) to the current program address (kernel address).
+        let pc = offset__of!(user_pt_regs, pc) + kreg_off;
+        let id = arm64_core_reg_id!(KVM_REG_SIZE_U64, pc);
+        vcpufd
+            .set_one_reg(id, &boot_ip.to_le_bytes())
+            .map_err(|err| Error::SetOneReg(id, err))?;
+
+        // Last mandatory thing to set -> the address pointing to the FDT (also called DTB).
+        // "The device tree blob (dtb) must be placed on an 8-byte boundary and must
+        // not exceed 2 megabytes in size." -> https://www.kernel.org/doc/Documentation/arm64/booting.txt.
+        // We are choosing to place it the end of DRAM. See `get_fdt_addr`.
+        let regs0 = offset__of!(user_pt_regs, regs) + kreg_off;
+        let id = arm64_core_reg_id!(KVM_REG_SIZE_U64, regs0);
+        vcpufd
+            .set_one_reg(id, &get_fdt_addr(mem).to_le_bytes())
+            .map_err(|err| Error::SetOneReg(id, err))?;
+    }
+    Ok(())
+}
+
+/// Read the MPIDR - Multiprocessor Affinity Register.
+pub fn get_mpidr(vcpufd: &VcpuFd) -> Result<u64, Error> {
+    // MPIDR register is 64 bit wide on aarch64
+    let mut mpidr = [0_u8; 8];
+    match vcpufd.get_one_reg(MPIDR_EL1, &mut mpidr) {
+        Err(err) => Err(Error::GetOneReg(MPIDR_EL1, err)),
+        Ok(_) => Ok(u64::from_le_bytes(mpidr)),
+    }
+}
+
+/// Saves the states of the system registers into `state`.
+///
+/// # Arguments
+///
+/// * `regs` - Input/Output vector of registers.
+pub fn get_all_registers(vcpufd: &VcpuFd, state: &mut Aarch64RegisterVec) -> Result<(), Error> {
+    get_registers(vcpufd, &get_all_registers_ids(vcpufd)?, state)
+}
+
+/// Saves states of registers into `state`.
+///
+/// # Arguments
+///
+/// * `ids` - Slice of registers ids to save.
+/// * `regs` - Input/Output vector of registers.
+pub fn get_registers(
+    vcpufd: &VcpuFd,
+    ids: &[u64],
+    regs: &mut Aarch64RegisterVec,
+) -> Result<(), Error> {
+    let mut big_reg = [0_u8; 256];
+    for id in ids.iter() {
+        let reg_size = vcpufd
+            .get_one_reg(*id, &mut big_reg)
+            .map_err(|e| Error::GetOneReg(*id, e))?;
+        let reg_ref = Aarch64RegisterRef::new(*id, &big_reg[0..reg_size]);
+        regs.push(reg_ref);
+    }
+    Ok(())
+}
+
+/// Returns all registers ids, including core and system
+pub fn get_all_registers_ids(vcpufd: &VcpuFd) -> Result<Vec<u64>, Error> {
+    // Call KVM_GET_REG_LIST to get all registers available to the guest. For ArmV8 there are
+    // less than 500 registers.
+    let mut reg_list = RegList::new(500).map_err(Error::Fam)?;
+    vcpufd
+        .get_reg_list(&mut reg_list)
+        .map_err(Error::GetRegList)?;
+    Ok(reg_list.as_slice().to_vec())
+}
+
+/// Set the state of the system registers.
+///
+/// # Arguments
+///
+/// * `regs` - Slice of registers to be set.
+pub fn set_registers(vcpufd: &VcpuFd, regs: &Aarch64RegisterVec) -> Result<(), Error> {
+    for reg in regs.iter() {
+        vcpufd
+            .set_one_reg(reg.id, reg.as_slice())
+            .map_err(|e| Error::SetOneReg(reg.id, e))?;
+    }
+    Ok(())
+}
+
+/// Get the multistate processor.
+///
+/// # Arguments
+///
+/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
+pub fn get_mpstate(vcpufd: &VcpuFd) -> Result<kvm_mp_state, Error> {
+    vcpufd.get_mp_state().map_err(Error::GetMp)
+}
+
+/// Set the state of the system registers.
+///
+/// # Arguments
+///
+/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
+/// * `state` - Structure for returning the state of the system registers.
+pub fn set_mpstate(vcpufd: &VcpuFd, state: kvm_mp_state) -> Result<(), Error> {
+    vcpufd.set_mp_state(state).map_err(Error::SetMp)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
+    use kvm_ioctls::Kvm;
+
+    use super::*;
+    use crate::arch::aarch64::{arch_memory_regions, layout};
+
+    #[test]
+    fn test_setup_regs() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
+        let mem = utils::vm_memory::test_utils::create_anon_guest_memory(&regions, false)
+            .expect("Cannot initialize memory");
+
+        let res = setup_boot_regs(&vcpu, 0, 0x0, &mem);
+        assert!(matches!(
+            res.unwrap_err(),
+            Error::SetOneReg(0x6030000000100042, _)
+        ));
+
+        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi).unwrap();
+        vcpu.vcpu_init(&kvi).unwrap();
+
+        assert!(setup_boot_regs(&vcpu, 0, 0x0, &mem).is_ok());
+    }
+
+    #[test]
+    fn test_read_mpidr() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi).unwrap();
+
+        // Must fail when vcpu is not initialized yet.
+        let res = get_mpidr(&vcpu);
+        assert!(matches!(res.unwrap_err(), Error::GetOneReg(MPIDR_EL1, _)));
+
+        vcpu.vcpu_init(&kvi).unwrap();
+        assert_eq!(get_mpidr(&vcpu).unwrap(), 0x8000_0000);
+    }
+
+    #[test]
+    fn test_get_set_regs() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi).unwrap();
+
+        // Must fail when vcpu is not initialized yet.
+        let mut regs = Aarch64RegisterVec::default();
+        let res = get_all_registers(&vcpu, &mut regs);
+        assert!(matches!(res.unwrap_err(), Error::GetRegList(_)));
+
+        vcpu.vcpu_init(&kvi).unwrap();
+        get_all_registers(&vcpu, &mut regs).unwrap();
+        set_registers(&vcpu, &regs).unwrap();
+    }
+
+    #[test]
+    fn test_mpstate() {
+        use std::os::unix::io::AsRawFd;
+
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi).unwrap();
+
+        let res = get_mpstate(&vcpu);
+        assert!(res.is_ok());
+        assert!(set_mpstate(&vcpu, res.unwrap()).is_ok());
+
+        unsafe { libc::close(vcpu.as_raw_fd()) };
+
+        let res = get_mpstate(&vcpu);
+        assert!(matches!(res.unwrap_err(), Error::GetMp(_)));
+
+        let res = set_mpstate(&vcpu, kvm_mp_state::default());
+        assert!(matches!(res.unwrap_err(), Error::SetMp(_)));
+    }
+}

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -13,7 +13,7 @@ pub mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     arch_memory_regions, configure_system, get_kernel_start, initrd_load_addr,
-    layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, regs, Error, MMIO_MEM_SIZE,
+    layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, Error, MMIO_MEM_SIZE,
     MMIO_MEM_START,
 };
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -836,8 +836,9 @@ pub fn configure_system_for_boot(
 
     #[cfg(target_arch = "aarch64")]
     let cpu_config = {
-        use crate::arch::aarch64::regs::get_registers;
-        let mut regs = vec![];
+        use crate::arch::aarch64::regs::Aarch64RegisterVec;
+        use crate::arch::aarch64::vcpu::get_registers;
+        let mut regs = Aarch64RegisterVec::default();
         get_registers(&vcpus[0].kvm_vcpu.fd, &cpu_template.reg_list(), &mut regs)
             .map_err(GuestConfigError)?;
         CpuConfiguration { regs }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -22,7 +22,7 @@ use versionize_derive::Versionize;
 use virtio_gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 
 #[cfg(target_arch = "aarch64")]
-use crate::arch::regs::{get_manufacturer_id_from_host, get_manufacturer_id_from_state};
+use crate::arch::aarch64::vcpu::{get_manufacturer_id_from_host, get_manufacturer_id_from_state};
 use crate::builder::{self, BuildMicrovmFromSnapshotError};
 use crate::cpu_config::templates::StaticCpuTemplate;
 #[cfg(target_arch = "x86_64")]
@@ -426,7 +426,7 @@ pub fn validate_cpu_manufacturer_id(
         .map_err(|err| ValidateCpuManufacturerIdError::Host(err.to_string()))?;
 
     for state in &microvm_state.vcpu_states {
-        let state_man_id = get_manufacturer_id_from_state(state.regs.as_slice())
+        let state_man_id = get_manufacturer_id_from_state(&state.regs)
             .map_err(|err| ValidateCpuManufacturerIdError::Snapshot(err.to_string()))?;
 
         if host_man_id != state_man_id {

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -13,7 +13,6 @@ use crate::devices::virtio::block::persist::BlockState;
 use crate::devices::virtio::net::persist::NetConfigSpaceState;
 use crate::devices::virtio::QueueState;
 use crate::persist::VmInfo;
-#[cfg(target_arch = "x86_64")]
 use crate::vstate::vcpu::VcpuState;
 
 /// Snap version for Firecracker v0.23
@@ -72,10 +71,10 @@ lazy_static! {
         // v1.4 state change mappings.
         version_map.new_version().set_type_version(DeviceStates::type_id(), 4);
 
-        // v1.5 - no changes introduced, but we need to bump as mapping
-        // between firecracker minor versions and snapshot versions needs
-        // to be 1-to-1 (see below)
+        // v1.5 state change mappings.
         version_map.new_version();
+        #[cfg(target_arch = "aarch64")]
+        version_map.set_type_version(VcpuState::type_id(), 2);
 
         version_map
     };

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -27,7 +27,7 @@ def is_on_skylake():
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {"Intel": 83.76, "AMD": 83.34, "ARM": 83.12}
 else:
-    COVERAGE_DICT = {"Intel": 81.02, "AMD": 80.55, "ARM": 80.12}
+    COVERAGE_DICT = {"Intel": 81.02, "AMD": 80.55, "ARM": 80.19}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

- Updated `kvm-bindings` to 1.4 which changes `get/set_one_reg` methods.
- Updated internal representation of aarch64 registers:

Now we are able to work with register wider then 128 bits. All registers are stored in the `Aarch64RegisterVec` in one byte array. This way registers of different sizes can be efficiently stored and iterated on.
Supported sizes are: 8, 16, 32, 64, 128, 256, 512, 1024, 2048 bits (all sizes supported by KVM).
Register size is determined by the ID of the register.
Interactions with registers are happening using `Aarch64RegisterRef` or `Aarch64RegisterRefMut`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
