### PR TITLE
fix: restore the id parameter default

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -144,6 +144,7 @@ fn main_exec() -> Result<(), MainError> {
             .arg(
                 Argument::new("id")
                     .takes_value(true)
+                    .default_value(vmm::logger::DEFAULT_INSTANCE_ID)
                     .help("MicroVM unique identifier."),
             )
             .arg(
@@ -262,8 +263,6 @@ fn main_exec() -> Result<(), MainError> {
         return Ok(());
     }
 
-    info!("Running Firecracker v{FIRECRACKER_VERSION}");
-
     register_signal_handlers().map_err(MainError::RegisterSignalHandlers)?;
 
     #[cfg(target_arch = "aarch64")]
@@ -298,11 +297,9 @@ fn main_exec() -> Result<(), MainError> {
         app_name: "Firecracker".to_string(),
     };
 
-    let id = arguments
-        .single_value("id")
-        .map(|s| s.as_str())
-        .unwrap_or(vmm::logger::DEFAULT_INSTANCE_ID);
+    let id = arguments.single_value("id").map(|s| s.as_str()).unwrap();
     vmm::logger::INSTANCE_ID.set(String::from(id)).unwrap();
+    info!("Running Firecracker v{FIRECRACKER_VERSION}");
 
     // Apply the logger configuration.
     let log_path = arguments.single_value("log-path").map(PathBuf::from);

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -3,6 +3,7 @@
 """Tests that ensure the correctness of the command line parameters."""
 
 import platform
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -130,3 +131,18 @@ def test_cli_metrics_if_resume_no_metrics(uvm_plain, microvm_factory):
     # Then: the old metrics configuration does not exist
     metrics2 = Path(uvm2.jailer.chroot_path()) / metrics_path.name
     assert not metrics2.exists()
+
+
+def test_cli_no_params():
+    """
+    Test running firecracker with no parameters should work
+    """
+
+    fc_binary, _ = get_firecracker_binaries()
+    process = subprocess.Popen(fc_binary)
+    try:
+        process.communicate(timeout=3)
+        assert process.returncode is None
+    except subprocess.TimeoutExpired:
+        # The good case
+        process.kill()


### PR DESCRIPTION
## Changes

Restore the default value of the `--id` parameter, since it can cause a panic. And move the "running" message after the option is processed.

## Reason

Without the change:

```
% sudo ./firecracker
2023-10-09T09:49:41.031007002 [anonymous-instance:main] Running Firecracker v1.5.0-dev
2023-10-09T09:49:41.031082658 [anonymous-instance:main] Firecracker panicked at 'called `Option::unwrap()` on a `None` value', src/firecracker/src/main.rs:291:52
[1]    980007 IOT instruction  ./build/cargo_target/x86_64-unknown-linux-musl/debug/firecracker
```

```
% sudo ./firecracker --id myname
2023-10-09T09:50:40.670878137 [anonymous-instance:main] Running Firecracker v1.5.0-dev
```

With the change:

```
% sudo ./firecracker
2023-10-09T10:01:11.604960827 [anonymous-instance:main] Running Firecracker v1.5.0-dev
# [doesn't panic]
```

```
% sudo ./firecracker --id myname
2023-10-09T10:00:39.098812475 [myname:main] Running Firecracker v1.5.0-dev
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
