### PR TITLE
test(perf): Accumulated Block Test fixes + baselines

### DIFF
--- a/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
@@ -12,7 +12,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 944584
+                                                    "target": 935745
                                                 }
                                             }
                                         },
@@ -20,7 +20,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1594918
+                                                    "target": 1798083
                                                 }
                                             }
                                         }
@@ -31,16 +31,16 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 875947
+                                                    "delta_percentage": 7,
+                                                    "target": 887915
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1759857
+                                                    "delta_percentage": 11,
+                                                    "target": 1754367
                                                 }
                                             }
                                         }
@@ -52,10 +52,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 934430
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1620683
+                                                }
                                             }
                                         }
                                     }
@@ -64,10 +72,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 876167
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1713739
+                                                }
                                             }
                                         }
                                     }
@@ -81,12 +97,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -101,12 +125,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -121,16 +153,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 61
+                                                    "delta_percentage": 9,
+                                                    "target": 47
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 58
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 62
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 73
+                                                    "target": 71
                                                 }
                                             }
                                         }
@@ -141,16 +181,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 45
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 57
+                                                    "target": 54
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 69
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 74
+                                                    "target": 73
                                                 }
                                             }
                                         }
@@ -172,16 +220,16 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 420423
+                                                    "delta_percentage": 6,
+                                                    "target": 392494
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 1028476
+                                                    "delta_percentage": 9,
+                                                    "target": 1094289
                                                 }
                                             }
                                         }
@@ -192,16 +240,16 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 419754
+                                                    "delta_percentage": 6,
+                                                    "target": 389179
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 947719
+                                                    "delta_percentage": 7,
+                                                    "target": 1065578
                                                 }
                                             }
                                         }
@@ -213,10 +261,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 389268
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 885564
+                                                }
                                             }
                                         }
                                     }
@@ -225,10 +281,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 386365
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 865267
+                                                }
                                             }
                                         }
                                     }
@@ -242,12 +306,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -262,14 +334,22 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 168
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
                                                 }
                                             }
                                         }
@@ -283,7 +363,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 49
+                                                    "target": 43
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 52
                                                 }
                                             }
                                         },
@@ -291,7 +375,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 78
+                                                    "target": 76
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 79
                                                 }
                                             }
                                         }
@@ -302,16 +390,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 49
+                                                    "delta_percentage": 6,
+                                                    "target": 43
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 51
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 74
+                                                    "delta_percentage": 6,
+                                                    "target": 75
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 78
                                                 }
                                             }
                                         }
@@ -329,16 +425,16 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 17,
-                                                    "target": 661470
+                                                    "delta_percentage": 8,
+                                                    "target": 577468
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1655535
+                                                    "delta_percentage": 10,
+                                                    "target": 1675686
                                                 }
                                             }
                                         }
@@ -349,16 +445,16 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 665203
+                                                    "delta_percentage": 8,
+                                                    "target": 571465
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1637524
+                                                    "delta_percentage": 12,
+                                                    "target": 1483646
                                                 }
                                             }
                                         }
@@ -370,10 +466,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 19,
+                                                    "target": 603000
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1432547
+                                                }
                                             }
                                         }
                                     }
@@ -382,10 +486,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 15,
+                                                    "target": 606593
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1310847
+                                                }
                                             }
                                         }
                                     }
@@ -399,12 +511,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -419,12 +539,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -440,15 +568,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 45
+                                                    "target": 37
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 13,
+                                                    "target": 49
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 59
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 72
+                                                    "target": 76
                                                 }
                                             }
                                         }
@@ -459,14 +595,22 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 45
+                                                    "delta_percentage": 9,
+                                                    "target": 36
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 49
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 65
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 70
                                                 }
@@ -491,15 +635,15 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 666334
+                                                    "target": 658527
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 49,
-                                                    "target": 1888893
+                                                    "delta_percentage": 41,
+                                                    "target": 2010147
                                                 }
                                             }
                                         }
@@ -511,15 +655,15 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 677991
+                                                    "target": 663559
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 2198233
+                                                    "delta_percentage": 13,
+                                                    "target": 1965095
                                                 }
                                             }
                                         }
@@ -531,10 +675,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 650260
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 23,
+                                                    "target": 2065050
+                                                }
                                             }
                                         }
                                     }
@@ -543,10 +695,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 671812
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 15,
+                                                    "target": 2005666
+                                                }
                                             }
                                         }
                                     }
@@ -560,12 +720,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -580,6 +748,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -588,6 +760,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 171
                                                 }
                                             }
                                         }
@@ -600,16 +776,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 36
+                                                    "delta_percentage": 7,
+                                                    "target": 32
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 40
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 68
+                                                    "delta_percentage": 11,
+                                                    "target": 62
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 75
                                                 }
                                             }
                                         }
@@ -620,16 +804,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 36
+                                                    "delta_percentage": 8,
+                                                    "target": 32
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 41
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 72
+                                                    "delta_percentage": 8,
+                                                    "target": 66
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 71
                                                 }
                                             }
                                         }
@@ -651,16 +843,16 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 721416
+                                                    "delta_percentage": 26,
+                                                    "target": 666194
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1248524
+                                                    "delta_percentage": 11,
+                                                    "target": 1384089
                                                 }
                                             }
                                         }
@@ -671,16 +863,16 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 577206
+                                                    "delta_percentage": 13,
+                                                    "target": 586804
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 1072702
+                                                    "delta_percentage": 7,
+                                                    "target": 1415491
                                                 }
                                             }
                                         }
@@ -692,10 +884,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 702723
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1230806
+                                                }
                                             }
                                         }
                                     }
@@ -704,10 +904,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 658625
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 35,
+                                                    "target": 1171192
+                                                }
                                             }
                                         }
                                     }
@@ -721,12 +929,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -741,12 +957,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -761,16 +985,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 59
+                                                    "delta_percentage": 7,
+                                                    "target": 47
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 56
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 65
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 73
+                                                    "target": 72
                                                 }
                                             }
                                         }
@@ -781,16 +1013,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 51
+                                                    "delta_percentage": 8,
+                                                    "target": 46
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 53
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 67
+                                                    "delta_percentage": 7,
+                                                    "target": 69
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 18,
+                                                    "target": 68
                                                 }
                                             }
                                         }
@@ -812,16 +1052,16 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 747217
+                                                    "delta_percentage": 11,
+                                                    "target": 636372
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 1693772
+                                                    "delta_percentage": 7,
+                                                    "target": 1841568
                                                 }
                                             }
                                         }
@@ -832,16 +1072,16 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 746760
+                                                    "delta_percentage": 14,
+                                                    "target": 650562
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1728290
+                                                    "delta_percentage": 9,
+                                                    "target": 1843245
                                                 }
                                             }
                                         }
@@ -853,10 +1093,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 720994
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 1623874
+                                                }
                                             }
                                         }
                                     }
@@ -865,10 +1113,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 728558
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1524952
+                                                }
                                             }
                                         }
                                     }
@@ -881,6 +1137,10 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
+                                                    "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
                                                     "target": 86
                                                 }
                                             }
@@ -888,6 +1148,10 @@
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -902,12 +1166,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -922,6 +1194,10 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 39
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 49
                                                 }
@@ -931,7 +1207,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 72
+                                                    "target": 60
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 74
                                                 }
                                             }
                                         }
@@ -942,8 +1222,12 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 48
+                                                    "delta_percentage": 7,
+                                                    "target": 39
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 49
                                                 }
                                             }
                                         },
@@ -951,7 +1235,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 71
+                                                    "target": 67
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 69
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
@@ -1357,7 +1357,6 @@
             }
         }
     },
-    "load_factor": 1,
     "measurements": {
         "bw_read": {
             "statistics": [

--- a/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
@@ -1,12 +1,4 @@
 {
-    "block_device_size": 2048,
-    "fio_blk_sizes": [
-        4096
-    ],
-    "fio_modes": [
-        "randrw",
-        "randread"
-    ],
     "hosts": {
         "instances": {
             "c7g.metal": {
@@ -1402,7 +1394,5 @@
             ],
             "unit": "percentage"
         }
-    },
-    "omit": 10,
-    "time": 300
+    }
 }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
@@ -13,10 +13,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 944584
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 461388
                                                 }
                                             }
                                         },
@@ -25,10 +21,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1594918
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 784122
                                                 }
                                             }
                                         }
@@ -41,10 +33,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 875947
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 422226
                                                 }
                                             }
                                         },
@@ -53,10 +41,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1759857
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 859220
                                                 }
                                             }
                                         }
@@ -68,18 +52,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 461383
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 784130
-                                                }
                                             }
                                         }
                                     }
@@ -88,18 +64,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 422219
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 859206
-                                                }
                                             }
                                         }
                                     }
@@ -113,20 +81,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -141,20 +101,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -171,20 +123,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 61
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 60
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 73
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 73
                                                 }
@@ -199,20 +143,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 57
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 55
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 74
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 74
                                                 }
@@ -238,10 +174,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 420423
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 208260
                                                 }
                                             }
                                         },
@@ -250,10 +182,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 1028476
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 472852
                                                 }
                                             }
                                         }
@@ -266,10 +194,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 419754
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 208579
                                                 }
                                             }
                                         },
@@ -278,10 +202,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 14,
                                                     "target": 947719
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 458831
                                                 }
                                             }
                                         }
@@ -293,18 +213,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 208263
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 472844
-                                                }
                                             }
                                         }
                                     }
@@ -313,18 +225,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 208601
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 458874
-                                                }
                                             }
                                         }
                                     }
@@ -338,20 +242,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -366,10 +262,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -378,10 +270,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 12,
                                                     "target": 168
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
                                                 }
                                             }
                                         }
