### PR TITLE
vmm: Deprecate static CPU templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@
 - Added support for the /dev/userfaultfd device available on linux kernels >=
   6.1. This is the default for creating UFFD handlers on these kernel versions.
   If it is unavailable, Firecracker falls back to the userfaultfd syscall.
+- Deprecated `cpu_template` field in `PUT` and `PATCH` requests on `/machine-config`
+  API, which is used to set a static CPU template. Custom CPU templates added in
+  v1.4.0 are available as an improved iteration of the static CPU templates. For
+  more information about the transition from static CPU templates to custom CPU
+  templates, please refer to [this GitHub discussion](https://github.com/firecracker-microvm/firecracker/discussions/4135).
 
 ### Fixed
 

--- a/docs/api-change-runbook.md
+++ b/docs/api-change-runbook.md
@@ -247,9 +247,6 @@ Firecracker API.
   * Update any relevant documentation.
 * We update the python integration tests to reflect the change (reference
   implementation in [this commit][4]).
-  * We find the relevant resource in `tests/framework/resources.py` and
-    update its API, in this case by making the `vsock_id` parameter optional
-    in `Vsock.create_json()`.
   * We refactor the relevant
     `tests/integration_tests/functional/test_api.py` test to use the artifact
     model instead of the fixture one. If the test already uses the artifact

--- a/docs/cpu_templates/cpu-templates.md
+++ b/docs/cpu_templates/cpu-templates.md
@@ -35,6 +35,13 @@ Firecracker supports two types of CPU templates:
   format and pass them to Firecracker
 
 > **Note**
+Static CPU templates are deprecated starting from v1.5.0 and will be removed in
+accordance with our deprecation policy. Even after the removal, custom CPU
+templates are available as an improved iteration of static CPU templates. For
+more information about the transition from static CPU templates to custom CPU
+templates, please refer to [this GitHub discussion](https://github.com/firecracker-microvm/firecracker/discussions/4135).
+
+> **Note**
 CPU templates for ARM (both static and custom) require the following patch
 to be available in the host kernel: [Support writable CPU ID registers from userspace](https://lore.kernel.org/kvm/20230212215830.2975485-1-jingzhangos@google.com/#t).
 Otherwise KVM will fail to write to the ARM registers.

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -227,21 +227,21 @@ mod tests {
     /// test deserialization and logging.
     #[cfg(target_arch = "x86_64")]
     const TEST_UNESCAPED_JSON_TEMPLATE: &str = r#"{
-      "msr_modifiers": [
-        {
-          "addr": "0x0\n\n\n\nTEST\n\n\n\n",
-          "bitmap": "0b00"
-        }
-      ]
+        "msr_modifiers": [
+            {
+                "addr": "0x0\n\n\n\nTEST\n\n\n\n",
+                "bitmap": "0b00"
+            }
+        ]
     }"#;
     #[cfg(target_arch = "aarch64")]
     pub const TEST_UNESCAPED_JSON_TEMPLATE: &str = r#"{
-      "reg_modifiers": [
-        {
-          "addr": "0x0\n\n\n\nTEST\n\n\n\n",
-          "bitmap": "0b00"
-        }
-      ]
+        "reg_modifiers": [
+            {
+                "addr": "0x0\n\n\n\nTEST\n\n\n\n",
+                "bitmap": "0b00"
+            }
+        ]
     }"#;
 
     #[test]

--- a/src/api_server/src/request/balloon.rs
+++ b/src/api_server/src/request/balloon.rs
@@ -127,24 +127,24 @@ mod tests {
         let body = r#"{
             "amount_mib": 1
         }"#;
-        #[allow(clippy::match_wild_err_arm)]
-        match vmm_action_from_request(parse_patch_balloon(&Body::new(body), None).unwrap()) {
-            VmmAction::UpdateBalloon(balloon_cfg) => assert_eq!(balloon_cfg.amount_mib, 1),
-            _ => panic!("Test failed: Invalid parameters"),
-        };
+        let expected_config = BalloonUpdateConfig { amount_mib: 1 };
+        assert_eq!(
+            vmm_action_from_request(parse_patch_balloon(&Body::new(body), None).unwrap()),
+            VmmAction::UpdateBalloon(expected_config)
+        );
 
         let body = r#"{
             "stats_polling_interval_s": 1
         }"#;
-        #[allow(clippy::match_wild_err_arm)]
-        match vmm_action_from_request(
-            parse_patch_balloon(&Body::new(body), Some("statistics")).unwrap(),
-        ) {
-            VmmAction::UpdateBalloonStatistics(balloon_cfg) => {
-                assert_eq!(balloon_cfg.stats_polling_interval_s, 1)
-            }
-            _ => panic!("Test failed: Invalid parameters"),
+        let expected_config = BalloonUpdateStatsConfig {
+            stats_polling_interval_s: 1,
         };
+        assert_eq!(
+            vmm_action_from_request(
+                parse_patch_balloon(&Body::new(body), Some("statistics")).unwrap()
+            ),
+            VmmAction::UpdateBalloonStatistics(expected_config)
+        );
     }
 
     #[test]

--- a/src/api_server/src/request/balloon.rs
+++ b/src/api_server/src/request/balloon.rs
@@ -69,64 +69,64 @@ mod tests {
 
         // PATCH with invalid fields.
         let body = r#"{
-                "amount_mib": "bar",
-                "foo": "bar"
-              }"#;
+            "amount_mib": "bar",
+            "foo": "bar"
+        }"#;
         assert!(parse_patch_balloon(&Body::new(body), None).is_err());
 
         // PATCH with invalid types on fields. Adding a polling interval as string instead of bool.
         let body = r#"{
-                "amount_mib": 1000,
-                "stats_polling_interval_s": "false"
-              }"#;
+            "amount_mib": 1000,
+            "stats_polling_interval_s": "false"
+        }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
         assert!(res.is_err());
 
         // PATCH with invalid types on fields. Adding a amount_mib as a negative number.
         let body = r#"{
-                "amount_mib": -1000,
-                "stats_polling_interval_s": true
-              }"#;
+            "amount_mib": -1000,
+            "stats_polling_interval_s": true
+        }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
         assert!(res.is_err());
 
         // PATCH on statistics with missing ppolling interval field.
         let body = r#"{
-                "amount_mib": 100
-              }"#;
+            "amount_mib": 100
+        }"#;
         let res = parse_patch_balloon(&Body::new(body), Some("statistics"));
         assert!(res.is_err());
 
         // PATCH with missing amount_mib field.
         let body = r#"{
-                "stats_polling_interval_s": 0
-              }"#;
+            "stats_polling_interval_s": 0
+        }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
         assert!(res.is_err());
 
         // PATCH that tries to update something else other than allowed fields.
         let body = r#"{
-                "amount_mib": "dummy_id",
-                "stats_polling_interval_s": "dummy_host"
-              }"#;
+            "amount_mib": "dummy_id",
+            "stats_polling_interval_s": "dummy_host"
+        }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
         assert!(res.is_err());
 
         // PATCH with payload that is not a json.
         let body = r#"{
-                "fields": "dummy_field"
-              }"#;
+            "fields": "dummy_field"
+        }"#;
         assert!(parse_patch_balloon(&Body::new(body), None).is_err());
 
         // PATCH on unrecognized path.
         let body = r#"{
             "fields": "dummy_field"
-          }"#;
+        }"#;
         assert!(parse_patch_balloon(&Body::new(body), Some("config")).is_err());
 
         let body = r#"{
