### PR TITLE
fix(vmm): Add vendor ID normalization

### DIFF
--- a/docs/cpu_templates/cpuid-normalization.md
+++ b/docs/cpu_templates/cpuid-normalization.md
@@ -11,20 +11,21 @@ See also: [boot protocol settings](boot-protocol.md)
 
 ## x86_64 common CPUID normalization
 
-| Description                                                                          | Leaf       | Subleaf | Register | Bits  |
-|--------------------------------------------------------------------------------------|:----------:|:-------:|:--------:|:-----:|
-| Set CLFLUSH line size                                                                | 0x1        | -       | EBX      | 15:8  |
-| Set maximum number of addressable IDs for logical processors in the physical package | 0x1        | -       | EBX      | 23:16 |
-| Set initial APIC ID                                                                  | 0x1        | -       | EBX      | 31:24 |
-| Disable PDCM (Perfmon and Debug Capability)                                          | 0x1        | -       | ECX      | 15    |
-| Enable TSC_DEADLINE                                                                  | 0x1        | -       | ECX      | 24    |
-| Enable HYPERVISOR                                                                    | 0x1        | -       | ECX      | 31    |
-| Set HTT value if the microVM's CPU count is greater than 1                           | 0x1        | -       | EDX      | 28    |
-| Insert leaf 0xb, subleaf 0x1 filled with `0` if it is not already present            | 0xb        | 0x1     | all      | all   |
-| Update extended topology enumeration                                                 | 0xb        | all     | EAX      | 4:0   |
-| Update extended topology enumeration                                                 | 0xb        | all     | EBX      | 15:0  |
-| Update extended topology enumeration                                                 | 0xb        | all     | ECX      | 15:8  |
-| Pass through cache information from host                                             | 0x80000006 | -       | all      | all   |
+| Description                                                                          | Leaf       | Subleaf | Register      | Bits  |
+|--------------------------------------------------------------------------------------|:----------:|:-------:|:-------------:|:-----:|
+| Pass through vendor ID from host                                                     | 0x0        | -       | EBX, ECX, EDX | all   |
+| Set CLFLUSH line size                                                                | 0x1        | -       | EBX           | 15:8  |
+| Set maximum number of addressable IDs for logical processors in the physical package | 0x1        | -       | EBX           | 23:16 |
+| Set initial APIC ID                                                                  | 0x1        | -       | EBX           | 31:24 |
+| Disable PDCM (Perfmon and Debug Capability)                                          | 0x1        | -       | ECX           | 15    |
+| Enable TSC_DEADLINE                                                                  | 0x1        | -       | ECX           | 24    |
+| Enable HYPERVISOR                                                                    | 0x1        | -       | ECX           | 31    |
+| Set HTT value if the microVM's CPU count is greater than 1                           | 0x1        | -       | EDX           | 28    |
+| Insert leaf 0xb, subleaf 0x1 filled with `0` if it is not already present            | 0xb        | 0x1     | all           | all   |
+| Update extended topology enumeration                                                 | 0xb        | all     | EAX           | 4:0   |
+| Update extended topology enumeration                                                 | 0xb        | all     | EBX           | 15:0  |
+| Update extended topology enumeration                                                 | 0xb        | all     | ECX           | 15:8  |
+| Pass through cache information from host                                             | 0x80000006 | -       | all           | all   |
 
 ## Intel-specific CPUID normalization
 

--- a/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
@@ -529,6 +529,43 @@ mod tests {
     }
 
     #[test]
+    fn test_update_vendor_id() {
+        // Check `update_vendor_id()` passes through the vendor ID from the host correctly.
+
+        // Pseudo CPUID with invalid vendor ID.
+        let mut guest_cpuid = Cpuid::Intel(IntelCpuid(BTreeMap::from([(
+            CpuidKey {
+                leaf: 0x0,
+                subleaf: 0x0,
+            },
+            CpuidEntry {
+                flags: KvmCpuidFlags::EMPTY,
+                result: CpuidRegisters {
+                    eax: 0,
+                    ebx: 0x0123_4567,
+                    ecx: 0x89ab_cdef,
+                    edx: 0x55aa_55aa,
+                },
+            },
+        )])));
+
+        // Pass through vendor ID from host.
+        guest_cpuid.update_vendor_id().unwrap();
+
+        // Check if the guest vendor ID matches the host one.
+        let guest_leaf_0 = guest_cpuid
+            .get(&CpuidKey {
+                leaf: 0x0,
+                subleaf: 0x0,
+            })
+            .unwrap();
+        let host_leaf_0 = cpuid(0x0);
+        assert_eq!(guest_leaf_0.result.ebx, host_leaf_0.ebx);
+        assert_eq!(guest_leaf_0.result.ecx, host_leaf_0.ecx);
+        assert_eq!(guest_leaf_0.result.edx, host_leaf_0.edx);
+    }
+
+    #[test]
     fn check_leaf_0xb_subleaf_0x1_added() {
         // Check leaf 0xb / subleaf 0x1 is added in `update_extended_topology_entry()` even when it
         // isn't included.

--- a/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
@@ -205,24 +205,21 @@ impl super::Cpuid {
             .checked_shl(u32::from(cpu_bits))
             .ok_or(NormalizeCpuidError::CpuBits(cpu_bits))?;
         self.update_vendor_id()?;
-        self.update_feature_info_entry(cpu_index, cpu_count)
-            .map_err(NormalizeCpuidError::FeatureInformation)?;
-        self.update_extended_topology_entry(cpu_index, cpu_count, cpu_bits, cpus_per_core)
-            .map_err(NormalizeCpuidError::ExtendedTopology)?;
-        self.update_extended_cache_features()
-            .map_err(NormalizeCpuidError::ExtendedCacheFeatures)?;
+        self.update_feature_info_entry(cpu_index, cpu_count)?;
+        self.update_extended_topology_entry(cpu_index, cpu_count, cpu_bits, cpus_per_core)?;
+        self.update_extended_cache_features()?;
 
         // Apply manufacturer specific modifications.
         match self {
             // Apply Intel specific modifications.
-            Self::Intel(intel_cpuid) => intel_cpuid
-                .normalize(cpu_index, cpu_count, cpus_per_core)
-                .map_err(NormalizeCpuidError::Intel),
+            Self::Intel(intel_cpuid) => {
+                intel_cpuid.normalize(cpu_index, cpu_count, cpus_per_core)?;
+            }
             // Apply AMD specific modifications.
-            Self::Amd(amd_cpuid) => amd_cpuid
-                .normalize(cpu_index, cpu_count, cpus_per_core)
-                .map_err(NormalizeCpuidError::Amd),
+            Self::Amd(amd_cpuid) => amd_cpuid.normalize(cpu_index, cpu_count, cpus_per_core)?,
         }
+
+        Ok(())
     }
 
     /// Pass-through the vendor ID from the host. This is used to prevent modification of the vendor


### PR DESCRIPTION
## Changes

- Add vendor ID normalization

## Reason

The custom CPU template feature allows users to modify vendor ID. This
results in a situation where the vendor ID mismatch the brand string,
because the normalization is enforced on the brand string based on the
host value.

**Note that this PR should be backported to v1.4 release branch in PR #3791.**

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
