### PR TITLE
Re-enable performance baselines

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -47,7 +47,7 @@ def build_group(test):
     retries = test.pop("retries")
     return group(
         label=test.pop("label"),
-        command=f"./tools/devtool -y test {devtool_opts} -- -m nonci --reruns {retries} {test_path}",
+        command=f"./tools/devtool -y test {devtool_opts} -- -m nonci --reruns {retries} --perf-fail {test_path}",
         artifacts=["./test_results/*"],
         instances=test.pop("instances"),
         platforms=test.pop("platforms"),

--- a/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
@@ -6,13 +6,13 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 935745
+                                                    "target": 911248
                                                 }
                                             }
                                         },
@@ -20,14 +20,34 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1798083
+                                                    "target": 1753599
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 885803
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1774979
                                                 }
                                             }
                                         }
                                     }
                                 },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -48,13 +68,13 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 934430
+                                                    "delta_percentage": 7,
+                                                    "target": 913996
                                                 }
                                             }
                                         },
@@ -62,14 +82,34 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1620683
+                                                    "target": 1593635
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 864957
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 1758214
                                                 }
                                             }
                                         }
                                     }
                                 },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
@@ -90,8 +130,36 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 174
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -119,7 +187,7 @@
                                     }
                                 },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -148,16 +216,16 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 47
+                                                    "delta_percentage": 7,
+                                                    "target": 46
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 58
                                                 }
                                             }
@@ -166,7 +234,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 62
+                                                    "target": 61
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
@@ -176,8 +244,36 @@
                                         }
                                     }
                                 },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 45
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 54
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 69
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 74
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -215,13 +311,33 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 392494
+                                                    "target": 290314
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 953899
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 293700
                                                 }
                                             }
                                         },
@@ -229,27 +345,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 1094289
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 389179
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1065578
+                                                    "target": 946739
                                                 }
                                             }
                                         }
@@ -257,41 +353,41 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 389268
+                                                    "delta_percentage": 24,
+                                                    "target": 340132
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 885564
+                                                    "delta_percentage": 6,
+                                                    "target": 856704
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 386365
+                                                    "delta_percentage": 5,
+                                                    "target": 365664
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 865267
+                                                    "delta_percentage": 5,
+                                                    "target": 868071
                                                 }
                                             }
                                         }
@@ -299,8 +395,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -327,8 +423,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -357,45 +453,45 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 43
+                                                    "delta_percentage": 7,
+                                                    "target": 40
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 52
+                                                    "delta_percentage": 11,
+                                                    "target": 48
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 76
+                                                    "delta_percentage": 5,
+                                                    "target": 72
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 79
+                                                    "delta_percentage": 6,
+                                                    "target": 78
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 43
+                                                    "delta_percentage": 8,
+                                                    "target": 41
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 51
+                                                    "delta_percentage": 7,
+                                                    "target": 49
                                                 }
                                             }
                                         },
@@ -403,7 +499,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 75
+                                                    "target": 73
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -420,13 +516,13 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 577468
+                                                    "target": 567705
                                                 }
                                             }
                                         },
@@ -434,27 +530,27 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
-                                                    "target": 1675686
+                                                    "target": 1605901
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 571465
+                                                    "delta_percentage": 9,
+                                                    "target": 573249
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1483646
+                                                    "delta_percentage": 14,
+                                                    "target": 1560202
                                                 }
                                             }
                                         }
@@ -462,13 +558,33 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 19,
-                                                    "target": 603000
+                                                    "delta_percentage": 7,
+                                                    "target": 558000
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1396105
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 23,
+                                                    "target": 615123
                                                 }
                                             }
                                         },
@@ -476,27 +592,7 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1432547
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 606593
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1310847
+                                                    "target": 1301415
                                                 }
                                             }
                                         }
@@ -504,8 +600,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -532,8 +628,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -562,17 +658,17 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 37
+                                                    "delta_percentage": 7,
+                                                    "target": 36
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 49
+                                                    "delta_percentage": 8,
+                                                    "target": 48
                                                 }
                                             }
                                         },
@@ -580,27 +676,27 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 59
+                                                    "target": 58
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 76
+                                                    "target": 75
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 36
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 49
+                                                    "delta_percentage": 13,
+                                                    "target": 50
                                                 }
                                             }
                                         },
@@ -608,10 +704,10 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 65
+                                                    "target": 66
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 70
                                                 }
                                             }
@@ -629,41 +725,41 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 658527
+                                                    "delta_percentage": 9,
+                                                    "target": 629248
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 41,
-                                                    "target": 2010147
+                                                    "delta_percentage": 8,
+                                                    "target": 1966038
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 663559
+                                                    "delta_percentage": 7,
+                                                    "target": 626714
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 1965095
+                                                    "delta_percentage": 8,
+                                                    "target": 1755571
                                                 }
                                             }
                                         }
@@ -671,41 +767,41 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 650260
+                                                    "delta_percentage": 8,
+                                                    "target": 616525
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 23,
-                                                    "target": 2065050
+                                                    "delta_percentage": 8,
+                                                    "target": 1978765
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 671812
+                                                    "delta_percentage": 7,
+                                                    "target": 629537
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 2005666
+                                                    "delta_percentage": 13,
+                                                    "target": 2059834
                                                 }
                                             }
                                         }
@@ -713,8 +809,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -741,8 +837,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -771,57 +867,57 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 32
+                                                    "delta_percentage": 10,
+                                                    "target": 31
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 40
+                                                    "delta_percentage": 8,
+                                                    "target": 39
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 62
+                                                    "delta_percentage": 6,
+                                                    "target": 63
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 75
+                                                    "delta_percentage": 7,
+                                                    "target": 74
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 32
+                                                    "delta_percentage": 7,
+                                                    "target": 30
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 41
+                                                    "target": 39
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 66
+                                                    "delta_percentage": 7,
+                                                    "target": 63
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 71
+                                                    "delta_percentage": 10,
+                                                    "target": 72
                                                 }
                                             }
                                         }
@@ -838,33 +934,33 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 26,
-                                                    "target": 666194
+                                                    "delta_percentage": 17,
+                                                    "target": 596933
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1384089
+                                                    "delta_percentage": 10,
+                                                    "target": 1334806
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 586804
+                                                    "delta_percentage": 8,
+                                                    "target": 578730
                                                 }
                                             }
                                         },
@@ -872,7 +968,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 1415491
+                                                    "target": 1406510
                                                 }
                                             }
                                         }
@@ -880,41 +976,41 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 702723
+                                                    "delta_percentage": 7,
+                                                    "target": 697823
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1230806
+                                                    "delta_percentage": 7,
+                                                    "target": 1216393
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 658625
+                                                    "delta_percentage": 20,
+                                                    "target": 595259
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 35,
-                                                    "target": 1171192
+                                                    "delta_percentage": 22,
+                                                    "target": 1188844
                                                 }
                                             }
                                         }
@@ -922,8 +1018,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -950,8 +1046,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -980,25 +1076,25 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 47
+                                                    "delta_percentage": 8,
+                                                    "target": 48
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 56
+                                                    "target": 57
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 65
+                                                    "delta_percentage": 9,
+                                                    "target": 64
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
@@ -1008,29 +1104,29 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 46
+                                                    "target": 48
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 53
+                                                    "delta_percentage": 14,
+                                                    "target": 51
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 69
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 18,
-                                                    "target": 68
+                                                    "delta_percentage": 13,
+                                                    "target": 70
                                                 }
                                             }
                                         }
@@ -1047,33 +1143,13 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 636372
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1841568
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 650562
+                                                    "delta_percentage": 6,
+                                                    "target": 604620
                                                 }
                                             }
                                         },
@@ -1081,7 +1157,27 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 1843245
+                                                    "target": 1781827
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 613354
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 13,
+                                                    "target": 1777307
                                                 }
                                             }
                                         }
@@ -1089,13 +1185,13 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 720994
+                                                    "target": 596754
                                                 }
                                             }
                                         },
@@ -1103,27 +1199,27 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 1623874
+                                                    "target": 1578933
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 728558
+                                                    "delta_percentage": 12,
+                                                    "target": 700695
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1524952
+                                                    "delta_percentage": 9,
+                                                    "target": 1501333
                                                 }
                                             }
                                         }
@@ -1131,13 +1227,13 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 87
+                                                    "target": 86
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -1159,8 +1255,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1189,8 +1285,36 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 38
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 47
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 60
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 74
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1198,35 +1322,7 @@
                                                     "target": 39
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 49
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 60
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 74
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 39
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 49
                                                 }
                                             }
@@ -1238,7 +1334,7 @@
                                                     "target": 67
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 69
                                                 }
                                             }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
@@ -6,73 +6,73 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 853222
+                                                    "delta_percentage": 11,
+                                                    "target": 802469
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1873241
+                                                    "delta_percentage": 10,
+                                                    "target": 1814979
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 855948
+                                                    "delta_percentage": 6,
+                                                    "target": 836522
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1703010
+                                                    "delta_percentage": 8,
+                                                    "target": 1644505
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 806914
+                                                    "delta_percentage": 11,
+                                                    "target": 808061
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1692898
+                                                    "delta_percentage": 10,
+                                                    "target": 1691808
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 820774
+                                                    "delta_percentage": 11,
+                                                    "target": 833168
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1706256
+                                                    "delta_percentage": 8,
+                                                    "target": 1707148
                                                 }
                                             }
                                         }
@@ -80,29 +80,29 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 732870
+                                                    "delta_percentage": 9,
+                                                    "target": 705398
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 1825055
+                                                    "delta_percentage": 11,
+                                                    "target": 1806379
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 849182
+                                                    "delta_percentage": 6,
+                                                    "target": 824612
                                                 }
                                             }
                                         },
@@ -110,43 +110,43 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 1582634
+                                                    "target": 1539441
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 12,
-                                                    "target": 656101
+                                                    "target": 737186
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1779342
+                                                    "delta_percentage": 14,
+                                                    "target": 1772264
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 808956
+                                                    "delta_percentage": 6,
+                                                    "target": 829674
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 22,
-                                                    "target": 1370805
+                                                    "delta_percentage": 7,
+                                                    "target": 1348832
                                                 }
                                             }
                                         }
@@ -154,8 +154,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -206,8 +206,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -260,13 +260,65 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 65
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 75
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 73
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 87
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 48
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 60
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 63
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 80
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 67
+                                                    "target": 66
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
@@ -277,8 +329,8 @@
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 74
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -289,8 +341,8 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 49
+                                                    "delta_percentage": 7,
+                                                    "target": 48
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
@@ -301,63 +353,11 @@
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 65
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 80
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 65
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 73
-                                                }
-                                            }
-                                        },
-                                        "async_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 87
-                                                }
-                                            }
-                                        },
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 48
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 58
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
                                                     "delta_percentage": 6,
                                                     "target": 80
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 16,
+                                                    "delta_percentage": 7,
                                                     "target": 76
                                                 }
                                             }
@@ -375,73 +375,73 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 279138
+                                                    "delta_percentage": 6,
+                                                    "target": 264108
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 833033
+                                                    "delta_percentage": 13,
+                                                    "target": 762900
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 30,
-                                                    "target": 379111
+                                                    "delta_percentage": 6,
+                                                    "target": 303798
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1062322
+                                                    "delta_percentage": 7,
+                                                    "target": 991627
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 274117
+                                                    "target": 264819
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 845227
+                                                    "delta_percentage": 12,
+                                                    "target": 754200
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 26,
-                                                    "target": 369869
+                                                    "delta_percentage": 6,
+                                                    "target": 305838
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1112276
+                                                    "delta_percentage": 11,
+                                                    "target": 976424
                                                 }
                                             }
                                         }
@@ -449,29 +449,29 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 237140
+                                                    "target": 228814
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1362749
+                                                    "delta_percentage": 8,
+                                                    "target": 865846
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 404788
+                                                    "delta_percentage": 9,
+                                                    "target": 303278
                                                 }
                                             }
                                         },
@@ -479,43 +479,43 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 866058
+                                                    "target": 848377
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 232623
+                                                    "delta_percentage": 6,
+                                                    "target": 223847
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1368485
+                                                    "delta_percentage": 7,
+                                                    "target": 1354415
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 405571
+                                                    "delta_percentage": 25,
+                                                    "target": 336192
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 763672
+                                                    "delta_percentage": 7,
+                                                    "target": 767653
                                                 }
                                             }
                                         }
@@ -523,8 +523,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -533,7 +533,7 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 85
+                                                    "target": 86
                                                 }
                                             }
                                         },
@@ -545,7 +545,7 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 172
+                                                    "target": 169
                                                 }
                                             }
                                         },
@@ -575,8 +575,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -584,7 +584,7 @@
                                                     "target": 86
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 86
                                                 }
                                             }
@@ -597,7 +597,7 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 172
+                                                    "target": 171
                                                 }
                                             }
                                         },
@@ -629,49 +629,49 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 57
+                                                    "delta_percentage": 7,
+                                                    "target": 53
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 58
+                                                    "delta_percentage": 7,
+                                                    "target": 56
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 79
+                                                    "delta_percentage": 8,
+                                                    "target": 78
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 85
+                                                    "delta_percentage": 6,
+                                                    "target": 79
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 43
+                                                    "delta_percentage": 7,
+                                                    "target": 40
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 53
+                                                    "delta_percentage": 9,
+                                                    "target": 47
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 74
+                                                    "delta_percentage": 6,
+                                                    "target": 72
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -681,25 +681,25 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 55
+                                                    "delta_percentage": 8,
+                                                    "target": 53
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 57
+                                                    "delta_percentage": 7,
+                                                    "target": 56
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 79
+                                                    "delta_percentage": 7,
+                                                    "target": 78
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -710,12 +710,12 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 43
+                                                    "delta_percentage": 7,
+                                                    "target": 40
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 53
+                                                    "delta_percentage": 11,
+                                                    "target": 48
                                                 }
                                             }
                                         },
@@ -723,10 +723,10 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 76
+                                                    "target": 73
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 72
                                                 }
                                             }
@@ -740,29 +740,29 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 408375
+                                                    "delta_percentage": 8,
+                                                    "target": 388367
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1546861
+                                                    "delta_percentage": 7,
+                                                    "target": 1519487
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 588958
+                                                    "delta_percentage": 7,
+                                                    "target": 576912
                                                 }
                                             }
                                         },
@@ -770,43 +770,43 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1653366
+                                                    "target": 1604870
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 395657
+                                                    "delta_percentage": 11,
+                                                    "target": 393163
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1093900
+                                                    "delta_percentage": 7,
+                                                    "target": 1104880
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 587810
+                                                    "delta_percentage": 8,
+                                                    "target": 580582
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 1451496
+                                                    "delta_percentage": 13,
+                                                    "target": 1491555
                                                 }
                                             }
                                         }
@@ -814,13 +814,13 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 327959
+                                                    "delta_percentage": 8,
+                                                    "target": 323404
                                                 }
                                             }
                                         },
@@ -828,7 +828,7 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1531080
+                                                    "target": 1546215
                                                 }
                                             }
                                         },
@@ -836,7 +836,7 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 585939
+                                                    "target": 571450
                                                 }
                                             }
                                         },
@@ -844,43 +844,43 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1428960
+                                                    "target": 1400668
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 325986
+                                                    "delta_percentage": 8,
+                                                    "target": 325097
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1512563
+                                                    "delta_percentage": 10,
+                                                    "target": 1516543
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 595356
+                                                    "delta_percentage": 8,
+                                                    "target": 585429
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1301006
+                                                    "delta_percentage": 8,
+                                                    "target": 1349295
                                                 }
                                             }
                                         }
@@ -888,8 +888,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -940,8 +940,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -949,7 +949,7 @@
                                                     "target": 86
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 86
                                                 }
                                             }
@@ -985,8 +985,8 @@
                                                     "target": 172
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 167
+                                                    "delta_percentage": 6,
+                                                    "target": 172
                                                 }
                                             }
                                         }
@@ -994,80 +994,28 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 45
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 54
-                                                }
-                                            }
-                                        },
-                                        "async_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 70
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 85
-                                                }
-                                            }
-                                        },
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 36
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 48
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 59
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 75
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 10,
                                                     "target": 44
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 54
+                                                    "target": 53
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 72
+                                                    "delta_percentage": 8,
+                                                    "target": 68
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 85
                                                 }
                                             }
@@ -1079,7 +1027,59 @@
                                                     "target": 35
                                                 },
                                                 "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 47
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 58
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 75
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
                                                     "delta_percentage": 10,
+                                                    "target": 43
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 53
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 71
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 85
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 35
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
                                                     "target": 48
                                                 }
                                             }
@@ -1091,8 +1091,8 @@
                                                     "target": 63
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 69
+                                                    "delta_percentage": 8,
+                                                    "target": 72
                                                 }
                                             }
                                         }
@@ -1109,57 +1109,21 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 458587
+                                                    "delta_percentage": 7,
+                                                    "target": 437717
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 30,
-                                                    "target": 1662172
-                                                }
-                                            }
-                                        },
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 21,
-                                                    "target": 583106
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 33,
-                                                    "target": 2040787
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 456753
-                                                }
-                                            }
-                                        },
-                                        "async_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1436205
+                                                    "delta_percentage": 12,
+                                                    "target": 1474234
                                                 }
                                             }
                                         },
@@ -1167,15 +1131,51 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 11,
-                                                    "target": 662183
+                                                    "target": 501409
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 18,
-                                                    "target": 1746666
+                                                    "delta_percentage": 10,
+                                                    "target": 1933756
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 438432
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 1391792
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 13,
+                                                    "target": 500663
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 1607775
                                                 }
                                             }
                                         }
@@ -1183,29 +1183,65 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 545903
+                                                    "delta_percentage": 7,
+                                                    "target": 520457
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1667210
+                                                    "delta_percentage": 12,
+                                                    "target": 1677390
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
+                                                    "delta_percentage": 14,
+                                                    "target": 606847
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 1910809
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 662192
+                                                    "target": 521704
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 11,
+                                                    "target": 1684400
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 651405
                                                 }
                                             }
                                         },
@@ -1213,43 +1249,7 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 2030186
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 547736
-                                                }
-                                            }
-                                        },
-                                        "async_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1663350
-                                                }
-                                            }
-                                        },
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 676014
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1970040
+                                                    "target": 1986786
                                                 }
                                             }
                                         }
@@ -1257,8 +1257,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1309,8 +1309,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1354,7 +1354,7 @@
                                                     "target": 172
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 172
                                                 }
                                             }
@@ -1363,17 +1363,17 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 38
+                                                    "target": 37
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 51
+                                                    "delta_percentage": 7,
+                                                    "target": 49
                                                 }
                                             }
                                         },
@@ -1384,7 +1384,7 @@
                                                     "target": 70
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 85
                                                 }
                                             }
@@ -1396,44 +1396,44 @@
                                                     "target": 27
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 38
+                                                    "delta_percentage": 9,
+                                                    "target": 36
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 61
+                                                    "delta_percentage": 7,
+                                                    "target": 60
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 75
+                                                    "target": 73
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 37
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 51
+                                                    "delta_percentage": 7,
+                                                    "target": 49
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 73
+                                                    "delta_percentage": 7,
+                                                    "target": 71
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -1445,23 +1445,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 28
+                                                    "target": 27
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 38
+                                                    "delta_percentage": 8,
+                                                    "target": 37
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 62
+                                                    "delta_percentage": 7,
+                                                    "target": 60
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 71
+                                                    "target": 73
                                                 }
                                             }
                                         }
@@ -1478,13 +1478,13 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 601980
+                                                    "delta_percentage": 8,
+                                                    "target": 587147
                                                 }
                                             }
                                         },
@@ -1492,35 +1492,35 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1447505
+                                                    "target": 1410548
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 521409
+                                                    "delta_percentage": 15,
+                                                    "target": 509562
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1357763
+                                                    "delta_percentage": 12,
+                                                    "target": 1310494
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 582802
+                                                    "delta_percentage": 14,
+                                                    "target": 577386
                                                 }
                                             }
                                         },
@@ -1528,23 +1528,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 1078942
+                                                    "target": 1084085
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 506108
+                                                    "delta_percentage": 31,
+                                                    "target": 479172
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1388335
+                                                    "delta_percentage": 11,
+                                                    "target": 1371461
                                                 }
                                             }
                                         }
