### PR TITLE
chore: update maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,13 +3,10 @@
 Firecracker is maintained by a dedicated team within Amazon:
 
 - Alexandra Iordache <aghecen@amazon.com>
-- Andrei-Cristian Traistaru <atc@amazon.com>
 - Babis Chalios <bchalios@amazon.com>
 - Diana Popa <dpopa@amazon.com>
 - Jonathan Woollett-Light <jcawl@amazon.com>
-- Luminita Voicu <lumivo@amazon.com>
 - Marco Cali <xmarcalx@amazon.com>
-- Matthew Schlebush <schlebus@amazon.com>
 - Nikita Kalyazin <kalyazin@amazon.com>
 - Pablo Barbachano <pablob@amazon.com>
 - Patrick Roy <roypat@amazon.com>


### PR DESCRIPTION
## Changes

Few members are not part of the team anymore so updating the list.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ]~If a specific issue led to this PR, this PR closes the issue.~
- [ ]~The description of changes is clear and encompassing.~
- [ ]~Any required documentation changes (code and docs) are included in this PR.~
- [ ]~API changes follow the [Runbook for Firecracker API changes][2].~
- [ ]~User-facing changes are mentioned in `CHANGELOG.md`.~
- [ ]~All added/changed functionality is tested.~
- [ ]~New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
