### PR TITLE
A/B-Testing utilities for specifically testing changes introduced by a PR

### DIFF
--- a/tests/framework/ab_test.py
+++ b/tests/framework/ab_test.py
@@ -1,0 +1,132 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Defines utilities for performing A/B-tests.
+
+A/B-Tests are style of tests where we do not care what state a test is in, but only that this state does not change
+across a pull request. This is useful if
+1. Validating the state requires some baseline to be persisted in the repository, and maintaining this baseline
+   adds significant operational burden (for example, performance tests), or
+2. The state can change due to outside factors (e.g. Hardware changes), and such external changes would block all
+   pull requests until they are resolved.
+
+Consider for example a `cargo audit` tests, which is used to reject usage of dependency versinos that have known
+security vulnerabilities, or which have been yanked. The "state" here is "list of vulnerable dependencies". Clearly,
+this can change due to external action (a new vulnerability is discovered and published to RustSec). At this point,
+every PR would fail until this dependency is removed, blocking all development. Simply removing the test from PR CI
+is not an option, since we want to avoid the scenario where a PR adds a dependency with a known vulnerability (e.g.
+the PR itself changes the "list of vulnerable dependencies"). A/B-Testing allows us to not block PRs on the former case,
+while still preventing the latter: We run cargo audit twice, once on main HEAD, and once on the PR HEAD. If the output
+of both invocations is the same, the test passes (with us being alerted to this situtation via a special pipeline that
+does not block PRs). If not, it fails, preventing PRs from introducing new vulnerable dependencies.
+"""
+import contextlib
+import os
+from tempfile import TemporaryDirectory
+from typing import Callable, Optional, TypeVar
+
+from framework import utils
+
+# Locally, this will always compare against main, even if we try to merge into, say, a feature branch.
+# We might want to do a more sophisticated way to determine a "parent" branch here.
+DEFAULT_A_REVISION = os.environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")
+
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+def default_comparator(ah: T, be: T) -> bool:
+    """Returns `true` iff that the two arguments are equal.
+
+    The default assertion for A/B-tests using `ab_test`.
+
+    Ridiculous variable names sponsored by pylint."""
+    return ah == be
+
+
+def git_ab_test(
+    test_runner: Callable[[bool], T],
+    comparator: Callable[[T, T], U] = default_comparator,
+    *,
+    a_revision: str = DEFAULT_A_REVISION,
+    b_revision: Optional[str] = None,
+) -> (T, T, U):
+    """
+    Performs an A/B-test using the given test runner between the specified revision, and the currently checked out revision.
+    The specified revisions will be checked out in temporary directories, with `test_runner` getting executed in the
+    repository root. If the test depends on firecracker binaries built from the requested revision, care has to be taken
+    that they are built from the sources in the temporary directory (which can be ensured via the `workspace` parameter
+    to `cargo_build.get_binary`).
+
+    Note that there are no guarantees on the order in which the two tests are run.
+
+    :param test_runner: A callable which when executed runs the test in the context of the current working directory. Its
+                        parameter is `true` if and only if it is currently running the "A" test.
+    :param comparator: A callable taking two outputs from `test_runner` and comparing them. Should return some value
+                       indicating whether the test should pass or no, which will be returned by the `ab_test` functions,
+                       and on which the caller can then do an assertion.
+    :param a_revision: The revision to checkout for the "A" part of the test. Defaults to the pull request target branch
+                       if run in CI, and "main" otherwise.
+    :param b_revision: The git revision to check out for "B" part of the test. Defaults to whatever is currently checked
+                       out (in which case no temporary directory will be created).
+    :return: The output of both "A" test, the "B" test and the comparator, which can then be used for assertions
+             (alternatively, your comparator can perform any required assertions and not return anything).
+    """
+
+    # We can't just checkout random branches in the current working directory. Locally, this might not work because of
+    # uncommitted changes. In the CI this will not work because multiple tests will run in parallel, and thus switching
+    # branches will cause random failures in other tests.
+    with temporary_checkout(a_revision) as a_tmp:
+        with chdir(a_tmp):
+            result_a = test_runner(True)
+
+        if b_revision:
+            with temporary_checkout(b_revision) as b_tmp:
+                with chdir(b_tmp):
+                    result_b = test_runner(False)
+                # Have to call comparator here to make sure both temporary directories exist (as the comparator
+                # might rely on some files that were created during test running, see the benchmark test)
+                comparison = comparator(result_a, result_b)
+        else:
+            # By default, pytest execution happens inside the `tests` subdirectory. Change to the repository root, as
+            # documented.
+            with chdir(".."):
+                result_b = test_runner(False)
+            comparison = comparator(result_a, result_b)
+
+        return result_a, result_b, comparison
+
+
+@contextlib.contextmanager
+def temporary_checkout(revision: str):
+    """
+    Context manager that checks out firecracker in a temporary directory and `chdir`s into it
+
+    Will change back to whatever was the current directory when the context manager was entered, even if exceptions
+    happen along the way.
+    """
+    with TemporaryDirectory() as tmp_dir:
+        utils.run_cmd(
+            f"git clone https://github.com/firecracker-microvm/firecracker {tmp_dir}"
+        )
+
+        with chdir(tmp_dir):
+            utils.run_cmd(f"git checkout {revision}")
+
+        yield tmp_dir
+
+
+# Once we upgrade to python 3.11, this will be in contextlib:
+# https://docs.python.org/3/library/contextlib.html#contextlib.chdir
+@contextlib.contextmanager
+def chdir(to):
+    """Context manager that temporarily `chdir`s to the specified path"""
+    cur = os.getcwd()
+
+    try:
+        os.chdir(to)
+        yield
+    finally:
+        os.chdir(cur)

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -231,6 +231,7 @@ class JailerContext:
                         fargs=[controller],
                         exceptions=TimeoutError,
                         max_delay=5,
+                        logger=None,
                     )
                 except TimeoutError:
                     pass

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -348,7 +348,7 @@ class Microvm:
         return self.api.describe.get().json()["state"]
 
     @property
-    @retry(delay=0.1, tries=5)
+    @retry(delay=0.1, tries=5, logger=None)
     def pid_in_new_ns(self):
         """Get the pid of the Firecracker process in the new namespace.
 