@@ -396,10 +284,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 49
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 52
                                                 }
                                             }
                                         },
@@ -408,10 +292,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 78
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 79
                                                 }
                                             }
                                         }
@@ -424,10 +304,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 49
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 52
                                                 }
                                             }
                                         },
@@ -436,10 +312,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 74
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 77
                                                 }
                                             }
                                         }
@@ -459,10 +331,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 17,
                                                     "target": 661470
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 331668
                                                 }
                                             }
                                         },
@@ -471,10 +339,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1655535
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 762638
                                                 }
                                             }
                                         }
@@ -487,10 +351,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
                                                     "target": 665203
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 335227
                                                 }
                                             }
                                         },
@@ -499,10 +359,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1637524
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 707653
                                                 }
                                             }
                                         }
@@ -514,18 +370,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 331682
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 762693
-                                                }
                                             }
                                         }
                                     }
@@ -534,18 +382,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 335239
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 707628
-                                                }
                                             }
                                         }
                                     }
@@ -559,20 +399,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -587,20 +419,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -617,10 +441,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 45
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 49
                                                 }
                                             }
                                         },
@@ -629,10 +449,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 72
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 75
                                                 }
                                             }
                                         }
@@ -645,20 +461,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 45
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 49
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 70
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 70
                                                 }
@@ -684,10 +492,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 666334
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 327293
                                                 }
                                             }
                                         },
@@ -696,10 +500,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 49,
                                                     "target": 1888893
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 18,
-                                                    "target": 1043927
                                                 }
                                             }
                                         }
@@ -712,10 +512,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 677991
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 333233
                                                 }
                                             }
                                         },
@@ -724,10 +520,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 2198233
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1069561
                                                 }
                                             }
                                         }
@@ -739,18 +531,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 327293
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 18,
-                                                    "target": 1043936
-                                                }
                                             }
                                         }
                                     }
@@ -759,18 +543,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 333220
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1069535
-                                                }
                                             }
                                         }
                                     }
@@ -784,20 +560,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -812,20 +580,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -842,10 +602,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 36
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 37
                                                 }
                                             }
                                         },
@@ -854,10 +610,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 20,
                                                     "target": 68
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 74
                                                 }
                                             }
                                         }
@@ -870,10 +622,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 36
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 38
                                                 }
                                             }
                                         },
@@ -882,10 +630,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 72
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 73
                                                 }
                                             }
                                         }
@@ -909,10 +653,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 721416
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 348034
                                                 }
                                             }
                                         },
@@ -921,10 +661,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 1248524
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 604373
                                                 }
                                             }
                                         }
@@ -937,10 +673,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 577206
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 277837
                                                 }
                                             }
                                         },
@@ -949,10 +681,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 16,
                                                     "target": 1072702
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 593177
                                                 }
                                             }
                                         }
@@ -964,18 +692,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 348044
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 604394
-                                                }
                                             }
                                         }
                                     }
@@ -984,18 +704,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 277835
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 593195
-                                                }
                                             }
                                         }
                                     }
@@ -1009,20 +721,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1037,20 +741,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1067,20 +763,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 59
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 58
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 73
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 73
                                                 }
@@ -1095,10 +783,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 51
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 50
                                                 }
                                             }
                                         },
@@ -1107,10 +791,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 67
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 71
                                                 }
                                             }
                                         }
@@ -1134,10 +814,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 747217
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 358499
                                                 }
                                             }
                                         },
@@ -1146,10 +822,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 1693772
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 816304
                                                 }
                                             }
                                         }
@@ -1162,10 +834,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 746760
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 360791
                                                 }
                                             }
                                         },
@@ -1174,10 +842,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1728290
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 775687
                                                 }
                                             }
                                         }
@@ -1189,18 +853,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 358524
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 816390
-                                                }
                                             }
                                         }
                                     }
@@ -1209,18 +865,10 @@
                                     "ubuntu-18.04.ext4": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 360783
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 775676
-                                                }
                                             }
                                         }
                                     }
@@ -1234,20 +882,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -1262,20 +902,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -1292,10 +924,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 49
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 49
                                                 }
                                             }
                                         },
@@ -1304,10 +932,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 72
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 73
                                                 }
                                             }
                                         }
@@ -1320,10 +944,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 48
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 49
                                                 }
                                             }
                                         },
@@ -1332,10 +952,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 71
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 69
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
@@ -13,10 +13,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 994523
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 439313
                                                 }
                                             }
                                         },
@@ -25,10 +21,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 2083550
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1004722
                                                 }
                                             }
                                         },
@@ -37,10 +29,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 862065
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 422378
                                                 }
                                             }
                                         },
@@ -49,10 +37,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1602015
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 785426
                                                 }
                                             }
                                         }
@@ -65,10 +49,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 863029
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 400974
                                                 }
                                             }
                                         },
@@ -77,10 +57,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 2122125
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 997699
                                                 }
                                             }
                                         },
@@ -89,10 +65,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 839565
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 408325
                                                 }
                                             }
                                         },
@@ -101,10 +73,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1377671
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 18,
-                                                    "target": 702190
                                                 }
                                             }
                                         }
@@ -116,34 +84,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 439317
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1004731
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 422384
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 785432
-                                                }
                                             }
                                         }
                                     }
@@ -152,34 +104,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 400952
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 997698
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 408313
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 18,
-                                                    "target": 702178
-                                                }
                                             }
                                         }
                                     }
@@ -193,10 +129,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -205,10 +137,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -217,20 +145,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -245,10 +165,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -257,10 +173,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -269,20 +181,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -299,20 +203,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 75
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 76
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -323,10 +219,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 63
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 63
                                                 }
                                             }
                                         },
@@ -335,10 +227,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 81
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 82
                                                 }
                                             }
                                         }
@@ -351,20 +239,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 12,
                                                     "target": 68
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 72
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -375,10 +255,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 61
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 60
                                                 }
                                             }
                                         },
@@ -387,10 +263,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 77
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 78
                                                 }
                                             }
                                         }
@@ -414,10 +286,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 16,
                                                     "target": 326202
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 142823
                                                 }
                                             }
                                         },
@@ -426,10 +294,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 19,
                                                     "target": 1018682
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 578569
                                                 }
                                             }
                                         },
@@ -438,10 +302,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 448686
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 220767
                                                 }
                                             }
                                         },
@@ -450,10 +310,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 1050550
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 460706
                                                 }
                                             }
                                         }
@@ -466,10 +322,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 15,
                                                     "target": 321718
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 142909
                                                 }
                                             }
                                         },
@@ -478,10 +330,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 27,
                                                     "target": 1175424
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 784926
                                                 }
                                             }
                                         },
@@ -490,10 +338,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 447983
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 221305
                                                 }
                                             }
                                         },
@@ -502,10 +346,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1020341
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 417493
                                                 }
                                             }
                                         }
@@ -517,34 +357,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 142832
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 578560
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 220759
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 460679
-                                                }
                                             }
                                         }
                                     }
@@ -553,34 +377,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 142914
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 784922
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 221322
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 417500
-                                                }
                                             }
                                         }
                                     }
@@ -594,10 +402,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -606,10 +410,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 170
                                                 }
                                             }
                                         },
@@ -618,20 +418,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -646,10 +438,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 85
                                                 }
                                             }
                                         },
@@ -658,10 +446,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 170
                                                 }
                                             }
                                         },
@@ -670,20 +454,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -700,10 +476,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 60
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 60
                                                 }
                                             }
                                         },
@@ -712,10 +484,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 80
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 81
                                                 }
                                             }
                                         },
@@ -724,10 +492,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 50
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 53
                                                 }
                                             }
                                         },
@@ -736,10 +500,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 79
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 78
                                                 }
                                             }
                                         }
@@ -752,10 +512,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 60
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 60
                                                 }
                                             }
                                         },
@@ -764,10 +520,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 81
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -776,10 +528,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 50
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 53
                                                 }
                                             }
                                         },
@@ -788,10 +536,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 77
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 73
                                                 }
                                             }
                                         }
@@ -811,10 +555,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 18,
                                                     "target": 551148
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 234072
                                                 }
                                             }
                                         },
@@ -823,10 +563,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 1788874
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 939162
                                                 }
                                             }
                                         },
@@ -835,10 +571,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 672806
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 339626
                                                 }
                                             }
                                         },
@@ -847,10 +579,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1650455
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 761198
                                                 }
                                             }
                                         }
@@ -863,10 +591,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 21,
                                                     "target": 523405
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 224650
                                                 }
                                             }
                                         },
@@ -875,10 +599,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 2030557
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 937203
                                                 }
                                             }
                                         },
@@ -887,10 +607,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 672797
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 333762
                                                 }
                                             }
                                         },
@@ -899,10 +615,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1630015
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 696698
                                                 }
                                             }
                                         }
@@ -914,34 +626,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 234104
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 939162
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 339567
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 761164
-                                                }
                                             }
                                         }
                                     }
@@ -950,34 +646,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 224622
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 937254
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 333767
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 696663
-                                                }
                                             }
                                         }
                                     }
@@ -991,10 +671,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -1003,10 +679,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 171
                                                 }
                                             }
                                         },
@@ -1015,20 +687,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -1043,10 +707,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -1055,20 +715,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 171
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
                                                 }
@@ -1079,10 +731,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 170
                                                 }
                                             }
                                         }
@@ -1097,10 +745,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 52
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 57
                                                 }
                                             }
                                         },
@@ -1109,10 +753,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 80
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -1121,10 +761,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 45
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 50
                                                 }
                                             }
                                         },
@@ -1133,10 +769,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 72
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 75
                                                 }
                                             }
                                         }