@@ -1552,29 +1552,29 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 24,
-                                                    "target": 488013
+                                                    "delta_percentage": 21,
+                                                    "target": 467494
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1529788
+                                                    "delta_percentage": 12,
+                                                    "target": 1528204
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 622777
+                                                    "delta_percentage": 24,
+                                                    "target": 552838
                                                 }
                                             }
                                         },
@@ -1582,19 +1582,19 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 1257482
+                                                    "target": 1239413
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 31,
-                                                    "target": 433824
+                                                    "delta_percentage": 41,
+                                                    "target": 461436
                                                 }
                                             }
                                         },
@@ -1602,23 +1602,23 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 10,
-                                                    "target": 1499173
+                                                    "target": 1510446
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 25,
-                                                    "target": 557197
+                                                    "delta_percentage": 30,
+                                                    "target": 599222
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1272570
+                                                    "delta_percentage": 7,
+                                                    "target": 1337807
                                                 }
                                             }
                                         }
@@ -1626,8 +1626,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1678,8 +1678,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1732,16 +1732,16 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 64
+                                                    "delta_percentage": 9,
+                                                    "target": 62
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 8,
                                                     "target": 70
                                                 }
                                             }
@@ -1750,7 +1750,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 74
+                                                    "target": 73
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -1761,39 +1761,39 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 45
+                                                    "delta_percentage": 14,
+                                                    "target": 44
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 55
+                                                    "delta_percentage": 11,
+                                                    "target": 54
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 65
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 77
+                                                    "delta_percentage": 6,
+                                                    "target": 78
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 11,
                                                     "target": 62
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 14,
                                                     "target": 69
                                                 }
                                             }
@@ -1813,24 +1813,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 44
+                                                    "delta_percentage": 17,
+                                                    "target": 43
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 53
+                                                    "delta_percentage": 17,
+                                                    "target": 54
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 75
+                                                    "delta_percentage": 6,
+                                                    "target": 76
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 84
+                                                    "target": 85
                                                 }
                                             }
                                         }
@@ -1847,29 +1847,29 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 560624
+                                                    "delta_percentage": 7,
+                                                    "target": 546530
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1755345
+                                                    "delta_percentage": 7,
+                                                    "target": 1681896
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 640961
+                                                    "delta_percentage": 7,
+                                                    "target": 623704
                                                 }
                                             }
                                         },
@@ -1877,27 +1877,27 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 1827282
+                                                    "target": 1753690
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 561735
+                                                    "delta_percentage": 7,
+                                                    "target": 551368
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 1164783
+                                                    "delta_percentage": 13,
+                                                    "target": 1159844
                                                 }
                                             }
                                         },
@@ -1905,15 +1905,15 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 643011
+                                                    "target": 625963
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 1689586
+                                                    "delta_percentage": 10,
+                                                    "target": 1647893
                                                 }
                                             }
                                         }
@@ -1921,21 +1921,21 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 313806
+                                                    "delta_percentage": 15,
+                                                    "target": 312647
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1695536
+                                                    "delta_percentage": 9,
+                                                    "target": 1727220
                                                 }
                                             }
                                         },
@@ -1943,51 +1943,51 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 627277
+                                                    "target": 606910
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1634466
+                                                    "delta_percentage": 8,
+                                                    "target": 1572321
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 311361
+                                                    "target": 306489
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1700093
+                                                    "delta_percentage": 10,
+                                                    "target": 1722850
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 638328
+                                                    "delta_percentage": 8,
+                                                    "target": 625874
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1590743
+                                                    "delta_percentage": 15,
+                                                    "target": 1571901
                                                 }
                                             }
                                         }
@@ -1995,13 +1995,13 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 87
+                                                    "target": 86
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -2047,8 +2047,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -2093,7 +2093,7 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 172
+                                                    "target": 171
                                                 }
                                             }
                                         }
@@ -2101,8 +2101,60 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 45
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 54
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 69
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 85
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 37
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 46
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 59
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 74
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -2118,7 +2170,7 @@
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 70
                                                 },
                                                 "randwrite-bs4096": {
@@ -2131,59 +2183,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 38
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 46
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 59
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 74
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 45
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 54
-                                                }
-                                            }
-                                        },
-                                        "async_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 71
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 85
-                                                }
-                                            }
-                                        },
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 38
+                                                    "target": 37
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
@@ -2195,10 +2195,10 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 66
+                                                    "target": 65
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 10,
                                                     "target": 72
                                                 }
                                             }

--- a/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_6.1.json
@@ -6,13 +6,13 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 901586
+                                                    "delta_percentage": 13,
+                                                    "target": 871712
                                                 }
                                             }
                                         },
@@ -20,43 +20,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 10,
-                                                    "target": 1868818
-                                                }
-                                            }
-                                        },
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 908520
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1693577
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 864224
-                                                }
-                                            }
-                                        },
-                                        "async_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 22,
-                                                    "target": 1447936
+                                                    "target": 1825247
                                                 }
                                             }
                                         },
@@ -64,15 +28,51 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 883932
+                                                    "target": 878951
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1801051
+                                                    "delta_percentage": 8,
+                                                    "target": 1660478
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 862570
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 14,
+                                                    "target": 1435883
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 864404
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 12,
+                                                    "target": 1803450
                                                 }
                                             }
                                         }
@@ -80,29 +80,29 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 674135
+                                                    "delta_percentage": 13,
+                                                    "target": 677825
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 1536357
+                                                    "delta_percentage": 12,
+                                                    "target": 1515373
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 902603
+                                                    "delta_percentage": 7,
+                                                    "target": 878533
                                                 }
                                             }
                                         },
@@ -110,43 +110,43 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1633687
+                                                    "target": 1596700
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 17,
-                                                    "target": 619371
+                                                    "delta_percentage": 12,
+                                                    "target": 639296
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 19,
-                                                    "target": 2070391
+                                                    "delta_percentage": 16,
+                                                    "target": 2088261
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 871585
+                                                    "delta_percentage": 7,
+                                                    "target": 867220
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1668604
+                                                    "delta_percentage": 26,
+                                                    "target": 1574324
                                                 }
                                             }
                                         }
@@ -154,8 +154,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -206,8 +206,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -260,13 +260,13 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 59
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
@@ -278,10 +278,10 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 69
+                                                    "target": 68
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 84
                                                 }
                                             }
@@ -289,11 +289,11 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 43
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 56
                                                 }
                                             }
@@ -306,18 +306,18 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 75
+                                                    "target": 76
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 59
                                                 },
                                                 "randwrite-bs4096": {
@@ -329,8 +329,8 @@
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 86
+                                                    "delta_percentage": 5,
+                                                    "target": 87
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -341,12 +341,12 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 42
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 54
+                                                    "target": 56
                                                 }
                                             }
                                         },
@@ -357,8 +357,8 @@
                                                     "target": 74
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 81
+                                                    "delta_percentage": 20,
+                                                    "target": 79
                                                 }
                                             }
                                         }
@@ -375,49 +375,49 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 365668
+                                                    "delta_percentage": 15,
+                                                    "target": 282829
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 829203
+                                                    "delta_percentage": 6,
+                                                    "target": 783728
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 421588
+                                                    "delta_percentage": 9,
+                                                    "target": 393886
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1114892
+                                                    "delta_percentage": 7,
+                                                    "target": 970548
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 30,
-                                                    "target": 352435
+                                                    "delta_percentage": 22,
+                                                    "target": 299607
                                                 }
                                             }
                                         },
@@ -425,15 +425,15 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 870549
+                                                    "target": 795790
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 418514
+                                                    "delta_percentage": 7,
+                                                    "target": 401083
                                                 }
                                             }
                                         },
@@ -441,7 +441,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1111024
+                                                    "target": 1025492
                                                 }
                                             }
                                         }
@@ -449,65 +449,65 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 234867
+                                                    "delta_percentage": 8,
+                                                    "target": 216356
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1001308
+                                                    "delta_percentage": 9,
+                                                    "target": 873899
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 421741
+                                                    "delta_percentage": 7,
+                                                    "target": 385109
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 814447
+                                                    "delta_percentage": 6,
+                                                    "target": 780607
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 24,
-                                                    "target": 238501
+                                                    "delta_percentage": 7,
+                                                    "target": 218628
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 46,
-                                                    "target": 1211156
+                                                    "delta_percentage": 10,
+                                                    "target": 942393
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 423716
+                                                    "delta_percentage": 7,
+                                                    "target": 394880
                                                 }
                                             }
                                         },
@@ -515,7 +515,7 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 10,
-                                                    "target": 735063
+                                                    "target": 745084
                                                 }
                                             }
                                         }
@@ -523,8 +523,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -541,11 +541,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 174
+                                                    "target": 173
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 169
+                                                    "delta_percentage": 5,
+                                                    "target": 172
                                                 }
                                             }
                                         },
@@ -575,8 +575,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -596,8 +596,8 @@
                                                     "target": 173
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 169
+                                                    "delta_percentage": 5,
+                                                    "target": 172
                                                 }
                                             }
                                         },
@@ -617,11 +617,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 174
+                                                    "target": 173
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 173
+                                                    "delta_percentage": 5,
+                                                    "target": 172
                                                 }
                                             }
                                         }
@@ -629,17 +629,17 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 52
+                                                    "delta_percentage": 7,
+                                                    "target": 55
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 50
+                                                    "delta_percentage": 7,
+                                                    "target": 51
                                                 }
                                             }
                                         },
@@ -651,47 +651,47 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 77
+                                                    "target": 75
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 42
+                                                    "delta_percentage": 10,
+                                                    "target": 41
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 53
+                                                    "delta_percentage": 8,
+                                                    "target": 50
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 71
+                                                    "delta_percentage": 6,
+                                                    "target": 68
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 74
+                                                    "delta_percentage": 5,
+                                                    "target": 73
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 52
+                                                    "target": 55
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 50
+                                                    "delta_percentage": 6,
+                                                    "target": 51
                                                 }
                                             }
                                         },
@@ -702,32 +702,32 @@
                                                     "target": 75
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 79
+                                                    "delta_percentage": 6,
+                                                    "target": 76
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 42
+                                                    "delta_percentage": 8,
+                                                    "target": 41
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 53
+                                                    "delta_percentage": 8,
+                                                    "target": 51
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 71
+                                                    "delta_percentage": 6,
+                                                    "target": 70
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 68
+                                                    "delta_percentage": 9,
+                                                    "target": 71
                                                 }
                                             }
                                         }
@@ -740,13 +740,13 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 571610
+                                                    "delta_percentage": 5,
+                                                    "target": 547673
                                                 }
                                             }
                                         },
@@ -754,59 +754,59 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 1605089
+                                                    "target": 1569847
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 640879
+                                                    "delta_percentage": 5,
+                                                    "target": 620722
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1646224
+                                                    "delta_percentage": 9,
+                                                    "target": 1572465
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 568151
+                                                    "delta_percentage": 6,
+                                                    "target": 557631
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1180961
+                                                    "delta_percentage": 12,
+                                                    "target": 1242563
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 642366
+                                                    "delta_percentage": 5,
+                                                    "target": 632182
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 16,
-                                                    "target": 1475321
+                                                    "delta_percentage": 7,
+                                                    "target": 1650900
                                                 }
                                             }
                                         }
@@ -814,29 +814,65 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 374403
+                                                    "delta_percentage": 10,
+                                                    "target": 337193
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1755644
+                                                    "delta_percentage": 5,
+                                                    "target": 1713088
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 17,
-                                                    "target": 667251
+                                                    "delta_percentage": 10,
+                                                    "target": 624579
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 5,
+                                                    "target": 1344693
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 339803
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 1691795
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 724023
                                                 }
                                             }
                                         },
@@ -844,43 +880,7 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 1411356
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 370638
-                                                }
-                                            }
-                                        },
-                                        "async_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 1696784
-                                                }
-                                            }
-                                        },
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 686988
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 1350606
+                                                    "target": 1278293
                                                 }
                                             }
                                         }
@@ -888,8 +888,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -898,7 +898,7 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 86
+                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -909,8 +909,8 @@
                                                     "target": 174
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 172
+                                                    "delta_percentage": 5,
+                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -940,8 +940,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -950,19 +950,19 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 86
+                                                    "target": 87
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 174
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 172
+                                                    "target": 173
                                                 }
                                             }
                                         },
@@ -970,7 +970,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 87
+                                                    "target": 88
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -985,8 +985,8 @@
                                                     "target": 174
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 173
+                                                    "delta_percentage": 5,
+                                                    "target": 174
                                                 }
                                             }
                                         }
@@ -994,16 +994,16 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 42
+                                                    "delta_percentage": 11,
+                                                    "target": 43
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 43
                                                 }
                                             }
@@ -1011,11 +1011,11 @@
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 64
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 84
                                                 }
                                             }
@@ -1023,8 +1023,8 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 32
+                                                    "delta_percentage": 8,
+                                                    "target": 33
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 12,
@@ -1035,39 +1035,39 @@
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 9,
                                                     "target": 52
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 73
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 41
-                                                },
-                                                "randwrite-bs4096": {
                                                     "delta_percentage": 7,
                                                     "target": 43
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 8,
+                                                    "target": 44
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 67
+                                                    "delta_percentage": 9,
+                                                    "target": 68
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 83
                                                 }
                                             }
@@ -1075,24 +1075,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 32
+                                                    "delta_percentage": 6,
+                                                    "target": 34
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 48
+                                                    "delta_percentage": 9,
+                                                    "target": 51
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 56
+                                                    "delta_percentage": 5,
+                                                    "target": 60
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 70
+                                                    "delta_percentage": 5,
+                                                    "target": 69
                                                 }
                                             }
                                         }
@@ -1109,73 +1109,73 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 792773
+                                                    "delta_percentage": 8,
+                                                    "target": 762037
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 24,
-                                                    "target": 2386918
+                                                    "delta_percentage": 9,
+                                                    "target": 2267559
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 912132
+                                                    "delta_percentage": 8,
+                                                    "target": 869459
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 24,
-                                                    "target": 2440759
+                                                    "delta_percentage": 13,
+                                                    "target": 2373534
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 812987
+                                                    "delta_percentage": 14,
+                                                    "target": 775659
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 1901128
+                                                    "delta_percentage": 10,
+                                                    "target": 1815433
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 17,
-                                                    "target": 974390
+                                                    "delta_percentage": 12,
+                                                    "target": 892531
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 2228023
+                                                    "delta_percentage": 13,
+                                                    "target": 2114532
                                                 }
                                             }
                                         }
@@ -1183,49 +1183,49 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 17,
-                                                    "target": 712744
+                                                    "target": 743221
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1847448
+                                                    "delta_percentage": 15,
+                                                    "target": 1816353
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 966079
+                                                    "delta_percentage": 10,
+                                                    "target": 839217
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2164717
+                                                    "delta_percentage": 13,
+                                                    "target": 1957716
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 20,
-                                                    "target": 779116
+                                                    "delta_percentage": 16,
+                                                    "target": 832752
                                                 }
                                             }
                                         },
@@ -1233,15 +1233,15 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 12,
-                                                    "target": 1816448
+                                                    "target": 1806351
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1039325
+                                                    "delta_percentage": 9,
+                                                    "target": 1025412
                                                 }
                                             }
                                         },
@@ -1249,7 +1249,7 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 1901595
+                                                    "target": 1819265
                                                 }
                                             }
                                         }
@@ -1257,8 +1257,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1266,7 +1266,7 @@
                                                     "target": 87
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 87
                                                 }
                                             }
@@ -1309,8 +1309,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1318,7 +1318,7 @@
                                                     "target": 87
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 87
                                                 }
                                             }
@@ -1363,69 +1363,17 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 42
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 13,
-                                                    "target": 50
-                                                }
-                                            }
-                                        },
-                                        "async_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 65
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 5,
-                                                    "target": 85
-                                                }
-                                            }
-                                        },
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 33
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 46
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 54
+                                                    "target": 41
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 6,
-                                                    "target": 72
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 43
-                                                },
-                                                "randwrite-bs4096": {
-                                                    "delta_percentage": 15,
-                                                    "target": 53
+                                                    "delta_percentage": 13,
+                                                    "target": 52
                                                 }
                                             }
                                         },
@@ -1433,7 +1381,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 67
+                                                    "target": 64
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
@@ -1444,24 +1392,76 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 33
+                                                    "delta_percentage": 10,
+                                                    "target": 32
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 47
+                                                    "delta_percentage": 9,
+                                                    "target": 44
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 58
+                                                    "delta_percentage": 6,
+                                                    "target": 55
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 67
+                                                    "target": 70
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 42
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 13,
+                                                    "target": 55
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 66
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 6,
+                                                    "target": 84
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 33
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 48
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 10,
+                                                    "target": 57
+                                                },
+                                                "randwrite-bs4096": {
+                                                    "delta_percentage": 7,
+                                                    "target": 66
                                                 }
                                             }
                                         }
@@ -1478,49 +1478,13 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "async_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 656376
-                                                }
-                                            }
-                                        },
-                                        "async_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1450713
-                                                }
-                                            }
-                                        },
-                                        "sync_1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 564514
-                                                }
-                                            }
-                                        },
-                                        "sync_2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "randread-bs4096": {
-                                                    "delta_percentage": 14,
-                                                    "target": 1317760
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 650069
+                                                    "target": 640106
                                                 }
                                             }
                                         },
@@ -1528,23 +1492,59 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1176875
+                                                    "target": 1415878
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 556645
+                                                    "delta_percentage": 19,
+                                                    "target": 572908
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
+                                                    "delta_percentage": 17,
+                                                    "target": 1278157
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 1365314
+                                                    "target": 627893
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 9,
+                                                    "target": 1147213
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 13,
+                                                    "target": 537983
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randread-bs4096": {
+                                                    "delta_percentage": 13,
+                                                    "target": 1318924
                                                 }
                                             }
                                         }
@@ -1552,13 +1552,13 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 382798
+                                                    "delta_percentage": 13,
+                                                    "target": 401324
                                                 }
                                             }
                                         },
@@ -1566,15 +1566,15 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 1138402
+                                                    "target": 1134641
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 674053
+                                                    "delta_percentage": 9,
+                                                    "target": 668841
                                                 }
                                             }
                                         },
@@ -1582,35 +1582,35 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1252589
+                                                    "target": 1230688
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 373215
+                                                    "delta_percentage": 13,
+                                                    "target": 370088
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 31,
-                                                    "target": 1399382
+                                                    "delta_percentage": 34,
+                                                    "target": 1623937
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 11,
-                                                    "target": 663822
+                                                    "delta_percentage": 18,
+                                                    "target": 653404
                                                 }
                                             }
                                         },
@@ -1618,7 +1618,7 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1283213
+                                                    "target": 1320069
                                                 }
                                             }
                                         }
@@ -1626,8 +1626,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1678,8 +1678,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -1732,13 +1732,13 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 53
+                                                    "target": 54
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
@@ -1749,8 +1749,8 @@
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 68
+                                                    "delta_percentage": 8,
+                                                    "target": 69
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
@@ -1761,36 +1761,36 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 40
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 50
+                                                    "target": 51
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 58
+                                                    "delta_percentage": 11,
+                                                    "target": 59
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 73
+                                                    "target": 74
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 9,
-                                                    "target": 53
+                                                    "target": 52
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
@@ -1805,19 +1805,19 @@
                                                     "target": 84
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 84
+                                                    "delta_percentage": 8,
+                                                    "target": 86
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 40
+                                                    "delta_percentage": 13,
+                                                    "target": 39
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 14,
                                                     "target": 50
                                                 }
                                             }
@@ -1830,7 +1830,7 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 79
+                                                    "target": 81
                                                 }
                                             }
                                         }
@@ -1847,13 +1847,13 @@
                     {
                         "baselines": {
                             "bw_read": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 634445
+                                                    "delta_percentage": 6,
+                                                    "target": 610412
                                                 }
                                             }
                                         },
@@ -1861,59 +1861,59 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 1814477
+                                                    "target": 1748157
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 708636
+                                                    "delta_percentage": 6,
+                                                    "target": 686865
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1843495
+                                                    "delta_percentage": 8,
+                                                    "target": 1789831
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 636239
+                                                    "delta_percentage": 6,
+                                                    "target": 624928
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1304204
+                                                    "delta_percentage": 11,
+                                                    "target": 1280157
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 7,
-                                                    "target": 716646
+                                                    "delta_percentage": 13,
+                                                    "target": 707745
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1817398
+                                                    "delta_percentage": 8,
+                                                    "target": 1826181
                                                 }
                                             }
                                         }
@@ -1921,13 +1921,13 @@
                                 }
                             },
                             "bw_write": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 343285
