### PR TITLE
fix(vmm): Changes T2A to set RstrFpErrPtrs bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Fixed the T2A CPU template not to unset the MMX bit (CPUID.80000001h:EDX[23])
   and the FXSR bit (CPUID.80000001h:EDX[24]).
+- Fixed the T2A CPU template to set the RstrFpErrPtrs bit
+  (CPUID.80000008h:EBX[2]).
 
 ## [1.4.0]
 

--- a/resources/tests/static_cpu_templates/t2a.json
+++ b/resources/tests/static_cpu_templates/t2a.json
@@ -82,7 +82,7 @@
       "modifiers": [
         {
           "register": "ebx",
-          "bitmap": "0bxxxxxxxxxxx111xxxxxxxx0xxxxxx0x0"
+          "bitmap": "0bxxxxxxxxxxx111xxxxxxxx0xxxxxx1x0"
         }
       ]
     }

--- a/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2a.rs
+++ b/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2a.rs
@@ -235,7 +235,7 @@ pub fn t2a() -> CustomCpuTemplate {
                         register: CpuidRegister::Ebx,
                         bitmap: RegisterValueFilter {
                             filter: 0b0000_0000_0001_1100_0000_0010_0000_0101,
-                            value: 0b0000_0000_0001_1100_0000_0000_0000_0000,
+                            value: 0b0000_0000_0001_1100_0000_0000_0000_0100,
                         },
                     },
                 ],

--- a/tests/integration_tests/functional/test_feat_parity.py
+++ b/tests/integration_tests/functional/test_feat_parity.py
@@ -129,7 +129,6 @@ def test_feat_parity_cpuid_inst_set(vm):
         ),
         (0x80000008, 0x0, "ebx",
             (1 << 0) | # CLZERO
-            (1 << 2) | # RstrFpErrPtrs
             (1 << 4) | # RDPRU
             (1 << 8) | # MCOMMIT
             (1 << 9) | # WBNOINVD


### PR DESCRIPTION
## Changes

- Changes the T2A template to set the RstrFpErrPtrs bit ( CPUID.0x80000008:EBX[bit 2] ).

## Reason

According to AMD APM, the RstrFpErrPtrs bit ( CPUID.0x80000008:EBX[bit 2] ) indicates that FXSAVE, XSAVE, FXSAVEOPT, XSAVEC, XSAVES always save error pointers and FXRSTOR, XRSTOR, XRSTORS always restore error pointers.

Historically, the error pointers have been saved on Intel CPUs but were not on old AMD CPUs (called "FXSAVE leak"). To handle this difference, the linux kernel enables a workaround. See the following commit for more details.
https://github.com/torvalds/linux/commit/18bd057b1408

Given this sitaution, AMD decided to make their CPUs behave same as Intel CPUs and also added the CPUID bit to let softwares know this behavior.
https://github.com/torvalds/linux/commit/f2dbad36c55e

In terms of KVM, KVM forgot to expose the bit until kernel 5.4 via KVM_GET_SUPPORTED_CPUID and has passed through from host since the following commit.
https://github.com/torvalds/linux/commit/504ce1954fba

As this bit is set on m6a.metal and the T2A template aims to provide feature parity with guests on Intel Cascade Lake and Ice Lake with the T2CL template, it would be better to set this bit in the T2A template. Given the fact that firecracker supports not only kernel 5.10 but also 4.14 (where the pass-through by KVM  has not been available), the T2A template should set the bit to 1 rather than passing through.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
