### PR TITLE
test: Run unittests in debug mode

### DIFF
--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -3,6 +3,7 @@
 """A test that ensures that all unit tests pass at integration time."""
 
 import platform
+
 import pytest
 
 import host_tools.cargo_build as host  # pylint:disable=import-error
@@ -13,12 +14,13 @@ MACHINE = platform.machine()
 # run coverage with the `gnu` toolchains and run unit tests with the `musl` toolchains.
 TARGET = "{}-unknown-linux-musl".format(MACHINE)
 
+
 @pytest.mark.timeout(600)
 def test_unittests(test_fc_session_root_path):
     """
     Run unit and doc tests for all supported targets.
     """
-    extra_args = "--release --target {} ".format(TARGET)
+    extra_args = "--target {} ".format(TARGET)
 
     host.cargo_test(test_fc_session_root_path, extra_args=extra_args)
 


### PR DESCRIPTION
Running unittests in debug mode gives us greater correctness guarantees, since `debug_assert!`s will be triggered. These are often used to perform "sanity checks" that are supposed to get compiled out in release mode for performance reasons. Additionally, our coverage test runs in debug bug, so this will make the behavior between the two tests consistent (whereas otherwise a failure of one but not the other due to a debug assertion will be confusing).


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
