### PR TITLE
Snapshot editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- [#4045](https://github.com/firecracker-microvm/firecracker/pull/4045)
+  Added `snapshot-editor` tool for modifications of snapshot files.
 - [#3967](https://github.com/firecracker-microvm/firecracker/pull/3967/):
   Added new fields to the custom CPU templates. (aarch64 only) `vcpu_features`
   field allows modifications of vCPU features enabled during vCPU

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-num"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488557e97528174edaa2ee268b23a809e0c598213a4bbcb4f34575a46fda147e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1187,18 @@ dependencies = [
  "thiserror",
  "versionize",
  "versionize_derive",
+]
+
+[[package]]
+name = "snapshot-editor"
+version = "1.5.0"
+dependencies = [
+ "clap",
+ "clap-num",
+ "libc",
+ "snapshot",
+ "thiserror",
+ "vmm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["src/cpu-template-helper", "src/firecracker", "src/jailer", "src/rebase-snap", "src/seccompiler"]
+members = ["src/cpu-template-helper", "src/firecracker", "src/jailer", "src/rebase-snap", "src/seccompiler", "src/snapshot-editor"]
 default-members = ["src/firecracker"]
 resolver = "2"
 

--- a/docs/snapshotting/snapshot-editor.md
+++ b/docs/snapshotting/snapshot-editor.md
@@ -1,0 +1,91 @@
+# Snapshot editor
+
+The `snapshot-editor` is a program for modification of Firecracker snapshots.
+
+## Prior knowledge
+
+Firecracker snapshot consists of 2 files:
+
+- `vmstate` file: file with Firecracker internal data such as vcpu states,
+  devices states etc.
+- `memory` file: file with guest memory.
+
+`snapshot-editor` (currently) allows to modify only `vmstate` files only
+on aarch64 platform.
+
+## Usage
+
+### `edit-vmstate` command
+
+#### `remove-regs` subcommand (aarch64 only)
+
+This command is used to remove specified registers from vcpu states inside
+vmstate snapshot file.
+
+Arguments:
+
+- `VMSTATE_PATH` - path to the `vmstate` file
+- `OUTPUT_PATH` - path to the file where the output will be placed
+- `[REGS]` - set of u32 values representing registers ids as they are defined
+  in KVM. Can be both in decimal and in hex formats.
+
+Usage:
+
+```bash
+snapshot-editor edit-vmstate remove-regs \
+    --vmstate-path <VMSTATE_PATH> \
+    --output-path <OUTPUT_PATH> \
+    [REGS]...
+```
+
+Example:
+
+```bash
+./snapshot-editor edit-vmstate remove-regs \
+    --vmstate-path ./vmstate_file \
+    --output-path ./new_vmstate_file \
+    0x1 0x2
+```
+
+### `info-vmstate` command
+
+#### `version` subcommand
+
+This command is used to print version of the provided
+vmstate file.
+
+Arguments:
+
+- `VMSTATE_PATH` - path to the `vmstate` file
+
+Usage:
+
+```bash
+snapshot-editor info-vmstate version --vmstate-path <VMSTATE_PATH>
+```
+
+Example:
+
+```bash
+./snapshot-editor info-vmstate version --vmstate-path ./vmstate_file
+```
+
+#### `vcpu-states` subcommand (aarch64 only)
+
+This command is used to print the vCPU states inside vmstate snapshot file.
+
+Arguments:
+
+- `VMSTATE_PATH` - path to the `vmstate` file
+
+Usage:
+
+```bash
+snapshot-editor info-vmstate vcpu-states --vmstate-path <VMSTATE_PATH>
+```
+
+Example:
+
+```bash
+./snapshot-editor info-vmstate vcpu-states --vmstate-path ./vmstate_file
+```

--- a/src/snapshot-editor/Cargo.toml
+++ b/src/snapshot-editor/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "snapshot-editor"
+version = "1.5.0"
+authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2021"
+build = "../../build.rs"
+license = "Apache-2.0"
+
+[dependencies]
+clap = { version = "4.3.19", features = ["derive", "string"] }
+clap-num = "1.0.2"
+libc = "0.2.147"
+snapshot = { path = "../snapshot" }
+thiserror = "1.0.44"
+vmm = { path = "../vmm" }

--- a/src/snapshot-editor/src/edit_vmstate.rs
+++ b/src/snapshot-editor/src/edit_vmstate.rs
@@ -1,0 +1,195 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+use clap_num::maybe_hex;
+use vmm::arch::aarch64::regs::Aarch64RegisterVec;
+use vmm::persist::MicrovmState;
+
+use crate::utils::{open_vmstate, save_vmstate, UtilsError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum EditVmStateError {
+    #[error("{0}")]
+    Utils(#[from] UtilsError),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EditVmStateSubCommand {
+    /// Remove registers from vcpu states.
+    RemoveRegs {
+        /// Set of registers to remove.
+        /// Values should be registers ids as the are defined in KVM.
+        #[arg(value_parser=maybe_hex::<u64>, num_args = 1.., value_delimiter = ' ')]
+        regs: Vec<u64>,
+        /// Path to the vmstate file.
+        #[arg(short, long)]
+        vmstate_path: PathBuf,
+        /// Path of output file.
+        #[arg(short, long)]
+        output_path: PathBuf,
+    },
+}
+
+pub fn edit_vmstate_command(command: EditVmStateSubCommand) -> Result<(), EditVmStateError> {
+    match command {
+        EditVmStateSubCommand::RemoveRegs {
+            regs,
+            vmstate_path,
+            output_path,
+        } => edit(&vmstate_path, &output_path, |state| {
+            remove_regs(state, &regs)
+        })?,
+    }
+    Ok(())
+}
+
+fn edit(
+    vmstate_path: &PathBuf,
+    output_path: &PathBuf,
+    f: impl Fn(MicrovmState) -> Result<MicrovmState, EditVmStateError>,
+) -> Result<(), EditVmStateError> {
+    let (microvm_state, version) = open_vmstate(vmstate_path)?;
+    let microvm_state = f(microvm_state)?;
+    save_vmstate(microvm_state, output_path, version)?;
+    Ok(())
+}
+
+fn remove_regs(
+    mut state: MicrovmState,
+    remove_regs: &[u64],
+) -> Result<MicrovmState, EditVmStateError> {
+    for (i, vcpu_state) in state.vcpu_states.iter_mut().enumerate() {
+        println!("Modifying state for vCPU {i}");
+
+        let mut removed = vec![false; remove_regs.len()];
+        let mut new_regs = Aarch64RegisterVec::default();
+        for reg in vcpu_state.regs.iter().filter(|reg| {
+            if let Some(pos) = remove_regs.iter().position(|r| r == &reg.id) {
+                removed[pos] = true;
+                false
+            } else {
+                true
+            }
+        }) {
+            new_regs.push(reg);
+        }
+        vcpu_state.regs = new_regs;
+        for (reg, removed) in remove_regs.iter().zip(removed.iter()) {
+            print!("Regsiter {reg:#x}: ");
+            match removed {
+                true => println!("removed"),
+                false => println!("not present"),
+            }
+        }
+    }
+    Ok(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remove_regs() {
+        const KVM_REG_SIZE_U8: u64 = 0;
+        const KVM_REG_SIZE_U16: u64 = 0x10000000000000;
+        const KVM_REG_SIZE_U32: u64 = 0x20000000000000;
+
+        use vmm::arch::aarch64::regs::Aarch64RegisterRef;
+        use vmm::vstate::vcpu::aarch64::VcpuState;
+
+        let vcpu_state = VcpuState {
+            regs: {
+                let mut regs = Aarch64RegisterVec::default();
+                let reg_data: u8 = 69;
+                regs.push(Aarch64RegisterRef::new(
+                    KVM_REG_SIZE_U8,
+                    &reg_data.to_le_bytes(),
+                ));
+                let reg_data: u16 = 69;
+                regs.push(Aarch64RegisterRef::new(
+                    KVM_REG_SIZE_U16,
+                    &reg_data.to_le_bytes(),
+                ));
+                let reg_data: u32 = 69;
+                regs.push(Aarch64RegisterRef::new(
+                    KVM_REG_SIZE_U32,
+                    &reg_data.to_le_bytes(),
+                ));
+                regs
+            },
+            ..Default::default()
+        };
+        let state = MicrovmState {
+            vcpu_states: vec![vcpu_state],
+            ..Default::default()
+        };
+
+        let new_state = remove_regs(state, &[KVM_REG_SIZE_U32]).unwrap();
+
+        let expected_vcpu_state = VcpuState {
+            regs: {
+                let mut regs = Aarch64RegisterVec::default();
+                let reg_data: u8 = 69;
+                regs.push(Aarch64RegisterRef::new(
+                    KVM_REG_SIZE_U8,
+                    &reg_data.to_le_bytes(),
+                ));
+                let reg_data: u16 = 69;
+                regs.push(Aarch64RegisterRef::new(
+                    KVM_REG_SIZE_U16,
+                    &reg_data.to_le_bytes(),
+                ));
+                regs
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(new_state.vcpu_states[0].regs, expected_vcpu_state.regs);
+    }
+
+    #[test]
+    fn test_remove_non_existed_regs() {
+        const KVM_REG_SIZE_U8: u64 = 0;
+        const KVM_REG_SIZE_U16: u64 = 0x10000000000000;
+        const KVM_REG_SIZE_U32: u64 = 0x20000000000000;
+
+        use vmm::arch::aarch64::regs::Aarch64RegisterRef;
+        use vmm::vstate::vcpu::aarch64::VcpuState;
+
+        let vcpu_state = VcpuState {
+            regs: {
+                let mut regs = Aarch64RegisterVec::default();
+                let reg_data: u8 = 69;
+                regs.push(Aarch64RegisterRef::new(
+                    KVM_REG_SIZE_U8,
+                    &reg_data.to_le_bytes(),
+                ));
+                let reg_data: u16 = 69;
+                regs.push(Aarch64RegisterRef::new(
+                    KVM_REG_SIZE_U16,
+                    &reg_data.to_le_bytes(),
+                ));
+                regs
+            },
+            ..Default::default()
+        };
+
+        let state_clone = MicrovmState {
+            vcpu_states: vec![vcpu_state.clone()],
+            ..Default::default()
+        };
+
+        let state = MicrovmState {
+            vcpu_states: vec![vcpu_state],
+            ..Default::default()
+        };
+
+        let new_state = remove_regs(state_clone, &[KVM_REG_SIZE_U32]).unwrap();
+
+        assert_eq!(new_state.vcpu_states[0].regs, state.vcpu_states[0].regs);
+    }
+}

--- a/src/snapshot-editor/src/info.rs
+++ b/src/snapshot-editor/src/info.rs
@@ -1,0 +1,89 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+use vmm::persist::MicrovmState;
+use vmm::version_map::FC_VERSION_TO_SNAP_VERSION;
+
+use crate::utils::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum InfoVmStateError {
+    #[error("Cannot translate snapshot data version {0} to Firecracker microVM version")]
+    InvalidVersion(u16),
+    #[error("{0}")]
+    Utils(#[from] UtilsError),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum InfoVmStateSubCommand {
+    /// Print snapshot version.
+    Version {
+        /// Path to the vmstate file.
+        #[arg(short, long)]
+        vmstate_path: PathBuf,
+    },
+    /// Print info about vcpu states.
+    #[cfg(target_arch = "aarch64")]
+    VcpuStates {
+        /// Path to the vmstate file.
+        #[arg(short, long)]
+        vmstate_path: PathBuf,
+    },
+}
+
+pub fn info_vmstate_command(command: InfoVmStateSubCommand) -> Result<(), InfoVmStateError> {
+    match command {
+        InfoVmStateSubCommand::Version { vmstate_path } => info(&vmstate_path, info_version)?,
+        #[cfg(target_arch = "aarch64")]
+        InfoVmStateSubCommand::VcpuStates { vmstate_path } => {
+            info(&vmstate_path, info_vcpu_states)?
+        }
+    }
+    Ok(())
+}
+
+fn info(
+    vmstate_path: &PathBuf,
+    f: impl Fn(&MicrovmState, u16) -> Result<(), InfoVmStateError>,
+) -> Result<(), InfoVmStateError> {
+    let (vmstate, version) = open_vmstate(vmstate_path)?;
+    f(&vmstate, version)?;
+    Ok(())
+}
+
+fn info_version(_: &MicrovmState, version: u16) -> Result<(), InfoVmStateError> {
+    match FC_VERSION_TO_SNAP_VERSION
+        .iter()
+        .find(|(_, &v)| v == version)
+    {
+        Some((key, _)) => {
+            println!("v{key}");
+            Ok(())
+        }
+        None => Err(InfoVmStateError::InvalidVersion(version)),
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn info_vcpu_states(state: &MicrovmState, _: u16) -> Result<(), InfoVmStateError> {
+    for (i, state) in state.vcpu_states.iter().enumerate() {
+        println!("vcpu {i}:");
+        println!("kvm_mp_state: {:#x}", state.mp_state.mp_state);
+        println!("mpidr: {:#x}", state.mpidr);
+        for reg in state.regs.iter() {
+            println!(
+                "{:#x} 0x{}",
+                reg.id,
+                reg.as_slice()
+                    .iter()
+                    .rev()
+                    .map(|b| format!("{b:x}"))
+                    .collect::<String>()
+            );
+        }
+    }
+    Ok(())
+}

--- a/src/snapshot-editor/src/main.rs
+++ b/src/snapshot-editor/src/main.rs
@@ -1,0 +1,60 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::{Parser, Subcommand};
+
+#[cfg(target_arch = "aarch64")]
+mod edit_vmstate;
+mod info;
+mod utils;
+
+#[cfg(target_arch = "aarch64")]
+use edit_vmstate::{edit_vmstate_command, EditVmStateError, EditVmStateSubCommand};
+use info::{info_vmstate_command, InfoVmStateError, InfoVmStateSubCommand};
+
+#[derive(Debug, thiserror::Error)]
+enum SnapEditorError {
+    #[cfg(target_arch = "aarch64")]
+    #[error("Error during editing vmstate file: {0}")]
+    EditVmState(#[from] EditVmStateError),
+    #[error("Error during getting info from a vmstate file: {0}")]
+    InfoVmState(#[from] InfoVmStateError),
+}
+
+#[derive(Debug, Parser)]
+#[command(version = format!("v{}", env!("FIRECRACKER_VERSION")))]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    #[cfg(target_arch = "aarch64")]
+    #[command(subcommand)]
+    EditVmstate(EditVmStateSubCommand),
+    #[command(subcommand)]
+    InfoVmstate(InfoVmStateSubCommand),
+}
+
+fn main_exec() -> Result<(), SnapEditorError> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        #[cfg(target_arch = "aarch64")]
+        Command::EditVmstate(command) => edit_vmstate_command(command)?,
+        Command::InfoVmstate(command) => info_vmstate_command(command)?,
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<(), SnapEditorError> {
+    let result = main_exec();
+    if let Err(e) = result {
+        eprintln!("{}", e);
+        Err(e)
+    } else {
+        Ok(())
+    }
+}

--- a/src/snapshot-editor/src/utils.rs
+++ b/src/snapshot-editor/src/utils.rs
@@ -1,0 +1,55 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::{File, OpenOptions};
+use std::path::PathBuf;
+
+use snapshot::Snapshot;
+use vmm::persist::MicrovmState;
+use vmm::version_map::VERSION_MAP;
+
+// Some errors are only used in aarch64 code
+#[allow(unused)]
+#[derive(Debug, thiserror::Error)]
+pub enum UtilsError {
+    #[error("Can not open snapshot file: {0}")]
+    VmStateFileOpen(std::io::Error),
+    #[error("Can not retrieve metadata for snapshot file: {0}")]
+    VmStateFileMeta(std::io::Error),
+    #[error("Can not load snapshot: {0}")]
+    VmStateLoad(snapshot::Error),
+    #[error("Can not open output file: {0}")]
+    OutputFileOpen(std::io::Error),
+    #[error("Can not save snapshot: {0}")]
+    VmStateSave(snapshot::Error),
+}
+
+#[allow(unused)]
+pub fn open_vmstate(snapshot_path: &PathBuf) -> Result<(MicrovmState, u16), UtilsError> {
+    let version_map = VERSION_MAP.clone();
+    let mut snapshot_reader = File::open(snapshot_path).map_err(UtilsError::VmStateFileOpen)?;
+    let metadata = std::fs::metadata(snapshot_path).map_err(UtilsError::VmStateFileMeta)?;
+    let snapshot_len = metadata.len() as usize;
+    Snapshot::load(&mut snapshot_reader, snapshot_len, version_map).map_err(UtilsError::VmStateLoad)
+}
+
+// This method is used only in aarch64 code so far
+#[allow(unused)]
+pub fn save_vmstate(
+    microvm_state: MicrovmState,
+    output_path: &PathBuf,
+    version: u16,
+) -> Result<(), UtilsError> {
+    let version_map = VERSION_MAP.clone();
+    let mut output_file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(output_path)
+        .map_err(UtilsError::OutputFileOpen)?;
+    let mut snapshot = Snapshot::new(version_map, version);
+    snapshot
+        .save(&mut output_file, &microvm_state)
+        .map_err(UtilsError::VmStateSave)?;
+    Ok(())
+}

--- a/src/snapshot/tests/test.rs
+++ b/src/snapshot/tests/test.rs
@@ -94,7 +94,8 @@ fn test_hardcoded_snapshot_deserialization() {
 
     let mut snapshot_blob = v1_hardcoded_snapshot;
 
-    let mut restored_struct: A = Snapshot::unchecked_load(&mut snapshot_blob, vm.clone()).unwrap();
+    let (mut restored_struct, _) =
+        Snapshot::unchecked_load::<_, A>(&mut snapshot_blob, vm.clone()).unwrap();
 
     let mut expected_struct = A {
         a: 16u32,
@@ -106,7 +107,8 @@ fn test_hardcoded_snapshot_deserialization() {
 
     snapshot_blob = v2_hardcoded_snapshot;
 
-    restored_struct = Snapshot::unchecked_load(&mut snapshot_blob, vm.clone()).unwrap();
+    (restored_struct, _) =
+        Snapshot::unchecked_load::<_, A>(&mut snapshot_blob, vm.clone()).unwrap();
 
     expected_struct = A {
         a: 16u32,
@@ -141,7 +143,7 @@ fn test_invalid_format_version() {
         0x01, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     ];
 
-    let mut result: Result<A, Error> =
+    let mut result: Result<(A, _), Error> =
         Snapshot::unchecked_load(&mut invalid_format_snap, VersionMap::new());
     let mut expected_err = Error::InvalidFormatVersion(0xAAAA);
     assert_eq!(result.unwrap_err(), expected_err);
@@ -196,7 +198,7 @@ fn test_invalid_data_version() {
         // + inner enum value (4 bytes).
         0x01, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     ];
-    let mut result: Result<A, Error> =
+    let mut result: Result<(A, _), Error> =
         Snapshot::unchecked_load(&mut invalid_data_version_snap, VersionMap::new());
     let mut expected_err = Error::InvalidDataVersion(0xAAAA);
     assert_eq!(result.unwrap_err(), expected_err);

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -167,7 +167,7 @@ impl From<MmdsVersion> for MmdsVersionState {
 
 /// Holds the device states.
 // NOTICE: Any changes to this structure require a snapshot version bump.
-#[derive(Debug, Clone, Versionize)]
+#[derive(Debug, Default, Clone, Versionize)]
 pub struct DeviceStates {
     #[cfg(target_arch = "aarch64")]
     // State of legacy devices in MMIO space.

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -98,8 +98,8 @@ pub mod utilities;
 pub mod version_map;
 /// Wrappers over structures used to configure the VMM.
 pub mod vmm_config;
-
-mod vstate;
+/// Module with virtual state structs.
+pub mod vstate;
 
 use std::collections::HashMap;
 use std::io;

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -581,8 +581,9 @@ fn snapshot_state_from_file(
         File::open(snapshot_path).map_err(SnapshotStateFromFileError::Open)?;
     let metadata = std::fs::metadata(snapshot_path).map_err(SnapshotStateFromFileError::Meta)?;
     let snapshot_len = metadata.len() as usize;
-    Snapshot::load(&mut snapshot_reader, snapshot_len, version_map)
-        .map_err(SnapshotStateFromFileError::Load)
+    let (state, _) = Snapshot::load(&mut snapshot_reader, snapshot_len, version_map)
+        .map_err(SnapshotStateFromFileError::Load)?;
+    Ok(state)
 }
 
 /// Error type for [`guest_memory_from_file`].

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -121,7 +121,7 @@ impl From<&VmResources> for VmInfo {
 }
 
 /// Contains the necesary state for saving/restoring a microVM.
-#[derive(Debug, Versionize)]
+#[derive(Debug, Default, Versionize)]
 // NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct MicrovmState {
     /// Miscellaneous VM info.

--- a/src/vmm/src/vstate/mod.rs
+++ b/src/vmm/src/vstate/mod.rs
@@ -1,5 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub(crate) mod vcpu;
-pub(crate) mod vm;
+/// Module with Vcpu implementation.
+pub mod vcpu;
+/// Module with Vm implementation.
+pub mod vm;

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -238,7 +238,7 @@ impl KvmVcpu {
 pub struct VcpuState {
     pub mp_state: kvm_bindings::kvm_mp_state,
     #[version(end = 2, default_fn = "default_old_regs")]
-    old_regs: Vec<Aarch64RegisterOld>,
+    pub old_regs: Vec<Aarch64RegisterOld>,
     #[version(start = 2, de_fn = "de_regs", ser_fn = "ser_regs")]
     pub regs: Aarch64RegisterVec,
     // We will be using the mpidr for passing it to the VmState.

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -28,8 +28,10 @@ use crate::cpu_config::templates::{CpuConfiguration, GuestConfigError};
 use crate::vstate::vm::Vm;
 use crate::FcExitCode;
 
+/// Module with aarch64 vCPU implementation.
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
+/// Module with x86_64 vCPU implementation.
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
@@ -681,10 +683,14 @@ impl Drop for VcpuHandle {
     }
 }
 
+/// Vcpu emulation state.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum VcpuEmulation {
+    /// Handled.
     Handled,
+    /// Interrupted.
     Interrupted,
+    /// Stopped.
     Stopped,
 }
 

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -29,17 +29,17 @@ use crate::vstate::vm::Vm;
 use crate::FcExitCode;
 
 #[cfg(target_arch = "aarch64")]
-pub(crate) mod aarch64;
+pub mod aarch64;
 #[cfg(target_arch = "x86_64")]
-pub(crate) mod x86_64;
+pub mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
-pub(crate) use aarch64::{KvmVcpuError, *};
+pub use aarch64::{KvmVcpuError, *};
 #[cfg(target_arch = "x86_64")]
-pub(crate) use x86_64::{KvmVcpuError, *};
+pub use x86_64::{KvmVcpuError, *};
 
 /// Signal number (SIGRTMIN) used to kick Vcpus.
-pub(crate) const VCPU_RTSIG_OFFSET: i32 = 0;
+pub const VCPU_RTSIG_OFFSET: i32 = 0;
 
 /// Errors associated with the wrappers over KVM ioctls.
 #[derive(Debug, thiserror::Error)]

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -103,19 +103,25 @@ pub enum VmError {
 }
 
 /// Error type for [`Vm::restore_state`]
+#[allow(missing_docs)]
 #[cfg(target_arch = "x86_64")]
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum RestoreStateError {
     #[error("{0}")]
     SetPit2(kvm_ioctls::Error),
+    /// SetClock.
     #[error("{0}")]
     SetClock(kvm_ioctls::Error),
+    /// SetIrqChipPicMaster.
     #[error("{0}")]
     SetIrqChipPicMaster(kvm_ioctls::Error),
+    /// SetIrqChipPicSlave.
     #[error("{0}")]
     SetIrqChipPicSlave(kvm_ioctls::Error),
+    /// SetIrqChipIoAPIC.
     #[error("{0}")]
     SetIrqChipIoAPIC(kvm_ioctls::Error),
+    /// Vm Error
     #[error("{0}")]
     VmError(VmError),
 }
@@ -127,6 +133,7 @@ pub enum RestoreStateError {
     /// GIC Error
     #[error("{0}")]
     GicError(crate::arch::aarch64::gic::GicError),
+    /// Vm Error
     #[error("{0}")]
     VmError(VmError),
 }
@@ -340,7 +347,9 @@ impl Vm {
 #[cfg(target_arch = "aarch64")]
 #[derive(Debug, Default, Versionize)]
 pub struct VmState {
+    /// GIC state.
     pub gic: GicState,
+    /// Additional capabilities that were specified in cpu template.
     #[version(start = 2, default_fn = "default_caps")]
     pub kvm_cap_modifiers: Vec<KvmCapability>,
 }
@@ -471,6 +480,7 @@ pub struct VmState {
     pic_slave: kvm_irqchip,
     ioapic: kvm_irqchip,
 
+    /// Additional capabilities that were specified in cpu template.
     #[version(start = 2, default_fn = "default_caps")]
     pub kvm_cap_modifiers: Vec<KvmCapability>,
 }

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -459,7 +459,7 @@ impl Vm {
 }
 
 #[cfg(target_arch = "x86_64")]
-#[derive(Versionize)]
+#[derive(Default, Versionize)]
 /// Structure holding VM kvm state.
 // NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VmState {

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -213,7 +213,7 @@ fn verify_create_snapshot(is_diff: bool) -> (TempFile, TempFile) {
     let snapshot_path = snapshot_file.as_path().to_path_buf();
     let snapshot_file_metadata = std::fs::metadata(snapshot_path).unwrap();
     let snapshot_len = snapshot_file_metadata.len() as usize;
-    let restored_microvm_state: MicrovmState = Snapshot::load(
+    let (restored_microvm_state, _) = Snapshot::load::<_, MicrovmState>(
         &mut snapshot_file.as_file(),
         snapshot_len,
         VERSION_MAP.clone(),
@@ -243,7 +243,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
     let snapshot_file_metadata = snapshot_file.as_file().metadata().unwrap();
     let snapshot_len = snapshot_file_metadata.len() as usize;
     snapshot_file.as_file().seek(SeekFrom::Start(0)).unwrap();
-    let microvm_state: MicrovmState = Snapshot::load(
+    let (microvm_state, _) = Snapshot::load::<_, MicrovmState>(
         &mut snapshot_file.as_file(),
         snapshot_len,
         VERSION_MAP.clone(),
@@ -347,10 +347,11 @@ fn get_microvm_state_from_snapshot() -> MicrovmState {
     let snapshot_file_metadata = snapshot_file.as_file().metadata().unwrap();
     let snapshot_len = snapshot_file_metadata.len() as usize;
     snapshot_file.as_file().seek(SeekFrom::Start(0)).unwrap();
-    Snapshot::load(
+    let (state, _) = Snapshot::load(
         &mut snapshot_file.as_file(),
         snapshot_len,
         VERSION_MAP.clone(),
     )
-    .unwrap()
+    .unwrap();
+    state
 }

--- a/tests/integration_tests/functional/test_snapshot_editor.py
+++ b/tests/integration_tests/functional/test_snapshot_editor.py
@@ -1,0 +1,78 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for snapshot-editor tool."""
+
+import platform
+
+import pytest
+
+import host_tools.cargo_build as host
+from framework import utils
+
+PLATFORM = platform.machine()
+MIDR_EL1 = hex(0x603000000013C000)
+
+
+@pytest.mark.skipif(
+    PLATFORM != "aarch64",
+    reason="This is aarch64 specific test.",
+)
+def test_remove_regs(uvm_nano, microvm_factory):
+    """
+    This test verifies `remove-regs` method of `snapshot-editor`.
+    Here we create snapshot and try to romeve MIDR_EL1 register
+    from it. Then we try to restore uVM from the snapshot.
+    """
+
+    vm = uvm_nano
+    vm.add_net_iface()
+    vm.start()
+
+    snapshot = vm.snapshot_full()
+
+    snap_editor = host.get_binary("snapshot-editor")
+
+    # Test that MIDR_EL1 is in the snapshot
+    cmd = [
+        str(snap_editor),
+        "info-vmstate",
+        "vcpu-states",
+        "--vmstate-path",
+        str(snapshot.vmstate),
+    ]
+    _, stdout, _ = utils.run_cmd(cmd)
+    assert MIDR_EL1 in stdout
+
+    # Remove MIDR_EL1 register from the snapshot
+    cmd = [
+        str(snap_editor),
+        "edit-vmstate",
+        "remove-regs",
+        "--vmstate-path",
+        str(snapshot.vmstate),
+        "--output-path",
+        str(snapshot.vmstate),
+        str(MIDR_EL1),
+    ]
+    utils.run_cmd(cmd)
+
+    # Test that MIDR_EL1 is not in the snapshot
+    cmd = [
+        str(snap_editor),
+        "info-vmstate",
+        "vcpu-states",
+        "--vmstate-path",
+        str(snapshot.vmstate),
+    ]
+    _, stdout, _ = utils.run_cmd(cmd)
+    assert MIDR_EL1 not in stdout
+
+    # test that we can restore from a snapshot
+    new_vm = microvm_factory.build()
+    new_vm.spawn()
+    new_vm.restore_from_snapshot(snapshot, resume=True)
+
+    # Attempt to connect to resumed microvm.
+    # Verify if guest can run commands.
+    exit_code, _, _ = new_vm.ssh.run("ls")
+    assert exit_code == 0


### PR DESCRIPTION
## Changes
Added initial version of `snapshot-editor` tool.
Initial functionality is:
- (aarch64 only) remove registers from vcpu states
- (aarch64 only)  print all vcpu states from vmstate file

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
