### PR TITLE
fix: move the logging message where it's effective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Fixed
 
+- Fixed a bug that ignored the `--show-log-origin` option, preventing it from
+  printing the source code file of the log messages.
+
 ## [1.5.0]
 
 ### Added

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -263,6 +263,32 @@ fn main_exec() -> Result<(), MainError> {
         return Ok(());
     }
 
+    // It's safe to unwrap here because the field's been provided with a default value.
+    let instance_id = arguments.single_value("id").unwrap();
+    validate_instance_id(instance_id.as_str()).expect("Invalid instance ID");
+
+    // Apply the logger configuration.
+    vmm::logger::INSTANCE_ID
+        .set(String::from(instance_id))
+        .unwrap();
+    let log_path = arguments.single_value("log-path").map(PathBuf::from);
+    let level = arguments
+        .single_value("level")
+        .map(|s| vmm::logger::LevelFilter::from_str(s))
+        .transpose()
+        .map_err(MainError::InvalidLogLevel)?;
+    let show_level = arguments.flag_present("show-level").then_some(true);
+    let show_log_origin = arguments.flag_present("show-level").then_some(true);
+    LOGGER
+        .update(LoggerConfig {
+            log_path,
+            level,
+            show_level,
+            show_log_origin,
+        })
+        .map_err(MainError::LoggerInitialization)?;
+    info!("Running Firecracker v{FIRECRACKER_VERSION}");
+
     register_signal_handlers().map_err(MainError::RegisterSignalHandlers)?;
 
     #[cfg(target_arch = "aarch64")]
@@ -286,38 +312,12 @@ fn main_exec() -> Result<(), MainError> {
     // deprecating one.
     // warn_deprecated_parameters(&arguments);
 
-    // It's safe to unwrap here because the field's been provided with a default value.
-    let instance_id = arguments.single_value("id").unwrap();
-    validate_instance_id(instance_id.as_str()).expect("Invalid instance ID");
-
     let instance_info = InstanceInfo {
         id: instance_id.clone(),
         state: VmState::NotStarted,
         vmm_version: FIRECRACKER_VERSION.to_string(),
         app_name: "Firecracker".to_string(),
     };
-
-    let id = arguments.single_value("id").map(|s| s.as_str()).unwrap();
-    vmm::logger::INSTANCE_ID.set(String::from(id)).unwrap();
-    info!("Running Firecracker v{FIRECRACKER_VERSION}");
-
-    // Apply the logger configuration.
-    let log_path = arguments.single_value("log-path").map(PathBuf::from);
-    let level = arguments
-        .single_value("level")
-        .map(|s| vmm::logger::LevelFilter::from_str(s))
-        .transpose()
-        .map_err(MainError::InvalidLogLevel)?;
-    let show_level = arguments.flag_present("show-level").then_some(true);
-    let show_log_origin = arguments.flag_present("show-level").then_some(true);
-    LOGGER
-        .update(LoggerConfig {
-            log_path,
-            level,
-            show_level,
-            show_log_origin,
-        })
-        .map_err(MainError::LoggerInitialization)?;
 
     if let Some(metrics_path) = arguments.single_value("metrics-path") {
         let metrics_config = MetricsConfig {

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -278,7 +278,7 @@ fn main_exec() -> Result<(), MainError> {
         .transpose()
         .map_err(MainError::InvalidLogLevel)?;
     let show_level = arguments.flag_present("show-level").then_some(true);
-    let show_log_origin = arguments.flag_present("show-level").then_some(true);
+    let show_log_origin = arguments.flag_present("show-log-origin").then_some(true);
     LOGGER
         .update(LoggerConfig {
             log_path,

--- a/src/vmm/src/logger/logging.rs
+++ b/src/vmm/src/logger/logging.rs
@@ -22,8 +22,6 @@ pub const DEFAULT_LEVEL: log::LevelFilter = log::LevelFilter::Info;
 pub const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
 /// Instance id.
 pub static INSTANCE_ID: OnceLock<String> = OnceLock::new();
-/// Semver version of Firecracker.
-const FIRECRACKER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The logger.
 ///
@@ -62,7 +60,7 @@ impl Logger {
                 .unwrap_or(DEFAULT_LEVEL),
         );
 
-        let target_changed = if let Some(log_path) = config.log_path {
+        if let Some(log_path) = config.log_path {
             let file = std::fs::OpenOptions::new()
                 .custom_flags(libc::O_NONBLOCK)
                 .read(true)
@@ -71,9 +69,6 @@ impl Logger {
                 .map_err(LoggerUpdateError)?;
 
             guard.target = Some(file);
-            true
-        } else {
-            false
         };
 
         if let Some(show_level) = config.show_level {
@@ -87,11 +82,6 @@ impl Logger {
         // Ensure we drop the guard before attempting to log, otherwise this
         // would deadlock.
         drop(guard);
-        if target_changed {
-            // We log this when a target is changed so it is always the 1st line logged, this
-            // maintains some previous behavior to minimize a breaking change.
-            log::info!("Running Firecracker v{FIRECRACKER_VERSION}");
-        }
 
         Ok(())
     }

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -450,6 +450,8 @@ class Microvm:
         self,
         log_file="fc.log",
         log_level="Debug",
+        log_show_level=False,
+        log_show_origin=False,
         metrics_path="fc.ndjson",
     ):
         """Start a microVM as a daemon or in a screen session."""
@@ -461,10 +463,14 @@ class Microvm:
             self.log_file = Path(self.path) / log_file
             self.log_file.touch()
             self.create_jailed_resource(self.log_file)
-            # The default value for `level`, when configuring the
-            # logger via cmd line, is `Warning`. We set the level
-            # to `Debug` to also have the boot time printed in fifo.
+            # The default value for `level`, when configuring the logger via cmd
+            # line, is `Info`. We set the level to `Debug` to also have the boot
+            # time printed in the log.
             self.jailer.extra_args.update({"log-path": log_file, "level": log_level})
+            if log_show_level:
+                self.jailer.extra_args["show-level"] = None
+            if log_show_origin:
+                self.jailer.extra_args["show-log-origin"] = None
 
         if metrics_path is not None:
             self.metrics_file = Path(self.path) / metrics_path


### PR DESCRIPTION
Move the message after the logger has been configured, so it actually gets printed.

Eliminate redundant message that outputs internal vmm crate version 0.1.0.

Fixes: 96ed4576, 332f218

## Changes

It can happen that the version printed is v0.1.0, instead of the expected version.

```
2023-10-12T15:15:39.609772934 [4a97aac2-88bc-4f59-8fe1-167bc078ac7e:main] Running Firecracker v0.1.0
```

## Reason

This behavior may confuse users of the logs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
