### PR TITLE
Support AL2023 officially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- [#3837](https://github.com/firecracker-microvm/firecracker/issues/3837): Added
+  official support for Linux 6.1. See
+  [prod-host-setup](./docs/prod-host-setup.md) for some security and performance
+  considerations.
 - [#4045](https://github.com/firecracker-microvm/firecracker/pull/4045)
   and [#4075](https://github.com/firecracker-microvm/firecracker/pull/4075):
   Added `snapshot-editor` tool for modifications of snapshot files.

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ We test all combinations of:
 
 | Instance   | Host OS & Kernel   | Guest Rootfs   | Guest Kernel   |
 | :--------- | :----------------- | :------------- | :------------- |
-| m5d.metal  | al2    linux_4.1   | ubuntu 18.04   | linux_4.14     |
+| m5d.metal  | al2    linux_4.1   | ubuntu 22.04   | linux_4.14     |
 | m6i.metal  | al2    linux_5.10  |                | linux_5.10     |
-| m6a.metal  |                    |                |                |
+| m6a.metal  | al2023 linux_6.1   |                |                |
 | m6g.metal  |                    |                |                |
 | c7g.metal  |                    |                |                |
 

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -35,6 +35,24 @@ def get_os_version():
     return match.group(1)
 
 
+def get_host_os(kv: str = None):
+    """
+    Extract OS information from the kernel if it's there.
+
+    This only works for AL2 and AL2023
+
+    >>> get_host_os("6.1.41-63.118.amzn2023.x86_64")
+    amzn2023
+    """
+    if kv is None:
+        kv = platform.release()
+    parts = kv.split("-")
+    misc = parts[1].split(".")
+    if len(misc) > 2 and misc[2] in {"amzn2", "amzn2023"}:
+        return misc[2]
+    return None
+
+
 class GlobalProps:
     """Class to hold metadata about the testrun environment"""
 
@@ -52,6 +70,7 @@ class GlobalProps:
         # major.minor.patch
         self.host_linux_patch = get_kernel_version(2)
         self.os = get_os_version()
+        self.host_os = get_host_os()
         self.libc_ver = "-".join(platform.libc_ver())
         self.git_commit_id = run_cmd("git rev-parse HEAD")
         self.git_branch = run_cmd("git show -s --pretty=%D HEAD")

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -72,12 +72,18 @@ class GlobalProps:
         self.os = get_os_version()
         self.host_os = get_host_os()
         self.libc_ver = "-".join(platform.libc_ver())
-        self.git_commit_id = run_cmd("git rev-parse HEAD")
-        self.git_branch = run_cmd("git show -s --pretty=%D HEAD")
-        self.git_origin_url = run_cmd("git config --get remote.origin.url")
         self.rust_version = run_cmd("rustc --version |awk '{print $2}'")
         self.buildkite_pipeline_slug = os.environ.get("BUILDKITE_PIPELINE_SLUG")
         self.buildkite_build_number = os.environ.get("BUILDKITE_BUILD_NUMBER")
+
+        if self._in_git_repo():
+            self.git_commit_id = run_cmd("git rev-parse HEAD")
+            self.git_branch = run_cmd("git show -s --pretty=%D HEAD")
+            self.git_origin_url = run_cmd("git config --get remote.origin.url")
+        else:
+            self.git_commit_id = None
+            self.git_branch = None
+            self.git_origin_url = None
 
         self.environment = self._detect_environment()
         if self.is_ec2:
@@ -105,6 +111,12 @@ class GlobalProps:
         except Exception:
             return "local"
 
+    def _in_git_repo(self):
+        try:
+            run_cmd("git rev-parse --show-toplevel")
+        except subprocess.CalledProcessError:
+            return False
+        return True
+
 
 global_props = GlobalProps()
-# TBD could do a props fixture for tests to use...

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -56,11 +56,6 @@ def test_no_boottime(test_microvm_with_api):
     assert not timestamps
 
 
-# temporarily disable this test in 6.1
-@pytest.mark.xfail(
-    global_props.host_linux_version == "6.1",
-    reason="perf regression under investigation",
-)
 @pytest.mark.skipif(
     global_props.cpu_codename == "INTEL_SKYLAKE"
     and global_props.host_linux_version == "5.10",
@@ -84,11 +79,6 @@ def test_boottime_no_network(fast_microvm, record_property, metrics):
     ), f"boot time {boottime_us} cannot be greater than: {MAX_BOOT_TIME_US} us"
 
 
-# temporarily disable this test in 6.1
-@pytest.mark.xfail(
-    global_props.host_linux_version == "6.1",
-    reason="perf regression under investigation",
-)
 @pytest.mark.skipif(
     global_props.cpu_codename == "INTEL_SKYLAKE"
     and global_props.host_linux_version == "5.10",

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -26,6 +26,7 @@ DEFAULT_BOOT_ARGS = (
 DIMENSIONS = {
     "instance": global_props.instance,
     "cpu_model": global_props.cpu_model,
+    "host_os": global_props.host_os,
     "host_kernel": "linux-" + global_props.host_linux_version,
 }
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -531,6 +531,53 @@ ensure_ci_artifacts() {
     fi
 }
 
+apply_linux_61_tweaks() {
+    KV=$(uname -r)
+    if [[ $KV != 6.1.* ]] || [ $(uname -m) != x86_64 ]; then
+        return
+    fi
+    say "Applying Linux 6.1 boot-time regression mitigations"
+
+    KVM_VENDOR_MOD=$(lsmod |grep -P "^kvm_(amd|intel)" | awk '{print $1}')
+    ITLB_MULTIHIT=/sys/devices/system/cpu/vulnerabilities/itlb_multihit
+    NX_HUGEPAGES=/sys/module/kvm/parameters/nx_huge_pages
+
+    # If m6a/m6i
+    if grep -q "Not affected" $ITLB_MULTIHIT; then
+        echo -e "CPU not vulnerable to iTLB multihit, using kvm.nx_huge_pages=never mitigation"
+        # we need a lock so another process is not running the same thing and to
+        # avoid race conditions.
+        lockfile="/tmp/.linux61_tweaks.lock"
+        set -C # noclobber
+        while true; do
+            if echo "$$" > "$lockfile"; then
+                echo "Successfully acquired lock"
+                if ! grep -q "never" $NX_HUGEPAGES; then
+                    echo "Reloading KVM modules with nx_huge_pages=never"
+                    sudo modprobe -r $KVM_VENDOR_MOD kvm
+                    sudo modprobe kvm nx_huge_pages=never
+                    sudo modprobe $KVM_VENDOR_MOD
+                fi
+                rm "$lockfile"
+                break
+            else
+                sleep 5s
+            fi
+        done
+        tail -v $ITLB_MULTIHIT $NX_HUGEPAGES
+    # else (m5d Skylake and CascadeLake)
+    else
+        echo "CPU vulnerable to iTLB_multihit, checking if favordynmods is enabled"
+        mount |grep cgroup |grep -q favordynmods
+        if [ $? -ne 0 ]; then
+            say_warn "cgroups' favordynmods option not enabled; VM creation performance may be impacted"
+        else
+            echo "favordynmods is enabled"
+        fi
+    fi
+}
+
+
 # `$0 test` - run integration tests
 # Please see `$0 help` for more information.
 #
@@ -565,9 +612,12 @@ cmd_test() {
     ensure_build_dir
     ensure_ci_artifacts
 
+    apply_linux_61_tweaks
+
     # If we got to here, we've got all we need to continue.
     say "Kernel version: $(uname -r)"
     say "$(sed '/^processor.*: 0$/,/^processor.*: 1$/!d; /^processor.*: 1$/d' /proc/cpuinfo)"
+    say "RPM microcode_ctl version: $(rpm -q microcode_ctl)"
     say "Starting test run ..."
 
     # Testing (running Firecracker via the jailer) needs root access,


### PR DESCRIPTION
## Changes

- Note in the changelog that we officially support Linux 6.1 kernel.
- Document how to deal with performance regressions in Linux 6.1.
- Enforce the boot time SLA of 150ms in 6.1 back (reverts 1c0b992cafa0fa6712b7db9f370539da06fe50aa)

Closes #3837 

## Reason

To keep up to date with stable Linux kernel releases.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
