### PR TITLE
test: Simplify test_kani.py

### DIFF
--- a/tests/integration_tests/test_kani.py
+++ b/tests/integration_tests/test_kani.py
@@ -11,13 +11,11 @@ import pytest
 from framework import utils
 
 PLATFORM = platform.machine()
-CRATES_WITH_PROOFS = ["dumbo", "vmm"]
 
 
 @pytest.mark.timeout(1800)
 @pytest.mark.skipif(PLATFORM != "x86_64", reason="Kani proofs run only on x86_64.")
-@pytest.mark.parametrize("crate", CRATES_WITH_PROOFS)
-def test_kani(results_dir, crate):
+def test_kani(results_dir):
     """
     Test all Kani proof harnesses.
     """
@@ -27,9 +25,9 @@ def test_kani(results_dir, crate):
     # --output-format terse is required by -j
     # --enable-unstable is needed for each of the above
     rc, stdout, stderr = utils.run_cmd(
-        f"cargo kani -p {crate} --enable-unstable --enable-stubbing --restrict-vtable -j --output-format terse"
+        "cargo kani --enable-unstable --enable-stubbing --restrict-vtable -j --output-format terse"
     )
 
     assert rc == 0, stderr
 
-    (results_dir / f"kani_log_{crate}").write_text(stdout, encoding="utf-8")
+    (results_dir / "kani_log").write_text(stdout, encoding="utf-8")


### PR DESCRIPTION
Prior to #4120, our unique way of runnign seccompiler inside of build.rs made it impossible to run kani or miri on the workspace (requiring it to be run on some crate which did not use the build script). With that all gone, we can finally run kani properly.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