+                                                    "delta_percentage": 13,
+                                                    "target": 348552
                                                 }
                                             }
                                         },
@@ -1935,15 +1935,15 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 2001307
+                                                    "target": 1988805
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 805845
+                                                    "delta_percentage": 13,
+                                                    "target": 758760
                                                 }
                                             }
                                         },
@@ -1951,27 +1951,27 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 1611252
+                                                    "target": 1550858
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 343769
+                                                    "delta_percentage": 23,
+                                                    "target": 382032
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1926805
+                                                    "delta_percentage": 8,
+                                                    "target": 1980138
                                                 }
                                             }
                                         },
@@ -1979,15 +1979,15 @@
                                             "Avg": {
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 820968
+                                                    "target": 793236
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 10,
-                                                    "target": 1528741
+                                                    "delta_percentage": 9,
+                                                    "target": 1448092
                                                 }
                                             }
                                         }
@@ -1995,8 +1995,8 @@
                                 }
                             },
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -2005,7 +2005,7 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 86
+                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -2047,8 +2047,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
@@ -2057,7 +2057,7 @@
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
-                                                    "target": 86
+                                                    "target": 87
                                                 }
                                             }
                                         },
@@ -2101,25 +2101,25 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 41
+                                                    "delta_percentage": 8,
+                                                    "target": 42
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 41
+                                                    "delta_percentage": 7,
+                                                    "target": 42
                                                 }
                                             }
                                         },
                                         "async_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 65
+                                                    "delta_percentage": 7,
+                                                    "target": 64
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 5,
@@ -2131,11 +2131,11 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 8,
-                                                    "target": 32
+                                                    "target": 33
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 46
+                                                    "delta_percentage": 10,
+                                                    "target": 47
                                                 }
                                             }
                                         },
@@ -2153,17 +2153,17 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "async_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 9,
-                                                    "target": 41
+                                                    "delta_percentage": 8,
+                                                    "target": 43
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 41
+                                                    "delta_percentage": 9,
+                                                    "target": 42
                                                 }
                                             }
                                         },
@@ -2171,23 +2171,23 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 69
+                                                    "target": 68
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 6,
-                                                    "target": 83
+                                                    "target": 84
                                                 }
                                             }
                                         },
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randread-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 32
+                                                    "delta_percentage": 9,
+                                                    "target": 33
                                                 },
                                                 "randwrite-bs4096": {
-                                                    "delta_percentage": 8,
-                                                    "target": 47
+                                                    "delta_percentage": 7,
+                                                    "target": 48
                                                 }
                                             }
                                         },
@@ -2195,7 +2195,7 @@
                                             "Avg": {
                                                 "randread-bs4096": {
                                                     "delta_percentage": 7,
-                                                    "target": 56
+                                                    "target": 57
                                                 },
                                                 "randwrite-bs4096": {
                                                     "delta_percentage": 7,

--- a/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
@@ -6,20 +6,32 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 24.1,
-                                                    "target": 0.025
+                                                    "delta_percentage": 42,
+                                                    "target": 0.026
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "delta_percentage": 16,
+                                                    "target": 0.032
                                                 }
                                             }
                                         }
                                     }
                                 },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
@@ -41,25 +53,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 10.1,
-                                                    "target": 0.059
+                                                    "delta_percentage": 10,
+                                                    "target": 0.046
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 7.1,
-                                                    "target": 0.067
+                                                    "delta_percentage": 8,
+                                                    "target": 0.055
                                                 }
                                             }
                                         }
@@ -72,25 +84,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 10.1,
-                                                    "target": 0.08
+                                                    "delta_percentage": 11,
+                                                    "target": 0.06
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 6.1,
-                                                    "target": 0.094
+                                                    "delta_percentage": 11,
+                                                    "target": 0.074
                                                 }
                                             }
                                         }
@@ -107,25 +119,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 9.1,
-                                                    "target": 0.147
+                                                    "delta_percentage": 12,
+                                                    "target": 0.124
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 8.1,
-                                                    "target": 0.161
+                                                    "delta_percentage": 8,
+                                                    "target": 0.142
                                                 }
                                             }
                                         }
@@ -142,25 +154,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 20.1,
-                                                    "target": 0.034
+                                                    "delta_percentage": 9,
+                                                    "target": 0.032
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 12.1,
-                                                    "target": 0.04
+                                                    "delta_percentage": 13,
+                                                    "target": 0.038
                                                 }
                                             }
                                         }
@@ -177,25 +189,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 23.1,
-                                                    "target": 0.105
+                                                    "delta_percentage": 27,
+                                                    "target": 0.078
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 22.1,
-                                                    "target": 0.119
+                                                    "delta_percentage": 40,
+                                                    "target": 0.101
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
@@ -6,25 +6,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 15.1,
-                                                    "target": 0.026
+                                                    "delta_percentage": 13,
+                                                    "target": 0.027
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 15.1,
-                                                    "target": 0.028
+                                                    "delta_percentage": 15,
+                                                    "target": 0.029
                                                 }
                                             }
                                         }
@@ -41,25 +41,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 33.1,
-                                                    "target": 0.062
+                                                    "delta_percentage": 13,
+                                                    "target": 0.048
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 10.1,
-                                                    "target": 0.066
+                                                    "delta_percentage": 17,
+                                                    "target": 0.054
                                                 }
                                             }
                                         }
@@ -72,25 +72,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 14.1,
-                                                    "target": 0.08
+                                                    "delta_percentage": 17,
+                                                    "target": 0.062
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 12.1,
-                                                    "target": 0.085
+                                                    "delta_percentage": 13,
+                                                    "target": 0.072
                                                 }
                                             }
                                         }
@@ -107,25 +107,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 13.1,
-                                                    "target": 0.088
+                                                    "delta_percentage": 22,
+                                                    "target": 0.073
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 7.1,
-                                                    "target": 0.099
+                                                    "delta_percentage": 16,
+                                                    "target": 0.086
                                                 }
                                             }
                                         }
@@ -142,25 +142,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 22.1,
-                                                    "target": 0.033
+                                                    "delta_percentage": 15,
+                                                    "target": 0.032
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 24.1,
-                                                    "target": 0.037
+                                                    "delta_percentage": 18,
+                                                    "target": 0.035
                                                 }
                                             }
                                         }
@@ -177,25 +177,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 12.1,
-                                                    "target": 0.043
+                                                    "delta_percentage": 16,
+                                                    "target": 0.033
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 12.1,
-                                                    "target": 0.044
+                                                    "delta_percentage": 15,
+                                                    "target": 0.038
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_latency_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_6.1.json
@@ -6,24 +6,24 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 18.1,
+                                                    "delta_percentage": 12,
                                                     "target": 0.026
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 12.1,
+                                                    "delta_percentage": 13,
                                                     "target": 0.026
                                                 }
                                             }
@@ -41,25 +41,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 8.1,
-                                                    "target": 0.054
+                                                    "delta_percentage": 10,
+                                                    "target": 0.044
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 9.1,
-                                                    "target": 0.061
+                                                    "delta_percentage": 14,
+                                                    "target": 0.053
                                                 }
                                             }
                                         }
@@ -72,25 +72,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 5.1,
-                                                    "target": 0.077
+                                                    "delta_percentage": 9,
+                                                    "target": 0.06
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 3.1,
-                                                    "target": 0.087
+                                                    "delta_percentage": 8,
+                                                    "target": 0.072
                                                 }
                                             }
                                         }
@@ -107,25 +107,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 8.1,
-                                                    "target": 0.074
+                                                    "delta_percentage": 20,
+                                                    "target": 0.061
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 8.1,
-                                                    "target": 0.085
+                                                    "delta_percentage": 12,
+                                                    "target": 0.073
                                                 }
                                             }
                                         }
@@ -142,24 +142,24 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 6.1,
-                                                    "target": 0.03
+                                                    "delta_percentage": 12,
+                                                    "target": 0.031
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 12.1,
+                                                    "delta_percentage": 14,
                                                     "target": 0.032
                                                 }
                                             }
@@ -177,25 +177,25 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 6.1,
-                                                    "target": 0.036
+                                                    "delta_percentage": 10,
+                                                    "target": 0.029
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 8.1,
-                                                    "target": 0.041
+                                                    "delta_percentage": 13,
+                                                    "target": 0.036
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
@@ -6,8 +6,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -31,12 +31,12 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 200
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 154
+                                                    "delta_percentage": 11,
+                                                    "target": 144
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -58,8 +58,60 @@
                                         }
                                     }
                                 },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 12,
+                                                    "target": 155
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 185
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -112,21 +164,73 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 94
+                                                    "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 91
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 97
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 6,
+                                                    "target": 92
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 92
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 96
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 7,
+                                                    "target": 92
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 91
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 97
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 8,
+                                                    "target": 89
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 8,
+                                                    "target": 91
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 88
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
@@ -137,24 +241,24 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 92
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 92
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
                                                     "target": 95
                                                 },
-                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 5,
+                                                    "target": 94
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 91
+                                                    "target": 96
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 8,
+                                                    "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 90
+                                                    "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -165,7 +269,7 @@
                                     }
                                 },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -218,60 +322,112 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 20,
-                                                    "target": 57561
+                                                    "delta_percentage": 13,
+                                                    "target": 53028
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 54164
+                                                    "target": 54405
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 50444
+                                                    "delta_percentage": 6,
+                                                    "target": 48526
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 53263
+                                                    "delta_percentage": 5,
+                                                    "target": 52798
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 50448
+                                                    "delta_percentage": 5,
+                                                    "target": 49471
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 48644
+                                                    "target": 47386
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 53198
+                                                    "target": 53121
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 46474
+                                                    "delta_percentage": 5,
+                                                    "target": 45640
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 45965
+                                                    "delta_percentage": 6,
+                                                    "target": 44705
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 50349
+                                                    "target": 49770
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 5,
+                                                    "target": 50872
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 52473
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 47613
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 53054
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 5,
+                                                    "target": 51876
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 5,
+                                                    "target": 50307
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 53279
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 5,
+                                                    "target": 50067
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 5,
+                                                    "target": 46799
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 50806
                                                 }
                                             }
                                         }
                                     }
                                 },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -333,8 +489,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -342,12 +498,12 @@
                                                     "target": 99
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 21,
-                                                    "target": 84
+                                                    "delta_percentage": 20,
+                                                    "target": 92
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
@@ -358,48 +514,48 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 10,
-                                                    "target": 143
+                                                    "delta_percentage": 9,
+                                                    "target": 144
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 124
+                                                    "delta_percentage": 8,
+                                                    "target": 125
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 178
+                                                    "delta_percentage": 9,
+                                                    "target": 175
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 12,
                                                     "target": 148
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 9,
                                                     "target": 109
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 189
+                                                    "target": 188
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 16,
-                                                    "target": 94
+                                                    "delta_percentage": 12,
+                                                    "target": 97
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 21,
-                                                    "target": 88
+                                                    "delta_percentage": 18,
+                                                    "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -410,28 +566,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 124
+                                                    "delta_percentage": 7,
+                                                    "target": 125
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 115
+                                                    "delta_percentage": 11,
+                                                    "target": 114
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 179
+                                                    "delta_percentage": 10,
+                                                    "target": 177
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 128
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 111
+                                                    "delta_percentage": 9,
+                                                    "target": 112
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 184
+                                                    "target": 185
                                                 }
                                             }
                                         }
@@ -439,24 +595,24 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 90
+                                                    "delta_percentage": 7,
+                                                    "target": 91
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 87
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
                                                     "target": 88
                                                 },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
+                                                    "target": 89
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 7,
                                                     "target": 89
                                                 }
                                             }
@@ -469,11 +625,11 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 89
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 87
+                                                    "target": 88
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
@@ -481,27 +637,27 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 89
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 93
+                                                    "target": 92
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 89
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 85
+                                                    "delta_percentage": 7,
+                                                    "target": 87
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
@@ -509,34 +665,34 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 87
+                                                    "target": 91
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 94
+                                                    "delta_percentage": 6,
+                                                    "target": 95
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
                                                     "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 95
+                                                    "delta_percentage": 6,
+                                                    "target": 94
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 96
                                                 }
                                             }
@@ -545,105 +701,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 27953
+                                                    "delta_percentage": 8,
+                                                    "target": 28327
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 29786
+                                                    "delta_percentage": 7,
+                                                    "target": 30125
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 26306
+                                                    "delta_percentage": 7,
+                                                    "target": 26457
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 28385
+                                                    "delta_percentage": 7,
+                                                    "target": 28957
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 10,
-                                                    "target": 27919
+                                                    "delta_percentage": 8,
+                                                    "target": 28228
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 27694
+                                                    "delta_percentage": 7,
+                                                    "target": 27349
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 29247
+                                                    "target": 29392
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 26793
+                                                    "delta_percentage": 9,
+                                                    "target": 26693
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 26683
+                                                    "delta_percentage": 7,
+                                                    "target": 26524
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 27988
+                                                    "target": 28192
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 28282
+                                                    "delta_percentage": 8,
+                                                    "target": 28507
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 29073
+                                                    "delta_percentage": 7,
+                                                    "target": 30044
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 27351
+                                                    "delta_percentage": 7,
+                                                    "target": 27233
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 27283
+                                                    "delta_percentage": 7,
+                                                    "target": 28726
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 30821
+                                                    "delta_percentage": 8,
+                                                    "target": 30789
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 29013
+                                                    "delta_percentage": 9,
+                                                    "target": 28589
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 31476
+                                                    "delta_percentage": 11,
+                                                    "target": 31341
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 30261
+                                                    "delta_percentage": 7,
+                                                    "target": 30384
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 27534
+                                                    "target": 27486
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 30321
+                                                    "delta_percentage": 8,
+                                                    "target": 30458
                                                 }
                                             }
                                         }
@@ -656,12 +812,12 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 4,
                                                     "target": 99
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
@@ -669,51 +825,51 @@
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 96
+                                                    "delta_percentage": 8,
+                                                    "target": 98
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 99
+                                                    "target": 98
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 153
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 129
+                                                    "target": 128
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 175
+                                                    "delta_percentage": 9,
+                                                    "target": 178
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
                                                     "target": 155
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 116
+                                                    "delta_percentage": 8,
+                                                    "target": 115
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 191
+                                                    "target": 190
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
@@ -726,35 +882,35 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 99
+                                                    "target": 100
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 128
+                                                    "delta_percentage": 5,
+                                                    "target": 129
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 127
+                                                    "target": 129
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 185
+                                                    "target": 184
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 130
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 11,
                                                     "target": 116
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 196
+                                                    "target": 195
                                                 }
                                             }
                                         }
@@ -762,32 +918,32 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 8,
                                                     "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 89
+                                                    "target": 88
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 89
+                                                    "delta_percentage": 6,
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 89
+                                                    "target": 88
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -796,42 +952,42 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 88
+                                                    "target": 87
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 90
+                                                    "delta_percentage": 5,
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 92
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 88
+                                                    "delta_percentage": 5,
+                                                    "target": 86
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 88
+                                                    "delta_percentage": 10,
+                                                    "target": 87
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 90
+                                                    "delta_percentage": 5,
+                                                    "target": 88
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 90
                                                 }
                                             }
@@ -839,28 +995,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 90
+                                                    "delta_percentage": 6,
+                                                    "target": 91
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 92
+                                                    "delta_percentage": 6,
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 95
+                                                    "delta_percentage": 6,
+                                                    "target": 94
                                                 }
                                             }
                                         }
@@ -868,25 +1024,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 33107
+                                                    "target": 33121
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 35079
+                                                    "target": 35379
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 31181
+                                                    "delta_percentage": 7,
+                                                    "target": 31113
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 33126
+                                                    "delta_percentage": 6,
+                                                    "target": 33379
                                                 }
                                             }
                                         },
@@ -894,79 +1050,79 @@
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 33232
+                                                    "target": 33049
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 32494
+                                                    "target": 32174
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 34486
+                                                    "target": 34348
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 31640
+                                                    "delta_percentage": 4,
+                                                    "target": 31424
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 31324
+                                                    "target": 30962
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 33036
+                                                    "target": 32840
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 32307
+                                                    "delta_percentage": 7,
+                                                    "target": 31929
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 34384
+                                                    "delta_percentage": 11,
+                                                    "target": 34092
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 32080
+                                                    "delta_percentage": 4,
+                                                    "target": 31457
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 33005
+                                                    "delta_percentage": 6,
+                                                    "target": 33196
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 35553
+                                                    "delta_percentage": 4,
+                                                    "target": 35455
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 32989
+                                                    "target": 32475
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 35673
+                                                    "target": 35279
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 34621
+                                                    "target": 34623
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 31838
+                                                    "target": 31526
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 34844
+                                                    "delta_percentage": 6,
+                                                    "target": 34277
                                                 }
                                             }
                                         }
@@ -983,24 +1139,24 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 18,
-                                                    "target": 96
+                                                    "delta_percentage": 44,
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 42,
-                                                    "target": 92
+                                                    "delta_percentage": 64,
+                                                    "target": 86
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -1008,35 +1164,35 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 17,
-                                                    "target": 189
+                                                    "delta_percentage": 18,
+                                                    "target": 182
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 23,
-                                                    "target": 187
+                                                    "delta_percentage": 75,
+                                                    "target": 155
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 21,
-                                                    "target": 185
+                                                    "delta_percentage": 20,
+                                                    "target": 190
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 45,
-                                                    "target": 168
+                                                    "delta_percentage": 66,
+                                                    "target": 147
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 197
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1044,7 +1200,7 @@
                                                     "target": 99
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -1060,28 +1216,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 11,
-                                                    "target": 197
+                                                    "delta_percentage": 74,
+                                                    "target": 158
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 28,
-                                                    "target": 180
+                                                    "delta_percentage": 69,
+                                                    "target": 150
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 197
+                                                    "delta_percentage": 8,
+                                                    "target": 196
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 31,
-                                                    "target": 184
+                                                    "delta_percentage": 70,
+                                                    "target": 155
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 36,
-                                                    "target": 168
+                                                    "delta_percentage": 59,
+                                                    "target": 148
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 }
                                             }
                                         }
@@ -1089,104 +1245,104 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 45,
-                                                    "target": 51
+                                                    "delta_percentage": 72,
+                                                    "target": 71
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 36,
-                                                    "target": 53
+                                                    "delta_percentage": 61,
+                                                    "target": 69
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 23,
-                                                    "target": 79
+                                                    "delta_percentage": 24,
+                                                    "target": 81
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 39,
-                                                    "target": 54
+                                                    "delta_percentage": 61,
+                                                    "target": 72
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 92
+                                                    "delta_percentage": 13,
+                                                    "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 25,
-                                                    "target": 80
+                                                    "delta_percentage": 17,
+                                                    "target": 86
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 90
+                                                    "delta_percentage": 10,
+                                                    "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 88
+                                                    "delta_percentage": 10,
+                                                    "target": 87
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 15,
-                                                    "target": 84
+                                                    "target": 87
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 80
+                                                    "delta_percentage": 20,
+                                                    "target": 81
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 35,
-                                                    "target": 50
+                                                    "delta_percentage": 73,
+                                                    "target": 70
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
+                                                    "delta_percentage": 15,
                                                     "target": 80
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 45,
-                                                    "target": 52
+                                                    "delta_percentage": 64,
+                                                    "target": 61
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 11,
-                                                    "target": 89
+                                                    "delta_percentage": 10,
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 85
+                                                    "delta_percentage": 11,
+                                                    "target": 86
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 23,
-                                                    "target": 77
+                                                    "delta_percentage": 29,
+                                                    "target": 83
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 96
+                                                    "delta_percentage": 21,
+                                                    "target": 92
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 11,
                                                     "target": 84
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 13,
+                                                    "delta_percentage": 20,
                                                     "target": 84
                                                 }
                                             }