-                "amount_mib": 1
-              }"#;
+            "amount_mib": 1
+        }"#;
         #[allow(clippy::match_wild_err_arm)]
         match vmm_action_from_request(parse_patch_balloon(&Body::new(body), None).unwrap()) {
             VmmAction::UpdateBalloon(balloon_cfg) => assert_eq!(balloon_cfg.amount_mib, 1),
@@ -134,8 +134,8 @@ mod tests {
         };
 
         let body = r#"{
-                "stats_polling_interval_s": 1
-            }"#;
+            "stats_polling_interval_s": 1
+        }"#;
         #[allow(clippy::match_wild_err_arm)]
         match vmm_action_from_request(
             parse_patch_balloon(&Body::new(body), Some("statistics")).unwrap(),
@@ -153,17 +153,17 @@ mod tests {
 
         // PUT with invalid fields.
         let body = r#"{
-                "amount_mib": "bar",
-                "is_read_only": false
-              }"#;
+            "amount_mib": "bar",
+            "is_read_only": false
+        }"#;
         assert!(parse_put_balloon(&Body::new(body)).is_err());
 
         // PUT with valid input fields.
         let body = r#"{
-                "amount_mib": 1000,
-                "deflate_on_oom": true,
-                "stats_polling_interval_s": 0
-            }"#;
+            "amount_mib": 1000,
+            "deflate_on_oom": true,
+            "stats_polling_interval_s": 0
+        }"#;
         assert!(parse_put_balloon(&Body::new(body)).is_ok());
     }
 }

--- a/src/api_server/src/request/boot_source.rs
+++ b/src/api_server/src/request/boot_source.rs
@@ -27,10 +27,10 @@ mod tests {
         assert!(parse_put_boot_source(&Body::new("invalid_payload")).is_err());
 
         let body = r#"{
-                "kernel_image_path": "/foo/bar",
-                "initrd_path": "/bar/foo",
-                "boot_args": "foobar"
-              }"#;
+            "kernel_image_path": "/foo/bar",
+            "initrd_path": "/bar/foo",
+            "boot_args": "foobar"
+        }"#;
         let same_body = BootSourceConfig {
             kernel_image_path: String::from("/foo/bar"),
             initrd_path: Some(String::from("/bar/foo")),

--- a/src/api_server/src/request/cpu_configuration.rs
+++ b/src/api_server/src/request/cpu_configuration.rs
@@ -40,18 +40,14 @@ mod tests {
         );
         let cpu_template_json = cpu_config_json_result.unwrap();
 
-        {
-            match vmm_action_from_request(
-                parse_put_cpu_config(&Body::new(cpu_template_json.as_bytes())).unwrap(),
-            ) {
-                VmmAction::PutCpuConfiguration(received_cpu_template) => {
-                    // Test that the CPU config to be used for KVM config is the
-                    // the same that was read in from a test file.
-                    assert_eq!(cpu_template, received_cpu_template);
-                }
-                _ => panic!("Test failed - Expected VmmAction::PutCpuConfiguration() call"),
-            }
-        }
+        // Test that the CPU config to be used for KVM config is the same that
+        // was read in from a test file.
+        assert_eq!(
+            vmm_action_from_request(
+                parse_put_cpu_config(&Body::new(cpu_template_json.as_bytes())).unwrap()
+            ),
+            VmmAction::PutCpuConfiguration(cpu_template)
+        );
 
         // Test empty request succeeds
         let parse_cpu_config_result = parse_put_cpu_config(&Body::new(r#"{ }"#));

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -96,60 +96,60 @@ mod tests {
 
         // PATCH with invalid fields.
         let body = r#"{
-                "drive_id": "bar",
-                "is_read_only": false
-              }"#;
+            "drive_id": "bar",
+            "is_read_only": false
+        }"#;
         assert!(parse_patch_drive(&Body::new(body), Some("2")).is_err());
 
         // PATCH with invalid types on fields. Adding a drive_id as number instead of string.
         let body = r#"{
-                "drive_id": 1000,
-                "path_on_host": "dummy"
-              }"#;
+            "drive_id": 1000,
+            "path_on_host": "dummy"
+        }"#;
         let res = parse_patch_drive(&Body::new(body), Some("1000"));
         assert!(res.is_err());
 
         // PATCH with invalid types on fields. Adding a path_on_host as bool instead of string.
         let body = r#"{
-                "drive_id": 1000,
-                "path_on_host": true
-              }"#;
+            "drive_id": 1000,
+            "path_on_host": true
+        }"#;
         let res = parse_patch_drive(&Body::new(body), Some("1000"));
         assert!(res.is_err());
 
         // PATCH with missing path_on_host field.
         let body = r#"{
-                "drive_id": "dummy_id"
-              }"#;
+            "drive_id": "dummy_id"
+        }"#;
         let res = parse_patch_drive(&Body::new(body), Some("dummy_id"));
         assert!(res.is_err());
 
         // PATCH with missing drive_id field.
         let body = r#"{
-                "path_on_host": true
-              }"#;
+            "path_on_host": true
+        }"#;
         let res = parse_patch_drive(&Body::new(body), Some("1000"));
         assert!(res.is_err());
 
         // PATCH that tries to update something else other than path_on_host.
         let body = r#"{
-                "drive_id": "dummy_id",
-                "path_on_host": "dummy_host",
-                "is_read_only": false
-              }"#;
+            "drive_id": "dummy_id",
+            "path_on_host": "dummy_host",
+            "is_read_only": false
+        }"#;
         let res = parse_patch_drive(&Body::new(body), Some("1234"));
         assert!(res.is_err());
 
         // PATCH with payload that is not a json.
         let body = r#"{
-                "fields": "dummy_field"
-              }"#;
+            "fields": "dummy_field"
+        }"#;
         assert!(parse_patch_drive(&Body::new(body), Some("1234")).is_err());
 
         let body = r#"{
-                "drive_id": "foo",
-                "path_on_host": "dummy"
-              }"#;
+            "drive_id": "foo",
+            "path_on_host": "dummy"
+        }"#;
         #[allow(clippy::match_wild_err_arm)]
         match vmm_action_from_request(parse_patch_drive(&Body::new(body), Some("foo")).unwrap()) {
             VmmAction::UpdateBlockDevice(cfg) => {
@@ -219,9 +219,9 @@ mod tests {
 
         // PUT with invalid fields.
         let body = r#"{
-                "drive_id": "bar",
-                "is_read_only": false
-              }"#;
+            "drive_id": "bar",
+            "is_read_only": false
+        }"#;
         assert!(parse_put_drive(&Body::new(body), Some("2")).is_err());
 
         // PUT with missing all optional fields.
@@ -238,26 +238,26 @@ mod tests {
 
         // PUT with the complete configuration.
         let body = r#"{
-                "drive_id": "1000",
-                "path_on_host": "dummy",
-                "is_root_device": true,
-                "partuuid": "string",
-                "is_read_only": true,
-                "cache_type": "Unsafe",
-                "io_engine": "Sync",
-                "rate_limiter": {
-                    "bandwidth": {
-                        "size": 0,
-                        "one_time_burst": 0,
-                        "refill_time": 0
-                    },
-                    "ops": {
+            "drive_id": "1000",
+            "path_on_host": "dummy",
+            "is_root_device": true,
+            "partuuid": "string",
+            "is_read_only": true,
+            "cache_type": "Unsafe",
+            "io_engine": "Sync",
+            "rate_limiter": {
+                "bandwidth": {
                     "size": 0,
                     "one_time_burst": 0,
                     "refill_time": 0
-                    }
+                },
+                "ops": {
+                    "size": 0,
+                    "one_time_burst": 0,
+                    "refill_time": 0
                 }
-            }"#;
+            }
+        }"#;
         assert!(parse_put_drive(&Body::new(body), Some("1000")).is_ok());
     }
 }

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -150,14 +150,15 @@ mod tests {
             "drive_id": "foo",
             "path_on_host": "dummy"
         }"#;
