### PR TITLE
chore(perf): updated m6a vsock_throughput perf

### DIFF
--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
@@ -988,11 +988,11 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -1009,7 +1009,7 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 114
+                                                    "target": 113
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
@@ -1017,19 +1017,19 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 126
+                                                    "target": 123
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 115
+                                                    "delta_percentage": 7,
+                                                    "target": 113
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 127
+                                                    "target": 124
                                                 }
                                             }
                                         }
@@ -1044,7 +1044,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-g2h": {
@@ -1052,7 +1052,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
@@ -1060,7 +1060,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 104
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -1068,20 +1068,20 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 121
+                                                    "delta_percentage": 6,
+                                                    "target": 117
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 7,
                                                     "target": 104
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 119
+                                                    "target": 116
                                                 }
                                             }
                                         }
@@ -1098,12 +1098,12 @@
                                                     "target": 50
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 60
+                                                    "delta_percentage": 10,
+                                                    "target": 61
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 50
+                                                    "delta_percentage": 12,
+                                                    "target": 49
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 9,
@@ -1115,27 +1115,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 63
+                                                    "target": 64
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 10,
                                                     "target": 64
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 74
+                                                    "delta_percentage": 9,
+                                                    "target": 73
                                                 },
                                                 "vsock-p64K-bd": {
+                                                    "delta_percentage": 8,
+                                                    "target": 65
+                                                },
+                                                "vsock-p64K-g2h": {
                                                     "delta_percentage": 9,
                                                     "target": 64
                                                 },
-                                                "vsock-p64K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 64
-                                                },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 74
+                                                    "delta_percentage": 8,
+                                                    "target": 73
                                                 }
                                             }
                                         }
@@ -1146,47 +1146,47 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 14,
+                                                    "delta_percentage": 11,
                                                     "target": 33
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 61
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 14,
+                                                    "delta_percentage": 12,
                                                     "target": 33
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 59
+                                                    "delta_percentage": 8,
+                                                    "target": 60
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 61
+                                                    "delta_percentage": 9,
+                                                    "target": 62
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 40
+                                                    "delta_percentage": 10,
+                                                    "target": 41
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 69
+                                                    "delta_percentage": 8,
+                                                    "target": 70
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 61
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 13,
                                                     "target": 40
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 70
                                                 }
                                             }
@@ -1201,47 +1201,47 @@
                                             "total": {
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 12,
-                                                    "target": 9339
+                                                    "target": 9183
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 6575
+                                                    "delta_percentage": 8,
+                                                    "target": 5999
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 12,
-                                                    "target": 9302
+                                                    "target": 9194
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 6423
+                                                    "delta_percentage": 9,
+                                                    "target": 5868
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 10,
-                                                    "target": 7578
+                                                    "delta_percentage": 8,
+                                                    "target": 6974
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 11082
+                                                    "delta_percentage": 14,
+                                                    "target": 10818
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 7939
+                                                    "delta_percentage": 9,
+                                                    "target": 7416
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 7495
+                                                    "target": 6898
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 11131
+                                                    "delta_percentage": 13,
+                                                    "target": 10743
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 7793
+                                                    "delta_percentage": 9,
+                                                    "target": 7266
                                                 }
                                             }
                                         }
@@ -1252,48 +1252,48 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 16928
+                                                    "delta_percentage": 7,
+                                                    "target": 16345
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 6554
+                                                    "delta_percentage": 9,
+                                                    "target": 6005
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 16988
+                                                    "delta_percentage": 8,
+                                                    "target": 16417
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 6359
+                                                    "target": 5827
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 11,
-                                                    "target": 7810
+                                                    "delta_percentage": 10,
+                                                    "target": 7175
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 25129
+                                                    "target": 24086
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 8004
+                                                    "target": 7461
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 7786
+                                                    "delta_percentage": 8,
+                                                    "target": 7131
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 24841
+                                                    "delta_percentage": 9,
+                                                    "target": 23831
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 7769
+                                                    "delta_percentage": 8,
+                                                    "target": 7265
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_6.1.json
@@ -992,11 +992,11 @@
                                                     "target": 100
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 100
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 100
                                                 },
                                                 "vsock-p64K-h2g": {
@@ -1009,27 +1009,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 113
+                                                    "target": 112
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 124
+                                                    "delta_percentage": 7,
+                                                    "target": 122
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 114
+                                                    "target": 112
                                                 },
                                                 "vsock-p64K-g2h": {
                                                     "delta_percentage": 4,
                                                     "target": 200
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 127
+                                                    "delta_percentage": 7,
+                                                    "target": 124
                                                 }
                                             }
                                         }
@@ -1040,7 +1040,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 4,
                                                     "target": 100
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -1052,7 +1052,7 @@
                                                     "target": 100
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 100
                                                 }
                                             }
@@ -1068,8 +1068,8 @@
                                                     "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 125
+                                                    "delta_percentage": 10,
+                                                    "target": 123
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 6,
@@ -1081,7 +1081,7 @@
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 122
+                                                    "target": 121
                                                 }
                                             }
                                         }
@@ -1094,20 +1094,20 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 53
+                                                    "delta_percentage": 12,
+                                                    "target": 54
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 55
+                                                    "target": 56
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 53
+                                                    "delta_percentage": 10,
+                                                    "target": 54
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 10,
-                                                    "target": 55
+                                                    "target": 57
                                                 }
                                             }
                                         },
@@ -1115,27 +1115,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 58
+                                                    "target": 59
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 65
+                                                    "delta_percentage": 8,
+                                                    "target": 66
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 8,
                                                     "target": 67
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 59
+                                                    "delta_percentage": 10,
+                                                    "target": 60
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 65
+                                                    "delta_percentage": 10,
+                                                    "target": 67
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 67
+                                                    "delta_percentage": 9,
+                                                    "target": 68
                                                 }
                                             }
                                         }