@@ -1149,10 +781,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 51
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 56
                                                 }
                                             }
                                         },
@@ -1161,10 +789,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 82
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -1173,10 +797,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 45
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 50
                                                 }
                                             }
                                         },
@@ -1185,10 +805,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 69
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 70
                                                 }
                                             }
                                         }
@@ -1212,10 +828,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 58,
                                                     "target": 501863
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 21,
-                                                    "target": 267027
                                                 }
                                             }
                                         },
@@ -1224,10 +836,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 90,
                                                     "target": 1707390
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 23,
-                                                    "target": 1085397
                                                 }
                                             }
                                         },
@@ -1236,10 +844,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 21,
                                                     "target": 700593
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 343152
                                                 }
                                             }
                                         },
@@ -1248,10 +852,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 37,
                                                     "target": 2075897
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 1039692
                                                 }
                                             }
                                         }
@@ -1264,10 +864,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 71,
                                                     "target": 508821
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 25,
-                                                    "target": 268955
                                                 }
                                             }
                                         },
@@ -1276,10 +872,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 63,
                                                     "target": 1854315
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 1091252
                                                 }
                                             }
                                         },
@@ -1288,10 +880,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 22,
                                                     "target": 716701
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 22,
-                                                    "target": 351584
                                                 }
                                             }
                                         },
@@ -1300,10 +888,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 2205226
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1009310
                                                 }
                                             }
                                         }
@@ -1315,34 +899,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 21,
-                                                    "target": 267018
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 23,
-                                                    "target": 1085370
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 343155
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 1039709
-                                                }
                                             }
                                         }
                                     }
@@ -1351,34 +919,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 25,
-                                                    "target": 268955
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 1091252
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 22,
-                                                    "target": 351577
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1009304
-                                                }
                                             }
                                         }
                                     }
@@ -1392,10 +944,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -1404,10 +952,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 171
                                                 }
                                             }
                                         },
@@ -1416,20 +960,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -1444,10 +980,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -1456,10 +988,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 171
                                                 }
                                             }
                                         },
@@ -1468,20 +996,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -1498,10 +1018,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 27,
                                                     "target": 44
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 50
                                                 }
                                             }
                                         },
@@ -1510,10 +1026,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 15,
                                                     "target": 75
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -1522,10 +1034,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 36,
                                                     "target": 37
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 35,
-                                                    "target": 39
                                                 }
                                             }
                                         },
@@ -1534,10 +1042,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 17,
                                                     "target": 72
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 75
                                                 }
                                             }
                                         }
@@ -1550,10 +1054,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 28,
                                                     "target": 44
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 50
                                                 }
                                             }
                                         },
@@ -1562,10 +1062,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
                                                     "target": 78
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -1574,10 +1070,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 35,
                                                     "target": 38
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 34,
-                                                    "target": 40
                                                 }
                                             }
                                         },
@@ -1586,10 +1078,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 73
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 72
                                                 }
                                             }
                                         }
@@ -1613,10 +1101,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 633758
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 306190
                                                 }
                                             }
                                         },
@@ -1625,10 +1109,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 14,
                                                     "target": 1653071
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 766314
                                                 }
                                             }
                                         },
@@ -1637,10 +1117,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 660917
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 319055
                                                 }
                                             }
                                         },
@@ -1649,10 +1125,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1260687
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 615567
                                                 }
                                             }
                                         }
@@ -1665,10 +1137,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 605349
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 285874
                                                 }
                                             }
                                         },
@@ -1677,10 +1145,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 1677780
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 756810
                                                 }
                                             }
                                         },
@@ -1689,10 +1153,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 16,
                                                     "target": 631110
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 27,
-                                                    "target": 284351
                                                 }
                                             }
                                         },
@@ -1701,10 +1161,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1348203
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 655726
                                                 }
                                             }
                                         }
@@ -1716,34 +1172,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 306197
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 766363
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 319065
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 615599
-                                                }
                                             }
                                         }
                                     }
@@ -1752,34 +1192,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 285863
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 756813
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 27,
-                                                    "target": 284353
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 655743
-                                                }
                                             }
                                         }
                                     }
@@ -1793,10 +1217,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -1805,10 +1225,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -1817,20 +1233,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1845,10 +1253,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -1857,10 +1261,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -1869,20 +1269,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1899,10 +1291,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 65
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 72
                                                 }
                                             }
                                         },
@@ -1911,10 +1299,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -1923,20 +1307,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 59
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 58
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 81
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 81
                                                 }
@@ -1951,20 +1327,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 62
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 70
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -1975,20 +1343,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 12,
                                                     "target": 57
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 55
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 85
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 85
                                                 }
@@ -2014,10 +1374,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 557707
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 238585
                                                 }
                                             }
                                         },
@@ -2026,10 +1382,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 1721746
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 1048781
                                                 }
                                             }
                                         },
@@ -2038,10 +1390,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
                                                     "target": 661756
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 314424
                                                 }
                                             }
                                         },
@@ -2050,10 +1398,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 1706759
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 817717
                                                 }
                                             }
                                         }
@@ -2066,10 +1410,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 564728
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 239799
                                                 }
                                             }
                                         },
@@ -2078,10 +1418,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 20,
                                                     "target": 2043386
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 1072254
                                                 }
                                             }
                                         },
@@ -2090,10 +1426,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 17,
                                                     "target": 669427
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 318010
                                                 }
                                             }
                                         },
@@ -2102,10 +1434,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 1653977
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 793706
                                                 }
                                             }
                                         }
@@ -2117,34 +1445,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 238595
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 1048794
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 314424
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 817673
-                                                }
                                             }
                                         }
                                     }
@@ -2153,34 +1465,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 239778
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 1072166
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 318015
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 793715
-                                                }
                                             }
                                         }
                                     }
@@ -2194,10 +1490,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -2206,10 +1498,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 171
                                                 }
                                             }
                                         },
@@ -2218,20 +1506,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -2246,10 +1526,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -2258,10 +1534,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 171
                                                 }
                                             }
                                         },
@@ -2270,20 +1542,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -2300,10 +1564,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 52
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 55
                                                 }
                                             }
                                         },
@@ -2312,10 +1572,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 79
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -2323,10 +1579,6 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 46
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
                                                     "target": 46
                                                 }
                                             }
@@ -2336,10 +1588,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 72
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 73
                                                 }
                                             }
                                         }
@@ -2352,10 +1600,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 52
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 54
                                                 }
                                             }
                                         },
@@ -2364,10 +1608,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 82
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -2375,10 +1615,6 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 46
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
                                                     "target": 46
                                                 }
                                             }
@@ -2388,10 +1624,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 69
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 70
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
@@ -2413,7 +2413,6 @@
             }
         }
     },
-    "load_factor": 1,
     "measurements": {
         "bw_read": {
             "statistics": [

--- a/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
@@ -11,32 +11,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 994523
+                                                    "delta_percentage": 15,
+                                                    "target": 853222
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 2083550
+                                                    "delta_percentage": 9,
+                                                    "target": 1873241
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 862065
+                                                    "delta_percentage": 8,
+                                                    "target": 855948
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1602015
+                                                    "delta_percentage": 9,
+                                                    "target": 1703010
                                                 }
                                             }
                                         }
@@ -47,8 +47,8 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 863029
+                                                    "delta_percentage": 9,
+                                                    "target": 806914
                                                 }
                                             }
                                         },
@@ -56,23 +56,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
-                                                    "target": 2122125
+                                                    "target": 1692898
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 839565
+                                                    "delta_percentage": 12,
+                                                    "target": 820774
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1377671
+                                                    "delta_percentage": 9,
+                                                    "target": 1706256
                                                 }
                                             }
                                         }
@@ -84,18 +84,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 732870
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 13,
+                                                    "target": 1825055
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 849182
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1582634
+                                                }
                                             }
                                         }
                                     }
@@ -104,18 +120,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 656101
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 1779342
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 808956
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 22,
+                                                    "target": 1370805
+                                                }
                                             }
                                         }
                                     }
@@ -129,12 +161,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -145,12 +185,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -165,12 +213,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -181,12 +237,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -201,7 +265,11 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
+                                                    "target": 67
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
                                                     "target": 75
                                                 }
                                             }
@@ -209,6 +277,10 @@
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 74
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -218,15 +290,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 63
+                                                    "target": 49
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 61
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 65
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 81
+                                                    "target": 80
                                                 }
                                             }
                                         }
@@ -237,14 +317,22 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 68
+                                                    "delta_percentage": 7,
+                                                    "target": 65
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 73
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -254,15 +342,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 61
+                                                    "target": 48
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 58
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 77
+                                                    "delta_percentage": 6,
+                                                    "target": 80
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 16,
+                                                    "target": 76
                                                 }
                                             }
                                         }
@@ -284,32 +380,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 326202
+                                                    "delta_percentage": 8,
+                                                    "target": 279138
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 19,
-                                                    "target": 1018682
+                                                    "delta_percentage": 11,
+                                                    "target": 833033
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 448686
+                                                    "delta_percentage": 30,
+                                                    "target": 379111
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 1050550
+                                                    "delta_percentage": 11,
+                                                    "target": 1062322
                                                 }
                                             }
                                         }
@@ -320,32 +416,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 321718
+                                                    "delta_percentage": 7,
+                                                    "target": 274117
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 27,
-                                                    "target": 1175424
+                                                    "delta_percentage": 9,
+                                                    "target": 845227
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 447983
+                                                    "delta_percentage": 26,
+                                                    "target": 369869
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1020341
+                                                    "delta_percentage": 10,
+                                                    "target": 1112276
                                                 }
                                             }
                                         }
