### PR TITLE
test(fix): Increase timeout to avoid artifact copy timeouts

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
+++ b/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
@@ -116,6 +116,7 @@ def _test_mmds(vm, mmds_net_iface):
     assert json.load(stdout) == data_store
 
 
+@pytest.mark.timeout(600)
 @pytest.mark.nonci
 @pytest.mark.parametrize(
     "cpu_template",


### PR DESCRIPTION
It is observed that copying the artifacts sometimes take more time than the alloted time of 300sec for the test to finish. Since the timeout due to copy is not related to the test itself, increase the test timeout to ignore these intermittent issue.

## Changes

Increase timeout for integration_tests/functional/test_snapshot_restore_cross_kernel.py::test_snap_restore_from_artifacts

## Reason

Test fails with error Timeout >300.0s while trying to copy artifacts.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [N/A] Any required documentation changes (code and docs) are included in this PR.
- [N/A] API changes follow the [Runbook for Firecracker API changes][2].
- [N/A] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [N/A] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [N/A] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
