### PR TITLE
Backport for CPU templates - Decimal number support and benchmark update (#3695, #3798)

### DIFF
--- a/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs
+++ b/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs
@@ -157,10 +157,13 @@ mod tests {
                 }"#,
         );
         assert!(cpu_config_result.is_err());
-        assert!(cpu_config_result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse string [j] as a number for CPU template"));
+        let error_msg: String = cpu_config_result.unwrap_err().to_string();
+        // Formatted error expected clarifying the number system prefix is missing
+        assert!(
+            error_msg.contains("No supported number system prefix found in value"),
+            "{}",
+            error_msg
+        );
 
         // Malformed address as binary
         let cpu_config_result = serde_json::from_str::<CustomCpuTemplate>(
@@ -184,7 +187,7 @@ mod tests {
             r#"{
                     "reg_modifiers":  [
                         {
-                            "addr": "200",
+                            "addr": "0x200",
                             "bitmap": "0bx0?100x?x1xxxx00xxx1xxxxxxxxxxx1"
                         },
                     ]
@@ -201,7 +204,7 @@ mod tests {
             r#"{
                     "reg_modifiers":  [
                         {
-                            "addr": "200",
+                            "addr": "0x200",
                             "bitmap": "0bx00100x0x1xxxx05xxx1xxxxxxxxxxx1"
                         },
                     ]

--- a/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
+++ b/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
@@ -390,10 +390,13 @@ mod tests {
                 }"#,
         );
         assert!(cpu_template_result.is_err());
-        assert!(cpu_template_result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse string [0jj0] as a number for CPU template -"));
+        let error_msg: String = cpu_template_result.unwrap_err().to_string();
+        // Formatted error expected clarifying the number system prefix is missing
+        assert!(
+            error_msg.contains("No supported number system prefix found in value"),
+            "{}",
+            error_msg
+        );
 
         // Malformed CPUID leaf address
         let cpu_template_result = serde_json::from_str::<CustomCpuTemplate>(
@@ -414,33 +417,38 @@ mod tests {
                 }"#,
         );
         assert!(cpu_template_result.is_err());
-        assert!(cpu_template_result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse string [k] as a number for CPU template"));
-
+        let error_msg: String = cpu_template_result.unwrap_err().to_string();
+        // Formatted error expected clarifying the number system prefix is missing
+        assert!(
+            error_msg.contains("No supported number system prefix found in value"),
+            "{}",
+            error_msg
+        );
         // Malformed 64-bit bitmap - filter failed
         let cpu_template_result = serde_json::from_str::<CustomCpuTemplate>(
             r#"{
                     "msr_modifiers":  [
                         {
-                            "addr": "200",
+                            "addr": "0x200",
                             "bitmap": "0bx0?100x?x1xxxx00xxx1xxxxxxxxxxx1"
                         },
                     ]
                 }"#,
         );
         assert!(cpu_template_result.is_err());
-        assert!(cpu_template_result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse string [x0?100x?x1xxxx00xxx1xxxxxxxxxxx1] as a bitmap"));
+        let err_msg = cpu_template_result.unwrap_err().to_string();
+        assert!(
+            err_msg
+                .contains("Failed to parse string [x0?100x?x1xxxx00xxx1xxxxxxxxxxx1] as a bitmap"),
+            "Unexpected error message. Actual error message: {}",
+            err_msg
+        );
         // Malformed 64-bit bitmap - value failed
         let cpu_template_result = serde_json::from_str::<CustomCpuTemplate>(
             r#"{
                     "msr_modifiers":  [
                         {
-                            "addr": "200",
+                            "addr": "0x200",
                             "bitmap": "0bx00100x0x1xxxx05xxx1xxxxxxxxxxx1"
                         },
                     ]

--- a/src/vmm/src/cpu_config/x86_64/test_utils.rs
+++ b/src/vmm/src/cpu_config/x86_64/test_utils.rs
@@ -88,7 +88,7 @@ pub const TEST_TEMPLATE_JSON: &str = r#"{
             "bitmap": "0bx00111xxx1xxxx111xxxxx101xxxxxx1"
         },
         {
-            "addr": "2",
+            "addr": "0b11",
             "bitmap": "0bx00100xxx1xxxxxx0000000xxxxxxxx1"
         },
         {

--- a/tests/integration_tests/performance/test_cpu_template_benchmark.py
+++ b/tests/integration_tests/performance/test_cpu_template_benchmark.py
@@ -9,8 +9,6 @@ import platform
 import shutil
 from pathlib import Path
 
-import pytest
-
 from framework import utils
 from framework.defs import FC_WORKSPACE_DIR
 from host_tools import proc
@@ -24,16 +22,16 @@ NSEC_IN_MSEC = 1000000
 
 BASELINES = {
     "Intel": {
-        "deserialize": {"target": 0.025, "delta": 0.02},  # milliseconds
-        "serialize": {"target": 0.015, "delta": 0.02},  # milliseconds
+        "deserialize": {"max_target": 0.05},  # milliseconds
+        "serialize": {"max_target": 0.05},  # milliseconds
     },
     "AMD": {
-        "deserialize": {"target": 0.025, "delta": 0.02},  # milliseconds
-        "serialize": {"target": 0.015, "delta": 0.02},  # milliseconds
+        "deserialize": {"max_target": 0.05},  # milliseconds
+        "serialize": {"max_target": 0.05},  # milliseconds
     },
     "ARM": {
-        "deserialize": {"target": 0.0015, "delta": 0.001},  # milliseconds
-        "serialize": {"target": 0.0015, "delta": 0.006},  # milliseconds
+        "deserialize": {"max_target": 0.006},  # milliseconds
+        "serialize": {"max_target": 0.006},  # milliseconds
     },
 }
 
@@ -48,17 +46,14 @@ def _check_statistics(directory, mean):
         bench = "serialize"
 
     measure = BASELINES[proc_model[0]][bench]
-    target, delta = measure["target"], measure["delta"]
+    max_target = measure["max_target"]
 
     # When using multiple data sets where the delta can
     # vary substantially, consider making use of the
     # 'rel' parameter for more flexibility.
-    assert mean == pytest.approx(
-        target,
-        abs=delta,
-    ), f"Benchmark result {directory} has changed!"
+    assert mean < max_target, f"Benchmark result {directory} has changed!"
 
-    return f"{target - delta} <= result <= {target + delta}"
+    return f"{max_target} > result"
 
 
 def test_cpu_template_benchmark(monkeypatch, record_property):


### PR DESCRIPTION
## Changes

Backport of [PR 3695](https://github.com/firecracker-microvm/firecracker/pull/3695/) (removing decimal number support for CPU templates and [PR 3798](https://github.com/firecracker-microvm/firecracker/pull/3798) (cpu-config benchmark tweak to improve pass reliability).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][1].

[1]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
