### PR TITLE
chore: Update vm-memory to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,9 +744,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "linux-loader"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3adb7b28e189741eca3b1a4a27de0bf15e0907c9d4b0c74bd2d7d84ef72e08"
+checksum = "1db6a725c8000971f83fa93ed7ee1b600e55a1471a2a653379d3c84f72effdcf"
 dependencies = [
  "vm-memory",
 ]
@@ -1455,11 +1455,12 @@ checksum = "f43fb5a6bd1a7d423ad72802801036719b7546cf847a103f8fe4575f5b0d45a6"
 
 [[package]]
 name = "vm-memory"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6ea57fe00f9086c59eeeb68e102dd611686bc3c28520fa465996d4d4bdce07"
+checksum = "9dc276f0d00c17b9aeb584da0f1e1c673df0d183cc2539e3636ec8cbc5eae99b"
 dependencies = [
  "libc",
+ "thiserror",
  "winapi",
 ]
 

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0.32"
 versionize = "0.1.10"
 versionize_derive = "0.1.5"
 vmm-sys-util = "0.11.0"
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-bitmap"] }
 
 net_gen = { path = "../net_gen" }
 

--- a/src/utils/src/vm_memory.rs
+++ b/src/utils/src/vm_memory.rs
@@ -272,7 +272,8 @@ fn read_volatile_raw_fd<Fd: AsRawFd + Debug>(
     buf: &mut VolatileSlice<impl BitmapSlice>,
 ) -> Result<usize, VolatileMemoryError> {
     let fd = raw_fd.as_raw_fd();
-    let dst = buf.as_ptr().cast::<libc::c_void>();
+    let guard = buf.ptr_guard_mut();
+    let dst = guard.as_ptr().cast::<libc::c_void>();
 
     // SAFETY: We got a valid file descriptor from `AsRawFd`. The memory pointed to by `dst` is
     // valid for writes of length `buf.len() by the invariants upheld by the constructor
@@ -318,7 +319,8 @@ fn write_volatile_raw_fd<Fd: AsRawFd + Debug>(
     buf: &VolatileSlice<impl BitmapSlice>,
 ) -> Result<usize, VolatileMemoryError> {
     let fd = raw_fd.as_raw_fd();
-    let src = buf.as_ptr().cast::<libc::c_void>();
+    let guard = buf.ptr_guard();
+    let src = guard.as_ptr().cast::<libc::c_void>();
 
     // SAFETY: We got a valid file descriptor from `AsRawFd`. The memory pointed to by `src` is
     // valid for reads of length `buf.len() by the invariants upheld by the constructor

--- a/src/vmm/src/devices/virtio/block/io/async_io.rs
+++ b/src/vmm/src/devices/virtio/block/io/async_io.rs
@@ -110,7 +110,7 @@ impl<T: Debug> AsyncFileEngine<T> {
         user_data: T,
     ) -> Result<(), UserDataError<T, AsyncIoError>> {
         let buf = match mem.get_slice(addr, count as usize) {
-            Ok(slice) => slice.as_ptr(),
+            Ok(slice) => slice.ptr_guard_mut().as_ptr(),
             Err(err) => {
                 return Err(UserDataError {
                     user_data,
@@ -147,7 +147,7 @@ impl<T: Debug> AsyncFileEngine<T> {
         user_data: T,
     ) -> Result<(), UserDataError<T, AsyncIoError>> {
         let buf = match mem.get_slice(addr, count as usize) {
-            Ok(slice) => slice.as_ptr(),
+            Ok(slice) => slice.ptr_guard_mut().as_ptr(),
             Err(err) => {
                 return Err(UserDataError {
                     user_data,

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -141,6 +141,7 @@ impl IoVecBuffer {
             // region in the GuestMemoryMmap.
             let iov_base = mem
                 .get_slice(desc.addr, desc.len as usize)?
+                .ptr_guard_mut()
                 .as_ptr()
                 .cast::<c_void>();
             vecs.push(iovec {
@@ -250,7 +251,7 @@ impl IoVecBufferMut {
             // vm-memory related information after converting down to iovecs.
             slice.bitmap().mark_dirty(0, desc.len as usize);
 
-            let iov_base = slice.as_ptr().cast::<c_void>();
+            let iov_base = slice.ptr_guard_mut().as_ptr().cast::<c_void>();
             vecs.push(iovec {
                 iov_base,
                 iov_len: desc.len as size_t,

--- a/src/vmm/tests/io_uring.rs
+++ b/src/vmm/tests/io_uring.rs
@@ -41,6 +41,7 @@ mod test_utils {
                             .as_volatile_slice()
                             .subslice(i, 1)
                             .unwrap()
+                            .ptr_guard_mut()
                             .as_ptr() as usize,
                         1,
                         i as u64,
@@ -52,6 +53,7 @@ mod test_utils {
                             .as_volatile_slice()
                             .subslice(i, 1)
                             .unwrap()
+                            .ptr_guard_mut()
                             .as_ptr() as usize,
                         1,
                         i as u64,


### PR DESCRIPTION
With 0.12.1, .as_ptr() got deprecated because on Xen, some additional guards need to be around before VolatileSlices can be accessed (as memory is mapped in on-demand, and those guards call mmap and mmunmap). On KVM, these are no-ops, so just inserting .ptr_guard() at the correct spaces is okay.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
