### PR TITLE
docs(test): mention kvm as a requirement for integ tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,8 @@ For help on usage, see `tools/devtool help`.
 
 ### Dependencies
 
-- A bare-metal `Linux` host with `uname -r` >= 4.14.
+- A bare-metal `Linux` host with `uname -r` >= 4.14 and KVM enabled
+  (`/dev/kvm` device node exists).
 - Docker.
 
 ## Rustacean Integration Tests


### PR DESCRIPTION
## Changes

Mention KVM as a requirement for running integration tests.

## Reason

KVM being enabled on the host is a prerequisite for running most of the integration tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- ~~[ ] All added/changed functionality is tested.~~
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
