### PR TITLE
Utilize codecov.io for coverage test

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,25 @@
+codecov:
+  # We utilize optional statuses that are okay to fail, so
+  # having codecov only post if all statuses pass won't work.
+  require_ci_to_pass: no
+  notify:
+    # No need to wait for long running tests if the build tests are done.
+    wait_for_ci: false
+coverage:
+  # Our target is 80% coverage
+  range: 80..100
+  status:
+    project:
+      firecracker:
+        # Allow drop of up to 0.5%
+        threshold: 0.5%
+        target: 80%
+# There are 15 uploads per commit (|{instance type} x {kernel version}| = 15).
+# Codecov will update the comment with every new upload. If we want to instead
+# only post the comment after all 15 reports are received, add `after_n_builds: 15`
+# below
+comment:
+  # Only relevant for initial report: We want a report even though
+  # codecov integration is not merged to main yet, to see it works
+  # without having to go through multiple PR cycles.
+  require_base: false

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -1,33 +1,15 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Tests enforcing code coverage for production code."""
+import os
+import warnings
 
 import pytest
 
-import framework.utils_cpuid as cpuid_utils
 from framework import utils
+from framework.properties import global_props
 from host_tools import proc
 from host_tools.cargo_build import cargo
-
-# We have different coverages based on the host kernel version. This is
-# caused by io_uring, which is only supported by FC for kernels newer
-# than 5.10.
-
-
-def is_on_skylake():
-    """Test is executed on a Skylake host."""
-    return "8175M CPU" in cpuid_utils.get_cpu_model_name()
-
-
-# AMD has a slightly different coverage due to
-# the appearance of the brand string. On Intel,
-# this contains the frequency while on AMD it does not.
-# Checkout the cpuid crate. In the future other
-# differences may appear.
-if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.53, "AMD": 81.78, "ARM": 81.03}
-else:
-    COVERAGE_DICT = {"Intel": 79.85, "AMD": 79.0, "ARM": 78.09}
 
 PROC_MODEL = proc.proc_type()
 
@@ -50,19 +32,10 @@ else:
 # run coverage with the `gnu` toolchains and run unit tests with the `musl` toolchains.
 TARGET = f"{ARCH}-unknown-linux-gnu"
 
-# We allow coverage to have a max difference of `COVERAGE_MAX_DELTA` as percentage before failing
-# the test (currently 0.05%).
-COVERAGE_MAX_DELTA = 0.05
-
 
 @pytest.mark.timeout(600)
-def test_coverage(monkeypatch, record_property, metrics):
+def test_coverage(monkeypatch):
     """Test code coverage"""
-    # Get coverage target.
-    processor_model = [item for item in COVERAGE_DICT if item in PROC_MODEL]
-    assert len(processor_model) == 1, "Could not get processor model!"
-    coverage_target = COVERAGE_DICT[processor_model[0]]
-
     # Re-direct to repository root.
     monkeypatch.chdir("..")
 
@@ -77,6 +50,8 @@ def test_coverage(monkeypatch, record_property, metrics):
         },
     )
 
+    lcov_file = "./build/cargo_target/coverage.lcov"
+
     # Generate coverage report.
     cmd = f"""
         grcov . \
@@ -88,9 +63,9 @@ def test_coverage(monkeypatch, record_property, metrics):
             --ignore "**/test_utils*" \
             --ignore "**/mock_*" \
             --ignore "src/firecracker/examples/*" \
-            -t html \
+            -t lcov \
             --ignore-not-existing \
-            -o ./build/cargo_target/{TARGET}/debug/coverage"""
+            -o {lcov_file}"""
 
     # Ignore code not relevant for the intended platform
     # - CPUID and CPU template
@@ -111,29 +86,20 @@ def test_coverage(monkeypatch, record_property, metrics):
 
     utils.run_cmd(cmd)
 
-    # Extract coverage from html report.
-    #
-    # The line looks like `<abbr title="44724 / 49237">90.83 %</abbr></p>` and is the first
-    # occurrence of the `<abbr>` element in the file.
-    #
-    # When we update grcov to 0.8.* we can update this to pull the coverage from a generated .json
-    # file.
-    index = open(
-        f"./build/cargo_target/{TARGET}/debug/coverage/index.html", encoding="utf-8"
-    )
-    index_contents = index.read()
-    end = index_contents.find(" %</abbr></p>")
-    start = index_contents[:end].rfind(">")
-    coverage_str = index_contents[start + 1 : end]
-    coverage = float(coverage_str)
+    # Only upload if token is present and we're in EC2
+    if "CODECOV_TOKEN" in os.environ and global_props.is_ec2:
+        pr_number = os.environ.get("BUILDKITE_PULL_REQUEST")
+        _, branch, _ = utils.run_cmd("git rev-parse --abbrev-ref HEAD")
 
-    # Record coverage.
-    record_property(
-        "coverage", f"{coverage}% {coverage_target}% ±{COVERAGE_MAX_DELTA:.2f}%"
-    )
-    metrics.set_dimensions({"cpu_arch": ARCH})
-    metrics.put_metric("code_coverage", coverage, unit="Percent")
+        codecov_cmd = f"codecov -f {lcov_file} -F {global_props.host_linux_version}-{global_props.instance}"
 
-    assert coverage == pytest.approx(
-        coverage_target, abs=COVERAGE_MAX_DELTA
-    ), f"Current code coverage ({coverage:.2f}%) deviates more than {COVERAGE_MAX_DELTA:.2f}% from target ({coverage_target:.2f})"
+        if pr_number:
+            codecov_cmd += f" -P {pr_number}"
+        else:
+            codecov_cmd += f" -B {branch}"
+
+        utils.run_cmd(codecov_cmd)
+    else:
+        warnings.warn(
+            "Not uploading coverage report due to missing CODECOV_TOKEN environment variable"
+        )

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends \
         # essential build tools
         gcc make libc-dev binutils-dev libssl-dev \
+        # Useful utilifies
+        gdbserver \
         # Needed in order to be able to compile `userfaultfd-sys`.
         clang \
         curl \
@@ -97,6 +99,14 @@ RUN mkdir "$TMP_BUILD_DIR" && cd "$TMP_BUILD_DIR" \
     && cp src/iperf3 /usr/local/bin/iperf3-vsock \
     && cd / \
     && rm -rf "$TMP_BUILD_DIR"
+
+# Download the codecov.io uploader
+RUN cd /usr/local/bin \
+    && (if [ "$ARCH" = "x86_64" ]; then  \
+      curl -O https://uploader.codecov.io/latest/linux/codecov; else \
+      curl -O https://uploader.codecov.io/latest/aarch64/codecov; fi) \
+    && chmod +x codecov \
+    && cd -
 
 ADD tools/devctr/ctr_gitconfig /root/.gitconfig
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -599,7 +599,7 @@ cmd_test() {
     # in order to set-up the Firecracker jail (manipulating cgroups, net
     # namespaces, etc).
     # We need to run a privileged container to get that kind of access.
-    env |grep -P "^(AWS_EMF_|BUILDKITE_)" > env.list
+    env |grep -P "^(AWS_EMF_|BUILDKITE_|CODECOV_)" > env.list
 
     if [[ "$BUILDKITE" = "true" ]]; then
       # Disable turbo boost. Some of our tests are performance tests, and we want minimum variability wrt processor frequency

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v62}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v63}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
## Changes

Changes the code coverage test to no longer compare to a fixed threshold and instead upload a report to codecov.io

## Reason

Less PR churn due to adjusting coverage values in a dictionary and better insights into coverage

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
