### PR TITLE
Adding `clippy::exit` lint

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -7,7 +7,8 @@ rustflags = [
   "-Dclippy::cast_lossless",
   "-Dclippy::cast_possible_wrap",
   "-Dclippy::cast_sign_loss",
-  "-Dmissing_debug_implementations"
+  "-Dmissing_debug_implementations",
+  "-Dclippy::exit",
 ]
 
 [net]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,7 @@ name = "rebase-snap"
 version = "1.5.0-dev"
 dependencies = [
  "libc",
+ "thiserror",
  "utils",
 ]
 

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -496,6 +496,10 @@
                 "comment": "sigaltstack is used by Rust stdlib to remove alternative signal stack during thread teardown."
             },
             {
+              "syscall": "getrandom",
+              "comment": "getrandom is used by `HttpServer` to reinialize `HashMap` after moving to the API thread"
+            },
+            {
                 "syscall": "accept4",
                 "comment": "Called to accept socket connections",
                 "args": [

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -508,6 +508,10 @@
                 "comment": "sigaltstack is used by Rust stdlib to remove alternative signal stack during thread teardown."
             },
             {
+              "syscall": "getrandom",
+              "comment": "getrandom is used by `HttpServer` to reinialize `HashMap` after moving to the API thread"
+            },
+            {
                 "syscall": "accept4",
                 "comment": "Called to accept socket connections",
                 "args": [

--- a/src/cpu-template-helper/src/fingerprint/compare.rs
+++ b/src/cpu-template-helper/src/fingerprint/compare.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use crate::fingerprint::{Fingerprint, FingerprintField};
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum FingerprintCompareError {
     /// Difference detected between source and target.
     #[error("Difference detected between source and target:\n{0}")]
     DiffDetected(String),
@@ -26,7 +26,7 @@ pub fn compare(
     prev: Fingerprint,
     curr: Fingerprint,
     filters: Vec<FingerprintField>,
-) -> Result<(), Error> {
+) -> Result<(), FingerprintCompareError> {
     let compare =
         |field: &FingerprintField, val1, val2| -> Option<Result<String, serde_json::Error>> {
             if val1 != val2 {
@@ -87,7 +87,7 @@ pub fn compare(
     if results.is_empty() {
         Ok(())
     } else {
-        Err(Error::DiffDetected(results.join("\n")))
+        Err(FingerprintCompareError::DiffDetected(results.join("\n")))
     }
 }
 
@@ -131,7 +131,7 @@ mod tests {
         let filters = vec![FingerprintField::kernel_version];
         let result = compare(f1, f2, filters);
         match result {
-            Err(Error::DiffDetected(err)) => {
+            Err(FingerprintCompareError::DiffDetected(err)) => {
                 assert_eq!(
                     err,
                     "{\

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -11,8 +11,6 @@ mod fingerprint;
 mod template;
 mod utils;
 
-const EXIT_CODE_ERROR: i32 = 1;
-
 #[derive(Debug, thiserror::Error)]
 enum Error {
     #[error("Failed to operate file: {0}")]
@@ -182,12 +180,14 @@ fn run(cli: Cli) -> Result<()> {
     Ok(())
 }
 
-fn main() {
+fn main() -> Result<()> {
     let cli = Cli::parse();
-
-    if let Err(e) = run(cli) {
-        eprintln!("Error: {}", e);
-        std::process::exit(EXIT_CODE_ERROR);
+    let result = run(cli);
+    if let Err(e) = result {
+        eprintln!("{}", e);
+        Err(e)
+    } else {
+        Ok(())
     }
 }
 

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -7,33 +7,33 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand, ValueEnum};
 use vmm::cpu_config::templates::{CustomCpuTemplate, GetCpuTemplate, GetCpuTemplateError};
 
+use crate::utils::UtilsError;
+
 mod fingerprint;
 mod template;
 mod utils;
 
 #[derive(Debug, thiserror::Error)]
-enum Error {
+enum HelperError {
     #[error("Failed to operate file: {0}")]
     FileIo(#[from] std::io::Error),
     #[error("{0}")]
-    FingerprintCompare(#[from] fingerprint::compare::Error),
+    FingerprintCompare(#[from] fingerprint::compare::FingerprintCompareError),
     #[error("{0}")]
-    FingerprintDump(#[from] fingerprint::dump::Error),
+    FingerprintDump(#[from] fingerprint::dump::FingerprintDumpError),
     #[error("CPU template is not specified: {0}")]
     NoCpuTemplate(#[from] GetCpuTemplateError),
     #[error("Failed to serialize/deserialize JSON file: {0}")]
     Serde(#[from] serde_json::Error),
     #[error("{0}")]
-    Utils(#[from] utils::Error),
+    Utils(#[from] UtilsError),
     #[error("{0}")]
-    TemplateDump(#[from] template::dump::Error),
+    TemplateDump(#[from] template::dump::DumpError),
     #[error("{0}")]
-    TemplateStrip(#[from] template::strip::Error),
+    TemplateStrip(#[from] template::strip::StripError),
     #[error("{0}")]
-    TemplateVerify(#[from] template::verify::Error),
+    TemplateVerify(#[from] template::verify::VerifyError),
 }
-
-type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Parser)]
 #[command(version = format!("v{}", crate::utils::CPU_TEMPLATE_HELPER_VERSION))]
@@ -111,7 +111,7 @@ enum FingerprintOperation {
     },
 }
 
-fn run(cli: Cli) -> Result<()> {
+fn run(cli: Cli) -> Result<(), HelperError> {
     match cli.command {
         Command::Template(op) => match op {
             TemplateOperation::Dump { config, output } => {
@@ -180,7 +180,7 @@ fn run(cli: Cli) -> Result<()> {
     Ok(())
 }
 
-fn main() -> Result<()> {
+fn main() -> Result<(), HelperError> {
     let cli = Cli::parse();
     let result = run(cli);
     if let Err(e) = result {

--- a/src/cpu-template-helper/src/template/dump/mod.rs
+++ b/src/cpu-template-helper/src/template/dump/mod.rs
@@ -17,13 +17,13 @@ use crate::template::dump::aarch64::config_to_template;
 use crate::template::dump::x86_64::config_to_template;
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum DumpError {
     /// Failed to dump CPU configuration.
     #[error("Failed to dump CPU config: {0}")]
     DumpCpuConfig(#[from] DumpCpuConfigError),
 }
 
-pub fn dump(vmm: Arc<Mutex<Vmm>>) -> Result<CustomCpuTemplate, Error> {
+pub fn dump(vmm: Arc<Mutex<Vmm>>) -> Result<CustomCpuTemplate, DumpError> {
     // Get CPU configuration.
     let cpu_configs = vmm.lock().unwrap().dump_cpu_config()?;
 

--- a/src/cpu-template-helper/src/template/strip/aarch64.rs
+++ b/src/cpu-template-helper/src/template/strip/aarch64.rs
@@ -4,11 +4,11 @@
 use vmm::cpu_config::aarch64::custom_cpu_template::RegisterModifier;
 use vmm::cpu_config::templates::CustomCpuTemplate;
 
-use crate::template::strip::{strip_common, Error};
+use crate::template::strip::{strip_common, StripError};
 use crate::utils::aarch64::RegModifierMap;
 
 #[allow(dead_code)]
-pub fn strip(templates: Vec<CustomCpuTemplate>) -> Result<Vec<CustomCpuTemplate>, Error> {
+pub fn strip(templates: Vec<CustomCpuTemplate>) -> Result<Vec<CustomCpuTemplate>, StripError> {
     // Convert `Vec<CustomCpuTemplate>` to `Vec<HashMap<_>>`.
     let mut reg_modifiers_maps = templates
         .into_iter()

--- a/src/cpu-template-helper/src/template/strip/mod.rs
+++ b/src/cpu-template-helper/src/template/strip/mod.rs
@@ -19,19 +19,19 @@ mod x86_64;
 pub use x86_64::strip;
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum StripError {
     /// The number of inputs should be two or more.
     #[error("The number of inputs should be two or more.")]
     NumberOfInputs,
 }
 
-fn strip_common<K, V>(maps: &mut [HashMap<K, RegisterValueFilter<V>>]) -> Result<(), Error>
+fn strip_common<K, V>(maps: &mut [HashMap<K, RegisterValueFilter<V>>]) -> Result<(), StripError>
 where
     K: ModifierMapKey + Debug,
     V: Numeric + Debug,
 {
     if maps.len() < 2 {
-        return Err(Error::NumberOfInputs);
+        return Err(StripError::NumberOfInputs);
     }
 
     // Initialize `common` with the cloned `maps[0]`.
@@ -94,7 +94,7 @@ mod tests {
         let mut input = vec![HashMap::from([mock_modifier!(0x0, 0b0000_0000)])];
 
         match strip_common(&mut input) {
-            Err(Error::NumberOfInputs) => (),
+            Err(StripError::NumberOfInputs) => (),
             _ => panic!("Should fail with `Error::NumberOfInputs`."),
         }
     }

--- a/src/cpu-template-helper/src/template/strip/x86_64.rs
+++ b/src/cpu-template-helper/src/template/strip/x86_64.rs
@@ -4,11 +4,11 @@
 use vmm::cpu_config::templates::CustomCpuTemplate;
 use vmm::cpu_config::x86_64::custom_cpu_template::{CpuidLeafModifier, RegisterModifier};
 
-use crate::template::strip::{strip_common, Error};
+use crate::template::strip::{strip_common, StripError};
 use crate::utils::x86_64::{CpuidModifierMap, MsrModifierMap};
 
 #[allow(dead_code)]
-pub fn strip(templates: Vec<CustomCpuTemplate>) -> Result<Vec<CustomCpuTemplate>, Error> {
+pub fn strip(templates: Vec<CustomCpuTemplate>) -> Result<Vec<CustomCpuTemplate>, StripError> {
     // Convert `Vec<CustomCpuTemplate>` to two `Vec<HashMap<_>>` of modifiers.
     let (mut cpuid_modifiers_maps, mut msr_modifiers_maps): (Vec<_>, Vec<_>) = templates
         .into_iter()

--- a/src/cpu-template-helper/src/template/verify/aarch64.rs
+++ b/src/cpu-template-helper/src/template/verify/aarch64.rs
@@ -3,10 +3,13 @@
 
 use vmm::cpu_config::templates::CustomCpuTemplate;
 
-use super::{verify_common, Error};
+use super::{verify_common, VerifyError};
 use crate::utils::aarch64::RegModifierMap;
 
-pub fn verify(cpu_template: CustomCpuTemplate, cpu_config: CustomCpuTemplate) -> Result<(), Error> {
+pub fn verify(
+    cpu_template: CustomCpuTemplate,
+    cpu_config: CustomCpuTemplate,
+) -> Result<(), VerifyError> {
     let reg_template = RegModifierMap::from(cpu_template.reg_modifiers);
     let reg_config = RegModifierMap::from(cpu_config.reg_modifiers);
     verify_common(reg_template.0, reg_config.0)

--- a/src/cpu-template-helper/src/template/verify/mod.rs
+++ b/src/cpu-template-helper/src/template/verify/mod.rs
@@ -19,7 +19,7 @@ pub use x86_64::verify;
 
 #[rustfmt::skip]
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum VerifyError {
     #[error("{0} not found in CPU configuration.")]
     KeyNotFound(String),
     #[error("Value for {0} mismatched.\n{1}")]
@@ -34,7 +34,7 @@ pub enum Error {
 pub fn verify_common<K, V>(
     template: HashMap<K, RegisterValueFilter<V>>,
     config: HashMap<K, RegisterValueFilter<V>>,
-) -> Result<(), Error>
+) -> Result<(), VerifyError>
 where
     K: ModifierMapKey + Debug,
     V: Numeric + Debug,
@@ -42,13 +42,13 @@ where
     for (key, template_value_filter) in template {
         let config_value_filter = config
             .get(&key)
-            .ok_or(Error::KeyNotFound(key.to_string()))?;
+            .ok_or(VerifyError::KeyNotFound(key.to_string()))?;
 
         let template_value = template_value_filter.value & template_value_filter.filter;
         let config_value = config_value_filter.value & template_value_filter.filter;
 
         if template_value != config_value {
-            return Err(Error::ValueMismatched(
+            return Err(VerifyError::ValueMismatched(
                 key.to_string(),
                 V::to_diff_string(template_value, config_value),
             ));

--- a/src/cpu-template-helper/src/template/verify/x86_64.rs
+++ b/src/cpu-template-helper/src/template/verify/x86_64.rs
@@ -3,10 +3,13 @@
 
 use vmm::cpu_config::templates::CustomCpuTemplate;
 
-use super::{verify_common, Error};
+use super::{verify_common, VerifyError};
 use crate::utils::x86_64::{CpuidModifierMap, MsrModifierMap};
 
-pub fn verify(cpu_template: CustomCpuTemplate, cpu_config: CustomCpuTemplate) -> Result<(), Error> {
+pub fn verify(
+    cpu_template: CustomCpuTemplate,
+    cpu_config: CustomCpuTemplate,
+) -> Result<(), VerifyError> {
     let cpuid_template = CpuidModifierMap::from(cpu_template.cpuid_modifiers);
     let cpuid_config = CpuidModifierMap::from(cpu_config.cpuid_modifiers);
     verify_common(cpuid_template.0, cpuid_config.0)?;

--- a/src/cpu-template-helper/src/utils/mod.rs
+++ b/src/cpu-template-helper/src/utils/mod.rs
@@ -59,7 +59,7 @@ impl<V: Numeric> DiffString<V> for V {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum UtilsError {
     /// Failed to create VmResources.
     #[error("Failed to create VmResources: {0}")]
     CreateVmResources(vmm::resources::ResourcesError),
@@ -68,7 +68,9 @@ pub enum Error {
     BuildMicroVm(#[from] StartMicrovmError),
 }
 
-pub fn build_microvm_from_config(config: &str) -> Result<(Arc<Mutex<Vmm>>, VmResources), Error> {
+pub fn build_microvm_from_config(
+    config: &str,
+) -> Result<(Arc<Mutex<Vmm>>, VmResources), UtilsError> {
     // Prepare resources from the given config file.
     let instance_info = InstanceInfo {
         id: "anonymous-instance".to_string(),
@@ -77,7 +79,7 @@ pub fn build_microvm_from_config(config: &str) -> Result<(Arc<Mutex<Vmm>>, VmRes
         app_name: "cpu-template-helper".to_string(),
     };
     let vm_resources = VmResources::from_json(config, &instance_info, HTTP_MAX_PAYLOAD_SIZE, None)
-        .map_err(Error::CreateVmResources)?;
+        .map_err(UtilsError::CreateVmResources)?;
     let mut event_manager = EventManager::new().unwrap();
     let seccomp_filters = get_empty_filters();
 
@@ -172,7 +174,7 @@ pub mod tests {
 
         match build_microvm_from_config(&invalid_config) {
             Ok(_) => panic!("Should fail with `No such file or directory`."),
-            Err(Error::CreateVmResources(_)) => (),
+            Err(UtilsError::CreateVmResources(_)) => (),
             Err(err) => panic!("Unexpected error: {err}"),
         }
     }

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -7,22 +7,26 @@ mod seccomp;
 
 use std::fs::{self, File};
 use std::path::PathBuf;
+use std::process::ExitCode;
 use std::sync::{Arc, Mutex};
-use std::{io, panic, process};
+use std::{io, panic};
 
+use api_server_adapter::ApiServerError;
 use event_manager::SubscriberOps;
 use logger::{error, info, ProcessTimeReporter, StoreMetric, LOGGER, METRICS};
+use seccomp::FilterError;
 use seccompiler::BpfThreadMap;
-use snapshot::Snapshot;
+use snapshot::{Error as SnapshotError, Snapshot};
 use utils::arg_parser::{ArgParser, Argument};
 use utils::terminal::Terminal;
 use utils::validators::validate_instance_id;
+use vmm::builder::StartMicrovmError;
 use vmm::resources::VmResources;
 use vmm::signal_handler::register_signal_handlers;
 use vmm::version_map::{FC_VERSION_TO_SNAP_VERSION, VERSION_MAP};
 use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
-use vmm::vmm_config::logger::{init_logger, LoggerConfig, LoggerLevel};
-use vmm::vmm_config::metrics::{init_metrics, MetricsConfig};
+use vmm::vmm_config::logger::{init_logger, LoggerConfig, LoggerConfigError, LoggerLevel};
+use vmm::vmm_config::metrics::{init_metrics, MetricsConfig, MetricsConfigError};
 use vmm::{EventManager, FcExitCode, HTTP_MAX_PAYLOAD_SIZE};
 
 use crate::seccomp::SeccompConfig;
@@ -35,51 +39,58 @@ const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
 const FIRECRACKER_VERSION: &str = env!("FIRECRACKER_VERSION");
 const MMDS_CONTENT_ARG: &str = "metadata";
 
-#[cfg(target_arch = "aarch64")]
-/// Enable SSBD mitigation through `prctl`.
-pub fn enable_ssbd_mitigation() {
-    // Parameters for `prctl`
-    // TODO: generate bindings for these from the kernel sources.
-    // https://elixir.bootlin.com/linux/v4.17/source/include/uapi/linux/prctl.h#L212
-    const PR_SET_SPECULATION_CTRL: i32 = 53;
-    const PR_SPEC_STORE_BYPASS: u64 = 0;
-    const PR_SPEC_FORCE_DISABLE: u64 = 1u64 << 3;
+#[derive(Debug, thiserror::Error)]
+enum MainError {
+    #[error("Failed to register signal handlers: {0}")]
+    RegisterSignalHandlers(#[source] utils::errno::Error),
+    #[error("Arguments parsing error: {0} \n\nFor more information try --help.")]
+    ParseArguments(#[from] utils::arg_parser::Error),
+    #[error("When printing Snapshot Data format: {0}")]
+    PrintSnapshotDataFormat(#[from] SnapshotVersionError),
+    #[error("Invalid value for logger level: {0}.Possible values: [Error, Warning, Info, Debug]")]
+    InvalidLogLevel(LoggerConfigError),
+    #[error("Could not initialize logger: {0}")]
+    LoggerInitialization(LoggerConfigError),
+    #[error("Could not initialize metrics: {0:?}")]
+    MetricsInitialization(MetricsConfigError),
+    #[error("Seccomp error: {0}")]
+    SeccompFilter(FilterError),
+    #[error("RunWithApiError error: {0}")]
+    RunWithApi(ApiServerError),
+    #[error("RunWithoutApiError error: {0}")]
+    RunWithoutApiError(RunWithoutApiError),
+}
 
-    // SAFETY: Parameters are valid since they are copied verbatim
-    // from the kernel's UAPI.
-    // PR_SET_SPECULATION_CTRL only uses those 2 parameters, so it's ok
-    // to leave the latter 2 as zero.
-    let ret = unsafe {
-        libc::prctl(
-            PR_SET_SPECULATION_CTRL,
-            PR_SPEC_STORE_BYPASS,
-            PR_SPEC_FORCE_DISABLE,
-            0,
-            0,
-        )
-    };
+impl From<MainError> for ExitCode {
+    fn from(value: MainError) -> Self {
+        let exit_code = match value {
+            MainError::ParseArguments(_) => FcExitCode::ArgParsing,
+            MainError::InvalidLogLevel(_) => FcExitCode::BadConfiguration,
+            MainError::RunWithApi(ApiServerError::MicroVMStoppedWithoutError(code)) => code,
+            MainError::RunWithApi(ApiServerError::MicroVMStoppedWithError(code)) => code,
+            _ => FcExitCode::GenericError,
+        };
 
-    if ret < 0 {
-        let last_error = std::io::Error::last_os_error().raw_os_error().unwrap();
-        error!(
-            "Could not enable SSBD mitigation through prctl, error {}",
-            last_error
-        );
-        if last_error == libc::EINVAL {
-            error!("The host does not support SSBD mitigation through prctl.");
-        }
+        ExitCode::from(exit_code as u8)
     }
 }
 
-fn main_exitable() -> FcExitCode {
+fn main() -> ExitCode {
+    let result = main_exec();
+    if let Err(e) = result {
+        error!("{}", e);
+        e.into()
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn main_exec() -> Result<(), MainError> {
     LOGGER
         .configure(Some(DEFAULT_INSTANCE_ID.to_string()))
         .expect("Failed to register logger");
 
-    if let Err(err) = register_signal_handlers() {
-        error!("Failed to register signal handlers: {}", err);
-        return vmm::FcExitCode::GenericError;
-    }
+    register_signal_handlers().map_err(MainError::RegisterSignalHandlers)?;
 
     #[cfg(target_arch = "aarch64")]
     enable_ssbd_mitigation();
@@ -231,35 +242,25 @@ fn main_exitable() -> FcExitCode {
                 .help("Mmds data store limit, in bytes."),
         );
 
-    let arguments = match arg_parser.parse_from_cmdline() {
-        Err(err) => {
-            error!(
-                "Arguments parsing error: {} \n\nFor more information try --help.",
-                err
-            );
-            return vmm::FcExitCode::ArgParsing;
-        }
-        _ => {
-            if arg_parser.arguments().flag_present("help") {
-                println!("Firecracker v{}\n", FIRECRACKER_VERSION);
-                println!("{}", arg_parser.formatted_help());
-                return vmm::FcExitCode::Ok;
-            }
+    arg_parser.parse_from_cmdline()?;
+    let arguments = arg_parser.arguments();
 
-            if arg_parser.arguments().flag_present("version") {
-                println!("Firecracker v{}\n", FIRECRACKER_VERSION);
-                print_supported_snapshot_versions();
-                return vmm::FcExitCode::Ok;
-            }
+    if arguments.flag_present("help") {
+        println!("Firecracker v{}\n", FIRECRACKER_VERSION);
+        println!("{}", arg_parser.formatted_help());
+        return Ok(());
+    }
 
-            if let Some(snapshot_path) = arg_parser.arguments().single_value("describe-snapshot") {
-                print_snapshot_data_format(snapshot_path);
-                return vmm::FcExitCode::Ok;
-            }
+    if arguments.flag_present("version") {
+        println!("Firecracker v{}\n", FIRECRACKER_VERSION);
+        print_supported_snapshot_versions();
+        return Ok(());
+    }
 
-            arg_parser.arguments()
-        }
-    };
+    if let Some(snapshot_path) = arguments.single_value("describe-snapshot") {
+        print_snapshot_data_format(snapshot_path)?;
+        return Ok(());
+    }
 
     // Display warnings for any used deprecated parameters.
     // Currently unused since there are no deprecated parameters. Uncomment the line when
@@ -282,16 +283,7 @@ fn main_exitable() -> FcExitCode {
     if let Some(log) = arguments.single_value("log-path") {
         // It's safe to unwrap here because the field's been provided with a default value.
         let level = arguments.single_value("level").unwrap().to_owned();
-        let logger_level = match LoggerLevel::from_string(level) {
-            Ok(level) => level,
-            Err(err) => {
-                return generic_error_exit(&format!(
-                    "Invalid value for logger level: {}.Possible values: [Error, Warning, Info, \
-                     Debug]",
-                    err
-                ));
-            }
-        };
+        let logger_level = LoggerLevel::from_string(level).map_err(MainError::InvalidLogLevel)?;
         let show_level = arguments.flag_present("show-level");
         let show_log_origin = arguments.flag_present("show-log-origin");
 
@@ -301,31 +293,22 @@ fn main_exitable() -> FcExitCode {
             show_level,
             show_log_origin,
         };
-        if let Err(err) = init_logger(logger_config, &instance_info) {
-            return generic_error_exit(&format!("Could not initialize logger: {}", err));
-        };
+        init_logger(logger_config, &instance_info).map_err(MainError::LoggerInitialization)?;
     }
 
     if let Some(metrics_path) = arguments.single_value("metrics-path") {
         let metrics_config = MetricsConfig {
             metrics_path: PathBuf::from(metrics_path),
         };
-        if let Err(err) = init_metrics(metrics_config) {
-            return generic_error_exit(&format!("Could not initialize metrics: {}", err));
-        };
+        init_metrics(metrics_config).map_err(MainError::MetricsInitialization)?;
     }
 
-    let mut seccomp_filters: BpfThreadMap = match SeccompConfig::from_args(
+    let mut seccomp_filters: BpfThreadMap = SeccompConfig::from_args(
         arguments.flag_present("no-seccomp"),
         arguments.single_value("seccomp-filter"),
     )
     .and_then(seccomp::get_filters)
-    {
-        Ok(filters) => filters,
-        Err(err) => {
-            return generic_error_exit(&format!("Seccomp error: {}", err));
-        }
-    };
+    .map_err(MainError::SeccompFilter)?;
 
     let vmm_config_json = arguments
         .single_value("config-file")
@@ -395,6 +378,7 @@ fn main_exitable() -> FcExitCode {
             mmds_size_limit,
             metadata_json.as_deref(),
         )
+        .map_err(MainError::RunWithApi)
     } else {
         let seccomp_filters: BpfThreadMap = seccomp_filters
             .into_iter()
@@ -408,28 +392,44 @@ fn main_exitable() -> FcExitCode {
             mmds_size_limit,
             metadata_json.as_deref(),
         )
+        .map_err(MainError::RunWithoutApiError)
     }
 }
 
-fn main() {
-    // This idiom is the prescribed way to get a clean shutdown of Rust (that will report
-    // no leaks in Valgrind or sanitizers).  Calling `unsafe { libc::exit() }` does no
-    // cleanup, and std::process::exit() does more--but does not run destructors.  So the
-    // best thing to do is to is bubble up the exit code through the whole stack, and
-    // only exit when everything potentially destructible has cleaned itself up.
-    //
-    // https://doc.rust-lang.org/std/process/fn.exit.html
-    //
-    // See process_exitable() method of Subscriber trait for what triggers the exit_code.
-    //
-    let exit_code = main_exitable();
-    std::process::exit(exit_code as i32);
-}
+/// Enable SSBD mitigation through `prctl`.
+#[cfg(target_arch = "aarch64")]
+pub fn enable_ssbd_mitigation() {
+    // Parameters for `prctl`
+    // TODO: generate bindings for these from the kernel sources.
+    // https://elixir.bootlin.com/linux/v4.17/source/include/uapi/linux/prctl.h#L212
+    const PR_SET_SPECULATION_CTRL: i32 = 53;
+    const PR_SPEC_STORE_BYPASS: u64 = 0;
+    const PR_SPEC_FORCE_DISABLE: u64 = 1u64 << 3;
 
-// Exit gracefully with a generic error code.
-fn generic_error_exit(msg: &str) -> FcExitCode {
-    error!("{}", msg);
-    vmm::FcExitCode::GenericError
+    // SAFETY: Parameters are valid since they are copied verbatim
+    // from the kernel's UAPI.
+    // PR_SET_SPECULATION_CTRL only uses those 2 parameters, so it's ok
+    // to leave the latter 2 as zero.
+    let ret = unsafe {
+        libc::prctl(
+            PR_SET_SPECULATION_CTRL,
+            PR_SPEC_STORE_BYPASS,
+            PR_SPEC_FORCE_DISABLE,
+            0,
+            0,
+        )
+    };
+
+    if ret < 0 {
+        let last_error = std::io::Error::last_os_error().raw_os_error().unwrap();
+        error!(
+            "Could not enable SSBD mitigation through prctl, error {}",
+            last_error
+        );
+        if last_error == libc::EINVAL {
+            error!("The host does not support SSBD mitigation through prctl.");
+        }
+    }
 }
 
 // Log a warning for any usage of deprecated parameters.
@@ -450,31 +450,39 @@ fn print_supported_snapshot_versions() {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+enum SnapshotVersionError {
+    #[error("Unable to open snapshot state file: {0}")]
+    OpenSnapshot(io::Error),
+    #[error("Invalid data format version of snapshot file: {0}")]
+    SnapshotVersion(SnapshotError),
+    #[error("Cannot translate snapshot data version {0} to Firecracker microVM version")]
+    FirecrackerVersion(u16),
+}
+
 // Print data format of provided snapshot state file.
-fn print_snapshot_data_format(snapshot_path: &str) {
-    let mut snapshot_reader = File::open(snapshot_path).unwrap_or_else(|err| {
-        process::exit(
-            generic_error_exit(&format!("Unable to open snapshot state file: {:?}", err)) as i32,
-        );
-    });
+fn print_snapshot_data_format(snapshot_path: &str) -> Result<(), SnapshotVersionError> {
+    let mut snapshot_reader =
+        File::open(snapshot_path).map_err(SnapshotVersionError::OpenSnapshot)?;
+
     let data_format_version = Snapshot::get_data_version(&mut snapshot_reader, &VERSION_MAP)
-        .unwrap_or_else(|err| {
-            process::exit(generic_error_exit(&format!(
-                "Invalid data format version of snapshot file: {:?}",
-                err
-            )) as i32);
-        });
+        .map_err(SnapshotVersionError::SnapshotVersion)?;
 
     let (key, _) = FC_VERSION_TO_SNAP_VERSION
         .iter()
         .find(|(_, &val)| val == data_format_version)
-        .unwrap_or_else(|| {
-            process::exit(generic_error_exit(&format!(
-                "Cannot translate snapshot data version {} to Firecracker microVM version",
-                data_format_version
-            )) as i32);
-        });
+        .ok_or_else(|| SnapshotVersionError::FirecrackerVersion(data_format_version))?;
+
     println!("v{}", key);
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuildFromJsonError {
+    #[error("Configuration for VMM from one single json failed: {0}")]
+    ParseFromJson(vmm::resources::ResourcesError),
+    #[error("Could not Start MicroVM from one single json: {0}")]
+    StartMicroVM(StartMicrovmError),
 }
 
 // Configure and start a microVM as described by the command-line JSON.
@@ -486,13 +494,10 @@ fn build_microvm_from_json(
     boot_timer_enabled: bool,
     mmds_size_limit: usize,
     metadata_json: Option<&str>,
-) -> std::result::Result<(VmResources, Arc<Mutex<vmm::Vmm>>), FcExitCode> {
+) -> Result<(VmResources, Arc<Mutex<vmm::Vmm>>), BuildFromJsonError> {
     let mut vm_resources =
         VmResources::from_json(&config_json, &instance_info, mmds_size_limit, metadata_json)
-            .map_err(|err| {
-                error!("Configuration for VMM from one single json failed: {}", err);
-                vmm::FcExitCode::BadConfiguration
-            })?;
+            .map_err(BuildFromJsonError::ParseFromJson)?;
     vm_resources.boot_timer = boot_timer_enabled;
     let vmm = vmm::builder::build_and_boot_microvm(
         &instance_info,
@@ -500,16 +505,19 @@ fn build_microvm_from_json(
         event_manager,
         seccomp_filters,
     )
-    .map_err(|err| {
-        error!(
-            "Building VMM configured from cmdline json failed: {:?}",
-            err
-        );
-        vmm::FcExitCode::BadConfiguration
-    })?;
+    .map_err(BuildFromJsonError::StartMicroVM)?;
+
     info!("Successfully started microvm that was configured from one single json");
 
     Ok((vm_resources, vmm))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RunWithoutApiError {
+    #[error("MicroVMStopped without an error: {0:?}")]
+    Shutdown(FcExitCode),
+    #[error("Failed to build MicroVM from Json: {0}")]
+    BuildMicroVMFromJson(BuildFromJsonError),
 }
 
 fn run_without_api(
@@ -519,7 +527,7 @@ fn run_without_api(
     bool_timer_enabled: bool,
     mmds_size_limit: usize,
     metadata_json: Option<&str>,
-) -> FcExitCode {
+) -> Result<(), RunWithoutApiError> {
     let mut event_manager = EventManager::new().expect("Unable to create EventManager");
 
     // Create the firecracker metrics object responsible for periodically printing metrics.
@@ -527,7 +535,7 @@ fn run_without_api(
     event_manager.add_subscriber(firecracker_metrics.clone());
 
     // Build the microVm. We can ignore VmResources since it's not used without api.
-    let (_, vmm) = match build_microvm_from_json(
+    let (_, vmm) = build_microvm_from_json(
         seccomp_filters,
         &mut event_manager,
         // Safe to unwrap since '--no-api' requires this to be set.
@@ -536,10 +544,8 @@ fn run_without_api(
         bool_timer_enabled,
         mmds_size_limit,
         metadata_json,
-    ) {
-        Ok((res, vmm)) => (res, vmm),
-        Err(exit_code) => return exit_code,
-    };
+    )
+    .map_err(RunWithoutApiError::BuildMicroVMFromJson)?;
 
     // Start the metrics.
     firecracker_metrics
@@ -554,7 +560,7 @@ fn run_without_api(
             .expect("Failed to start the event manager");
 
         if let Some(exit_code) = vmm.lock().unwrap().shutdown_exit_code() {
-            return exit_code;
+            return Err(RunWithoutApiError::Shutdown(exit_code));
         }
     }
 }

--- a/src/jailer/src/chroot.rs
+++ b/src/jailer/src/chroot.rs
@@ -8,7 +8,7 @@ use std::ptr::null;
 
 use utils::syscall::SyscallReturnCode;
 
-use super::{to_cstring, Error, Result};
+use super::{to_cstring, JailerError};
 
 const OLD_ROOT_DIR_NAME_NUL_TERMINATED: &[u8] = b"old_root\0";
 const ROOT_DIR_NUL_TERMINATED: &[u8] = b"/\0";
@@ -16,16 +16,16 @@ const CURRENT_DIR_NUL_TERMINATED: &[u8] = b".\0";
 
 // This uses switching to a new mount namespace + pivot_root(), together with the regular chroot,
 // to provide a hardened jail (at least compared to only relying on chroot).
-pub fn chroot(path: &Path) -> Result<()> {
+pub fn chroot(path: &Path) -> Result<(), JailerError> {
     // We unshare into a new mount namespace.
     // SAFETY: The call is safe because we're invoking a C library
     // function with valid parameters.
     SyscallReturnCode(unsafe { libc::unshare(libc::CLONE_NEWNS) })
         .into_empty_result()
-        .map_err(Error::UnshareNewNs)?;
+        .map_err(JailerError::UnshareNewNs)?;
 
-    let root_dir =
-        CStr::from_bytes_with_nul(ROOT_DIR_NUL_TERMINATED).map_err(Error::FromBytesWithNul)?;
+    let root_dir = CStr::from_bytes_with_nul(ROOT_DIR_NUL_TERMINATED)
+        .map_err(JailerError::FromBytesWithNul)?;
 
     // Recursively change the propagation type of all the mounts in this namespace to SLAVE, so
     // we can call pivot_root.
@@ -40,7 +40,7 @@ pub fn chroot(path: &Path) -> Result<()> {
         )
     })
     .into_empty_result()
-    .map_err(Error::MountPropagationSlave)?;
+    .map_err(JailerError::MountPropagationSlave)?;
 
     // We need a CString for the following mount call.
     let chroot_dir = to_cstring(path)?;
@@ -59,24 +59,24 @@ pub fn chroot(path: &Path) -> Result<()> {
         )
     })
     .into_empty_result()
-    .map_err(Error::MountBind)?;
+    .map_err(JailerError::MountBind)?;
 
     // Change current dir to the chroot dir, so we only need to handle relative paths from now on.
-    env::set_current_dir(path).map_err(Error::SetCurrentDir)?;
+    env::set_current_dir(path).map_err(JailerError::SetCurrentDir)?;
 
     // We use the CStr conversion to make sure the contents of the byte slice would be a
     // valid C string (and for the as_ptr() method).
     let old_root_dir = CStr::from_bytes_with_nul(OLD_ROOT_DIR_NAME_NUL_TERMINATED)
-        .map_err(Error::FromBytesWithNul)?;
+        .map_err(JailerError::FromBytesWithNul)?;
 
     // Create the old_root folder we're going to use for pivot_root, using a relative path.
     // SAFETY: The call is safe because we provide valid arguments.
     SyscallReturnCode(unsafe { libc::mkdir(old_root_dir.as_ptr(), libc::S_IRUSR | libc::S_IWUSR) })
         .into_empty_result()
-        .map_err(Error::MkdirOldRoot)?;
+        .map_err(JailerError::MkdirOldRoot)?;
 
-    let cwd =
-        CStr::from_bytes_with_nul(CURRENT_DIR_NUL_TERMINATED).map_err(Error::FromBytesWithNul)?;
+    let cwd = CStr::from_bytes_with_nul(CURRENT_DIR_NUL_TERMINATED)
+        .map_err(JailerError::FromBytesWithNul)?;
 
     // We are now ready to call pivot_root. We have to use sys_call because there is no libc
     // wrapper for pivot_root.
@@ -85,24 +85,24 @@ pub fn chroot(path: &Path) -> Result<()> {
         libc::syscall(libc::SYS_pivot_root, cwd.as_ptr(), old_root_dir.as_ptr())
     } as libc::c_int)
     .into_empty_result()
-    .map_err(Error::PivotRoot)?;
+    .map_err(JailerError::PivotRoot)?;
 
     // pivot_root doesn't guarantee that we will be in "/" at this point, so switch to "/"
     // explicitly.
     // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe { libc::chdir(root_dir.as_ptr()) })
         .into_empty_result()
-        .map_err(Error::ChdirNewRoot)?;
+        .map_err(JailerError::ChdirNewRoot)?;
 
     // Umount the old_root, thus isolating the process from everything outside the jail root folder.
     // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe { libc::umount2(old_root_dir.as_ptr(), libc::MNT_DETACH) })
         .into_empty_result()
-        .map_err(Error::UmountOldRoot)?;
+        .map_err(JailerError::UmountOldRoot)?;
 
     // Remove the no longer necessary old_root directory.
     // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe { libc::rmdir(old_root_dir.as_ptr()) })
         .into_empty_result()
-        .map_err(Error::RmOldRootDir)
+        .map_err(JailerError::RmOldRootDir)
 }

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -12,5 +12,6 @@ bench = false
 
 [dependencies]
 libc = "0.2.147"
+thiserror = "1.0.40"
 
 utils = { path = "../utils" }

--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -1,28 +1,44 @@
 // Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom};
 use std::os::unix::io::AsRawFd;
-use std::{env, process};
 
-use utils::arg_parser::{ArgParser, Argument, Arguments};
+use utils::arg_parser::{ArgParser, Argument, Arguments, Error as ArgError};
 use utils::seek_hole::SeekHole;
 
 const REBASE_SNAP_VERSION: &str = env!("FIRECRACKER_VERSION");
-const EXIT_CODE_SUCCESS: i32 = 0;
 const BASE_FILE: &str = "base-file";
 const DIFF_FILE: &str = "diff-file";
 
-#[derive(Debug)]
-enum Error {
+#[derive(Debug, thiserror::Error)]
+enum FileError {
+    #[error("Invalid base file: {0:?}")]
     InvalidBaseFile(std::io::Error),
+    #[error("Invalid diff file: {0:?}")]
     InvalidDiffFile(std::io::Error),
+    #[error("Failed to seek data: {0:?}")]
     SeekData(std::io::Error),
+    #[error("Failed to seek hole: {0:?}")]
     SeekHole(std::io::Error),
+    #[error("Failed to seek: {0:?}")]
     Seek(std::io::Error),
-    Sendfile(std::io::Error),
+    #[error("Failed to send the file: {0:?}")]
+    SendFile(std::io::Error),
+    #[error("Failed to get metadata: {0:?}")]
     Metadata(std::io::Error),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RebaseSnapError {
+    #[error("Arguments parsing error: {0} \n\nFor more information try --help.")]
+    ArgParse(ArgError),
+    #[error("Error parsing the cmd line args: {0}")]
+    SnapFile(FileError),
+    #[error("Error merging the files: {0}")]
+    RebaseFiles(FileError),
 }
 
 fn build_arg_parser<'a>() -> ArgParser<'a> {
@@ -43,62 +59,41 @@ fn build_arg_parser<'a>() -> ArgParser<'a> {
     arg_parser
 }
 
-fn extract_args<'a>(arg_parser: &'a mut ArgParser<'a>) -> &'a Arguments<'a> {
-    arg_parser.parse_from_cmdline().unwrap_or_else(|err| {
-        panic!(
-            "Arguments parsing error: {} \n\nFor more information try --help.",
-            err
-        );
-    });
-
-    if arg_parser.arguments().flag_present("help") {
-        println!("Rebase_snap v{}", REBASE_SNAP_VERSION);
-        println!(
-            "Tool that copies all the non-sparse sections from a diff file onto a base file\n"
-        );
-        println!("{}", arg_parser.formatted_help());
-        process::exit(EXIT_CODE_SUCCESS);
-    }
-    if arg_parser.arguments().flag_present("version") {
-        println!("Rebase_snap v{}\n", REBASE_SNAP_VERSION);
-        process::exit(EXIT_CODE_SUCCESS);
-    }
-
-    arg_parser.arguments()
-}
-
-fn parse_args(args: &Arguments) -> Result<(File, File), Error> {
+fn get_files(args: &Arguments) -> Result<(File, File), FileError> {
     // Safe to unwrap since the required arguments are checked as part of
     // `arg_parser.parse_from_cmdline()`
     let base_file_path = args.single_value(BASE_FILE).unwrap();
     let base_file = OpenOptions::new()
         .write(true)
         .open(base_file_path)
-        .map_err(Error::InvalidBaseFile)?;
+        .map_err(FileError::InvalidBaseFile)?;
     // Safe to unwrap since the required arguments are checked as part of
     // `arg_parser.parse_from_cmdline()`
     let diff_file_path = args.single_value(DIFF_FILE).unwrap();
     let diff_file = OpenOptions::new()
         .read(true)
         .open(diff_file_path)
-        .map_err(Error::InvalidDiffFile)?;
+        .map_err(FileError::InvalidDiffFile)?;
 
     Ok((base_file, diff_file))
 }
 
-fn rebase(base_file: &mut File, diff_file: &mut File) -> Result<(), Error> {
+fn rebase(base_file: &mut File, diff_file: &mut File) -> Result<(), FileError> {
     let mut cursor: u64 = 0;
-    while let Some(block_start) = diff_file.seek_data(cursor).map_err(Error::SeekData)? {
+    while let Some(block_start) = diff_file.seek_data(cursor).map_err(FileError::SeekData)? {
         cursor = block_start;
-        let block_end = match diff_file.seek_hole(block_start).map_err(Error::SeekHole)? {
+        let block_end = match diff_file
+            .seek_hole(block_start)
+            .map_err(FileError::SeekHole)?
+        {
             Some(hole_start) => hole_start,
-            None => diff_file.metadata().map_err(Error::Metadata)?.len(),
+            None => diff_file.metadata().map_err(FileError::Metadata)?.len(),
         };
 
         while cursor < block_end {
             base_file
                 .seek(SeekFrom::Start(cursor))
-                .map_err(Error::Seek)?;
+                .map_err(FileError::Seek)?;
 
             // SAFETY: Safe because the parameters are valid.
             let num_transferred_bytes = unsafe {
@@ -110,7 +105,7 @@ fn rebase(base_file: &mut File, diff_file: &mut File) -> Result<(), Error> {
                 )
             };
             if num_transferred_bytes < 0 {
-                return Err(Error::Sendfile(std::io::Error::last_os_error()));
+                return Err(FileError::SendFile(std::io::Error::last_os_error()));
             }
         }
     }
@@ -118,14 +113,42 @@ fn rebase(base_file: &mut File, diff_file: &mut File) -> Result<(), Error> {
     Ok(())
 }
 
-fn main() {
-    let mut arg_parser = build_arg_parser();
-    let args = extract_args(&mut arg_parser);
-    let (mut base_file, mut diff_file) =
-        parse_args(args).unwrap_or_else(|err| panic!("Error parsing the cmd line args: {:?}", err));
+fn main() -> Result<(), RebaseSnapError> {
+    let result = main_exec();
+    if let Err(e) = result {
+        eprintln!("{}", e);
+        Err(e)
+    } else {
+        Ok(())
+    }
+}
 
-    rebase(&mut base_file, &mut diff_file)
-        .unwrap_or_else(|err| panic!("Error merging the files: {:?}", err));
+fn main_exec() -> Result<(), RebaseSnapError> {
+    let mut arg_parser = build_arg_parser();
+
+    arg_parser
+        .parse_from_cmdline()
+        .map_err(RebaseSnapError::ArgParse)?;
+    let arguments = arg_parser.arguments();
+
+    if arguments.flag_present("help") {
+        println!("Rebase_snap v{}", REBASE_SNAP_VERSION);
+        println!(
+            "Tool that copies all the non-sparse sections from a diff file onto a base file\n"
+        );
+        println!("{}", arg_parser.formatted_help());
+        return Ok(());
+    }
+    if arguments.flag_present("version") {
+        println!("Rebase_snap v{}\n", REBASE_SNAP_VERSION);
+        return Ok(());
+    }
+
+    let (mut base_file, mut diff_file) = get_files(arguments).map_err(RebaseSnapError::SnapFile)?;
+
+    rebase(&mut base_file, &mut diff_file).map_err(RebaseSnapError::RebaseFiles)?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -173,7 +196,7 @@ mod tests {
                 .as_ref(),
             )
             .unwrap();
-        assert_err!(parse_args(arguments), Error::InvalidBaseFile(_));
+        assert_err!(get_files(arguments), FileError::InvalidBaseFile(_));
 
         let arguments = &mut arg_parser.arguments().clone();
         arguments
@@ -191,7 +214,7 @@ mod tests {
                 .as_ref(),
             )
             .unwrap();
-        assert_err!(parse_args(arguments), Error::InvalidDiffFile(_));
+        assert_err!(get_files(arguments), FileError::InvalidDiffFile(_));
 
         let arguments = &mut arg_parser.arguments().clone();
         arguments
@@ -209,7 +232,7 @@ mod tests {
                 .as_ref(),
             )
             .unwrap();
-        assert!(parse_args(arguments).is_ok());
+        assert!(get_files(arguments).is_ok());
     }
 
     fn check_file_content(file: &mut File, expected_content: &[u8]) {

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -46,7 +46,7 @@ mod syscall_table;
 use backend::{TargetArch, TargetArchError};
 use bincode::Error as BincodeError;
 use common::BpfProgram;
-use compiler::{Compiler, Error as FilterFormatError, JsonFile};
+use compiler::{CompilationError, Compiler, JsonFile};
 use serde_json::error::Error as JSONError;
 use utils::arg_parser::{ArgParser, Argument, Arguments as ArgumentsBag, Error as ArgParserError};
 
@@ -54,11 +54,11 @@ const SECCOMPILER_VERSION: &str = env!("FIRECRACKER_VERSION");
 const DEFAULT_OUTPUT_FILENAME: &str = "seccomp_binary_filter.out";
 
 #[derive(Debug, thiserror::Error)]
-enum Error {
+enum SeccompError {
     #[error("Bincode (de)serialization failed: {0}")]
     Bincode(BincodeError),
     #[error("{0}")]
-    FileFormat(FilterFormatError),
+    Compilation(CompilationError),
     #[error("{}", format!("Failed to open file {:?}: {1}", .0, .1).replace('\"', ""))]
     FileOpen(PathBuf, std::io::Error),
     #[error("Error parsing JSON: {0}")]
@@ -70,8 +70,6 @@ enum Error {
     #[error("{0}")]
     Arch(#[from] TargetArchError),
 }
-
-type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, PartialEq)]
 struct Arguments {
@@ -111,16 +109,16 @@ fn build_arg_parser() -> ArgParser<'static> {
         ))
 }
 
-fn get_argument_values(arguments: &ArgumentsBag) -> Result<Arguments> {
+fn get_argument_values(arguments: &ArgumentsBag) -> Result<Arguments, SeccompError> {
     let arch_string = arguments.single_value("target-arch");
     if arch_string.is_none() {
-        return Err(Error::MissingTargetArch);
+        return Err(SeccompError::MissingTargetArch);
     }
     let target_arch: TargetArch = arch_string.unwrap().as_str().try_into()?;
 
     let input_file = arguments.single_value("input-file");
     if input_file.is_none() {
-        return Err(Error::MissingInputFile);
+        return Err(SeccompError::MissingInputFile);
     }
 
     let is_basic = arguments.flag_present("basic");
@@ -140,22 +138,23 @@ fn get_argument_values(arguments: &ArgumentsBag) -> Result<Arguments> {
     })
 }
 
-fn compile(args: &Arguments) -> Result<()> {
+fn compile(args: &Arguments) -> Result<(), SeccompError> {
     let input_file = File::open(&args.input_file)
-        .map_err(|err| Error::FileOpen(PathBuf::from(&args.input_file), err))?;
+        .map_err(|err| SeccompError::FileOpen(PathBuf::from(&args.input_file), err))?;
     let mut input_reader = BufReader::new(input_file);
-    let filters = serde_json::from_reader::<_, JsonFile>(&mut input_reader).map_err(Error::Json)?;
+    let filters =
+        serde_json::from_reader::<_, JsonFile>(&mut input_reader).map_err(SeccompError::Json)?;
     let compiler = Compiler::new(args.target_arch);
 
     // transform the IR into a Map of BPFPrograms
     let bpf_data: BTreeMap<String, BpfProgram> = compiler
         .compile_blob(filters.0, args.is_basic)
-        .map_err(Error::FileFormat)?;
+        .map_err(SeccompError::Compilation)?;
 
     // serialize the BPF programs & output them to a file
     let output_file = File::create(&args.output_file)
-        .map_err(|err| Error::FileOpen(PathBuf::from(&args.output_file), err))?;
-    bincode::serialize_into(output_file, &bpf_data).map_err(Error::Bincode)?;
+        .map_err(|err| SeccompError::FileOpen(PathBuf::from(&args.output_file), err))?;
+    bincode::serialize_into(output_file, &bpf_data).map_err(SeccompError::Bincode)?;
 
     Ok(())
 }
@@ -165,9 +164,9 @@ enum SeccompilerError {
     #[error("Argument Parsing Error: {0}")]
     ArgParsing(ArgParserError),
     #[error("{0} \n\nFor more information try --help.")]
-    InvalidArgumentValue(Error),
+    InvalidArgumentValue(SeccompError),
     #[error("{0}")]
-    Error(Error),
+    Error(SeccompError),
 }
 
 fn main() -> core::result::Result<(), SeccompilerError> {
@@ -217,9 +216,10 @@ mod tests {
     use bincode::Error as BincodeError;
     use utils::tempfile::TempFile;
 
-    use super::compiler::Error as FilterFormatError;
+    use super::compiler::CompilationError as FilterFormatError;
     use super::{
-        build_arg_parser, compile, get_argument_values, Arguments, Error, DEFAULT_OUTPUT_FILENAME,
+        build_arg_parser, compile, get_argument_values, Arguments, SeccompError,
+        DEFAULT_OUTPUT_FILENAME,
     };
     use crate::backend::{TargetArch, TargetArchError};
 
@@ -327,7 +327,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Error::Bincode(BincodeError::new(bincode::ErrorKind::SizeLimit))
+                SeccompError::Bincode(BincodeError::new(bincode::ErrorKind::SizeLimit))
             ),
             format!(
                 "Bincode (de)serialization failed: {}",
@@ -337,7 +337,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Error::FileFormat(FilterFormatError::SyscallName(
+                SeccompError::Compilation(FilterFormatError::SyscallName(
                     "dsaa".to_string(),
                     TargetArch::aarch64
                 ))
@@ -350,7 +350,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Error::FileOpen(path.clone(), io::Error::from_raw_os_error(2))
+                SeccompError::FileOpen(path.clone(), io::Error::from_raw_os_error(2))
             ),
             format!(
                 "Failed to open file {:?}: {}",
@@ -362,7 +362,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Error::Json(serde_json::from_str::<serde_json::Value>("").unwrap_err())
+                SeccompError::Json(serde_json::from_str::<serde_json::Value>("").unwrap_err())
             ),
             format!(
                 "Error parsing JSON: {}",
@@ -370,17 +370,17 @@ mod tests {
             )
         );
         assert_eq!(
-            format!("{}", Error::MissingInputFile),
+            format!("{}", SeccompError::MissingInputFile),
             "Missing input file."
         );
         assert_eq!(
-            format!("{}", Error::MissingTargetArch),
+            format!("{}", SeccompError::MissingTargetArch),
             "Missing target arch."
         );
         assert_eq!(
             format!(
                 "{}",
-                Error::Arch(TargetArchError::InvalidString("lala".to_string()))
+                SeccompError::Arch(TargetArchError::InvalidString("lala".to_string()))
             ),
             format!("{}", TargetArchError::InvalidString("lala".to_string()))
         );
@@ -538,7 +538,7 @@ mod tests {
             };
 
             match compile(&args).unwrap_err() {
-                Error::FileOpen(buf, _) => assert_eq!(buf, PathBuf::from(in_file.as_path())),
+                SeccompError::FileOpen(buf, _) => assert_eq!(buf, PathBuf::from(in_file.as_path())),
                 _ => panic!("Expected FileOpen error."),
             }
         }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -25,9 +25,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.44, "AMD": 81.68, "ARM": 80.95}
+    COVERAGE_DICT = {"Intel": 82.53, "AMD": 81.78, "ARM": 81.03}
 else:
-    COVERAGE_DICT = {"Intel": 79.76, "AMD": 78.90, "ARM": 78.01}
+    COVERAGE_DICT = {"Intel": 79.85, "AMD": 79.0, "ARM": 78.09}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -220,8 +220,8 @@ def test_config_machine_config_params(test_microvm_with_api, test_config):
     if check_for_failed_start:
         test_microvm.check_any_log_message(
             [
-                "Building VMM configured from cmdline json failed: ",
-                "Configuration for VMM from one single json failed",
+                "Failed to build MicroVM from Json",
+                "Could not Start MicroVM from one single json",
             ]
         )
     else:


### PR DESCRIPTION
## Changes
This PR is build on top of another PR: #3575
Adds new lint: `clippy::exit` and makes necessary changes for it.
Updates `Error` and `Result` types for several crates.

## Reason
Enables the use of `clippy::exit`. Fixes #3233

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
