### PR TITLE
chore(baselines): updated vsock throughput beselines for m6g and m6a

### DIFF
--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -988,15 +988,15 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
-                                                },
-                                                "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
                                                     "target": 99
                                                 },
-                                                "vsock-pDEFAULT-g2h": {
+                                                "vsock-p1024K-h2g": {
                                                     "delta_percentage": 5,
+                                                    "target": 99
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -1012,7 +1012,7 @@
                                                     "target": 112
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -1021,14 +1021,14 @@
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 113
+                                                    "target": 114
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 123
                                                 }
                                             }
@@ -1060,24 +1060,24 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 105
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 119
+                                                    "delta_percentage": 7,
+                                                    "target": 118
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 105
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -1094,16 +1094,16 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 47
+                                                    "delta_percentage": 12,
+                                                    "target": 43
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 59
+                                                    "delta_percentage": 10,
+                                                    "target": 58
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 48
+                                                    "delta_percentage": 13,
+                                                    "target": 44
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 10,
@@ -1114,27 +1114,27 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 62
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 61
+                                                    "delta_percentage": 10,
+                                                    "target": 57
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 71
+                                                    "delta_percentage": 8,
+                                                    "target": 70
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 62
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 61
+                                                    "target": 57
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 71
                                                 }
                                             }
@@ -1146,20 +1146,20 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 32
+                                                    "delta_percentage": 12,
+                                                    "target": 33
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 60
+                                                    "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 14,
+                                                    "delta_percentage": 12,
                                                     "target": 32
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 59
+                                                    "target": 58
                                                 }
                                             }
                                         },
@@ -1171,18 +1171,18 @@
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 11,
-                                                    "target": 36
+                                                    "target": 37
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 71
+                                                    "target": 70
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 59
+                                                    "target": 58
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
+                                                    "delta_percentage": 11,
                                                     "target": 37
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -1200,20 +1200,20 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 9560
+                                                    "delta_percentage": 9,
+                                                    "target": 10260
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 6111
+                                                    "delta_percentage": 7,
+                                                    "target": 6147
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 9679
+                                                    "target": 10281
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 6016
+                                                    "delta_percentage": 7,
+                                                    "target": 6009
                                                 }
                                             }
                                         },
@@ -1221,27 +1221,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 7168
+                                                    "target": 7139
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 11582
+                                                    "delta_percentage": 10,
+                                                    "target": 12908
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 7720
+                                                    "delta_percentage": 9,
+                                                    "target": 7652
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7112
+                                                    "delta_percentage": 6,
+                                                    "target": 7144
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 11626
+                                                    "target": 12955
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7645
+                                                    "delta_percentage": 8,
+                                                    "target": 7602
                                                 }
                                             }
                                         }
@@ -1252,48 +1252,48 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 17470
+                                                    "delta_percentage": 6,
+                                                    "target": 17596
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 6103
+                                                    "target": 6184
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 17500
+                                                    "delta_percentage": 9,
+                                                    "target": 17549
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5956
+                                                    "delta_percentage": 7,
+                                                    "target": 5974
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 7336
+                                                    "delta_percentage": 8,
+                                                    "target": 7300
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 25013
+                                                    "delta_percentage": 6,
+                                                    "target": 25004
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 8698
+                                                    "delta_percentage": 9,
+                                                    "target": 8694
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 7347
+                                                    "delta_percentage": 8,
+                                                    "target": 7344
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 25119
+                                                    "delta_percentage": 8,
+                                                    "target": 25250
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 8365
+                                                    "delta_percentage": 8,
+                                                    "target": 8342
                                                 }
                                             }
                                         }
@@ -1421,16 +1421,16 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 58
+                                                    "delta_percentage": 10,
+                                                    "target": 60
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 79
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 58
+                                                    "delta_percentage": 8,
+                                                    "target": 60
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 7,
@@ -1442,26 +1442,26 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 81
+                                                    "target": 83
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 71
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 85
+                                                    "target": 84
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 82
+                                                    "delta_percentage": 7,
+                                                    "target": 83
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 70
+                                                    "delta_percentage": 8,
+                                                    "target": 71
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 85
                                                 }
                                             }
@@ -1473,12 +1473,12 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 55
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 77
+                                                    "delta_percentage": 7,
+                                                    "target": 78
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 8,
@@ -1494,27 +1494,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 77
+                                                    "target": 80
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 59
+                                                    "delta_percentage": 9,
+                                                    "target": 58
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 84
+                                                    "delta_percentage": 8,
+                                                    "target": 83
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 79
+                                                    "target": 80
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 59
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 85
+                                                    "target": 84
                                                 }
                                             }
                                         }
