### PR TITLE
refactor: Simplify `build_microvm_from_requests`

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -24,16 +24,11 @@ pub use micro_http::{
 use seccompiler::BpfProgramRef;
 use serde_json::json;
 use utils::eventfd::EventFd;
-use vmm::rpc_interface::{VmmAction, VmmActionError, VmmData};
+use vmm::rpc_interface::{ApiRequest, ApiResponse, VmmAction, VmmData};
 use vmm::vmm_config::snapshot::SnapshotType;
 
 use crate::parsed_request::{ParsedRequest, RequestAction};
 use crate::Error::ServerCreation;
-
-/// Shorthand type for a request containing a boxed VmmAction.
-pub type ApiRequest = Box<VmmAction>;
-/// Shorthand type for a response containing a boxed Result.
-pub type ApiResponse = Box<std::result::Result<VmmData, VmmActionError>>;
 
 /// Errors thrown when binding the API server to the socket path.
 #[derive(Debug)]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,9 +25,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.64, "AMD": 81.89, "ARM": 81.18}
+    COVERAGE_DICT = {"Intel": 82.44, "AMD": 81.68, "ARM": 80.95}
 else:
-    COVERAGE_DICT = {"Intel": 79.95, "AMD": 79.11, "ARM": 78.23}
+    COVERAGE_DICT = {"Intel": 79.76, "AMD": 78.90, "ARM": 78.01}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Simplifies `build_microvm_from_requests` by  removing generic `Fn` arguments which where not needed.

## Reason

Generic function arguments are unweidly and add uneeded complexity.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
