### PR TITLE
test: Run devtool build in CI

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -40,6 +40,12 @@ defaults = {
 }
 defaults = overlay_dict(defaults, args.step_param)
 
+devtool_build_grp = group(
+    "📦 Devtool Sanity Build",
+    "./tools/devtool -y build",
+    **defaults,
+)
+
 build_grp = group(
     "📦 Build",
     "./tools/devtool -y test -- ../tests/integration_tests/build/",
@@ -100,6 +106,11 @@ for step in kani_grp["steps"]:
 
 steps = [step_style]
 changed_files = get_changed_files("main")
+
+# run sanity build of devtool if Dockerfile is changed
+if any(x.parts[-1] == "Dockerfile" for x in changed_files):
+    steps += [devtool_build_grp]
+
 # run the whole test suite if either of:
 # - any file changed that is not documentation nor GitHub action config file
 # - no files changed


### PR DESCRIPTION
Thisshould solve issue #3966 It would prevent us from breaking devtool build cmd when updating the devctr

## Changes
Adding check which tries to execute `tools/devtool -y test`

## Reason
We want to avoid introducing breakings change like #3960 

Close #3966.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
