### PR TITLE
fix: Correctly determine branch name for non-prs

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -89,7 +89,10 @@ def test_coverage(monkeypatch):
     # Only upload if token is present and we're in EC2
     if "CODECOV_TOKEN" in os.environ and global_props.is_ec2:
         pr_number = os.environ.get("BUILDKITE_PULL_REQUEST")
-        _, branch, _ = utils.run_cmd("git rev-parse --abbrev-ref HEAD")
+        branch = os.environ.get("BUILDKITE_BRANCH")
+
+        if not branch:
+            branch = utils.run_cmd("git rev-parse --abbrev-ref HEAD").stdout
 
         codecov_cmd = f"codecov -f {lcov_file} -F {global_props.host_linux_version}-{global_props.instance}"
 


### PR DESCRIPTION
Buildkite does not checkout a branch, it checks out a specific commit and stores the branch which triggered the build in the BUILDKITE_BRANCH environment variable.

... the amount of things I got wrong here are embarrassing. Sorry >.>

Without this PR, every non-PR codecov report is attributed to a non-existing "master" branch. Sadly this is starts being a problem once we work with feature branches, as they would also have their commits associated with said non-existing branch. With this PR hopefully everything will get attributed to the correct branch (note that this is only important for the dashboarding on codecov.io, the comparisons posted in PR comments and the github statuses are always correct since they are commit-hash based). 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
