### PR TITLE
feat: added `armsharker` integration test

### DIFF
--- a/.buildkite/pipeline_cpu_template.py
+++ b/.buildkite/pipeline_cpu_template.py
@@ -64,6 +64,14 @@ cpu_template_test = {
         "instances": ["m6g.metal", "c7g.metal"],
         "platforms": [("al2_armpatch", "linux_5.10")],
     },
+    "aarch64_armshaker": {
+        BkStep.COMMAND: [
+            "tools/devtool -y test -- -s -ra -m nonci --log-cli-level=INFO integration_tests/functional/test_aarch64_armshaker.py"
+        ],
+        BkStep.LABEL: "📖 armshaker",
+        "instances": ["m6g.metal", "c7g.metal"],
+        "platforms": DEFAULT_PLATFORMS,
+    },
 }
 
 
@@ -164,6 +172,8 @@ def main():
     elif test_args.test == "cpuid_wrmsr":
         test_group = group_snapshot_restore(cpu_template_test[test_args.test])
     elif test_args.test == "aarch64_cpu_templates":
+        test_group = group_single(cpu_template_test[test_args.test])
+    elif test_args.test == "aarch64_armshaker":
         test_group = group_single(cpu_template_test[test_args.test])
 
     pipeline = {"steps": test_group}

--- a/tests/integration_tests/functional/test_aarch64_armshaker.py
+++ b/tests/integration_tests/functional/test_aarch64_armshaker.py
@@ -1,0 +1,115 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Opcode fuzzer test for aarch64."""
+
+import platform
+import time
+
+import pytest
+
+from framework import utils
+from framework.utils_cpu_templates import nonci_on_arm
+
+PLATFORM = platform.machine()
+
+TIMEOUT = 4 * 60 * 60
+
+
+def run_armshaker(vm):
+    """
+    Run armshaker inside uVM
+    """
+
+    # Git clone armshaker
+    # We are using fork of `armsharker` because original version
+    # does not compile with new versions of `glibc`
+    # (`SIGSTKSZ` is not a constant anymore)
+    cmd = "git clone https://github.com/ShadowCurse/armshaker"
+    utils.run_cmd(cmd)
+
+    # Compile armshaker
+    utils.run_cmd("make", cwd="armshaker")
+
+    # Copy armshaker to uVM
+    vm.ssh.scp_put("armshaker/fuzzer", "/tmp/fuzzer")
+
+    # Start armshaker inside tmux in order to let it run headless
+    code, stdout, stderr = vm.ssh.execute_command(
+        "tmux new-session -d 'cd /tmp && ./fuzzer'"
+    )
+    print("tmux armshaker code: ", code)
+    print("tmux armshaker stdout: ", stdout)
+    print("tmux armshaker stderr: ", stderr)
+
+    curr_inst = ""
+    # Armshaker tests all instructions from 0 to ffffffff
+    while curr_inst != "ffffffff":
+        time.sleep(10 * 60)
+        code, stdout, stderr = vm.ssh.execute_command("cat /tmp/data/status")
+        if stdout != "":
+            curr_inst = stdout.split("\n")[0].split(":")[1]
+            print("instuctions tested: ", curr_inst)
+        else:
+            print("couldn't read /tmp/data/status")
+            print("code: ", code)
+            print("stdout: ", stdout)
+            print("stderr: ", stderr)
+
+    # Execution succeeded. Print last status
+    _, stdout, _ = vm.ssh.execute_command("cat /tmp/data/status")
+    print("final status: ", stdout)
+
+
+@pytest.mark.skipif(
+    PLATFORM != "aarch64",
+    reason="This is aarch64 specific test.",
+)
+@pytest.mark.timeout(TIMEOUT)
+@pytest.mark.nonci
+def test_armshaker_default(test_microvm_with_api):
+    """
+    Run armshaker inside default uVM
+    """
+    vm = test_microvm_with_api
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+    vm.start()
+    run_armshaker(vm)
+
+
+@pytest.mark.skipif(
+    PLATFORM != "aarch64",
+    reason="This is aarch64 specific test.",
+)
+@pytest.mark.timeout(TIMEOUT)
+@nonci_on_arm
+def test_armshaker_with_static_template(test_microvm_with_api, cpu_template):
+    """
+    Run armshaker inside uVM with static templates
+    """
+    vm = test_microvm_with_api
+    vm.spawn()
+    vm.basic_config(cpu_template=cpu_template)
+    vm.add_net_iface()
+    vm.start()
+    run_armshaker(vm)
+
+
+@pytest.mark.skipif(
+    PLATFORM != "aarch64",
+    reason="This is aarch64 specific test.",
+)
+@pytest.mark.timeout(TIMEOUT)
+@nonci_on_arm
+def test_armshaker_with_custom_template(test_microvm_with_api, custom_cpu_template):
+    """
+    Run armshaker inside uVM with custom templates
+    """
+    vm = test_microvm_with_api
+    vm.spawn()
+    vm.basic_config()
+    vm.cpu_config(custom_cpu_template["template"])
+    vm.add_net_iface()
+    vm.start()
+    run_armshaker(vm)


### PR DESCRIPTION
## Changes
Added `armsharker` integration test for aarch64 hosts in order to verify stability of the systems.
We are using fork of `armsharker` because original version does not compile with new versions of `glibc`
(`SIGSTKSZ` is not a constant anymore)

## Reason
Adding instruction fuzzing allows us to verify stability of the uVMs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
