### PR TITLE
fix: handle BUILDKITE_PULL_REQUEST correctly for non PRs

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -93,7 +93,7 @@ def test_coverage(monkeypatch):
 
         codecov_cmd = f"codecov -f {lcov_file} -F {global_props.host_linux_version}-{global_props.instance}"
 
-        if pr_number:
+        if pr_number and pr_number != "false":
             codecov_cmd += f" -P {pr_number}"
         else:
             codecov_cmd += f" -B {branch}"


### PR DESCRIPTION
For pull requests, the variable is set to the number of the pull request. For builds triggers not on pull requests its... the string literal "false". That broke submitting coverage data from non-pr branches because it tried to submit coverage data for a pull request with number "false", instead of submitting for the branch on which the test was run.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
