### PR TITLE
test: Make test_guest_cpu_config_change optional 

### DIFF
--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -337,6 +337,7 @@ def detect_fingerprint_change(microvm, tmp_path, cpu_template_helper, filters):
     )
 
 
+@pytest.mark.no_block_pr
 @pytest.mark.skipif(
     utils.get_kernel_version(level=1) not in SUPPORTED_HOST_KERNELS,
     reason=f"Supported kernels are {SUPPORTED_HOST_KERNELS}",


### PR DESCRIPTION
## Changes / Reason

This test compares the baseline guest_cpu_config gathered in the past with the current one and fails potentially due to firecracker's code changes or kernel/microcode updates. To be aware correctly that CPU config has been changed by firecracker, the test was set as a mandatory requirement to merge PRs.

However, since the introduction of the test (commit 8161c0bca20d ("test(tool): verify CPU config has not changed") on 2023 Apr 5, the following CPU config changes have been caused by non-firecracker changes:
- The RRSBA bit of IA32_ARCH_CAPABILITIES MSR flipped from 0 to 1 on Intel Cascade Lake.
- The GDS_CTRL bit of IA32_ARCH_CAPABILITIES MSR flipped from 0 to 1 on combinations of (Intel Skylake, Intel Cascade Lake, Intel Ice Lake) x (host kernel 4.14).

Although this kind of CPU config changes should be investigated and handled appropriately, it blocks all PRs and we cannot merge any PRs until it is fixed. So this commit makes the test optional. Even it is made optional, it is run every PR and we can be aware of its failures.

**Note: This PR just makes the test optional and the flip of IA32_ARCH_CAPABILITIES[GDS_CTRL] will be handled in a follow-up commit.**

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
