### PR TITLE
fix: Pass through no-API shutdown exit code (main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 - Fixed a bug that ignored the `--show-log-origin` option, preventing it from
   printing the source code file of the log messages.
+- [#4178](https://github.com/firecracker-microvm/firecracker/pull/4178):
+  Fixed a bug reporting a non-zero exit code on successful shutdown when
+  starting Firecracker with `--no-api`.
 
 ## [1.5.0]
 

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -83,6 +83,7 @@ impl From<MainError> for ExitCode {
             MainError::InvalidLogLevel(_) => FcExitCode::BadConfiguration,
             MainError::RunWithApi(ApiServerError::MicroVMStoppedWithoutError(code)) => code,
             MainError::RunWithApi(ApiServerError::MicroVMStoppedWithError(code)) => code,
+            MainError::RunWithoutApiError(RunWithoutApiError::Shutdown(code)) => code,
             _ => FcExitCode::GenericError,
         };
 

--- a/tests/framework/vm_config_network.json
+++ b/tests/framework/vm_config_network.json
@@ -1,0 +1,41 @@
+{
+  "boot-source": {
+    "kernel_image_path": "vmlinux.bin",
+    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off",
+    "initrd_path": null
+  },
+  "drives": [
+    {
+      "drive_id": "rootfs",
+      "path_on_host": "bionic.rootfs.ext4",
+      "is_root_device": true,
+      "partuuid": null,
+      "is_read_only": false,
+      "cache_type": "Unsafe",
+      "io_engine": "Sync",
+      "rate_limiter": null
+    }
+  ],
+  "machine-config": {
+    "vcpu_count": 2,
+    "mem_size_mib": 1024,
+    "smt": false,
+    "track_dirty_pages": false
+  },
+  "cpu-config": null,
+  "balloon": null,
+  "network-interfaces": [
+    {
+      "iface_id": "eth0",
+      "host_dev_name": "tap0",
+      "guest_mac": "06:00:c0:a8:00:02",
+      "rx_rate_limiter": null,
+      "tx_rate_limiter": null
+    }
+  ],
+  "vsock": null,
+  "logger": null,
+  "metrics": null,
+  "mmds-config": null,
+  "entropy": null
+}


### PR DESCRIPTION
## Changes

Pass through no-API shutdown exit code

## Reason

https://github.com/firecracker-microvm/firecracker/issues/4176

Without passing through the exit code a non-zero exit code was returned on a successful no-API shutdown.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
