### PR TITLE
fix: minor fix of `release.sh`

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -52,7 +52,7 @@ function strip-and-split-debuginfo {
 }
 
 function get-firecracker-version {
-    (cd src/firecracker; cargo pkgid | cut -d# -f2 | cut -d: -f2)
+    (cd src/firecracker; cargo pkgid | cut -d# -f2 | (echo -n v; cut -d: -f2))
 }
 
 #### MAIN ####


### PR DESCRIPTION
## Changes
Previously version of FC obtained from binary in `release.sh` contained `v` (so it was `v.1.4.0`). But in `Cargo.toml` of FC version was `1.4.0`. Because of this difference release process was failing. This change fixes this issue.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
