### PR TITLE
test: Only run clippy lint test with -Dwarnings

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,13 +2,13 @@
 target-dir = "build/cargo_target"
 target = "x86_64-unknown-linux-musl"
 rustflags = [
-  "-Dclippy::ptr_as_ptr",
-  "-Dclippy::undocumented_unsafe_blocks",
-  "-Dclippy::cast_lossless",
-  "-Dclippy::cast_possible_wrap",
-  "-Dclippy::cast_sign_loss",
-  "-Dmissing_debug_implementations",
-  "-Dclippy::exit",
+  "-Wclippy::ptr_as_ptr",
+  "-Wclippy::undocumented_unsafe_blocks",
+  "-Wclippy::cast_lossless",
+  "-Wclippy::cast_possible_wrap",
+  "-Wclippy::cast_sign_loss",
+  "-Wmissing_debug_implementations",
+  "-Wclippy::exit",
 ]
 
 [net]

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -43,10 +43,9 @@ def cargo(
 
 def get_rustflags():
     """Get the relevant rustflags for building/unit testing."""
-    rustflags = "-D warnings"
     if platform.machine() == "aarch64":
-        rustflags += " -C link-arg=-lgcc -C link-arg=-lfdt "
-    return rustflags
+        return "-C link-arg=-lgcc -C link-arg=-lfdt "
+    return ""
 
 
 @with_filelock


### PR DESCRIPTION
Currently, every cargo invocation in the integration tests runs with -Dwarnings. This is fairly annoying, because it causes all tests to fail if there is a single compilation warning emitted somewhere. When locally testing some changes, this means that code needs to be cleaned up to fix all warnings before any test can be run, which makes rapid prototyping very slow.

This commit changes our testing to only pass -Dwarnings to our clippy lint test. This way we still block CI on compiler warnings, but no longer prevent literally every test from running if a single warning is emitted anywhere.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