-        #[allow(clippy::match_wild_err_arm)]
-        match vmm_action_from_request(parse_patch_drive(&Body::new(body), Some("foo")).unwrap()) {
-            VmmAction::UpdateBlockDevice(cfg) => {
-                assert_eq!(cfg.drive_id, "foo".to_string());
-                assert_eq!(cfg.path_on_host.unwrap(), "dummy".to_string());
-            }
-            _ => panic!("Test failed: Invalid parameters"),
+        let expected_config = BlockDeviceUpdateConfig {
+            drive_id: "foo".to_string(),
+            path_on_host: Some("dummy".to_string()),
+            rate_limiter: None,
         };
+        assert_eq!(
+            vmm_action_from_request(parse_patch_drive(&Body::new(body), Some("foo")).unwrap()),
+            VmmAction::UpdateBlockDevice(expected_config)
+        );
 
         let body = r#"{
             "drive_id": "foo",

--- a/src/api_server/src/request/logger.rs
+++ b/src/api_server/src/request/logger.rs
@@ -29,41 +29,39 @@ mod tests {
 
     #[test]
     fn test_parse_put_logger_request() {
-        let mut body = r#"{
+        let body = r#"{
             "log_path": "log",
             "level": "Warning",
             "show_level": false,
             "show_log_origin": false
         }"#;
-
-        let mut expected_cfg = LoggerConfig {
+        let expected_config = LoggerConfig {
             log_path: PathBuf::from("log"),
             level: LoggerLevel::Warning,
             show_level: false,
             show_log_origin: false,
         };
-        match vmm_action_from_request(parse_put_logger(&Body::new(body)).unwrap()) {
-            VmmAction::ConfigureLogger(cfg) => assert_eq!(cfg, expected_cfg),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            vmm_action_from_request(parse_put_logger(&Body::new(body)).unwrap()),
+            VmmAction::ConfigureLogger(expected_config)
+        );
 
-        body = r#"{
+        let body = r#"{
             "log_path": "log",
             "level": "DEBUG",
             "show_level": false,
             "show_log_origin": false
         }"#;
-
-        expected_cfg = LoggerConfig {
+        let expected_config = LoggerConfig {
             log_path: PathBuf::from("log"),
             level: LoggerLevel::Debug,
             show_level: false,
             show_log_origin: false,
         };
-        match vmm_action_from_request(parse_put_logger(&Body::new(body)).unwrap()) {
-            VmmAction::ConfigureLogger(cfg) => assert_eq!(cfg, expected_cfg),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            vmm_action_from_request(parse_put_logger(&Body::new(body)).unwrap()),
+            VmmAction::ConfigureLogger(expected_config)
+        );
 
         let invalid_body = r#"{
             "invalid_field": "log",
@@ -71,7 +69,6 @@ mod tests {
             "show_level": false,
             "show_log_origin": false
         }"#;
-
         assert!(parse_put_logger(&Body::new(invalid_body)).is_err());
     }
 }

--- a/src/api_server/src/request/logger.rs
+++ b/src/api_server/src/request/logger.rs
@@ -30,11 +30,11 @@ mod tests {
     #[test]
     fn test_parse_put_logger_request() {
         let mut body = r#"{
-                "log_path": "log",
-                "level": "Warning",
-                "show_level": false,
-                "show_log_origin": false
-              }"#;
+            "log_path": "log",
+            "level": "Warning",
+            "show_level": false,
+            "show_log_origin": false
+        }"#;
 
         let mut expected_cfg = LoggerConfig {
             log_path: PathBuf::from("log"),
@@ -48,11 +48,11 @@ mod tests {
         }
 
         body = r#"{
-                "log_path": "log",
-                "level": "DEBUG",
-                "show_level": false,
-                "show_log_origin": false
-              }"#;
+            "log_path": "log",
+            "level": "DEBUG",
+            "show_level": false,
+            "show_log_origin": false
+        }"#;
 
         expected_cfg = LoggerConfig {
             log_path: PathBuf::from("log"),
@@ -66,11 +66,11 @@ mod tests {
         }
 
         let invalid_body = r#"{
-                "invalid_field": "log",
-                "level": "Warning",
-                "show_level": false,
-                "show_log_origin": false
-              }"#;
+            "invalid_field": "log",
+            "level": "Warning",
+            "show_level": false,
+            "show_log_origin": false
+        }"#;
 
         assert!(parse_put_logger(&Body::new(invalid_body)).is_err());
     }

--- a/src/api_server/src/request/machine_configuration.rs
+++ b/src/api_server/src/request/machine_configuration.rs
@@ -65,20 +65,20 @@ mod tests {
 
         // 2. Test case for mandatory fields.
         let body = r#"{
-                "mem_size_mib": 1024
-              }"#;
+            "mem_size_mib": 1024
+        }"#;
         assert!(parse_put_machine_config(&Body::new(body)).is_err());
 
         let body = r#"{
-                "vcpu_count": 8
-                }"#;
+            "vcpu_count": 8
+        }"#;
         assert!(parse_put_machine_config(&Body::new(body)).is_err());
 
         // 3. Test case for success scenarios for both architectures.
         let body = r#"{
-                "vcpu_count": 8,
-                "mem_size_mib": 1024
-              }"#;
+            "vcpu_count": 8,
+            "mem_size_mib": 1024
+        }"#;
         let expected_config = MachineConfigUpdate {
             vcpu_count: Some(8),
             mem_size_mib: Some(1024),
@@ -93,11 +93,11 @@ mod tests {
         }
 
         let body = r#"{
-                "vcpu_count": 8,
-                "mem_size_mib": 1024,
-                "smt": false,
-                "track_dirty_pages": true
-            }"#;
+            "vcpu_count": 8,
+            "mem_size_mib": 1024,
+            "smt": false,
+            "track_dirty_pages": true
+        }"#;
         let expected_config = MachineConfigUpdate {
             vcpu_count: Some(8),
             mem_size_mib: Some(1024),
@@ -113,12 +113,12 @@ mod tests {
 
         // 4. Test that applying a CPU template is successful on x86_64 while on aarch64, it is not.
         let body = r#"{
-                "vcpu_count": 8,
-                "mem_size_mib": 1024,
-                "smt": false,
-                "cpu_template": "T2",
-                "track_dirty_pages": true
-              }"#;
+            "vcpu_count": 8,
+            "mem_size_mib": 1024,
+            "smt": false,
+            "cpu_template": "T2",
+            "track_dirty_pages": true
+        }"#;
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -147,7 +147,7 @@ mod tests {
             "mem_size_mib": 1024,
             "smt": true,
             "track_dirty_pages": true
-          }"#;
+        }"#;
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -178,31 +178,31 @@ mod tests {
 
         // 2. Check currently supported fields that can be patched.
         let body = r#"{
-                "track_dirty_pages": true
-              }"#;
+            "track_dirty_pages": true
+        }"#;
         assert!(parse_patch_machine_config(&Body::new(body)).is_ok());
 
         // On aarch64, CPU template is also not patch compatible.
         let body = r#"{
-                "cpu_template": "T2"
-              }"#;
+            "cpu_template": "T2"
+        }"#;
         #[cfg(target_arch = "aarch64")]
         assert!(parse_patch_machine_config(&Body::new(body)).is_err());
         #[cfg(target_arch = "x86_64")]
         assert!(parse_patch_machine_config(&Body::new(body)).is_ok());
 
         let body = r#"{
