### PR TITLE
Change the strip feature of the CPU template helper tool to operate bitwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   of '_' as a separator.
 - Set FDP_EXCPTN_ONLY bit (CPUID.7h.0:EBX[6]) and ZERO_FCS_FDS bit
   (CPUID.7h.0:EBX[13]) in Intel's CPUID normalization process.
+- Changed the strip feature of `cpu-template-helper` tool to operate bitwise.
 
 ### Fixed
 

--- a/src/cpu-template-helper/src/template/strip/aarch64.rs
+++ b/src/cpu-template-helper/src/template/strip/aarch64.rs
@@ -39,11 +39,9 @@ mod tests {
     use crate::utils::aarch64::reg_modifier;
 
     // Summary of reg modifiers:
-    // * As addr 0x0 modifier exists in all the templates but its values are different, it should be
-    //   preserved.
-    // * As addr 0x1 modifier exists in all the templates and its values are same, it should be
-    //   removed.
-    // * As addr 0x2 modifier only exist in the third template, it should be preserved.
+    // * An addr 0x0 modifier exists in all the templates but its value is different.
+    // * An addr 0x1 modifier exists in all the templates and its value is same.
+    // * An addr 0x2 modifier only exist in the third template.
     #[rustfmt::skip]
     fn build_input_templates() -> Vec<CustomCpuTemplate> {
         vec![
@@ -74,17 +72,17 @@ mod tests {
         vec![
             CustomCpuTemplate {
                 reg_modifiers: vec![
-                    reg_modifier!(0x0, 0x0),
+                    reg_modifier!(0x0, 0x0, 0b11),
                 ],
             },
             CustomCpuTemplate {
                 reg_modifiers: vec![
-                    reg_modifier!(0x0, 0x1),
+                    reg_modifier!(0x0, 0x1, 0b11),
                 ],
             },
             CustomCpuTemplate {
                 reg_modifiers: vec![
-                    reg_modifier!(0x0, 0x2),
+                    reg_modifier!(0x0, 0x2, 0b11),
                     reg_modifier!(0x2, 0x1),
                 ],
             },

--- a/src/cpu-template-helper/src/template/strip/mod.rs
+++ b/src/cpu-template-helper/src/template/strip/mod.rs
@@ -33,14 +33,50 @@ where
         return Err(Error::NumberOfInputs);
     }
 
-    // Get common items shared by all the sets.
+    // Initialize `common` with the cloned `maps[0]`.
     let mut common = maps[0].clone();
-    common.retain(|key, value| maps[1..].iter().all(|map| map.get(key) == Some(value)));
 
-    // Remove the common items from all the sets.
-    for key in common.keys() {
+    // Iterate all items included in the `common`.
+    // Use `maps[0]` instead of `common` since the `common` is mutated in the loop.
+    for (key, common_vf) in &maps[0] {
+        // Hold which bits are different from the `common`'s value/filter.
+        // `diff` remains 0 if all the filtered values in all the `maps` are same.
+        let mut diff = V::zero();
+
+        for map in maps[1..].iter() {
+            match map.get(key) {
+                // Record which bits of filtered value are different from the `common` if the `key`
+                // is found in the `map`.
+                Some(map_vf) => {
+                    let map_filtered_value = map_vf.value & map_vf.filter;
+                    let common_filtered_value = common_vf.value & common_vf.filter;
+                    diff |= map_filtered_value ^ common_filtered_value;
+                }
+                // Remove the `key` from the `common` if at least one of the `maps` does not have
+                // the `key`.
+                None => {
+                    common.remove(key);
+                }
+            }
+        }
+
+        // Store the `diff` in the `common`'s `filter` if the `key` exist in all the `maps`.
+        if let Some(common_vf) = common.get_mut(key) {
+            common_vf.filter = diff;
+        }
+    }
+
+    // Remove the `common` items from all the `maps`.
+    for (key, common_vf) in common {
         for map in maps.iter_mut() {
-            map.remove(key);
+            if common_vf.filter == V::zero() {
+                // Remove the `key` if the filtered value is identical in all the `maps`.
+                map.remove(&key).unwrap();
+            } else {
+                // Update the `filter` with `diff`.
+                let map_vf = map.get_mut(&key).unwrap();
+                map_vf.filter = map_vf.filter & common_vf.filter;
+            }
         }
     }
 
@@ -66,33 +102,45 @@ mod tests {
     fn test_strip_common() {
         let mut input = vec![
             HashMap::from([
-                mock_modifier!(0x0, 0b0000_0000),
-                mock_modifier!(0x1, 0b1111_0000),
-                mock_modifier!(0x2, 0b1111_1111),
+                mock_modifier!(0x0, 0b1111_1111, 0b1111_1111), // 0x0 => 0b1111_1111
+                mock_modifier!(0x1, 0b1111_1111, 0b1111_1111), // 0x1 => 0b1111_1111
+                mock_modifier!(0x3, 0b1111_1111, 0b1111_1111), // 0x3 => 0b1111_1111
+                mock_modifier!(0x4, 0b1111_1111, 0b1111_1111), // 0x4 => 0b1111_1111
+                mock_modifier!(0x5, 0b1111_1111, 0b1111_1111), // 0x5 => 0b1111_1111
             ]),
             HashMap::from([
-                mock_modifier!(0x0, 0b0000_0000),
-                mock_modifier!(0x1, 0b0000_1111),
-                mock_modifier!(0x2, 0b1111_1111),
+                mock_modifier!(0x0, 0b1111_1111, 0b1111_1111), // 0x0 => 0b1111_1111
+                mock_modifier!(0x2, 0b1111_1111, 0b1111_1111), // 0x2 => 0b1111_1111
+                mock_modifier!(0x3, 0b0000_1111, 0b1111_1111), // 0x3 => 0b0000_1111
+                mock_modifier!(0x4, 0b1111_0000, 0b1111_1111), // 0x4 => 0b1111_0000
+                mock_modifier!(0x5, 0b1100_0000, 0b1100_1100), // 0x5 => 0b11xx_00xx
             ]),
             HashMap::from([
-                mock_modifier!(0x0, 0b0000_0000),
-                mock_modifier!(0x1, 0b1111_1111),
-                mock_modifier!(0x3, 0b1111_1111),
+                mock_modifier!(0x0, 0b1111_1111, 0b1111_1111), // 0x0 => 0b1111_1111
+                mock_modifier!(0x1, 0b1111_1111, 0b1111_1111), // 0x1 => 0b1111_1111
+                mock_modifier!(0x3, 0b1111_0000, 0b1111_1111), // 0x3 => 0b1111_0000
+                mock_modifier!(0x4, 0b1100_1100, 0b1111_1111), // 0x4 => 0b1100_1100
+                mock_modifier!(0x5, 0b1010_0000, 0b1111_0000), // 0x5 => 0b1010_xxxx
             ]),
         ];
         let expected = vec![
             HashMap::from([
-                mock_modifier!(0x1, 0b1111_0000),
-                mock_modifier!(0x2, 0b1111_1111),
+                mock_modifier!(0x1, 0b1111_1111, 0b1111_1111), // 0x1 => 0b1111_1111
+                mock_modifier!(0x3, 0b1111_1111, 0b1111_1111), // 0x3 => 0b1111_1111
+                mock_modifier!(0x4, 0b1111_1111, 0b0011_1111), // 0x4 => 0bxx11_1111
+                mock_modifier!(0x5, 0b1111_1111, 0b0111_1111), // 0x5 => 0bx111_1111
             ]),
             HashMap::from([
-                mock_modifier!(0x1, 0b0000_1111),
-                mock_modifier!(0x2, 0b1111_1111),
+                mock_modifier!(0x2, 0b1111_1111, 0b1111_1111), // 0x2 => 0b1111_1111
+                mock_modifier!(0x3, 0b0000_1111, 0b1111_1111), // 0x3 => 0b0000_1111
+                mock_modifier!(0x4, 0b1111_0000, 0b0011_1111), // 0x4 => 0bxx11_0000
+                mock_modifier!(0x5, 0b1100_0000, 0b0100_1100), // 0x5 => 0bx1xx_00xx
             ]),
             HashMap::from([
-                mock_modifier!(0x1, 0b1111_1111),
-                mock_modifier!(0x3, 0b1111_1111),
+                mock_modifier!(0x1, 0b1111_1111, 0b1111_1111), // 0x1 => 0b1111_1111
+                mock_modifier!(0x3, 0b1111_0000, 0b1111_1111), // 0x3 => 0b1111_0000
+                mock_modifier!(0x4, 0b1100_1100, 0b0011_1111), // 0x4 => 0bxx00_1100
+                mock_modifier!(0x5, 0b1010_0000, 0b0111_0000), // 0x5 => 0bx010_xxxx
             ]),
         ];
 

--- a/src/cpu-template-helper/src/template/strip/mod.rs
+++ b/src/cpu-template-helper/src/template/strip/mod.rs
@@ -3,7 +3,9 @@
 
 use std::collections::HashMap;
 
-use crate::utils::{ModifierMapKey, ModifierMapValue};
+use vmm::cpu_config::templates::{Numeric, RegisterValueFilter};
+
+use crate::utils::ModifierMapKey;
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
@@ -22,10 +24,10 @@ pub enum Error {
     NumberOfInputs,
 }
 
-fn strip_common<K, V>(maps: &mut [HashMap<K, V>]) -> Result<(), Error>
+fn strip_common<K, V>(maps: &mut [HashMap<K, RegisterValueFilter<V>>]) -> Result<(), Error>
 where
     K: ModifierMapKey,
-    V: ModifierMapValue,
+    V: Numeric,
 {
     if maps.len() < 2 {
         return Err(Error::NumberOfInputs);
@@ -48,7 +50,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::tests::{mock_modifier, MockModifierMapKey, MockModifierMapValue};
+    use crate::utils::tests::{mock_modifier, MockModifierMapKey};
 
     #[test]
     fn test_strip_common_with_single_input() {

--- a/src/cpu-template-helper/src/template/strip/mod.rs
+++ b/src/cpu-template-helper/src/template/strip/mod.rs
@@ -54,10 +54,7 @@ mod tests {
 
     #[test]
     fn test_strip_common_with_single_input() {
-        let mut input = vec![HashMap::from([mock_modifier!(
-            0x0,
-            (0b1111_1111, 0b0000_0000)
-        )])];
+        let mut input = vec![HashMap::from([mock_modifier!(0x0, 0b0000_0000)])];
 
         match strip_common(&mut input) {
             Err(Error::NumberOfInputs) => (),
@@ -69,33 +66,33 @@ mod tests {
     fn test_strip_common() {
         let mut input = vec![
             HashMap::from([
-                mock_modifier!(0x0, (0b1111_1111, 0b0000_0000)),
-                mock_modifier!(0x1, (0b1111_0000, 0b1111_1111)),
-                mock_modifier!(0x2, (0b1111_1111, 0b1111_1111)),
+                mock_modifier!(0x0, 0b0000_0000),
+                mock_modifier!(0x1, 0b1111_0000),
+                mock_modifier!(0x2, 0b1111_1111),
             ]),
             HashMap::from([
-                mock_modifier!(0x0, (0b1111_1111, 0b0000_0000)),
-                mock_modifier!(0x1, (0b0000_1111, 0b1111_1111)),
-                mock_modifier!(0x2, (0b1111_1111, 0b1111_1111)),
+                mock_modifier!(0x0, 0b0000_0000),
+                mock_modifier!(0x1, 0b0000_1111),
+                mock_modifier!(0x2, 0b1111_1111),
             ]),
             HashMap::from([
-                mock_modifier!(0x0, (0b1111_1111, 0b0000_0000)),
-                mock_modifier!(0x1, (0b1111_1111, 0b1111_1111)),
-                mock_modifier!(0x3, (0b1111_1111, 0b1111_1111)),
+                mock_modifier!(0x0, 0b0000_0000),
+                mock_modifier!(0x1, 0b1111_1111),
+                mock_modifier!(0x3, 0b1111_1111),
             ]),
         ];
         let expected = vec![
             HashMap::from([
-                mock_modifier!(0x1, (0b1111_0000, 0b1111_1111)),
-                mock_modifier!(0x2, (0b1111_1111, 0b1111_1111)),
+                mock_modifier!(0x1, 0b1111_0000),
+                mock_modifier!(0x2, 0b1111_1111),
             ]),
             HashMap::from([
-                mock_modifier!(0x1, (0b0000_1111, 0b1111_1111)),
-                mock_modifier!(0x2, (0b1111_1111, 0b1111_1111)),
+                mock_modifier!(0x1, 0b0000_1111),
+                mock_modifier!(0x2, 0b1111_1111),
             ]),
             HashMap::from([
-                mock_modifier!(0x1, (0b1111_1111, 0b1111_1111)),
-                mock_modifier!(0x3, (0b1111_1111, 0b1111_1111)),
+                mock_modifier!(0x1, 0b1111_1111),
+                mock_modifier!(0x3, 0b1111_1111),
             ]),
         ];
 

--- a/src/cpu-template-helper/src/template/strip/x86_64.rs
+++ b/src/cpu-template-helper/src/template/strip/x86_64.rs
@@ -56,13 +56,10 @@ mod tests {
     use crate::utils::x86_64::{cpuid_leaf_modifier, cpuid_reg_modifier, msr_modifier};
 
     // Summary of CPUID modifiers:
-    // * As CPUID leaf 0x0 / subleaf 0x0 modifier exists in all the templates and its values are
-    //   different, it should be removed.
-    // * As CPUID leaf 0x1 / subleaf 0x0 modifier only exists in the second template, it should be
-    //   preserved.
-    // * As CPUID leaf 0x2 / subleaf 0x1 modifier exists in all the templates, EAX values are same
-    //   but EBX values are different, the EAX register modifier should be removed and the EBX
-    //   register modifier should be preserved.
+    // * A CPUID leaf 0x0 / subleaf 0x0 modifier exists in all the templates and its value is same.
+    // * A CPUID leaf 0x1 / subleaf 0x0 modifier only exists in the second template.
+    // * A CPUID leaf 0x2 / subleaf 0x1 modifier exists in all the templates, but EAX value is same
+    //   and EBX value is different across them.
     #[rustfmt::skip]
     fn build_input_cpuid_templates() -> Vec<CustomCpuTemplate> {
         vec![
@@ -114,7 +111,7 @@ mod tests {
             CustomCpuTemplate {
                 cpuid_modifiers: vec![
                     cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
-                        cpuid_reg_modifier!(Ebx, 0x0),
+                        cpuid_reg_modifier!(Ebx, 0x0, 0b11),
                     ]),
                 ],
                 msr_modifiers: vec![],
@@ -125,7 +122,7 @@ mod tests {
                         cpuid_reg_modifier!(Eax, 0x0),
                     ]),
                     cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
-                        cpuid_reg_modifier!(Ebx, 0x1),
+                        cpuid_reg_modifier!(Ebx, 0x1, 0b11),
                     ]),
                 ],
                 msr_modifiers: vec![],
@@ -133,7 +130,7 @@ mod tests {
             CustomCpuTemplate {
                 cpuid_modifiers: vec![
                     cpuid_leaf_modifier!(0x2, 0x1, KvmCpuidFlags::SIGNIFICANT_INDEX, vec![
-                        cpuid_reg_modifier!(Ebx, 0x2),
+                        cpuid_reg_modifier!(Ebx, 0x2, 0b11),
                     ]),
                 ],
                 msr_modifiers: vec![],
@@ -142,11 +139,9 @@ mod tests {
     }
 
     // Summary of MSR modifiers:
-    // * As addr 0x0 modifier exists in all the templates but its values are different, it should be
-    //   preserved.
-    // * As addr 0x1 modifier exists in all the templates and its values are same, it should be
-    //   removed.
-    // * As addr 0x2 modifier only exist in the third template, it should be preserved.
+    // * An addr 0x0 modifier exists in all the templates but its value is different.
+    // * An addr 0x1 modifier exists in all the templates and its value is same.
+    // * An addr 0x2 modifier only exists in the third template.
     #[rustfmt::skip]
     fn build_input_msr_templates() -> Vec<CustomCpuTemplate> {
         vec![
@@ -181,19 +176,19 @@ mod tests {
             CustomCpuTemplate {
                 cpuid_modifiers: vec![],
                 msr_modifiers: vec![
-                    msr_modifier!(0x0, 0x0),
+                    msr_modifier!(0x0, 0x0, 0b11),
                 ],
             },
             CustomCpuTemplate {
                 cpuid_modifiers: vec![],
                 msr_modifiers: vec![
-                    msr_modifier!(0x0, 0x1),
+                    msr_modifier!(0x0, 0x1, 0b11),
                 ],
             },
             CustomCpuTemplate {
                 cpuid_modifiers: vec![],
                 msr_modifiers: vec![
-                    msr_modifier!(0x0, 0x2),
+                    msr_modifier!(0x0, 0x2, 0b11),
                     msr_modifier!(0x2, 0x1),
                 ],
             },

--- a/src/cpu-template-helper/src/template/verify/mod.rs
+++ b/src/cpu-template-helper/src/template/verify/mod.rs
@@ -64,9 +64,8 @@ mod tests {
 
     #[test]
     fn test_verify_modifier_map_with_non_existing_key() {
-        // Test with a sample whose key exists in CPU template but not in CPU config.
-        let cpu_template_map =
-            HashMap::from([mock_modifier!(0b0000_0000, (0b0000_0000, 0b0000_0000))]);
+        // Test with a sample where a key in CPU template is not found in CPU config.
+        let cpu_template_map = HashMap::from([mock_modifier!(0x0, 0b0000_0000)]);
         let cpu_config_map = HashMap::new();
 
         assert_eq!(
@@ -82,9 +81,9 @@ mod tests {
     fn test_verify_modifier_map_with_mismatched_value() {
         // Test with a sample whose filtered value mismatches between CPU config and CPU template.
         let cpu_template_map =
-            HashMap::from([mock_modifier!(0b0000_0000, (0b0000_1111, 0b0000_0101))]);
+            HashMap::from([mock_modifier!(0x0, 0b0000_0101, 0b0000_1111)]);
         let cpu_config_map =
-            HashMap::from([mock_modifier!(0b0000_0000, (u8::MAX, 0b0000_0000))]);
+            HashMap::from([mock_modifier!(0x0, 0b0000_0000, 0b1111_1111)]);
 
         assert_eq!(
             verify_common(cpu_template_map, cpu_config_map)
@@ -100,9 +99,8 @@ mod tests {
     #[test]
     fn test_verify_modifier_map_with_valid_value() {
         // Test with valid CPU template and CPU config.
-        let cpu_template_map =
-            HashMap::from([mock_modifier!(0b0000_0000, (0b0000_1111, 0b0000_1010))]);
-        let cpu_config_map = HashMap::from([mock_modifier!(0b0000_0000, (u8::MAX, 0b1010_1010))]);
+        let cpu_template_map = HashMap::from([mock_modifier!(0x0, 0b0000_1010, 0b0000_1111)]);
+        let cpu_config_map = HashMap::from([mock_modifier!(0x0, 0b1010_1010, 0b1111_1111)]);
 
         verify_common(cpu_template_map, cpu_config_map).unwrap();
     }

--- a/src/cpu-template-helper/src/template/verify/x86_64.rs
+++ b/src/cpu-template-helper/src/template/verify/x86_64.rs
@@ -32,7 +32,7 @@ mod tests {
     use super::*;
     use crate::utils::x86_64::{
         cpuid_leaf_modifier, cpuid_reg_modifier, msr_modifier, CpuidModifierMapKey,
-        CpuidModifierMapValue, MsrModifierMapKey, MsrModifierMapValue,
+        MsrModifierMapKey,
     };
 
     macro_rules! cpuid_modifier_map {
@@ -44,10 +44,10 @@ mod tests {
                     flags: $flags,
                     register: $register,
                 },
-                CpuidModifierMapValue(RegisterValueFilter {
+                RegisterValueFilter {
                     filter: u32::MAX.into(),
                     value: $value,
-                }),
+                },
             )
         };
     }
@@ -56,10 +56,10 @@ mod tests {
         ($addr:expr, $value:expr) => {
             (
                 MsrModifierMapKey($addr),
-                MsrModifierMapValue(RegisterValueFilter {
+                RegisterValueFilter {
                     filter: u64::MAX.into(),
                     value: $value,
-                }),
+                },
             )
         };
     }

--- a/src/cpu-template-helper/src/utils/mod.rs
+++ b/src/cpu-template-helper/src/utils/mod.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::ffi::OsString;
-use std::fmt::{Binary, Display};
+use std::fmt::Display;
 use std::hash::Hash;
-use std::ops::{BitAnd, Shl};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use vmm::builder::{build_microvm_for_boot, StartMicrovmError};
+use vmm::cpu_config::templates::Numeric;
 use vmm::resources::VmResources;
 use vmm::seccomp_filters::get_empty_filters;
 use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
@@ -26,42 +26,21 @@ pub const CPU_TEMPLATE_HELPER_VERSION: &str = env!("FIRECRACKER_VERSION");
 /// This is a wrapper trait of some traits required for a key of `HashMap` modifier.
 pub trait ModifierMapKey: Eq + PartialEq + Hash + Display + Clone {}
 
-/// Trait for value of `HashMap`-based modifier.
-pub trait ModifierMapValue: Eq + PartialEq + Clone {
-    // The data size of `Self::Type` varies depending on the target modifier.
-    // * x86_64 CPUID: `u32`
-    // * x86_64 MSR: `u64`
-    // * aarch64 registers: `u128`
-    //
-    // These trait bounds are required for the following reasons:
-    // * `PartialEq + Eq`: To compare `Self::Type` values (like `filter()` and `value()`).
-    // * `BitAnd<Output = Self::Type>`: To use AND operation (like `filter() & value()`).
-    // * `Binary`: To display in a bitwise format.
-    // * `From<bool> + Shl<usize, Output = Self::Type>`: To construct bit masks in
-    //   `to_diff_string()`.
-    type Type: PartialEq
-        + Eq
-        + Copy
-        + BitAnd<Output = Self::Type>
-        + Binary
-        + From<bool>
-        + Shl<usize, Output = Self::Type>;
-
-    // Return `filter` of arch-specific `RegisterValueFilter` in the size for the target.
-    fn filter(&self) -> Self::Type;
-
-    // Return `value` of arch-specific `RegisterValueFilter` in the size for the target.
-    fn value(&self) -> Self::Type;
-
+pub trait DiffString<V> {
     // Generate a string to display difference of filtered values between CPU template and guest
     // CPU config.
     #[rustfmt::skip]
-    fn to_diff_string(template: Self::Type, config: Self::Type) -> String {
-        let nbits = std::mem::size_of::<Self::Type>() * 8;
+    fn to_diff_string(template: V, config: V) -> String;
+}
 
+impl<V: Numeric> DiffString<V> for V {
+    // Generate a string to display difference of filtered values between CPU template and guest
+    // CPU config.
+    #[rustfmt::skip]
+    fn to_diff_string(template: V, config: V) -> String {
         let mut diff = String::new();
-        for i in (0..nbits).rev() {
-            let mask = Self::Type::from(true) << i;
+        for i in (0..V::BITS).rev() {
+            let mask = V::one() << i;
             let template_bit = template & mask;
             let config_bit = config & mask;
             diff.push(match template_bit == config_bit {
@@ -74,7 +53,7 @@ pub trait ModifierMapValue: Eq + PartialEq + Clone {
             "* CPU template     : 0b{template:0width$b}\n\
              * CPU configuration: 0b{config:0width$b}\n\
              * Diff             :   {diff}",
-            width = nbits,
+            width = V::BITS as usize,
         )
     }
 }
@@ -150,29 +129,11 @@ pub mod tests {
         }
     }
 
-    #[derive(Debug, PartialEq, Eq, Clone)]
-    pub struct MockModifierMapValue {
-        pub filter: u8,
-        pub value: u8,
-    }
-
-    impl ModifierMapValue for MockModifierMapValue {
-        type Type = u8;
-
-        fn filter(&self) -> Self::Type {
-            self.filter
-        }
-
-        fn value(&self) -> Self::Type {
-            self.value
-        }
-    }
-
     macro_rules! mock_modifier {
         ($key:expr, ($filter:expr, $value:expr)) => {
             (
                 MockModifierMapKey($key),
-                MockModifierMapValue {
+                RegisterValueFilter::<u8> {
                     filter: $filter,
                     value: $value,
                 },

--- a/src/cpu-template-helper/src/utils/mod.rs
+++ b/src/cpu-template-helper/src/utils/mod.rs
@@ -130,7 +130,16 @@ pub mod tests {
     }
 
     macro_rules! mock_modifier {
-        ($key:expr, ($filter:expr, $value:expr)) => {
+        ($key:expr, $value:expr) => {
+            (
+                MockModifierMapKey($key),
+                RegisterValueFilter::<u8> {
+                    filter: u8::MAX,
+                    value: $value,
+                },
+            )
+        };
+        ($key:expr, $value:expr, $filter:expr) => {
             (
                 MockModifierMapKey($key),
                 RegisterValueFilter::<u8> {

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -102,7 +102,7 @@ pub trait Numeric:
     + std::ops::BitAnd<Output = Self>
     + std::ops::BitOr<Output = Self>
     + std::ops::BitOrAssign<Self>
-    + std::ops::Shl<Output = Self>
+    + std::ops::Shl<u32, Output = Self>
     + std::ops::AddAssign<Self>
 {
     /// Number of bits for type
@@ -120,7 +120,7 @@ macro_rules! impl_numeric {
         impl Numeric for $type {
             const BITS: u32 = $type::BITS;
             fn bit(&self, pos: u32) -> bool {
-                (self & (1 << pos)) != 0
+                (self & (Self::one() << pos)) != 0
             }
             fn zero() -> Self {
                 0
@@ -188,7 +188,7 @@ where
         let stripped_str = original_str.strip_prefix("0b").unwrap_or(&original_str);
 
         let (mut filter, mut value) = (V::zero(), V::zero());
-        let mut i = V::zero();
+        let mut i = 0;
         for s in stripped_str.as_bytes().iter().rev() {
             match s {
                 b'_' => continue,
@@ -207,7 +207,7 @@ where
                     )))
                 }
             }
-            i += V::one();
+            i += 1;
         }
         Ok(RegisterValueFilter { filter, value })
     }

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -103,6 +103,7 @@ pub trait Numeric:
     + std::ops::BitAnd<Output = Self>
     + std::ops::BitOr<Output = Self>
     + std::ops::BitOrAssign<Self>
+    + std::ops::BitXor<Output = Self>
     + std::ops::Shl<u32, Output = Self>
     + std::ops::AddAssign<Self>
 {

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -98,6 +98,7 @@ pub trait Numeric:
     Sized
     + Copy
     + PartialEq<Self>
+    + std::fmt::Binary
     + std::ops::Not<Output = Self>
     + std::ops::BitAnd<Output = Self>
     + std::ops::BitOr<Output = Self>

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,9 +25,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.09, "AMD": 83.34, "ARM": 83.18}
+    COVERAGE_DICT = {"Intel": 84.09, "AMD": 83.40, "ARM": 83.18}
 else:
-    COVERAGE_DICT = {"Intel": 81.39, "AMD": 80.55, "ARM": 80.19}
+    COVERAGE_DICT = {"Intel": 81.39, "AMD": 80.61, "ARM": 80.25}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

- Change the strip feature of the CPU template helper tool to operate bitwise.

## Reason

In a case where only 1 bit of a CPUID register value is different across inputs, all the other 31 bits are also preserved in the stripped outputs.
Ignoring all the other bits by eyes is quite troublesome from user perspective.

example of value-wise output
```
    {
      "leaf": "0x0",
      "subleaf": "0x0",
      "flags": 0,
      "modifiers": [
        {
          "register": "eax",
          "bitmap": "0b00000000000000000000000000001001"
        }
      ]
    },
```

example of bit-wise output
```
    {
      "leaf": "0x0",
      "subleaf": "0x0",
      "flags": 0,
      "modifiers": [
        {
          "register": "eax",
          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxx01x01"
        }
      ]
    },
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
