### PR TITLE
Fix spelling of 'nomodule' kernel param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@
 - Fixed the T2S CPU template to set the GDS_NO bit of the IA32_ARCH_CAPABILITIES
   MSR to 1 in accordance with an Intel microcode update. To use the template
   securely, users should apply the latest microcode update on the host.
+- Fixed the spelling of the `nomodule` param passed in the default kernel
+  command line parameters. This is a **breaking change** for setups that
+  use the default kernel command line which also depend on being able to
+  load kernel modules at runtime. This may also break setups which use the
+  default kernel command line and which use an init binary that
+  inadvertently depends on the misspelled param ("nomodules") being
+  present at the command line, since this param will no longer be passed.
 
 ## [1.4.0]
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -134,7 +134,7 @@ line that enables the serial console (which goes in the `boot_args` field of
 the `/boot-source` Firecracker API resource):
 
 ```console
-console=ttyS0 reboot=k panic=1 pci=off nomodules
+console=ttyS0 reboot=k panic=1 pci=off nomodule
 ```
 
 ### How can I configure multiple Ethernet devices through the kernel command line?

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -1448,7 +1448,7 @@ mod tests {
     #[test]
     fn test_set_boot_source() {
         let tmp_file = TempFile::new().unwrap();
-        let cmdline = "reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0";
+        let cmdline = "reboot=k panic=1 pci=off nomodule 8250.nr_uarts=0";
         let expected_boot_cfg = BootSourceConfig {
             kernel_image_path: String::from(tmp_file.as_path().to_str().unwrap()),
             initrd_path: Some(String::from(tmp_file.as_path().to_str().unwrap())),

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -12,13 +12,13 @@ use versionize_derive::Versionize;
 /// - `reboot=k` shut down the guest on reboot, instead of well... rebooting;
 /// - `panic=1` on panic, reboot after 1 second;
 /// - `pci=off` do not scan for PCI devices (save boot time);
-/// - `nomodules` disable loadable kernel module support;
+/// - `nomodule` disable loadable kernel module support;
 /// - `8250.nr_uarts=0` disable 8250 serial interface;
 /// - `i8042.noaux` do not probe the i8042 controller for an attached mouse (save boot time);
 /// - `i8042.nomux` do not probe i8042 for a multiplexing controller (save boot time);
 /// - `i8042.nopnp` do not use ACPIPnP to discover KBD/AUX controllers (save boot time);
 /// - `i8042.dumbkbd` do not attempt to control kbd state via the i8042 (save boot time).
-pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0 \
+pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodule 8250.nr_uarts=0 \
                                           i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd";
 
 /// Strongly typed data structure used to configure the boot source of the
@@ -30,8 +30,8 @@ pub struct BootSourceConfig {
     pub kernel_image_path: String,
     /// Path of the initrd, if there is one.
     pub initrd_path: Option<String>,
-    /// The boot arguments to pass to the kernel. If this field is uninitialized, the default
-    /// kernel command line is used: `reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0`.
+    /// The boot arguments to pass to the kernel. If this field is uninitialized,
+    /// DEFAULT_KERNEL_CMDLINE is used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boot_args: Option<String>,
 }

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -558,7 +558,7 @@ class Microvm:
         the response is within the interval [200, 300).
 
         If boot_args is None, the default boot_args in Firecracker is
-            reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0
+            reboot=k panic=1 pci=off nomodule 8250.nr_uarts=0
             i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd
 
         Reference: file:../../src/vmm/src/vmm_config/boot_source.rs::DEFAULT_KERNEL_CMDLINE

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -18,7 +18,7 @@ MAX_BOOT_TIME_US = 150000
 TIMESTAMP_LOG_REGEX = r"Guest-boot-time\s+\=\s+(\d+)\s+us"
 
 DEFAULT_BOOT_ARGS = (
-    "reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0"
+    "reboot=k panic=1 pci=off nomodule 8250.nr_uarts=0"
     " i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd"
 )
 


### PR DESCRIPTION
## Changes

Changes "nomodules" in the default kernel cmdline to "nomodule", the correct spelling. The old argument was not recognized by the kernel and incorrectly forwarded to init binaries.

Reference: https://www.kernel.org/doc/html/v4.10/admin-guide/kernel-parameters.html

Note, **this is a breaking change** for anyone who is relying on the default kernel command line, and happens to be loading kernel modules at runtime - or if their init binary was inadvertently relying on `nomodules` to be present in argv.

Fixes https://github.com/firecracker-microvm/firecracker/issues/4090

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
