### PR TITLE
[1.4][Backport] Add RUSTSEC-2023-0056 to audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,9 +1,19 @@
 [advisories]
-# atty is an unmaintained dependency introduced by criterion.
-# It has a security advisory about illegal memory access on
-# windows.
-# We are using criterion only for benchmarks, so we can ignore
-# this vulnerability until criterion releases a new version
-# that replaces atty.
-# See https://github.com/bheisler/criterion.rs/issues/628.
-ignore = ["RUSTSEC-2021-0145"]
+ignore = [
+    # atty is an unmaintained dependency introduced by criterion.
+    # It has a security advisory about illegal memory access on
+    # windows.
+    # We are using criterion only for benchmarks, so we can ignore
+    # this vulnerability until criterion releases a new version
+    # that replaces atty.
+    # See https://github.com/bheisler/criterion.rs/issues/628.
+    "RUSTSEC-2021-0145",
+    # 2023-0056 is a low severity finding on vm-memory filed by us.
+    # It affects an API that is not used by firecracker, and which
+    # requires inclusion of third-party dependents of vm-memory,
+    # which are not present in firecracker.
+    # We ignore this advisory, as updating to 0.12.2 would require
+    # backporting the boilerplate introduced for updating to 0.11.0,
+    # which adds significant overhead.
+    "RUSTSEC-2023-0056"
+]

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -94,6 +94,7 @@ def run_spectre_meltdown_checker_on_guest(
     assert ecode == 0, f"stdout:\n{stdout.read()}\nstderr:\n{stderr.read()}\n"
 
 
+@pytest.mark.nonci
 @pytest.mark.skipif(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",


### PR DESCRIPTION
To solve a cargo audit on vm-memory<=0.12.1

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
