### PR TITLE
chore: collect network latency baselines

### DIFF
--- a/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
@@ -46,8 +46,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 38.1,
-                                                    "target": 0.208
+                                                    "delta_percentage": 10.1,
+                                                    "target": 0.059
                                                 }
                                             }
                                         }
@@ -58,8 +58,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 37.1,
-                                                    "target": 0.221
+                                                    "delta_percentage": 7.1,
+                                                    "target": 0.067
                                                 }
                                             }
                                         }
@@ -77,8 +77,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 37.1,
-                                                    "target": 0.237
+                                                    "delta_percentage": 10.1,
+                                                    "target": 0.08
                                                 }
                                             }
                                         }
@@ -89,8 +89,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 38.1,
-                                                    "target": 0.251
+                                                    "delta_percentage": 6.1,
+                                                    "target": 0.094
                                                 }
                                             }
                                         }
@@ -112,8 +112,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 4.1,
-                                                    "target": 0.155
+                                                    "delta_percentage": 9.1,
+                                                    "target": 0.147
                                                 }
                                             }
                                         }
@@ -124,8 +124,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 4.1,
-                                                    "target": 0.172
+                                                    "delta_percentage": 8.1,
+                                                    "target": 0.161
                                                 }
                                             }
                                         }
@@ -182,8 +182,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 22.1,
-                                                    "target": 0.241
+                                                    "delta_percentage": 23.1,
+                                                    "target": 0.105
                                                 }
                                             }
                                         }
@@ -194,8 +194,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 8.1,
-                                                    "target": 0.262
+                                                    "delta_percentage": 22.1,
+                                                    "target": 0.119
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
@@ -46,8 +46,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 2.1,
-                                                    "target": 0.231
+                                                    "delta_percentage": 33.1,
+                                                    "target": 0.062
                                                 }
                                             }
                                         }
@@ -58,8 +58,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 3.1,
-                                                    "target": 0.24
+                                                    "delta_percentage": 10.1,
+                                                    "target": 0.066
                                                 }
                                             }
                                         }
@@ -77,8 +77,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 2.1,
-                                                    "target": 0.26
+                                                    "delta_percentage": 14.1,
+                                                    "target": 0.08
                                                 }
                                             }
                                         }
@@ -89,8 +89,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 3.1,
-                                                    "target": 0.271
+                                                    "delta_percentage": 12.1,
+                                                    "target": 0.085
                                                 }
                                             }
                                         }
@@ -112,8 +112,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 4.1,
-                                                    "target": 0.153
+                                                    "delta_percentage": 13.1,
+                                                    "target": 0.088
                                                 }
                                             }
                                         }
@@ -124,8 +124,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 3.1,
-                                                    "target": 0.168
+                                                    "delta_percentage": 7.1,
+                                                    "target": 0.099
                                                 }
                                             }
                                         }
@@ -182,8 +182,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 6.1,
-                                                    "target": 0.256
+                                                    "delta_percentage": 12.1,
+                                                    "target": 0.043
                                                 }
                                             }
                                         }
@@ -194,8 +194,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 6.1,
-                                                    "target": 0.27
+                                                    "delta_percentage": 12.1,
+                                                    "target": 0.044
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_latency_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_6.1.json
@@ -46,8 +46,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 2.1,
-                                                    "target": 0.237
+                                                    "delta_percentage": 8.1,
+                                                    "target": 0.054
                                                 }
                                             }
                                         }
@@ -58,8 +58,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 2.1,
-                                                    "target": 0.248
+                                                    "delta_percentage": 9.1,
+                                                    "target": 0.061
                                                 }
                                             }
                                         }
@@ -77,8 +77,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 2.1,
-                                                    "target": 0.268
+                                                    "delta_percentage": 5.1,
+                                                    "target": 0.077
                                                 }
                                             }
                                         }
@@ -89,8 +89,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 2.1,
-                                                    "target": 0.281
+                                                    "delta_percentage": 3.1,
+                                                    "target": 0.087
                                                 }
                                             }
                                         }
@@ -112,8 +112,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 14.1,
-                                                    "target": 0.151
+                                                    "delta_percentage": 8.1,
+                                                    "target": 0.074
                                                 }
                                             }
                                         }
@@ -124,8 +124,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 18.1,
-                                                    "target": 0.161
+                                                    "delta_percentage": 8.1,
+                                                    "target": 0.085
                                                 }
                                             }
                                         }
@@ -182,8 +182,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 10.1,
-                                                    "target": 0.26
+                                                    "delta_percentage": 6.1,
+                                                    "target": 0.036
                                                 }
                                             }
                                         }
@@ -194,8 +194,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 11.1,
-                                                    "target": 0.274
+                                                    "delta_percentage": 8.1,
+                                                    "target": 0.041
                                                 }
                                             }
                                         }


### PR DESCRIPTION
A recent change in our CI infrastructure disabled deep C-states, which improves performance on x86 for tests that are no very cpu-bound (since cores no longer need to "wake" from idle states).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