@@ -357,18 +453,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 237140
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1362749
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 404788
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 866058
+                                                }
                                             }
                                         }
                                     }
@@ -377,18 +489,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 232623
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1368485
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 405571
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 763672
+                                                }
                                             }
                                         }
                                     }
@@ -402,12 +530,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 85
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -418,12 +554,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -438,12 +582,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -454,12 +606,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -474,8 +634,12 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 60
+                                                    "delta_percentage": 10,
+                                                    "target": 57
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 58
                                                 }
                                             }
                                         },
@@ -483,23 +647,35 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 80
+                                                    "target": 79
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 85
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 50
+                                                    "delta_percentage": 10,
+                                                    "target": 43
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 53
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 74
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 79
+                                                    "target": 78
                                                 }
                                             }
                                         }
@@ -510,32 +686,48 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 55
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 57
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 81
+                                                    "delta_percentage": 5,
+                                                    "target": 79
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 85
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 50
+                                                    "delta_percentage": 9,
+                                                    "target": 43
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 53
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 77
+                                                    "delta_percentage": 6,
+                                                    "target": 76
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 72
                                                 }
                                             }
                                         }
@@ -553,32 +745,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 18,
-                                                    "target": 551148
+                                                    "delta_percentage": 16,
+                                                    "target": 408375
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1788874
+                                                    "delta_percentage": 12,
+                                                    "target": 1546861
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 672806
+                                                    "delta_percentage": 8,
+                                                    "target": 588958
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1650455
+                                                    "delta_percentage": 8,
+                                                    "target": 1653366
                                                 }
                                             }
                                         }
@@ -589,32 +781,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 21,
-                                                    "target": 523405
+                                                    "delta_percentage": 10,
+                                                    "target": 395657
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 2030557
+                                                    "delta_percentage": 10,
+                                                    "target": 1093900
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 672797
+                                                    "delta_percentage": 9,
+                                                    "target": 587810
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1630015
+                                                    "delta_percentage": 15,
+                                                    "target": 1451496
                                                 }
                                             }
                                         }
@@ -626,18 +818,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 327959
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1531080
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 585939
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1428960
+                                                }
                                             }
                                         }
                                     }
@@ -646,18 +854,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 325986
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 1512563
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 595356
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 1301006
+                                                }
                                             }
                                         }
                                     }
@@ -671,12 +895,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -687,12 +919,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -707,12 +947,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -723,6 +971,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -731,6 +983,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 167
                                                 }
                                             }
                                         }
@@ -743,32 +999,48 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 52
+                                                    "delta_percentage": 9,
+                                                    "target": 45
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 54
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 80
+                                                    "delta_percentage": 9,
+                                                    "target": 70
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 85
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 45
+                                                    "delta_percentage": 9,
+                                                    "target": 36
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 48
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 59
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 72
+                                                    "target": 75
                                                 }
                                             }
                                         }
@@ -779,31 +1051,47 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 51
+                                                    "delta_percentage": 10,
+                                                    "target": 44
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 54
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 72
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 82
+                                                    "target": 85
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 45
+                                                    "delta_percentage": 9,
+                                                    "target": 35
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 48
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
+                                                    "target": 63
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
                                                     "target": 69
                                                 }
                                             }
@@ -826,16 +1114,16 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 58,
-                                                    "target": 501863
+                                                    "delta_percentage": 6,
+                                                    "target": 458587
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 90,
-                                                    "target": 1707390
+                                                    "delta_percentage": 30,
+                                                    "target": 1662172
                                                 }
                                             }
                                         },
@@ -843,15 +1131,15 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 21,
-                                                    "target": 700593
+                                                    "target": 583106
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 37,
-                                                    "target": 2075897
+                                                    "delta_percentage": 33,
+                                                    "target": 2040787
                                                 }
                                             }
                                         }
@@ -862,32 +1150,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 71,
-                                                    "target": 508821
+                                                    "delta_percentage": 7,
+                                                    "target": 456753
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 63,
-                                                    "target": 1854315
+                                                    "delta_percentage": 7,
+                                                    "target": 1436205
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 22,
-                                                    "target": 716701
+                                                    "delta_percentage": 11,
+                                                    "target": 662183
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 2205226
+                                                    "delta_percentage": 18,
+                                                    "target": 1746666
                                                 }
                                             }
                                         }
@@ -899,18 +1187,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 545903
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 1667210
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 662192
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 2030186
+                                                }
                                             }
                                         }
                                     }
@@ -919,18 +1223,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 547736
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 1663350
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 676014
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 1970040
+                                                }
                                             }
                                         }
                                     }
@@ -944,6 +1264,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -952,6 +1276,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 171
                                                 }
                                             }
                                         },
@@ -960,12 +1288,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -980,6 +1316,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -988,6 +1328,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 171
                                                 }
                                             }
                                         },
@@ -996,12 +1340,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -1016,32 +1368,48 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 27,
-                                                    "target": 44
+                                                    "delta_percentage": 9,
+                                                    "target": 38
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 51
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 75
+                                                    "delta_percentage": 7,
+                                                    "target": 70
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 85
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 36,
-                                                    "target": 37
+                                                    "delta_percentage": 7,
+                                                    "target": 27
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 38
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 17,
-                                                    "target": 72
+                                                    "delta_percentage": 15,
+                                                    "target": 61
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 75
                                                 }
                                             }
                                         }
@@ -1052,23 +1420,35 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 28,
-                                                    "target": 44
+                                                    "delta_percentage": 9,
+                                                    "target": 37
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 51
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 78
+                                                    "delta_percentage": 6,
+                                                    "target": 73
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 85
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 35,
+                                                    "delta_percentage": 9,
+                                                    "target": 28
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
                                                     "target": 38
                                                 }
                                             }
@@ -1076,8 +1456,12 @@
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 73
+                                                    "delta_percentage": 6,
+                                                    "target": 62
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 71
                                                 }
                                             }
                                         }
@@ -1099,32 +1483,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 633758
+                                                    "delta_percentage": 6,
+                                                    "target": 601980
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 1653071
+                                                    "delta_percentage": 8,
+                                                    "target": 1447505
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 660917
+                                                    "delta_percentage": 7,
+                                                    "target": 521409
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1260687
+                                                    "delta_percentage": 8,
+                                                    "target": 1357763
                                                 }
                                             }
                                         }
@@ -1136,31 +1520,31 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 605349
+                                                    "target": 582802
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1677780
+                                                    "delta_percentage": 9,
+                                                    "target": 1078942
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 631110
+                                                    "delta_percentage": 8,
+                                                    "target": 506108
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1348203
+                                                    "delta_percentage": 9,
+                                                    "target": 1388335
                                                 }
                                             }
                                         }
@@ -1172,18 +1556,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 24,
+                                                    "target": 488013
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 1529788
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 20,
+                                                    "target": 622777
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1257482
+                                                }
                                             }
                                         }
                                     }
@@ -1192,18 +1592,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 31,
+                                                    "target": 433824
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 1499173
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 25,
+                                                    "target": 557197
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1272570
+                                                }
                                             }
                                         }
                                     }
@@ -1217,12 +1633,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1233,12 +1657,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1253,12 +1685,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1269,12 +1709,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1289,14 +1737,22 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 65
+                                                    "delta_percentage": 8,
+                                                    "target": 64
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 70
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 74
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -1305,16 +1761,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 59
+                                                    "delta_percentage": 9,
+                                                    "target": 45
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 55
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 81
+                                                    "delta_percentage": 7,
+                                                    "target": 65
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 77
                                                 }
                                             }
                                         }
@@ -1325,8 +1789,12 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 8,
                                                     "target": 62
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 69
                                                 }
                                             }
                                         },
@@ -1335,22 +1803,34 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 57
+                                                    "delta_percentage": 10,
+                                                    "target": 44
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 53
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 75
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 85
+                                                    "target": 84
                                                 }
                                             }
                                         }
@@ -1372,32 +1852,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 557707
+                                                    "delta_percentage": 6,
+                                                    "target": 560624
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1721746
+                                                    "delta_percentage": 8,
+                                                    "target": 1755345
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 661756
+                                                    "delta_percentage": 6,
+                                                    "target": 640961
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 1706759
+                                                    "delta_percentage": 7,
+                                                    "target": 1827282
                                                 }
                                             }
                                         }
@@ -1408,32 +1888,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 564728
+                                                    "delta_percentage": 6,
+                                                    "target": 561735
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 2043386
+                                                    "delta_percentage": 16,
+                                                    "target": 1164783
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 17,
-                                                    "target": 669427
+                                                    "delta_percentage": 7,
+                                                    "target": 643011
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1653977
+                                                    "delta_percentage": 13,
+                                                    "target": 1689586
                                                 }
                                             }
                                         }
@@ -1445,18 +1925,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 313806
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1695536
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 627277
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1634466
+                                                }
                                             }
                                         }
                                     }
@@ -1465,18 +1961,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 311361
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 1700093
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 638328
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 1590743
+                                                }
                                             }
                                         }
                                     }
@@ -1489,6 +2001,10 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
+                                                    "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
                                                     "target": 86
                                                 }
                                             }
@@ -1496,6 +2012,10 @@
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -1506,12 +2026,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -1526,12 +2054,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 172
                                                 }
@@ -1542,6 +2078,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 86
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -1549,6 +2089,10 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
+                                                    "target": 172
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
                                                     "target": 172
                                                 }
                                             }
@@ -1562,23 +2106,35 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 52
+                                                    "delta_percentage": 9,
+                                                    "target": 45
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 54
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 79
+                                                    "delta_percentage": 8,
+                                                    "target": 70
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 85
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
+                                                    "target": 38
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
                                                     "target": 46
                                                 }
                                             }
