### PR TITLE
chore: update vsock perf baseline for m6a and c7g for 6.1

### DIFF
--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_6.1.json
@@ -118,31 +118,31 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 60
+                                                    "target": 61
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 79
+                                                    "target": 80
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 61
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 79
+                                                    "target": 80
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 85
+                                                    "delta_percentage": 7,
+                                                    "target": 86
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 64
+                                                    "delta_percentage": 7,
+                                                    "target": 66
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
@@ -150,15 +150,15 @@
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 86
+                                                    "target": 87
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 65
+                                                    "delta_percentage": 7,
+                                                    "target": 66
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 97
+                                                    "target": 98
                                                 }
                                             }
                                         }
@@ -170,19 +170,19 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 11,
-                                                    "target": 47
+                                                    "target": 48
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 77
+                                                    "target": 78
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 48
+                                                    "delta_percentage": 10,
+                                                    "target": 47
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 77
+                                                    "target": 78
                                                 }
                                             }
                                         },
@@ -190,27 +190,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 75
+                                                    "target": 76
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 51
+                                                    "delta_percentage": 11,
+                                                    "target": 50
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 84
+                                                    "target": 85
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 75
+                                                    "delta_percentage": 7,
+                                                    "target": 77
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 51
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 85
+                                                    "target": 86
                                                 }
                                             }
                                         }
@@ -223,20 +223,20 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 9817
+                                                    "delta_percentage": 6,
+                                                    "target": 9638
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7836
+                                                    "delta_percentage": 6,
+                                                    "target": 7412
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 9800
+                                                    "delta_percentage": 6,
+                                                    "target": 9651
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7578
+                                                    "delta_percentage": 7,
+                                                    "target": 7149
                                                 }
                                             }
                                         },
@@ -244,27 +244,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 8052
+                                                    "target": 7602
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 10411
+                                                    "delta_percentage": 6,
+                                                    "target": 10341
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 16,
-                                                    "target": 6920
+                                                    "delta_percentage": 14,
+                                                    "target": 6596
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 8037
+                                                    "delta_percentage": 8,
+                                                    "target": 7563
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 10433
+                                                    "target": 10361
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 15,
-                                                    "target": 6959
+                                                    "delta_percentage": 13,
+                                                    "target": 6661
                                                 }
                                             }
                                         }
@@ -276,47 +276,47 @@
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 20966
+                                                    "target": 20832
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7640
+                                                    "delta_percentage": 6,
+                                                    "target": 7235
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 21035
+                                                    "delta_percentage": 8,
+                                                    "target": 20873
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7333
+                                                    "delta_percentage": 6,
+                                                    "target": 6967
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 8921
+                                                    "delta_percentage": 6,
+                                                    "target": 8434
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 26545
+                                                    "delta_percentage": 9,
+                                                    "target": 26485
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 8323
+                                                    "delta_percentage": 7,
+                                                    "target": 7929
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 8867
+                                                    "delta_percentage": 6,
+                                                    "target": 8422
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 26715
+                                                    "delta_percentage": 6,
+                                                    "target": 26429
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 8206
+                                                    "target": 7769
                                                 }
                                             }
                                         }
@@ -988,7 +988,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 100
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -996,7 +996,7 @@
                                                     "target": 100
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 100
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -1016,7 +1016,7 @@
                                                     "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 126
                                                 },
                                                 "vsock-pDEFAULT-bd": {
@@ -1029,7 +1029,7 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 129
+                                                    "target": 128
                                                 }
                                             }
                                         }
@@ -1060,19 +1060,19 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 105
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 199
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 125
+                                                    "delta_percentage": 9,
+                                                    "target": 128
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 105
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -1081,7 +1081,7 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 121
+                                                    "target": 120
                                                 }
                                             }
                                         }
@@ -1095,18 +1095,18 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 53
+                                                    "target": 52
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 55
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 53
+                                                    "delta_percentage": 9,
+                                                    "target": 52
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 9,
                                                     "target": 55
                                                 }
                                             }
@@ -1114,19 +1114,19 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 58
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 63
+                                                    "delta_percentage": 8,
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
                                                     "target": 68
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -1134,8 +1134,8 @@
                                                     "target": 64
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 68
+                                                    "delta_percentage": 8,
+                                                    "target": 69
                                                 }
                                             }
                                         }
@@ -1146,20 +1146,20 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 16,
-                                                    "target": 37
+                                                    "delta_percentage": 21,
+                                                    "target": 36
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 55
+                                                    "delta_percentage": 10,
+                                                    "target": 56
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 19,
                                                     "target": 37
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 54
+                                                    "delta_percentage": 9,
+                                                    "target": 55
                                                 }
                                             }
                                         },
