### PR TITLE
Test the current binary as a regular release

### DIFF
--- a/tests/framework/stats/core.py
+++ b/tests/framework/stats/core.py
@@ -7,8 +7,7 @@
 import types
 from collections import defaultdict, namedtuple
 from datetime import datetime
-
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 from framework.utils import ExceptionAggregator
 

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -550,37 +550,6 @@ def get_firecracker_version_from_toml():
     return packaging.version.parse(stdout)
 
 
-def compare_versions(first, second):
-    """
-    Compare two versions with format `X.Y.Z`.
-
-    :param first: first version string
-    :param second: second version string
-    :returns: 0 if equal, <0 if first < second, >0 if second < first
-    """
-    first = list(map(int, first.split(".")))
-    second = list(map(int, second.split(".")))
-
-    for i in range(3):
-        diff = first[i] - second[i]
-        if diff != 0:
-            return diff
-
-    return 0
-
-
-def sanitize_version(version):
-    """
-    Get rid of dirty version information.
-
-    Transform version from format `vX.Y.Z-W` to `X.Y.Z`.
-    """
-    if version[0].isalpha():
-        version = version[1:]
-
-    return version.split("-", 1)[0]
-
-
 def get_kernel_version(level=2):
     """Return the current kernel version in format `major.minor.patch`."""
     linux_version = platform.release()
@@ -600,7 +569,9 @@ def is_io_uring_supported():
 
     ...version.
     """
-    return compare_versions(get_kernel_version(), MIN_KERNEL_VERSION_FOR_IO_URING) >= 0
+    kv = packaging.version.parse(get_kernel_version())
+    min_kv = packaging.version.parse(MIN_KERNEL_VERSION_FOR_IO_URING)
+    return kv >= min_kv
 
 
 def generate_mmds_session_token(ssh_connection, ipv4_address, token_ttl):
@@ -631,19 +602,12 @@ def generate_mmds_get_request(ipv4_address, token=None, app_json=True):
     return cmd
 
 
-def configure_mmds(
-    test_microvm, iface_ids, version=None, ipv4_address=None, fc_version=None
-):
+def configure_mmds(test_microvm, iface_ids, version=None, ipv4_address=None):
     """Configure mmds service."""
     mmds_config = {"network_interfaces": iface_ids}
 
     if version is not None:
         mmds_config["version"] = version
-
-    # For versions prior to v1.0.0, the mmds config only contains
-    # the ipv4_address.
-    if fc_version is not None and compare_versions(fc_version, "1.0.0") < 0:
-        mmds_config = {}
 
     if ipv4_address:
         mmds_config["ipv4_address"] = ipv4_address

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -45,7 +45,6 @@ def _validate_mmds_snapshot(
         version=version,
         iface_ids=["eth0"],
         ipv4_address=ipv4_address,
-        fc_version=target_fc_version,
     )
 
     expected_mmds_config = {

--- a/tools/devctr/pyproject.toml
+++ b/tools/devctr/pyproject.toml
@@ -28,7 +28,6 @@ requests-unixsocket = "^0.3.0"
 retry = "^0.9.2"
 setproctitle = "^1.3.2"
 tenacity = "^8.2.2"
-typing-extensions = "^4.6.1"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
## Changes


## Reason

With our current firecracker_release fixture, some tests are only run
against released firecracker versions that we keep in an S3 bucket. This
means the binary in the working copy does not execute those tests, and
we may only realize until we make a release, at which point is too late
and we have to make a patch release.

Fix it by extending the firecracker_release fixture to also test the
current binary as a regular release, so it goes through the same tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
