### PR TITLE
ci: Disable network latency baseline

### DIFF
--- a/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
@@ -223,12 +223,7 @@
     },
     "measurements": {
         "latency": {
-            "statistics": [
-                {
-                    "criteria": "EqualWith",
-                    "function": "Avg"
-                }
-            ],
+            "statistics": [],
             "unit": "ms"
         }
     }

--- a/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
@@ -211,12 +211,7 @@
     },
     "measurements": {
         "latency": {
-            "statistics": [
-                {
-                    "criteria": "EqualWith",
-                    "function": "Avg"
-                }
-            ],
+            "statistics": [],
             "unit": "ms"
         }
     }

--- a/tests/integration_tests/performance/configs/test_network_latency_config_6.1.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_6.1.json
@@ -211,12 +211,7 @@
     },
     "measurements": {
         "latency": {
-            "statistics": [
-                {
-                    "criteria": "EqualWith",
-                    "function": "Avg"
-                }
-            ],
+            "statistics": [],
             "unit": "ms"
         }
     }


### PR DESCRIPTION


Jonathan Woollett-Light <jcawl@amazon.co.uk>

## Changes

Disables 5.10 network latency baseline by removing the statistic.

## Reason

To mitigate intermittent failures due to non-Firecracker changes.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