@@ -1195,105 +1351,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 38,
-                                                    "target": 22616
+                                                    "delta_percentage": 125,
+                                                    "target": 36619
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 23049
+                                                    "delta_percentage": 150,
+                                                    "target": 46317
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 36,
-                                                    "target": 47450
+                                                    "delta_percentage": 48,
+                                                    "target": 45216
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 20,
-                                                    "target": 22929
+                                                    "delta_percentage": 141,
+                                                    "target": 44181
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 31,
-                                                    "target": 59206
+                                                    "delta_percentage": 44,
+                                                    "target": 57356
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 29,
-                                                    "target": 59074
+                                                    "delta_percentage": 34,
+                                                    "target": 56370
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 46107
+                                                    "delta_percentage": 45,
+                                                    "target": 50957
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 32,
-                                                    "target": 57605
+                                                    "delta_percentage": 36,
+                                                    "target": 54722
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 26,
-                                                    "target": 55578
+                                                    "target": 54069
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 33,
-                                                    "target": 48747
+                                                    "delta_percentage": 37,
+                                                    "target": 47622
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 50,
-                                                    "target": 53465
+                                                    "delta_percentage": 49,
+                                                    "target": 50907
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 13,
-                                                    "target": 23211
+                                                    "delta_percentage": 147,
+                                                    "target": 45618
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 39,
-                                                    "target": 50905
+                                                    "delta_percentage": 42,
+                                                    "target": 48019
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 50,
-                                                    "target": 24182
+                                                    "delta_percentage": 91,
+                                                    "target": 30352
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 34,
-                                                    "target": 57234
+                                                    "delta_percentage": 30,
+                                                    "target": 58063
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 23,
-                                                    "target": 53501
+                                                    "delta_percentage": 33,
+                                                    "target": 52340
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 23,
-                                                    "target": 48162
+                                                    "delta_percentage": 53,
+                                                    "target": 54106
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 37,
-                                                    "target": 63303
+                                                    "delta_percentage": 36,
+                                                    "target": 53624
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 22,
-                                                    "target": 52741
+                                                    "delta_percentage": 31,
+                                                    "target": 50049
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 41,
-                                                    "target": 54669
+                                                    "delta_percentage": 51,
+                                                    "target": 50619
                                                 }
                                             }
                                         }
@@ -1310,8 +1466,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1335,24 +1491,24 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 190
+                                                    "delta_percentage": 6,
+                                                    "target": 189
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 130
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 192
+                                                    "target": 194
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 4,
-                                                    "target": 200
+                                                    "target": 199
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 121
+                                                    "delta_percentage": 6,
+                                                    "target": 120
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -1362,8 +1518,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1388,22 +1544,22 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 195
+                                                    "target": 193
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 131
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 197
+                                                    "target": 192
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 199
+                                                    "target": 198
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 123
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
@@ -1416,8 +1572,8 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1425,31 +1581,31 @@
                                                     "target": 95
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 95
+                                                    "delta_percentage": 7,
+                                                    "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 97
+                                                    "target": 98
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 94
+                                                    "delta_percentage": 7,
+                                                    "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
@@ -1468,8 +1624,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1477,16 +1633,16 @@
                                                     "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 96
+                                                    "delta_percentage": 7,
+                                                    "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 94
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 97
+                                                    "target": 98
                                                 }
                                             }
                                         },
@@ -1498,19 +1654,19 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 96
+                                                    "target": 97
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 98
+                                                    "delta_percentage": 6,
+                                                    "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
                                                     "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 96
+                                                    "delta_percentage": 5,
+                                                    "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -1522,25 +1678,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 28470
+                                                    "target": 27855
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 30334
+                                                    "target": 30145
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 26755
+                                                    "delta_percentage": 6,
+                                                    "target": 26069
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 28600
+                                                    "delta_percentage": 5,
+                                                    "target": 28491
                                                 }
                                             }
                                         },
@@ -1548,79 +1704,79 @@
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 27891
+                                                    "target": 27348
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 26876
+                                                    "target": 26265
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 29390
+                                                    "target": 29263
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 26192
+                                                    "target": 25709
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 26089
+                                                    "delta_percentage": 4,
+                                                    "target": 25570
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 27494
+                                                    "target": 27067
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 27160
+                                                    "target": 26736
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 30446
+                                                    "delta_percentage": 8,
+                                                    "target": 29677
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 26975
+                                                    "target": 26436
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 28789
+                                                    "target": 28505
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 28649
+                                                    "delta_percentage": 4,
+                                                    "target": 28124
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 28806
+                                                    "delta_percentage": 5,
+                                                    "target": 28189
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 29791
+                                                    "delta_percentage": 4,
+                                                    "target": 29633
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 27369
+                                                    "delta_percentage": 4,
+                                                    "target": 26933
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 27276
+                                                    "delta_percentage": 5,
+                                                    "target": 26922
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 27967
+                                                    "target": 27657
                                                 }
                                             }
                                         }
@@ -1637,8 +1793,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1650,8 +1806,8 @@
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 25,
-                                                    "target": 70
+                                                    "delta_percentage": 31,
+                                                    "target": 75
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
@@ -1662,35 +1818,35 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 179
+                                                    "delta_percentage": 7,
+                                                    "target": 180
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 124
+                                                    "delta_percentage": 7,
+                                                    "target": 125
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 181
+                                                    "delta_percentage": 6,
+                                                    "target": 182
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 182
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 110
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 191
+                                                    "target": 192
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1714,28 +1870,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 132
+                                                    "delta_percentage": 7,
+                                                    "target": 131
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 125
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 193
-                                                },
-                                                "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
                                                     "target": 124
                                                 },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 192
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 113
+                                                    "target": 123
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 8,
+                                                    "target": 112
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 196
+                                                    "target": 197
                                                 }
                                             }
                                         }
@@ -1743,21 +1899,21 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 9,
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 86
+                                                    "delta_percentage": 8,
+                                                    "target": 87
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 88
+                                                    "delta_percentage": 7,
+                                                    "target": 87
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
@@ -1772,15 +1928,15 @@
                                                     "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 90
+                                                    "delta_percentage": 7,
+                                                    "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 86
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -1789,23 +1945,23 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 91
+                                                    "target": 90
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 82
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 87
+                                                    "target": 88
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
@@ -1813,7 +1969,7 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 90
+                                                    "target": 91
                                                 }
                                             }
                                         },
@@ -1824,24 +1980,24 @@
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 90
+                                                    "delta_percentage": 8,
+                                                    "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 91
+                                                    "delta_percentage": 7,
+                                                    "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
                                                     "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 89
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 95
+                                                    "delta_percentage": 7,
+                                                    "target": 93
                                                 }
                                             }
                                         }
@@ -1849,25 +2005,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 17,
-                                                    "target": 52625
+                                                    "delta_percentage": 23,
+                                                    "target": 51979
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 43109
+                                                    "delta_percentage": 5,
+                                                    "target": 42851
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 37634
+                                                    "delta_percentage": 7,
+                                                    "target": 37400
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 41675
+                                                    "target": 41245
                                                 }
                                             }
                                         },
@@ -1875,51 +2031,51 @@
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 43209
+                                                    "target": 42532
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 40826
+                                                    "delta_percentage": 9,
+                                                    "target": 39588
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 41489
+                                                    "target": 41237
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 38422
+                                                    "target": 38068
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 36046
+                                                    "delta_percentage": 6,
+                                                    "target": 35685
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 39849
+                                                    "target": 39483
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 43904
+                                                    "delta_percentage": 6,
+                                                    "target": 43653
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 41498
+                                                    "delta_percentage": 5,
+                                                    "target": 41623
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 38429
+                                                    "target": 37998
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 40046
+                                                    "delta_percentage": 5,
+                                                    "target": 40420
                                                 }
                                             }
                                         },
@@ -1927,27 +2083,27 @@
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 46747
+                                                    "target": 46286
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 41917
+                                                    "delta_percentage": 7,
+                                                    "target": 41248
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 42743
+                                                    "delta_percentage": 5,
+                                                    "target": 41757
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 42948
+                                                    "delta_percentage": 7,
+                                                    "target": 42664
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 36401
+                                                    "delta_percentage": 6,
+                                                    "target": 35966
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 43109
+                                                    "target": 41623
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
@@ -6,8 +6,60 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 3,
+                                                    "target": 100
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 134
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 9,
+                                                    "target": 183
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -35,8 +87,8 @@
                                                     "target": 200
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 140
+                                                    "delta_percentage": 7,
+                                                    "target": 136
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -48,59 +100,7 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 183
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 140
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
-                                                },
-                                                "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 181
+                                                    "target": 178
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -112,8 +112,8 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -121,8 +121,8 @@
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 93
+                                                    "delta_percentage": 9,
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
@@ -138,7 +138,7 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 94
+                                                    "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
@@ -154,62 +154,62 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 91
+                                                    "target": 92
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 89
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 94
+                                                    "target": 92
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 8,
                                                     "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 99
+                                                    "delta_percentage": 5,
+                                                    "target": 100
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 97
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 96
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 98
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 95
+                                                    "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 100
                                                 }
                                             }
@@ -218,105 +218,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 16,
-                                                    "target": 55626
+                                                    "delta_percentage": 15,
+                                                    "target": 51026
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 52049
+                                                    "target": 50990
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 49464
+                                                    "delta_percentage": 6,
+                                                    "target": 47591
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 51331
+                                                    "delta_percentage": 5,
+                                                    "target": 50975
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 48060
+                                                    "delta_percentage": 6,
+                                                    "target": 46310
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 47231
+                                                    "delta_percentage": 6,
+                                                    "target": 45189
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 51440
+                                                    "target": 50882
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 44553
+                                                    "delta_percentage": 5,
+                                                    "target": 43196
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 44514
+                                                    "delta_percentage": 5,
+                                                    "target": 42731
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 48571
+                                                    "target": 47894
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 50842
+                                                    "target": 49195
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 52669
+                                                    "delta_percentage": 6,
+                                                    "target": 51011
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 53295
+                                                    "delta_percentage": 13,
+                                                    "target": 48885
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 51867
+                                                    "target": 51452
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 51129
+                                                    "delta_percentage": 7,
+                                                    "target": 49633
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 49975
+                                                    "delta_percentage": 6,
+                                                    "target": 47987
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 52046
+                                                    "target": 51620
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 49694
+                                                    "delta_percentage": 5,
+                                                    "target": 48423
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 46161
+                                                    "delta_percentage": 7,
+                                                    "target": 44593
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 49678
+                                                    "delta_percentage": 6,
+                                                    "target": 49104
                                                 }
                                             }
                                         }
@@ -333,65 +333,13 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 99
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 99
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 94
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 99
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 144
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 115
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 188
-                                                },
-                                                "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 14,
-                                                    "target": 146
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 114
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 190
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 98
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
@@ -399,7 +347,59 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 22,
+                                                    "target": 95
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 99
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 11,
+                                                    "target": 142
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 11,
+                                                    "target": 116
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 186
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 16,
+                                                    "target": 144
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 11,
+                                                    "target": 114
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 191
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 11,
                                                     "target": 97
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 100
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 25,
+                                                    "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
@@ -411,27 +411,27 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 125
+                                                    "target": 124
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 8,
                                                     "target": 117
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 191
+                                                    "delta_percentage": 7,
+                                                    "target": 190
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 8,
                                                     "target": 127
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 114
+                                                    "delta_percentage": 10,
+                                                    "target": 113
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 190
+                                                    "target": 189
                                                 }
                                             }
                                         }
@@ -439,8 +439,8 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -448,31 +448,31 @@
                                                     "target": 91
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 89
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
                                                     "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 90
+                                                    "delta_percentage": 7,
+                                                    "target": 92
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 90
+                                                    "delta_percentage": 6,
+                                                    "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
                                                     "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 92
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
@@ -480,8 +480,8 @@
                                                     "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 89
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -491,25 +491,25 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 89
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 88
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
                                                     "target": 90
                                                 },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 88
+                                                    "target": 91
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 90
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 8,
+                                                    "target": 91
                                                 }
                                             }
                                         },
@@ -520,24 +520,24 @@
                                                     "target": 95
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 94
+                                                    "delta_percentage": 8,
+                                                    "target": 95
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 98
+                                                    "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 98
+                                                    "delta_percentage": 6,
+                                                    "target": 97
                                                 }
                                             }
                                         }
@@ -545,105 +545,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 29077
+                                                    "target": 28810
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 30585
+                                                    "delta_percentage": 10,
+                                                    "target": 30225
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 27429
+                                                    "delta_percentage": 10,
+                                                    "target": 27077
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 28868
+                                                    "target": 29199
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 28367
+                                                    "delta_percentage": 10,
+                                                    "target": 27986
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 28167
+                                                    "delta_percentage": 10,
+                                                    "target": 27879
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 30418
+                                                    "delta_percentage": 9,
+                                                    "target": 30123
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 26882
+                                                    "delta_percentage": 11,
+                                                    "target": 26366
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 27061
+                                                    "delta_percentage": 9,
+                                                    "target": 26710
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 29053
+                                                    "delta_percentage": 8,
+                                                    "target": 28661
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 29761
+                                                    "delta_percentage": 8,
+                                                    "target": 28917
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 30373
+                                                    "delta_percentage": 10,
+                                                    "target": 31088
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 28862
+                                                    "delta_percentage": 11,
+                                                    "target": 27975
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 27612
+                                                    "delta_percentage": 10,
+                                                    "target": 28498
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 30914
+                                                    "delta_percentage": 11,
+                                                    "target": 30381
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 30142
+                                                    "delta_percentage": 9,
+                                                    "target": 29719
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 32138
+                                                    "delta_percentage": 9,
+                                                    "target": 32219
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 30026
+                                                    "delta_percentage": 12,
+                                                    "target": 29489
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 28890
+                                                    "delta_percentage": 11,
+                                                    "target": 28097
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 30290
+                                                    "delta_percentage": 9,
+                                                    "target": 30119
                                                 }
                                             }
                                         }
@@ -656,8 +656,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -665,11 +665,11 @@
                                                     "target": 99
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
@@ -681,47 +681,47 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 154
+                                                    "delta_percentage": 6,
+                                                    "target": 153
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 127
+                                                    "delta_percentage": 6,
+                                                    "target": 128
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 187
+                                                    "target": 186
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 155
+                                                    "delta_percentage": 7,
+                                                    "target": 154
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 120
+                                                    "delta_percentage": 8,
+                                                    "target": 121
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 192
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 100
+                                                    "delta_percentage": 6,
+                                                    "target": 99
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
@@ -733,28 +733,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 129
+                                                    "delta_percentage": 6,
+                                                    "target": 127
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 122
+                                                    "delta_percentage": 6,
+                                                    "target": 123
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 185
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 129
+                                                    "target": 130
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 116
+                                                    "delta_percentage": 6,
+                                                    "target": 115
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 195
+                                                    "delta_percentage": 6,
+                                                    "target": 196
                                                 }
                                             }
                                         }
@@ -762,24 +762,24 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 5,
                                                     "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 90
                                                 }
                                             }
@@ -788,18 +788,18 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 90
+                                                    "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 91
+                                                    "delta_percentage": 8,
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 5,
                                                     "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -807,31 +807,31 @@
                                                     "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 95
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 5,
                                                     "target": 87
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 92
+                                                    "delta_percentage": 6,
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
                                                     "target": 88
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 91
                                                 }
                                             }
@@ -839,7 +839,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 95
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -848,15 +848,15 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 95
+                                                    "target": 94
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
                                                     "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 92
+                                                    "delta_percentage": 8,
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -868,105 +868,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 34321
+                                                    "target": 33426
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 35590
+                                                    "delta_percentage": 5,
+                                                    "target": 35046
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 32616
+                                                    "delta_percentage": 7,
+                                                    "target": 32164
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 33345
+                                                    "delta_percentage": 4,
+                                                    "target": 32993
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 33317
+                                                    "delta_percentage": 5,
+                                                    "target": 32904
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 33075
+                                                    "delta_percentage": 5,
+                                                    "target": 32552
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 35154
+                                                    "delta_percentage": 5,
+                                                    "target": 34501
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 31679
+                                                    "delta_percentage": 5,
+                                                    "target": 31215
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 32114
+                                                    "delta_percentage": 5,
+                                                    "target": 31646
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 33916
+                                                    "delta_percentage": 4,
+                                                    "target": 33296
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 33186
+                                                    "target": 32533
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 36157
+                                                    "delta_percentage": 5,
+                                                    "target": 35591
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 32981
+                                                    "delta_percentage": 7,
+                                                    "target": 32573
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 33084
+                                                    "delta_percentage": 6,
+                                                    "target": 32687
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 35766
+                                                    "delta_percentage": 5,
+                                                    "target": 35287
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 34081
+                                                    "delta_percentage": 5,
+                                                    "target": 33625
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 36573
+                                                    "delta_percentage": 5,
+                                                    "target": 36035
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 34421
+                                                    "delta_percentage": 5,
+                                                    "target": 34037
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 32754
+                                                    "delta_percentage": 4,
+                                                    "target": 32333
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 35148
+                                                    "delta_percentage": 4,
+                                                    "target": 34642
                                                 }
                                             }
                                         }
@@ -983,21 +983,21 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 25,
-                                                    "target": 92
+                                                    "delta_percentage": 27,
+                                                    "target": 95
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 80,
-                                                    "target": 74
+                                                    "delta_percentage": 50,
+                                                    "target": 88
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
@@ -1008,35 +1008,35 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 15,
+                                                    "delta_percentage": 20,
                                                     "target": 186
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 23,
-                                                    "target": 186
+                                                    "delta_percentage": 64,
+                                                    "target": 163
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 21,
-                                                    "target": 186
+                                                    "delta_percentage": 24,
+                                                    "target": 185
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 52,
-                                                    "target": 157
+                                                    "delta_percentage": 59,
+                                                    "target": 140
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1044,7 +1044,7 @@
                                                     "target": 99
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -1060,28 +1060,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 197
+                                                    "delta_percentage": 68,
+                                                    "target": 170
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 45,
-                                                    "target": 173
+                                                    "delta_percentage": 61,
+                                                    "target": 158
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 197
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 31,
-                                                    "target": 185
+                                                    "delta_percentage": 65,
+                                                    "target": 169
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 48,
-                                                    "target": 163
+                                                    "delta_percentage": 42,
+                                                    "target": 151
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 }
                                             }
                                         }
@@ -1089,25 +1089,25 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 57,
-                                                    "target": 55
+                                                    "delta_percentage": 84,
+                                                    "target": 63
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 35,
-                                                    "target": 53
+                                                    "delta_percentage": 71,
+                                                    "target": 63
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 83
+                                                    "delta_percentage": 18,
+                                                    "target": 80
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 34,
-                                                    "target": 54
+                                                    "delta_percentage": 84,
+                                                    "target": 64
                                                 }
                                             }
                                         },
@@ -1115,78 +1115,78 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 89
+                                                    "target": 88
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 92
+                                                    "delta_percentage": 14,
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 23,
-                                                    "target": 83
+                                                    "delta_percentage": 24,
+                                                    "target": 82
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 90
+                                                    "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 90
+                                                    "delta_percentage": 9,
+                                                    "target": 87
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 16,
-                                                    "target": 86
+                                                    "delta_percentage": 17,
+                                                    "target": 87
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 16,
-                                                    "target": 82
+                                                    "delta_percentage": 24,
+                                                    "target": 78
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 35,
-                                                    "target": 51
+                                                    "delta_percentage": 86,
+                                                    "target": 63
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 19,
-                                                    "target": 81
+                                                    "delta_percentage": 20,
+                                                    "target": 79
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 38,
-                                                    "target": 52
+                                                    "delta_percentage": 65,
+                                                    "target": 59
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 15,
-                                                    "target": 84
+                                                    "delta_percentage": 21,
+                                                    "target": 86
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 86
+                                                    "target": 85
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 23,
-                                                    "target": 76
+                                                    "delta_percentage": 38,
+                                                    "target": 82
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 97
+                                                    "delta_percentage": 9,
+                                                    "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 10,
                                                     "target": 85
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 14,
+                                                    "delta_percentage": 22,
                                                     "target": 86
                                                 }
                                             }
