### PR TITLE
test: add a new test to run Firecracker in popular Docker containers

### DIFF
--- a/tools/test-popular-containers/build_rootfs.sh
+++ b/tools/test-popular-containers/build_rootfs.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# fail if we encounter an error, uninitialized variable or a pipe breaks
+set -eu -o pipefail
+set -x
+
+cd $(dirname $0)
+TOPDIR=$(git rev-parse --show-cdup)
+
+function make_rootfs {
+    local LABEL=$1
+    local rootfs=$LABEL
+    local IMG=$LABEL.ext4
+    mkdir $LABEL
+    ctr image pull docker.io/library/$LABEL
+    ctr image mount --rw docker.io/library/$LABEL $LABEL
+    MNT_SIZE=$(du -sb $LABEL |cut -f1)
+    SIZE=$(( $MNT_SIZE + 512 * 2**20 ))
+
+    # Generate key for ssh access from host
+    if [ ! -s id_rsa ]; then
+        ssh-keygen -f id_rsa -N ""
+    fi
+    cp id_rsa $rootfs.id_rsa
+
+    truncate -s "$SIZE" "$IMG"
+    mkfs.ext4 -F "$IMG" -d $LABEL
+    ctr image unmount $LABEL
+    rmdir $LABEL
+
+    mkdir mnt
+    mount $IMG mnt
+    install -d -m 0600 "mnt/root/.ssh/"
+    cp -v id_rsa.pub "mnt/root/.ssh/authorized_keys"
+    cp -rvf $TOPDIR/resources/overlay/* mnt
+    SYSINIT=mnt/etc/systemd/system/sysinit.target.wants
+    mkdir -pv $SYSINIT
+    ln -svf /etc/systemd/system/fcnet.service $SYSINIT/fcnet.service
+    mkdir mnt/etc/local.d
+    cp -v fcnet.start mnt/etc/local.d
+    umount -l mnt
+    rmdir mnt
+
+    systemd-nspawn --pipe -i $IMG /bin/sh <<EOF
+set -x
+. /etc/os-release
+passwd -d root
+case \$ID in
+ubuntu)
+    export DEBIAN_FRONTEND=noninteractive
+    apt update
+    apt install -y openssh-server iproute2
+    ;;
+alpine)
+    apk add openssh openrc
+    rc-update add sshd
+    rc-update add local default
+    echo "ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100" >>/etc/inittab
+    ;;
+esac
+EOF
+}
+
+make_rootfs alpine:latest
+make_rootfs ubuntu:22.04
+make_rootfs ubuntu:23.04
+# make_rootfs ubuntu:latest

--- a/tools/test-popular-containers/fcnet.start
+++ b/tools/test-popular-containers/fcnet.start
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+mount -t sysfs sysfs /sys
+devs=$(ls /sys/class/net | grep -v lo)
+for dev in $devs; do
+    ip=$(printf "%d.%d.%d.%d" $(echo -n 0x; cut -d: -f3- -O ' 0x' /sys/class/net/$dev/address))
+    ip addr add "$ip/30" dev $dev
+    ip link set $dev up
+done

--- a/tools/test-popular-containers/test-docker-rootfs.py
+++ b/tools/test-popular-containers/test-docker-rootfs.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint:disable=invalid-name
+
+"""
+Test all the ext4 rootfs in the current directory
+"""
+
+from pathlib import Path
+
+from framework.artifacts import kernels
+from framework.microvm import MicroVMFactory
+
+kernels = list(kernels("vmlinux-*"))
+# Use the latest guest kernel
+kernel = kernels[-1]
+
+vmfcty = MicroVMFactory("/srv", None)
+# (may take a while to compile Firecracker...)
+
+for rootfs in Path(".").glob("*.ext4"):
+    print(f">>>> Testing {rootfs}")
+    uvm = vmfcty.build(kernel, rootfs)
+    uvm.spawn()
+    uvm.add_net_iface()
+    uvm.basic_config()
+    uvm.start()
+    rc, stdout, stderr = uvm.ssh.run("cat /etc/issue")
+    print(rc, stdout, stderr)


### PR DESCRIPTION
The test is separated from the main integration tests as it reuires to build rootfs before running.

## Changes

Add a new test for popular Docker containers.

## Reason

Ensure Firecracker can run the latest popular container images.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
