### PR TITLE
Final PVH fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to
 
 ### Changed
 
+- Added support for PVH boot mode. This is used when an x86 kernel provides the
+  appropriate ELF Note to indicate that PVH boot mode is supported. Linux
+  kernels newer than 5.0 compiled with `CONFIG_PVH=y` set this ELF Note, as do
+  FreeBSD kernels.
+
 ### Deprecated
 
 ### Removed
@@ -140,10 +145,6 @@ and this project adheres to
   [random for clones](docs/snapshotting/random-for-clones.md) documention for
   more info on VMGenID. VMGenID state is part of the snapshot format of
   Firecracker. As a result, Firecracker snapshot version is now 2.0.0.
-- Added support for PVH boot mode.  This is used when an x86 kernel provides
-  the appropriate ELF Note to indicate that PVH boot mode is supported.
-  Linux kernels newer than 5.0 compiled with `CONFIG_PVH=y` set this ELF Note,
-  as do FreeBSD kernels.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,8 +142,8 @@ and this project adheres to
   Firecracker. As a result, Firecracker snapshot version is now 2.0.0.
 - Added support for PVH boot mode.  This is used when an x86 kernel provides
   the appropriate ELF Note to indicate that PVH boot mode is supported.
-  Linux kernels compiled with CONFIG_XEN_PVH=y set this ELF Note, as do
-  FreeBSD kernels.
+  Linux kernels newer than 5.0 compiled with `CONFIG_PVH=y` set this ELF Note,
+  as do FreeBSD kernels.
 
 ### Changed
 

--- a/docs/pvh.md
+++ b/docs/pvh.md
@@ -7,7 +7,7 @@ then this boot mode will be used.  This boot mode was designed for virtualized
 environments which load the kernel directly, and is simpler than the "Linux
 boot" mode which is designed to be launched from a legacy boot loader.
 
-PVH boot mode can be enabled for Linux by setting CONFIG_XEN_PVH=y in the
+PVH boot mode can be enabled for Linux by setting `CONFIG_PVH=y` in the
 kernel configuration.  (This is not the default setting.)
 
 PVH boot mode is enabled by default in FreeBSD, which has support for