@@ -1195,105 +1195,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 62,
-                                                    "target": 24141
+                                                    "delta_percentage": 152,
+                                                    "target": 34450
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 23167
+                                                    "delta_percentage": 165,
+                                                    "target": 38030
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 45,
-                                                    "target": 48480
+                                                    "delta_percentage": 39,
+                                                    "target": 48130
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 22374
+                                                    "delta_percentage": 163,
+                                                    "target": 35605
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 38,
-                                                    "target": 61265
+                                                    "delta_percentage": 36,
+                                                    "target": 58427
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 41,
-                                                    "target": 59185
+                                                    "delta_percentage": 35,
+                                                    "target": 56654
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 45902
+                                                    "delta_percentage": 52,
+                                                    "target": 49197
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 45,
-                                                    "target": 58807
+                                                    "delta_percentage": 40,
+                                                    "target": 55608
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 41,
-                                                    "target": 54731
+                                                    "delta_percentage": 32,
+                                                    "target": 53997
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 33,
-                                                    "target": 49363
+                                                    "delta_percentage": 44,
+                                                    "target": 49533
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 58,
-                                                    "target": 54005
+                                                    "delta_percentage": 57,
+                                                    "target": 54183
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 23280
+                                                    "delta_percentage": 166,
+                                                    "target": 37920
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 54,
-                                                    "target": 50799
+                                                    "delta_percentage": 48,
+                                                    "target": 49588
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 35,
-                                                    "target": 22601
+                                                    "delta_percentage": 122,
+                                                    "target": 30847
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 24,
-                                                    "target": 50045
+                                                    "delta_percentage": 34,
+                                                    "target": 51494
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 36,
-                                                    "target": 53762
+                                                    "delta_percentage": 33,
+                                                    "target": 53138
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 46219
+                                                    "delta_percentage": 61,
+                                                    "target": 50462
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 42,
-                                                    "target": 62248
+                                                    "delta_percentage": 37,
+                                                    "target": 56777
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 35,
-                                                    "target": 53304
+                                                    "delta_percentage": 31,
+                                                    "target": 52242
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 36,
-                                                    "target": 55129
+                                                    "delta_percentage": 59,
+                                                    "target": 48945
                                                 }
                                             }
                                         }
@@ -1310,8 +1310,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1339,7 +1339,7 @@
                                                     "target": 197
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 134
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
@@ -1348,7 +1348,7 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 4,
-                                                    "target": 200
+                                                    "target": 199
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
@@ -1362,8 +1362,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1395,8 +1395,8 @@
                                                     "target": 137
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 197
+                                                    "delta_percentage": 6,
+                                                    "target": 191
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 4,
@@ -1404,7 +1404,7 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 128
+                                                    "target": 127
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -1416,8 +1416,8 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1429,7 +1429,7 @@
                                                     "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 5,
                                                     "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
@@ -1446,14 +1446,14 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 94
+                                                    "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 98
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -1461,20 +1461,20 @@
                                                     "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 85
+                                                    "target": 84
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -1482,11 +1482,11 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 94
+                                                    "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
+                                                    "delta_percentage": 6,
+                                                    "target": 98
                                                 }
                                             }
                                         },
@@ -1501,8 +1501,8 @@
                                                     "target": 97
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 99
+                                                    "delta_percentage": 7,
+                                                    "target": 98
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
@@ -1513,8 +1513,8 @@
                                                     "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
+                                                    "delta_percentage": 6,
+                                                    "target": 100
                                                 }
                                             }
                                         }
@@ -1522,105 +1522,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 33545
+                                                    "delta_percentage": 6,
+                                                    "target": 33571
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 29131
+                                                    "target": 29085
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 31156
+                                                    "target": 30812
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 27987
+                                                    "target": 27907
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 28943
+                                                    "delta_percentage": 5,
+                                                    "target": 28843
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 30486
+                                                    "delta_percentage": 5,
+                                                    "target": 30404
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 28399
+                                                    "target": 28282
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 27025
+                                                    "delta_percentage": 5,
+                                                    "target": 26915
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 28917
+                                                    "delta_percentage": 5,
+                                                    "target": 28628
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 26246
+                                                    "delta_percentage": 4,
+                                                    "target": 26004
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 30677
+                                                    "delta_percentage": 5,
+                                                    "target": 30441
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 29048
+                                                    "delta_percentage": 6,
+                                                    "target": 28941
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 32542
+                                                    "delta_percentage": 7,
+                                                    "target": 32062
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 27891
+                                                    "target": 27684
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 30464
+                                                    "delta_percentage": 5,
+                                                    "target": 30245
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 32966
+                                                    "delta_percentage": 7,
+                                                    "target": 32516
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 28792
+                                                    "target": 28651
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 28563
+                                                    "delta_percentage": 5,
+                                                    "target": 28395
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 30650
+                                                    "delta_percentage": 5,
+                                                    "target": 30496
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 26942
+                                                    "target": 26898
                                                 }
                                             }
                                         }
@@ -1637,8 +1637,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1650,11 +1650,11 @@
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
@@ -1670,16 +1670,16 @@
                                                     "target": 125
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 190
+                                                    "delta_percentage": 6,
+                                                    "target": 191
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 188
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 116
+                                                    "delta_percentage": 6,
+                                                    "target": 118
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
@@ -1689,8 +1689,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1706,7 +1706,7 @@
                                                     "target": 99
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -1714,28 +1714,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 129
+                                                    "delta_percentage": 7,
+                                                    "target": 131
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 126
+                                                    "delta_percentage": 8,
+                                                    "target": 127
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
                                                     "target": 195
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 123
+                                                    "delta_percentage": 7,
+                                                    "target": 124
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 117
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 197
+                                                    "target": 196
                                                 }
                                             }
                                         }
@@ -1743,96 +1743,96 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 8,
+                                                    "target": 94
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 8,
+                                                    "target": 88
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 8,
+                                                    "target": 89
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 92
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 7,
+                                                    "target": 90
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 91
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 89
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 6,
+                                                    "target": 90
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 90
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 93
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 10,
+                                                    "target": 81
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 90
+                                                    "delta_percentage": 9,
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 93
+                                                    "delta_percentage": 8,
+                                                    "target": 91
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 5,
+                                                    "target": 94
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
                                                     "target": 91
                                                 },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 91
-                                                },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 90
+                                                    "delta_percentage": 7,
+                                                    "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 90
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 90
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 94
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 82
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 90
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 92
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 94
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 94
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 91
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 96
-                                                },
-                                                "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
                                                     "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -1849,105 +1849,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 54368
+                                                    "delta_percentage": 9,
+                                                    "target": 54815
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 44148
+                                                    "delta_percentage": 7,
+                                                    "target": 43531
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 43214
+                                                    "delta_percentage": 8,
+                                                    "target": 41814
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 42423
+                                                    "delta_percentage": 6,
+                                                    "target": 41982
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 44238
+                                                    "delta_percentage": 7,
+                                                    "target": 43644
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 44208
+                                                    "delta_percentage": 7,
+                                                    "target": 43903
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 42395
+                                                    "target": 41986
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 39947
+                                                    "delta_percentage": 6,
+                                                    "target": 39807
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 39338
+                                                    "delta_percentage": 7,
+                                                    "target": 39421
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 41193
+                                                    "delta_percentage": 6,
+                                                    "target": 40714
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 45186
+                                                    "delta_percentage": 8,
+                                                    "target": 44241
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 43886
+                                                    "delta_percentage": 7,
+                                                    "target": 42749
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 50073
+                                                    "delta_percentage": 18,
+                                                    "target": 48393
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 42741
+                                                    "delta_percentage": 8,
+                                                    "target": 40454
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 46917
+                                                    "delta_percentage": 7,
+                                                    "target": 47016
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 45113
+                                                    "delta_percentage": 7,
+                                                    "target": 44742
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 44739
+                                                    "delta_percentage": 8,
+                                                    "target": 44638
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 44108
+                                                    "delta_percentage": 7,
+                                                    "target": 44337
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 39453
+                                                    "delta_percentage": 7,
+                                                    "target": 39335
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 43562
+                                                    "target": 43636
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_6.1.json
@@ -6,8 +6,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -31,7 +31,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 200
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -47,8 +47,8 @@
                                                     "target": 200
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 155
+                                                    "delta_percentage": 8,
+                                                    "target": 153
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -58,8 +58,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -88,7 +88,7 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 126
+                                                    "target": 127
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -99,8 +99,8 @@
                                                     "target": 200
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 158
+                                                    "delta_percentage": 7,
+                                                    "target": 155
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -112,8 +112,8 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -121,16 +121,16 @@
                                                     "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 92
+                                                    "delta_percentage": 7,
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 97
+                                                    "target": 98
                                                 }
                                             }
                                         },
@@ -138,14 +138,14 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 92
+                                                    "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
                                                     "target": 92
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
@@ -154,18 +154,18 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 91
+                                                    "target": 92
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -173,7 +173,7 @@
                                                     "target": 92
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 7,
                                                     "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -218,105 +218,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 41810
+                                                    "delta_percentage": 6,
+                                                    "target": 41379
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 52238
+                                                    "target": 51371
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 40947
+                                                    "delta_percentage": 5,
+                                                    "target": 39274
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 51318
+                                                    "delta_percentage": 5,
+                                                    "target": 50880
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 41543
+                                                    "delta_percentage": 5,
+                                                    "target": 41153
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 40795
+                                                    "delta_percentage": 5,
+                                                    "target": 40056
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 51346
+                                                    "delta_percentage": 5,
+                                                    "target": 50833
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 39022
+                                                    "delta_percentage": 5,
+                                                    "target": 39003
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 39017
+                                                    "delta_percentage": 5,
+                                                    "target": 38190
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 48501
+                                                    "delta_percentage": 5,
+                                                    "target": 47857
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 43147
+                                                    "delta_percentage": 8,
+                                                    "target": 41414
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 51949
+                                                    "delta_percentage": 6,
+                                                    "target": 50759
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 41247
+                                                    "delta_percentage": 7,
+                                                    "target": 39513
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 51993
+                                                    "delta_percentage": 5,
+                                                    "target": 51251
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 43936
+                                                    "delta_percentage": 5,
+                                                    "target": 44059
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 42389
+                                                    "delta_percentage": 5,
+                                                    "target": 42149
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 51576
+                                                    "delta_percentage": 5,
+                                                    "target": 51356
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 43517
+                                                    "delta_percentage": 6,
+                                                    "target": 43356
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 40666
+                                                    "delta_percentage": 5,
+                                                    "target": 39868
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 49141
+                                                    "delta_percentage": 5,
+                                                    "target": 48663
                                                 }
                                             }
                                         }
@@ -333,101 +333,49 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 26,
+                                                    "target": 89
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 10,
+                                                    "target": 71
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 3,
+                                                    "target": 100
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 12,
+                                                    "target": 124
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 19,
                                                     "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 70
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 17,
-                                                    "target": 123
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 35,
-                                                    "target": 99
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 185
+                                                    "delta_percentage": 7,
+                                                    "target": 186
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 18,
-                                                    "target": 119
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 97
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 192
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 86
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 80
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 115
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 104
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 13,
-                                                    "target": 187
-                                                },
-                                                "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 15,
                                                     "target": 120
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 102
+                                                    "delta_percentage": 10,
+                                                    "target": 96
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -436,11 +384,63 @@
                                             }
                                         }
                                     }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 14,
+                                                    "target": 87
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 11,
+                                                    "target": 77
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 9,
+                                                    "target": 115
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 9,
+                                                    "target": 103
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 11,
+                                                    "target": 184
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 9,
+                                                    "target": 118
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 11,
+                                                    "target": 102
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 188
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -448,8 +448,8 @@
                                                     "target": 91
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 89
+                                                    "delta_percentage": 6,
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
@@ -457,18 +457,18 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 89
+                                                    "target": 91
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 88
+                                                    "delta_percentage": 8,
+                                                    "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 7,
                                                     "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
@@ -476,40 +476,40 @@
                                                     "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 89
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 88
+                                                    "delta_percentage": 6,
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 95
+                                                    "target": 94
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 89
+                                                    "delta_percentage": 6,
+                                                    "target": 91
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 89
+                                                    "delta_percentage": 6,
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 90
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 90
+                                                    "target": 94
                                                 }
                                             }
                                         },
@@ -517,14 +517,14 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 95
+                                                    "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 93
+                                                    "delta_percentage": 7,
+                                                    "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
@@ -533,11 +533,11 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 93
+                                                    "target": 94
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 97
+                                                    "delta_percentage": 6,
+                                                    "target": 96
                                                 }
                                             }
                                         }
@@ -545,25 +545,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 26186
+                                                    "delta_percentage": 10,
+                                                    "target": 25834
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 31075
+                                                    "delta_percentage": 8,
+                                                    "target": 31358
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 25026
+                                                    "delta_percentage": 8,
+                                                    "target": 24597
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 28931
+                                                    "delta_percentage": 9,
+                                                    "target": 29148
                                                 }
                                             }
                                         },
@@ -571,79 +571,79 @@
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 26069
+                                                    "target": 25974
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 25783
+                                                    "target": 25286
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 30521
+                                                    "delta_percentage": 9,
+                                                    "target": 30531
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 25107
+                                                    "target": 24939
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 25043
+                                                    "delta_percentage": 8,
+                                                    "target": 24548
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 28788
+                                                    "delta_percentage": 8,
+                                                    "target": 28555
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 26529
+                                                    "delta_percentage": 9,
+                                                    "target": 26247
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 31188
+                                                    "delta_percentage": 8,
+                                                    "target": 31555
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 26242
+                                                    "target": 25850
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 28519
+                                                    "target": 29895
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 28120
+                                                    "delta_percentage": 8,
+                                                    "target": 28177
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 27002
+                                                    "delta_percentage": 8,
+                                                    "target": 26743
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 32396
+                                                    "delta_percentage": 9,
+                                                    "target": 32058
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 28100
+                                                    "delta_percentage": 10,
+                                                    "target": 27580
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 26035
+                                                    "delta_percentage": 8,
+                                                    "target": 25946
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 29813
+                                                    "delta_percentage": 8,
+                                                    "target": 29736
                                                 }
                                             }
                                         }
@@ -656,12 +656,12 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 100
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
@@ -669,59 +669,7 @@
                                                     "target": 100
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 22,
-                                                    "target": 87
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 140
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 125
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 188
-                                                },
-                                                "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 14,
-                                                    "target": 137
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 109
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 193
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 90
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 22,
+                                                    "delta_percentage": 20,
                                                     "target": 86
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
@@ -733,28 +681,80 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 122
+                                                    "delta_percentage": 10,
+                                                    "target": 139
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 111
+                                                    "delta_percentage": 8,
+                                                    "target": 127
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 182
+                                                    "target": 188
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 125
+                                                    "delta_percentage": 11,
+                                                    "target": 134
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 10,
+                                                    "target": 108
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 192
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 90
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 112
+                                                    "target": 82
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 192
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 8,
+                                                    "target": 121
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 10,
+                                                    "target": 112
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 183
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 7,
+                                                    "target": 124
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 8,
+                                                    "target": 111
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 194
                                                 }
                                             }
                                         }
@@ -762,44 +762,44 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 91
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 90
+                                                    "target": 89
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 90
+                                                    "target": 91
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 92
+                                                    "delta_percentage": 8,
+                                                    "target": 91
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -807,15 +807,15 @@
                                                     "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 95
+                                                    "delta_percentage": 8,
+                                                    "target": 94
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -823,15 +823,15 @@
                                                     "target": 88
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 91
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 90
+                                                    "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 93
                                                 }
                                             }
@@ -839,28 +839,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 91
+                                                    "target": 92
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 95
+                                                    "delta_percentage": 6,
+                                                    "target": 94
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 91
+                                                    "target": 92
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 97
+                                                    "delta_percentage": 7,
+                                                    "target": 96
                                                 }
                                             }
                                         }
@@ -868,25 +868,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 31673
+                                                    "delta_percentage": 5,
+                                                    "target": 30971
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 36546
+                                                    "delta_percentage": 5,
+                                                    "target": 36038
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 30521
+                                                    "delta_percentage": 5,
+                                                    "target": 29828
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 34386
+                                                    "delta_percentage": 6,
+                                                    "target": 33687
                                                 }
                                             }
                                         },
@@ -894,79 +894,79 @@
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 31549
+                                                    "target": 30989
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 31472
+                                                    "target": 30990
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 35518
+                                                    "delta_percentage": 6,
+                                                    "target": 35152
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 30545
+                                                    "delta_percentage": 8,
+                                                    "target": 29863
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 30454
+                                                    "delta_percentage": 5,
+                                                    "target": 29741
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 33989
+                                                    "target": 33457
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 31204
+                                                    "delta_percentage": 5,
+                                                    "target": 30258
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 37077
+                                                    "target": 36629
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 31427
+                                                    "delta_percentage": 5,
+                                                    "target": 30343
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 34818
+                                                    "delta_percentage": 5,
+                                                    "target": 34183
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 33735
+                                                    "delta_percentage": 6,
+                                                    "target": 33089
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 31615
+                                                    "delta_percentage": 6,
+                                                    "target": 31142
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 36787
+                                                    "target": 36538
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 32998
+                                                    "delta_percentage": 6,
+                                                    "target": 32411
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 31104
+                                                    "delta_percentage": 5,
+                                                    "target": 30506
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 34788
+                                                    "delta_percentage": 6,
+                                                    "target": 34581
                                                 }
                                             }
                                         }
@@ -983,21 +983,21 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
+                                                    "delta_percentage": 22,
+                                                    "target": 97
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
                                                     "target": 100
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 92,
-                                                    "target": 77
+                                                    "delta_percentage": 79,
+                                                    "target": 84
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -1008,35 +1008,35 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 197
+                                                    "delta_percentage": 15,
+                                                    "target": 192
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 16,
-                                                    "target": 188
+                                                    "delta_percentage": 62,
+                                                    "target": 164
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
                                                     "target": 200
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 196
+                                                    "delta_percentage": 13,
+                                                    "target": 193
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 45,
-                                                    "target": 162
+                                                    "delta_percentage": 54,
+                                                    "target": 136
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 200
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1044,7 +1044,7 @@
                                                     "target": 100
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 100
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -1060,24 +1060,24 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
+                                                    "delta_percentage": 68,
+                                                    "target": 172
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 34,
-                                                    "target": 180
+                                                    "delta_percentage": 62,
+                                                    "target": 159
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
                                                     "target": 200
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 22,
-                                                    "target": 190
+                                                    "delta_percentage": 63,
+                                                    "target": 171
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 36,
-                                                    "target": 162
+                                                    "delta_percentage": 52,
+                                                    "target": 154
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -1089,60 +1089,60 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 32,
-                                                    "target": 48
+                                                    "delta_percentage": 91,
+                                                    "target": 63
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 38,
-                                                    "target": 52
+                                                    "delta_percentage": 86,
+                                                    "target": 62
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 12,
-                                                    "target": 86
+                                                    "target": 84
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 36,
-                                                    "target": 48
+                                                    "delta_percentage": 90,
+                                                    "target": 65
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 85
+                                                    "delta_percentage": 10,
+                                                    "target": 87
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 91
+                                                    "delta_percentage": 12,
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 29,
-                                                    "target": 81
+                                                    "delta_percentage": 25,
+                                                    "target": 84
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 12,
                                                     "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 21,
-                                                    "target": 85
+                                                    "delta_percentage": 23,
+                                                    "target": 86
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1150,44 +1150,44 @@
                                                     "target": 84
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 30,
-                                                    "target": 52
+                                                    "delta_percentage": 88,
+                                                    "target": 65
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 85
+                                                    "delta_percentage": 16,
+                                                    "target": 84
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 32,
-                                                    "target": 52
+                                                    "delta_percentage": 73,
+                                                    "target": 61
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 19,
-                                                    "target": 80
+                                                    "delta_percentage": 26,
+                                                    "target": 86
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 90
+                                                    "delta_percentage": 9,
+                                                    "target": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 27,
-                                                    "target": 77
+                                                    "delta_percentage": 39,
+                                                    "target": 84
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 21,
-                                                    "target": 90
+                                                    "delta_percentage": 19,
+                                                    "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 10,
                                                     "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 13,
-                                                    "target": 88
+                                                    "delta_percentage": 17,
+                                                    "target": 90
                                                 }
                                             }
                                         }
