### PR TITLE
chore: Update vsock throughput baseline for m6a.metal + kernel 4.14

### DIFF
--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -988,7 +988,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -996,7 +996,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -1009,26 +1009,26 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 112
+                                                    "target": 113
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 9,
                                                     "target": 121
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 114
+                                                    "target": 113
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 10,
                                                     "target": 123
                                                 }
                                             }
@@ -1060,8 +1060,8 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 105
+                                                    "delta_percentage": 7,
+                                                    "target": 104
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
@@ -1069,19 +1069,19 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 118
+                                                    "target": 117
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 7,
                                                     "target": 105
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 197
+                                                    "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 118
+                                                    "delta_percentage": 7,
+                                                    "target": 117
                                                 }
                                             }
                                         }
@@ -1095,18 +1095,18 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 12,
-                                                    "target": 43
+                                                    "target": 47
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 58
+                                                    "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 44
+                                                    "delta_percentage": 10,
+                                                    "target": 48
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 59
                                                 }
                                             }
@@ -1114,27 +1114,27 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 62
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 57
+                                                    "target": 61
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 70
+                                                    "delta_percentage": 17,
+                                                    "target": 71
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 62
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 57
+                                                    "delta_percentage": 12,
+                                                    "target": 61
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 15,
                                                     "target": 71
                                                 }
                                             }
@@ -1146,48 +1146,48 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 33
+                                                    "delta_percentage": 14,
+                                                    "target": 34
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
                                                     "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 32
+                                                    "delta_percentage": 17,
+                                                    "target": 33
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 58
+                                                    "target": 59
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 59
+                                                    "delta_percentage": 8,
+                                                    "target": 60
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 37
+                                                    "delta_percentage": 14,
+                                                    "target": 39
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 70
+                                                    "delta_percentage": 9,
+                                                    "target": 69
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 58
+                                                    "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 37
+                                                    "delta_percentage": 13,
+                                                    "target": 39
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 70
+                                                    "delta_percentage": 8,
+                                                    "target": 69
                                                 }
                                             }
                                         }
@@ -1200,48 +1200,48 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 10260
+                                                    "delta_percentage": 16,
+                                                    "target": 9458
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6147
+                                                    "delta_percentage": 8,
+                                                    "target": 6078
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 10281
+                                                    "delta_percentage": 14,
+                                                    "target": 9412
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6009
+                                                    "delta_percentage": 8,
+                                                    "target": 5979
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7139
+                                                    "delta_percentage": 8,
+                                                    "target": 7075
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 12908
+                                                    "target": 11534
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 7652
+                                                    "delta_percentage": 20,
+                                                    "target": 7688
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7144
+                                                    "delta_percentage": 7,
+                                                    "target": 7029
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 12955
+                                                    "delta_percentage": 11,
+                                                    "target": 11610
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7602
+                                                    "delta_percentage": 19,
+                                                    "target": 7579
                                                 }
                                             }
                                         }
@@ -1252,48 +1252,48 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 17596
+                                                    "delta_percentage": 26,
+                                                    "target": 16184
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 6184
+                                                    "target": 6127
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 17549
+                                                    "delta_percentage": 24,
+                                                    "target": 15709
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5974
+                                                    "delta_percentage": 8,
+                                                    "target": 5939
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7300
+                                                    "delta_percentage": 9,
+                                                    "target": 7334
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 25004
+                                                    "delta_percentage": 15,
+                                                    "target": 23846
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 8694
+                                                    "delta_percentage": 11,
+                                                    "target": 8142
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 7344
+                                                    "target": 7317
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 25250
+                                                    "delta_percentage": 15,
+                                                    "target": 24018
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 8342
+                                                    "delta_percentage": 10,
+                                                    "target": 7744
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes

Updates the performance baselines of vsock throughput tests for m6a.metal + kernel 4.14

## Reason

Performance changes were introduced on 5 Jul 2023 due to AMI update (not due to firecracker changes).
I've confirmed that the test passes on the old AMI not on the new AMI.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
