### PR TITLE
ci: Skip 5.10 sky lake bootime test

### DIFF
--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -60,6 +60,11 @@ def test_no_boottime(test_microvm_with_api):
     global_props.host_linux_version == "6.1",
     reason="perf regression under investigation",
 )
+@pytest.mark.skipif(
+    global_props.cpu_codename == "INTEL_SKYLAKE"
+    and global_props.host_linux_version == "5.10",
+    reason="perf regression under investigation",
+)
 def test_boottime_no_network(fast_microvm, record_property, metrics):
     """
     Check boot time of microVM without a network device.
@@ -81,6 +86,11 @@ def test_boottime_no_network(fast_microvm, record_property, metrics):
 # temporarily disable this test in 6.1
 @pytest.mark.xfail(
     global_props.host_linux_version == "6.1",
+    reason="perf regression under investigation",
+)
+@pytest.mark.skipif(
+    global_props.cpu_codename == "INTEL_SKYLAKE"
+    and global_props.host_linux_version == "5.10",
     reason="perf regression under investigation",
 )
 def test_boottime_with_network(fast_microvm, record_property, metrics):


### PR DESCRIPTION
## Changes

See title.

## Reason

There is a performance regression on 5.10 sky lake hosts that
cannot be easily resolved. To allow the CI to function well while
investigating this, this test will be skipped on this host.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
