### PR TITLE
doc: update quickstart artifacts

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,16 +70,16 @@ guide will not use the [`jailer`](../src/jailer/).
 ARCH="$(uname -m)"
 
 # Download a linux kernel binary
-wget https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/${ARCH}/kernels/vmlinux.bin
+wget https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.5/${ARCH}/vmlinux-5.10.186
 
 # Download a rootfs
-wget https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/disks/${ARCH}/ubuntu-18.04.ext4
+wget https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.5/${ARCH}/ubuntu-22.04.ext4
 
 # Download the ssh key for the rootfs
-wget https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/disks/${ARCH}/ubuntu-18.04.id_rsa
+wget https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.5/${ARCH}/ubuntu-22.04.id_rsa
 
 # Set user read permission on the ssh key
-chmod 400 ./ubuntu-18.04.id_rsa
+chmod 400 ./ubuntu-22.04.id_rsa
 
 # Clone the firecracker repository
 git clone https://github.com/firecracker-microvm/firecracker
@@ -147,7 +147,7 @@ curl -X PUT --unix-socket "${API_SOCKET}" \
     }" \
     "http://localhost/logger"
 
-KERNEL="./vmlinux.bin"
+KERNEL="./vmlinux-5.10.186"
 KERNEL_BOOT_ARGS="console=ttyS0 reboot=k panic=1 pci=off"
 
 ARCH=$(uname -m)
@@ -164,7 +164,7 @@ curl -X PUT --unix-socket "${API_SOCKET}" \
     }" \
     "http://localhost/boot-source"
 
-ROOTFS="./ubuntu-18.04.ext4"
+ROOTFS="./ubuntu-22.04.ext4"
 
 # Set rootfs
 curl -X PUT --unix-socket "${API_SOCKET}" \
@@ -206,7 +206,7 @@ curl -X PUT --unix-socket "${API_SOCKET}" \
 sleep 0.015s
 
 # SSH into the microVM
-sudo ssh -i ./ubuntu-18.04.id_rsa 172.16.0.2
+ssh -i ./ubuntu-22.04.id_rsa root@172.16.0.2
 
 # Use `root` for both the login and password.
 # Run `reboot` to exit.


### PR DESCRIPTION
Previously we had a separate set of artifacts for the quickstart guide. This increases maintenance burden. Instead, let's use our normal CI artifacts in the quickstart guide.

## Changes

...

## Reason

This way we don't need to maintain a separate set of artifacts for the quickstart

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
