### PR TITLE
chore(tool): Remove message for debug

### DIFF
--- a/src/cpu-template-helper/src/fingerprint/dump.rs
+++ b/src/cpu-template-helper/src/fingerprint/dump.rs
@@ -73,7 +73,7 @@ fn run_shell_command(cmd: &str) -> Result<String, Error> {
         .args(["-c", cmd])
         .output()
         .map_err(|err| Error::ShellCommand(cmd.to_string(), err.to_string()))?;
-    println!("{:?}", output.status.code());
+
     if !output.status.success() {
         return Err(Error::ShellCommand(
             cmd.to_string(),


### PR DESCRIPTION
## Changes

Removes a message used for debug in the fingerprint dump command of the CPU template helper tool.

```
$ sudo cpu-template-helper fingerprint dump --config config.json
Some(0)
```

**Note: This command will be backported into 1.4 release branch.**

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