@@ -507,19 +507,19 @@ class Microvm:
         if self.log_file:
             self.check_log_message("Running Firecracker")
 
-    @retry(delay=0.2, tries=5)
+    @retry(delay=0.2, tries=5, logger=None)
     def _wait_create(self):
         """Wait until the API socket and chroot folder are available."""
         os.stat(self.jailer.api_socket_path())
 
-    @retry(delay=0.2, tries=5)
+    @retry(delay=0.2, tries=5, logger=None)
     def check_log_message(self, message):
         """Wait until `message` appears in logging output."""
         assert (
             message in self.log_data
         ), f'Message ("{message}") not found in log data ("{self.log_data}").'
 
-    @retry(delay=0.2, tries=5)
+    @retry(delay=0.2, tries=5, logger=None)
     def check_any_log_message(self, messages):
         """Wait until any message in `messages` appears in logging output."""
         for message in messages:

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -522,7 +522,7 @@ def run_guest_cmd(ssh_connection, cmd, expected, use_json=False):
     assert stdout == expected
 
 
-@retry(delay=0.5, tries=5)
+@retry(delay=0.5, tries=5, logger=None)
 def wait_process_termination(p_pid):
     """Wait for a process to terminate.
 
@@ -687,6 +687,7 @@ def start_screen_process(screen_log, session_name, binary_path, binary_params):
         exceptions=RuntimeError,
         tries=30,
         delay=1,
+        logger=None,
     ).group(1)
 
     # Make sure the screen process launched successfully
@@ -735,7 +736,7 @@ def check_entropy(ssh_connection):
     assert exit_code == 0, stderr
 
 
-@retry(delay=0.5, tries=5)
+@retry(delay=0.5, tries=5, logger=None)
 def wait_process_running(process):
     """Wait for a process to run.
 

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -76,7 +76,7 @@ class SSHConnection:
             opts.append("-r")
         self._scp(self.remote_path(remote_path), local_path, opts)
 
-    @retry(ConnectionError, delay=0.15, tries=20)
+    @retry(ConnectionError, delay=0.15, tries=20, logger=None)
     def _init_connection(self):
         """Create an initial SSH client connection (retry until it works).
 

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -13,7 +13,7 @@ from framework.utils import get_free_mem_ssh, run_cmd
 STATS_POLLING_INTERVAL_S = 1
 
 
-@retry(delay=0.5, tries=10)
+@retry(delay=0.5, tries=10, logger=None)
 def get_stable_rss_mem_by_pid(pid, percentage_delta=1):
     """
     Get the RSS memory that a guest uses, given the pid of the guest.

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -152,6 +152,7 @@ def test_config_start_no_api(uvm_plain, vm_config_file):
         exceptions=RuntimeError,
         tries=10,
         delay=1,
+        logger=None,
     )
 
 

--- a/tests/integration_tests/performance/test_benchmarks.py
+++ b/tests/integration_tests/performance/test_benchmarks.py
@@ -1,23 +1,38 @@
 # Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Optional benchmarks-do-not-regress test"""
-
 import json
 import logging
 import os
 import platform
+import shutil
+from pathlib import Path
 
 import pytest
 
 from framework import utils
+from framework.ab_test import git_ab_test
 from host_tools.cargo_build import cargo
 
-TARGET_BRANCH = os.environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH") or "main"
 LOGGER = logging.getLogger(__name__)
 
 