--- a/docs/pvh.md
+++ b/docs/pvh.md
@@ -3,13 +3,13 @@
 Firecracker supports booting x86 kernels in "PVH direct boot" mode
 [as specified by the Xen project](https://github.com/xen-project/xen/blob/master/docs/misc/pvh.pandoc).
 If a kernel is provided which contains the XEN_ELFNOTE_PHYS32_ENTRY ELF Note
-then this boot mode will be used.  This boot mode was designed for virtualized
+then this boot mode will be used. This boot mode was designed for virtualized
 environments which load the kernel directly, and is simpler than the "Linux
 boot" mode which is designed to be launched from a legacy boot loader.
 
-PVH boot mode can be enabled for Linux by setting `CONFIG_PVH=y` in the
-kernel configuration.  (This is not the default setting.)
+PVH boot mode can be enabled for Linux by setting `CONFIG_PVH=y` in the kernel
+configuration. (This is not the default setting.)
 
 PVH boot mode is enabled by default in FreeBSD, which has support for
-Firecracker starting with FreeBSD 14.0.  Instructions on building a FreeBSD
+Firecracker starting with FreeBSD 14.0. Instructions on building a FreeBSD
 kernel and root filesystem are available [here](rootfs-and-kernel-setup.md).

--- a/docs/rootfs-and-kernel-setup.md
+++ b/docs/rootfs-and-kernel-setup.md
@@ -191,16 +191,16 @@ Firecracker.
 Here's a quick step-by-step guide to building a FreeBSD rootfs and kernel that
 Firecracker can boot:
 
-1. Boot a FreeBSD system.  In EC2, the
+1. Boot a FreeBSD system. In EC2, the
    [FreeBSD 13 Marketplace image](https://aws.amazon.com/marketplace/pp/prodview-ukzmy5dzc6nbq)
    is a good option; you can also use weekly snapshot AMIs published by the
-   FreeBSD project.  (Firecracker support is in FreeBSD 14 and later, so you'll
+   FreeBSD project. (Firecracker support is in FreeBSD 14 and later, so you'll
    need FreeBSD 13 or later to build it.)
 
    The build will require about 50 GB of disk space, so size the disk
    appropriately.
 
-1. Log in to the FreeBSD system and become root.  If using EC2, you'll want to
+1. Log in to the FreeBSD system and become root. If using EC2, you'll want to
    ssh in as `ec2-user` with your chosen SSH key and then `su` to become root.
 
 1. Install git and check out the FreeBSD src tree:
@@ -220,10 +220,10 @@ Firecracker can boot:
    make -C /usr/src/release firecracker DESTDIR=`pwd`
    ```
 
-You should now have a rootfs `freebsd-rootfs.bin` and a kernel `freebsd-kern.bin`
-in the current directory (or elsewhere if you change the `DESTDIR` value) that
-you can boot with Firecracker.  Note that the FreeBSD rootfs generated in this
-manner is somewhat minimized compared to "stock" FreeBSD; it omits utilities
-which are only relevant on physical systems (e.g., utilities related to floppy
-disks, USB devices, and some network interfaces) and also debug files and the
-system compiler.
+You should now have a rootfs `freebsd-rootfs.bin` and a kernel
+`freebsd-kern.bin` in the current directory (or elsewhere if you change the
+`DESTDIR` value) that you can boot with Firecracker. Note that the FreeBSD
+rootfs generated in this manner is somewhat minimized compared to "stock"
+FreeBSD; it omits utilities which are only relevant on physical systems (e.g.,
+utilities related to floppy disks, USB devices, and some network interfaces) and
+also debug files and the system compiler.

--- a/src/vmm/src/arch/x86_64/gdt.rs
+++ b/src/vmm/src/arch/x86_64/gdt.rs
@@ -49,6 +49,7 @@ fn get_base(entry: u64) -> u64 {
 // (For more information concerning the formats of segment descriptors, VMCS fields, et cetera,
 // please consult the Intel Software Developer Manual.)
 fn get_limit(entry: u64) -> u32 {
+    #[allow(clippy::cast_possible_truncation)] // clearly, truncation is not possible
     let limit: u32 =
         ((((entry) & 0x000F_0000_0000_0000) >> 32) | ((entry) & 0x0000_0000_0000_FFFF)) as u32;
 

--- a/src/vmm/src/arch/x86_64/regs.rs
+++ b/src/vmm/src/arch/x86_64/regs.rs
@@ -406,7 +406,7 @@ mod tests {
         [BootProtocol::LinuxBoot, BootProtocol::PvhBoot]
             .iter()
             .for_each(|boot_prot| {
-                assert!(vcpu.set_sregs(&Default::default()).is_ok());
+                vcpu.set_sregs(&Default::default()).unwrap();
                 setup_sregs(&gm, &vcpu, *boot_prot).unwrap();
 
                 let mut sregs: kvm_sregs = vcpu.get_sregs().unwrap();

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -349,7 +349,7 @@ pub fn build_microvm_for_boot(
 
     #[cfg(feature = "gdb")]
     if let Some(gdb_socket_path) = &vm_resources.vm_config.gdb_socket_path {
-        gdb::gdb_thread(vmm.clone(), vcpu_fds, gdb_rx, entry_addr, gdb_socket_path)
+        gdb::gdb_thread(vmm.clone(), vcpu_fds, gdb_rx, entry_point.entry_addr, gdb_socket_path)
             .map_err(GdbServer)?;
     } else {
         debug!("No GDB socket provided not starting gdb server.");

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -349,8 +349,14 @@ pub fn build_microvm_for_boot(
 
     #[cfg(feature = "gdb")]
     if let Some(gdb_socket_path) = &vm_resources.vm_config.gdb_socket_path {
-        gdb::gdb_thread(vmm.clone(), vcpu_fds, gdb_rx, entry_point.entry_addr, gdb_socket_path)
-            .map_err(GdbServer)?;
+        gdb::gdb_thread(
+            vmm.clone(),
+            vcpu_fds,
+            gdb_rx,
+            entry_point.entry_addr,
+            gdb_socket_path,
+        )
+        .map_err(GdbServer)?;
     } else {
         debug!("No GDB socket provided not starting gdb server.");
     }

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -301,7 +301,7 @@ mod tests {
     use std::os::unix::io::AsRawFd;
 
     use kvm_bindings::{KVM_ARM_VCPU_PSCI_0_2, KVM_REG_SIZE_U64};
-
+    use vm_memory::GuestAddress;
     use super::*;
     use crate::arch::aarch64::regs::Aarch64RegisterRef;
     use crate::arch::BootProtocol;

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -302,6 +302,7 @@ mod tests {
 
     use kvm_bindings::{KVM_ARM_VCPU_PSCI_0_2, KVM_REG_SIZE_U64};
     use vm_memory::GuestAddress;
+
     use super::*;
     use crate::arch::aarch64::regs::Aarch64RegisterRef;
     use crate::arch::BootProtocol;
@@ -344,16 +345,15 @@ mod tests {
             cpu_config: CpuConfiguration::default(),
         };
 
-        vcpu
-            .configure(
-                &vm_mem,
-                EntryPoint {
-                    entry_addr: GuestAddress(crate::arch::get_kernel_start()),
-                    protocol: BootProtocol::LinuxBoot,
-                },
-                &vcpu_config,
-            )
-            .unwrap();
+        vcpu.configure(
+            &vm_mem,
+            EntryPoint {
+                entry_addr: GuestAddress(crate::arch::get_kernel_start()),
+                protocol: BootProtocol::LinuxBoot,
+            },
+            &vcpu_config,
+        )
+        .unwrap();
 
         unsafe { libc::close(vcpu.fd.as_raw_fd()) };
 

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -673,3 +673,8 @@ class Timeout:
 
     def __exit__(self, _type, _value, _traceback):
         signal.alarm(0)
+
+
+def pvh_supported() -> bool:
+    """Checks if PVH boot is supported"""
+    return platform.architecture() == "x86_64"

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -16,7 +16,7 @@ import pytest
 
 import host_tools.drive as drive_tools
 import host_tools.network as net_tools
-from framework import utils_cpuid
+from framework import utils, utils_cpuid
 from framework.utils import get_firecracker_version_from_toml, is_io_uring_supported
 
 MEM_LIMIT = 1000000000
@@ -41,6 +41,9 @@ def test_api_happy_start(uvm_plain):
     test_microvm.basic_config()
 
     test_microvm.start()
+
+    if utils.pvh_supported():
+        assert "Kernel loaded using PVH boot protocol" in test_microvm.log_data
 
 
 def test_drive_io_engine(uvm_plain):

--- a/tests/integration_tests/style/test_gitlint.py
+++ b/tests/integration_tests/style/test_gitlint.py
@@ -5,6 +5,7 @@
 import os
 
 from framework import utils
+from framework.ab_test import DEFAULT_A_REVISION
 
 
 def test_gitlint():
@@ -15,6 +16,6 @@ def test_gitlint():
     os.environ["LANG"] = "C.UTF-8"
 
     rc, _, stderr = utils.run_cmd(
-        "gitlint --commits origin/main..HEAD -C ../.gitlint --extra-path framework/gitlint_rules.py",
+        f"gitlint --commits origin/{DEFAULT_A_REVISION}..HEAD -C ../.gitlint --extra-path framework/gitlint_rules.py",
     )
     assert rc == 0, "Commit message violates gitlint rules: {}".format(stderr)


### PR DESCRIPTION
Bring the feature branch up-to-date with all changes that happened in `main` since it was last updated, and which didn't show up as a merge conflict. Also do some minor doc fixes, and add integration testing.

Since these days all our CI kernels are compiled with `CONFIG_PVH=y`, integration testing is just a matter of adding an assert to verify that PVH boot mode is indeed being used. We are not adding FreeBSD tests to our CI, as we have no easy means for maintaining FreeBSD artifacts, and last time I checked (which admittedly was August 23), it also didn't boot on AMD instances. 

See also https://github.com/firecracker-microvm/firecracker/issues/3041 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
