### PR TITLE
chore: updated baselines for network latency for aarch64

### DIFF
--- a/tests/integration_tests/performance/configs/test_network_latency_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_6.1.json
@@ -11,8 +11,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 9.1,
-                                                    "target": 0.024
+                                                    "delta_percentage": 18.1,
+                                                    "target": 0.026
                                                 }
                                             }
                                         }
@@ -23,8 +23,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 9.1,
-                                                    "target": 0.025
+                                                    "delta_percentage": 12.1,
+                                                    "target": 0.026
                                                 }
                                             }
                                         }
@@ -147,8 +147,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 9.1,
-                                                    "target": 0.028
+                                                    "delta_percentage": 6.1,
+                                                    "target": 0.03
                                                 }
                                             }
                                         }
@@ -159,8 +159,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 10.1,
-                                                    "target": 0.03
+                                                    "delta_percentage": 12.1,
+                                                    "target": 0.032
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes
Updated baselines for network latency for aarch64

Diff: 
```json
{
    "source": "50b9fce7a2f9ea016423288524c11f94afab2b34/tests/integration_tests/performance/configs/",
    "target": "bbe7fc957ef0ab4b5530432beaff57565be4115e/tests/integration_tests/performance/configs/",
    "test_network_latency_config_6.1.json": {
        "test": "network_latency",
        "kernel": "6.1",
        "cpus": [
            {
                "instance": "c7g.metal",
                "model": "ARM_NEOVERSE_V1",
                "stats": {
                    "latency": {
                        "target_diff_percentage": {
                            "mean": 6.166666666666609,
                            "stdev": 3.0641293851416824
                        },
                        "delta_percentage_diff": {
                            "mean": 6.000000000000001,
                            "stdev": 4.2426406871192865
                        }
                    }
                }
            },
            {
                "instance": "m6g.metal",
                "model": "ARM_NEOVERSE_N1",
                "stats": {
                    "latency": {
                        "target_diff_percentage": {
                            "mean": 6.9047619047618465,
                            "stdev": 0.33671751485072005
                        },
                        "delta_percentage_diff": {
                            "mean": -0.5,
                            "stdev": 3.5355339059327378
                        }
                    }
                }
            }
        ]
    }
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
