### PR TITLE
test(vmm): add regression test for virtio device write_config()

### DIFF
--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -762,6 +762,12 @@ pub(crate) mod tests {
         // Make sure nothing got written.
         balloon.read_config(0, &mut actual_config_space);
         assert_eq!(actual_config_space, expected_config_space);
+
+        // Large offset that may cause an overflow.
+        balloon.write_config(u64::MAX, &new_config_space);
+        // Make sure nothing got written.
+        balloon.read_config(0, &mut actual_config_space);
+        assert_eq!(actual_config_space, expected_config_space);
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -755,6 +755,12 @@ mod tests {
         // Make sure nothing got written.
         block.read_config(0, &mut actual_config_space);
         assert_eq!(actual_config_space, expected_config_space);
+
+        // Large offset that may cause an overflow.
+        block.write_config(u64::MAX, &new_config_space);
+        // Make sure nothing got written.
+        block.read_config(0, &mut actual_config_space);
+        assert_eq!(actual_config_space, expected_config_space);
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -998,6 +998,13 @@ pub mod tests {
         new_config_read = [0u8; MAC_ADDR_LEN];
         net.read_config(0, &mut new_config_read);
         assert_eq!(new_config, new_config_read);
+
+        // Large offset that may cause an overflow.
+        net.write_config(u64::MAX, &new_config);
+        // Verify old config was untouched.
+        new_config_read = [0u8; MAC_ADDR_LEN];
+        net.read_config(0, &mut new_config_read);
+        assert_eq!(new_config, new_config_read);
     }
 
     #[test]


### PR DESCRIPTION
## Changes

The test makes sure that a large offset value does not cause an overflow inside VirtioDevice::write_config().

## Reason

Regression test for https://github.com/firecracker-microvm/firecracker/pull/3869 .

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
