### PR TITLE
Microvm helpers for interactive usage

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -35,6 +35,7 @@ from framework.artifacts import NetIfaceConfig
 from framework.defs import FC_PID_FILE_NAME, MAX_API_CALL_DURATION_MS
 from framework.http_api import Api
 from framework.jailer import JailerContext
+from framework.microvm_helpers import MicrovmHelpers
 from framework.properties import global_props
 from host_tools.memory import MemoryMonitor
 
@@ -169,6 +170,7 @@ class Microvm:
         self.rootfs_file = None
         self.ssh_key = None
         self.initrd_file = None
+        self.boot_args = None
 
         # The binaries this microvm will use to start.
         if fc_binary_path is None:
@@ -220,6 +222,8 @@ class Microvm:
 
         # MMDS content from file
         self.metadata_file = None
+
+        self.help = MicrovmHelpers(self)
 
     def __repr__(self):
         return f"<Microvm id={self.id}>"
@@ -576,9 +580,11 @@ class Microvm:
         if self.memory_monitor:
             self.memory_monitor.start()
 
+        if boot_args is not None:
+            self.boot_args = boot_args
         boot_source_args = {
             "kernel_image_path": self.create_jailed_resource(self.kernel_file),
-            "boot_args": boot_args,
+            "boot_args": self.boot_args,
         }
 
         if use_initrd and self.initrd_file is not None:

--- a/tests/framework/microvm_helpers.py
+++ b/tests/framework/microvm_helpers.py
@@ -1,0 +1,162 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Microvm helper functions for interactive use"""
+
+import os
+import platform
+import subprocess
+
+
+class DockerInfo:
+    """Class to extract information from the Docker environment"""
+
+    @property
+    def ip(self):
+        """Return this container's IP address"""
+        return (
+            subprocess.check_output(
+                "ip -j address show eth0 |jq -r '.[].addr_info[].local'",
+                shell=True,
+            )
+            .decode("ascii")
+            .strip()
+        )
+
+    @property
+    def id(self):
+        """Return this container's id"""
+        return platform.node()
+
+
+DOCKER = DockerInfo()
+
+
+class MicrovmHelpers:
+    """Microvm helper functions for interactive use"""
+
+    def __init__(self, vm):
+        self.vm = vm
+
+    def print_log(self):
+        """Print Firecracker's log"""
+        print(self.vm.log_data)
+
+    def resize_disk(self, disk, size: int = 2**30):
+        """Resize a filesystem
+
+        The filesystem should be unmounted for this to work
+        """
+        os.truncate(disk, size)
+        subprocess.check_output(["resize2fs", disk])
+
+    def gdbserver(self, port=2000):
+        """Attach gdbserver to the FC process
+
+        See https://sourceware.org/gdb/current/onlinedocs/gdb.html/Remote-Debugging.html#Remote-Debugging
+        """
+        comm = f"localhost:{port}"
+        subprocess.Popen(["gdbserver", "--attach", comm, str(self.vm.jailer_clone_pid)])
+        print(f"Connect gdb with:\n\tgdb --ex 'target remote {DOCKER.ip}:{port}'")
+
+    def lldbserver(self, port=2001):
+        """Attach lldb-server to the FC process
+
+        See https://lldb.llvm.org/use/remote.html
+
+        TBD does not work. Fails with
+          error: attach failed: lost connection
+        """
+        # Unlike gdbserver, lldb-server is not a separate package, but is part
+        # of lldb and it's about ~400MB to install, so we don't include it in
+        # the devctr
+        subprocess.run("apt update && apt install lldb", shell=True, check=True)
+        subprocess.Popen(["lldb-server", "p", "--listen", f"*:{port}", "--server"])
+        print(
+            f"Connect lldb with\n\tlldb -o 'platform select remote-linux' -o 'platform connect connect://{DOCKER.ip}:{port}' -o 'attach {self.vm.jailer_clone_pid}'"
+        )
+
+    def tmux_neww(self, cmd: str):
+        """Open a window in the local tmux"""
+        return subprocess.run(["tmux", "neww", cmd], check=True)
+
+    def how_to_ssh(self):
+        """Print how to SSH to the microvm
+
+        This may be useful for example to get a terminal
+        """
+        ip = self.vm.iface["eth0"]["iface"].guest_ip
+        return f"ip netns exec {self.vm.jailer.netns} ssh -o StrictHostKeyChecking=no -i {self.vm.ssh_key} root@{ip}"
+
+    def tmux_ssh(self):
+        """Open a tmux window with an SSH session to the VM"""
+        return self.tmux_neww(self.how_to_ssh())
+
+    def enable_console(self):
+        """Helper method to attach a console, before the machine boots"""
+        if self.vm.api is not None:
+            raise RuntimeError(".spawn already called, too late to enable the console")
+        if self.vm.boot_args is None:
+            self.vm.boot_args = ""
+        self.vm.boot_args += "console=ttyS0 reboot=k panic=1"
+        self.vm.jailer.daemonize = False
+
+    def how_to_console(self):
+        """Print how to connect to the VM console"""
+        return f"screen -dR {self.vm.screen_session}"
+
+    def tmux_console(self):
+        """Open a tmux window with the console"""
+        return self.tmux_neww(self.how_to_console())
+
+    def how_to_docker(self):
+        """How to get into this container from outside"""
+        return f"docker exec -it {DOCKER.id}"
+
+    def enable_ip_forwarding(self):
+        """
+        Enables IP forwarding
+
+        TBD this only works for a single microvm. allow several microvms.
+          we need to make the veth network smaller and **allocate** them
+          accordingly
+        """
+        netns = self.vm.jailer.netns
+        vethhost = "vethhost0"
+        vethhost_ip = "10.0.0.1"
+        veth_net = "10.0.0.0/255.255.255.0"
+        tap_net = "192.168.0.0/255.255.255.0"
+        tap_host_ip = self.vm.iface["eth0"]["iface"].host_ip
+
+        def run(cmd):
+            return subprocess.run(cmd, shell=True, check=True)
+
+        def run_in_netns(cmd):
+            return run(f"ip netns exec {netns} " + cmd)
+
+        # outside netns
+        # iptables -L -v -n
+        run(f"ip link add name {vethhost} type veth peer name vethvpn0 netns {netns}")
+        run(f"ip addr add {vethhost_ip}/24 dev {vethhost}")
+        run_in_netns("ip addr add 10.0.0.2/24 dev vethvpn0")
+        run(f"ip link set {vethhost} up")
+        run_in_netns("ip link set vethvpn0 up")
+
+        run("iptables -P FORWARD DROP")
+        # iptables -L FORWARD
+        # iptables -t nat -L
+        run(f"iptables -t nat -A POSTROUTING -s {veth_net} -o eth0 -j MASQUERADE")
+        run("iptables -A FORWARD -i eth0 -o vethhost0 -j ACCEPT")
+        run("iptables -A FORWARD -i vethhost0 -o eth0 -j ACCEPT")
+
+        # in the netns
+        run_in_netns(f"ip route add default via {vethhost_ip}")
+        # tap_ip = ipaddress.ip_network("192.168.0.1/30", False)
+        run_in_netns("iptables -A FORWARD -i tap0 -o vethvpn0 -j ACCEPT")
+        run_in_netns("iptables -A FORWARD -i vethvpn0 -o tap0  -j ACCEPT")
+        run_in_netns(
+            f"iptables -t nat -A POSTROUTING -s {tap_net} -o vethvpn0 -j MASQUERADE"
+        )
+
+        self.vm.ssh.run(f"ip route add default via {tap_host_ip}")
+        self.vm.ssh.run("echo nameserver 8.8.8.8 >/etc/resolv.conf")

