### PR TITLE
fix block_ab and snapshot_ab after 4160

### DIFF
--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -87,7 +87,7 @@ def run_fio(microvm, mode, block_size):
     with concurrent.futures.ThreadPoolExecutor() as executor:
         cpu_load_future = executor.submit(
             get_cpu_percent,
-            microvm.jailer_clone_pid,
+            microvm.firecracker_pid,
             RUNTIME_SEC,
             omit=WARMUP_SEC,
         )

--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -1,11 +1,9 @@
 # Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Performance benchmark for snapshot restore."""
-import shutil
 import tempfile
 from dataclasses import dataclass
 from functools import lru_cache
-from pathlib import Path
 from typing import List
 
 import pytest
@@ -105,7 +103,6 @@ class SnapshotRestoreTest:
             assert value > 0
             values.append(value)
             microvm.kill()
-            shutil.rmtree(Path(microvm.chroot()))
 
         snapshot.delete()
         return values


### PR DESCRIPTION
Some functions get renamed but the tests didn't get updated.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
