### PR TITLE
test: Disable Turbo Boost

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -601,6 +601,19 @@ cmd_test() {
     # We need to run a privileged container to get that kind of access.
     env |grep -P "^(AWS_EMF_|BUILDKITE_)" > env.list
 
+    if [[ "$BUILDKITE" = "true" ]]; then
+      # Disable turbo boost. Some of our tests are performance tests, and we want minimum variability wrt processor frequency
+      # See also https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html
+      sudo sh -c "echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo" &> /dev/null
+
+      # The governor is a linux component that can adjust CPU frequency. "performance" tells it to always run CPUs at
+      # their maximum safe frequency. It seems to be the default for Amazon Linux, but it doesn't hurt to make this explicit.
+      # See also https://wiki.archlinux.org/title/CPU_frequency_scaling
+      sudo sh -c "echo "performance" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor" &> /dev/null
+
+      say "Detected CI, tuning CPU frequency scaling for reduced variability"
+    fi
+
     run_devctr \
         --privileged \
         --security-opt seccomp=unconfined \


### PR DESCRIPTION
Turbo boost allows the CPU of the .metal instance running our test suite to temporarily operate at a higher frequency. Since some of our tests are performance tests, this add non-deterministic variability into the processor frequency. Therefore, disable it.

Also explicitly set the scaling governor to "performance" to prevent the kernel from adjusting CPU frequency for us.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
