### PR TITLE
Add serde_derive>1.0.171,<1.0.184 to deny.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
  "snapshot",
  "thiserror",
  "timerfd",
- "userfaultfd 0.6.0",
+ "userfaultfd",
  "utils",
  "vmm",
 ]
@@ -1329,20 +1329,6 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "userfaultfd"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2320ae2edd0b11cf05dcd53614e5c72cb9f9ac9aab1b4ff4fe4f1cc4f92e3592"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "nix",
- "thiserror",
- "userfaultfd-sys",
-]
-
-[[package]]
-name = "userfaultfd"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec82f2a09c9279eb320bd9945f0df0232613d4621c093d8ba02edcb45624fd4"
@@ -1486,7 +1472,7 @@ dependencies = [
  "snapshot",
  "thiserror",
  "timerfd",
- "userfaultfd 0.5.1",
+ "userfaultfd",
  "utils",
  "versionize",
  "versionize_derive",

--- a/deny.toml
+++ b/deny.toml
@@ -6,3 +6,7 @@ allow = [
     "ISC",
     "Unicode-DFS-2016"
 ]
+
+[[bans.deny]]
+name = "serde_derive"
+version = ">1.0.171, < 1.0.184"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -23,7 +23,7 @@ semver = { version = "1.0.17", features = ["serde"] }
 serde_json = "1.0.78"
 timerfd = "1.5.0"
 thiserror = "1.0.32"
-userfaultfd = "0.5.1"
+userfaultfd = "0.6.0"
 versionize = "0.1.10"
 versionize_derive = "0.1.5"
 vm-allocator = "0.1.0"

--- a/tests/integration_tests/build/test_dependencies.py
+++ b/tests/integration_tests/build/test_dependencies.py
@@ -24,4 +24,4 @@ def test_licenses():
         os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../../Cargo.toml")
     )
 
-    cargo("deny", f"--manifest-path {toml_file} check licenses")
+    cargo("deny", f"--manifest-path {toml_file} check licenses bans")


### PR DESCRIPTION
## Changes

These versions of serde_derive used a precompiled binary to generate the
proc-macro output on x86_64-unknown-linux-gnu. We do not want to
accidentally reintroduce these versions through a transitive dependency,
so explicitly forbid this.

## Reason

https://github.com/serde-rs/serde/issues/2538

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
