### PR TITLE
Fix of kvm caps checks during restore

### DIFF
--- a/src/vmm/src/arch/aarch64/gic/mod.rs
+++ b/src/vmm/src/arch/aarch64/gic/mod.rs
@@ -42,7 +42,7 @@ impl GIC {
 }
 
 /// Errors thrown while setting up the GIC.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum GicError {
     /// Error while calling KVM ioctl for setting up the global interrupt controller.
     #[error("Error while calling KVM ioctl for setting up the global interrupt controller: {0}")]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -457,7 +457,7 @@ pub fn build_microvm_from_snapshot(
         uffd,
         track_dirty_pages,
         vcpu_count,
-        vec![],
+        microvm_state.vm_state.kvm_cap_modifiers.clone(),
     )?;
 
     #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -332,17 +332,6 @@ impl Vm {
         self.get_irqchip()
             .restore_device(mpidrs, &state.gic)
             .map_err(RestoreStateError::GicError)?;
-
-        let kvm = Kvm::new()
-            .map_err(VmError::Kvm)
-            .map_err(RestoreStateError::VmError)?;
-        let total_caps = Self::combine_capabilities(&state.kvm_cap_modifiers);
-        Self::check_capabilities(&kvm, &total_caps)
-            .map_err(VmError::Capabilities)
-            .map_err(RestoreStateError::VmError)?;
-
-        self.kvm_cap_modifiers = state.kvm_cap_modifiers.clone();
-
         Ok(())
     }
 }
@@ -411,17 +400,6 @@ impl Vm {
         self.fd
             .set_irqchip(&state.ioapic)
             .map_err(RestoreStateError::SetIrqChipIoAPIC)?;
-
-        let kvm = Kvm::new()
-            .map_err(VmError::Kvm)
-            .map_err(RestoreStateError::VmError)?;
-        let total_caps = Self::combine_capabilities(&state.kvm_cap_modifiers);
-        Self::check_capabilities(&kvm, &total_caps)
-            .map_err(VmError::Capabilities)
-            .map_err(RestoreStateError::VmError)?;
-
-        self.kvm_cap_modifiers = state.kvm_cap_modifiers.clone();
-
         Ok(())
     }
 


### PR DESCRIPTION
## Changes
Fixes kvm capability checks during snapshot restore.

Previously kvm capabilities were checked twice on snapshot
restore:
- when `Vm` was created with `create_vmm_and_vcpus`
- when `vm.restore_state` was called.

During first check `Vm` would not know about any modifications
to the list of kvm capabilities, so it would check
`DEFAULT_CAPABILITIES`. The problem is that if some
capabilities were removed from the check list
(for example if "!123" was specified in `kvm_capabilities`
field in the cpu-template for VM before snapshot)
they would still be checked during `Vm::new` call.

The fix is trivial, just pass the `kvm_capabilities` from `vm_state`
to `create_vmm_and_vcpus` call. Also removed kvm capabilities checks
from `restore_state` calls as they are not needed anymore.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
