### PR TITLE
docs: Update broken link in snapshotting documentation

### DIFF
--- a/docs/snapshotting/handling-page-faults-on-snapshot-resume.md
+++ b/docs/snapshotting/handling-page-faults-on-snapshot-resume.md
@@ -127,7 +127,7 @@ unexpected cases when Firecracker crashes before being able to connect/send data
 
 ### Example
 
-An example of a handler process can be found [here](../../tests/host_tools/uffd/src/bin/valid_handler.rs).
+An example of a handler process can be found [here](../../src/firecracker/examples/uffd/valid_handler.rs).
 The process is designed to tackle faults on a certain address by loading into
 memory the entire region that the address belongs to, but users can choose any
 other behavior that suits their use case best.


### PR DESCRIPTION
Update the broken link of page faults handler process example.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
