### PR TITLE
Final A/B-Tests

### DIFF
--- a/.buildkite/pipeline_ab.py
+++ b/.buildkite/pipeline_ab.py
@@ -26,6 +26,12 @@ perf_test = {
         "devtool_opts": "-c 1-12 -m 0",
         "timeout_in_minutes": 60,
     },
+    "vsock-throughput": {
+        "label": "🧦 Vsock Throughput",
+        "test_path": "integration_tests/performance/test_vsock_ab.py",
+        "devtool_opts": "-c 1-10 -m 0",
+        "timeout_in_minutes": 40,
+    },
 }
 
 

--- a/.buildkite/pipeline_ab.py
+++ b/.buildkite/pipeline_ab.py
@@ -16,9 +16,15 @@ perf_test = {
     },
     "network-latency": {
         "label": "🖧 Network Latency",
-        "test_path": "integration_tests/performance/test_network_ab.py",
+        "test_path": "integration_tests/performance/test_network_ab.py::test_network_latency",
         "devtool_opts": "-c 1-10 -m 0",
         "timeout_in_minutes": 30,
+    },
+    "network-throughput": {
+        "label": "🖧 Network TCP Throughput",
+        "test_path": "integration_tests/performance/test_network_ab.py::test_network_tcp_throughput",
+        "devtool_opts": "-c 1-10 -m 0",
+        "timeout_in_minutes": 50,
     },
     "snapshot-latency": {
         "label": "📸 Snapshot Latency",

--- a/tests/framework/utils_iperf.py
+++ b/tests/framework/utils_iperf.py
@@ -167,3 +167,27 @@ def consume_iperf3_output(stats_consumer, iperf_result):
             (f"cpu_utilization_{thread_name}", x, "Percent")
             for x in list(data.values())[0]
         ]
+
+
+def emit_iperf3_metrics(metrics, iperf_result):
+    """Consume the iperf3 data produced by the tcp/vsock throughput performance tests"""
+    for cpu_util_data_point in list(
+        iperf_result["cpu_load_raw"]["firecracker"].values()
+    )[0]:
+        metrics.put_metric("cpu_utilization_vmm", cpu_util_data_point, "Percent")
+
+    for time_series in iperf_result["g2h"]:
+        for interval in time_series["intervals"]:
+            metrics.put_metric(
+                "throughput_guest_to_host",
+                interval["sum"]["bits_per_second"],
+                "Bits/Second",
+            )
+
+    for time_series in iperf_result["h2g"]:
+        for interval in time_series["intervals"]:
+            metrics.put_metric(
+                "throughput_host_to_guest",
+                interval["sum"]["bits_per_second"],
+                "Bits/Second",
+            )

--- a/tests/framework/utils_iperf.py
+++ b/tests/framework/utils_iperf.py
@@ -169,7 +169,7 @@ def consume_iperf3_output(stats_consumer, iperf_result):
         ]
 
 