@@ -1587,7 +2143,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 72
+                                                    "target": 59
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 74
                                                 }
                                             }
                                         }
@@ -1599,15 +2159,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 52
+                                                    "target": 45
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 54
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 82
+                                                    "delta_percentage": 6,
+                                                    "target": 71
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 85
                                                 }
                                             }
                                         },
@@ -1615,7 +2183,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 46
+                                                    "target": 38
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 47
                                                 }
                                             }
                                         },
@@ -1623,7 +2195,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 69
+                                                    "target": 66
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 72
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
@@ -1,12 +1,4 @@
 {
-    "block_device_size": 2048,
-    "fio_blk_sizes": [
-        4096
-    ],
-    "fio_modes": [
-        "randrw",
-        "randread"
-    ],
     "hosts": {
         "instances": {
             "c7g.metal": {
@@ -2458,7 +2450,5 @@
             ],
             "unit": "percentage"
         }
-    },
-    "omit": 10,
-    "time": 300
+    }
 }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
@@ -13,10 +13,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 15,
                                                     "target": 1128129
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 435987
                                                 }
                                             }
                                         },
@@ -25,10 +21,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 12,
                                                     "target": 1878506
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 793898
                                                 }
                                             }
                                         },
@@ -37,10 +29,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 919977
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 448672
                                                 }
                                             }
                                         },
@@ -49,10 +37,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1645541
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 808358
                                                 }
                                             }
                                         }
@@ -65,10 +49,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 914572
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 399603
                                                 }
                                             }
                                         },
@@ -77,10 +57,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 2244729
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1151413
                                                 }
                                             }
                                         },
@@ -89,10 +65,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 894016
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 434770
                                                 }
                                             }
                                         },
@@ -101,10 +73,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 15,
                                                     "target": 1464828
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 826728
                                                 }
                                             }
                                         }
@@ -116,34 +84,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 435991
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 793918
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 448670
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 808332
-                                                }
                                             }
                                         }
                                     }
@@ -152,34 +104,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 399609
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1151418
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 434795
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 826707
-                                                }
                                             }
                                         }
                                     }
@@ -193,10 +129,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -205,10 +137,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -217,20 +145,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -245,10 +165,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -257,10 +173,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -269,20 +181,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -299,10 +203,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 73
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 68
                                                 }
                                             }
                                         },
@@ -310,10 +210,6 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 85
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
                                                     "target": 85
                                                 }
                                             }
@@ -323,10 +219,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 58
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 57
                                                 }
                                             }
                                         },
@@ -334,10 +226,6 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 78
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
                                                     "target": 78
                                                 }
                                             }
@@ -351,20 +239,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 62
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 63
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -375,10 +255,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 56
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 56
                                                 }
                                             }
                                         },
@@ -387,10 +263,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
                                                     "target": 74
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 83
                                                 }
                                             }
                                         }
@@ -414,10 +286,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 15,
                                                     "target": 394901
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 156068
                                                 }
                                             }
                                         },
@@ -426,10 +294,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 14,
                                                     "target": 960119
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 506703
                                                 }
                                             }
                                         },
@@ -438,10 +302,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 471082
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 233623
                                                 }
                                             }
                                         },
@@ -450,10 +310,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1030395
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 449613
                                                 }
                                             }
                                         }
@@ -466,10 +322,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 387411
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 155635
                                                 }
                                             }
                                         },
@@ -478,10 +330,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 17,
                                                     "target": 1060845
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 492974
                                                 }
                                             }
                                         },
@@ -490,10 +338,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 473742
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 234334
                                                 }
                                             }
                                         },
@@ -502,10 +346,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1029619
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 415396
                                                 }
                                             }
                                         }
@@ -517,34 +357,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 156074
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 506685
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 233620
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 449631
-                                                }
                                             }
                                         }
                                     }
@@ -553,34 +377,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 155636
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 492952
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 234357
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 415405
-                                                }
                                             }
                                         }
                                     }
@@ -594,10 +402,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -606,20 +410,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 173
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 169
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -630,10 +426,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 173
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
                                                 }
                                             }
                                         }
@@ -646,10 +438,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -658,10 +446,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 173
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 169
                                                 }
                                             }
                                         },
@@ -670,20 +454,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 173
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 173
                                                 }
@@ -700,20 +476,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 55
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 54
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 77
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 77
                                                 }
@@ -724,20 +492,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 48
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 52
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 74
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 74
                                                 }
@@ -752,10 +512,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 55
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 54
                                                 }
                                             }
                                         },
@@ -764,10 +520,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 78
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 75
                                                 }
                                             }
                                         },
@@ -776,10 +528,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 48
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 52
                                                 }
                                             }
                                         },
@@ -788,10 +536,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 73
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 69
                                                 }
                                             }
                                         }
@@ -811,10 +555,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
                                                     "target": 651071
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 258630
                                                 }
                                             }
                                         },
@@ -823,10 +563,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1719551
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 724615
                                                 }
                                             }
                                         },
@@ -835,10 +571,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 15,
                                                     "target": 760516
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 385467
                                                 }
                                             }
                                         },
@@ -847,10 +579,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 1676449
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 765564
                                                 }
                                             }
                                         }
@@ -863,10 +591,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 626125
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 254515
                                                 }
                                             }
                                         },
@@ -875,10 +599,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 29,
                                                     "target": 1868958
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1089749
                                                 }
                                             }
                                         },
@@ -887,10 +607,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
                                                     "target": 743280
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 382210
                                                 }
                                             }
                                         },
@@ -899,10 +615,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1658956
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 709406
                                                 }
                                             }
                                         }
@@ -914,34 +626,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 258615
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 724652
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 385484
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 765494
-                                                }
                                             }
                                         }
                                     }
@@ -950,34 +646,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 254485
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1089750
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 382216
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 709419
-                                                }
                                             }
                                         }
                                     }
@@ -991,10 +671,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -1003,10 +679,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 169
                                                 }
                                             }
                                         },
@@ -1015,20 +687,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1043,10 +707,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -1055,20 +715,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 168
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -1079,10 +731,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 172
                                                 }
                                             }
                                         }
@@ -1097,10 +745,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 46
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 46
                                                 }
                                             }
                                         },
@@ -1109,10 +753,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 75
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 74
                                                 }
                                             }
                                         },
@@ -1121,10 +761,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 40
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 46
                                                 }
                                             }
                                         },
@@ -1133,10 +769,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 66
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 72
                                                 }
                                             }
                                         }
@@ -1149,10 +781,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 46
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 46
                                                 }
                                             }
                                         },
@@ -1161,10 +789,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 79
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 82
                                                 }
                                             }
                                         },
@@ -1173,10 +797,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
                                                     "target": 40
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 46
                                                 }
                                             }
                                         },
@@ -1185,10 +805,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 65
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 67
                                                 }
                                             }
                                         }
@@ -1212,10 +828,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 872462
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 400139
                                                 }
                                             }
                                         },
@@ -1224,10 +836,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 72,
                                                     "target": 2036518
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1231625
                                                 }
                                             }
                                         },
@@ -1236,10 +844,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
                                                     "target": 1010677
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 487220
                                                 }
                                             }
                                         },
@@ -1248,10 +852,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 38,
                                                     "target": 2158593
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1108937
                                                 }
                                             }
                                         }
@@ -1264,10 +864,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 887830
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 401633
                                                 }
                                             }
                                         },
@@ -1276,10 +872,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 22,
                                                     "target": 3292773
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1223899
                                                 }
                                             }
                                         },
@@ -1288,10 +880,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1070715
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 521732
                                                 }
                                             }
                                         },
@@ -1300,10 +888,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 2405160
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1023890
                                                 }
                                             }
                                         }
@@ -1315,34 +899,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 400127
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1231602
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 487231
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1108954
-                                                }
                                             }
                                         }
                                     }
@@ -1351,34 +919,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 401650
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1223888
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 521769
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1023864
-                                                }
                                             }
                                         }
                                     }
@@ -1392,10 +944,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -1404,10 +952,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 172
                                                 }
                                             }
                                         },
@@ -1416,20 +960,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1444,10 +980,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -1456,10 +988,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 172
                                                 }
                                             }
                                         },
@@ -1468,20 +996,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1498,10 +1018,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 48
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 54
                                                 }
                                             }
                                         },
@@ -1510,10 +1026,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 22,
                                                     "target": 72
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 82
                                                 }
                                             }
                                         },
@@ -1522,10 +1034,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
                                                     "target": 41
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 44
                                                 }
                                             }
                                         },
@@ -1534,10 +1042,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 22,
                                                     "target": 65
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 71
                                                 }
                                             }
                                         }
@@ -1550,10 +1054,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
                                                     "target": 48
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 53
                                                 }
                                             }
                                         },
@@ -1562,10 +1062,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 82
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 83
                                                 }
                                             }
                                         },
@@ -1574,10 +1070,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
                                                     "target": 42
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 46
                                                 }
                                             }
                                         },
@@ -1585,10 +1077,6 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
-                                                    "target": 67
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
                                                     "target": 67
                                                 }
                                             }
@@ -1613,10 +1101,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 16,
                                                     "target": 779911
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 315691
                                                 }
                                             }
                                         },
@@ -1625,10 +1109,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 12,
                                                     "target": 1549816
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 639441
                                                 }
                                             }
                                         },
@@ -1637,10 +1117,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 14,
                                                     "target": 703549
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 343198
                                                 }
                                             }
                                         },
@@ -1649,10 +1125,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1286617
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 626210
                                                 }
                                             }
                                         }
@@ -1665,10 +1137,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 16,
                                                     "target": 673844
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 296402
                                                 }
                                             }
                                         },
