### PR TITLE
[Kani] Introduce formal verification harnesses for ratelimiter and dumbo

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -37,6 +37,7 @@ defaults = {
     "priority": DEFAULT_PRIORITY,
     "timeout_in_minutes": 45,
     "env": dict(args.step_env),
+    "artifacts": ["./test_results/**/*"],
 }
 defaults.update(args.step_param)
 

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -79,6 +79,23 @@ performance_grp = group(
     **defaults_for_performance,
 )
 
+defaults_for_kani = defaults.copy()
+defaults_for_kani.update(
+    # Kani runs fastest on m6i.metal
+    instances=["m6i.metal"],
+    platforms=[("al2", "linux_5.10")],
+    timeout_in_minutes=300,
+    agent_tags=["ag=1"],
+)
+
+kani_grp = group(
+    "🔍 Kani",
+    "./tools/devtool -y test -- ../tests/integration_tests/test_kani.py -n auto",
+    **defaults_for_kani,
+)
+for step in kani_grp["steps"]:
+    step["label"] = "🔍 Kani"
+
 steps = [step_style]
 changed_files = get_changed_files("main")
 # run the whole test suite if either of:
@@ -89,6 +106,7 @@ if not changed_files or any(
     for x in changed_files
 ):
     steps += [
+        kani_grp,
         build_grp,
         functional_1_grp,
         functional_2_grp,

--- a/docs/formal-verification.md
+++ b/docs/formal-verification.md
@@ -1,0 +1,187 @@
+# Formal Verification in Firecracker
+
+According to Firecracker’s [threat
+model](https://github.com/firecracker-microvm/firecracker/blob/main/docs/design.md#threat-containment),
+all vCPUs are considered to be running potentially malicious code from the
+moment they are started. This means Firecracker can make no assumptions about
+well-formedness of data passed to it by the guest, and have to operate *safely*
+no matter what input it is faced with. Traditional testing methods alone cannot
+guarantee about the general absence of safety issues, as for this we would need
+to write and run every possible unit test, exercising every possible code path -
+a prohibitively large task.
+
+To partially address these limitations, Firecracker is additionally using
+formal verification to go further in verifying that safety issues such as
+buffer overruns, panics, use-after-frees or integer overflows cannot occur
+in critical components. We employ
+[Kani](https://github.com/model-checking/kani/), a formal verification tool
+written specifically for Rust, which allows us to express functional properties
+(such as any user-specified assertion) in familiar Rust-style by replacing
+concrete values in unit tests with `kani::any()`. For more details on how Kani
+works, and what properties it can verify, check out its official [Kani
+book](https://model-checking.github.io/kani/) or try out this
+[tutorial](https://model-checking.github.io/kani/kani-tutorial.html).
+
+We aim to have Kani harnesses for components that directly interact with data
+from the guest, such as the TCP/IP stack powering our microVM Metadata Service
+(MMDS) integration, or which are difficult to test traditionally, such as our
+I/O Rate Limiter. Our Kani harnesses live in `verification` modules that are
+tagged with `#[cfg(kani)]`, similar to how unit tests in Rust are usually
+structured.
+
+Note that for some harnesses, Kani uses a “bounded” approach, where the inputs
+are restricted based on some assumptions (e.g. the size of an Ethernet frame
+being 1514 bytes). **Harnesses are only as strong as the assumptions they make,
+so all guarantees from the harness are only valid based on the set of
+assumptions we have in our Kani harnesses.** Generally, they should strive to
+*over-approximate*, meaning it is preferred they cover some “impossible”
+situations instead of making too strong assumptions that cause them to
+exclude realistic scenarios.
+
+## How to run Kani harnesses
+
+To ensure that no incoming code changes cause regressions on formally verified
+properties, **all Kani harnesses are run on every pull request in our CI.** To
+check whether the harnesses all work for your pull request, check out the
+“Kani” [Buildkite](https://buildkite.com/) step.
+
+You can also execute our harnesses locally through `./tools/devtool test --
+integration_tests/build/test_kani.py`. To only run individual harnesses, you
+will need to first [install
+Kani](https://model-checking.github.io/kani/install-guide.html#installing-the-latest-version)
+locally.
+From there on, individual test can be run via `cargo kani` similarly to how
+`cargo test` can run individual unit tests, the only difference being that the
+harness needs to be specified via `--harness`. Note that the first invocation
+of Kani post-installation might take a while, due to it setting up some
+dependencies.
+
+## An example harness
+
+The following is adapted from our Rate Limiter harness suite. It aims to verify
+that creation of a rate-limiting policy upholds all [Kani supported safety
+invariants](https://model-checking.github.io/kani/tutorial-kinds-of-failure.html)
+(which can roughly be summarized as “everything that leads to a panic in a
+debug build”), as well as results in a valid policy. A first attempt might look
+something like this:
+
+```
+#[kani::proof]
+fn verify_token_bucket_new() {
+    let token_budget = kani::any();
+    let complete_refill_time_ms = kani::any();
+
+    // Checks if the `TokenBucket` is created with invalid inputs, the result
+    // is always `None`.
+    match TokenBucket::new(token_budget, 0, complete_refill_time_ms) {
+        None => assert!(size == 0 || complete_refill_time_ms == 0),
+        Some(bucket) => assert!(bucket.is_valid()),
+    }
+}
+```
+
+The `#[kani::proof]` attribute tells us that the function is a harness to be
+picked up by the Kani compiler. It is the Kani equivalent of `#[test]`. Lines
+3-5 indicate that we want to verify that policy creation works for arbitrarily
+sized token buckets and arbitrary refill times. **This is the key difference to
+a unit test**, where we would be using concrete values instead (e.g. `let
+token_budget = 10;`). Note that Kani will not produce an executable, but
+instead *statically* verifies that code does not violate invariants. We do not
+actually execute the creation code for all possible inputs.
+
+The final match statement tells us the property we want to verify, which is
+“*bucket creation only fails if size of refill time are zero*”. In all other
+cases, we assert `new` to give us a valid bucket. We mapped these properties
+with assertions. If the verification fails, then that is because one of our
+properties do not hold.
+
+Now that we understand the code in the harness, let's try to verify
+`TokenBucket::new` with the Kani!
+
+If we run `cargo kani --harness verify_token_bucket_new` we will be greeted by
+
+```
+SUMMARY: ** 1 of 147 failed Failed Checks: attempt to multiply with overflow
+File: "src/rate_limiter/src/lib.rs", line 136, in TokenBucket::new
+
+VERIFICATION:- FAILED
+Verification Time: 0.21081695s
+```
+
+In this particular case, Kani has found a safety issue related to an integer
+overflow! Due to `complete_refill_time_ms` getting converted from milliseconds
+to nanoseconds in the constructor, we have to take into consideration that the
+nanosecond value might not fit into a `u64` anymore. Here, the finding is
+benign, as no one would reasonably configure a `ratelimiter` with a replenish
+time of 599730287.457 *years*. A [quick
+check](https://github.com/firecracker-microvm/firecracker/commit/0db2a130ca4eeffeca9a46e7b6bd45c1bc1c9e21)
+in the constructor fixes it. However, we will also have to adjust our harness!
+Rerunning the harness from above now yields:
+
+```
+SUMMARY: ** 1 of 149 failed Failed Checks: assertion failed: size == 0
+                                            || complete_refill_time_ms == 0
+File: "src/rate_limiter/src/lib.rs", line 734, in verification::verify_token_bucket_new
+
+VERIFICATION:- FAILED
+Verification Time: 0.21587047s
+```
+
+This makes sense: There are now more scenarios in which we explicitly fail
+construction. Changing our failure property from `size == 0 ||
+complete_refill_time_ms == 0` to `size == 0 || complete_refill_time_ms == 0 ||
+complete_refill_time >= u64::MAX / 1_000_000` in the harness will account for
+this change, and rerunning the harness will now tell us that no more issues are
+found:
+
+```
+SUMMARY: ** 0 of 150 failed
+
+VERIFICATION:- SUCCESSFUL
+Verification Time: 0.19135727s
+```
+
+## FAQ
+
+**Q:** What is the Kani verifier?\
+**A:** The [Kani Rust
+Verifier](https://github.com/model-checking/kani) is a bit-precise model
+checker for Rust. Kani is particularly useful for verifying unsafe code blocks
+in Rust, where the “[unsafe
+superpowers](https://doc.rust-lang.org/stable/book/ch19-01-unsafe-rust.html#unsafe-superpowers)"
+are unchecked by the compiler.
+
+**Q:** What safety properties does Kani verify?\
+**A:** Kani verifies memory
+safety properties (e.g., invalid-pointer dereferences, out-of-bounds array
+access), user-specified assertions (i.e., `assert!(...)`), the absence of
+`panic!()`s (e.g., `unwrap()` on `None` values), and the absence of some types of
+unexpected behavior (e.g., arithmetic overflows). For a full overview, see the
+[Kani
+documentation](https://model-checking.github.io/kani/tutorial-kinds-of-failure.html).
+
+**Q:** Do we expect all contributors to write harnesses for newly introduced
+code?\
+**A:** No. Kani is complementary to unit testing, and we do not have
+target for “proof coverage”. We employ formal verification in especially
+critical code areas. Generally we do not expect someone who might not be
+familiar with formal tools to contribute harnesses. We do expect all
+contributed code to pass verification though, just like we expect it to pass
+unit test!
+
+**Q:** How should I report issues related to any Firecracker harnesses?\
+**A:**
+Our Kani harnesses verify safety critical invariants. If you discover a flaw in
+a harness, please report it using the [security issue disclosure
+process](https://github.com/firecracker-microvm/firecracker/blob/main/SECURITY.md).
+
+**Q:** How do I know which properties I should prove in the Kani harness?\
+**A:** Generally, these are given by some sort of specification. This can
+either be the function contract described in its document (e.g. what relation
+between input and output do callers expect?), or even something formal such as
+the TCP/IP standard. Don't forget to mention the specification in your proof
+harness!
+
+**Q:** Where do I debug a broken proof?\
+**A:** Check out the Kani book section
+on [debugging verification failures](https://model-checking.github.io/kani/debugging-verification-failures.html).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -526,3 +526,23 @@ def io_engine(request):
     if request.param == "Async" and not is_io_uring_supported():
         pytest.skip("io_uring not supported in this kernel")
     return request.param
+
+
+@pytest.fixture
+def results_dir(request):
+    """
+    Fixture yielding the path to a directory into which the test can dump its results
+
+    Directories are unique per test, and named after the test name. Everything the tests puts
+    into its directory will to be uploaded to S3. Directory will be placed inside defs.TEST_RESULTS_DIR.
+
+    For example
+    ```py
+    def test_my_file(results_dir):
+        (results_dir / "output.txt").write_text("Hello World")
+    ```
+    will result in `defs.TEST_RESULTS_DIR`/test_my_file/output.txt.
+    """
+    results_dir = defs.TEST_RESULTS_DIR / request.node.originalname
+    results_dir.mkdir(parents=True, exist_ok=True)
+    return results_dir

--- a/tests/integration_tests/performance/conftest.py
+++ b/tests/integration_tests/performance/conftest.py
@@ -16,23 +16,7 @@ from framework.stats import core
 
 
 # pylint: disable=too-few-public-methods
-class ResultsDumperInterface:
-    """Interface for dumping results to file."""
-
-    def dump(self, result):
-        """Dump the results in JSON format."""
-
-
-# pylint: disable=too-few-public-methods
-class NopResultsDumper(ResultsDumperInterface):
-    """Interface for dummy dumping results to file."""
-
-    def dump(self, result):
-        """Do not do anything."""
-
-
-# pylint: disable=too-few-public-methods
-class JsonFileDumper(ResultsDumperInterface):
+class JsonFileDumper:
     """Class responsible with outputting test results to files."""
 
     def __init__(self, test_name):

--- a/tests/integration_tests/test_kani.py
+++ b/tests/integration_tests/test_kani.py
@@ -1,0 +1,30 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Proofs ensuring memory safety properites, user-defined assertions,
+absence of panics and some types of unexpected behavior (e.g., arithmetic overflows).
+"""
+import platform
+
+import pytest
+
+from framework import utils
+
+PLATFORM = platform.machine()
+CRATES_WITH_PROOFS = ["dumbo", "rate_limiter"]
+
+
+@pytest.mark.timeout(1800)
+@pytest.mark.skipif(PLATFORM != "x86_64", reason="Kani proofs run only on x86_64.")
+@pytest.mark.parametrize("crate", CRATES_WITH_PROOFS)
+def test_kani(results_dir, crate):
+    """
+    Test all Kani proof harnesses.
+    """
+    rc, stdout, stderr = utils.run_cmd(
+        f"cargo kani -p {crate} --enable-unstable --enable-stubbing"
+    )
+
+    assert rc == 0, stderr
+
+    (results_dir / f"kani_log_{crate}").write_text(stdout, encoding="utf-8")

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -76,6 +76,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOL
     && rustup target add $ARCH-unknown-linux-musl \
     && rustup component add llvm-tools-preview \
     && cargo install cargo-audit cargo-deny grcov cargo-sort \
+    && (if [ "$ARCH" = "x86_64" ]; then cargo install kani-verifier && cargo kani setup; else true; fi) # Kani only work on x86_64 \
     && rm -rf "$CARGO_HOME/registry" \
     && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
     && rm -rf "$CARGO_HOME/git" \

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v60}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v61}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
## Changes

Introduces formal verification harnesses verifying the safety and correctness of the ethernet module of dumbo, and the rate limiter implementation. Additionally, add CI integration to run the verification on every PR.

## Reason

Formal verification will significantly raise our safety and correctness bar. Please see the documentation included in this PR for details. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
