### PR TITLE
Allow for combination of no_block_pr and nonci pytest markers

### DIFF
--- a/.buildkite/pipeline_pr_no_block.py
+++ b/.buildkite/pipeline_pr_no_block.py
@@ -33,7 +33,7 @@ defaults = overlay_dict(defaults, args.step_param)
 
 optional_grp = group(
     "❓ Optional",
-    "./tools/devtool -y test -c 1-10 -m 0 -- ../tests/integration_tests/ -m no_block_pr --log-cli-level=INFO",
+    "./tools/devtool -y test -c 1-10 -m 0 -- ../tests/integration_tests/ -m 'no_block_pr and not nonci' --log-cli-level=INFO",
     **defaults,
 )
 

--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -79,7 +79,8 @@ def get_supported_custom_cpu_templates():
 SUPPORTED_CUSTOM_CPU_TEMPLATES = get_supported_custom_cpu_templates()
 
 
-skip_on_arm = pytest.mark.skipif(
-    cpuid_utils.get_cpu_vendor() == cpuid_utils.CpuVendor.ARM,
-    reason="skip specific cpu template related tests on ARM platforms until kernel patches required for V1N1 come",
-)
+def nonci_on_arm(func):
+    """Temporary decorator used to mark specific cpu template related tests as nonci on ARM platforms"""
+    if cpuid_utils.get_cpu_vendor() == cpuid_utils.CpuVendor.ARM:
+        return pytest.mark.nonci(func)
+    return func

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -16,7 +16,7 @@ import host_tools.drive as drive_tools
 import host_tools.network as net_tools
 from framework import utils_cpuid
 from framework.utils import get_firecracker_version_from_toml, is_io_uring_supported
-from framework.utils_cpu_templates import skip_on_arm
+from framework.utils_cpu_templates import nonci_on_arm
 
 MEM_LIMIT = 1000000000
 
@@ -473,7 +473,7 @@ def test_api_machine_config(test_microvm_with_api):
     assert json["machine-config"]["smt"] is False
 
 
-@skip_on_arm
+@nonci_on_arm
 def test_api_cpu_config(test_microvm_with_api, custom_cpu_template):
     """
     Test /cpu-config PUT scenarios.

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -7,7 +7,7 @@ import platform
 import pytest
 
 import framework.utils_cpuid as cpuid_utils
-from framework.utils_cpu_templates import skip_on_arm
+from framework.utils_cpu_templates import nonci_on_arm
 
 PLATFORM = platform.machine()
 
@@ -94,7 +94,7 @@ def test_default_cpu_features(test_microvm_with_api):
     PLATFORM != "aarch64",
     reason="This is aarch64 specific test.",
 )
-@skip_on_arm
+@nonci_on_arm
 def test_cpu_features_with_static_template(test_microvm_with_api, cpu_template):
     """
     Check the CPU features for a microvm with the specified config.
@@ -111,7 +111,7 @@ def test_cpu_features_with_static_template(test_microvm_with_api, cpu_template):
     PLATFORM != "aarch64",
     reason="This is aarch64 specific test.",
 )
-@skip_on_arm
+@nonci_on_arm
 def test_cpu_features_with_custom_template(test_microvm_with_api, custom_cpu_template):
     """
     Check the CPU features for a microvm with the specified config.

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -11,7 +11,7 @@ import pytest
 from framework import utils
 from framework.defs import SUPPORTED_HOST_KERNELS
 from framework.properties import global_props
-from framework.utils_cpu_templates import skip_on_arm
+from framework.utils_cpu_templates import nonci_on_arm
 from framework.utils_cpuid import get_guest_cpuid
 from host_tools import cargo_build
 
@@ -383,7 +383,7 @@ def test_host_fingerprint_change(test_microvm_with_api, tmp_path, cpu_template_h
     )
 
 
-@skip_on_arm
+@nonci_on_arm
 def test_json_static_templates(
     test_microvm_with_api, cpu_template_helper, tmp_path, custom_cpu_template
 ):

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -11,7 +11,7 @@ import requests
 
 from framework import utils
 from framework.properties import global_props
-from framework.utils_cpu_templates import skip_on_arm
+from framework.utils_cpu_templates import nonci_on_arm
 
 CHECKER_URL = "https://meltdown.ovh"
 CHECKER_FILENAME = "spectre-meltdown-checker.sh"
@@ -140,7 +140,7 @@ def test_spectre_meltdown_checker_on_restored_guest(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@skip_on_arm
+@nonci_on_arm
 def test_spectre_meltdown_checker_on_guest_with_template(
     spectre_meltdown_checker,
     microvm_with_template,
@@ -160,7 +160,7 @@ def test_spectre_meltdown_checker_on_guest_with_template(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@skip_on_arm
+@nonci_on_arm
 def test_spectre_meltdown_checker_on_guest_with_custom_template(
     spectre_meltdown_checker,
     microvm_with_custom_cpu_template,
@@ -180,7 +180,7 @@ def test_spectre_meltdown_checker_on_guest_with_custom_template(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@skip_on_arm
+@nonci_on_arm
 def test_spectre_meltdown_checker_on_restored_guest_with_template(
     spectre_meltdown_checker,
     microvm_with_template,
@@ -208,7 +208,7 @@ def test_spectre_meltdown_checker_on_restored_guest_with_template(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@skip_on_arm
+@nonci_on_arm
 def test_spectre_meltdown_checker_on_restored_guest_with_custom_template(
     spectre_meltdown_checker,
     microvm_with_custom_cpu_template,
@@ -272,7 +272,7 @@ def test_vulnerabilities_files_on_restored_guest(
 
 
 @pytest.mark.no_block_pr
-@skip_on_arm
+@nonci_on_arm
 def test_vulnerabilities_files_on_guest_with_template(
     microvm_with_template,
 ):
@@ -283,7 +283,7 @@ def test_vulnerabilities_files_on_guest_with_template(
 
 
 @pytest.mark.no_block_pr
-@skip_on_arm
+@nonci_on_arm
 def test_vulnerabilities_files_on_guest_with_custom_template(
     microvm_with_custom_cpu_template,
 ):
@@ -294,7 +294,7 @@ def test_vulnerabilities_files_on_guest_with_custom_template(
 
 
 @pytest.mark.no_block_pr
-@skip_on_arm
+@nonci_on_arm
 def test_vulnerabilities_files_on_restored_guest_with_template(
     microvm_with_template,
     microvm_factory,
@@ -313,7 +313,7 @@ def test_vulnerabilities_files_on_restored_guest_with_template(
 
 
 @pytest.mark.no_block_pr
-@skip_on_arm
+@nonci_on_arm
 def test_vulnerabilities_files_on_restored_guest_with_custom_template(
     microvm_with_custom_cpu_template,
     microvm_factory,


### PR DESCRIPTION
We have recently introduced tests that are marked with the combination
of nonci and optional. This is because the tests are parameterized
to use different templates on x86 and ARM, but the ARM template tests
cannot be run in our PR CI due to requiring a specially compiled host
kernel. Therefore, whatever can run in our CI should run in optional,
and ARM should only run nightly.

This commit allows for what is described above.
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
