### PR TITLE
Update removal policy of deprecated API elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changed
 
+- Simplified and clarified the removal policy of deprecated API elements
+  to follow semantic versioning 2.0.0. For more information, please refer to
+  [this GitHub discussion](https://github.com/firecracker-microvm/firecracker/discussions/4135).
+
 ### Deprecated
 
 ### Fixed
@@ -71,6 +75,7 @@
   [`Warn`](https://docs.rs/log/latest/log/enum.Level.html#variant.Warn) to
   [`Info`](https://docs.rs/log/latest/log/enum.Level.html#variant.Info). This
   results in more logs being output by default.
+
 ### Fixed
 
 - Fixed a change in behavior of normalize host brand string that breaks

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -109,18 +109,12 @@ work as expected with all Firecracker binary versions X.V.W, where V >= Y.
 
 ### Deprecation of elements in the API
 
-We will consider a deprecated API endpoint to be an endpoint which still has
-backing functionality and can be used, but will be removed completely along
-with said functionality in an upcoming API version. All deprecated endpoints
-are supported until at least the next MAJOR version release, where they _may
-be removed_.
-
-When elements of the API are deprecated in a MINOR release, they will still
-work for the longest of the following:
-
-* all subsequent Firecracker MINOR releases of the same MAJOR release;
-* any Firecracker MINOR release for at least 6 months from release date;
-* the next 2 Firecracker releases, regardless if they are MAJOR or MINOR.
+Firecracker uses [semantic versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
+in terms of deprecating and removing API elements. We will consider a deprecated
+API element to be an element which still has backing functionality and will be
+supported at least until the next MAJOR version, where they _will be removed_.
+The support period of deprecated API elements is tied to
+[the Firecracker release support](https://github.com/firecracker-microvm/firecracker/blob/main/docs/RELEASE_POLICY.md#release-support).
 
 ## Developer preview features
 

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -6,10 +6,10 @@ customers effectively plan their Firecracker based operations.
 
 ## Firecracker releases
 
-Firecracker uses [semantic versioning 2.0.0](http://semver.org/) for all
-releases. By definition, the API version implemented by a Firecracker binary
-is equivalent to that binary’s version. Semantic versions are comprised of
-three fields in the form: `vMAJOR.MINOR.PATCH`. Additional labels for
+Firecracker uses [semantic versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
+for all releases. By definition, the API version implemented by a Firecracker
+binary is equivalent to that binary’s version. Semantic versions are comprised
+of three fields in the form: `vMAJOR.MINOR.PATCH`. Additional labels for
 pre-release and build metadata are available as extensions to the
 MAJOR.MINOR.PATCH format.
 

--- a/docs/api-change-runbook.md
+++ b/docs/api-change-runbook.md
@@ -62,8 +62,8 @@ non-exhaustive list of such changes:
 ## Implementing API changes
 
 API changes result in version increases. As Firecracker’s support policy is
-based on [semantic versioning][1], we will look at API changes from this point
-of view.
+based on [semantic versioning 2.0.0][1], we will look at API changes from this
+point of view.
 
 > Given a version number MAJOR.MINOR.PATCH, increment the:
 > MAJOR version when you make incompatible API changes;
@@ -268,7 +268,7 @@ Firecracker API.
     the header anyway, resulting in a fail in our test when it shouldn’t.
   * Fix all other failing integration tests.
 
-[1]: https://semver.org/
+[1]: https://semver.org/spec/v2.0.0.html
 [2]: https://github.com/firecracker-microvm/firecracker/pull/2763
 [3]: https://github.com/firecracker-microvm/firecracker/commit/83aa098245a42ad93a6b70ccd70ad593cf453a3c
 [4]: https://github.com/firecracker-microvm/firecracker/commit/472a81dbccd89562578919b76d87c30ee7db17aa


### PR DESCRIPTION
## Changes

- Points semver links to the v2.0.0-specific one.
- Simplifies and clarifies the removal policy of deprecated API elements

## Reason

Closes #4157 .

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- ~~[ ] All added/changed functionality is tested.~~
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
