### PR TITLE
chore: update baseline for vsock throughput for m6g.metal+6.1 kv

### DIFF
--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_6.1.json
@@ -1421,31 +1421,31 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 57
+                                                    "delta_percentage": 9,
+                                                    "target": 58
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 77
+                                                    "delta_percentage": 8,
+                                                    "target": 78
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 58
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 78
+                                                    "delta_percentage": 6,
+                                                    "target": 79
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 85
+                                                    "delta_percentage": 8,
+                                                    "target": 86
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 66
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -1454,10 +1454,10 @@
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 85
+                                                    "target": 86
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 66
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -1478,43 +1478,43 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 77
+                                                    "target": 78
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 55
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 77
+                                                    "target": 78
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 79
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 64
+                                                    "target": 63
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 85
+                                                    "delta_percentage": 7,
+                                                    "target": 86
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 79
+                                                    "target": 80
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 11,
                                                     "target": 63
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 86
+                                                    "delta_percentage": 7,
+                                                    "target": 88
                                                 }
                                             }
                                         }
@@ -1528,47 +1528,47 @@
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6766
+                                                    "target": 6639
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6249
+                                                    "target": 5962
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6767
+                                                    "target": 6643
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6046
+                                                    "delta_percentage": 5,
+                                                    "target": 5782
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6448
+                                                    "delta_percentage": 6,
+                                                    "target": 6187
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7368
+                                                    "delta_percentage": 5,
+                                                    "target": 7388
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5728
+                                                    "delta_percentage": 7,
+                                                    "target": 5579
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6531
+                                                    "delta_percentage": 6,
+                                                    "target": 6256
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 7387
+                                                    "target": 7397
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5792
+                                                    "delta_percentage": 8,
+                                                    "target": 5644
                                                 }
                                             }
                                         }
@@ -1579,20 +1579,20 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 13741
+                                                    "delta_percentage": 6,
+                                                    "target": 13643
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6237
+                                                    "delta_percentage": 5,
+                                                    "target": 5974
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 13766
+                                                    "target": 13679
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5987
+                                                    "delta_percentage": 5,
+                                                    "target": 5747
                                                 }
                                             }
                                         },
@@ -1600,27 +1600,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 7260
+                                                    "target": 6929
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 17933
+                                                    "delta_percentage": 6,
+                                                    "target": 17777
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6535
+                                                    "delta_percentage": 5,
+                                                    "target": 6222
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 7298
+                                                    "target": 6979
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 17644
+                                                    "target": 17484
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 6479
+                                                    "target": 6177
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes

Update performance baseline for vsock throughput tests to reflect the change introduced by an AMI update on 27 Jul 2023 on m6g.metal + 6.1 kernel.

Diff:

```json
{
    "source": "a99527728df177b90e1a951afa1244e453600ef2/tests/integration_tests/performance/configs/",
    "target": "tests/integration_tests/performance/configs/",
    "test_vsock_throughput_config_6.1.json": {
        "test": "vsock_throughput",
        "kernel": "6.1",
        "cpus": [
            {
                "instance": "m6g.metal",
                "model": "ARM_NEOVERSE_N1",
                "stats": {
                    "cpu_utilization_vmm": {
                        "target_diff_percentage": {
                            "mean": 0.6245428543966136,
                            "stdev": 0.9056726720121695
                        },
                        "delta_percentage_diff": {
                            "mean": 0.1,
                            "stdev": 0.7880689256524125
                        }
                    },
                    "throughput": {
                        "target_diff_percentage": {
                            "mean": -2.7702661453821653,
                            "stdev": 1.8057381374168133
                        },
                        "delta_percentage_diff": {
                            "mean": -0.35,
                            "stdev": 0.6708203932499369
                        }
                    },
                    "cpu_utilization_vcpus_total": {
                        "target_diff_percentage": {
                            "mean": 0.0,
                            "stdev": 0.0
                        },
                        "delta_percentage_diff": {
                            "mean": 0.0,
                            "stdev": 0.0
                        }
                    }
                }
            },
        ]
    }
}
```

## Reason

No code change since Jul 27, 2023. The only change is that there was an AMI update on 27th July 2023.
The same commit that is failing now was passing on old AMI.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [N/A] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [N/A] Any required documentation changes (code and docs) are included in this PR.
- [N/A] API changes follow the [Runbook for Firecracker API changes][2].
- [N/A] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [N/A] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [N/A] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
