### PR TITLE
Nightly security buildkite pipeline

### DIFF
--- a/.buildkite/pipeline_security.py
+++ b/.buildkite/pipeline_security.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate Buildkite nightly security pipelines dynamically"""
+
+from common import COMMON_PARSER, group, overlay_dict, pipeline_to_json
+
+args = COMMON_PARSER.parse_args()
+
+defaults = {
+    "instances": args.instances,
+    "platforms": args.platforms,
+}
+defaults = overlay_dict(defaults, args.step_param)
+
+
+vulnerabilities_grp = group(
+    "🛡️ Vulnerabilities",
+    "./tools/devtool -y test -- ../tests/integration_tests/security/test_vulnerabilities.py -m 'no_block_pr and not nonci'",
+    **defaults,
+)
+
+fingerprint_grp = group(
+    "🖐️ Fingerprint",
+    "./tools/devtool -y test -- ../tests/integration_tests/functional/test_cpu_template_helper.py -m nonci -k test_fingerprint_change",
+    **defaults,
+)
+
+
+pipeline = {"steps": [vulnerabilities_grp, fingerprint_grp]}
+print(pipeline_to_json(pipeline))

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -68,8 +68,9 @@ class CpuTemplateHelper:
         cmd = (
             f"{self.binary} fingerprint compare"
             f" --prev {prev_path} --curr {curr_path}"
-            f" --filters {' '.join(filters)}"
         )
+        if filters:
+            cmd += f" --filters {' '.join(filters)}"
         utils.run_cmd(cmd)
 
 
@@ -347,7 +348,7 @@ def test_cpu_config_dump_vs_actual(
         ), f"Mismatched MSR for {key:#010x}: {actual=:#066b} vs. {dump=:#066b}"
 
 
-def detect_fingerprint_change(microvm, tmp_path, cpu_template_helper, filters):
+def detect_fingerprint_change(microvm, tmp_path, cpu_template_helper, filters=None):
     """
     Compare fingerprint files with filters between one taken at the moment and
     a baseline file taken in a specific point in time.
@@ -403,21 +404,15 @@ def test_guest_cpu_config_change(test_microvm_with_api, tmp_path, cpu_template_h
 
 
 @pytest.mark.nonci
-def test_host_fingerprint_change(test_microvm_with_api, tmp_path, cpu_template_helper):
+def test_fingerprint_change(test_microvm_with_api, tmp_path, cpu_template_helper):
     """
-    Verify that the host fingerprint has not changed since the baseline
-    fingerprint was gathered.
+    Verify that all the fields of the fingerprint has not changed since the
+    baseline fingerprint was gathered.
     """
     detect_fingerprint_change(
         test_microvm_with_api,
         tmp_path,
         cpu_template_helper,
-        [
-            "kernel_version",
-            "microcode_version",
-            "bios_version",
-            "bios_revision",
-        ],
     )
 
 


### PR DESCRIPTION
## Changes / Reason

PR https://github.com/firecracker-microvm/firecracker/pull/4021 made some hardware vulnerability tests optional for PR merge, since those tests can fail due to changes outside the Firecracker code (such as kernel/microcode updates) and the failures would prevents PRs merged. The disadvantage of this approach is that an author and reviewers might miss failures caused by the PR.

To keep our eyes on those failures and address them correctly, we'd like to run it nightly and get noticed. This commit adds a script that generate buildkite steps to run those vulnerability tests as well as fingerprint checks.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