@@ -1677,10 +1145,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 1811676
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 915529
                                                 }
                                             }
                                         },
@@ -1689,10 +1153,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 12,
                                                     "target": 685919
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 333610
                                                 }
                                             }
                                         },
@@ -1701,10 +1161,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1349846
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 658464
                                                 }
                                             }
                                         }
@@ -1716,34 +1172,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 315682
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 639456
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 343208
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 626206
-                                                }
                                             }
                                         }
                                     }
@@ -1752,34 +1192,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 296398
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 915545
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 333620
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 658462
-                                                }
                                             }
                                         }
                                     }
@@ -1793,10 +1217,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -1805,10 +1225,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -1817,20 +1233,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1845,10 +1253,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -1857,10 +1261,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -1869,20 +1269,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1899,10 +1291,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 68
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 64
                                                 }
                                             }
                                         },
@@ -1911,10 +1299,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 85
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -1922,10 +1306,6 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 54
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
                                                     "target": 54
                                                 }
                                             }
@@ -1935,10 +1315,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 77
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 76
                                                 }
                                             }
                                         }
@@ -1951,10 +1327,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 65
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 61
                                                 }
                                             }
                                         },
@@ -1963,10 +1335,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -1975,20 +1343,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 53
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 52
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 82
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 82
                                                 }
@@ -2014,10 +1374,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 688394
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 281750
                                                 }
                                             }
                                         },
@@ -2026,10 +1382,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1724966
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 758676
                                                 }
                                             }
                                         },
@@ -2038,10 +1390,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 834694
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 389860
                                                 }
                                             }
                                         },
@@ -2050,10 +1398,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1715869
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 816356
                                                 }
                                             }
                                         }
@@ -2066,10 +1410,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 689102
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 283349
                                                 }
                                             }
                                         },
@@ -2078,10 +1418,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 15,
                                                     "target": 1991041
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 1157907
                                                 }
                                             }
                                         },
@@ -2090,10 +1426,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 837520
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 396170
                                                 }
                                             }
                                         },
@@ -2102,10 +1434,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 1703002
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 798223
                                                 }
                                             }
                                         }
@@ -2117,34 +1445,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 281728
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 758708
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 389854
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 816325
-                                                }
                                             }
                                         }
                                     }
@@ -2153,34 +1465,18 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 283363
-                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 1157920
-                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 396184
-                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 798211
-                                                }
                                             }
                                         }
                                     }
@@ -2194,10 +1490,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -2206,10 +1498,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
                                                 }
                                             }
                                         },
@@ -2218,20 +1506,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -2246,10 +1526,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -2258,10 +1534,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 172
                                                 }
                                             }
                                         },
@@ -2270,20 +1542,12 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
-                                                },
-                                                "randrw-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -2300,10 +1564,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 49
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 47
                                                 }
                                             }
                                         },
@@ -2312,10 +1572,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 77
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 75
                                                 }
                                             }
                                         },
@@ -2323,10 +1579,6 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 44
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 9,
                                                     "target": 44
                                                 }
                                             }
@@ -2336,10 +1588,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 67
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 69
                                                 }
                                             }
                                         }
@@ -2352,10 +1600,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
                                                     "target": 49
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 47
                                                 }
                                             }
                                         },
@@ -2364,10 +1608,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 80
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 83
                                                 }
                                             }
                                         },
@@ -2376,10 +1616,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
                                                     "target": 43
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 45
                                                 }
                                             }
                                         },
@@ -2388,10 +1624,6 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 67
-                                                },
-                                                "randrw-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 68
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
@@ -2413,7 +2413,6 @@
             }
         }
     },
-    "load_factor": 1,
     "measurements": {
         "bw_read": {
             "statistics": [

--- a/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
@@ -1,12 +1,4 @@
 {
-    "block_device_size": 2048,
-    "fio_blk_sizes": [
-        4096
-    ],
-    "fio_modes": [
-        "randrw",
-        "randread"
-    ],
     "hosts": {
         "instances": {
             "c7g.metal": {
@@ -2458,7 +2450,5 @@
             ],
             "unit": "percentage"
         }
-    },
-    "omit": 10,
-    "time": 300
+    }
 }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
@@ -12,15 +12,15 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 15,
-                                                    "target": 1128129
+                                                    "target": 901586
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1878506
+                                                    "delta_percentage": 10,
+                                                    "target": 1868818
                                                 }
                                             }
                                         },
@@ -28,15 +28,15 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 919977
+                                                    "target": 908520
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1645541
+                                                    "delta_percentage": 8,
+                                                    "target": 1693577
                                                 }
                                             }
                                         }
@@ -47,16 +47,16 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 914572
+                                                    "delta_percentage": 13,
+                                                    "target": 864224
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 2244729
+                                                    "delta_percentage": 22,
+                                                    "target": 1447936
                                                 }
                                             }
                                         },
@@ -64,15 +64,15 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 894016
+                                                    "target": 883932
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 1464828
+                                                    "delta_percentage": 11,
+                                                    "target": 1801051
                                                 }
                                             }
                                         }
@@ -84,18 +84,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 14,
+                                                    "target": 674135
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 13,
+                                                    "target": 1536357
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 902603
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1633687
+                                                }
                                             }
                                         }
                                     }
@@ -104,18 +120,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 17,
+                                                    "target": 619371
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 19,
+                                                    "target": 2070391
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 871585
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1668604
+                                                }
                                             }
                                         }
                                     }
@@ -129,6 +161,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -137,6 +173,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -145,12 +185,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -165,12 +213,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -181,12 +237,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -202,7 +266,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
-                                                    "target": 73
+                                                    "target": 60
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 58
                                                 }
                                             }
                                         },
@@ -210,7 +278,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 85
+                                                    "target": 69
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -218,15 +290,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 58
+                                                    "target": 43
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 56
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 78
+                                                    "delta_percentage": 8,
+                                                    "target": 57
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 75
                                                 }
                                             }
                                         }
@@ -238,13 +318,21 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 62
+                                                    "target": 59
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 57
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 86
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -253,16 +341,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 56
+                                                    "delta_percentage": 9,
+                                                    "target": 42
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 54
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
+                                                    "delta_percentage": 6,
                                                     "target": 74
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 81
                                                 }
                                             }
                                         }
@@ -284,32 +380,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 394901
+                                                    "delta_percentage": 12,
+                                                    "target": 365668
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 960119
+                                                    "delta_percentage": 20,
+                                                    "target": 829203
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 471082
+                                                    "delta_percentage": 6,
+                                                    "target": 421588
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1030395
+                                                    "delta_percentage": 10,
+                                                    "target": 1114892
                                                 }
                                             }
                                         }
@@ -320,32 +416,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 387411
+                                                    "delta_percentage": 30,
+                                                    "target": 352435
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 17,
-                                                    "target": 1060845
+                                                    "delta_percentage": 7,
+                                                    "target": 870549
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 473742
+                                                    "delta_percentage": 6,
+                                                    "target": 418514
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1029619
+                                                    "delta_percentage": 8,
+                                                    "target": 1111024
                                                 }
                                             }
                                         }
@@ -357,18 +453,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 16,
+                                                    "target": 234867
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1001308
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 421741
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 814447
+                                                }
                                             }
                                         }
                                     }
@@ -377,18 +489,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 24,
+                                                    "target": 238501
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 46,
+                                                    "target": 1211156
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 423716
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 735063
+                                                }
                                             }
                                         }
                                     }
@@ -402,6 +530,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -409,7 +541,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 173
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 169
                                                 }
                                             }
                                         },
@@ -418,12 +554,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 173
                                                 }
@@ -438,6 +582,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -446,12 +594,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 173
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 169
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -461,6 +617,10 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
                                                     "target": 173
                                                 }
                                             }
@@ -474,8 +634,12 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 55
+                                                    "delta_percentage": 8,
+                                                    "target": 52
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 50
                                                 }
                                             }
                                         },
@@ -483,6 +647,10 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
+                                                    "target": 76
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
                                                     "target": 77
                                                 }
                                             }
@@ -490,14 +658,22 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 48
+                                                    "delta_percentage": 8,
+                                                    "target": 42
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 53
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 71
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 74
                                                 }
@@ -510,32 +686,48 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 52
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 55
+                                                    "target": 50
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 78
+                                                    "delta_percentage": 5,
+                                                    "target": 75
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 15,
+                                                    "target": 79
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 48
+                                                    "delta_percentage": 7,
+                                                    "target": 42
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 53
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 73
+                                                    "delta_percentage": 7,
+                                                    "target": 71
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 68
                                                 }
                                             }
                                         }
@@ -553,32 +745,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 651071
+                                                    "delta_percentage": 8,
+                                                    "target": 571610
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1719551
+                                                    "delta_percentage": 9,
+                                                    "target": 1605089
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 760516
+                                                    "delta_percentage": 8,
+                                                    "target": 640879
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 1676449
+                                                    "delta_percentage": 10,
+                                                    "target": 1646224
                                                 }
                                             }
                                         }
@@ -589,32 +781,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 626125
+                                                    "delta_percentage": 9,
+                                                    "target": 568151
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 29,
-                                                    "target": 1868958
+                                                    "delta_percentage": 11,
+                                                    "target": 1180961
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 743280
+                                                    "delta_percentage": 8,
+                                                    "target": 642366
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1658956
+                                                    "delta_percentage": 16,
+                                                    "target": 1475321
                                                 }
                                             }
                                         }
@@ -626,18 +818,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 374403
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 1755644
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 17,
+                                                    "target": 667251
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1411356
+                                                }
                                             }
                                         }
                                     }