-                "vcpu_count": 8,
-                "mem_size_mib": 1024
-              }"#;
+            "vcpu_count": 8,
+            "mem_size_mib": 1024
+        }"#;
         assert!(parse_patch_machine_config(&Body::new(body)).is_ok());
 
         // On aarch64, we allow `smt` to be configured to `false` but not `true`.
         let body = r#"{
-                "vcpu_count": 8,
-                "mem_size_mib": 1024,
-                "smt": false
-              }"#;
+            "vcpu_count": 8,
+            "mem_size_mib": 1024,
+            "smt": false
+        }"#;
         assert!(parse_patch_machine_config(&Body::new(body)).is_ok());
 
         // 3. Check to see if an empty body returns an error.

--- a/src/api_server/src/request/machine_configuration.rs
+++ b/src/api_server/src/request/machine_configuration.rs
@@ -86,11 +86,10 @@ mod tests {
             cpu_template: Some(StaticCpuTemplate::None),
             track_dirty_pages: Some(false),
         };
-
-        match vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()) {
-            VmmAction::UpdateVmConfiguration(config) => assert_eq!(config, expected_config),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
+            VmmAction::UpdateVmConfiguration(expected_config)
+        );
 
         let body = r#"{
             "vcpu_count": 8,
@@ -105,11 +104,10 @@ mod tests {
             cpu_template: Some(StaticCpuTemplate::None),
             track_dirty_pages: Some(true),
         };
-
-        match vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()) {
-            VmmAction::UpdateVmConfiguration(config) => assert_eq!(config, expected_config),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
+            VmmAction::UpdateVmConfiguration(expected_config)
+        );
 
         // 4. Test that applying a CPU template is successful on x86_64 while on aarch64, it is not.
         let body = r#"{
@@ -119,7 +117,6 @@ mod tests {
             "cpu_template": "T2",
             "track_dirty_pages": true
         }"#;
-
         #[cfg(target_arch = "x86_64")]
         {
             let expected_config = MachineConfigUpdate {
@@ -129,13 +126,11 @@ mod tests {
                 cpu_template: Some(StaticCpuTemplate::T2),
                 track_dirty_pages: Some(true),
             };
-
-            match vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()) {
-                VmmAction::UpdateVmConfiguration(config) => assert_eq!(config, expected_config),
-                _ => panic!("Test failed."),
-            }
+            assert_eq!(
+                vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
+                VmmAction::UpdateVmConfiguration(expected_config)
+            );
         }
-
         #[cfg(target_arch = "aarch64")]
         {
             assert!(parse_put_machine_config(&Body::new(body)).is_err());
@@ -148,7 +143,6 @@ mod tests {
             "smt": true,
             "track_dirty_pages": true
         }"#;
-
         #[cfg(target_arch = "x86_64")]
         {
             let expected_config = MachineConfigUpdate {
@@ -158,13 +152,11 @@ mod tests {
                 cpu_template: Some(StaticCpuTemplate::None),
                 track_dirty_pages: Some(true),
             };
-
-            match vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()) {
-                VmmAction::UpdateVmConfiguration(config) => assert_eq!(config, expected_config),
-                _ => panic!("Test failed."),
-            }
+            assert_eq!(
+                vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
+                VmmAction::UpdateVmConfiguration(expected_config)
+            );
         }
-
         #[cfg(target_arch = "aarch64")]
         {
             assert!(parse_put_machine_config(&Body::new(body)).is_err());

--- a/src/api_server/src/request/machine_configuration.rs
+++ b/src/api_server/src/request/machine_configuration.rs
@@ -20,11 +20,25 @@ pub(crate) fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Err
         err
     })?;
 
+    // Check for the presence of deprecated `cpu_template` field.
+    let mut deprecation_message = None;
+    if config.cpu_template.is_some() {
+        // `cpu_template` field in request is deprecated.
+        METRICS.deprecated_api.deprecated_http_api_calls.inc();
+        deprecation_message = Some("PUT /machine-config: cpu_template field is deprecated.");
+    }
+
+    // Convert `MachineConfig` to `MachineConfigUpdate`.
     let config_update = MachineConfigUpdate::from(config);
 
-    Ok(ParsedRequest::new_sync(VmmAction::UpdateVmConfiguration(
-        config_update,
-    )))
+    // Construct the `ParsedRequest` object.
+    let mut parsed_req = ParsedRequest::new_sync(VmmAction::UpdateVmConfiguration(config_update));
+    // If `cpu_template` was present, set the deprecation message in `parsing_info`.
+    if let Some(msg) = deprecation_message {
+        parsed_req.parsing_info().append_deprecation_message(msg);
+    }
+
+    Ok(parsed_req)
 }
 
 pub(crate) fn parse_patch_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
@@ -39,9 +53,22 @@ pub(crate) fn parse_patch_machine_config(body: &Body) -> Result<ParsedRequest, E
         return method_to_error(Method::Patch);
     }
 
-    Ok(ParsedRequest::new_sync(VmmAction::UpdateVmConfiguration(
-        config_update,
-    )))
+    // Check for the presence of deprecated `cpu_template` field.
+    let mut deprecation_message = None;
+    if config_update.cpu_template.is_some() {
+        // `cpu_template` field in request is deprecated.
+        METRICS.deprecated_api.deprecated_http_api_calls.inc();
+        deprecation_message = Some("PATCH /machine-config: cpu_template field is deprecated.");
+    }
+
+    // Construct the `ParsedRequest` object.
+    let mut parsed_req = ParsedRequest::new_sync(VmmAction::UpdateVmConfiguration(config_update));
+    // If `cpu_template` was present, set the deprecation message in `parsing_info`.
+    if let Some(msg) = deprecation_message {
+        parsed_req.parsing_info().append_deprecation_message(msg);
+    }
+
+    Ok(parsed_req)
 }
 
 #[cfg(test)]
