### PR TITLE
test: Improve Cargo.lock dirty check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo" 
+  - package-ecosystem: "cargo"
     directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    allow:
+      - dependency-type: "all"
+    open-pull-requests-limit: 100
+  - package-ecosystem: "cargo"
+    directory: "/tests/host_tools/uffd/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    allow:
+      - dependency-type: "all"
+    open-pull-requests-limit: 100
+  - package-ecosystem: "cargo"
+    directory: "/tests/integration_tests/security/demo_seccomp/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/deny_dirty_cargo_locks.yml
+++ b/.github/workflows/deny_dirty_cargo_locks.yml
@@ -14,10 +14,10 @@ jobs:
       - name: "Check no Cargo.lock files are dirty"
         run: |
           exit_code=0
-          is_dirty=0
           # This breaks for paths with whitespaces in them, but we have an integration test
           # that prevents those from existing in this repository.
           for f in $(find . -name 'Cargo.lock' -not -path "./build/*"); do
+            is_dirty=0
             (
               cd "$(dirname "$f")"
               cargo --locked metadata --format-version 1 >/dev/null 2>&1


### PR DESCRIPTION

## Changes

- Fixes non-dirty files being reported as dirty.
- Adds directories to dependabot.yaml.

## Reason

Derived from discussions on PR #3850.
Please see commit messages.

**Note that adding directories to dependabot.yaml could be noisy if it created a PR per directory. But let's go forward for now and see how it goes!**

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
