### PR TITLE
test: refactor test_rate_limiter.py

### DIFF
--- a/tests/integration_tests/functional/test_rate_limiter.py
+++ b/tests/integration_tests/functional/test_rate_limiter.py
@@ -154,7 +154,7 @@ def test_rx_rate_limiting_cpu_load(test_microvm_with_api, network_config):
     test_microvm.start()
 
     # Start iperf server on guest.
-    _start_iperf_on_guest(test_microvm, guest_ip)
+    _start_iperf_server_on_guest(test_microvm, guest_ip)
 
     # Run iperf client sending UDP traffic.
     iperf_cmd = "{} {} -u -c {} -b 1000000000 -t{} -f KBytes".format(
@@ -177,13 +177,13 @@ def test_rx_rate_limiting_cpu_load(test_microvm_with_api, network_config):
         threshold=20,
     )
     with cpu_load_monitor:
-        _run_local_iperf(iperf_cmd)
+        _run_iperf_on_host(iperf_cmd)
 
 
 def _check_tx_rate_limiting(test_microvm, guest_ips, host_ips):
     """Check that the transmit rate is within expectations."""
-    # Start iperf on the host as this is the tx rate limiting test.
-    _start_local_iperf(test_microvm.jailer.netns_cmd_prefix())
+    # Start iperf server on the host as this is the tx rate limiting test.
+    _start_iperf_server_on_host(test_microvm.jailer.netns_cmd_prefix())
 
     # First step: get the transfer rate when no rate limiting is enabled.
     # We are receiving the result in KBytes from iperf.
@@ -226,8 +226,8 @@ def _check_tx_rate_limiting(test_microvm, guest_ips, host_ips):
 
 def _check_rx_rate_limiting(test_microvm, guest_ips):
     """Check that the receiving rate is within expectations."""
-    # Start iperf on guest.
-    _start_iperf_on_guest(test_microvm, guest_ips[0])
+    # Start iperf server on guest.
+    _start_iperf_server_on_guest(test_microvm, guest_ips[0])
 
     # First step: get the transfer rate when no rate limiting is enabled.
     # We are receiving the result in KBytes from iperf.
@@ -251,7 +251,7 @@ def _check_rx_rate_limiting(test_microvm, guest_ips):
 
     # Third step: get the number of bytes when rate limiting is on and there is
     # an initial burst size from where to consume.
-    print("Run guest TX iperf with exact burst size")
+    print("Run guest RX iperf with exact burst size")
     # Use iperf to obtain the bandwidth when there is burst to consume from,
     # send exactly BURST_SIZE packets.
     iperf_cmd = "{} {} -c {} -n {} -f KBytes -w {} -N".format(
@@ -261,7 +261,7 @@ def _check_rx_rate_limiting(test_microvm, guest_ips):
         BURST_SIZE,
         IPERF_TCP_WINDOW,
     )
-    iperf_out = _run_local_iperf(iperf_cmd)
+    iperf_out = _run_iperf_on_host(iperf_cmd)
     print(iperf_out)
     _, burst_kbps = _process_iperf_output(iperf_out)
     print("RX burst_kbps: {}".format(burst_kbps))
@@ -395,7 +395,7 @@ def _get_rx_bandwidth_with_duration(test_microvm, guest_ip, duration):
         duration,
         IPERF_TCP_WINDOW,
     )
-    iperf_out = _run_local_iperf(iperf_cmd)
+    iperf_out = _run_iperf_on_host(iperf_cmd)
     print(iperf_out)
 
     _, observed_kbps = _process_iperf_output(iperf_out)
