### PR TITLE
A/B-Tests for network latency and block performance

### DIFF
--- a/.buildkite/pipeline_ab.py
+++ b/.buildkite/pipeline_ab.py
@@ -8,6 +8,12 @@ import os
 from common import COMMON_PARSER, group, overlay_dict, pipeline_to_json
 
 perf_test = {
+    "network-latency": {
+        "label": "🖧 Network Latency",
+        "test_path": "integration_tests/performance/test_network_ab.py",
+        "devtool_opts": "-c 1-10 -m 0",
+        "timeout_in_minutes": 30,
+    },
     "snapshot-latency": {
         "label": "📸 Snapshot Latency",
         "test_path": "integration_tests/performance/test_snapshot_ab.py",

--- a/.buildkite/pipeline_ab.py
+++ b/.buildkite/pipeline_ab.py
@@ -8,6 +8,12 @@ import os
 from common import COMMON_PARSER, group, overlay_dict, pipeline_to_json
 
 perf_test = {
+    "block": {
+        "label": "🖴 Block Performance",
+        "test_path": "integration_tests/performance/test_block_ab.py",
+        "devtool_opts": "-c 1-10 -m 0",
+        "timeout_in_minutes": 40,
+    },
     "network-latency": {
         "label": "🖧 Network Latency",
         "test_path": "integration_tests/performance/test_network_ab.py",

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -360,6 +360,19 @@ class Microvm:
         # Read the PID stored inside the file.
         return int(pid_file_path.read_text(encoding="ascii"))
 
+    @property
+    def dimensions(self):
+        """Gets a default set of cloudwatch dimensions describing the configuration of this microvm"""
+        return {
+            "instance": global_props.instance,
+            "cpu_model": global_props.cpu_model,
+            "host_kernel": f"linux-{global_props.host_linux_version}",
+            "guest_kernel": self.kernel_file.stem[2:],
+            "rootfs": self.rootfs_file.name,
+            "vcpus": str(self.vcpus_count),
+            "guest_memory": f"{self.mem_size_bytes / (1024 * 1024)}MB",
+        }
+
     def flush_metrics(self):
         """Flush the microvm metrics and get the latest datapoint"""
         self.api.actions.put(action_type="FlushMetrics")

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -7,7 +7,7 @@
 """
 Metadata we want to attach to tests for further analysis and troubleshooting
 """
-
+import os
 import platform
 import re
 import subprocess
@@ -57,6 +57,8 @@ class GlobalProps:
         self.git_branch = run_cmd("git show -s --pretty=%D HEAD")
         self.git_origin_url = run_cmd("git config --get remote.origin.url")
         self.rust_version = run_cmd("rustc --version |awk '{print $2}'")
+        self.buildkite_pipeline_slug = os.environ.get("BUILDKITE_PIPELINE_SLUG")
+        self.buildkite_build_number = os.environ.get("BUILDKITE_BUILD_NUMBER")
 
         self.environment = self._detect_environment()
         if self.is_ec2:

--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import pytest
 
 import host_tools.drive as drive_tools
-from framework.properties import global_props
 from framework.utils import CmdBuilder, get_cpu_percent, run_cmd
 
 # size of the block device used in the test, in MB
@@ -168,16 +167,10 @@ def test_block_performance(
 
     metrics.set_dimensions(
         {
-            "instance": global_props.instance,
-            "cpu_model": global_props.cpu_model,
-            "host_kernel": "linux-" + global_props.host_linux_version,
-            "guest_kernel": guest_kernel.stem[2:],
-            "rootfs": rootfs.name,
             "performance_test": "test_block_performance",
-            "vcpus": str(vcpus),
-            "guest_memory": f"{GUEST_MEM_MIB}MB",
             "io_engine": io_engine,
             "fio_mode": fio_mode,
             "fio_block_size": str(fio_block_size),
+            **vm.dimensions,
         }
     )

--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -1,0 +1,183 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Performance benchmark for block device emulation."""
+
+import concurrent
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+import host_tools.drive as drive_tools
+from framework.properties import global_props
+from framework.utils import CmdBuilder, get_cpu_percent, run_cmd
+
+# size of the block device used in the test, in MB
+BLOCK_DEVICE_SIZE_MB = 2048
+
+# Time (in seconds) for which fio "warms up"
+WARMUP_SEC = 10
+
+# Time (in seconds) for which fio runs after warmup is done
+RUNTIME_SEC = 30
+
+# VM guest memory size
+GUEST_MEM_MIB = 1024
+
+
+def prepare_microvm_for_test(microvm):
+    """Prepares the microvm for running a fio-based performance test by tweaking
+    various performance related parameters."""
+    rc, _, stderr = microvm.ssh.run("echo 'none' > /sys/block/vdb/queue/scheduler")
+    assert rc == 0, stderr
+    assert stderr == ""
+
+    # First, flush all guest cached data to host, then drop guest FS caches.
+    rc, _, stderr = microvm.ssh.run("sync")
+    assert rc == 0, stderr
+    assert stderr == ""
+    rc, _, stderr = microvm.ssh.run("echo 3 > /proc/sys/vm/drop_caches")
+    assert rc == 0, stderr
+    assert stderr == ""
+
+    # Then, flush all host cached data to hardware, also drop host FS caches.
+    run_cmd("sync")
+    run_cmd("echo 3 > /proc/sys/vm/drop_caches")
+
+
+def run_fio(microvm, mode, block_size):
+    """Run a fio test in the specified mode with block size bs."""
+    cmd = (
+        CmdBuilder("fio")
+        .with_arg(f"--name={mode}-{block_size}")
+        .with_arg(f"--rw={mode}")
+        .with_arg(f"--bs={block_size}")
+        .with_arg("--filename=/dev/vdb")
+        .with_arg("--time_base=1")
+        .with_arg(f"--size={BLOCK_DEVICE_SIZE_MB}M")
+        .with_arg("--direct=1")
+        .with_arg("--ioengine=libaio")
+        .with_arg("--iodepth=32")
+        .with_arg(f"--ramp_time={WARMUP_SEC}")
+        .with_arg(f"--numjobs={microvm.vcpus_count}")
+        # Set affinity of the entire fio process to a set of vCPUs equal in size to number of workers
+        .with_arg(
+            f"--cpus_allowed={','.join(str(i) for i in range(microvm.vcpus_count))}"
+        )
+        # Instruct fio to pin one worker per vcpu
+        .with_arg("--cpus_allowed_policy=split")
+        .with_arg("--randrepeat=0")
+        .with_arg(f"--runtime={RUNTIME_SEC}")
+        .with_arg(f"--write_bw_log={mode}")
+        .with_arg("--log_avg_msec=1000")
+        .with_arg("--output-format=json+")
+        .build()
+    )
+
+    logs_path = Path(microvm.jailer.chroot_base_with_id()) / "fio_output"
+
+    if logs_path.is_dir():
+        shutil.rmtree(logs_path)
+
+    logs_path.mkdir()
+
+    prepare_microvm_for_test(microvm)
+
+    # Start the CPU load monitor.
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        cpu_load_future = executor.submit(
+            get_cpu_percent,
+            microvm.jailer_clone_pid,
+            RUNTIME_SEC,
+            omit=WARMUP_SEC,
+        )
+
+        # Print the fio command in the log and run it
+        rc, _, stderr = microvm.ssh.run(f"cd /tmp; {cmd}")
+        assert rc == 0, stderr
+        assert stderr == ""
+
+        microvm.ssh.scp_get("/tmp/*.log", logs_path)
+        rc, _, stderr = microvm.ssh.run("rm /tmp/*.log")
+        assert rc == 0, stderr
+
+        return logs_path, cpu_load_future.result()
+
+
+def process_fio_logs(vm, fio_mode, logs_dir, metrics):
+    """Parses the fio logs in `{logs_dir}/{fio_mode}_bw.*.log and emits their contents as CloudWatch metrics"""
+    for job_id in range(vm.vcpus_count):
+        data = Path(f"{logs_dir}/{fio_mode}_bw.{job_id + 1}.log").read_text("UTF-8")
+
+        for line in data.splitlines():
+            _, value, direction, _ = line.split(",", maxsplit=3)
+            value = int(value.strip())
+
+            # See https://fio.readthedocs.io/en/latest/fio_doc.html#log-file-formats
+            match direction.strip():
+                case "0":
+                    metrics.put_metric("bw_read", value, "Kilobytes/Second")
+                case "1":
+                    metrics.put_metric("bw_write", value, "Kilobytes/Second")
+                case _:
+                    assert False
+
+
+@pytest.mark.nonci
+@pytest.mark.timeout(RUNTIME_SEC * 1000)  # 1.40 hours
+@pytest.mark.parametrize("vcpus", [1, 2], ids=["1vcpu", "2vcpu"])
+@pytest.mark.parametrize("fio_mode", ["randread", "randwrite"])
+@pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
+def test_block_performance(
+    microvm_factory,
+    guest_kernel,
+    rootfs,
+    vcpus,
+    fio_mode,
+    fio_block_size,
+    io_engine,
+    metrics,
+):
+    """
+    Execute block device emulation benchmarking scenarios.
+    """
+    vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
+    vm.spawn(log_level="Info")
+    vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
+    vm.add_net_iface()
+    # Add a secondary block device for benchmark tests.
+    fs = drive_tools.FilesystemFile(
+        os.path.join(vm.fsfiles, "scratch"), BLOCK_DEVICE_SIZE_MB
+    )
+    vm.add_drive("scratch", fs.path, io_engine=io_engine)
+    vm.start()
+
+    # Pin uVM threads to physical cores.
+    assert vm.pin_vmm(0), "Failed to pin firecracker thread."
+    assert vm.pin_api(1), "Failed to pin fc_api thread."
+    for i in range(vm.vcpus_count):
+        assert vm.pin_vcpu(i, i + 2), f"Failed to pin fc_vcpu {i} thread."
+
+    logs_dir, cpu_load = run_fio(vm, fio_mode, fio_block_size)
+
+    process_fio_logs(vm, fio_mode, logs_dir, metrics)
+
+    for cpu_util_data_point in list(cpu_load["firecracker"].values())[0]:
+        metrics.put_metric("cpu_utilization_vmm", cpu_util_data_point, "Percent")
+
+    metrics.set_dimensions(
+        {
+            "instance": global_props.instance,
+            "cpu_model": global_props.cpu_model,
+            "host_kernel": "linux-" + global_props.host_linux_version,
+            "guest_kernel": guest_kernel.stem[2:],
+            "rootfs": rootfs.name,
+            "performance_test": "test_block_performance",
+            "vcpus": str(vcpus),
+            "guest_memory": f"{GUEST_MEM_MIB}MB",
+            "io_engine": io_engine,
+            "fio_mode": fio_mode,
+            "fio_block_size": str(fio_block_size),
+        }
+    )

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -1,0 +1,101 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests the network latency of a Firecracker guest."""
+
+import re
+import statistics
+
+import pytest
+
+from framework.properties import global_props
+from framework.utils import CpuMap
+
+# each iteration is 30 * 0.2s = 6s
+# Thus 30 iterations are 6s * 30 = 5min
+REQUEST_PER_ITERATION = 30
+ITERATIONS = 30
+DELAY = 0.2
+
+#  MicroVM configuration
+GUEST_MEM_MIB = 1024
+GUEST_VCPUS = 1
+
+
+def consume_ping_output(ping_putput):
+    """Consume ping output.
+
+    Output example:
+    PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+    64 bytes from 8.8.8.8: icmp_seq=1 ttl=118 time=17.7 ms
+    64 bytes from 8.8.8.8: icmp_seq=2 ttl=118 time=17.7 ms
+    64 bytes from 8.8.8.8: icmp_seq=3 ttl=118 time=17.4 ms
+    64 bytes from 8.8.8.8: icmp_seq=4 ttl=118 time=17.8 ms
+
+    --- 8.8.8.8 ping statistics ---
+    4 packets transmitted, 4 received, 0% packet loss, time 3005ms
+    rtt min/avg/max/mdev = 17.478/17.705/17.808/0.210 ms
+    """
+    output = ping_putput.strip().split("\n")
+    assert len(output) > 2
+
+    # Compute percentiles.
+    seqs = output[1 : REQUEST_PER_ITERATION + 1]
+    pattern_time = ".+ bytes from .+: icmp_seq=.+ ttl=.+ time=(.+) ms"
+    for seq in seqs:
+        time = re.findall(pattern_time, seq)
+        assert len(time) == 1
+        yield float(time[0])
+
+
+@pytest.mark.nonci
+@pytest.mark.timeout(3600)
+def test_network_latency(microvm_factory, guest_kernel, rootfs, metrics):
+    """
+    Test network latency for multiple vm configurations.
+
+    Send a ping from the guest to the host.
+    """
+
+    vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
+    vm.spawn(log_level="Info")
+    vm.basic_config(vcpu_count=GUEST_VCPUS, mem_size_mib=GUEST_MEM_MIB)
+    iface = vm.add_net_iface()
+    vm.start()
+
+    # Check if the needed CPU cores are available. We have the API thread, VMM
+    # thread and then one thread for each configured vCPU.
+    assert CpuMap.len() >= 2 + vm.vcpus_count
+
+    # Pin uVM threads to physical cores.
+    assert vm.pin_vmm(0), "Failed to pin firecracker thread."
+    assert vm.pin_api(1), "Failed to pin fc_api thread."
+    for i in range(vm.vcpus_count):
+        assert vm.pin_vcpu(i, i + 2), f"Failed to pin fc_vcpu {i} thread."
+
+    samples = []
+
+    for _ in range(ITERATIONS):
+        rc, ping_output, stderr = vm.ssh.run(
+            f"ping -c {REQUEST_PER_ITERATION} -i {DELAY} {iface.host_ip}"
+        )
+        assert rc == 0, stderr
+
+        samples.extend(consume_ping_output(ping_output))
+
+    metrics.set_dimensions(
+        {
+            "instance": global_props.instance,
+            "cpu_model": global_props.cpu_model,
+            "host_kernel": "linux-" + global_props.host_linux_version,
+            "guest_kernel": guest_kernel.stem[2:],
+            "rootfs": rootfs.name,
+            "performance_test": "test_network_latency",
+            "vcpus": str(GUEST_VCPUS),
+            "guest_memory": f"{GUEST_MEM_MIB}MB",
+        }
+    )
+
+    metrics.put_metric("latency_Avg", statistics.mean(samples), "Milliseconds")
+
+    for sample in samples:
+        metrics.put_metric("latency", sample, "Milliseconds")

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -7,7 +7,6 @@ import statistics
 
 import pytest
 
-from framework.properties import global_props
 from framework.utils import CpuMap
 
 # each iteration is 30 * 0.2s = 6s
@@ -83,16 +82,7 @@ def test_network_latency(microvm_factory, guest_kernel, rootfs, metrics):
         samples.extend(consume_ping_output(ping_output))
 
     metrics.set_dimensions(
-        {
-            "instance": global_props.instance,
-            "cpu_model": global_props.cpu_model,
-            "host_kernel": "linux-" + global_props.host_linux_version,
-            "guest_kernel": guest_kernel.stem[2:],
-            "rootfs": rootfs.name,
-            "performance_test": "test_network_latency",
-            "vcpus": str(GUEST_VCPUS),
-            "guest_memory": f"{GUEST_MEM_MIB}MB",
-        }
+        {"performance_test": "test_network_latency", **vm.dimensions}
     )
 
     metrics.put_metric("latency_Avg", statistics.mean(samples), "Milliseconds")

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -149,8 +149,10 @@ def analyze_data(data_a, data_b):
             result = check_regression(a_result[property_name], b_result[property_name])
 
             metrics_logger.set_dimensions(dict(config))
-            metrics_logger.put_metric("p_value", result.pvalue, "None")
-            metrics_logger.put_metric("mean_difference", result.statistic, "None")
+            metrics_logger.put_metric("p_value", float(result.pvalue), "None")
+            metrics_logger.put_metric(
+                "mean_difference", float(result.statistic), "None"
+            )
             metrics_logger.set_property("data_a", a_result[property_name])
             metrics_logger.set_property("data_b", b_result[property_name])
             asyncio.run(metrics_logger.flush())

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -74,8 +74,17 @@ def load_data_series(revision: str):
             # we will need to rethink this heuristic.
             if line.startswith("{"):
                 dimensions, result = reemit_emf_and_get_data(line, revision)
+                key = frozenset(dimensions.items())
 
-                data[frozenset(dimensions.items())] = result
+                if key not in data:
+                    data[key] = result
+                else:
+                    # If there are many data points for a metric, they will be split across
+                    # multiple EMF log messages. We need to reassemble :(
+                    assert data[key].keys() == result.keys()
+
+                    for metric in data[key]:
+                        data[key][metric].extend(result[metric])
 
     return data
 

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -194,7 +194,7 @@ def ab_performance_test(a_revision, b_revision, test, p_thresh, strength_thresh)
     )
     print(commit_list.strip())
 
-    processed_emf_a, _, results = git_ab_test(
+    processed_emf_a, processed_emf_b, results = git_ab_test(
         lambda checkout, _: collect_data(checkout, test),
         analyze_data,
         a_revision=a_revision,
@@ -211,7 +211,14 @@ def ab_performance_test(a_revision, b_revision, test, p_thresh, strength_thresh)
             failures.append((dimension_set, metric, result, unit))
 
     failure_report = "\n".join(
-        f"\033[0;32m[Firecracker A/B-Test Runner]\033[0m A/B-testing shows a regression of \033[0;31m\033[1m{format_with_reduced_unit(result.statistic, unit)}\033[0m for metric \033[1m{metric}\033[0m with \033[0;31m\033[1mp={result.pvalue}\033[0m. This means that observing a change of this magnitude or worse, assuming that performance characteristics did not change across the tested commits, has a probability of {result.pvalue:.2%}. Tested Dimensions:\n{json.dumps(dict(dimension_set), indent=2)}"
+        f"\033[0;32m[Firecracker A/B-Test Runner]\033[0m A/B-testing shows a change of "
+        f"\033[0;31m\033[1m{format_with_reduced_unit(result.statistic, unit)}\033[0m "
+        f"(from {format_with_reduced_unit(statistics.mean(processed_emf_a[dimension_set][metric][0]), unit)} "
+        f"to {format_with_reduced_unit(statistics.mean(processed_emf_b[dimension_set][metric][0]), unit)}) "
+        f"for metric \033[1m{metric}\033[0m with \033[0;31m\033[1mp={result.pvalue}\033[0m. "
+        f"This means that observing a change of this magnitude or worse, assuming that performance "
+        f"characteristics did not change across the tested commits, has a probability of {result.pvalue:.2%}. "
+        f"Tested Dimensions:\n{json.dumps(dict(dimension_set), indent=2)}"
         for (dimension_set, metric, result, unit) in failures
     )
     assert not failures, "\n" + failure_report

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -41,6 +41,10 @@ from host_tools.metrics import emit_raw_emf, format_with_reduced_unit
 
 def extract_dimensions(emf):
     """Extracts the cloudwatch dimensions from an EMF log message"""
+    if not emf["_aws"]["CloudWatchMetrics"][0]["Dimensions"]:
+        # Skipped tests emit a duration metric, but have no dimensions set
+        return {}
+
     dimension_list = emf["_aws"]["CloudWatchMetrics"][0]["Dimensions"][0]
     return {key: emf[key] for key in emf if key in dimension_list}
 
@@ -88,6 +92,10 @@ def load_data_series(revision: str):
             # we will need to rethink this heuristic.
             if line.startswith("{"):
                 dimensions, result = reemit_emf_and_get_data(line, revision)
+
+                if not dimensions:
+                    continue
+
                 dimension_set = frozenset(dimensions.items())
 
                 if dimension_set not in processed_emf:


### PR DESCRIPTION
## Changes

Introduces A/B-compatible performance tests for block device throughput and network latency. Also contains minor QoL refractors, such as:
- Outputting correct units in test_ab.py (instead of declaring everything to be milliseconds), including logic to convert un-readable values such as "987654 Bytes" into "987.7KB".
- Introduce consistent naming for variables in test_ab.py, in hopes of making the code easier to read/maintain
- Generalize test_snapshot_ab.py's `TestSetup.dimensions` property to be a property of `Microvm` that returns a default set of dimensions shared across all perf tests. 

## Reason

More A/B-Testings and code cleanups

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