@@ -1195,105 +1195,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 21,
-                                                    "target": 20035
+                                                    "delta_percentage": 169,
+                                                    "target": 33632
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 23813
+                                                    "delta_percentage": 175,
+                                                    "target": 40166
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 53,
-                                                    "target": 53246
+                                                    "delta_percentage": 46,
+                                                    "target": 52248
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 22,
-                                                    "target": 22570
+                                                    "delta_percentage": 174,
+                                                    "target": 37912
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 37,
-                                                    "target": 55937
+                                                    "delta_percentage": 38,
+                                                    "target": 54487
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 31,
-                                                    "target": 59736
+                                                    "delta_percentage": 28,
+                                                    "target": 58188
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 47065
+                                                    "delta_percentage": 57,
+                                                    "target": 51293
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 26,
-                                                    "target": 62269
+                                                    "delta_percentage": 37,
+                                                    "target": 56246
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 21,
-                                                    "target": 59628
+                                                    "delta_percentage": 34,
+                                                    "target": 54376
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 33,
-                                                    "target": 49105
+                                                    "delta_percentage": 47,
+                                                    "target": 51079
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 69,
-                                                    "target": 53897
+                                                    "delta_percentage": 58,
+                                                    "target": 54752
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 23740
+                                                    "delta_percentage": 183,
+                                                    "target": 40927
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 47,
-                                                    "target": 56551
+                                                    "delta_percentage": 46,
+                                                    "target": 51669
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 18,
-                                                    "target": 22546
+                                                    "delta_percentage": 159,
+                                                    "target": 35280
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 45015
+                                                    "delta_percentage": 59,
+                                                    "target": 49410
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 28,
-                                                    "target": 60587
+                                                    "delta_percentage": 29,
+                                                    "target": 58382
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 46705
+                                                    "delta_percentage": 80,
+                                                    "target": 55188
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 49,
-                                                    "target": 57957
+                                                    "target": 55882
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 27,
-                                                    "target": 58302
+                                                    "delta_percentage": 32,
+                                                    "target": 55554
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 50,
-                                                    "target": 58405
+                                                    "delta_percentage": 39,
+                                                    "target": 62766
                                                 }
                                             }
                                         }
@@ -1310,8 +1310,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1323,8 +1323,8 @@
                                                     "target": 100
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 20,
-                                                    "target": 49
+                                                    "delta_percentage": 29,
+                                                    "target": 55
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -1336,23 +1336,23 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 184
+                                                    "target": 186
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 126
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 197
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 5,
                                                     "target": 196
                                                 },
-                                                "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 195
-                                                },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 117
+                                                    "target": 118
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -1362,8 +1362,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1388,19 +1388,19 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 189
+                                                    "target": 190
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 123
+                                                    "target": 124
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 195
+                                                    "delta_percentage": 6,
+                                                    "target": 189
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 195
+                                                    "target": 196
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
@@ -1416,8 +1416,8 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1430,10 +1430,10 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 94
+                                                    "target": 93
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
@@ -1445,7 +1445,7 @@
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
@@ -1457,19 +1457,19 @@
                                                     "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 94
+                                                    "delta_percentage": 6,
+                                                    "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1477,7 +1477,7 @@
                                                     "target": 95
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 94
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
@@ -1486,7 +1486,7 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 99
+                                                    "target": 98
                                                 }
                                             }
                                         },
@@ -1494,27 +1494,27 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 97
+                                                    "target": 96
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 97
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 98
+                                                    "delta_percentage": 7,
+                                                    "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
                                                     "target": 98
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 97
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 100
+                                                    "target": 99
                                                 }
                                             }
                                         }
@@ -1522,105 +1522,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 24027
+                                                    "delta_percentage": 4,
+                                                    "target": 23894
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 29377
+                                                    "target": 29166
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 23086
+                                                    "delta_percentage": 5,
+                                                    "target": 22894
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 28084
+                                                    "target": 28021
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 24330
+                                                    "delta_percentage": 4,
+                                                    "target": 24452
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 23123
+                                                    "delta_percentage": 4,
+                                                    "target": 23027
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 28464
+                                                    "target": 28436
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 23308
+                                                    "delta_percentage": 5,
+                                                    "target": 23478
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 22483
+                                                    "target": 22409
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 26328
+                                                    "target": 26181
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 24280
+                                                    "delta_percentage": 4,
+                                                    "target": 24079
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 29080
+                                                    "target": 28971
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 23890
+                                                    "delta_percentage": 5,
+                                                    "target": 23724
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 28333
+                                                    "delta_percentage": 5,
+                                                    "target": 27771
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 25194
+                                                    "delta_percentage": 5,
+                                                    "target": 25427
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 23891
+                                                    "delta_percentage": 4,
+                                                    "target": 23889
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 28812
+                                                    "target": 28695
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 24532
+                                                    "delta_percentage": 4,
+                                                    "target": 24668
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 23335
+                                                    "target": 23351
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 27150
+                                                    "target": 27060
                                                 }
                                             }
                                         }
@@ -1637,8 +1637,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1650,8 +1650,8 @@
                                                     "target": 100
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 17,
-                                                    "target": 76
+                                                    "delta_percentage": 15,
+                                                    "target": 81
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 4,
@@ -1666,20 +1666,20 @@
                                                     "target": 172
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 117
+                                                    "delta_percentage": 8,
+                                                    "target": 118
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 190
+                                                    "delta_percentage": 7,
+                                                    "target": 189
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 174
+                                                    "delta_percentage": 9,
+                                                    "target": 176
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 101
+                                                    "delta_percentage": 12,
+                                                    "target": 105
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -1689,8 +1689,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1715,22 +1715,22 @@
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 129
+                                                    "target": 130
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 120
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 193
+                                                    "target": 194
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
                                                     "delta_percentage": 6,
                                                     "target": 123
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 11,
                                                     "target": 104
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
@@ -1743,17 +1743,45 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 93
+                                                    "delta_percentage": 7,
+                                                    "target": 92
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 9,
                                                     "target": 88
+                                                },
+                                                "tcp-p128K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 88
+                                                },
+                                                "tcp-p128K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 93
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 7,
+                                                    "target": 89
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 90
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 90
+                                                },
+                                                "tcp-p128K-wsDEFAULT-bd": {
+                                                    "delta_percentage": 7,
+                                                    "target": 89
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
@@ -1764,43 +1792,15 @@
                                                     "target": 94
                                                 }
                                             }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 90
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 90
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 90
-                                                },
-                                                "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 89
-                                                },
-                                                "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 89
-                                                },
-                                                "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 95
-                                                }
-                                            }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 85
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
@@ -1812,15 +1812,15 @@
                                                     "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 95
+                                                    "delta_percentage": 6,
+                                                    "target": 93
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
@@ -1828,7 +1828,7 @@
                                                     "target": 91
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 95
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
@@ -1837,10 +1837,10 @@
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 91
+                                                    "target": 90
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 97
                                                 }
                                             }
@@ -1849,105 +1849,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 49444
+                                                    "delta_percentage": 10,
+                                                    "target": 48482
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 44790
+                                                    "target": 44126
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 40055
+                                                    "delta_percentage": 8,
+                                                    "target": 39639
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 43853
+                                                    "delta_percentage": 6,
+                                                    "target": 43055
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 42380
+                                                    "delta_percentage": 8,
+                                                    "target": 42004
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 39642
+                                                    "delta_percentage": 9,
+                                                    "target": 39309
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 43717
+                                                    "delta_percentage": 6,
+                                                    "target": 43234
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 4,
-                                                    "target": 38567
+                                                    "delta_percentage": 8,
+                                                    "target": 38461
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 34244
+                                                    "delta_percentage": 8,
+                                                    "target": 34326
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 42693
+                                                    "delta_percentage": 6,
+                                                    "target": 41999
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 44918
+                                                    "delta_percentage": 9,
+                                                    "target": 44720
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 44200
+                                                    "delta_percentage": 10,
+                                                    "target": 44115
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 43252
+                                                    "delta_percentage": 11,
+                                                    "target": 44189
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 44224
+                                                    "delta_percentage": 7,
+                                                    "target": 43147
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 45043
+                                                    "delta_percentage": 8,
+                                                    "target": 44954
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 40824
+                                                    "delta_percentage": 9,
+                                                    "target": 40627
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 45856
+                                                    "delta_percentage": 7,
+                                                    "target": 45861
                                                 },
                                                 "tcp-p128K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 41867
+                                                    "delta_percentage": 8,
+                                                    "target": 42058
                                                 },
                                                 "tcp-p128K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 35223
+                                                    "delta_percentage": 8,
+                                                    "target": 35215
                                                 },
                                                 "tcp-p128K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 44226
+                                                    "delta_percentage": 7,
+                                                    "target": 44145
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_snapshot_restore_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_snapshot_restore_performance_config_4.14.json
@@ -6,8 +6,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -93,8 +93,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -176,8 +176,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -263,8 +263,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -350,8 +350,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -437,8 +437,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {

--- a/tests/integration_tests/performance/configs/test_snapshot_restore_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_snapshot_restore_performance_config_5.10.json
@@ -6,8 +6,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -93,8 +93,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -176,8 +176,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -263,8 +263,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -350,8 +350,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -437,8 +437,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {

--- a/tests/integration_tests/performance/configs/test_snapshot_restore_performance_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_snapshot_restore_performance_config_6.1.json
@@ -6,8 +6,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -93,8 +93,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -176,8 +176,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -263,8 +263,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -350,8 +350,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {
@@ -437,8 +437,8 @@
                     {
                         "baselines": {
                             "latency": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb": {
                                             "Avg": {
                                                 "restore": {

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -6,8 +6,60 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -59,7 +111,7 @@
                                     }
                                 },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -112,25 +164,25 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 60
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 71
+                                                    "delta_percentage": 9,
+                                                    "target": 74
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 59
+                                                    "target": 60
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 72
+                                                    "delta_percentage": 9,
+                                                    "target": 75
                                                 }
                                             }
                                         },
@@ -138,34 +190,86 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 75
+                                                    "target": 77
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 66
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 84
+                                                    "target": 85
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 76
+                                                    "target": 78
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 66
+                                                    "target": 67
                                                 },
                                                 "vsock-p64K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 85
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 10,
+                                                    "target": 50
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 9,
+                                                    "target": 70
+                                                },
+                                                "vsock-p64K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 84
+                                                    "target": 50
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 71
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 8,
+                                                    "target": 67
+                                                },
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 10,
+                                                    "target": 53
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 76
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 9,
+                                                    "target": 68
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 10,
+                                                    "target": 52
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 78
                                                 }
                                             }
                                         }
                                     }
                                 },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -218,25 +322,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9956
+                                                    "target": 9683
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6503
+                                                    "target": 6530
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9934
+                                                    "target": 9729
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6413
+                                                    "target": 6425
                                                 }
                                             }
                                         },
@@ -244,34 +348,86 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 6709
+                                                    "target": 6705
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 10109
+                                                    "target": 9787
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 7635
+                                                    "target": 7565
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 6735
+                                                    "delta_percentage": 7,
+                                                    "target": 6750
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 10134
+                                                    "delta_percentage": 7,
+                                                    "target": 9810
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 7734
+                                                    "target": 7765
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10-no-sve": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 20432
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 6193
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 20480
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 6081
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 7,
+                                                    "target": 7751
+                                                },
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 25731
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 7172
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 7,
+                                                    "target": 7986
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 25603
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 7229
                                                 }
                                             }
                                         }
                                     }
                                 },
                                 "vmlinux-5.10-no-sve.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
@@ -333,13 +489,13 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 100
+                                                    "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 5,
@@ -363,14 +519,14 @@
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 116
+                                                    "delta_percentage": 7,
+                                                    "target": 117
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 113
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -378,15 +534,15 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 118
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -419,19 +575,19 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 114
+                                                    "target": 113
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 105
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 197
+                                                    "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 114
+                                                    "target": 113
                                                 }
                                             }
                                         }
@@ -439,25 +595,25 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 52
+                                                    "delta_percentage": 9,
+                                                    "target": 53
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 66
+                                                    "delta_percentage": 7,
+                                                    "target": 70
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 52
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 65
+                                                    "target": 69
                                                 }
                                             }
                                         },
@@ -473,70 +629,70 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 14,
-                                                    "target": 71
+                                                    "target": 74
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 72
+                                                    "delta_percentage": 9,
+                                                    "target": 71
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 7,
                                                     "target": 64
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 17,
-                                                    "target": 73
+                                                    "delta_percentage": 10,
+                                                    "target": 75
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 36
+                                                    "delta_percentage": 11,
+                                                    "target": 37
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 66
+                                                    "delta_percentage": 8,
+                                                    "target": 70
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 11,
-                                                    "target": 36
+                                                    "target": 38
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 65
+                                                    "delta_percentage": 7,
+                                                    "target": 70
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 9,
                                                     "target": 70
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 11,
-                                                    "target": 46
+                                                    "target": 50
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 77
+                                                    "target": 76
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 68
+                                                    "target": 69
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 44
+                                                    "target": 50
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 76
                                                 }
                                             }
@@ -545,105 +701,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4817
+                                                    "delta_percentage": 4,
+                                                    "target": 4926
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2847
+                                                    "delta_percentage": 7,
+                                                    "target": 2949
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 4812
+                                                    "delta_percentage": 9,
+                                                    "target": 4884
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 2757
+                                                    "target": 2892
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3344
+                                                    "delta_percentage": 5,
+                                                    "target": 3370
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 5636
+                                                    "delta_percentage": 7,
+                                                    "target": 5644
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 4134
+                                                    "delta_percentage": 10,
+                                                    "target": 3979
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3335
+                                                    "delta_percentage": 7,
+                                                    "target": 3350
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5619
+                                                    "delta_percentage": 8,
+                                                    "target": 5649
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 3918
+                                                    "delta_percentage": 9,
+                                                    "target": 3897
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 4,
-                                                    "target": 8909
+                                                    "target": 9458
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 2859
+                                                    "delta_percentage": 6,
+                                                    "target": 2973
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 8999
+                                                    "target": 9578
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 2780
+                                                    "target": 2899
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3531
+                                                    "delta_percentage": 5,
+                                                    "target": 3576
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 13593
+                                                    "delta_percentage": 6,
+                                                    "target": 14614
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 3732
+                                                    "target": 3774
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3512
+                                                    "delta_percentage": 7,
+                                                    "target": 3530
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 13169
+                                                    "delta_percentage": 6,
+                                                    "target": 14642
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3588
+                                                    "delta_percentage": 7,
+                                                    "target": 3629
                                                 }
                                             }
                                         }
@@ -656,8 +812,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -673,7 +829,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -681,35 +837,35 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 118
+                                                    "delta_percentage": 7,
+                                                    "target": 117
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 128
+                                                    "target": 127
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
                                                     "target": 118
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 198
+                                                    "delta_percentage": 4,
+                                                    "target": 197
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 128
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -721,7 +877,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-h2g": {
@@ -733,7 +889,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 105
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -741,15 +897,15 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 117
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 105
+                                                    "delta_percentage": 7,
+                                                    "target": 106
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
@@ -762,25 +918,25 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 52
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 62
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 52
+                                                    "delta_percentage": 9,
+                                                    "target": 53
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 61
+                                                    "target": 62
                                                 }
                                             }
                                         },
@@ -791,44 +947,44 @@
                                                     "target": 65
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 65
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 77
+                                                    "delta_percentage": 8,
+                                                    "target": 76
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 65
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 65
+                                                    "target": 66
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 77
+                                                    "delta_percentage": 8,
+                                                    "target": 76
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 11,
                                                     "target": 39
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 63
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 39
+                                                    "delta_percentage": 8,
+                                                    "target": 40
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
@@ -839,27 +995,27 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 62
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 45
+                                                    "delta_percentage": 12,
+                                                    "target": 46
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 70
+                                                    "target": 69
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 61
+                                                    "delta_percentage": 9,
+                                                    "target": 62
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 45
+                                                    "delta_percentage": 11,
+                                                    "target": 46
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 70
                                                 }
                                             }
@@ -868,25 +1024,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6649
+                                                    "target": 6804
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4445
+                                                    "delta_percentage": 8,
+                                                    "target": 4517
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6641
+                                                    "target": 6787
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4358
+                                                    "target": 4425
                                                 }
                                             }
                                         },
@@ -894,51 +1050,51 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 5112
+                                                    "target": 5170
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 7298
+                                                    "target": 7305
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5413
+                                                    "delta_percentage": 6,
+                                                    "target": 5513
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5050
+                                                    "delta_percentage": 5,
+                                                    "target": 5129
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 7335
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5316
+                                                    "delta_percentage": 8,
+                                                    "target": 5411
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 11827
+                                                    "delta_percentage": 4,
+                                                    "target": 11909
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 4533
+                                                    "delta_percentage": 8,
+                                                    "target": 4585
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 11860
+                                                    "target": 11927
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 4446
+                                                    "delta_percentage": 7,
+                                                    "target": 4486
                                                 }
                                             }
                                         },
@@ -946,27 +1102,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 5303
+                                                    "target": 5377
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 16149
+                                                    "delta_percentage": 4,
+                                                    "target": 16417
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5475
+                                                    "delta_percentage": 5,
+                                                    "target": 5546
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5310
+                                                    "delta_percentage": 7,
+                                                    "target": 5361
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 16211
+                                                    "delta_percentage": 4,
+                                                    "target": 16526
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5285
+                                                    "delta_percentage": 6,
+                                                    "target": 5409
                                                 }
                                             }
                                         }
@@ -983,8 +1139,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -992,7 +1148,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -1009,18 +1165,18 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 113
+                                                    "target": 112
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 121
+                                                    "delta_percentage": 8,
+                                                    "target": 122
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 113
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -1028,15 +1184,15 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 123
+                                                    "delta_percentage": 6,
+                                                    "target": 124
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1052,7 +1208,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
@@ -1069,7 +1225,7 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 117
+                                                    "target": 119
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
@@ -1081,7 +1237,7 @@
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 117
+                                                    "target": 118
                                                 }
                                             }
                                         }
@@ -1089,21 +1245,21 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 47
+                                                    "delta_percentage": 16,
+                                                    "target": 45
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 10,
                                                     "target": 59
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 48
+                                                    "delta_percentage": 15,
+                                                    "target": 46
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 9,
@@ -1114,11 +1270,11 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 62
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 13,
                                                     "target": 61
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -1126,52 +1282,52 @@
                                                     "target": 71
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 62
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 14,
                                                     "target": 61
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 15,
-                                                    "target": 71
+                                                    "delta_percentage": 8,
+                                                    "target": 72
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 34
+                                                    "delta_percentage": 12,
+                                                    "target": 33
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 59
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 17,
+                                                    "delta_percentage": 13,
                                                     "target": 33
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 59
+                                                    "target": 58
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 60
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 39
+                                                    "delta_percentage": 12,
+                                                    "target": 38
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
@@ -1183,10 +1339,10 @@
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 13,
-                                                    "target": 39
+                                                    "target": 38
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 69
                                                 }
                                             }
@@ -1195,25 +1351,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 16,
-                                                    "target": 9458
+                                                    "delta_percentage": 13,
+                                                    "target": 9919
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 6078
+                                                    "target": 6101
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 9412
+                                                    "delta_percentage": 13,
+                                                    "target": 9903
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 5979
+                                                    "target": 5993
                                                 }
                                             }
                                         },
@@ -1221,51 +1377,51 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 7075
+                                                    "target": 7062
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 11534
+                                                    "delta_percentage": 19,
+                                                    "target": 11867
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 20,
-                                                    "target": 7688
+                                                    "delta_percentage": 16,
+                                                    "target": 7689
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7029
+                                                    "delta_percentage": 8,
+                                                    "target": 7023
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 11610
+                                                    "delta_percentage": 18,
+                                                    "target": 11846
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 19,
-                                                    "target": 7579
+                                                    "delta_percentage": 9,
+                                                    "target": 7476
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 26,
-                                                    "target": 16184
+                                                    "delta_percentage": 8,
+                                                    "target": 16492
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 6127
+                                                    "delta_percentage": 9,
+                                                    "target": 6117
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 24,
-                                                    "target": 15709
+                                                    "delta_percentage": 8,
+                                                    "target": 16570
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5939
+                                                    "delta_percentage": 9,
+                                                    "target": 5949
                                                 }
                                             }
                                         },
@@ -1273,27 +1429,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 7334
+                                                    "target": 7247
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 23846
+                                                    "delta_percentage": 7,
+                                                    "target": 24057
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 8142
+                                                    "delta_percentage": 10,
+                                                    "target": 8164
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7317
+                                                    "delta_percentage": 9,
+                                                    "target": 7213
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 24018
+                                                    "delta_percentage": 6,
+                                                    "target": 24036
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 7744
+                                                    "delta_percentage": 9,
+                                                    "target": 7721
                                                 }
                                             }
                                         }
@@ -1310,8 +1466,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1362,8 +1518,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1416,25 +1572,25 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 8,
                                                     "target": 60
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 79
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 60
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 79
+                                                    "target": 80
                                                 }
                                             }
                                         },
@@ -1445,48 +1601,48 @@
                                                     "target": 83
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 71
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 84
+                                                    "target": 85
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
                                                     "target": 83
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 71
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 85
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 55
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 78
+                                                    "delta_percentage": 8,
+                                                    "target": 79
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 55
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 78
+                                                    "target": 79
                                                 }
                                             }
                                         },
