### PR TITLE
test: Update DEFAULT_G3_FEATURES_NO_SSBS to match new ci artifacts

### DIFF
--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -30,7 +30,7 @@ DEFAULT_G3_FEATURES = (
 DEFAULT_G3_FEATURES_NO_SSBS = (
     "fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp "
     "asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp "
-    "sha512 asimdfhm dit uscat ilrcpc flagm"
+    "sha512 asimdfhm dit uscat ilrcpc flagm dcpodp i8mm bf16 dgh rng"
 )
 
 DEFAULT_G3_FEATURES_V1N1 = (


### PR DESCRIPTION
With the new CI artifacts, the default G3 features changed (due to artifacts being more general purpose now). The DEFAULT_G3_FEATURES constant was updated in d1015be484d573f9f7ae92483f21a100da8aac4b, but DEFAULT_G3_FEATURES_NO_SSBS slipped through the cracks somehow.

This commit fixes a nightly test failures by updating the cpu features expected on G3 instances without SSBS.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