@@ -1527,20 +1527,20 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6739
+                                                    "delta_percentage": 6,
+                                                    "target": 6673
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5392
+                                                    "delta_percentage": 6,
+                                                    "target": 4999
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6748
+                                                    "delta_percentage": 6,
+                                                    "target": 6678
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5267
+                                                    "delta_percentage": 6,
+                                                    "target": 4895
                                                 }
                                             }
                                         },
@@ -1548,27 +1548,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 6052
+                                                    "target": 6200
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6517
+                                                    "target": 6562
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7079
+                                                    "delta_percentage": 7,
+                                                    "target": 6979
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 6293
+                                                    "target": 6302
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6526
+                                                    "delta_percentage": 6,
+                                                    "target": 6573
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7114
+                                                    "delta_percentage": 6,
+                                                    "target": 6771
                                                 }
                                             }
                                         }
@@ -1580,47 +1580,47 @@
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 14636
+                                                    "target": 14471
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5353
+                                                    "delta_percentage": 5,
+                                                    "target": 5146
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 14624
+                                                    "delta_percentage": 5,
+                                                    "target": 14466
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5276
+                                                    "delta_percentage": 5,
+                                                    "target": 5090
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 8028
+                                                    "delta_percentage": 9,
+                                                    "target": 8438
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 18777
+                                                    "delta_percentage": 6,
+                                                    "target": 18543
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 7747
+                                                    "target": 7388
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 8249
+                                                    "delta_percentage": 8,
+                                                    "target": 8612
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 18658
+                                                    "target": 18538
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 7611
+                                                    "target": 7236
                                                 }
                                             }
                                         }


### PR DESCRIPTION
Updated vsock throughput beselines for m6g and m6a

```bash
{
    "source": "6da185481fc5cf00dfa796f828c3958709c9a8ee/tests/integration_tests/performance/configs/",
    "target": "1fd4b15562fa86af90e1229636dc5af128d4bab1/tests/integration_tests/performance/configs/",
    "test_vsock_throughput_config_4.14.json": {
        "test": "vsock_throughput",
        "kernel": "4.14",
        "cpus": [
            {
                "instance": "m6g.metal",
                "model": "ARM_NEOVERSE_N1",
                "stats": {
                    "cpu_utilization_vcpus_total": {
                        "target_diff_percentage": {
                            "mean": 0.0,
                            "stdev": 0.0
                        },
                        "delta_percentage_diff": {
                            "mean": 0.0,
                            "stdev": 0.0
                        }
                    },
                    "throughput": {
                        "target_diff_percentage": {
                            "mean": -1.5073027234002798,
                            "stdev": 3.3625373822826403
                        },
                        "delta_percentage_diff": {
                            "mean": -0.3,
                            "stdev": 0.8645047258706174
                        }
                    },
                    "cpu_utilization_vmm": {
                        "target_diff_percentage": {
                            "mean": 0.6618033254365863,
                            "stdev": 1.6250164900608555
                        },
                        "delta_percentage_diff": {
                            "mean": -0.15,
                            "stdev": 0.9333020044867297
                        }
                    }
                }
            },
            {
                "instance": "m6a.metal",
                "model": "AMD EPYC 7R13 48-Core Processor",
                "stats": {
                    "cpu_utilization_vcpus_total": {
                        "target_diff_percentage": {
                            "mean": -0.023021544364594804,
                            "stdev": 0.30207943228610995
                        },
                        "delta_percentage_diff": {
                            "mean": 0.05,
                            "stdev": 0.6863327411532598
                        }
                    },
                    "throughput": {
                        "target_diff_percentage": {
                            "mean": 1.888021237650623,
                            "stdev": 3.89073605479705
                        },
                        "delta_percentage_diff": {
                            "mean": -0.3,
                            "stdev": 1.4179302929937965
                        }
                    },
                    "cpu_utilization_vmm": {
                        "target_diff_percentage": {
                            "mean": -1.6812130894808892,
                            "stdev": 3.2782326693794728
                        },
                        "delta_percentage_diff": {
                            "mean": 0.1,
                            "stdev": 1.020835571068081
                        }
                    }
                }
            }
        ]
    }
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