@@ -420,7 +420,7 @@ def _patch_iface_bw(test_microvm, iface_id, rx_or_tx, new_bucket_size, new_refil
     assert test_microvm.api_session.is_status_no_content(resp.status_code)
 
 
-def _start_iperf_on_guest(test_microvm, hostname):
+def _start_iperf_server_on_guest(test_microvm, hostname):
     """Start iperf in server mode through an SSH connection."""
     test_microvm.ssh_config["hostname"] = hostname
 
@@ -441,7 +441,7 @@ def _run_iperf_on_guest(test_microvm, iperf_cmd, hostname):
     return out
 
 
-def _start_local_iperf(netns_cmd_prefix):
+def _start_iperf_server_on_host(netns_cmd_prefix):
     """Start iperf in server mode after killing any leftover iperf daemon."""
     iperf_cmd = "pkill {}\n".format(IPERF_BINARY)
 
@@ -457,7 +457,7 @@ def _start_local_iperf(netns_cmd_prefix):
     time.sleep(1)
 
 
-def _run_local_iperf(iperf_cmd):
+def _run_iperf_on_host(iperf_cmd):
     """Execute a client related iperf command locally."""
     code, stdout, stderr = utils.run_cmd(iperf_cmd)
     assert code == 0, f"stdout: {stdout}\nstderr: {stderr}"

--- a/tests/integration_tests/functional/test_rate_limiter.py
+++ b/tests/integration_tests/functional/test_rate_limiter.py
@@ -434,8 +434,8 @@ def _start_iperf_on_guest(test_microvm, hostname):
 def _run_iperf_on_guest(test_microvm, iperf_cmd, hostname):
     """Run a client related iperf command through an SSH connection."""
     test_microvm.ssh_config["hostname"] = hostname
-    _, stdout, stderr = test_microvm.ssh.execute_command(iperf_cmd)
-    assert stderr.read() == ""
+    code, stdout, stderr = test_microvm.ssh.execute_command(iperf_cmd)
+    assert code == 0, f"stdout: {stdout.read()}\nstderr: {stderr.read()}"
 
     out = stdout.read()
     return out
@@ -459,8 +459,10 @@ def _start_local_iperf(netns_cmd_prefix):
 
 def _run_local_iperf(iperf_cmd):
     """Execute a client related iperf command locally."""
-    process = utils.run_cmd(iperf_cmd)
-    return process.stdout
+    code, stdout, stderr = utils.run_cmd(iperf_cmd)
+    assert code == 0, f"stdout: {stdout}\nstderr: {stderr}"
+
+    return stdout
 
 
 def _get_percentage_difference(measured, base):


### PR DESCRIPTION
## Changes

- Fail early when iperf3 client exits with non-0 code.
- Fixes wrong or vague comments and clarify function names (mode (server/client) and env (guest/host))

## Reason

Spurious failure occurred in `_check_tx_rate_limiting`.
```
integration_tests/functional/test_rate_limiter.py:218: in _check_tx_rate_limiting
--
  | _, burst_kbps = _process_iperf_output(iperf_out)
  | expected_kbps = 102400
  | guest_ips  = ['192.168.0.2', '192.168.0.6', '192.168.0.10']
  | host_ips   = ['192.168.0.1', '192.168.0.5', '192.168.0.9']
  | iperf_cmd  = 'iperf3 -c 192.168.0.9 -n 104857600 -f KBytes -w 256K -N'
  | iperf_out  = 'iperf3: error - unable to connect to server: Connection refused\n'
  | rate_no_limit_kbps = 3295251.5
  | test_microvm = <framework.microvm.Microvm object at 0x7fbd4f8671f0>
  | integration_tests/functional/test_rate_limiter.py:492: in _process_iperf_output
  | iperf_out_time = (send_time + rcv_time) / 2.0
  | E   UnboundLocalError: local variable 'send_time' referenced before assignment
  | iperf_out  = 'iperf3: error - unable to connect to server: Connection refused\n'
  | iperf_out_lines = ['iperf3: error - unable to connect to server: Connection refused']
  | line       = 'iperf3: error - unable to connect to server: Connection refused'
```

The issue seems to have occurred due to crash of iperf3 server running as a daemon.
This commit doesn't address the root cause of the crash, as it is not easy to debug it and the occurrence is rare enough.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
