### PR TITLE
chore(doc):Add security policy to the PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@ Developer Certificate of Origin and signing off your commits, please check
 
 ## PR Checklist
 
+- [ ] [security policy](https://github.com/firecracker-microvm/firecracker/blob/main/SECURITY.md) is reviewed and this is not a security PR.
 - [ ] If a specific issue led to this PR, this PR closes the issue.
 - [ ] The description of changes is clear and encompassing.
 - [ ] Any required documentation changes (code and docs) are included in this PR.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 # Security Issue Policy
 
-If you uncover a security issue with Firecracker, please write to us on
-<firecracker-security-disclosures@amazon.com>. Please encrypt sensitive
-information using the [PGP key](PGP-KEY.asc).
+If you uncover a security issue with Firecracker, instead of posting a PR
+please write to us on <firecracker-security-disclosures@amazon.com> with details of the patch.
+Please encrypt sensitive information using the [PGP key](PGP-KEY.asc).
 
 Once the Firecracker [maintainers](MAINTAINERS.md) become aware (or are made
 aware) of a security issue, they will immediately assess it. Based on impact and


### PR DESCRIPTION
It is possible that not all contributors go through security policy page before posting a PR so, add security policy to the PR checklist as an attempt to improve its visibility.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
