### PR TITLE
GitHub Action to orchestrate performance A/B-Tests

### DIFF
--- a/.buildkite/pipeline_ab.py
+++ b/.buildkite/pipeline_ab.py
@@ -3,39 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Generate Buildkite performance pipelines dynamically"""
+import os
 
 from common import COMMON_PARSER, group, overlay_dict, pipeline_to_json
 
 perf_test = {
-    "block": {
-        "label": "🖴 Block Performance",
-        "test_path": "integration_tests/performance/test_block_performance.py",
-        "devtool_opts": "-c 1-10 -m 0",
-        "timeout_in_minutes": 240,
-    },
     "snapshot-latency": {
         "label": "📸 Snapshot Latency",
-        "test_path": "integration_tests/performance/test_snapshot_restore_performance.py",
+        "test_path": "integration_tests/performance/test_snapshot_ab.py",
         "devtool_opts": "-c 1-12 -m 0",
         "timeout_in_minutes": 60,
-    },
-    "vsock-throughput": {
-        "label": "🧦 Vsock Throughput",
-        "test_path": "integration_tests/performance/test_vsock_throughput.py",
-        "devtool_opts": "-c 1-10 -m 0",
-        "timeout_in_minutes": 20,
-    },
-    "network-latency": {
-        "label": "🖧 Network Latency",
-        "test_path": "integration_tests/performance/test_network_latency.py",
-        "devtool_opts": "-c 1-10 -m 0",
-        "timeout_in_minutes": 10,
-    },
-    "network-throughput": {
-        "label": "🖧 Network TCP Throughput",
-        "test_path": "integration_tests/performance/test_network_tcp_throughput.py",
-        "devtool_opts": "-c 1-10 -m 0",
-        "timeout_in_minutes": 45,
     },
 }
 
@@ -44,10 +21,11 @@ def build_group(test):
     """Build a Buildkite pipeline `group` step"""
     devtool_opts = test.pop("devtool_opts")
     test_path = test.pop("test_path")
-    retries = test.pop("retries")
+    revision_a = os.environ["REVISION_A"]
+    revision_b = os.environ["REVISION_B"]
     return group(
         label=test.pop("label"),
-        command=f"./tools/devtool -y test {devtool_opts} -- -m nonci --reruns {retries} --perf-fail {test_path}",
+        command=f"./tools/devtool -y test --ab {devtool_opts} -- {revision_a} {revision_b} --test {test_path}",
         artifacts=["./test_results/*"],
         instances=test.pop("instances"),
         platforms=test.pop("platforms"),
@@ -59,12 +37,11 @@ def build_group(test):
 parser = COMMON_PARSER
 parser.add_argument(
     "--test",
-    required=True,
     choices=list(perf_test.keys()),
+    default=list(perf_test.keys()),
     help="performance test",
     action="append",
 )
-parser.add_argument("--retries", type=int, default=0)
 args = parser.parse_args()
 group_steps = []
 tests = [perf_test[test] for test in args.test]
@@ -73,8 +50,6 @@ for test_data in tests:
     test_data.setdefault("instances", args.instances)
     # use ag=1 instances to make sure no two performance tests are scheduled on the same instance
     test_data.setdefault("agents", {"ag": 1})
-    test_data["retries"] = args.retries
-    test_data["timeout_in_minutes"] *= args.retries + 1
     test_data = overlay_dict(test_data, args.step_param)
     test_data["retry"] = {
         "automatic": [

--- a/.github/workflows/trigger_ab_tests.yml
+++ b/.github/workflows/trigger_ab_tests.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger_ab_test:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.forced == false }}
+    steps:
+      - name: "Trigger Buildkite Pipeline"
+        run: |
+          curl -X POST https://api.buildkite.com/v2/organizations/firecracker/pipelines/performance-a-b-tests/builds \
+               -H 'Content-Type: application/json' \
+               -H 'Authorization: Bearer ${{ secrets.BUILDKITE_TOKEN }}' \
+               -d '{
+                    "commit": "HEAD",
+                    "branch": "${{ github.event.ref }}",
+                    "env": {
+                      "REVISION_A": "${{ github.event.before }}",
+                      "REVISION_B": "${{ github.event.after }}"
+                    }
+                  }'


### PR DESCRIPTION
## Changes

Adds a GitHub action that triggers the A/B-testing buildkite pipeline

## Reason

To do an A/B-test on PR merge, the buildkite pipeline needs to know both the revision that main had before a PR was merged, and the revision after the merge. However, buildkite only provides the latter (e.g. it does not forward all information from the github push webhook payload to the actual pipeline). Therefore, we use a shim GitHub action that forwards both revisions to the build in environment variables.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
