### PR TITLE
test: Make hardware vulnerability tests optional

### DIFF
--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -81,8 +81,7 @@ def get_supported_custom_cpu_templates():
 SUPPORTED_CUSTOM_CPU_TEMPLATES = get_supported_custom_cpu_templates()
 
 
-def nonci_on_arm(func):
-    """Temporary decorator used to mark specific cpu template related tests as nonci on ARM platforms"""
-    if cpuid_utils.get_cpu_vendor() == cpuid_utils.CpuVendor.ARM:
-        return pytest.mark.nonci(func)
-    return func
+skip_on_arm = pytest.mark.skipif(
+    cpuid_utils.get_cpu_vendor() == cpuid_utils.CpuVendor.ARM,
+    reason="skip specific cpu template related tests on ARM platforms until kernel patches required for V1N1 come",
+)

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -18,7 +18,7 @@ from framework import utils_cpuid
 from framework.artifacts import NetIfaceConfig, SnapshotType
 from framework.builder import MicrovmBuilder, SnapshotBuilder
 from framework.utils import get_firecracker_version_from_toml, is_io_uring_supported
-from framework.utils_cpu_templates import nonci_on_arm
+from framework.utils_cpu_templates import skip_on_arm
 
 MEM_LIMIT = 1000000000
 
@@ -475,7 +475,7 @@ def test_api_machine_config(test_microvm_with_api):
     assert json["machine-config"]["smt"] is False
 
 
-@nonci_on_arm
+@skip_on_arm
 def test_api_cpu_config(test_microvm_with_api, custom_cpu_template):
     """
     Test /cpu-config PUT scenarios.

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -9,7 +9,7 @@ import platform
 import pytest
 
 import framework.utils_cpuid as cpuid_utils
-from framework.utils_cpu_templates import nonci_on_arm
+from framework.utils_cpu_templates import skip_on_arm
 
 PLATFORM = platform.machine()
 
@@ -96,7 +96,7 @@ def test_default_cpu_features(test_microvm_with_api, network_config):
     PLATFORM != "aarch64",
     reason="This is aarch64 specific test.",
 )
-@nonci_on_arm
+@skip_on_arm
 def test_cpu_features_with_static_template(
     test_microvm_with_api, network_config, cpu_template
 ):
@@ -115,7 +115,7 @@ def test_cpu_features_with_static_template(
     PLATFORM != "aarch64",
     reason="This is aarch64 specific test.",
 )
-@nonci_on_arm
+@skip_on_arm
 def test_cpu_features_with_custom_template(
     test_microvm_with_api, network_config, custom_cpu_template
 ):

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -11,7 +11,7 @@ import pytest
 from framework import defs, utils
 from framework.defs import SUPPORTED_HOST_KERNELS
 from framework.properties import global_props
-from framework.utils_cpu_templates import nonci_on_arm
+from framework.utils_cpu_templates import skip_on_arm
 from framework.utils_cpuid import get_guest_cpuid
 from host_tools import cargo_build
 
@@ -373,7 +373,7 @@ def test_host_fingerprint_change(test_microvm_with_api, tmp_path, cpu_template_h
     )
 
 
-@nonci_on_arm
+@skip_on_arm
 def test_json_static_templates(
     test_microvm_with_api, cpu_template_helper, tmp_path, custom_cpu_template
 ):

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -236,7 +236,6 @@ def get_guest_msrs(microvm, msr_index_list):
         "System registers are not accessible on aarch64."
     ),
 )
-@nonci_on_arm
 def test_cpu_config_dump_vs_actual(
     test_microvm_with_api_and_msrtools,
     cpu_template_helper,

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -95,6 +95,7 @@ def run_spectre_meltdown_checker_on_guest(
     assert ecode == 0, f"stdout:\n{stdout.read()}\nstderr:\n{stderr.read()}\n"
 
 
+@pytest.mark.no_block_pr
 @pytest.mark.skipif(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
@@ -106,6 +107,7 @@ def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
     utils.run_cmd(f"sh {spectre_meltdown_checker} --explain")
 
 
+@pytest.mark.no_block_pr
 @pytest.mark.skipif(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
@@ -126,6 +128,7 @@ def test_spectre_meltdown_checker_on_guest(
     )
 
 
+@pytest.mark.no_block_pr
 @pytest.mark.skipif(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
@@ -151,6 +154,7 @@ def test_spectre_meltdown_checker_on_restored_guest(
     )
 
 
+@pytest.mark.no_block_pr
 @pytest.mark.skipif(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
@@ -175,6 +179,7 @@ def test_spectre_meltdown_checker_on_guest_with_template(
     )
 
 
+@pytest.mark.no_block_pr
 @pytest.mark.skipif(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
@@ -201,6 +206,7 @@ def test_spectre_meltdown_checker_on_guest_with_custom_template(
     )
 
 
+@pytest.mark.no_block_pr
 @pytest.mark.skipif(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
@@ -228,6 +234,7 @@ def test_spectre_meltdown_checker_on_restored_guest_with_template(
     )
 
 
+@pytest.mark.no_block_pr
 @pytest.mark.skipif(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
@@ -257,6 +264,7 @@ def test_spectre_meltdown_checker_on_restored_guest_with_custom_template(
     )
 
 
+@pytest.mark.no_block_pr
 def check_vulnerabilities_files_on_guest(microvm):
     """
     Check that the guest's vulnerabilities files do not contain `Vulnerable`.