@@ -49,7 +76,7 @@ mod tests {
     use vmm::cpu_config::templates::StaticCpuTemplate;
 
     use super::*;
-    use crate::parsed_request::tests::vmm_action_from_request;
+    use crate::parsed_request::tests::{depr_action_from_req, vmm_action_from_request};
 
     #[test]
     fn test_parse_get_machine_config_request() {
@@ -83,6 +110,23 @@ mod tests {
             vcpu_count: Some(8),
             mem_size_mib: Some(1024),
             smt: Some(false),
+            cpu_template: None,
+            track_dirty_pages: Some(false),
+        };
+        assert_eq!(
+            vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
+            VmmAction::UpdateVmConfiguration(expected_config)
+        );
+
+        let body = r#"{
+            "vcpu_count": 8,
+            "mem_size_mib": 1024,
+            "cpu_template": "None"
+        }"#;
+        let expected_config = MachineConfigUpdate {
+            vcpu_count: Some(8),
+            mem_size_mib: Some(1024),
+            smt: Some(false),
             cpu_template: Some(StaticCpuTemplate::None),
             track_dirty_pages: Some(false),
         };
@@ -101,7 +145,7 @@ mod tests {
             vcpu_count: Some(8),
             mem_size_mib: Some(1024),
             smt: Some(false),
-            cpu_template: Some(StaticCpuTemplate::None),
+            cpu_template: None,
             track_dirty_pages: Some(true),
         };
         assert_eq!(
@@ -149,7 +193,7 @@ mod tests {
                 vcpu_count: Some(8),
                 mem_size_mib: Some(1024),
                 smt: Some(true),
-                cpu_template: Some(StaticCpuTemplate::None),
+                cpu_template: None,
                 track_dirty_pages: Some(true),
             };
             assert_eq!(
@@ -200,5 +244,51 @@ mod tests {
         // 3. Check to see if an empty body returns an error.
         let body = r#"{}"#;
         assert!(parse_patch_machine_config(&Body::new(body)).is_err());
+    }
+
+    #[test]
+    fn test_depr_cpu_template_in_put_req() {
+        // Test that the deprecation message is shown when `cpu_template` is specified.
+        let body = r#"{
+            "vcpu_count": 8,
+            "mem_size_mib": 1024,
+            "cpu_template": "None"
+        }"#;
+        depr_action_from_req(
+            parse_put_machine_config(&Body::new(body)).unwrap(),
+            Some("PUT /machine-config: cpu_template field is deprecated.".to_string()),
+        );
+
+        // Test that the deprecation message is not shown when `cpu_template` is not specified.
+        let body = r#"{
+            "vcpu_count": 8,
+            "mem_size_mib": 1024
+        }"#;
+        let (_, mut parsing_info) = parse_put_machine_config(&Body::new(body))
+            .unwrap()
+            .into_parts();
+        assert!(parsing_info.take_deprecation_message().is_none());
+    }
+
+    #[test]
+    fn test_depr_cpu_template_in_patch_req() {
+        // Test that the deprecation message is shown when `cpu_template` is specified.
+        let body = r#"{
+            "vcpu_count": 8,
+            "cpu_template": "None"
+        }"#;
+        depr_action_from_req(
+            parse_patch_machine_config(&Body::new(body)).unwrap(),
+            Some("PATCH /machine-config: cpu_template field is deprecated.".to_string()),
+        );
+
+        // Test that the deprecation message is not shown when `cpu_template` is not specified.
+        let body = r#"{
+            "vcpu_count": 8
+        }"#;
+        let (_, mut parsing_info) = parse_patch_machine_config(&Body::new(body))
+            .unwrap()
+            .into_parts();
+        assert!(parsing_info.take_deprecation_message().is_none());
     }
 }

--- a/src/api_server/src/request/metrics.rs
+++ b/src/api_server/src/request/metrics.rs
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn test_parse_put_metrics_request() {
         let body = r#"{
-                "metrics_path": "metrics"
-              }"#;
+            "metrics_path": "metrics"
+        }"#;
 
         let expected_cfg = MetricsConfig {
             metrics_path: PathBuf::from("metrics"),
@@ -40,8 +40,8 @@ mod tests {
         }
 
         let invalid_body = r#"{
-                "invalid_field": "metrics"
-              }"#;
+            "invalid_field": "metrics"
+        }"#;
 
         assert!(parse_put_metrics(&Body::new(invalid_body)).is_err());
     }

--- a/src/api_server/src/request/metrics.rs
+++ b/src/api_server/src/request/metrics.rs
@@ -30,19 +30,17 @@ mod tests {
         let body = r#"{
             "metrics_path": "metrics"
         }"#;
-
-        let expected_cfg = MetricsConfig {
+        let expected_config = MetricsConfig {
             metrics_path: PathBuf::from("metrics"),
         };
-        match vmm_action_from_request(parse_put_metrics(&Body::new(body)).unwrap()) {
-            VmmAction::ConfigureMetrics(cfg) => assert_eq!(cfg, expected_cfg),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            vmm_action_from_request(parse_put_metrics(&Body::new(body)).unwrap()),
+            VmmAction::ConfigureMetrics(expected_config)
+        );
 
         let invalid_body = r#"{
             "invalid_field": "metrics"
         }"#;
-
         assert!(parse_put_metrics(&Body::new(invalid_body)).is_err());
     }
 }

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -82,8 +82,8 @@ mod tests {
     #[test]
     fn test_parse_put_mmds_request() {
         let body = r#"{
-                "foo": "bar"
-              }"#;
+            "foo": "bar"
+        }"#;
         assert!(parse_put_mmds(&Body::new(body), None).is_ok());
 
         let invalid_body = "invalid_body";
@@ -92,39 +92,39 @@ mod tests {
 
         // Test `config` path.
         let body = r#"{
-                "version": "V2",
-                "ipv4_address": "169.254.170.2",
-                "network_interfaces": []
-              }"#;
+            "version": "V2",
+            "ipv4_address": "169.254.170.2",
+            "network_interfaces": []
+        }"#;
         let config_path = "config";
         assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_ok());
 
         let body = r#"{
-                "network_interfaces": []
-              }"#;
+            "network_interfaces": []
+        }"#;
         assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_ok());
 
         let body = r#"{
-                "version": "foo",
-                "ipv4_address": "169.254.170.2",
-                "network_interfaces": []
-              }"#;
+            "version": "foo",
+            "ipv4_address": "169.254.170.2",
+            "network_interfaces": []
+        }"#;
         assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_err());
 
         let body = r#"{
-                "version": "V2"
-              }"#;
+            "version": "V2"
+        }"#;
         assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_err());
 
         let body = r#"{
-                "ipv4_address": "",
-                "network_interfaces": []
-              }"#;
+            "ipv4_address": "",
+            "network_interfaces": []
+        }"#;
         assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_err());
 
         let invalid_config_body = r#"{
-                "invalid_config": "invalid_value"
-              }"#;
+            "invalid_config": "invalid_value"
+        }"#;
         assert!(parse_put_mmds(&Body::new(invalid_config_body), Some(config_path)).is_err());
         assert!(parse_put_mmds(&Body::new(body), Some("invalid_path")).is_err());
         assert!(parse_put_mmds(&Body::new(invalid_body), Some(config_path)).is_err());
@@ -167,8 +167,8 @@ mod tests {
     #[test]
     fn test_parse_patch_mmds_request() {
         let body = r#"{
-                "foo": "bar"
-              }"#;
+            "foo": "bar"
+        }"#;
         assert!(parse_patch_mmds(&Body::new(body)).is_ok());
         assert!(METRICS.patch_api_requests.mmds_count.count() > 0);
         assert!(parse_patch_mmds(&Body::new("invalid_body")).is_err());

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -81,10 +81,10 @@ mod tests {
     #[test]
     fn test_parse_put_net_request() {
         let body = r#"{
-                "iface_id": "foo",
-                "host_dev_name": "bar",
-                "guest_mac": "12:34:56:78:9A:BC"
-              }"#;
+            "iface_id": "foo",
+            "host_dev_name": "bar",
+            "guest_mac": "12:34:56:78:9A:BC"
+        }"#;
         // 1. Exercise infamous "The id from the path does not match id from the body!".
         assert!(parse_put_net(&Body::new(body), Some("bar")).is_err());
         // 2. The `id_from_path` cannot be None.
@@ -98,8 +98,7 @@ mod tests {
         }
 
         // 4. Serde error for invalid field (bytes instead of bandwidth).
