### PR TITLE
Print MicrovmState from vmstate file of snapshot to make snapshot comparison easier

### DIFF
--- a/src/snapshot-editor/src/info.rs
+++ b/src/snapshot-editor/src/info.rs
@@ -32,6 +32,12 @@ pub enum InfoVmStateSubCommand {
         #[arg(short, long)]
         vmstate_path: PathBuf,
     },
+    /// Print readable MicroVM state.
+    VmState {
+        /// Path to the vmstate file.
+        #[arg(short, long)]
+        vmstate_path: PathBuf,
+    },
 }
 
 pub fn info_vmstate_command(command: InfoVmStateSubCommand) -> Result<(), InfoVmStateError> {
@@ -41,6 +47,7 @@ pub fn info_vmstate_command(command: InfoVmStateSubCommand) -> Result<(), InfoVm
         InfoVmStateSubCommand::VcpuStates { vmstate_path } => {
             info(&vmstate_path, info_vcpu_states)?
         }
+        InfoVmStateSubCommand::VmState { vmstate_path } => info(&vmstate_path, info_vmstate)?,
     }
     Ok(())
 }
@@ -86,4 +93,18 @@ fn info_vcpu_states(state: &MicrovmState, _: u16) -> Result<(), InfoVmStateError
         }
     }
     Ok(())
+}
+
+fn info_vmstate(vmstate: &MicrovmState, version: u16) -> Result<(), InfoVmStateError> {
+    println!("{vmstate:#?}");
+    match FC_VERSION_TO_SNAP_VERSION
+        .iter()
+        .find(|(_, &v)| v == version)
+    {
+        Some((key, _)) => {
+            println!("v{key}");
+            Ok(())
+        }
+        None => Err(InfoVmStateError::InvalidVersion(version)),
+    }
 }

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -5,6 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+use std::fmt::Debug;
 use std::collections::{HashMap, HashSet};
 
 use kvm_bindings::{
@@ -540,7 +541,7 @@ impl KvmVcpu {
     }
 }
 
-#[derive(Debug, Clone, Versionize)]
+#[derive(Clone, Versionize)]
 /// Structure holding VCPU kvm state.
 // NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VcpuState {
@@ -571,6 +572,31 @@ pub struct VcpuState {
     /// Tsc khz.
     #[version(start = 2, default_fn = "default_tsc_khz", ser_fn = "ser_tsc")]
     pub tsc_khz: Option<u32>,
+}
+
+impl Debug for VcpuState{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_kvm_regs: Vec<kvm_bindings::kvm_msrs> = Vec::new();
+        for kvm_msrs in self.saved_msrs.iter()
+        {
+            debug_kvm_regs = kvm_msrs.clone().into_raw();
+            debug_kvm_regs.sort_by_key(|msr| (msr.nmsrs, msr.pad));
+        }
+        f.debug_struct("VcpuState")
+        .field("cpuid", &self.cpuid)
+        .field("msrs", &self.msrs)
+        .field("saved_msrs", &debug_kvm_regs)
+        .field("debug_regs", &self.debug_regs)
+        .field("lapic", &self.lapic)
+        .field("mp_state", &self.mp_state)
+        .field("regs", &self.regs)
+        .field("sregs", &self.sregs)
+        .field("vcpu_events", &self.vcpu_events)
+        .field("xcrs", &self.xcrs)
+        .field("xsave", &self.xsave)
+        .field("tsc_khz", &self.tsc_khz)
+        .finish()
+    }
 }
 
 impl VcpuState {

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -5,8 +5,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::fmt::Debug;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
 
 use kvm_bindings::{
     kvm_debugregs, kvm_lapic_state, kvm_mp_state, kvm_regs, kvm_sregs, kvm_vcpu_events, kvm_xcrs,
@@ -574,28 +574,27 @@ pub struct VcpuState {
     pub tsc_khz: Option<u32>,
 }
 
-impl Debug for VcpuState{
+impl Debug for VcpuState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_kvm_regs: Vec<kvm_bindings::kvm_msrs> = Vec::new();
-        for kvm_msrs in self.saved_msrs.iter()
-        {
+        for kvm_msrs in self.saved_msrs.iter() {
             debug_kvm_regs = kvm_msrs.clone().into_raw();
             debug_kvm_regs.sort_by_key(|msr| (msr.nmsrs, msr.pad));
         }
         f.debug_struct("VcpuState")
-        .field("cpuid", &self.cpuid)
-        .field("msrs", &self.msrs)
-        .field("saved_msrs", &debug_kvm_regs)
-        .field("debug_regs", &self.debug_regs)
-        .field("lapic", &self.lapic)
-        .field("mp_state", &self.mp_state)
-        .field("regs", &self.regs)
-        .field("sregs", &self.sregs)
-        .field("vcpu_events", &self.vcpu_events)
-        .field("xcrs", &self.xcrs)
-        .field("xsave", &self.xsave)
-        .field("tsc_khz", &self.tsc_khz)
-        .finish()
+            .field("cpuid", &self.cpuid)
+            .field("msrs", &self.msrs)
+            .field("saved_msrs", &debug_kvm_regs)
+            .field("debug_regs", &self.debug_regs)
+            .field("lapic", &self.lapic)
+            .field("mp_state", &self.mp_state)
+            .field("regs", &self.regs)
+            .field("sregs", &self.sregs)
+            .field("vcpu_events", &self.vcpu_events)
+            .field("xcrs", &self.xcrs)
+            .field("xsave", &self.xsave)
+            .field("tsc_khz", &self.tsc_khz)
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Changes

Add subcommand in InfoVmStateSubCommand to print the VmState.

## Reason

The output of this command can be used to diff between 2 different snapshot files.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