@@ -1494,27 +1650,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 80
+                                                    "target": 79
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 58
+                                                    "delta_percentage": 8,
+                                                    "target": 62
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 83
+                                                    "delta_percentage": 6,
+                                                    "target": 84
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 80
+                                                    "target": 81
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 59
+                                                    "delta_percentage": 8,
+                                                    "target": 63
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 84
+                                                    "target": 85
                                                 }
                                             }
                                         }
@@ -1522,25 +1678,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 6673
+                                                    "target": 6658
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4999
+                                                    "target": 5106
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 6678
+                                                    "target": 6670
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4895
+                                                    "target": 4999
                                                 }
                                             }
                                         },
@@ -1548,51 +1704,51 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 6200
+                                                    "target": 6259
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6562
+                                                    "delta_percentage": 6,
+                                                    "target": 6524
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6979
+                                                    "delta_percentage": 6,
+                                                    "target": 7087
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 6302
+                                                    "target": 6365
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 6573
+                                                    "target": 6538
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6771
+                                                    "target": 6897
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 14471
+                                                    "target": 14488
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 5146
+                                                    "target": 5258
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 14466
+                                                    "target": 14520
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 5090
+                                                    "target": 5180
                                                 }
                                             }
                                         },
@@ -1600,27 +1756,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 8438
+                                                    "target": 8148
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 18543
+                                                    "delta_percentage": 5,
+                                                    "target": 19750
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 7388
+                                                    "target": 7523
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 8612
+                                                    "delta_percentage": 9,
+                                                    "target": 8397
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 18538
+                                                    "target": 19760
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 7236
+                                                    "target": 7380
                                                 }
                                             }
                                         }
@@ -1637,8 +1793,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1650,7 +1806,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-h2g": {
@@ -1663,14 +1819,14 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 118
+                                                    "target": 117
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 125
                                                 },
                                                 "vsock-p64K-bd": {
@@ -1682,15 +1838,15 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 126
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1706,7 +1862,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
@@ -1714,7 +1870,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 104
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -1727,15 +1883,15 @@
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 105
+                                                    "target": 104
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 117
+                                                    "delta_percentage": 6,
+                                                    "target": 118
                                                 }
                                             }
                                         }
@@ -1743,24 +1899,24 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 51
+                                                    "target": 52
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 60
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 51
+                                                    "delta_percentage": 9,
+                                                    "target": 53
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 60
                                                 }
                                             }
@@ -1769,14 +1925,14 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 62
+                                                    "target": 63
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 61
+                                                    "target": 62
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 73
                                                 },
                                                 "vsock-p64K-bd": {
@@ -1784,8 +1940,8 @@
                                                     "target": 63
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 61
+                                                    "delta_percentage": 8,
+                                                    "target": 62
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
@@ -1795,24 +1951,24 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 38
+                                                    "delta_percentage": 10,
+                                                    "target": 39
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
                                                     "target": 61
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 38
+                                                    "delta_percentage": 12,
+                                                    "target": 39
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 9,
                                                     "target": 61
                                                 }
                                             }
@@ -1821,26 +1977,26 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 60
+                                                    "target": 61
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 45
+                                                    "delta_percentage": 10,
+                                                    "target": 46
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 68
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 59
+                                                    "delta_percentage": 8,
+                                                    "target": 60
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 45
+                                                    "delta_percentage": 10,
+                                                    "target": 46
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 68
                                                 }
                                             }
@@ -1849,25 +2005,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 7276
+                                                    "delta_percentage": 6,
+                                                    "target": 7441
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4576
+                                                    "target": 4650
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 7234
+                                                    "delta_percentage": 6,
+                                                    "target": 7430
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 4467
+                                                    "delta_percentage": 5,
+                                                    "target": 4543
                                                 }
                                             }
                                         },
@@ -1875,79 +2031,79 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 5342
+                                                    "target": 5380
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 8757
+                                                    "delta_percentage": 7,
+                                                    "target": 8815
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5653
+                                                    "delta_percentage": 6,
+                                                    "target": 5735
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5267
+                                                    "delta_percentage": 5,
+                                                    "target": 5311
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 8761
+                                                    "delta_percentage": 7,
+                                                    "target": 8839
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 5555
+                                                    "target": 5623
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 12223
+                                                    "target": 12540
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 4674
+                                                    "target": 4730
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 12263
+                                                    "target": 12532
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4532
+                                                    "target": 4617
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5518
+                                                    "delta_percentage": 5,
+                                                    "target": 5568
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 17947
+                                                    "delta_percentage": 6,
+                                                    "target": 18280
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5843
+                                                    "target": 5851
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5494
+                                                    "delta_percentage": 7,
+                                                    "target": 5499
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 18032
+                                                    "target": 18410
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5594
+                                                    "delta_percentage": 5,
+                                                    "target": 5629
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
@@ -6,8 +6,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -58,8 +58,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -112,8 +112,8 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -122,15 +122,15 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 80
+                                                    "target": 81
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 63
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 80
+                                                    "target": 82
                                                 }
                                             }
                                         },
@@ -141,7 +141,7 @@
                                                     "target": 86
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 69
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -149,7 +149,7 @@
                                                     "target": 97
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 87
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -164,25 +164,25 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 53
+                                                    "delta_percentage": 9,
+                                                    "target": 54
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 79
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 53
+                                                    "delta_percentage": 7,
+                                                    "target": 54
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 78
+                                                    "target": 79
                                                 }
                                             }
                                         },
@@ -193,24 +193,24 @@
                                                     "target": 77
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 56
+                                                    "delta_percentage": 10,
+                                                    "target": 57
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 85
+                                                    "target": 86
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 77
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 7,
                                                     "target": 56
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 85
+                                                    "delta_percentage": 6,
+                                                    "target": 87
                                                 }
                                             }
                                         }
@@ -218,77 +218,77 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9103
+                                                    "target": 8863
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 7350
+                                                    "target": 7101
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 9100
+                                                    "delta_percentage": 6,
+                                                    "target": 8879
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 7125
+                                                    "target": 6895
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7688
+                                                    "delta_percentage": 7,
+                                                    "target": 7575
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 9237
+                                                    "target": 8896
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 6825
+                                                    "delta_percentage": 13,
+                                                    "target": 6973
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 7604
+                                                    "target": 7510
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 9240
+                                                    "target": 8937
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 6818
+                                                    "delta_percentage": 10,
+                                                    "target": 7068
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 19097
+                                                    "delta_percentage": 6,
+                                                    "target": 18777
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7198
+                                                    "delta_percentage": 7,
+                                                    "target": 6946
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 19116
+                                                    "delta_percentage": 6,
+                                                    "target": 18812
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6922
+                                                    "target": 6689
                                                 }
                                             }
                                         },
@@ -296,27 +296,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 8377
+                                                    "target": 8010
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 23784
+                                                    "target": 23509
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 7839
+                                                    "target": 7591
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 8307
+                                                    "target": 7976
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 23928
+                                                    "delta_percentage": 6,
+                                                    "target": 23336
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7709
+                                                    "delta_percentage": 7,
+                                                    "target": 7437
                                                 }
                                             }
                                         }
@@ -333,12 +333,12 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -358,39 +358,39 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 121
+                                                    "delta_percentage": 8,
+                                                    "target": 120
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 132
+                                                    "delta_percentage": 8,
+                                                    "target": 131
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 121
+                                                    "delta_percentage": 6,
+                                                    "target": 120
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 133
+                                                    "delta_percentage": 8,
+                                                    "target": 132
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -418,7 +418,7 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 119
                                                 },
                                                 "vsock-p64K-bd": {
@@ -426,12 +426,12 @@
                                                     "target": 105
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 119
+                                                    "delta_percentage": 6,
+                                                    "target": 120
                                                 }
                                             }
                                         }
@@ -439,21 +439,21 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 53
+                                                    "delta_percentage": 9,
+                                                    "target": 55
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 59
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 53
+                                                    "delta_percentage": 9,
+                                                    "target": 55
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
@@ -464,48 +464,48 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 63
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 66
+                                                    "target": 67
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 78
+                                                    "delta_percentage": 10,
+                                                    "target": 77
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 64
+                                                    "target": 63
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 66
+                                                    "target": 67
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 9,
                                                     "target": 77
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 11,
                                                     "target": 41
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 61
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 41
+                                                    "delta_percentage": 8,
+                                                    "target": 42
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
@@ -517,23 +517,23 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 60
+                                                    "target": 61
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 49
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 68
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 59
+                                                    "delta_percentage": 8,
+                                                    "target": 60
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 49
+                                                    "delta_percentage": 9,
+                                                    "target": 50
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
@@ -545,105 +545,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6587
+                                                    "target": 6680
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4894
+                                                    "target": 4971
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 6596
+                                                    "target": 6691
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 4741
+                                                    "target": 4817
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5580
+                                                    "delta_percentage": 8,
+                                                    "target": 5555
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 7030
+                                                    "target": 7080
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5647
+                                                    "delta_percentage": 8,
+                                                    "target": 5741
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5521
+                                                    "delta_percentage": 7,
+                                                    "target": 5493
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 7050
+                                                    "target": 7105
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5550
+                                                    "delta_percentage": 9,
+                                                    "target": 5638
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 4,
-                                                    "target": 11995
+                                                    "target": 12096
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5001
+                                                    "delta_percentage": 7,
+                                                    "target": 5050
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 12008
+                                                    "delta_percentage": 4,
+                                                    "target": 12105
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 4859
+                                                    "delta_percentage": 7,
+                                                    "target": 4959
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5824
+                                                    "delta_percentage": 7,
+                                                    "target": 5845
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 16173
+                                                    "delta_percentage": 4,
+                                                    "target": 16425
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5814
+                                                    "delta_percentage": 7,
+                                                    "target": 5852
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 5789
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 16217
+                                                    "target": 16511
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5633
+                                                    "delta_percentage": 7,
+                                                    "target": 5709
                                                 }
                                             }
                                         }
@@ -656,8 +656,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -681,7 +681,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 113
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -689,11 +689,11 @@
                                                     "target": 197
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 10,
                                                     "target": 119
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 115
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -701,15 +701,15 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 120
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -717,7 +717,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -725,7 +725,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -733,15 +733,15 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 104
+                                                    "delta_percentage": 7,
+                                                    "target": 105
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 114
                                                 },
                                                 "vsock-p64K-bd": {
@@ -750,7 +750,7 @@
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
@@ -762,105 +762,105 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 54
+                                                    "delta_percentage": 9,
+                                                    "target": 55
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 66
+                                                    "target": 69
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 11,
-                                                    "target": 55
+                                                    "target": 56
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 65
+                                                    "delta_percentage": 8,
+                                                    "target": 68
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 70
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 66
+                                                    "delta_percentage": 7,
+                                                    "target": 67
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 16,
-                                                    "target": 73
+                                                    "delta_percentage": 18,
+                                                    "target": 72
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
                                                     "target": 71
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 66
+                                                    "delta_percentage": 8,
+                                                    "target": 67
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 13,
-                                                    "target": 72
+                                                    "delta_percentage": 22,
+                                                    "target": 74
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 38
+                                                    "delta_percentage": 11,
+                                                    "target": 41
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 67
+                                                    "delta_percentage": 7,
+                                                    "target": 70
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 38
+                                                    "delta_percentage": 11,
+                                                    "target": 41
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 66
+                                                    "delta_percentage": 7,
+                                                    "target": 69
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 69
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 51
+                                                    "target": 53
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 76
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 67
+                                                    "delta_percentage": 8,
+                                                    "target": 68
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 49
+                                                    "delta_percentage": 7,
+                                                    "target": 53
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 75
+                                                    "delta_percentage": 8,
+                                                    "target": 76
                                                 }
                                             }
                                         }
@@ -868,25 +868,25 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4790
+                                                    "delta_percentage": 8,
+                                                    "target": 4879
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 3032
+                                                    "target": 3122
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4785
+                                                    "delta_percentage": 9,
+                                                    "target": 4863
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 2949
+                                                    "target": 3064
                                                 }
                                             }
                                         },
@@ -894,79 +894,79 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 3546
+                                                    "target": 3560
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5330
+                                                    "delta_percentage": 9,
+                                                    "target": 5301
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 15,
-                                                    "target": 4126
+                                                    "delta_percentage": 13,
+                                                    "target": 4193
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 3536
+                                                    "delta_percentage": 7,
+                                                    "target": 3545
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5353
+                                                    "delta_percentage": 9,
+                                                    "target": 5299
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 11,
-                                                    "target": 4113
+                                                    "target": 4100
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 9204
+                                                    "delta_percentage": 6,
+                                                    "target": 9811
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 3060
+                                                    "target": 3160
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 9235
+                                                    "delta_percentage": 7,
+                                                    "target": 9840
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 2954
+                                                    "delta_percentage": 7,
+                                                    "target": 3091
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 4,
-                                                    "target": 3782
+                                                    "delta_percentage": 6,
+                                                    "target": 3790
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 13982
+                                                    "delta_percentage": 7,
+                                                    "target": 14532
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3901
+                                                    "delta_percentage": 7,
+                                                    "target": 3897
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 3747
+                                                    "target": 3763
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 13730
+                                                    "delta_percentage": 7,
+                                                    "target": 14513
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 3734
+                                                    "delta_percentage": 6,
+                                                    "target": 3789
                                                 }
                                             }
                                         }
@@ -983,8 +983,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1016,11 +1016,11 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 125
+                                                    "delta_percentage": 7,
+                                                    "target": 126
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 115
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -1028,15 +1028,15 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 128
+                                                    "delta_percentage": 7,
+                                                    "target": 127
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1052,7 +1052,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -1060,8 +1060,8 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 105
+                                                    "delta_percentage": 7,
+                                                    "target": 104
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
@@ -1073,15 +1073,15 @@
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 105
+                                                    "target": 104
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 118
+                                                    "delta_percentage": 6,
+                                                    "target": 119
                                                 }
                                             }
                                         }
@@ -1089,8 +1089,8 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1099,14 +1099,14 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 59
+                                                    "target": 60
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 16,
+                                                    "delta_percentage": 14,
                                                     "target": 50
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 60
                                                 }
                                             }
@@ -1114,35 +1114,35 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 64
+                                                    "delta_percentage": 8,
+                                                    "target": 63
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 12,
-                                                    "target": 62
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 73
+                                                    "delta_percentage": 12,
+                                                    "target": 74
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 9,
                                                     "target": 64
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 62
+                                                    "delta_percentage": 12,
+                                                    "target": 64
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 10,
                                                     "target": 74
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1151,43 +1151,43 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 61
+                                                    "target": 60
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 16,
-                                                    "target": 34
+                                                    "delta_percentage": 14,
+                                                    "target": 33
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 60
+                                                    "target": 59
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 61
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 38
+                                                    "delta_percentage": 14,
+                                                    "target": 40
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 70
+                                                    "delta_percentage": 7,
+                                                    "target": 69
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 8,
                                                     "target": 60
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 39
+                                                    "delta_percentage": 13,
+                                                    "target": 40
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 69
+                                                    "delta_percentage": 8,
+                                                    "target": 70
                                                 }
                                             }
                                         }
@@ -1195,105 +1195,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 9455
+                                                    "delta_percentage": 12,
+                                                    "target": 9339
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 6809
+                                                    "delta_percentage": 9,
+                                                    "target": 6575
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 9513
+                                                    "delta_percentage": 12,
+                                                    "target": 9302
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 6658
+                                                    "target": 6423
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7775
+                                                    "delta_percentage": 10,
+                                                    "target": 7578
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 15,
-                                                    "target": 11398
+                                                    "target": 11082
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 8107
+                                                    "delta_percentage": 12,
+                                                    "target": 7939
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 7698
+                                                    "target": 7495
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 15,
-                                                    "target": 11308
+                                                    "target": 11131
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 8006
+                                                    "delta_percentage": 10,
+                                                    "target": 7793
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 17921
+                                                    "delta_percentage": 9,
+                                                    "target": 16928
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 6754
+                                                    "target": 6554
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 18027
+                                                    "target": 16988
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 6544
+                                                    "delta_percentage": 9,
+                                                    "target": 6359
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 7990
+                                                    "delta_percentage": 11,
+                                                    "target": 7810
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 25278
+                                                    "delta_percentage": 9,
+                                                    "target": 25129
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 8328
+                                                    "delta_percentage": 10,
+                                                    "target": 8004
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 7998
+                                                    "target": 7786
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 25296
+                                                    "delta_percentage": 10,
+                                                    "target": 24841
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 7975
+                                                    "delta_percentage": 10,
+                                                    "target": 7769
                                                 }
                                             }
                                         }
@@ -1310,105 +1310,105 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
+                                                    "delta_percentage": 4,
+                                                    "target": 100
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 99
+                                                    "delta_percentage": 4,
+                                                    "target": 100
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
+                                                    "delta_percentage": 4,
+                                                    "target": 100
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
+                                                    "delta_percentage": 4,
+                                                    "target": 100
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 198
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 197
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 197
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 198
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 197
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 198
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
+                                                    "delta_percentage": 4,
+                                                    "target": 100
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
+                                                    "delta_percentage": 4,
+                                                    "target": 100
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 99
+                                                    "delta_percentage": 4,
+                                                    "target": 100
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
+                                                    "delta_percentage": 4,
+                                                    "target": 100
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 198
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 198
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 197
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 198
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 197
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 197
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 }
                                             }
                                         }
@@ -1416,41 +1416,41 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 60
+                                                    "delta_percentage": 8,
+                                                    "target": 61
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 79
+                                                    "target": 80
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 60
+                                                    "target": 61
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 79
+                                                    "target": 81
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 87
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 71
+                                                    "delta_percentage": 7,
+                                                    "target": 72
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 98
+                                                    "target": 99
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
@@ -1458,7 +1458,7 @@
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 71
+                                                    "target": 72
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 5,
@@ -1468,25 +1468,25 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 56
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 79
+                                                    "target": 80
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 56
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 79
+                                                    "target": 80
                                                 }
                                             }
                                         },
@@ -1494,27 +1494,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 79
+                                                    "target": 78
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 60
+                                                    "delta_percentage": 8,
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 86
-                                                },
-                                                "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 80
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 60
-                                                },
-                                                "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 87
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 9,
+                                                    "target": 78
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 64
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 89
                                                 }
                                             }
                                         }
@@ -1522,77 +1522,77 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6300
+                                                    "target": 6264
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5814
+                                                    "target": 5726
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6321
+                                                    "target": 6281
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5615
+                                                    "delta_percentage": 5,
+                                                    "target": 5558
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5974
+                                                    "delta_percentage": 6,
+                                                    "target": 6032
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6424
+                                                    "delta_percentage": 7,
+                                                    "target": 6231
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 5400
+                                                    "target": 5836
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 6011
+                                                    "delta_percentage": 6,
+                                                    "target": 6050
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6433
+                                                    "delta_percentage": 6,
+                                                    "target": 6233
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5474
+                                                    "delta_percentage": 9,
+                                                    "target": 5890
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 13652
+                                                    "delta_percentage": 5,
+                                                    "target": 13692
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5811
+                                                    "delta_percentage": 5,
+                                                    "target": 5688
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 13600
+                                                    "delta_percentage": 5,
+                                                    "target": 13718
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5556
+                                                    "target": 5502
                                                 }
                                             }
                                         },
@@ -1600,27 +1600,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 6708
+                                                    "target": 6519
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 17240
+                                                    "delta_percentage": 5,
+                                                    "target": 18367
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6027
+                                                    "delta_percentage": 5,
+                                                    "target": 5963
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 6707
+                                                    "target": 6487
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 17363
+                                                    "delta_percentage": 5,
+                                                    "target": 18372
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 5967
+                                                    "target": 5965
                                                 }
                                             }
                                         }
@@ -1637,12 +1637,12 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -1663,14 +1663,14 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 120
+                                                    "target": 119
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 128
                                                 },
                                                 "vsock-p64K-bd": {
@@ -1689,8 +1689,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1722,8 +1722,8 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 119
+                                                    "delta_percentage": 6,
+                                                    "target": 120
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 6,
@@ -1743,24 +1743,24 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 53
+                                                    "delta_percentage": 8,
+                                                    "target": 54
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 58
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 53
+                                                    "delta_percentage": 10,
+                                                    "target": 54
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 58
                                                 }
                                             }
@@ -1768,51 +1768,51 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 62
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 63
+                                                    "delta_percentage": 9,
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 74
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 63
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 63
+                                                    "target": 64
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 74
+                                                    "delta_percentage": 9,
+                                                    "target": 73
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 40
+                                                    "target": 41
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 59
+                                                    "delta_percentage": 7,
+                                                    "target": 60
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 40
+                                                    "delta_percentage": 11,
+                                                    "target": 41
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 59
                                                 }
                                             }
