### PR TITLE
chore: sync RELEASE_POLICY and CHANGELOG after 1.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Fixed a change in behavior of normalize host brand string that breaks
+  Firecracker on external instances.
 - Fixed the T2A CPU template not to unset the MMX bit (CPUID.80000001h:EDX[23])
   and the FXSR bit (CPUID.80000001h:EDX[24]).
 - Fixed the T2A CPU template to set the RstrFpErrPtrs bit

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -86,8 +86,8 @@ also be specifying the supported kernel versions.
 
 | Release | Release Date | Latest Patch | Min. end of support | Official end of Support        |
 | ------: | -----------: | -----------: | ------------------: | :----------------------------- |
-| v1.4    |   2023-07-20 | v1.4.0       |          2024-01-20 | Supported                      |
-| v1.3    |   2023-03-02 | v1.3.2       |          2023-09-02 | Supported                      |
+| v1.4    |   2023-07-20 | v1.4.1       |          2024-01-20 | Supported                      |
+| v1.3    |   2023-03-02 | v1.3.3       |          2023-09-02 | Supported                      |
 | v1.2    |   2022-11-30 | v1.2.1       |          2023-05-30 | 2023-07-20 (v1.4 released)     |
 | v1.1    |   2022-05-06 | v1.1.4       |          2022-11-06 | 2023-03-02 (v1.3 released)     |
 | v1.0    |   2022-01-31 | v1.0.2       |          2022-07-31 | 2022-11-30 (v1.2 released)     |


### PR DESCRIPTION

## Changes

Sync RELEASE_POLICY and CHANGELOG between main and 1.4.1 branch. Also update latest supported version of 1.3.

## Reason

- latest version of 1.3 was not up to date in RELEASE_POLICY so update it.
- 1.4.1 branch has entries in CHANGELOG which need to be added to main.
- latest release of  1.4 is 1.4.1 so update main RELEASE_POLICY to highlight that.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] ❎If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] ❎API changes follow the [Runbook for Firecracker API changes][2].
- [ ] ❎User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] ❎New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] ❎This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