-def emit_iperf3_metrics(metrics, iperf_result):
+def emit_iperf3_metrics(metrics, iperf_result, omit):
     """Consume the iperf3 data produced by the tcp/vsock throughput performance tests"""
     for cpu_util_data_point in list(
         iperf_result["cpu_load_raw"]["firecracker"].values()
@@ -177,7 +177,7 @@ def emit_iperf3_metrics(metrics, iperf_result):
         metrics.put_metric("cpu_utilization_vmm", cpu_util_data_point, "Percent")
 
     for time_series in iperf_result["g2h"]:
-        for interval in time_series["intervals"]:
+        for interval in time_series["intervals"][omit:]:
             metrics.put_metric(
                 "throughput_guest_to_host",
                 interval["sum"]["bits_per_second"],
@@ -185,7 +185,7 @@ def emit_iperf3_metrics(metrics, iperf_result):
             )
 
     for time_series in iperf_result["h2g"]:
-        for interval in time_series["intervals"]:
+        for interval in time_series["intervals"][omit:]:
             metrics.put_metric(
                 "throughput_host_to_guest",
                 interval["sum"]["bits_per_second"],

--- a/tests/host_tools/metrics.py
+++ b/tests/host_tools/metrics.py
@@ -48,6 +48,7 @@ import os
 import socket
 from urllib.parse import urlparse
 
+from aws_embedded_metrics.constants import DEFAULT_NAMESPACE
 from aws_embedded_metrics.logger.metrics_logger_factory import create_metrics_logger
 
 
@@ -99,10 +100,12 @@ def emit_raw_emf(emf_msg: dict):
     if "AWS_EMF_AGENT_ENDPOINT" not in os.environ:
         return
 
+    namespace = os.environ.get("AWS_EMF_NAMESPACE", DEFAULT_NAMESPACE)
     emf_msg["_aws"]["LogGroupName"] = os.environ.get(
-        "AWS_EMF_LOG_GROUP_NAME", f"{os.environ['AWS_EMF_NAMESPACE']}-metrics"
+        "AWS_EMF_LOG_GROUP_NAME", f"{namespace}-metrics"
     )
-    emf_msg["_aws"]["LogStreamName"] = ""
+    emf_msg["_aws"]["LogStreamName"] = os.environ.get("AWS_EMF_LOG_STREAM_NAME", "")
+    emf_msg["_aws"]["Namespace"] = namespace
 
     emf_endpoint = urlparse(os.environ["AWS_EMF_AGENT_ENDPOINT"])
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -171,4 +171,4 @@ def test_network_tcp_throughput(
         }
     )
 
-    emit_iperf3_metrics(metrics, data)
+    emit_iperf3_metrics(metrics, data, TCPIPerf3Test.WARMUP_SEC)

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -8,6 +8,7 @@ import statistics
 import pytest
 
 from framework.utils import CpuMap
+from framework.utils_iperf import IPerf3Test, emit_iperf3_metrics
 
 # each iteration is 30 * 0.2s = 6s
 # Thus 30 iterations are 6s * 30 = 5min
@@ -89,3 +90,88 @@ def test_network_latency(microvm_factory, guest_kernel, rootfs, metrics):
 
     for sample in samples:
         metrics.put_metric("latency", sample, "Milliseconds")
+
+
+class TCPIPerf3Test(IPerf3Test):
+    """IPerf3 runner for the TCP throughput performance test"""
+
+    BASE_PORT = 5000
+
+    # How many clients/servers should be spawned per vcpu
+    LOAD_FACTOR = 1
+
+    # Time (in seconds) for which iperf "warms up"
+    WARMUP_SEC = 5
+
+    # Time (in seconds) for which iperf runs after warmup is done
+    RUNTIME_SEC = 20
+
+    def __init__(self, microvm, mode, host_ip, payload_length):
+        self._host_ip = host_ip
+
+        super().__init__(
+            microvm,
+            self.BASE_PORT,
+            self.RUNTIME_SEC,
+            self.WARMUP_SEC,
+            mode,
+            self.LOAD_FACTOR * microvm.vcpus_count,
+            host_ip,
+            payload_length=payload_length,
+        )
+
+
+@pytest.mark.nonci
+@pytest.mark.timeout(3600)
+@pytest.mark.parametrize("vcpus", [1, 2])
+@pytest.mark.parametrize("payload_length", ["128K", "1024K"], ids=["p128K", "p1024K"])
+@pytest.mark.parametrize("mode", ["g2h", "h2g", "bd"])
+def test_network_tcp_throughput(
+    microvm_factory,
+    guest_kernel,
+    rootfs,
+    vcpus,
+    payload_length,
+    mode,
+    metrics,
+):
+    """
+    Iperf between guest and host in both directions for TCP workload.
+    """
+
+    # We run bi-directional tests only on uVM with more than 2 vCPus
+    # because we need to pin one iperf3/direction per vCPU, and since we
+    # have two directions, we need at least two vCPUs.
+    if mode == "bd" and vcpus < 2:
+        pytest.skip("bidrectional test only done with at least 2 vcpus")
+
+    vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
+    vm.spawn(log_level="Info")
+    vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
+    iface = vm.add_net_iface()
+    vm.start()
+
+    # Check if the needed CPU cores are available. We have the API thread, VMM
+    # thread and then one thread for each configured vCPU. Lastly, we need one for
+    # the iperf server on the host.
+    assert CpuMap.len() > 2 + vm.vcpus_count
+
+    # Pin uVM threads to physical cores.
+    assert vm.pin_vmm(0), "Failed to pin firecracker thread."
+    assert vm.pin_api(1), "Failed to pin fc_api thread."
+    for i in range(vm.vcpus_count):
+        assert vm.pin_vcpu(i, i + 2), f"Failed to pin fc_vcpu {i} thread."
+
+    test = TCPIPerf3Test(vm, mode, iface.host_ip, payload_length)
+    data = test.run_test(vm.vcpus_count + 2)
+
+    metrics.set_dimensions(
+        {
+            "performance_test": "test_network_tcp_throughput",
+            "payload_length": payload_length,
+            "mode": mode,
+            **vm.dimensions,
+        }
+    )
+
+    emit_iperf3_metrics(metrics, data)

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -3,7 +3,6 @@
 """Tests the network latency of a Firecracker guest."""
 
 import re
-import statistics
 
 import pytest
 
@@ -86,10 +85,8 @@ def test_network_latency(microvm_factory, guest_kernel, rootfs, metrics):
         {"performance_test": "test_network_latency", **vm.dimensions}
     )
 