@@ -1146,20 +1146,20 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 23,
-                                                    "target": 35
+                                                    "delta_percentage": 18,
+                                                    "target": 37
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 55
+                                                    "delta_percentage": 9,
+                                                    "target": 56
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 21,
-                                                    "target": 35
+                                                    "delta_percentage": 16,
+                                                    "target": 37
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 54
+                                                    "delta_percentage": 9,
+                                                    "target": 56
                                                 }
                                             }
                                         },
@@ -1167,27 +1167,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 55
+                                                    "target": 57
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 14,
+                                                    "delta_percentage": 18,
                                                     "target": 42
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 65
+                                                    "delta_percentage": 8,
+                                                    "target": 67
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 11,
-                                                    "target": 55
+                                                    "delta_percentage": 10,
+                                                    "target": 56
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 16,
+                                                    "delta_percentage": 17,
                                                     "target": 41
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 64
+                                                    "delta_percentage": 8,
+                                                    "target": 66
                                                 }
                                             }
                                         }
@@ -1200,48 +1200,48 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 10184
+                                                    "delta_percentage": 11,
+                                                    "target": 9604
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 6348
+                                                    "delta_percentage": 8,
+                                                    "target": 5702
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 10171
+                                                    "delta_percentage": 10,
+                                                    "target": 9607
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 6257
+                                                    "target": 5609
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 7355
+                                                    "delta_percentage": 8,
+                                                    "target": 6607
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 12276
+                                                    "delta_percentage": 10,
+                                                    "target": 11524
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 8280
+                                                    "delta_percentage": 8,
+                                                    "target": 7565
                                                 },
                                                 "vsock-p64K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7345
+                                                    "delta_percentage": 8,
+                                                    "target": 6603
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 12341
+                                                    "delta_percentage": 12,
+                                                    "target": 11476
                                                 },
                                                 "vsock-p64K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 8177
+                                                    "target": 7462
                                                 }
                                             }
                                         }
@@ -1252,48 +1252,48 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 14,
-                                                    "target": 19106
+                                                    "delta_percentage": 15,
+                                                    "target": 17791
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 6380
+                                                    "delta_percentage": 9,
+                                                    "target": 5727
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 18971
+                                                    "delta_percentage": 13,
+                                                    "target": 17825
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 6247
+                                                    "delta_percentage": 7,
+                                                    "target": 5594
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 11,
-                                                    "target": 7634
+                                                    "delta_percentage": 10,
+                                                    "target": 6862
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 12,
-                                                    "target": 28697
+                                                    "target": 26793
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 8886
+                                                    "delta_percentage": 8,
+                                                    "target": 8218
                                                 },
                                                 "vsock-p64K-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 7644
+                                                    "target": 6893
                                                 },
                                                 "vsock-p64K-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 28572
+                                                    "delta_percentage": 12,
+                                                    "target": 26780
                                                 },
                                                 "vsock-p64K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 8347
+                                                    "delta_percentage": 8,
+                                                    "target": 7804
                                                 }
                                             }
                                         }


### PR DESCRIPTION
Updated m6a vsock_throughput perf

## Changes
```
{
    "source": "e2aabc2a76fd72b85dde734f2ae34ebe1ac5a16c/tests/integration_tests/performance/configs/",
    "target": "tests/integration_tests/performance/configs/",
    "test_vsock_throughput_config_5.10.json": {
        "test": "vsock_throughput",
        "kernel": "5.10",
        "cpus": [
            {
                "instance": "m6a.metal",
                "model": "AMD EPYC 7R13 48-Core Processor",
                "stats": {
                    "cpu_utilization_vcpus_total": {
                        "target_diff_percentage": {
                            "mean": -0.6593137024964435,
                            "stdev": 1.1152718594162747
                        },
                        "delta_percentage_diff": {
                            "mean": 0.0,
                            "stdev": 1.1239029738980326
                        }
                    },
                    "cpu_utilization_vmm": {
                        "target_diff_percentage": {
                            "mean": 0.5365316881725035,
                            "stdev": 1.2375661219742082
                        },
                        "delta_percentage_diff": {
                            "mean": -0.95,
                            "stdev": 1.6050905860647506
                        }
                    },
                    "throughput": {
                        "target_diff_percentage": {
                            "mean": -5.848277932993139,
                            "stdev": 2.590389181079875
                        },
                        "delta_percentage_diff": {
                            "mean": -0.9,
                            "stdev": 0.9679060415469871
                        }
                    }
                }
            }
        ]
    },
    "test_vsock_throughput_config_6.1.json": {
        "test": "vsock_throughput",
        "kernel": "6.1",
        "cpus": [
            {
                "instance": "m6a.metal",
                "model": "AMD EPYC 7R13 48-Core Processor",
                "stats": {
                    "cpu_utilization_vcpus_total": {
                        "target_diff_percentage": {
                            "mean": -0.45170608992440575,
                            "stdev": 0.7675517929439581
                        },
                        "delta_percentage_diff": {
                            "mean": 0.3,
                            "stdev": 0.8645047258706176
                        }
                    },
                    "cpu_utilization_vmm": {
                        "target_diff_percentage": {
                            "mean": 2.3681015478110234,
                            "stdev": 1.613911719800117
                        },
                        "delta_percentage_diff": {
                            "mean": -0.45,
                            "stdev": 2.211810403980842
                        }
                    },
                    "throughput": {
                        "target_diff_percentage": {
                            "mean": -8.151896985671634,
                            "stdev": 1.8772209502050234
                        },
                        "delta_percentage_diff": {
                            "mean": -0.35,
                            "stdev": 1.5652475842498528
                        }
                    }
                }
            }
        ]
    }
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