-        let body = r#"
-        {
+        let body = r#"{
             "iface_id": "foo",
             "rx_rate_limiter": {
                 "bytes": {
@@ -121,11 +120,9 @@ mod tests {
     #[test]
     fn test_parse_patch_net_request() {
         let body = r#"{
-                "iface_id": "foo",
-                "rx_rate_limiter": {
-                },
-                "tx_rate_limiter": {
-                }
+            "iface_id": "foo",
+            "rx_rate_limiter": {},
+            "tx_rate_limiter": {}
         }"#;
         // 1. Exercise infamous "The id from the path does not match id from the body!".
         assert!(parse_patch_net(&Body::new(body), Some("bar")).is_err());
@@ -140,8 +137,7 @@ mod tests {
         }
 
         // 4. Serde error for invalid field (bytes instead of bandwidth).
-        let body = r#"
-        {
+        let body = r#"{
             "iface_id": "foo",
             "rx_rate_limiter": {
                 "bytes": {

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -91,11 +91,11 @@ mod tests {
         assert!(parse_put_net(&Body::new(body), None).is_err());
 
         // 3. Success case.
-        let netif_clone = serde_json::from_str::<NetworkInterfaceConfig>(body).unwrap();
-        match vmm_action_from_request(parse_put_net(&Body::new(body), Some("foo")).unwrap()) {
-            VmmAction::InsertNetworkDevice(netif) => assert_eq!(netif, netif_clone),
-            _ => panic!("Test failed."),
-        }
+        let expected_config = serde_json::from_str::<NetworkInterfaceConfig>(body).unwrap();
+        assert_eq!(
+            vmm_action_from_request(parse_put_net(&Body::new(body), Some("foo")).unwrap()),
+            VmmAction::InsertNetworkDevice(expected_config)
+        );
 
         // 4. Serde error for invalid field (bytes instead of bandwidth).
         let body = r#"{
@@ -113,7 +113,6 @@ mod tests {
                 }
             }
         }"#;
-
         assert!(parse_put_net(&Body::new(body), Some("foo")).is_err());
     }
 
@@ -130,11 +129,11 @@ mod tests {
         assert!(parse_patch_net(&Body::new(body), None).is_err());
 
         // 3. Success case.
-        let netif_clone = serde_json::from_str::<NetworkInterfaceUpdateConfig>(body).unwrap();
-        match vmm_action_from_request(parse_patch_net(&Body::new(body), Some("foo")).unwrap()) {
-            VmmAction::UpdateNetworkInterface(netif) => assert_eq!(netif, netif_clone),
-            _ => panic!("Test failed."),
-        }
+        let expected_config = serde_json::from_str::<NetworkInterfaceUpdateConfig>(body).unwrap();
+        assert_eq!(
+            vmm_action_from_request(parse_patch_net(&Body::new(body), Some("foo")).unwrap()),
+            VmmAction::UpdateNetworkInterface(expected_config)
+        );
 
         // 4. Serde error for invalid field (bytes instead of bandwidth).
         let body = r#"{

--- a/src/api_server/src/request/snapshot.rs
+++ b/src/api_server/src/request/snapshot.rs
@@ -139,11 +139,11 @@ mod tests {
         use vmm::vmm_config::snapshot::SnapshotType;
 
         let mut body = r#"{
-                "snapshot_type": "Diff",
-                "snapshot_path": "foo",
-                "mem_file_path": "bar",
-                "version": "0.23.0"
-              }"#;
+            "snapshot_type": "Diff",
+            "snapshot_path": "foo",
+            "mem_file_path": "bar",
+            "version": "0.23.0"
+        }"#;
 
         let mut expected_cfg = CreateSnapshotParams {
             snapshot_type: SnapshotType::Diff,
@@ -162,9 +162,9 @@ mod tests {
         }
 
         body = r#"{
-                "snapshot_path": "foo",
-                "mem_file_path": "bar"
-              }"#;
+            "snapshot_path": "foo",
+            "mem_file_path": "bar"
+        }"#;
 
         expected_cfg = CreateSnapshotParams {
             snapshot_type: SnapshotType::Full,
@@ -180,19 +180,19 @@ mod tests {
         }
 
         let invalid_body = r#"{
-                "invalid_field": "foo",
-                "mem_file_path": "bar"
-              }"#;
+            "invalid_field": "foo",
+            "mem_file_path": "bar"
+        }"#;
 
         assert!(parse_put_snapshot(&Body::new(invalid_body), Some("create")).is_err());
 
         body = r#"{
-                "snapshot_path": "foo",
-                "mem_backend": {
-                    "backend_path": "bar",
-                    "backend_type": "File"
-                }
-              }"#;
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "File"
+            }
+        }"#;
 
         let mut expected_cfg = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
@@ -216,13 +216,13 @@ mod tests {
         }
 
         body = r#"{
-                "snapshot_path": "foo",
-                "mem_backend": {
-                    "backend_path": "bar",
-                    "backend_type": "File"
-                },
-                "enable_diff_snapshots": true
-              }"#;
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "File"
+            },
+            "enable_diff_snapshots": true
+        }"#;
 
         expected_cfg = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
@@ -245,13 +245,13 @@ mod tests {
         }
 
         body = r#"{
-                "snapshot_path": "foo",
-                "mem_backend": {
-                    "backend_path": "bar",
-                    "backend_type": "Uffd"
-                },
-                "resume_vm": true
-              }"#;
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "Uffd"
+            },
+            "resume_vm": true
+        }"#;
 
         expected_cfg = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
@@ -274,10 +274,10 @@ mod tests {
         }
 
         body = r#"{
-                "snapshot_path": "foo",
-                "mem_file_path": "bar",
-                "resume_vm": true
-              }"#;
+            "snapshot_path": "foo",
+            "mem_file_path": "bar",
+            "resume_vm": true
+        }"#;
 
         expected_cfg = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
@@ -296,11 +296,11 @@ mod tests {
         }
 
         body = r#"{
-                "snapshot_path": "foo",
-                "mem_backend": {
-                    "backend_path": "bar"
-                }
-              }"#;
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_path": "bar"
+            }
+        }"#;
 
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
@@ -308,15 +308,15 @@ mod tests {
                 .unwrap()
                 .to_string(),
             "An error occurred when deserializing the json body of a request: missing field \
-             `backend_type` at line 5 column 17."
+             `backend_type` at line 5 column 13."
         );
 
         body = r#"{
-                "snapshot_path": "foo",
-                "mem_backend": {
-                    "backend_type": "File",
-                }
-              }"#;
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_type": "File",
+            }
+        }"#;
 
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
@@ -324,17 +324,17 @@ mod tests {
                 .unwrap()
                 .to_string(),
             "An error occurred when deserializing the json body of a request: trailing comma at \
-             line 5 column 17."
+             line 5 column 13."
         );
 
         body = r#"{
-                "snapshot_path": "foo",
-                "mem_file_path": "bar",
-                "mem_backend": {
-                    "backend_path": "bar",
-                    "backend_type": "Uffd"
-                }
-              }"#;
+            "snapshot_path": "foo",
+            "mem_file_path": "bar",
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "Uffd"
+            }
+        }"#;
 
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
@@ -345,8 +345,8 @@ mod tests {
         );
 
         body = r#"{
-                "snapshot_path": "foo"
-              }"#;
+            "snapshot_path": "foo"
+        }"#;
 
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
@@ -357,11 +357,11 @@ mod tests {
         );
 
         body = r#"{
-                "mem_backend": {
-                    "backend_path": "bar",
-                    "backend_type": "Uffd"
-                }
-              }"#;
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "Uffd"
+            }
+        }"#;
 
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
@@ -369,7 +369,7 @@ mod tests {
                 .unwrap()
                 .to_string(),
             "An error occurred when deserializing the json body of a request: missing field \
-             `snapshot_path` at line 6 column 15."
+             `snapshot_path` at line 6 column 9."
         );
 
         assert!(parse_put_snapshot(&Body::new(body), Some("invalid")).is_err());
@@ -379,24 +379,24 @@ mod tests {
     #[test]
     fn test_parse_patch_vm_state() {
         let mut body = r#"{
-                "state": "Paused"
-              }"#;
+            "state": "Paused"
+        }"#;
 
         assert!(parse_patch_vm_state(&Body::new(body))
             .unwrap()
             .eq(&ParsedRequest::new_sync(VmmAction::Pause)));
 
         body = r#"{