-def cargo_bench():
-    """Executes all benchmarks by running "cargo bench --no-run", finding the executables, and running them pinned to some CPU"""
+@pytest.mark.no_block_pr
+@pytest.mark.timeout(600)
+def test_no_regression_relative_to_target_branch():
+    """
+    Run the microbenchmarks in this repository, comparing results from pull
+    request target branch against what's achieved on HEAD
+    """
+    git_ab_test(run_criterion, compare_results)
+
+
+def run_criterion(is_a: bool) -> Path:
+    """
+    Executes all benchmarks by running "cargo bench --no-run", finding the executables, and running them pinned to some CPU
+    """
+    baseline_name = "a_baseline" if is_a else "b_baseline"
+
     # Passing --message-format json to cargo tells it to print its log in a json format. At the end, instead of the
     # usual "placed executable <...> at <...>" we'll get a json object with an 'executable' key, from which we
     # extract the path to the compiled benchmark binary.
@@ -34,51 +49,44 @@ def cargo_bench():
             if executable:
                 executables.append(executable)
 
-    output = ""
-
     for executable in executables:
-        output += utils.run_cmd(
-            f"CARGO_TARGET_DIR=../build/cargo_target taskset -c 1 {executable} --bench"
-        ).stdout
+        utils.run_cmd(
+            f"CARGO_TARGET_DIR=build/cargo_target taskset -c 1 {executable} --bench --save-baseline {baseline_name}"
+        )
 
-    return output
+    return Path(os.getcwd()) / "build" / "cargo_target" / "criterion"
 
 
-@pytest.mark.no_block_pr
-@pytest.mark.timeout(600)
-def test_no_regression_relative_to_target_branch():
-    """
-    Run the microbenchmarks in this repository, comparing results from pull
-    request target branch against what's achieved on HEAD
-    """
-    # First, run benchmarks on pull request target branch (usually main). For this, cache the commit at which
-    # the test was originally executed
-    _, pr_head_commit_sha, _ = utils.run_cmd("git rev-parse HEAD")
-    utils.run_cmd(f"git switch {TARGET_BRANCH}")
-    cargo_bench()
+def compare_results(location_a_baselines: Path, location_b_baselines: Path):
+    """Compares the two recorded criterion baselines for regressions, assuming that "A" is the baseline from main"""
+    for benchmark in location_b_baselines.glob("*"):
+        data = json.loads(
+            (benchmark / "b_baseline" / "estimates.json").read_text("utf-8")
+        )
 
-    # Switch back to pull request, and run benchmarks again. Criterion will automatically notice that
-    # data from a previous run exists, and do a comparison
-    utils.run_cmd(f"git checkout {pr_head_commit_sha}")
-    criterion_output = cargo_bench()
-
-    # Criterion separates reports for benchmarks by two newlines. We filter and print the ones
-    # that contain the string 'Performance has regression.', which criterion uses to indicate a regression
-    regressions_only = "\n\n".join(
-        result
-        for result in criterion_output.split("\n\n")
-        if "Performance has regressed." in result
-    )
-
-    for benchmark in os.listdir("../build/cargo_target/criterion"):
-        with open(
-            f"../build/cargo_target/criterion/{benchmark}/new/estimates.json",
-            encoding="utf-8",
-        ) as file:
-            data = json.load(file)
         average_ns = data["mean"]["point_estimate"]
 
-        LOGGER.info("%s mean: %iµs", benchmark, average_ns / 1000)
+        LOGGER.info("%s mean: %iµs", benchmark.name, average_ns / 1000)
+
+    # Assumption: location_b_baseline = cargo_target of current working directory. So just copy the a_baselines here
+    # to do the comparison
+    for benchmark in location_a_baselines.glob("*"):
+        shutil.copytree(
+            benchmark / "a_baseline",
+            location_b_baselines / benchmark.name / "a_baseline",
+        )
+
+    _, stdout, _ = cargo(
+        "bench",
+        f"--all --target {platform.machine()}-unknown-linux-musl",
+        "--load-baseline a_baseline --baseline b_baseline",
+    )
+
+    regressions_only = "\n\n".join(
+        result
+        for result in stdout.split("\n\n")
+        if "Performance has regressed." in result
+    )
 
     # If this string is anywhere in stdout, then at least one of our benchmarks
     # is now performing worse with the PR changes.


### PR DESCRIPTION
## Changes

Generalizes the A/B-testing approach used by the optional benchmark test (which does a dynamic comparison of PR HEAD vs main HEAD and determines pass state based on that). 

## Reason

We want to apply this approach to performance testing and some auditing test that can block PRs across the board due to hardware changes (for example the cpu-template-helper tool tests that ensure cpu fingerprint reported inside guests stay the same, but which can fail due to microcode updates)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
