### PR TITLE
backport: ci(gh_release.py): validate version parameter

### DIFF
--- a/tools/gh_release.py
+++ b/tools/gh_release.py
@@ -9,6 +9,7 @@ Assumes all the releases are in the current path.
 """
 
 import argparse
+import re
 import subprocess
 import tarfile
 from pathlib import Path
@@ -84,10 +85,21 @@ def github_release(tag_version, repo, github_token):
     print(f"Draft release created successful. Check it out at {release_url}")
 
 
+def version(version_str: str):
+    """Validate version parameter"""
+    if not re.fullmatch(r"v\d+\.\d+\.\d+", version_str):
+        raise ValueError("version does not match vX.Y.Z")
+    return version_str
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--version", required=True, help="Firecracker version. (v1.2.3)"
+        "--version",
+        required=True,
+        metavar="vX.Y.Z",
+        help="Firecracker version.",
+        type=version,
     )
     parser.add_argument(
         "--repository", required=False, default="firecracker-microvm/firecracker"


### PR DESCRIPTION
## Changes

Backport of [#3784](https://github.com/firecracker-microvm/firecracker/pull/3784).

```
The version parameter is vulnerable to command injection. I.e.

    gh_release.py --version '**v1.2.4;id #**'

Validate the version parameter so it's not accepted.

    error: argument --version: invalid version value: '**v1.2.4;id #**'
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][1].

[1]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
