### PR TITLE
virtio: fix integer overflows

### DIFF
--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -553,14 +553,18 @@ impl VirtioDevice for Balloon {
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {
-        let data_len = data.len() as u64;
         let config_space_bytes = self.config_space.as_mut_slice();
-        let config_len = config_space_bytes.len() as u64;
-        if offset + data_len > config_len {
+        let start = usize::try_from(offset).ok();
+        let end = start.and_then(|s| s.checked_add(data.len()));
+        let Some(dst) = start
+            .zip(end)
+            .and_then(|(start, end)| config_space_bytes.get_mut(start..end)) else
+        {
             error!("Failed to write config space");
             return;
-        }
-        config_space_bytes[offset as usize..(offset + data_len) as usize].copy_from_slice(data);
+        };
+
+        dst.copy_from_slice(data);
     }
 
     fn activate(&mut self, mem: GuestMemoryMmap) -> ActivateResult {

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -790,16 +790,19 @@ impl VirtioDevice for Net {
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {
-        let data_len = data.len() as u64;
         let config_space_bytes = self.config_space.as_mut_slice();
-        let config_len = config_space_bytes.len() as u64;
-        if offset + data_len > config_len {
+        let start = usize::try_from(offset).ok();
+        let end = start.and_then(|s| s.checked_add(data.len()));
+        let Some(dst) = start
+            .zip(end)
+            .and_then(|(start, end)| config_space_bytes.get_mut(start..end)) else
+        {
             error!("Failed to write config space");
             METRICS.net.cfg_fails.inc();
             return;
-        }
+        };
 
-        config_space_bytes[offset as usize..(offset + data_len) as usize].copy_from_slice(data);
+        dst.copy_from_slice(data);
         self.guest_mac = Some(self.config_space.guest_mac);
         METRICS.net.mac_address_updates.inc();
     }


### PR DESCRIPTION

## Changes

In `Block::write_config()`, when computing the end of the destination slice for a configuration write, an addition might overflow (`offset + data_len`). This will immediately cause a panic in debug builds, and panic on slice indexing a few lines below for release builds.

https://github.com/firecracker-microvm/firecracker/blob/06256c309069e2db535bd0cdf55422e48eeb61c9/src/vmm/src/devices/virtio/block/device.rs#L583-L589

Fix this by using `usize::checked_add()` and `slice::get_mut()`.

There are similar issues in other devices.

## Reason

The hypervisor should not panic when given an invalid device configuration offset.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [X] If a specific issue led to this PR, this PR closes the issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] API changes follow the [Runbook for Firecracker API changes][2].
- [X] User-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.
- [X] New `TODO`s link to an issue.
- [X] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [X] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
