### PR TITLE
Deprecate Firecracker v1.2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -403,7 +403,7 @@ def firecracker_artifacts(*args, **kwargs):
     # until the next minor version (but not including)
     max_version = (version.major, version.minor + 1, 0)
     params = {
-        "min_version": "1.2.0",
+        "min_version": "1.3.0",
         "max_version_open": ".".join(str(x) for x in max_version),
     }
     params.update(kwargs)

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -641,11 +641,6 @@ def test_mmds_snapshot(bin_cloner_path, version, firecracker_release):
     the firecracker version does not support it.
     """
 
-    # 1.2.0 and above snapshots are incompatible with any past release due to
-    # notification suppression.
-    if firecracker_release.version_tuple < (1, 2, 0):
-        pytest.skip("unsupported due to notification suppression")
-
     vm_builder = MicrovmBuilder(bin_cloner_path)
     iface_cfg = NetIfaceConfig()
     vm_instance = vm_builder.build_vm_nano(net_ifaces=[iface_cfg])

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -28,14 +28,6 @@ def test_restore_old_to_current(bin_cloner_path, firecracker_release):
     2. Restore with the current build
     """
 
-    # due to ARM bug fixed in commit 822009ce
-    if platform.machine() == "aarch64" and firecracker_release.version_tuple < (
-        1,
-        1,
-        4,
-    ):
-        pytest.skip("incompatible with aarch64 and Firecracker <1.1.4")
-
     # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("old_snapshot_to_current")
     builder = MicrovmBuilder(bin_cloner_path)
@@ -74,11 +66,6 @@ def test_restore_current_to_old(bin_cloner_path, firecracker_release):
     1. Snapshot with the current build
     2. Restore with the past release
     """
-
-    # Current snapshot (i.e a machine snapshotted with current build) is
-    # incompatible with any past release due to notification suppression.
-    if firecracker_release.version_tuple < (1, 2, 0):
-        pytest.skip("incompatible with Firecracker <1.2.0")
 
     # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("current_snapshot_to_old")

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,6 +5,7 @@ addopts =
     --durations=10
     --showlocals
     -m 'not nonci and not no_block_pr'
+    --json-report --json-report-file=../test_results/test-report.json
 
 markers =
     no_block_pr: tests whose failure does not block PR merging.


### PR DESCRIPTION
## Changes

Deprecate v1.2 by raising the minimum supported version to 1.3

## Reason

Per release policy after v1.4 was released

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
