### PR TITLE
Forward-Port 1.5 branch hot-fixes + correctly bump snapshot version for 1.6

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -49,7 +49,7 @@ devctr_grp = group(
 
 release_grp = group(
     "📦 Release Sanity Build",
-    "mkdir -p ./test_results && touch ./test_results/test-report.json && ./tools/devtool -y sh ./tools/release.sh --libc musl --profile release --make-release",
+    "./tools/devtool -y make_release",
     **defaults_once_per_architecture,
 )
 

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -81,10 +81,11 @@ lazy_static! {
         version_map.set_type_version(VcpuState::type_id(), 2);
 
         version_map.set_type_version(VmState::type_id(), 2);
-        version_map.set_type_version(VirtioDeviceState::type_id(), 2);
 
         // v1.6 state change mappings
         version_map.new_version();
+
+        version_map.set_type_version(VirtioDeviceState::type_id(), 2);
 
         version_map
     };

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -865,7 +865,7 @@ class MicroVMFactory:
 class Serial:
     """Class for serial console communication with a Microvm."""
 
-    RX_TIMEOUT_S = 20
+    RX_TIMEOUT_S = 60
 
     def __init__(self, vm):
         """Initialize a new Serial object."""

--- a/tests/integration_tests/functional/test_concurrency.py
+++ b/tests/integration_tests/functional/test_concurrency.py
@@ -80,6 +80,7 @@ def test_run_concurrency(microvm_factory, guest_kernel, rootfs):
 
     def launch1():
         microvm = microvm_factory.build(guest_kernel, rootfs)
+        microvm.time_api_requests = False  # is flaky because of parallelism
         microvm.spawn()
         microvm.basic_config(vcpu_count=1, mem_size_mib=128)
         microvm.add_net_iface()

--- a/tools/devtool
+++ b/tools/devtool
@@ -486,7 +486,10 @@ cmd_build() {
 }
 
 function cmd_make_release {
-    cmd_test -- --reruns 2 || die "Tests failed!"
+    OPTS="--reruns=7"
+    # run build tests first so that functional tests reuse compilation artifacts
+    cmd_test -- $OPTS --json-report-file=../test_results/test-report-perf+build.json integration_tests/{build,performance} || die "Tests failed!"
+    cmd_test -- $OPTS --json-report-file=../test_results/test-report-functional+security.json -n8 --dist=worksteal integration_tests/{functional,security,style} || die "Tests failed!"
 
     run_devctr \
         --user "$(id -u):$(id -g)" \

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -115,10 +115,6 @@ if [ "$PROFILE" = "release" ]; then
     CARGO_OPTS+=" --release"
 fi
 
-# Artificially trigger a re-run of the build script,
-# to make sure that `firecracker --version` reports the latest changes.
-touch build.rs
-
 ARTIFACTS=(firecracker jailer seccompiler-bin rebase-snap cpu-template-helper snapshot-editor)
 
 if [ "$LIBC" == "gnu" ]; then
@@ -167,7 +163,8 @@ cp -v -t "$RELEASE_DIR" LICENSE NOTICE THIRD-PARTY
 check_swagger_artifact src/api_server/swagger/firecracker.yaml "$VERSION"
 cp -v src/api_server/swagger/firecracker.yaml "$RELEASE_DIR/firecracker_spec-$VERSION.yaml"
 
-cp -v test_results/test-report.json "$RELEASE_DIR/"
+cp -v test_results/test-report-functional+security.json "$RELEASE_DIR/"
+cp -v test_results/test-report-perf+build.json "$RELEASE_DIR/"
 
 (
     cd "$RELEASE_DIR"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -119,13 +119,13 @@ fi
 # to make sure that `firecracker --version` reports the latest changes.
 touch build.rs
 
-ARTIFACTS=(firecracker jailer seccompiler-bin rebase-snap cpu-template-helper)
+ARTIFACTS=(firecracker jailer seccompiler-bin rebase-snap cpu-template-helper snapshot-editor)
 
 if [ "$LIBC" == "gnu" ]; then
     # Don't build jailer. See commit 3bf285c8f
     echo "Not building jailer because glibc selected instead of musl"
     CARGO_OPTS+=" --exclude jailer"
-    ARTIFACTS=(firecracker seccompiler-bin rebase-snap cpu-template-helper)
+    ARTIFACTS=(firecracker seccompiler-bin rebase-snap cpu-template-helper snapshot-editor)
 fi
 
 say "Building version=$VERSION, profile=$PROFILE, target=$CARGO_TARGET..."

--- a/tools/update-credits.sh
+++ b/tools/update-credits.sh
@@ -31,5 +31,5 @@ written in Rust with a focus on safety and security. Thanks go to:
 Contributors to the Firecracker repository:
 EOH
     echo
-    git log --format='* %aN <%aE>' | LC_ALL=C.UTF-8 sort -uf
+    git log --format='* %aN <%aE>' | LC_ALL=C.UTF-8 sort -uf | grep -v "dependabot"
 } > CREDITS.md


### PR DESCRIPTION
It seems a rebase gone awry caused the version bump from https://github.com/firecracker-microvm/firecracker/pull/3557 to be
considered as part of 1.5, even though it will only land with 1.6. Swap
the two lines to unblock CI.

Also includes some commits from the 1.5 branch 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
