### PR TITLE
fix: Refactor error propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Simplified and clarified the removal policy of deprecated API elements
   to follow semantic versioning 2.0.0. For more information, please refer to
   [this GitHub discussion](https://github.com/firecracker-microvm/firecracker/discussions/4135).
+- [#4180](https://github.com/firecracker-microvm/firecracker/pull/4180):
+  Refactored error propagation to avoid logging and printing an error on
+  exits with a zero exit code. Now, on successful exit
+  "Firecracker exited successfully" is logged.
 
 ### Deprecated
 

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -98,6 +98,7 @@ fn main() -> ExitCode {
         eprintln!("Error: {err:?}");
         ExitCode::from(err)
     } else {
+        info!("Firecracker exited successfully");
         ExitCode::SUCCESS
     }
 }
@@ -631,8 +632,11 @@ fn run_without_api(
             .run()
             .expect("Failed to start the event manager");
 
-        if let Some(exit_code) = vmm.lock().unwrap().shutdown_exit_code() {
-            return Err(RunWithoutApiError::Shutdown(exit_code));
+        match vmm.lock().unwrap().shutdown_exit_code() {
+            Some(FcExitCode::Ok) => break,
+            Some(exit_code) => return Err(RunWithoutApiError::Shutdown(exit_code)),
+            None => continue,
         }
     }
+    Ok(())
 }

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -170,9 +170,7 @@ def test_config_start_no_api_exit(uvm_plain, vm_config_file):
     time.sleep(3)  # Wait for shutdown
 
     # Check error log
-    test_microvm.check_log_message(
-        "RunWithoutApiError error: MicroVMStopped without an error: Ok"
-    )
+    test_microvm.check_log_message("Firecracker exited successfully")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


## Changes

Refactors error propagation to avoid logging and printing misleading error messages.

## Reason

#4176 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
