### PR TITLE
chore(test): Remove ignorance of RUSTSEC-2021-0145

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,9 +1,1 @@
 [advisories]
-# atty is an unmaintained dependency introduced by criterion.
-# It has a security advisory about illegal memory access on
-# windows.
-# We are using criterion only for benchmarks, so we can ignore
-# this vulnerability until criterion releases a new version
-# that replaces atty.
-# See https://github.com/bheisler/criterion.rs/issues/628.
-ignore = ["RUSTSEC-2021-0145"]


### PR DESCRIPTION
## Changes

Removes the ignorance of RUSTSEC-2021-0145 from cargo audit test.

## Reason

Now we're consuming criterion 0.5.1 that no longer depends on atty.

Closes #3284

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
