### PR TITLE
Set MAP_POPULATE on guest mmap

### DIFF
--- a/src/utils/src/vm_memory.rs
+++ b/src/utils/src/vm_memory.rs
@@ -119,7 +119,7 @@ pub fn create_guest_memory(
 
     for region in regions {
         let flags = match region.0 {
-            None => libc::MAP_NORESERVE | libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            None => libc::MAP_NORESERVE | libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_POPULATE,
             Some(_) => libc::MAP_NORESERVE | libc::MAP_PRIVATE,
         };
 


### PR DESCRIPTION
This directs the Linux kernel to set up page tables eagerly instead of the default lazy behaviour, reducing the FreeBSD kernel boot time from 29 ms to 24 ms.

Note that the total VM launch time improvement may be less than this since the initial mmap call will take longer; however mapping eagerly has the advantage of reducing context-switching overhead so as long as *most* pages end up being used it's probably still a net win.

## Changes

As above, sets the MAP_POPULATE flag on mmap.

## Reason

Speeding up boot times is good.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [N/A] If a specific issue led to this PR, this PR closes the issue.
- [X] The description of changes is clear and encompassing.
- [N/A] Any required documentation changes (code and docs) are included in this PR.
- [N/A] API changes follow the [Runbook for Firecracker API changes][2].
- [N/A] User-facing changes are mentioned in `CHANGELOG.md`.
- [N/A] All added/changed functionality is tested.
- [N/A] New `TODO`s link to an issue.
- [X] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [X] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
