### PR TITLE
fix: remove default target for cargo + check static linking of firecracker release binary

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -49,7 +49,7 @@ devctr_grp = group(
 
 release_grp = group(
     "📦 Release Sanity Build",
-    "touch ./tests/test-report.json && ./tools/devtool -y sh ./tools/release.sh --libc musl --profile release --make-release",
+    "mkdir -p ./test_results && touch ./test_results/test-report.json && ./tools/devtool -y sh ./tools/release.sh --libc musl --profile release --make-release",
     **defaults_once_per_architecture,
 )
 

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -49,7 +49,7 @@ devctr_grp = group(
 
 release_grp = group(
     "📦 Release Sanity Build",
-    "./tools/devtool -y sh ./tools/release.sh --libc musl --profile release --make-release",
+    "touch ./tests/test-report.json && ./tools/devtool -y sh ./tools/release.sh --libc musl --profile release --make-release",
     **defaults_once_per_architecture,
 )
 

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,5 @@
 [build]
 target-dir = "build/cargo_target"
-target = "x86_64-unknown-linux-musl"
 rustflags = [
   "-Wclippy::ptr_as_ptr",
   "-Wclippy::undocumented_unsafe_blocks",

--- a/tests/integration_tests/build/test_binary_static_linking.py
+++ b/tests/integration_tests/build/test_binary_static_linking.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests to check if the release binary is statically linked.
+
+"""
+
+import pytest
+import host_tools.cargo_build as host
+from framework import utils
+
+@pytest.mark.timeout(500)
+def test_firecracker_binary_static_linking():
+    """
+    Test to make sure the firecracker binary is statically linked.
+    """
+    fc_binary_path = host.get_binary("firecracker")
+    _, stdout,stderr = utils.run_cmd(f"file {fc_binary_path}")
+    assert "" in stderr
+    # expected "statically linked" for aarch64 and
+    # "static-pie linked" for x86_64
+    assert "statically linked" in stdout or \
+           "static-pie linked" in stdout

--- a/tools/devtool
+++ b/tools/devtool
@@ -483,7 +483,7 @@ cmd_build() {
 }
 
 function cmd_make_release {
-    cmd_test -- --json-report --json-report-file=test-report.json || die "Tests failed!"
+    cmd_test || die "Tests failed!"
 
     run_devctr \
         --user "$(id -u):$(id -g)" \

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -167,7 +167,7 @@ cp -v -t "$RELEASE_DIR" LICENSE NOTICE THIRD-PARTY
 check_swagger_artifact src/api_server/swagger/firecracker.yaml "$VERSION"
 cp -v src/api_server/swagger/firecracker.yaml "$RELEASE_DIR/firecracker_spec-$VERSION.yaml"
 
-cp -v tests/test-report.json "$RELEASE_DIR/"
+cp -v test_results/test-report.json "$RELEASE_DIR/"
 
 (
     cd "$RELEASE_DIR"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -134,6 +134,16 @@ cargo build --target "$CARGO_TARGET" $CARGO_OPTS --workspace
 
 say "Binaries placed under $CARGO_TARGET_DIR"
 
+# Check static linking:
+# expected "statically linked" for aarch64 and
+# "static-pie linked" for x86_64
+binary_format=$(file $CARGO_TARGET_DIR/firecracker)
+if [[ "$PROFILE" = "release"
+        && "$binary_format" != *"statically linked"*
+        && "$binary_format" != *"static-pie linked"* ]]; then
+    die "Binary not statically linked: $binary_format"
+fi
+
 # # # # Make a release
 if [ -z "$MAKE_RELEASE" ]; then
     exit 0


### PR DESCRIPTION
## Changes

- Remove default target from .cargo/config
- check if Firecracker release binary is actually compiled using musl (static link) or gnu (dynamic link)
- test static linking of release binary
- create a dummy tests/test-report that release.sh can copy to avoid copy error

## Reason

- The global `target` directive in .cargo/build forced the x86_64-unknown-linux-musl target whenever `--target` flag was not provided and because of this `cargo build` produced x86_64 binaries even if we tried to build on ARM. Though `devtool build` is the documented way to build Firecracker and does not have this issue since it always specifies the right arch `--target`, we would like to fix issues like #3221 and be able to just run `cargo run` without specifying the target.
- We want to make sure Firecracker release binary is always compiled with static linking.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] ~If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] ~API changes follow the [Runbook for Firecracker API changes][2].~
- [ ] ~User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
- [ ] ~New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
