### PR TITLE
chore: check max devices for aarch64

### DIFF
--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -6,57 +6,86 @@ import platform
 
 import pytest
 
-# IRQs are available from 5 to 23, so the maximum number of devices
+# On x86_64 IRQs are available from 5 to 23, so the maximum number of devices
 # supported at the same time is 19.
-MAX_DEVICES_ATTACHED = 19
+# On aarch64 IRQ_MAX is 128.
+# max_devices_attached = 19
 
 
-@pytest.mark.skipif(
-    platform.machine() != "x86_64", reason="Firecracker supports 24 IRQs on x86_64."
-)
-def test_attach_maximum_devices(test_microvm_with_api):
+# @pytest.mark.skipif(
+#     platform.machine() != "x86_64", reason="Firecracker supports 24 IRQs on x86_64."
+# )
+def test_attach_maximum_devices(
+    microvm_factory, guest_kernel_linux_5_10, rootfs_ubuntu_22
+):
     """
     Test attaching maximum number of devices to the microVM.
     """
-    test_microvm = test_microvm_with_api
+    # On x86_64 IRQs are available from 5 to 23, so the maximum number of devices
+    # supported at the same time is 19.
+    # On aarch64 IRQ_MAX is 128.
+    if platform.machine() != "x86_64":
+        max_devices_attached = 65
+    else:
+        max_devices_attached = 19
+    test_microvm = microvm_factory.build(
+        guest_kernel_linux_5_10, rootfs_ubuntu_22, monitor_memory=False
+    )
     test_microvm.spawn()
 
     # Set up a basic microVM.
     test_microvm.basic_config()
 
-    # Add (`MAX_DEVICES_ATTACHED` - 1) devices because the rootfs
+    # Add (`max_devices_attached` - 1) devices because the rootfs
     # has already been configured in the `basic_config()`function.
-    for _ in range(MAX_DEVICES_ATTACHED - 1):
+    for _ in range(max_devices_attached - 1):
         test_microvm.add_net_iface()
     test_microvm.start()
 
     # Test that network devices attached are operational.
-    for i in range(MAX_DEVICES_ATTACHED - 1):
+    for i in range(max_devices_attached - 1):
         # Verify if guest can run commands.
-        exit_code, _, _ = test_microvm.ssh_iface(i).run("sync")
+        try:
+            exit_code, _, _ = test_microvm.ssh_iface(i).run("sync")
+        except:
+            pass
         assert exit_code == 0
 
+    for i in range(max_devices_attached - 2):
+        # Verify if guest can run commands.
+            exit_code, _, _ = test_microvm.ssh_iface(i).run("sync")
 
-@pytest.mark.skipif(
-    platform.machine() != "x86_64", reason="Firecracker supports 24 IRQs on x86_64."
-)
-def test_attach_too_many_devices(test_microvm_with_api):
+# @pytest.mark.skipif(
+#     platform.machine() != "x86_64", reason="Firecracker supports 24 IRQs on x86_64."
+# )
+def test_attach_too_many_devices(
+    microvm_factory, guest_kernel_linux_5_10, rootfs_ubuntu_22
+):
     """
     Test attaching to a microVM more devices than available IRQs.
     """
-    test_microvm = test_microvm_with_api
+    # On x86_64 IRQs are available from 5 to 23, so the maximum number of devices
+    # supported at the same time is 19.
+    # On aarch64 IRQ_MAX is 128.
+    if platform.machine() != "x86_64":
+        max_devices_attached = 128
+    else:
+        max_devices_attached = 19
+    test_microvm = microvm_factory.build(
+        guest_kernel_linux_5_10, rootfs_ubuntu_22, monitor_memory=False
+    )
     test_microvm.spawn()
 
     # Set up a basic microVM.
     test_microvm.basic_config()
 
-    # Add `MAX_DEVICES_ATTACHED` network devices on top of the
+    # Add `max_devices_attached` network devices on top of the
     # already configured rootfs.
-    for _ in range(MAX_DEVICES_ATTACHED):
+    for _ in range(max_devices_attached):
         test_microvm.add_net_iface()
 
     # Attempting to start a microVM with more than
-    # `MAX_DEVICES_ATTACHED` devices should fail.
+    # `max_devices_attached` devices should fail.
     error_str = (
         "Failed to allocate requested resource: The requested resource"
         " is not available."


### PR DESCRIPTION
x86_64 has max 19 devices but aarch64 has 128
we should add test for aarch64.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