@@ -1170,24 +1170,24 @@
                                                     "target": 55
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 40
+                                                    "delta_percentage": 13,
+                                                    "target": 39
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 66
+                                                    "delta_percentage": 9,
+                                                    "target": 65
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 9,
                                                     "target": 55
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 14,
+                                                    "delta_percentage": 15,
                                                     "target": 40
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 65
+                                                    "target": 64
                                                 }
                                             }
                                         }
@@ -1200,20 +1200,20 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 10309
+                                                    "delta_percentage": 7,
+                                                    "target": 10038
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 6826
+                                                    "target": 6515
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 10369
+                                                    "delta_percentage": 7,
+                                                    "target": 10083
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 6660
+                                                    "delta_percentage": 8,
+                                                    "target": 6403
                                                 }
                                             }
                                         },
@@ -1221,27 +1221,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 7763
+                                                    "target": 7522
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 12556
+                                                    "delta_percentage": 8,
+                                                    "target": 12317
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 8643
+                                                    "target": 8310
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 7700
+                                                    "target": 7458
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 12600
+                                                    "delta_percentage": 8,
+                                                    "target": 12300
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 8518
+                                                    "target": 8196
                                                 }
                                             }
                                         }
@@ -1252,20 +1252,20 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 19651
+                                                    "delta_percentage": 12,
+                                                    "target": 19196
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 6858
+                                                    "delta_percentage": 10,
+                                                    "target": 6558
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 19818
+                                                    "delta_percentage": 11,
+                                                    "target": 19212
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 6652
+                                                    "delta_percentage": 8,
+                                                    "target": 6410
                                                 }
                                             }
                                         },
@@ -1273,27 +1273,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 10,
-                                                    "target": 8164
+                                                    "target": 7844
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 28642
+                                                    "delta_percentage": 12,
+                                                    "target": 27980
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 9440
+                                                    "delta_percentage": 10,
+                                                    "target": 8647
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 10,
-                                                    "target": 8186
+                                                    "delta_percentage": 8,
+                                                    "target": 7833
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 28557
+                                                    "delta_percentage": 12,
+                                                    "target": 27700
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 9140
+                                                    "delta_percentage": 10,
+                                                    "target": 8126
                                                 }
                                             }
                                         }


### PR DESCRIPTION
Update performance baseline for vsock throughput tests to fix intermittent performance issue introduced because of an AMI update on 27 Jul 2023 on c7g.metal and m6a.metal + 6.1 kernel.

diff 
```json
"test_vsock_throughput_config_6.1.json": {
    "test": "vsock_throughput",
    "kernel": "6.1",
    "cpus": [
        {
              "instance": "m6a.metal",
              "model": "AMD EPYC 7R13 48-Core Processor",
              "stats": {
                  "cpu_utilization_vmm": {
                      "target_diff_percentage": {
                          "mean": -0.26509885846733805,
                          "stdev": 1.3639893084026427
                      },
                      "delta_percentage_diff": {
                          "mean": -0.05,
                          "stdev": 1.5035046776746235
                      }
                  },
                  "throughput": {
                      "target_diff_percentage": {
                          "mean": -3.9195584017998852,
                          "stdev": 2.175046913062185
                      },
                      "delta_percentage_diff": {
                          "mean": -0.4,
                          "stdev": 0.9403246919632544
                      }
                  },
                  "cpu_utilization_vcpus_total": {
                      "target_diff_percentage": {
                          "mean": 0.06504362416863585,
                          "stdev": 0.6160931361326688
                      },
                      "delta_percentage_diff": {
                          "mean": 0.15,
                          "stdev": 0.812727700887249
                      }
                  }
              }
          },
          {
              "instance": "c7g.metal",
              "model": "ARM_NEOVERSE_V1",
              "stats": {
                  "cpu_utilization_vmm": {
                      "target_diff_percentage": {
                          "mean": 1.0473260432949838,
                          "stdev": 1.2675949778049607
                      },
                      "delta_percentage_diff": {
                          "mean": -0.4,
                          "stdev": 0.7539370349250519
                      }
                  },
                  "throughput": {
                      "target_diff_percentage": {
                          "mean": -3.488196898481598,
                          "stdev": 2.1978977629551286
                      },
                      "delta_percentage_diff": {
                          "mean": -0.7,
                          "stdev": 1.1285761872936695
                      }
                  },
                  "cpu_utilization_vcpus_total": {
                      "target_diff_percentage": {
                          "mean": 0.0,
                          "stdev": 0.0
                      },
                      "delta_percentage_diff": {
                          "mean": 0.0,
                          "stdev": 0.0
                      }
                  }
              }
            }
}

```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [N/A] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [N/A] API changes follow the [Runbook for Firecracker API changes][2].
- [N/A] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [N/A] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [N/A] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
