### PR TITLE
test: Name performance test data consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,9 +595,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "indexmap"

--- a/tests/framework/stats/core.py
+++ b/tests/framework/stats/core.py
@@ -73,7 +73,9 @@ class Core:
                     raws = pipe.consumer.ingest(iteration, data)
                     if raws is not None:
                         dimensions = self.custom.copy()
-                        dimensions["test"] = self.metrics_test
+                        test = tag.split("/")[-1]
+                        dimensions["test"] = test
+                        dimensions["performance_test"] = self.name
                         self.metrics.set_dimensions(dimensions)
                         for name, val, unit in raws:
                             self.metrics.put_metric(name, val, unit)


### PR DESCRIPTION
Changes the dimensions of the raw metrics output by the performance tests to match their aggregates. Prior to this change, all parameterizations of a single tests were only tagged with the test function name. This change instead includes the "tag" as well as full parameterized pytest test name, just like the aggregates.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