@@ -646,18 +854,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 370638
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 14,
+                                                    "target": 1696784
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 15,
+                                                    "target": 686988
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 1350606
+                                                }
                                             }
                                         }
                                     }
@@ -671,6 +895,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -679,6 +907,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 172
                                                 }
                                             }
                                         },
@@ -687,12 +919,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -707,6 +947,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -715,12 +959,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 172
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
                                                 }
@@ -731,6 +983,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 173
                                                 }
                                             }
                                         }
@@ -743,16 +999,24 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 46
+                                                    "delta_percentage": 9,
+                                                    "target": 42
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 43
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 64
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 75
+                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -760,7 +1024,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
-                                                    "target": 40
+                                                    "target": 32
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 47
                                                 }
                                             }
                                         },
@@ -768,7 +1036,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 66
+                                                    "target": 52
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 73
                                                 }
                                             }
                                         }
@@ -779,32 +1051,48 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 46
+                                                    "delta_percentage": 10,
+                                                    "target": 41
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 43
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 79
+                                                    "delta_percentage": 6,
+                                                    "target": 67
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 83
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 40
+                                                    "delta_percentage": 10,
+                                                    "target": 32
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 48
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 65
+                                                    "delta_percentage": 9,
+                                                    "target": 56
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 70
                                                 }
                                             }
                                         }
@@ -826,16 +1114,16 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 872462
+                                                    "delta_percentage": 9,
+                                                    "target": 792773
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 72,
-                                                    "target": 2036518
+                                                    "delta_percentage": 24,
+                                                    "target": 2386918
                                                 }
                                             }
                                         },
@@ -843,15 +1131,15 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 13,
-                                                    "target": 1010677
+                                                    "target": 912132
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 38,
-                                                    "target": 2158593
+                                                    "delta_percentage": 24,
+                                                    "target": 2440759
                                                 }
                                             }
                                         }
@@ -862,32 +1150,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 887830
+                                                    "delta_percentage": 13,
+                                                    "target": 812987
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 22,
-                                                    "target": 3292773
+                                                    "delta_percentage": 13,
+                                                    "target": 1901128
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1070715
+                                                    "delta_percentage": 17,
+                                                    "target": 974390
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 2405160
+                                                    "delta_percentage": 12,
+                                                    "target": 2228023
                                                 }
                                             }
                                         }
@@ -899,18 +1187,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 17,
+                                                    "target": 712744
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1847448
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 966079
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 2164717
+                                                }
                                             }
                                         }
                                     }
@@ -919,18 +1223,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 20,
+                                                    "target": 779116
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 1816448
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1039325
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1901595
+                                                }
                                             }
                                         }
                                     }
@@ -944,12 +1264,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -960,12 +1288,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -980,12 +1316,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -996,12 +1340,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1017,31 +1369,47 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
-                                                    "target": 48
+                                                    "target": 42
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 13,
+                                                    "target": 50
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 22,
-                                                    "target": 72
+                                                    "delta_percentage": 10,
+                                                    "target": 65
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 85
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 41
+                                                    "delta_percentage": 10,
+                                                    "target": 33
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 46
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 22,
-                                                    "target": 65
+                                                    "delta_percentage": 8,
+                                                    "target": 54
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 72
                                                 }
                                             }
                                         }
@@ -1052,8 +1420,12 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 48
+                                                    "delta_percentage": 9,
+                                                    "target": 43
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 15,
+                                                    "target": 53
                                                 }
                                             }
                                         },
@@ -1061,22 +1433,34 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 82
+                                                    "target": 67
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 84
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 42
+                                                    "delta_percentage": 11,
+                                                    "target": 33
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 47
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 8,
+                                                    "target": 58
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
                                                     "target": 67
                                                 }
                                             }
@@ -1099,32 +1483,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 779911
+                                                    "delta_percentage": 7,
+                                                    "target": 656376
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1549816
+                                                    "delta_percentage": 9,
+                                                    "target": 1450713
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 703549
+                                                    "delta_percentage": 9,
+                                                    "target": 564514
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1286617
+                                                    "delta_percentage": 14,
+                                                    "target": 1317760
                                                 }
                                             }
                                         }
@@ -1135,32 +1519,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 673844
+                                                    "delta_percentage": 9,
+                                                    "target": 650069
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1811676
+                                                    "delta_percentage": 8,
+                                                    "target": 1176875
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 685919
+                                                    "delta_percentage": 11,
+                                                    "target": 556645
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1349846
+                                                    "delta_percentage": 9,
+                                                    "target": 1365314
                                                 }
                                             }
                                         }
@@ -1172,18 +1556,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 382798
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1138402
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 674053
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1252589
+                                                }
                                             }
                                         }
                                     }
@@ -1192,18 +1592,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 373215
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 31,
+                                                    "target": 1399382
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 663822
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1283213
+                                                }
                                             }
                                         }
                                     }
@@ -1217,6 +1633,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -1225,6 +1645,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -1233,12 +1657,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1253,6 +1685,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -1261,6 +1697,10 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -1269,12 +1709,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1289,8 +1737,12 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 53
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 68
+                                                    "target": 53
                                                 }
                                             }
                                         },
@@ -1298,23 +1750,35 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 85
+                                                    "target": 68
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 80
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 40
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 54
+                                                    "target": 50
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 58
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 77
+                                                    "target": 73
                                                 }
                                             }
                                         }
@@ -1325,16 +1789,24 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 65
+                                                    "delta_percentage": 9,
+                                                    "target": 53
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 53
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
+                                                    "delta_percentage": 6,
+                                                    "target": 84
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 84
                                                 }
                                             }
                                         },
@@ -1342,7 +1814,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
-                                                    "target": 53
+                                                    "target": 40
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 50
                                                 }
                                             }
                                         },
@@ -1350,7 +1826,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 82
+                                                    "target": 69
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 79
                                                 }
                                             }
                                         }
@@ -1372,8 +1852,8 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 688394
+                                                    "delta_percentage": 8,
+                                                    "target": 634445
                                                 }
                                             }
                                         },
@@ -1381,23 +1861,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1724966
+                                                    "target": 1814477
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 834694
+                                                    "delta_percentage": 8,
+                                                    "target": 708636
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1715869
+                                                    "delta_percentage": 10,
+                                                    "target": 1843495
                                                 }
                                             }
                                         }
@@ -1408,32 +1888,32 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 689102
+                                                    "delta_percentage": 7,
+                                                    "target": 636239
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 1991041
+                                                    "delta_percentage": 12,
+                                                    "target": 1304204
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 837520
+                                                    "delta_percentage": 7,
+                                                    "target": 716646
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1703002
+                                                    "delta_percentage": 10,
+                                                    "target": 1817398
                                                 }
                                             }
                                         }
@@ -1445,18 +1925,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 343285
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 2001307
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 805845
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1611252
+                                                }
                                             }
                                         }
                                     }
@@ -1465,18 +1961,34 @@
                                     "ubuntu-18.04.ext4": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 343769
+                                                }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 1926805
+                                                }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 820968
+                                                }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 1528741
+                                                }
                                             }
                                         }
                                     }
@@ -1490,12 +2002,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1506,12 +2026,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1526,12 +2054,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1542,12 +2078,20 @@
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 5,
                                                     "target": 174
                                                 }
@@ -1562,16 +2106,24 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 41
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 49
+                                                    "target": 41
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 77
+                                                    "delta_percentage": 8,
+                                                    "target": 65
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 85
                                                 }
                                             }
                                         },
@@ -1579,7 +2131,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 44
+                                                    "target": 32
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 46
                                                 }
                                             }
                                         },
@@ -1587,7 +2143,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 67
+                                                    "target": 52
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 70
                                                 }
                                             }
                                         }
@@ -1598,16 +2158,24 @@
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 49
+                                                    "delta_percentage": 9,
+                                                    "target": 41
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 41
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 80
+                                                    "delta_percentage": 6,
+                                                    "target": 69
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 83
                                                 }
                                             }
                                         },
@@ -1615,13 +2183,21 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 43
+                                                    "target": 32
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 47
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 56
+                                                },
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 67
                                                 }

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -27,8 +27,7 @@ from integration_tests.performance.configs import defs
 TEST_ID = "block_performance"
 kernel_version = get_kernel_version(level=1)
 CONFIG_NAME_REL = "test_{}_config_{}.json".format(TEST_ID, kernel_version)
-CONFIG_NAME_ABS = os.path.join(defs.CFG_LOCATION, CONFIG_NAME_REL)
-CONFIG = json.load(open(CONFIG_NAME_ABS, encoding="utf-8"))
+CONFIG_NAME_ABS = defs.CFG_LOCATION / CONFIG_NAME_REL
 
 FIO = "fio"
 
@@ -298,9 +297,13 @@ def test_block_performance(
             "bs": fio_block_size,
         },
     )