@@ -1820,15 +1820,15 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 59
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 48
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 67
                                                 },
                                                 "vsock-p64K-bd": {
@@ -1837,11 +1837,11 @@
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 48
+                                                    "target": 49
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 67
+                                                    "delta_percentage": 8,
+                                                    "target": 68
                                                 }
                                             }
                                         }
@@ -1849,77 +1849,77 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 7187
+                                                    "delta_percentage": 6,
+                                                    "target": 7372
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5075
+                                                    "target": 5126
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 7215
+                                                    "delta_percentage": 6,
+                                                    "target": 7402
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4934
+                                                    "delta_percentage": 6,
+                                                    "target": 4996
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5857
+                                                    "delta_percentage": 6,
+                                                    "target": 5941
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 8456
+                                                    "delta_percentage": 7,
+                                                    "target": 8637
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 6026
+                                                    "target": 6149
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5768
+                                                    "delta_percentage": 6,
+                                                    "target": 5867
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 8486
+                                                    "delta_percentage": 7,
+                                                    "target": 8666
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5917
+                                                    "target": 6047
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 12444
+                                                    "delta_percentage": 6,
+                                                    "target": 12739
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5202
+                                                    "delta_percentage": 7,
+                                                    "target": 5246
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 12427
+                                                    "delta_percentage": 6,
+                                                    "target": 12693
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5015
+                                                    "delta_percentage": 8,
+                                                    "target": 5103
                                                 }
                                             }
                                         },
@@ -1927,27 +1927,27 @@
                                             "total": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 6076
+                                                    "target": 6162
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 17510
+                                                    "delta_percentage": 6,
+                                                    "target": 17904
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 6257
+                                                    "delta_percentage": 7,
+                                                    "target": 6310
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 6009
+                                                    "delta_percentage": 6,
+                                                    "target": 6112
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 17629
+                                                    "delta_percentage": 6,
+                                                    "target": 18021
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 6030
+                                                    "target": 6092
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_6.1.json
@@ -6,8 +6,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -58,8 +58,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -112,21 +112,21 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 61
+                                                    "target": 60
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 80
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 61
+                                                    "delta_percentage": 8,
+                                                    "target": 60
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
@@ -138,38 +138,38 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 86
+                                                    "target": 85
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 66
+                                                    "delta_percentage": 8,
+                                                    "target": 65
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 97
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 87
+                                                    "target": 86
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 66
+                                                    "delta_percentage": 8,
+                                                    "target": 64
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 98
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 9,
                                                     "target": 48
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -177,8 +177,8 @@
                                                     "target": 78
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 47
+                                                    "delta_percentage": 8,
+                                                    "target": 48
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
@@ -189,24 +189,24 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 76
+                                                    "delta_percentage": 7,
+                                                    "target": 75
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 50
+                                                    "delta_percentage": 12,
+                                                    "target": 54
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 85
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 77
+                                                    "target": 76
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 51
+                                                    "target": 52
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
@@ -218,105 +218,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9638
+                                                    "target": 9486
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7412
+                                                    "delta_percentage": 7,
+                                                    "target": 7460
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9651
+                                                    "target": 9508
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 7149
+                                                    "target": 7237
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7602
+                                                    "delta_percentage": 9,
+                                                    "target": 7935
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 10341
+                                                    "target": 10095
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 14,
-                                                    "target": 6596
+                                                    "delta_percentage": 17,
+                                                    "target": 6993
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 7563
+                                                    "target": 7781
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 10361
+                                                    "target": 10137
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 13,
-                                                    "target": 6661
+                                                    "delta_percentage": 17,
+                                                    "target": 6974
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 20832
+                                                    "delta_percentage": 6,
+                                                    "target": 20670
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7235
+                                                    "delta_percentage": 7,
+                                                    "target": 7312
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 20873
+                                                    "delta_percentage": 5,
+                                                    "target": 20682
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6967
+                                                    "delta_percentage": 7,
+                                                    "target": 7056
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 8434
+                                                    "delta_percentage": 7,
+                                                    "target": 8441
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 26485
+                                                    "target": 27504
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 7929
+                                                    "target": 7969
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 8422
+                                                    "delta_percentage": 7,
+                                                    "target": 8407
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 26429
+                                                    "delta_percentage": 7,
+                                                    "target": 26788
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7769
+                                                    "delta_percentage": 7,
+                                                    "target": 7794
                                                 }
                                             }
                                         }
@@ -333,8 +333,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -346,7 +346,7 @@
                                                     "target": 100
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 100
                                                 },
                                                 "vsock-p64K-h2g": {
@@ -359,34 +359,34 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 120
+                                                    "target": 119
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 199
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 132
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 121
+                                                    "target": 119
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 199
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 132
+                                                    "target": 133
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -394,7 +394,7 @@
                                                     "target": 100
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 3,
                                                     "target": 100
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -410,7 +410,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 106
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -418,11 +418,11 @@
                                                     "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 118
+                                                    "delta_percentage": 7,
+                                                    "target": 120
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 106
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -431,7 +431,7 @@
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 120
+                                                    "target": 124
                                                 }
                                             }
                                         }
@@ -439,24 +439,24 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 52
+                                                    "delta_percentage": 8,
+                                                    "target": 53
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 58
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 52
+                                                    "delta_percentage": 8,
+                                                    "target": 54
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 58
                                                 }
                                             }
@@ -464,76 +464,76 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 8,
                                                     "target": 61
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 63
+                                                    "delta_percentage": 8,
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 75
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 61
+                                                    "delta_percentage": 9,
+                                                    "target": 60
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 63
+                                                    "delta_percentage": 8,
+                                                    "target": 64
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 75
+                                                    "target": 74
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 11,
-                                                    "target": 38
+                                                    "target": 39
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 59
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 38
+                                                    "delta_percentage": 12,
+                                                    "target": 39
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 58
+                                                    "target": 59
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 58
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 46
+                                                    "delta_percentage": 10,
+                                                    "target": 48
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 66
+                                                    "delta_percentage": 6,
+                                                    "target": 65
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 57
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 45
+                                                    "delta_percentage": 11,
+                                                    "target": 47
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
@@ -545,105 +545,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6722
+                                                    "target": 6837
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 4727
+                                                    "delta_percentage": 5,
+                                                    "target": 4573
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6737
+                                                    "target": 6877
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 4566
+                                                    "delta_percentage": 5,
+                                                    "target": 4488
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5350
+                                                    "delta_percentage": 6,
+                                                    "target": 5208
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 7726
+                                                    "target": 7796
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5610
+                                                    "target": 5544
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5286
+                                                    "delta_percentage": 5,
+                                                    "target": 5145
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 7730
+                                                    "target": 7809
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5514
+                                                    "delta_percentage": 6,
+                                                    "target": 5494
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 12668
+                                                    "delta_percentage": 4,
+                                                    "target": 12634
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 4818
+                                                    "delta_percentage": 5,
+                                                    "target": 4662
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 12687
+                                                    "target": 12677
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4655
+                                                    "target": 4547
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5607
+                                                    "delta_percentage": 5,
+                                                    "target": 5455
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 17479
+                                                    "delta_percentage": 6,
+                                                    "target": 17718
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5593
+                                                    "delta_percentage": 5,
+                                                    "target": 5510
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 5584
+                                                    "target": 5437
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 17233
+                                                    "target": 17508
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5442
+                                                    "delta_percentage": 5,
+                                                    "target": 5428
                                                 }
                                             }
                                         }
@@ -656,8 +656,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -665,7 +665,334 @@
                                                     "target": 100
                                                 },
                                                 "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
+                                                    "target": 100
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 7,
+                                                    "target": 112
+                                                },
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 5,
+                                                    "target": 197
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 19,
+                                                    "target": 140
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 5,
+                                                    "target": 113
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 5,
+                                                    "target": 198
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 16,
+                                                    "target": 148
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 4,
+                                                    "target": 100
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 5,
+                                                    "target": 106
+                                                },
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 8,
+                                                    "target": 137
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 5,
+                                                    "target": 106
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 8,
+                                                    "target": 138
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vmm": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 12,
+                                                    "target": 56
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 65
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 10,
+                                                    "target": 56
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 9,
+                                                    "target": 65
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 8,
+                                                    "target": 66
+                                                },
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 8,
+                                                    "target": 66
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 15,
+                                                    "target": 75
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 9,
+                                                    "target": 67
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 8,
+                                                    "target": 66
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 9,
+                                                    "target": 76
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 12,
+                                                    "target": 39
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 66
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 9,
+                                                    "target": 39
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 8,
+                                                    "target": 65
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 8,
+                                                    "target": 65
+                                                },
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 12,
+                                                    "target": 48
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 72
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 7,
+                                                    "target": 64
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 10,
+                                                    "target": 48
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 72
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "throughput": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 4830
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 2833
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 4811
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 2774
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 6,
+                                                    "target": 3217
+                                                },
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 5,
+                                                    "target": 5557
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 3766
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 6,
+                                                    "target": 3210
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 7,
+                                                    "target": 5542
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 7,
+                                                    "target": 3732
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 9,
+                                                    "target": 9718
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 2863
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 5,
+                                                    "target": 9784
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 2779
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 5,
+                                                    "target": 3411
+                                                },
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 9,
+                                                    "target": 14760
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 3705
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 6,
+                                                    "target": 3409
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 8,
+                                                    "target": 14848
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 5,
+                                                    "target": 3573
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz"
+                    }
+                ]
+            },
+            "m6a.metal": {
+                "cpus": [
+                    {
+                        "baselines": {
+                            "cpu_utilization_vcpus_total": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 5,
+                                                    "target": 100
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 4,
                                                     "target": 100
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -685,31 +1012,31 @@
                                                     "target": 113
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 197
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 6,
                                                     "target": 124
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 114
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 197
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 131
+                                                    "delta_percentage": 6,
+                                                    "target": 127
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -733,28 +1060,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 106
+                                                    "delta_percentage": 6,
+                                                    "target": 105
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 4,
                                                     "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
+                                                    "target": 125
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 6,
+                                                    "target": 105
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 4,
+                                                    "target": 200
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 7,
                                                     "target": 122
-                                                },
-                                                "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 106
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 126
                                                 }
                                             }
                                         }
@@ -762,351 +1089,24 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 54
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 61
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 54
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 61
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 68
-                                                },
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 65
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 75
-                                                },
-                                                "vsock-p64K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 67
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 65
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 76
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 35
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 63
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 36
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 62
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 65
-                                                },
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 46
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 72
-                                                },
-                                                "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 64
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 46
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 71
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "total": {
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 4701
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2780
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 4698
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 2725
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "total": {
-                                                "vsock-p1024K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3268
-                                                },
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5503
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3764
-                                                },
-                                                "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3276
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5531
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3652
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "total": {
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 9157
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 2811
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 9198
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 2723
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "total": {
-                                                "vsock-p1024K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3472
-                                                },
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 14446
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3691
-                                                },
-                                                "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3438
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 14259
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3552
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz"
-                    }
-                ]
-            },
-            "m6a.metal": {
-                "cpus": [
-                    {
-                        "baselines": {
-                            "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 100
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 100
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 114
-                                                },
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 126
-                                                },
-                                                "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 115
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 128
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 100
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 4,
-                                                    "target": 100
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 105
-                                                },
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 128
-                                                },
-                                                "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 105
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 200
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 120
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 52
+                                                    "target": 53
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
                                                     "target": 55
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 52
+                                                    "delta_percentage": 11,
+                                                    "target": 53
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 55
                                                 }
                                             }
@@ -1118,48 +1118,48 @@
                                                     "target": 58
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 64
+                                                    "delta_percentage": 9,
+                                                    "target": 65
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 68
+                                                    "delta_percentage": 10,
+                                                    "target": 67
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 59
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 64
+                                                    "delta_percentage": 8,
+                                                    "target": 65
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 69
+                                                    "target": 67
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 21,
-                                                    "target": 36
+                                                    "delta_percentage": 23,
+                                                    "target": 35
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 56
+                                                    "target": 55
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 19,
-                                                    "target": 37
+                                                    "delta_percentage": 21,
+                                                    "target": 35
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 55
+                                                    "delta_percentage": 10,
+                                                    "target": 54
                                                 }
                                             }
                                         },
@@ -1170,23 +1170,23 @@
                                                     "target": 55
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 39
+                                                    "delta_percentage": 14,
+                                                    "target": 42
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 65
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 11,
                                                     "target": 55
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 40
+                                                    "delta_percentage": 16,
+                                                    "target": 41
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 10,
                                                     "target": 64
                                                 }
                                             }
@@ -1195,105 +1195,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 10038
+                                                    "delta_percentage": 9,
+                                                    "target": 10184
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 6515
+                                                    "delta_percentage": 10,
+                                                    "target": 6348
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 10083
+                                                    "delta_percentage": 9,
+                                                    "target": 10171
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 6403
+                                                    "target": 6257
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7522
+                                                    "delta_percentage": 9,
+                                                    "target": 7355
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 12317
+                                                    "delta_percentage": 9,
+                                                    "target": 12276
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 8310
+                                                    "delta_percentage": 9,
+                                                    "target": 8280
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7458
+                                                    "delta_percentage": 7,
+                                                    "target": 7345
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 12300
+                                                    "delta_percentage": 9,
+                                                    "target": 12341
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 8196
+                                                    "target": 8177
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 19196
+                                                    "delta_percentage": 14,
+                                                    "target": 19106
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 6558
+                                                    "target": 6380
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 19212
+                                                    "delta_percentage": 15,
+                                                    "target": 18971
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 6410
+                                                    "target": 6247
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 10,
-                                                    "target": 7844
+                                                    "delta_percentage": 11,
+                                                    "target": 7634
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 12,
-                                                    "target": 27980
+                                                    "target": 28697
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 8647
+                                                    "delta_percentage": 11,
+                                                    "target": 8886
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 7833
+                                                    "delta_percentage": 9,
+                                                    "target": 7644
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 27700
+                                                    "delta_percentage": 13,
+                                                    "target": 28572
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 8126
+                                                    "delta_percentage": 11,
+                                                    "target": 8347
                                                 }
                                             }
                                         }
@@ -1310,8 +1310,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1362,8 +1362,8 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1416,8 +1416,8 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1426,14 +1426,14 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 78
+                                                    "target": 79
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 58
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 79
                                                 }
                                             }
@@ -1441,24 +1441,24 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 86
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 66
+                                                    "delta_percentage": 8,
+                                                    "target": 67
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 98
+                                                    "delta_percentage": 5,
+                                                    "target": 99
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 86
+                                                    "delta_percentage": 7,
+                                                    "target": 87
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 66
+                                                    "delta_percentage": 7,
+                                                    "target": 67
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
@@ -1468,12 +1468,12 @@
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 55
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -1481,11 +1481,11 @@
                                                     "target": 78
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 55
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 78
                                                 }
                                             }
@@ -1493,28 +1493,28 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 79
+                                                    "delta_percentage": 8,
+                                                    "target": 78
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 63
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
                                                     "target": 86
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 80
+                                                    "delta_percentage": 7,
+                                                    "target": 79
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 63
+                                                    "delta_percentage": 8,
+                                                    "target": 64
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 88
+                                                    "delta_percentage": 8,
+                                                    "target": 87
                                                 }
                                             }
                                         }
@@ -1522,24 +1522,76 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6639
+                                                    "target": 6676
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5962
+                                                    "target": 6036
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 6643
+                                                    "target": 6682
                                                 },
                                                 "vsock-p64K-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 5862
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-bd": {
+                                                    "delta_percentage": 6,
+                                                    "target": 6337
+                                                },
+                                                "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
+                                                    "target": 7385
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 8,
+                                                    "target": 5913
+                                                },
+                                                "vsock-p64K-bd": {
+                                                    "delta_percentage": 6,
+                                                    "target": 6380
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 7392
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 8,
+                                                    "target": 5910
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 13584
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 6012
+                                                },
+                                                "vsock-p64K-g2h": {
+                                                    "delta_percentage": 6,
+                                                    "target": 13603
+                                                },
+                                                "vsock-p64K-h2g": {
+                                                    "delta_percentage": 6,
                                                     "target": 5782
                                                 }
                                             }
@@ -1547,80 +1599,28 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6187
-                                                },
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 7388
-                                                },
-                                                "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 5579
-                                                },
-                                                "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6256
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7397
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5644
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "total": {
-                                                "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 13643
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5974
-                                                },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 13679
-                                                },
-                                                "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5747
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "total": {
-                                                "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6929
+                                                    "target": 6905
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 17777
+                                                    "delta_percentage": 5,
+                                                    "target": 17754
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6222
+                                                    "delta_percentage": 6,
+                                                    "target": 6247
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6979
+                                                    "delta_percentage": 7,
+                                                    "target": 6925
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 17484
+                                                    "delta_percentage": 5,
+                                                    "target": 17814
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6177
+                                                    "delta_percentage": 6,
+                                                    "target": 6276
                                                 }
                                             }
                                         }
@@ -1637,8 +1637,8 @@
                     {
                         "baselines": {
                             "cpu_utilization_vcpus_total": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1663,19 +1663,19 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 121
+                                                    "target": 120
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 4,
                                                     "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 132
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 123
+                                                    "target": 122
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 4,
@@ -1683,14 +1683,14 @@
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 133
+                                                    "target": 132
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
@@ -1714,7 +1714,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 105
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -1723,7 +1723,7 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 121
+                                                    "target": 120
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 6,
@@ -1743,21 +1743,21 @@
                                 }
                             },
                             "cpu_utilization_vmm": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 53
+                                                    "delta_percentage": 8,
+                                                    "target": 54
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 57
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 53
+                                                    "delta_percentage": 8,
+                                                    "target": 54
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 9,
@@ -1772,36 +1772,36 @@
                                                     "target": 60
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 62
+                                                    "delta_percentage": 9,
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 75
+                                                    "delta_percentage": 7,
+                                                    "target": 74
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 8,
                                                     "target": 61
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 62
+                                                    "delta_percentage": 9,
+                                                    "target": 64
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 75
+                                                    "delta_percentage": 8,
+                                                    "target": 74
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 40
+                                                    "delta_percentage": 11,
+                                                    "target": 41
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
@@ -1809,10 +1809,10 @@
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 40
+                                                    "target": 41
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 58
                                                 }
                                             }
@@ -1824,20 +1824,20 @@
                                                     "target": 57
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 46
+                                                    "delta_percentage": 8,
+                                                    "target": 47
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 66
+                                                    "target": 65
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 9,
                                                     "target": 56
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 10,
-                                                    "target": 46
+                                                    "target": 47
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
@@ -1849,105 +1849,105 @@
                                 }
                             },
                             "throughput": {
-                                "vmlinux-4.14.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-4.14": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 7482
+                                                    "target": 7634
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5283
+                                                    "target": 5139
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7515
+                                                    "delta_percentage": 6,
+                                                    "target": 7648
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5134
+                                                    "target": 5004
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6016
+                                                    "delta_percentage": 6,
+                                                    "target": 5873
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 8732
+                                                    "delta_percentage": 6,
+                                                    "target": 8821
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6197
+                                                    "delta_percentage": 6,
+                                                    "target": 6088
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5975
+                                                    "delta_percentage": 6,
+                                                    "target": 5798
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 8745
+                                                    "delta_percentage": 6,
+                                                    "target": 8854
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6055
+                                                    "target": 5989
                                                 }
                                             }
                                         }
                                     }
                                 },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
+                                "linux-5.10": {
+                                    "ubuntu-22.04.squashfs": {
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 14615
+                                                    "delta_percentage": 6,
+                                                    "target": 14479
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5448
+                                                    "target": 5259
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 14646
+                                                    "delta_percentage": 6,
+                                                    "target": 14520
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5251
+                                                    "target": 5082
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6316
+                                                    "delta_percentage": 6,
+                                                    "target": 6136
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 18980
+                                                    "delta_percentage": 6,
+                                                    "target": 19077
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6464
+                                                    "delta_percentage": 7,
+                                                    "target": 6223
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 6226
+                                                    "delta_percentage": 7,
+                                                    "target": 6070
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 19136
+                                                    "target": 19254
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6178
+                                                    "target": 6015
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes

Update performance baselines and re-enable them.

## Reason

To continue monitoring performance until we implement a better way.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
