### PR TITLE
fix(vmm): Changes T2A to set EferLmsleUnsupported to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
   update.
 - Fixed passing through cache information from host in CPUID leaf 0x80000005.
 - Fixed the T2A CPU template to disable SVM (nested virtualization).
+- Fixed the T2A CPU template to set EferLmsleUnsupported bit
+  (CPUID.80000008h:EBX[20]), which indicates that EFER[LMSLE] is not supported.
 
 ## [1.3.0]
 

--- a/resources/tests/static_cpu_templates/t2a.json
+++ b/resources/tests/static_cpu_templates/t2a.json
@@ -82,7 +82,7 @@
       "modifiers": [
         {
           "register": "ebx",
-          "bitmap": "0bxxxxxxxxxxxx11xxxxxxxx0xxxxxx0x0"
+          "bitmap": "0bxxxxxxxxxxx111xxxxxxxx0xxxxxx0x0"
         }
       ]
     }

--- a/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2a.rs
+++ b/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2a.rs
@@ -232,11 +232,12 @@ pub fn t2a() -> CustomCpuTemplate {
                     // - Bit 09: WBNOINVD (AMD APM) / WBNOINVD (Intel SDM)
                     // - Bit 18: IbrsPreferred (ADM APM) / Reserved (Intel SDm)
                     // - Bit 19: IbrsSameMode (AMD APM) / Reserved (Intel SDM)
+                    // - Bit 20: EferLmsleUnsupported (AMD APM) / Reserved (Intel SDM)
                     CpuidRegisterModifier {
                         register: CpuidRegister::Ebx,
                         bitmap: RegisterValueFilter {
-                            filter: 0b0000_0000_0000_1100_0000_0010_0000_0101,
-                            value: 0b0000_0000_0000_1100_0000_0000_0000_0000,
+                            filter: 0b0000_0000_0001_1100_0000_0010_0000_0101,
+                            value: 0b0000_0000_0001_1100_0000_0000_0000_0000,
                         },
                     },
                 ],


### PR DESCRIPTION
## Changes

- Changes T2A template to set CPUID.0x80000008:EBX[20] to 1 which indicates that EFER[LMSLE] is not supported.

## Reason

As described in AMD64 APM Vol.2, EFER[LMSLE] has already been deprecated and is not supported by all processor implementations (including m6a.metal).

KVM allows nested virtualized guests to write to EFER[LMSLE] only for very specific software (SLES11 version of Xen 4.0 to boot nested SVM).
https://lore.kernel.org/all/1273068285-3105-5-git-send-email-joerg.roedel@amd.com/
On non-nested virtualized guests, writing to EFER[LMSLE] generates #GP which is identical to behavior on CPUs where EferLmsleUnsupported is set to 1.  As T2A template disables SVM, it is safer and better to let guests know that writing to EFER[LMSLE] is not supported.

As a side note, to revert the above commit on the upstream kernel, some discussions were made in the following email thread, but was cut off in the middle.
https://lore.kernel.org/all/20220920205922.1564814-1-jmattson@google.com/

We can notice whether upstream kernel changes this behavior on our CPU config monitoring tests.

**Note: this fix should be backported to v1.3 and v1.4.**

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
