### PR TITLE
Support log_enabled! via logger

### DIFF
--- a/resources/tests/custom_cpu_templates/malformed_x86_cpu_template.json
+++ b/resources/tests/custom_cpu_templates/malformed_x86_cpu_template.json
@@ -1,0 +1,29 @@
+{
+  "cpuid_modifiers": [
+    {
+      "leaf": "0x0\n\n\n\nTEST\n\n\n\n",
+      "subleaf": "0x0",
+      "flags": 0,
+      "modifiers": [
+        {
+          "register": "ecx",
+          "bitmap": "0b00"
+        },
+        {
+          "register": "edx",
+          "bitmap": "0b00"
+        },
+        {
+          "register": "ebx",
+          "bitmap": "0b00"
+        }
+      ]
+    }
+  ],
+  "msr_modifiers": [
+    {
+      "addr": "0x10a",
+      "bitmap": "0b0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ]
+}

--- a/src/logger/src/logger.rs
+++ b/src/logger/src/logger.rs
@@ -415,8 +415,7 @@ pub enum LoggerError {
 /// Implements the "Log" trait from the externally used "log" crate.
 impl Log for Logger {
     fn enabled(&self, _metadata: &Metadata) -> bool {
-        // No filtering beyond what the log crate already does based on level.
-        true
+        _metadata.level() <= max_level()
     }
 
     fn log(&self, record: &Record) {


### PR DESCRIPTION
## Changes

Implement/update the `Log` trait function `enabled()` to support using the `log_enabled!` macro.

## Reason

Follow on from [PR 3832](https://github.com/firecracker-microvm/firecracker/pull/3832/) to clean up logging with verbosity targeted when configuring the `Debug` log level.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][1].

---

[1]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
