### PR TITLE
Small fixes

### DIFF
--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -34,14 +34,10 @@ const DEV_PREVIEW_LOG_PREFIX: &str = "[DevPreview]";
 /// is in development preview.
 pub fn log_dev_preview_warning(feature_name: &str, msg_opt: Option<String>) {
     match msg_opt {
-        None => warn!(
-            "{} {} is in development preview.",
-            DEV_PREVIEW_LOG_PREFIX, feature_name
-        ),
-        Some(msg) => warn!(
-            "{} {} is in development preview - {}",
-            DEV_PREVIEW_LOG_PREFIX, feature_name, msg
-        ),
+        None => warn!("{DEV_PREVIEW_LOG_PREFIX} {feature_name} is in development preview."),
+        Some(msg) => {
+            warn!("{DEV_PREVIEW_LOG_PREFIX} {feature_name} is in development preview - {msg}")
+        }
     }
 }
 

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::metrics::{
     SharedStoreMetric, StoreMetric, METRICS,
 };
 
-#[allow(missing_docs)]
+/// Alias for `std::io::LineWriter<std::fs::File>`.
 pub type FcLineWriter = std::io::LineWriter<std::fs::File>;
 
 /// Prefix to be used in log lines for functions/modules in Firecracker


### PR DESCRIPTION
## Changes

- Adds  a doc comment to the `FcLineWriter` type alias.
- Uses inline format arguments within `log_dev_preview_warning`.

## Reason

Small fixes pulled out from a larger PR (https://github.com/firecracker-microvm/firecracker/pull/3971).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
