### PR TITLE
test(tcp/vsock throughput): Ignore final two cpu load datapoints

### DIFF
--- a/tests/framework/utils_iperf.py
+++ b/tests/framework/utils_iperf.py
@@ -70,7 +70,8 @@ class IPerf3Test:
             cpu_load_future = executor.submit(
                 get_cpu_percent,
                 self._microvm.jailer_clone_pid,
-                self._runtime,
+                # Ignore the final two data points as they are impacted by test teardown
+                self._runtime - 2,
                 self._omit,
             )
 
@@ -106,7 +107,7 @@ class IPerf3Test:
         cmd = self.guest_command(client_idx).with_arg(mode).build()
 
         pinned_cmd = (
-            f"taskset --cpu-list {client_idx % self._microvm.vcpus_count}" f" {cmd}"
+            f"taskset --cpu-list {client_idx % self._microvm.vcpus_count} {cmd}"
         )
         rc, stdout, stderr = self._microvm.ssh.execute_command(pinned_cmd)
 


### PR DESCRIPTION
Prior to 1e0fa78dc3bfba31e787425c8f907e7176956f22, the final two CPU load data points were ignored in the tcp and vsock throughput tests as they were seemingly impacted by test tear down. I accidentally removed that logic in my refractor, which caused the perf tests to fail. This commit reintroduces that logic.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