-    metrics.put_metric("latency_Avg", statistics.mean(samples), "Milliseconds")
-
     for sample in samples:
-        metrics.put_metric("latency", sample, "Milliseconds")
+        metrics.put_metric("ping_latency", sample, "Milliseconds")
 
 
 class TCPIPerf3Test(IPerf3Test):

--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Performance benchmark for snapshot restore."""
 import shutil
-import statistics
 import tempfile
 from dataclasses import dataclass
 from functools import lru_cache
@@ -158,8 +157,6 @@ def test_restore_latency(
             **vm.dimensions,
         }
     )
-
-    metrics.put_metric("latency_Avg", statistics.mean(samples), "Milliseconds")
 
     for sample in samples:
         metrics.put_metric("latency", sample, "Milliseconds")

--- a/tests/integration_tests/performance/test_vsock_ab.py
+++ b/tests/integration_tests/performance/test_vsock_ab.py
@@ -116,4 +116,4 @@ def test_vsock_throughput(
         }
     )
 
-    emit_iperf3_metrics(metrics, data)
+    emit_iperf3_metrics(metrics, data, VsockIPerf3Test.WARMUP_SEC)

--- a/tests/integration_tests/performance/test_vsock_ab.py
+++ b/tests/integration_tests/performance/test_vsock_ab.py
@@ -1,0 +1,119 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests the VSOCK throughput of Firecracker uVMs."""
+
+import os
+
+import pytest
+
+from framework.utils import CpuMap
+from framework.utils_iperf import IPerf3Test, emit_iperf3_metrics
+from framework.utils_vsock import VSOCK_UDS_PATH, make_host_port_path
+
+
+class VsockIPerf3Test(IPerf3Test):
+    """IPerf3 runner for the vsock throughput performance test"""
+
+    BASE_PORT = 5201
+
+    # How many clients/servers should be spawned per vcpu
+    LOAD_FACTOR = 1
+
+    # Time (in seconds) for which iperf "warms up"
+    WARMUP_SEC = 3
+
+    # Time (in seconds) for which iperf runs after warmup is done
+    RUNTIME_SEC = 20
+
+    # VM guest memory size
+    GUEST_MEM_MIB = 1024
+
+    def __init__(self, microvm, mode, payload_length):
+        super().__init__(
+            microvm,
+            self.BASE_PORT,
+            self.RUNTIME_SEC,
+            self.WARMUP_SEC,
+            mode,
+            self.LOAD_FACTOR * microvm.vcpus_count,
+            2,
+            iperf="/usr/local/bin/iperf3-vsock",
+            payload_length=payload_length,
+        )
+
+    def host_command(self, port_offset):
+        return (
+            super()
+            .host_command(port_offset)
+            .with_arg("--vsock")
+            .with_arg("-B", os.path.join(self._microvm.path, VSOCK_UDS_PATH))
+        )
+
+    def spawn_iperf3_client(self, client_idx):
+        # Bind the UDS in the jailer's root.
+        self._microvm.create_jailed_resource(
+            os.path.join(
+                self._microvm.path,
+                make_host_port_path(VSOCK_UDS_PATH, self._base_port + client_idx),
+            )
+        )
+        # The rootfs does not have iperf3-vsock
+        iperf3_guest = "/tmp/iperf3-vsock"
+
+        self._microvm.ssh.scp_put(self._iperf, iperf3_guest)
+        self._guest_iperf = iperf3_guest
+        return super().spawn_iperf3_client(client_idx)
+
+    def guest_command(self, port_offset):
+        return super().guest_command(port_offset).with_arg("--vsock")
+
+
+@pytest.mark.nonci
+@pytest.mark.parametrize("vcpus", [1, 2], ids=["1vcpu", "2vcpu"])
+@pytest.mark.parametrize("payload_length", ["64K", "1024K"], ids=["p64K", "p1024K"])
+@pytest.mark.parametrize("mode", ["g2h", "h2g", "bd"])
+def test_vsock_throughput(
+    microvm_factory, guest_kernel, rootfs, vcpus, payload_length, mode, metrics
+):
+    """
+    Test vsock throughput for multiple vm configurations.
+    """
+    # We run bi-directional tests only on uVM with more than 2 vCPus
+    # because we need to pin one iperf3/direction per vCPU, and since we
+    # have two directions, we need at least two vCPUs.
+    if mode == "bd" and vcpus < 2:
+        pytest.skip("bidrectional test only done with at least 2 vcpus")
+
+    mem_size_mib = 1024
+    vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
+    vm.spawn(log_level="Info")
+    vm.basic_config(vcpu_count=vcpus, mem_size_mib=mem_size_mib)
+    vm.add_net_iface()
+    # Create a vsock device
+    vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path="/" + VSOCK_UDS_PATH)
+    vm.start()
+
+    # Check if the needed CPU cores are available. We have the API thread, VMM
+    # thread and then one thread for each configured vCPU. Lastly, we need one for
+    # the iperf server on the host.
+    assert CpuMap.len() > 2 + vm.vcpus_count
+
+    # Pin uVM threads to physical cores.
+    assert vm.pin_vmm(0), "Failed to pin firecracker thread."
+    assert vm.pin_api(1), "Failed to pin fc_api thread."
+    for i in range(vm.vcpus_count):
+        assert vm.pin_vcpu(i, i + 2), f"Failed to pin fc_vcpu {i} thread."
+
+    test = VsockIPerf3Test(vm, mode, payload_length)
+    data = test.run_test(vm.vcpus_count + 2)
+
+    metrics.set_dimensions(
+        {
+            "performance_test": "test_vsock_throughput",
+            "payload_length": payload_length,
+            "mode": mode,
+            **vm.dimensions,
+        }
+    )
+
+    emit_iperf3_metrics(metrics, data)

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -172,7 +172,7 @@ def analyze_data(processed_emf_a, processed_emf_b):
             )
             result = check_regression(values_a, metrics_b[metric][0])
 
-            metrics_logger.set_dimensions(dict(dimension_set))
+            metrics_logger.set_dimensions({"metric": metric, **dict(dimension_set)})
             metrics_logger.put_metric("p_value", float(result.pvalue), "None")
             metrics_logger.put_metric("mean_difference", float(result.statistic), unit)
             metrics_logger.set_property("data_a", values_a)


### PR DESCRIPTION
## Changes

Adds A/B compatible versions of the vsock and tcp throughput tests. Also includes the following small refractorings/improvements:
- Declare specific tests are particularly unstable. These are the tests that already have significant delta values associated with them in the current testing setup.
- Correctly associate p-values with metrics when submitting to Cloudwatch
- Correctly propagate CW metadata when reemitting captured logs (namespace and log stream name)
- Only run A/B tests if rust/python code was modified.
- Merge the two network tests into one file, because they are significantly simpler now

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