--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -54,7 +54,10 @@ class MemoryMonitor(Thread):
         """
 
         guest_mem_bytes = self._vm.mem_size_bytes
-        ps = psutil.Process(self._vm.jailer_clone_pid)
+        try:
+            ps = psutil.Process(self._vm.jailer_clone_pid)
+        except psutil.NoSuchProcess:
+            return
         while not self._should_stop:
             try:
                 mmaps = ps.memory_maps(grouped=False)

--- a/tools/devtool
+++ b/tools/devtool
@@ -410,6 +410,11 @@ cmd_help() {
     echo "        -c, --cpuset-cpus cpulist    Set a dedicated cpulist to be used by the tests."
     echo "        -m, --cpuset-mems memlist    Set a dedicated memlist to be used by the tests."
     echo ""
+
+    cat <<EOF
+    test_debug [-- [<pytest args>]]
+        Run tests in a debugging environment
+EOF
 }
 
 
@@ -690,6 +695,10 @@ cmd_sh() {
         --workdir "$CTR_FC_ROOT_DIR" \
         -- \
         bash --norc -c "$*"
+}
+
+cmd_test_debug() {
+    cmd_sh "tmux new ./tools/test.sh --pdb $@"
 }
 
 # Auto-format all source code, to match the Firecracker requirements. For the


### PR DESCRIPTION
## Changes

Some unrelated changes included:
- a fix for the devctr sanity build
- remove some dead code

## Reason

This enables interactive use of Microvms, will follow up with a sandbox helper script.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
