### PR TITLE
test: Print error message if aws cli not available

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -506,6 +506,10 @@ cmd_distclean() {
 }
 
 ensure_ci_artifacts() {
+    if [ ! command -v aws >/dev/null ]; then
+      die "AWS CLI not installed, which is required for downloading artifacts for integration tests."
+    fi
+
     # Fetch all the artifacts so they are local
     say "Fetching CI artifacts from S3"
     S3_URL=s3://spec.ccfc.min/firecracker-ci/v1.5/$(uname -m)


### PR DESCRIPTION
## Changes

Currently, devtool test silently fails if aws cli is not installed, which results in CI artifacts not getting downloaded, which results in all tests being skipped. Since the error message from downloading artifacts is burried in other output, explicitly abort.

## Reason

We have received multiple reports of all integration tests being skipped due to "empty fixtures", which happens if artifacts fail to download. They can usually be traced back to aws cli not being installed, so make this case a bit more obvious.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