+
+    raw_baselines = json.loads(CONFIG_NAME_ABS.read_text("utf-8"))
+
     st_cons = st.consumer.LambdaConsumer(
         metadata_provider=DictMetadataProvider(
-            CONFIG["measurements"], BlockBaselinesProvider(env_id, fio_id)
+            raw_baselines["measurements"],
+            BlockBaselinesProvider(env_id, fio_id, raw_baselines),
         ),
         func=consume_fio_output,
         func_kwargs={

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -190,8 +190,6 @@ def read_values(cons, numjobs, env_id, mode, bs, measurement, logs_path):
         lines = file_path.read_text(encoding="utf-8").splitlines()
 
         direction_count = 1
-        if mode.endswith("rw"):
-            direction_count = 2
 
         for idx in range(0, len(lines), direction_count):
             value_idx = idx // direction_count
@@ -241,7 +239,7 @@ def consume_fio_output(cons, cpu_load, numjobs, mode, bs, env_id, logs_path):
 @pytest.mark.nonci
 @pytest.mark.timeout(RUNTIME_SEC * 1000)  # 1.40 hours
 @pytest.mark.parametrize("vcpus", [1, 2], ids=["1vcpu", "2vcpu"])
-@pytest.mark.parametrize("fio_mode", ["randread", "randrw"])
+@pytest.mark.parametrize("fio_mode", ["randread", "randwrite"])
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_block_performance(
     microvm_factory,

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -66,8 +66,6 @@ def run_fio(env_id, basevm, mode, bs):
     """Run a fio test in the specified mode with block size bs."""
     logs_path = f"{basevm.jailer.chroot_base_with_id()}/{env_id}/{mode}{bs}"
 
-    num_jobs = CONFIG["load_factor"] * basevm.vcpus_count
-
     # Compute the fio command. Pin it to the first guest CPU.
     cmd = (
         CmdBuilder(FIO)
@@ -81,9 +79,11 @@ def run_fio(env_id, basevm, mode, bs):
         .with_arg("--ioengine=libaio")
         .with_arg("--iodepth=32")
         .with_arg(f"--ramp_time={CONFIG['omit']}")
-        .with_arg(f"--numjobs={num_jobs}")
+        .with_arg(f"--numjobs={basevm.vcpus_count}")
         # Set affinity of the entire fio process to a set of vCPUs equal in size to number of workers
-        .with_arg(f"--cpus_allowed={','.join(str(i) for i in range(num_jobs))}")
+        .with_arg(
+            f"--cpus_allowed={','.join(str(i) for i in range(basevm.vcpus_count))}"
+        )
         # Instruct fio to pin one worker per vcpu
         .with_arg("--cpus_allowed_policy=split")
         .with_arg("--randrepeat=0")

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -66,6 +66,8 @@ def run_fio(env_id, basevm, mode, bs):
     """Run a fio test in the specified mode with block size bs."""
     logs_path = f"{basevm.jailer.chroot_base_with_id()}/{env_id}/{mode}{bs}"
 
+    num_jobs = CONFIG["load_factor"] * basevm.vcpus_count
+
     # Compute the fio command. Pin it to the first guest CPU.
     cmd = (
         CmdBuilder(FIO)
@@ -79,7 +81,11 @@ def run_fio(env_id, basevm, mode, bs):
         .with_arg("--ioengine=libaio")
         .with_arg("--iodepth=32")
         .with_arg(f"--ramp_time={CONFIG['omit']}")
-        .with_arg(f"--numjobs={CONFIG['load_factor'] * basevm.vcpus_count}")
+        .with_arg(f"--numjobs={num_jobs}")
+        # Set affinity of the entire fio process to a set of vCPUs equal in size to number of workers
+        .with_arg(f"--cpus_allowed={','.join(str(i) for i in range(num_jobs))}")
+        # Instruct fio to pin one worker per vcpu
+        .with_arg("--cpus_allowed_policy=split")
         .with_arg("--randrepeat=0")
         .with_arg(f"--runtime={CONFIG['time']}")
         .with_arg(f"--write_bw_log={mode}{bs}")

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -37,6 +37,18 @@ CPU_UTILIZATION_VMM = "cpu_utilization_vmm"
 CPU_UTILIZATION_VMM_SAMPLES_TAG = "cpu_utilization_vmm_samples"
 CPU_UTILIZATION_VCPUS_TOTAL = "cpu_utilization_vcpus_total"
 
+# size of the block device used in the test, in MB
+BLOCK_DEVICE_SIZE_MB = 2048
+
+# How many fio workloads should be spawned per vcpu
+LOAD_FACTOR = 1
+
+# Time (in seconds) for which fio "warms up"
+WARMUP_SEC = 10
+
+# Time (in seconds) for which fio runs after warmup is done
+RUNTIME_SEC = 300
+
 
 # pylint: disable=R0903
 class BlockBaselinesProvider(BaselineProvider):
@@ -74,11 +86,11 @@ def run_fio(env_id, basevm, mode, bs):
         .with_arg(f"--bs={bs}")
         .with_arg("--filename=/dev/vdb")
         .with_arg("--time_base=1")
-        .with_arg(f"--size={CONFIG['block_device_size']}M")
+        .with_arg(f"--size={BLOCK_DEVICE_SIZE_MB}M")
         .with_arg("--direct=1")
         .with_arg("--ioengine=libaio")
         .with_arg("--iodepth=32")
-        .with_arg(f"--ramp_time={CONFIG['omit']}")
+        .with_arg(f"--ramp_time={WARMUP_SEC}")
         .with_arg(f"--numjobs={basevm.vcpus_count}")
         # Set affinity of the entire fio process to a set of vCPUs equal in size to number of workers
         .with_arg(
@@ -87,7 +99,7 @@ def run_fio(env_id, basevm, mode, bs):
         # Instruct fio to pin one worker per vcpu
         .with_arg("--cpus_allowed_policy=split")
         .with_arg("--randrepeat=0")
-        .with_arg(f"--runtime={CONFIG['time']}")
+        .with_arg(f"--runtime={RUNTIME_SEC}")
         .with_arg(f"--write_bw_log={mode}{bs}")
         .with_arg("--log_avg_msec=1000")
         .with_arg("--output-format=json+")
@@ -117,8 +129,8 @@ def run_fio(env_id, basevm, mode, bs):
         cpu_load_future = executor.submit(
             get_cpu_percent,
             basevm.jailer_clone_pid,
-            CONFIG["time"],
-            omit=CONFIG["omit"],
+            RUNTIME_SEC,
+            omit=WARMUP_SEC,
         )
 
         # Print the fio command in the log and run it
@@ -227,14 +239,18 @@ def consume_fio_output(cons, cpu_load, numjobs, mode, bs, env_id, logs_path):
 
 
 @pytest.mark.nonci
-@pytest.mark.timeout(CONFIG["time"] * 1000)  # 1.40 hours
-@pytest.mark.parametrize("vcpus", [1, 2])
+@pytest.mark.timeout(RUNTIME_SEC * 1000)  # 1.40 hours
+@pytest.mark.parametrize("vcpus", [1, 2], ids=["1vcpu", "2vcpu"])
+@pytest.mark.parametrize("fio_mode", ["randread", "randrw"])
+@pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_block_performance(
     microvm_factory,
     network_config,
     guest_kernel,
     rootfs,
     vcpus,
+    fio_mode,
+    fio_block_size,
     io_engine,
     st_core,
 ):
@@ -248,7 +264,7 @@ def test_block_performance(
     vm.ssh_network_config(network_config, "1")
     # Add a secondary block device for benchmark tests.
     fs = drive_tools.FilesystemFile(
-        os.path.join(vm.fsfiles, "scratch"), CONFIG["block_device_size"]
+        os.path.join(vm.fsfiles, "scratch"), BLOCK_DEVICE_SIZE_MB
     )
     vm.add_drive("scratch", fs.path, io_engine=io_engine)
     vm.start()
@@ -274,33 +290,30 @@ def test_block_performance(
 
     env_id = f"{guest_kernel.name()}/{rootfs.name()}/{io_engine.lower()}_{microvm_cfg}"
 
-    for mode in CONFIG["fio_modes"]:
-        for bs in CONFIG["fio_blk_sizes"]:
-            fio_id = f"{mode}-bs{bs}"
-            st_prod = st.producer.LambdaProducer(
-                func=run_fio,
-                func_kwargs={
-                    "env_id": env_id,
-                    "basevm": vm,
-                    "mode": mode,
-                    "bs": bs,
-                },
-            )
-            st_cons = st.consumer.LambdaConsumer(
-                metadata_provider=DictMetadataProvider(
-                    CONFIG["measurements"],
-                    BlockBaselinesProvider(env_id, fio_id, CONFIG),
-                ),
-                func=consume_fio_output,
-                func_kwargs={
-                    "numjobs": vm.vcpus_count,
-                    "mode": mode,
-                    "bs": bs,
-                    "env_id": env_id,
-                    "logs_path": vm.jailer.chroot_base_with_id(),
-                },
-            )
-            st_core.add_pipe(st_prod, st_cons, tag=f"{env_id}/{fio_id}")
+    fio_id = f"{fio_mode}-bs{fio_block_size}"
+    st_prod = st.producer.LambdaProducer(
+        func=run_fio,
+        func_kwargs={
+            "env_id": env_id,
+            "basevm": vm,
+            "mode": fio_mode,
+            "bs": fio_block_size,
+        },
+    )
+    st_cons = st.consumer.LambdaConsumer(
+        metadata_provider=DictMetadataProvider(
+            CONFIG["measurements"], BlockBaselinesProvider(env_id, fio_id)
+        ),
+        func=consume_fio_output,
+        func_kwargs={
+            "numjobs": vm.vcpus_count,
+            "mode": fio_mode,
+            "bs": fio_block_size,
+            "env_id": env_id,
+            "logs_path": vm.jailer.chroot_base_with_id(),
+        },
+    )
+    st_core.add_pipe(st_prod, st_cons, tag=f"{env_id}/{fio_id}")
 
     # Gather results and verify pass criteria.
     st_core.run_exercise()


### PR DESCRIPTION
This PR accumulates some fixes to the block performance test that all each require new baselines. These include:
- Pinning the fio workers to vcpus inside of the guest to prevent guest-scheduling to impact test results
- Change parameterization from baseline level to pytest level to improve readability of test progress and do not reuse microvms across multiple tests
- Introduce a write test, as the randrw fio mode tries to balance reads and writes, leading to its results being highly correlated with the read tests. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
