### PR TITLE
Fix: Avoid microvm build if Api server thread fails

### DIFF
--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -199,17 +199,23 @@ pub(crate) fn run_with_api(
             mmds_size_limit,
             metadata_json,
         ),
-        None => PrebootApiController::build_microvm_from_requests(
-            seccomp_filters,
-            &mut event_manager,
-            instance_info,
-            &from_api,
-            &to_api,
-            &api_event_fd,
-            boot_timer_enabled,
-            mmds_size_limit,
-            metadata_json,
-        ),
+        None => {
+            if socket_ready_receiver.recv() == Ok(true) {
+                PrebootApiController::build_microvm_from_requests(
+                    seccomp_filters,
+                    &mut event_manager,
+                    instance_info,
+                    &from_api,
+                    &to_api,
+                    &api_event_fd,
+                    boot_timer_enabled,
+                    mmds_size_limit,
+                    metadata_json,
+                )
+            } else {
+                Err(vmm::FcExitCode::GenericError)
+            }
+        }
     };
 
     let exit_code = match build_result {


### PR DESCRIPTION
PrebootApiController::build_microvm_from_requests() should ideally start after Api server thread was able bind to a socket. Not doing so results in intermittent failures with below message:
```
The channel's sending half was disconnected. \
Cannot receive data.: RecvError
```
This message makes more sense if API server thread was actually able to bind to a socket and then disconnected.
So, change the code to make sure build_microvm_from_requests is called only if API server thread is able to bind to a socket.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
