### PR TITLE
test: Add retries to get firecracker PID in new ns

### DIFF
--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -625,6 +625,7 @@ def test_new_pid_ns_resource_limits(test_microvm_with_api):
 
     # Get Firecracker's PID.
     fc_pid = test_microvm.pid_in_new_ns
+
     # Check limit values were correctly set.
     check_limits(fc_pid, NOFILE, FSIZE)
 
@@ -641,7 +642,6 @@ def test_new_pid_namespace(test_microvm_with_api):
 
     # Check that the PID file exists.
     fc_pid = test_microvm.pid_in_new_ns
-    assert fc_pid is not None
 
     # Validate the PID.
     stdout = subprocess.check_output("pidof firecracker", shell=True)


### PR DESCRIPTION
## Changes

- Adds reties to `pid_in_new_ns`.

## Reason

When `pid_in_new_ns` is referenced before the pid file is created by jailer with `--new-pid-ns` flag, it returns `None` and some jailer integration tests fail.
```
___________________ test_new_pid_ns_resource_limits[ubuntu] ____________________
--
  | integration_tests/security/test_jail.py:629: in test_new_pid_ns_resource_limits
  | check_limits(fc_pid, NOFILE, FSIZE)
  | fc_pid     = None
  | test_microvm = <framework.microvm.Microvm object at 0x7fd92e890d30>
  | test_microvm_with_api = <framework.microvm.Microvm object at 0x7fd92e890d30>
  | integration_tests/security/test_jail.py:348: in check_limits
  | (soft, hard) = resource.prlimit(pid, resource.RLIMIT_NOFILE)
  | E   TypeError: 'NoneType' object cannot be interpreted as an integer
  | fsize      = 2097151
  | no_file    = 1024
  | pid        = None
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
