### PR TITLE
perf: Set log level to Debug

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -509,6 +509,9 @@ class Microvm:
 
         jailer_param_list = self.jailer.construct_param_list()
 
+        # Checking the timings requires DEBUG level log messages
+        self.time_api_requests = log_level == "Debug"
+
         # When the daemonize flag is on, we want to clone-exec into the
         # jailer rather than executing it via spawning a shell. Going
         # forward, we'll probably switch to this method for running

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -191,8 +191,6 @@ def test_load_snapshot_failure_handling(test_microvm_with_api):
     logger = logging.getLogger("snapshot_load_failure")
     vm = test_microvm_with_api
     vm.spawn(log_level="Info")
-    # only works if log level is Debug
-    vm.time_api_requests = False
 
     # Create two empty files for snapshot state and snapshot memory
     chroot_path = vm.jailer.chroot_path()

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -257,7 +257,7 @@ def test_block_performance(
     """
     guest_mem_mib = 1024
     vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
-    vm.spawn()
+    vm.spawn(log_level="Info")
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=guest_mem_mib)
     vm.ssh_network_config(network_config, "1")
     # Add a secondary block device for benchmark tests.

--- a/tests/integration_tests/performance/test_network_latency.py
+++ b/tests/integration_tests/performance/test_network_latency.py
@@ -120,7 +120,7 @@ def test_network_latency(
     guest_mem_mib = 1024
     guest_vcpus = 1
     vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
-    vm.spawn()
+    vm.spawn(log_level="Info")
     vm.basic_config(vcpu_count=guest_vcpus, mem_size_mib=guest_mem_mib)
     vm.ssh_network_config(network_config, "1")
     vm.start()

--- a/tests/integration_tests/performance/test_network_tcp_throughput.py
+++ b/tests/integration_tests/performance/test_network_tcp_throughput.py
@@ -300,7 +300,7 @@ def test_network_tcp_throughput(
 
     guest_mem_mib = 1024
     vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
-    vm.spawn()
+    vm.spawn(log_level="Info")
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=guest_mem_mib)
     vm.ssh_network_config(network_config, "1")
     vm.start()

--- a/tests/integration_tests/performance/test_snapshot_restore_performance.py
+++ b/tests/integration_tests/performance/test_snapshot_restore_performance.py
@@ -99,7 +99,7 @@ def get_snap_restore_latency(
     ifaces = net_ifaces[:nets]
 
     vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
-    vm.spawn(use_ramdisk=True)
+    vm.spawn(use_ramdisk=True, log_level="Info")
     vm.basic_config(
         vcpu_count=vcpus,
         mem_size_mib=mem_size,

--- a/tests/integration_tests/performance/test_vsock_throughput.py
+++ b/tests/integration_tests/performance/test_vsock_throughput.py
@@ -284,7 +284,7 @@ def test_vsock_throughput(
 
     mem_size_mib = 1024
     vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
-    vm.spawn()
+    vm.spawn(log_level="Info")
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=mem_size_mib)
     vm.ssh_network_config(network_config, "1")
     # Create a vsock device


### PR DESCRIPTION
In 9d7080a39f31cd9ecff8d658edb4bd3930a54470 we changed the default log level to Debug, which unintentionally affected performance tests with lots of log output (like vsock).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
