### PR TITLE
Performance test for vhost-user-blk

### DIFF
--- a/.buildkite/pipeline_ab.py
+++ b/.buildkite/pipeline_ab.py
@@ -15,9 +15,14 @@ from common import (
 )
 
 perf_test = {
-    "block": {
-        "label": "🖴 Block Performance",
-        "test_path": "integration_tests/performance/test_block_ab.py",
+    "virtio-block": {
+        "label": "🖴 Virtio Block Performance",
+        "test_path": "integration_tests/performance/test_block_ab.py::test_block_performance",
+        "devtool_opts": "-c 1-10 -m 0",
+    },
+    "vhost-user-block": {
+        "label": "🖴 vhost-user Block Performance",
+        "test_path": "integration_tests/performance/test_block_ab.py::test_block_vhost_user_performance",
         "devtool_opts": "-c 1-10 -m 0",
     },
     "network-latency": {

--- a/tests/framework/utils_vhost_user_backend.py
+++ b/tests/framework/utils_vhost_user_backend.py
@@ -1,0 +1,37 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for vhost-user-blk backend."""
+
+import os
+import subprocess
+import time
+
+from framework import utils
+
+VHOST_USER_SOCKET = "/vub.socket"
+
+
+def spawn_vhost_user_backend(vm, host_mem_path, readonly=False):
+    """Spawn vhost-user-blk backend."""
+
+    uid = vm.jailer.uid
+    gid = vm.jailer.gid
+
+    socket_path = f"{vm.chroot()}{VHOST_USER_SOCKET}"
+    args = ["vhost-user-blk", "-s", socket_path, "-b", host_mem_path]
+    if readonly:
+        args.append("-r")
+    proc = subprocess.Popen(args)
+
+    # Give the backend time to initialise.
+    time.sleep(1)
+
+    assert proc is not None and proc.poll() is None, "backend is not up"
+
+    with utils.chroot(vm.chroot()):
+        # The backend will create the socket path with root rights.
+        # Change rights to the jailer's.
+        os.chown(VHOST_USER_SOCKET, uid, gid)
+
+    return proc

--- a/tests/integration_tests/functional/test_drive_vhost_user.py
+++ b/tests/integration_tests/functional/test_drive_vhost_user.py
@@ -2,34 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for vhost-user-block device."""
 
-import os
-import subprocess
-import time
-
 from framework import utils
-
-VHOST_USER_SOCKET = "/vub.socket"
-
-
-def spawn_vhost_user_backend(vm, host_mem_path):
-    """Spawn vhost-user-block backend."""
-
-    uid = vm.jailer.uid
-    gid = vm.jailer.gid
-
-    sp = f"{vm.chroot()}{VHOST_USER_SOCKET}"
-    args = ["vhost-user-blk", "-s", sp, "-b", host_mem_path, "-r"]
-    proc = subprocess.Popen(args)
-
-    time.sleep(1)
-    if proc is None or proc.poll() is not None:
-        print("vub is not running")
-
-    with utils.chroot(vm.chroot()):
-        # The backend will create the socket path with root rights.
-        # Change rights to the jailer's.
-        os.chown(VHOST_USER_SOCKET, uid, gid)
-    return proc
+from framework.utils_vhost_user_backend import (
+    VHOST_USER_SOCKET,
+    spawn_vhost_user_backend,
+)
 
 
 def test_vhost_user_block(microvm_factory, guest_kernel, rootfs_ubuntu_22):
@@ -48,7 +25,7 @@ def test_vhost_user_block(microvm_factory, guest_kernel, rootfs_ubuntu_22):
     # Converting path from tmpfs ("./srv/..") to local
     # path on the host ("../build/..")
     rootfs_path = utils.to_local_dir_path(str(rootfs_ubuntu_22))
-    _backend = spawn_vhost_user_backend(vm, rootfs_path)
+    _backend = spawn_vhost_user_backend(vm, rootfs_path, readonly=True)
 
     vm.basic_config()
     vm.add_vhost_user_block("1", VHOST_USER_SOCKET, is_root_device=True)


### PR DESCRIPTION
## Changes

This adds a performance test for the vhost-user-blk device.

## Reason

vhost-user-blk device is added in https://github.com/firecracker-microvm/firecracker/pull/4170 .
We need to include performance tests for the new device.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~- [ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~
~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
~- [ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
