### PR TITLE
fix(vmm): Changes T2A not to unset MMX and FXSR bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 - Fixed the T2A CPU template to disable SVM (nested virtualization).
 - Fixed the T2A CPU template to set EferLmsleUnsupported bit
   (CPUID.80000008h:EBX[20]), which indicates that EFER[LMSLE] is not supported.
+- Fixed the T2A CPU template not to unset the MMX bit (CPUID.80000001h:EDX[23])
+  and the FXSR bit (CPUID.80000001h:EDX[24]).
 
 ## [1.3.0]
 

--- a/resources/tests/static_cpu_templates/t2a.json
+++ b/resources/tests/static_cpu_templates/t2a.json
@@ -71,7 +71,7 @@
         },
         {
           "register": "edx",
-          "bitmap": "0bxxxxx00000xxxxxxxxxxxxxxxxxxxxxx"
+          "bitmap": "0bxxxxx00xx0xxxxxxxxxxxxxxxxxxxxxx"
         }
       ]
     },

--- a/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2a.rs
+++ b/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2a.rs
@@ -208,14 +208,12 @@ pub fn t2a() -> CustomCpuTemplate {
                     },
                     // EDX:
                     // - Bit 22: MmxExt (AMD APM) / Reserved (Intel SDM)
-                    // - Bit 23: MMX (AMD APM) / Reserved (Intel SDM)
-                    // - Bit 24: FSXR (AMD APM) / Reserved (Intel SDM)
                     // - Bit 25: FFXSR (AMD APM) / Reserved (Intel SDM)
                     // - Bit 26: Page1GB (AMD APM) / 1-GByte pages (Intel SDM)
                     CpuidRegisterModifier {
                         register: CpuidRegister::Edx,
                         bitmap: RegisterValueFilter {
-                            filter: 0b0000_0111_1100_0000_0000_0000_0000_0000,
+                            filter: 0b0000_0110_0100_0000_0000_0000_0000_0000,
                             value: 0b0000_0000_0000_0000_0000_0000_0000_0000,
                         },
                     },

--- a/tests/integration_tests/functional/test_feat_parity.py
+++ b/tests/integration_tests/functional/test_feat_parity.py
@@ -125,8 +125,6 @@ def test_feat_parity_cpuid_inst_set(vm):
         ),
         (0x80000001, 0x0, "edx",
             (1 << 22) | # MmxExt
-            (1 << 23) | # MMX
-            (1 << 24) | # FXSR
             (1 << 25) # FFXSR
         ),
         (0x80000008, 0x0, "ebx",


### PR DESCRIPTION
## Changes

- Changes T2A not to unset MMX and FXSR bits

## Reason

The MMX bit (CPUID.80000001h:EDX[23]) and the FXSR bit (CPUID.80000001h:EDX[24]) are unset on Intel CPUs as they are reserved in Intel specification. However, as described in AMD APM, these bits are same as CPUID.01h:EDX[23] and CPUID.01h:EDX[24] respectively. These bits are set to 1 on T2 instance,  Intel Cascade Lake, Intel Ice Lake and AMD Milan. Thus, T2A template does not need to unset CPUID.80000001h:EDX[23,24].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
