### PR TITLE
refactor: Replace redundant `serde_json::from_slice(x.as_bytes())`

### DIFF
--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -319,7 +319,7 @@ mod tests {
             microcode_version: "sample_microcode_version".to_string(),
             bios_version: "sample_bios_version".to_string(),
             bios_revision: "sample_bios_revision".to_string(),
-            guest_cpu_config: serde_json::from_slice(SAMPLE_MODIFIERS.as_bytes()).unwrap(),
+            guest_cpu_config: serde_json::from_str(SAMPLE_MODIFIERS).unwrap(),
         };
         let file = TempFile::new().unwrap();
         file.as_file()

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -135,7 +135,7 @@ impl VmResources {
         mmds_size_limit: usize,
         metadata_json: Option<&str>,
     ) -> Result<Self, ResourcesError> {
-        let vmm_config: VmmConfig = serde_json::from_slice::<VmmConfig>(config_json.as_bytes())?;
+        let vmm_config = serde_json::from_str::<VmmConfig>(config_json)?;
 
         if let Some(logger) = vmm_config.logger {
             init_logger(logger, instance_info)?;
@@ -1186,8 +1186,7 @@ mod tests {
                 )
                 .unwrap();
 
-                let initial_vmm_config =
-                    serde_json::from_slice::<VmmConfig>(json.as_bytes()).unwrap();
+                let initial_vmm_config = serde_json::from_str::<VmmConfig>(&json).unwrap();
                 let vmm_config: VmmConfig = (&resources).into();
                 assert_eq!(initial_vmm_config, vmm_config);
             }
@@ -1202,8 +1201,7 @@ mod tests {
                 )
                 .unwrap();
 
-                let initial_vmm_config =
-                    serde_json::from_slice::<VmmConfig>(json.as_bytes()).unwrap();
+                let initial_vmm_config = serde_json::from_str::<VmmConfig>(&json).unwrap();
                 let vmm_config: VmmConfig = (&resources).into();
                 assert_eq!(initial_vmm_config, vmm_config);
             }
@@ -1263,7 +1261,7 @@ mod tests {
             )
             .unwrap();
 
-            let initial_vmm_config = serde_json::from_slice::<VmmConfig>(json.as_bytes()).unwrap();
+            let initial_vmm_config = serde_json::from_str::<VmmConfig>(&json).unwrap();
             let vmm_config: VmmConfig = (&resources).into();
             assert_eq!(initial_vmm_config, vmm_config);
         }
@@ -1322,7 +1320,7 @@ mod tests {
             )
             .unwrap();
 
-            let initial_vmm_config = serde_json::from_slice::<VmmConfig>(json.as_bytes()).unwrap();
+            let initial_vmm_config = serde_json::from_str::<VmmConfig>(&json).unwrap();
             let vmm_config: VmmConfig = (&resources).into();
             assert_eq!(initial_vmm_config, vmm_config);
         }


### PR DESCRIPTION
## Changes

Replaces instances of `serde_json::from_slice(x.as_bytes())` with the equivalent but simpler `serde_json::from_str(&x)`.

## Reason

Unnecessary complexity is bad.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