-                "state": "Resumed"
-              }"#;
+            "state": "Resumed"
+        }"#;
 
         assert!(parse_patch_vm_state(&Body::new(body))
             .unwrap()
             .eq(&ParsedRequest::new_sync(VmmAction::Resume)));
 
         let invalid_body = r#"{
-                "invalid": "Paused"
-              }"#;
+            "invalid": "Paused"
+        }"#;
 
         assert!(parse_patch_vm_state(&Body::new(invalid_body)).is_err());
     }

--- a/src/api_server/src/request/snapshot.rs
+++ b/src/api_server/src/request/snapshot.rs
@@ -138,63 +138,56 @@ mod tests {
 
         use vmm::vmm_config::snapshot::SnapshotType;
 
-        let mut body = r#"{
+        let body = r#"{
             "snapshot_type": "Diff",
             "snapshot_path": "foo",
             "mem_file_path": "bar",
             "version": "0.23.0"
         }"#;
-
-        let mut expected_cfg = CreateSnapshotParams {
+        let expected_config = CreateSnapshotParams {
             snapshot_type: SnapshotType::Diff,
             snapshot_path: PathBuf::from("foo"),
             mem_file_path: PathBuf::from("bar"),
             version: Some(Version::new(0, 23, 0)),
         };
-
         let parsed_request = parse_put_snapshot(&Body::new(body), Some("create")).unwrap();
-        match depr_action_from_req(
-            parsed_request,
-            Some(CREATE_WITH_VERSION_DEPRECATION_MESSAGE.to_string()),
-        ) {
-            VmmAction::CreateSnapshot(cfg) => assert_eq!(cfg, expected_cfg),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            depr_action_from_req(
+                parsed_request,
+                Some(CREATE_WITH_VERSION_DEPRECATION_MESSAGE.to_string())
+            ),
+            VmmAction::CreateSnapshot(expected_config)
+        );
 
-        body = r#"{
+        let body = r#"{
             "snapshot_path": "foo",
             "mem_file_path": "bar"
         }"#;
-
-        expected_cfg = CreateSnapshotParams {
+        let expected_config = CreateSnapshotParams {
             snapshot_type: SnapshotType::Full,
             snapshot_path: PathBuf::from("foo"),
             mem_file_path: PathBuf::from("bar"),
             version: None,
         };
-
-        match vmm_action_from_request(parse_put_snapshot(&Body::new(body), Some("create")).unwrap())
-        {
-            VmmAction::CreateSnapshot(cfg) => assert_eq!(cfg, expected_cfg),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            vmm_action_from_request(parse_put_snapshot(&Body::new(body), Some("create")).unwrap()),
+            VmmAction::CreateSnapshot(expected_config)
+        );
 
         let invalid_body = r#"{
             "invalid_field": "foo",
             "mem_file_path": "bar"
         }"#;
-
         assert!(parse_put_snapshot(&Body::new(invalid_body), Some("create")).is_err());
 
-        body = r#"{
+        let body = r#"{
             "snapshot_path": "foo",
             "mem_backend": {
                 "backend_path": "bar",
                 "backend_type": "File"
             }
         }"#;
-
-        let mut expected_cfg = LoadSnapshotParams {
+        let expected_config = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
             mem_backend: MemBackendConfig {
                 backend_path: PathBuf::from("bar"),
@@ -203,19 +196,17 @@ mod tests {
             enable_diff_snapshots: false,
             resume_vm: false,
         };
-
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(parsed_request
             .parsing_info()
             .take_deprecation_message()
             .is_none());
+        assert_eq!(
+            vmm_action_from_request(parsed_request),
+            VmmAction::LoadSnapshot(expected_config)
+        );
 
-        match vmm_action_from_request(parsed_request) {
-            VmmAction::LoadSnapshot(cfg) => assert_eq!(cfg, expected_cfg),
-            _ => panic!("Test failed."),
-        }
-
-        body = r#"{
+        let body = r#"{
             "snapshot_path": "foo",
             "mem_backend": {
                 "backend_path": "bar",
@@ -223,8 +214,7 @@ mod tests {
             },
             "enable_diff_snapshots": true
         }"#;
-
-        expected_cfg = LoadSnapshotParams {
+        let expected_config = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
             mem_backend: MemBackendConfig {
                 backend_path: PathBuf::from("bar"),
@@ -233,18 +223,17 @@ mod tests {
             enable_diff_snapshots: true,
             resume_vm: false,
         };
-
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(parsed_request
             .parsing_info()
             .take_deprecation_message()
             .is_none());
-        match vmm_action_from_request(parsed_request) {
-            VmmAction::LoadSnapshot(cfg) => assert_eq!(cfg, expected_cfg),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            vmm_action_from_request(parsed_request),
+            VmmAction::LoadSnapshot(expected_config)
+        );
 
-        body = r#"{
+        let body = r#"{
             "snapshot_path": "foo",
             "mem_backend": {
                 "backend_path": "bar",
@@ -252,8 +241,7 @@ mod tests {
             },
             "resume_vm": true
         }"#;
-
-        expected_cfg = LoadSnapshotParams {
+        let expected_config = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
             mem_backend: MemBackendConfig {
                 backend_path: PathBuf::from("bar"),
@@ -262,24 +250,22 @@ mod tests {
             enable_diff_snapshots: false,
             resume_vm: true,
         };
-
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(parsed_request
             .parsing_info()
             .take_deprecation_message()
             .is_none());
-        match vmm_action_from_request(parsed_request) {
-            VmmAction::LoadSnapshot(cfg) => assert_eq!(cfg, expected_cfg),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            vmm_action_from_request(parsed_request),
+            VmmAction::LoadSnapshot(expected_config)
+        );
 
-        body = r#"{
+        let body = r#"{
             "snapshot_path": "foo",
             "mem_file_path": "bar",
             "resume_vm": true
         }"#;
-
-        expected_cfg = LoadSnapshotParams {
+        let expected_config = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
             mem_backend: MemBackendConfig {
                 backend_path: PathBuf::from("bar"),
@@ -288,20 +274,18 @@ mod tests {
             enable_diff_snapshots: false,
             resume_vm: true,
         };
-
         let parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
-        match depr_action_from_req(parsed_request, Some(LOAD_DEPRECATION_MESSAGE.to_string())) {
-            VmmAction::LoadSnapshot(cfg) => assert_eq!(cfg, expected_cfg),
-            _ => panic!("Test failed."),
-        }
+        assert_eq!(
+            depr_action_from_req(parsed_request, Some(LOAD_DEPRECATION_MESSAGE.to_string())),
+            VmmAction::LoadSnapshot(expected_config)
+        );
 
-        body = r#"{
+        let body = r#"{
             "snapshot_path": "foo",
             "mem_backend": {
                 "backend_path": "bar"
             }
         }"#;
-
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
                 .err()
@@ -311,13 +295,12 @@ mod tests {
              `backend_type` at line 5 column 13."
         );
 
-        body = r#"{
+        let body = r#"{
             "snapshot_path": "foo",
             "mem_backend": {
                 "backend_type": "File",
             }
         }"#;
-
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
                 .err()
@@ -327,7 +310,7 @@ mod tests {
              line 5 column 13."
         );
 
-        body = r#"{
+        let body = r#"{
             "snapshot_path": "foo",
             "mem_file_path": "bar",
             "mem_backend": {
@@ -335,7 +318,6 @@ mod tests {
                 "backend_type": "Uffd"
             }
         }"#;
-
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
                 .err()
@@ -344,10 +326,9 @@ mod tests {
             Error::SerdeJson(serde_json::Error::custom(TOO_MANY_FIELDS.to_string())).to_string()
         );
 
-        body = r#"{
+        let body = r#"{
             "snapshot_path": "foo"
         }"#;
-
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
                 .err()
@@ -356,13 +337,12 @@ mod tests {
             Error::SerdeJson(serde_json::Error::custom(MISSING_FIELD.to_string())).to_string()
         );
 
-        body = r#"{
+        let body = r#"{
             "mem_backend": {
                 "backend_path": "bar",
                 "backend_type": "Uffd"
             }
         }"#;
-
         assert_eq!(
             parse_put_snapshot(&Body::new(body), Some("load"))
                 .err()
@@ -371,25 +351,22 @@ mod tests {
             "An error occurred when deserializing the json body of a request: missing field \
              `snapshot_path` at line 6 column 9."
         );
-
         assert!(parse_put_snapshot(&Body::new(body), Some("invalid")).is_err());
         assert!(parse_put_snapshot(&Body::new(body), None).is_err());
     }
 
     #[test]
     fn test_parse_patch_vm_state() {
-        let mut body = r#"{
+        let body = r#"{
             "state": "Paused"
         }"#;
-
         assert!(parse_patch_vm_state(&Body::new(body))
             .unwrap()
             .eq(&ParsedRequest::new_sync(VmmAction::Pause)));
 
-        body = r#"{
+        let body = r#"{
             "state": "Resumed"
         }"#;
-
         assert!(parse_patch_vm_state(&Body::new(body))
             .unwrap()
             .eq(&ParsedRequest::new_sync(VmmAction::Resume)));
@@ -397,7 +374,6 @@ mod tests {
         let invalid_body = r#"{
             "invalid": "Paused"
         }"#;
-
         assert!(parse_patch_vm_state(&Body::new(invalid_body)).is_err());
     }
 }

