### PR TITLE
tests: Warn on `clippy::as_conversions`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,12 +1,8 @@
 [build]
 target-dir = "build/cargo_target"
 rustflags = [
-  "-Wclippy::ptr_as_ptr",
+  "-Wclippy::as_conversions",
   "-Wclippy::undocumented_unsafe_blocks",
-  "-Wclippy::cast_lossless",
-  "-Wclippy::cast_possible_truncation",
-  "-Wclippy::cast_possible_wrap",
-  "-Wclippy::cast_sign_loss",
   "-Wmissing_debug_implementations",
   "-Wclippy::exit",
 ]

--- a/src/net_gen/src/if_tun.rs
+++ b/src/net_gen/src/if_tun.rs
@@ -8,7 +8,7 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
     missing_debug_implementations
 )]

--- a/src/net_gen/src/iff.rs
+++ b/src/net_gen/src/iff.rs
@@ -8,7 +8,7 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
     missing_debug_implementations
 )]

--- a/src/net_gen/src/sockios.rs
+++ b/src/net_gen/src/sockios.rs
@@ -8,7 +8,7 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
     missing_debug_implementations
 )]

--- a/src/virtio_gen/src/virtio_blk.rs
+++ b/src/virtio_gen/src/virtio_blk.rs
@@ -8,7 +8,7 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
     missing_debug_implementations
 )]

--- a/src/virtio_gen/src/virtio_net.rs
+++ b/src/virtio_gen/src/virtio_net.rs
@@ -8,7 +8,7 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
     missing_debug_implementations
 )]

--- a/src/virtio_gen/src/virtio_ring.rs
+++ b/src/virtio_gen/src/virtio_ring.rs
@@ -8,7 +8,7 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
     missing_debug_implementations
 )]

--- a/src/virtio_gen/src/virtio_rng.rs
+++ b/src/virtio_gen/src/virtio_rng.rs
@@ -8,7 +8,7 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
     missing_debug_implementations
 )]

--- a/src/vmm/src/arch_gen/x86/hyperv.rs
+++ b/src/vmm/src/arch_gen/x86/hyperv.rs
@@ -8,7 +8,7 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
     clippy::cast_lossless
 )]

--- a/src/vmm/src/arch_gen/x86/hyperv_tlfs.rs
+++ b/src/vmm/src/arch_gen/x86/hyperv_tlfs.rs
@@ -8,7 +8,7 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
     clippy::cast_lossless
 )]

--- a/src/vmm/src/arch_gen/x86/msr_index.rs
+++ b/src/vmm/src/arch_gen/x86/msr_index.rs
@@ -8,9 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
-    clippy::undocumented_unsafe_blocks,
-    clippy::cast_lossless
+    clippy::as_conversions,
+    clippy::undocumented_unsafe_blocks
 )]
 
 pub const MSR_EFER: u32 = 0xc0000080;

--- a/src/vmm/src/arch_gen/x86/perf_event.rs
+++ b/src/vmm/src/arch_gen/x86/perf_event.rs
@@ -8,9 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
-    clippy::undocumented_unsafe_blocks,
-    clippy::cast_lossless
+    clippy::as_conversions,
+    clippy::undocumented_unsafe_blocks
 )]
 
 pub const MSR_ARCH_PERFMON_PERFCTR0: u32 = 0xc1;

--- a/tools/bindgen.sh
+++ b/tools/bindgen.sh
@@ -31,9 +31,8 @@ function fc-bindgen {
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr,
+    clippy::as_conversions,
     clippy::undocumented_unsafe_blocks,
-    clippy::cast_lossless,
     missing_debug_implementations
 )]
 


### PR DESCRIPTION
## Changes

See below.

## Reason

`clippy::ptr_as_ptr`, `clippy::cast_lossless`,
`clippy::cast_possible_truncation`, `clippy::cast_possible_wrap` and `clippy::cast_sign_loss` are all enabled by `clippy::as_conversions`, with them all enabled we can now remove them and simply warn on `clippy::as_conversions`.

Closes #3161.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
