### PR TITLE
fix:import testing framework for few tools scripts

### DIFF
--- a/tools/create_snapshot_artifact/main.py
+++ b/tools/create_snapshot_artifact/main.py
@@ -11,14 +11,10 @@ import sys
 import tempfile
 from pathlib import Path
 
-from host_tools.cargo_build import get_firecracker_binaries
-
 # Hack to be able to import testing framework functions.
 sys.path.append(os.path.join(os.getcwd(), "tests"))  # noqa: E402
 
 # pylint: disable=wrong-import-position
-# The test infra assumes it is running from the `tests` directory.
-os.chdir("tests")
 from framework.artifacts import disks, kernels
 from framework.defs import DEFAULT_TEST_SESSION_ROOT_PATH
 from framework.microvm import MicroVMFactory
@@ -28,9 +24,9 @@ from framework.utils import (
     run_cmd,
 )
 from framework.utils_cpuid import CpuVendor, get_cpu_vendor
+from host_tools.cargo_build import get_firecracker_binaries
 
-# restore directory
-os.chdir("..")
+# pylint: enable=wrong-import-position
 
 # Default IPv4 address to route MMDS requests.
 IPV4_ADDRESS = "169.254.169.254"

--- a/tools/test-popular-containers/test-docker-rootfs.py
+++ b/tools/test-popular-containers/test-docker-rootfs.py
@@ -8,11 +8,19 @@
 Test all the ext4 rootfs in the current directory
 """
 
+import os
+import sys
 from pathlib import Path
 
+# Hack to be able to import testing framework functions.
+sys.path.append(os.path.join(os.getcwd(), "tests"))
+
+# pylint: disable=wrong-import-position
 from framework.artifacts import kernels
 from framework.microvm import MicroVMFactory
 from host_tools.cargo_build import get_firecracker_binaries
+
+# pylint: enable=wrong-import-position
 
 kernels = list(kernels("vmlinux-*"))
 # Use the latest guest kernel


### PR DESCRIPTION
## Changes

Make testing framework available so that the few tools scripts using them work as expected.

## Reason

changes added in #4089 breaks cross snapshot restore tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] ~If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [ ] ~Any required documentation changes (code and docs) are included in this PR.~
- [ ] ~API changes follow the [Runbook for Firecracker API changes][2].~
- [ ] ~User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
- [ ] ~New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