--- a/src/api_server/src/request/vsock.rs
+++ b/src/api_server/src/request/vsock.rs
@@ -41,34 +41,34 @@ mod tests {
     #[test]
     fn test_parse_put_vsock_request() {
         let body = r#"{
-                "guest_cid": 42,
-                "uds_path": "vsock.sock"
-              }"#;
+            "guest_cid": 42,
+            "uds_path": "vsock.sock"
+        }"#;
         assert!(parse_put_vsock(&Body::new(body)).is_ok());
 
         let body = r#"{
-                "guest_cid": 42,
-                "invalid_field": false
-              }"#;
+            "guest_cid": 42,
+            "invalid_field": false
+        }"#;
         assert!(parse_put_vsock(&Body::new(body)).is_err());
     }
 
     #[test]
     fn test_depr_vsock_id() {
         let body = r#"{
-                "vsock_id": "foo",
-                "guest_cid": 42,
-                "uds_path": "vsock.sock"
-              }"#;
+            "vsock_id": "foo",
+            "guest_cid": 42,
+            "uds_path": "vsock.sock"
+        }"#;
         depr_action_from_req(
             parse_put_vsock(&Body::new(body)).unwrap(),
             Some("PUT /vsock: vsock_id field is deprecated.".to_string()),
         );
 
         let body = r#"{
-                "guest_cid": 42,
-                "uds_path": "vsock.sock"
-              }"#;
+            "guest_cid": 42,
+            "uds_path": "vsock.sock"
+        }"#;
         let (_, mut parsing_info) = parse_put_vsock(&Body::new(body)).unwrap().into_parts();
         assert!(parsing_info.take_deprecation_message().is_none());
     }

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -1198,8 +1198,8 @@ definitions:
         type: string
         description:
           Path to the file that contains the guest memory to be loaded.
-          This parameter has been deprecated and is only allowed if
-          `mem_backend` is not present.
+          It is only allowed if `mem_backend` is not present. This parameter has
+          been deprecated and it will be removed in future Firecracker release.
       mem_backend:
         $ref: "#/definitions/MemoryBackend"
         description:
@@ -1302,4 +1302,6 @@ definitions:
         description: Path to UNIX domain socket, used to proxy vsock connections.
       vsock_id:
         type: string
-        description: This parameter has been deprecated since v1.0.0.
+        description:
+          This parameter has been deprecated and it will be removed in future
+          Firecracker release.

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -826,6 +826,8 @@ definitions:
     description:
       The CPU Template defines a set of flags to be disabled from the microvm so that
       the features exposed to the guest are the same as in the selected instance type.
+      This parameter has been deprecated and it will be removed in future Firecracker
+      release.
     enum:
       - C3
       - T2

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -63,11 +63,25 @@ pub enum CpuTemplateType {
     Static(StaticCpuTemplate),
 }
 
+// This conversion is only used for snapshot, but the static CPU template
+// information has not been saved into snapshot since v1.1.
 impl From<&Option<CpuTemplateType>> for StaticCpuTemplate {
     fn from(value: &Option<CpuTemplateType>) -> Self {
         match value {
             Some(CpuTemplateType::Static(template)) => *template,
             Some(CpuTemplateType::Custom(_)) | None => StaticCpuTemplate::None,
+        }
+    }
+}
+
+// This conversion will be used when converting `&VmConfig` to `MachineConfig`
+// to respond `GET /machine-config` and `GET /vm`.
+#[allow(dead_code)]
+impl From<&CpuTemplateType> for StaticCpuTemplate {
+    fn from(value: &CpuTemplateType) -> Self {
+        match value {
+            CpuTemplateType::Static(template) => *template,
+            CpuTemplateType::Custom(_) => StaticCpuTemplate::None,
         }
     }
 }

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -74,9 +74,8 @@ impl From<&Option<CpuTemplateType>> for StaticCpuTemplate {
     }
 }
 
-// This conversion will be used when converting `&VmConfig` to `MachineConfig`
-// to respond `GET /machine-config` and `GET /vm`.
-#[allow(dead_code)]
+// This conversion is used when converting `&VmConfig` to `MachineConfig` to
+// respond `GET /machine-config` and `GET /vm`.
 impl From<&CpuTemplateType> for StaticCpuTemplate {
     fn from(value: &CpuTemplateType) -> Self {
         match value {

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -40,8 +40,8 @@ pub struct MachineConfig {
     #[serde(default, deserialize_with = "deserialize_smt")]
     pub smt: bool,
     /// A CPU template that it is used to filter the CPU features exposed to the guest.
-    #[serde(default, skip_serializing_if = "StaticCpuTemplate::is_none")]
-    pub cpu_template: StaticCpuTemplate,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_template: Option<StaticCpuTemplate>,
     /// Enables or disables dirty page tracking. Enabling allows incremental snapshots.
     #[serde(default)]
     pub track_dirty_pages: bool,
@@ -122,7 +122,7 @@ impl From<MachineConfig> for MachineConfigUpdate {
             vcpu_count: Some(cfg.vcpu_count),
             mem_size_mib: Some(cfg.mem_size_mib),
             smt: Some(cfg.smt),
-            cpu_template: Some(cfg.cpu_template),
+            cpu_template: cfg.cpu_template,
             track_dirty_pages: Some(cfg.track_dirty_pages),
         }
     }
@@ -212,7 +212,7 @@ impl From<&VmConfig> for MachineConfig {
             vcpu_count: value.vcpu_count,
             mem_size_mib: value.mem_size_mib,
             smt: value.smt,
-            cpu_template: (&value.cpu_template).into(),
+            cpu_template: value.cpu_template.as_ref().map(|template| template.into()),
             track_dirty_pages: value.track_dirty_pages,
         }
     }


### PR DESCRIPTION
## Changes

Deprecate the `cpu_template` field in the `/machine-config` API, which is used to set static CPU templates.

## Reason

Since v1.4.0, Firecracker has supported custom CPU templates that allows users to define their own CPU templates and can be used as an alternative of static CPU templates.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