@@ -270,6 +278,7 @@ def check_vulnerabilities_files_on_guest(microvm):
     assert ecode == 1, f"stdout:\n{stdout.read()}\nstderr:\n{stderr.read()}\n"
 
 
+@pytest.mark.no_block_pr
 def test_vulnerabilities_files_on_guest(
     test_microvm_with_api,
     network_config,
@@ -282,6 +291,7 @@ def test_vulnerabilities_files_on_guest(
     check_vulnerabilities_files_on_guest(microvm)
 
 
+@pytest.mark.no_block_pr
 def test_vulnerabilities_files_on_restored_guest(
     test_microvm_with_api,
     network_config,
@@ -297,6 +307,7 @@ def test_vulnerabilities_files_on_restored_guest(
     check_vulnerabilities_files_on_guest(dst_vm)
 
 
+@pytest.mark.no_block_pr
 @nonci_on_arm
 def test_vulnerabilities_files_on_guest_with_template(
     test_microvm_with_api,
@@ -311,6 +322,7 @@ def test_vulnerabilities_files_on_guest_with_template(
     check_vulnerabilities_files_on_guest(microvm)
 
 
+@pytest.mark.no_block_pr
 @nonci_on_arm
 def test_vulnerabilities_files_on_guest_with_custom_template(
     test_microvm_with_api,
@@ -329,6 +341,7 @@ def test_vulnerabilities_files_on_guest_with_custom_template(
     check_vulnerabilities_files_on_guest(microvm)
 
 
+@pytest.mark.no_block_pr
 @nonci_on_arm
 def test_vulnerabilities_files_on_restored_guest_with_template(
     test_microvm_with_api,
@@ -348,6 +361,7 @@ def test_vulnerabilities_files_on_restored_guest_with_template(
     check_vulnerabilities_files_on_guest(dst_vm)
 
 
+@pytest.mark.no_block_pr
 @nonci_on_arm
 def test_vulnerabilities_files_on_restored_guest_with_custom_template(
     test_microvm_with_api,

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -14,7 +14,7 @@ import requests
 from framework import utils
 from framework.artifacts import DEFAULT_NETMASK
 from framework.properties import global_props
-from framework.utils_cpu_templates import nonci_on_arm
+from framework.utils_cpu_templates import skip_on_arm
 
 CHECKER_URL = "https://meltdown.ovh"
 CHECKER_FILENAME = "spectre-meltdown-checker.sh"
@@ -159,7 +159,7 @@ def test_spectre_meltdown_checker_on_restored_guest(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@nonci_on_arm
+@skip_on_arm
 def test_spectre_meltdown_checker_on_guest_with_template(
     spectre_meltdown_checker,
     test_microvm_with_spectre_meltdown,
@@ -184,7 +184,7 @@ def test_spectre_meltdown_checker_on_guest_with_template(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@nonci_on_arm
+@skip_on_arm
 def test_spectre_meltdown_checker_on_guest_with_custom_template(
     spectre_meltdown_checker,
     test_microvm_with_spectre_meltdown,
@@ -211,7 +211,7 @@ def test_spectre_meltdown_checker_on_guest_with_custom_template(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@nonci_on_arm
+@skip_on_arm
 def test_spectre_meltdown_checker_on_restored_guest_with_template(
     spectre_meltdown_checker,
     test_microvm_with_spectre_meltdown,
@@ -239,7 +239,7 @@ def test_spectre_meltdown_checker_on_restored_guest_with_template(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@nonci_on_arm
+@skip_on_arm
 def test_spectre_meltdown_checker_on_restored_guest_with_custom_template(
     spectre_meltdown_checker,
     test_microvm_with_spectre_meltdown,
@@ -308,7 +308,7 @@ def test_vulnerabilities_files_on_restored_guest(
 
 
 @pytest.mark.no_block_pr
-@nonci_on_arm
+@skip_on_arm
 def test_vulnerabilities_files_on_guest_with_template(
     test_microvm_with_api,
     network_config,
@@ -323,7 +323,7 @@ def test_vulnerabilities_files_on_guest_with_template(
 
 
 @pytest.mark.no_block_pr
-@nonci_on_arm
+@skip_on_arm
 def test_vulnerabilities_files_on_guest_with_custom_template(
     test_microvm_with_api,
     network_config,
@@ -342,7 +342,7 @@ def test_vulnerabilities_files_on_guest_with_custom_template(
 
 
 @pytest.mark.no_block_pr
-@nonci_on_arm
+@skip_on_arm
 def test_vulnerabilities_files_on_restored_guest_with_template(
     test_microvm_with_api,
     network_config,
@@ -362,7 +362,7 @@ def test_vulnerabilities_files_on_restored_guest_with_template(
 
 
 @pytest.mark.no_block_pr
-@nonci_on_arm
+@skip_on_arm
 def test_vulnerabilities_files_on_restored_guest_with_custom_template(
     test_microvm_with_api,
     network_config,


### PR DESCRIPTION
## Changes / Reason

As we did in PR #4011, hardware vulnerability tests may also fail due to changes outside the Firecracker code (such as kernel/microcode updates), and this could block PRs. To unblock them, this commit makes these tests optional. Even if made optional, these tests will be run for each PR, allowing us to notice any failures. Also, we will run these tests every night, and continue to monitor failures and take appropriate actions in a timely manner.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
