### PR TITLE
Remove guard pages

### DIFF
--- a/src/vmm/src/arch/x86_64/mptable.rs
+++ b/src/vmm/src/arch/x86_64/mptable.rs
@@ -306,7 +306,7 @@ mod tests {
     #[test]
     fn bounds_check() {
         let num_cpus = 4;
-        let mem = GuestMemoryMmap::from_raw_regions_unguarded(
+        let mem = GuestMemoryMmap::from_raw_regions(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus))],
             false,
         )
@@ -318,7 +318,7 @@ mod tests {
     #[test]
     fn bounds_check_fails() {
         let num_cpus = 4;
-        let mem = GuestMemoryMmap::from_raw_regions_unguarded(
+        let mem = GuestMemoryMmap::from_raw_regions(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus) - 1)],
             false,
         )
@@ -330,7 +330,7 @@ mod tests {
     #[test]
     fn mpf_intel_checksum() {
         let num_cpus = 1;
-        let mem = GuestMemoryMmap::from_raw_regions_unguarded(
+        let mem = GuestMemoryMmap::from_raw_regions(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus))],
             false,
         )
@@ -346,7 +346,7 @@ mod tests {
     #[test]
     fn mpc_table_checksum() {
         let num_cpus = 4;
-        let mem = GuestMemoryMmap::from_raw_regions_unguarded(
+        let mem = GuestMemoryMmap::from_raw_regions(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus))],
             false,
         )
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn cpu_entry_count() {
-        let mem = GuestMemoryMmap::from_raw_regions_unguarded(
+        let mem = GuestMemoryMmap::from_raw_regions(
             &[(
                 GuestAddress(MPTABLE_START),
                 compute_mp_size(MAX_SUPPORTED_CPUS),
@@ -409,7 +409,7 @@ mod tests {
     #[test]
     fn cpu_entry_count_max() {
         let cpus = MAX_SUPPORTED_CPUS + 1;
-        let mem = GuestMemoryMmap::from_raw_regions_unguarded(
+        let mem = GuestMemoryMmap::from_raw_regions(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(cpus))],
             false,
         )

--- a/src/vmm/src/arch/x86_64/regs.rs
+++ b/src/vmm/src/arch/x86_64/regs.rs
@@ -247,12 +247,7 @@ mod tests {
     fn create_guest_mem(mem_size: Option<u64>) -> GuestMemoryMmap {
         let page_size = 0x10000usize;
         let mem_size = u64_to_usize(mem_size.unwrap_or(page_size as u64));
-        if mem_size % page_size == 0 {
-            GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), mem_size)], false).unwrap()
-        } else {
-            GuestMemoryMmap::from_raw_regions_unguarded(&[(GuestAddress(0), mem_size)], false)
-                .unwrap()
-        }
+        GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), mem_size)], false).unwrap()
     }
 
     fn read_u64(gm: &GuestMemoryMmap, offset: u64) -> u64 {

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1214,7 +1214,7 @@ pub mod tests {
     }
 
     fn create_guest_mem_at(at: GuestAddress, size: usize) -> GuestMemoryMmap {
-        GuestMemoryMmap::from_raw_regions_unguarded(&[(at, size)], false).unwrap()
+        GuestMemoryMmap::from_raw_regions(&[(at, size)], false).unwrap()
     }
 
     pub(crate) fn create_guest_mem_with_size(size: usize) -> GuestMemoryMmap {

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -1134,8 +1134,7 @@ pub(crate) mod tests {
         assert!(balloon.update_size(1).is_err());
         // Switch the state to active.
         balloon.device_state = DeviceState::Activated(
-            GuestMemoryMmap::from_raw_regions_unguarded(&[(GuestAddress(0x0), 0x1)], false)
-                .unwrap(),
+            GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0x0), 0x1)], false).unwrap(),
         );
 
         assert_eq!(balloon.num_pages(), 0);

--- a/src/vmm/src/devices/virtio/net/test_utils.rs
+++ b/src/vmm/src/devices/virtio/net/test_utils.rs
@@ -396,11 +396,9 @@ pub mod test {
         pub fn get_default() -> TestHelper<'a> {
             let mut event_manager = EventManager::new().unwrap();
             let mut net = default_net();
-            let mem = GuestMemoryMmap::from_raw_regions_unguarded(
-                &[(GuestAddress(0), MAX_BUFFER_SIZE)],
-                false,
-            )
-            .unwrap();
+            let mem =
+                GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), MAX_BUFFER_SIZE)], false)
+                    .unwrap();
             // transmute mem_ref lifetime to 'a
             let mem_ref = unsafe { mem::transmute::<&GuestMemoryMmap, &'a GuestMemoryMmap>(&mem) };
 

--- a/src/vmm/src/devices/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/test_utils.rs
@@ -25,7 +25,7 @@ macro_rules! check_metric_after_block {
 /// Creates a [`GuestMemoryMmap`] with a single region of the given size starting at guest physical
 /// address 0
 pub fn single_region_mem(region_size: usize) -> GuestMemoryMmap {
-    GuestMemoryMmap::from_raw_regions_unguarded(&[(GuestAddress(0), region_size)], false).unwrap()
+    GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), region_size)], false).unwrap()
 }
 
 /// Creates a [`GuestMemoryMmap`] with a single region  of size 65536 (= 0x10000 hex) starting at
@@ -331,8 +331,7 @@ pub(crate) mod test {
     use crate::vstate::memory::{Address, GuestAddress, GuestMemoryExtension, GuestMemoryMmap};
 
     pub fn create_virtio_mem() -> GuestMemoryMmap {
-        GuestMemoryMmap::from_raw_regions_unguarded(&[(GuestAddress(0), MAX_BUFFER_SIZE)], false)
-            .unwrap()
+        GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), MAX_BUFFER_SIZE)], false).unwrap()
     }
 
     /// Provides functionality necessary for testing a VirtIO device with

--- a/src/vmm/src/devices/virtio/vsock/packet.rs
+++ b/src/vmm/src/devices/virtio/vsock/packet.rs
@@ -760,7 +760,7 @@ mod tests {
     fn test_check_bounds_for_buffer_access_edge_cases() {
         let mut test_ctx = TestContext::new();
 
-        test_ctx.mem = GuestMemoryMmap::from_raw_regions_unguarded(
+        test_ctx.mem = GuestMemoryMmap::from_raw_regions(
             &[
                 (GuestAddress(0), 500),
                 (GuestAddress(500), 100),

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -613,8 +613,7 @@ pub(crate) mod tests {
 
         // Trying to set a memory region with a size that is not a multiple of PAGE_SIZE
         // will result in error.
-        let gm =
-            GuestMemoryMmap::from_raw_regions_unguarded(&[(GuestAddress(0), 0x10)], false).unwrap();
+        let gm = GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), 0x10)], false).unwrap();
         let res = vm.set_kvm_memory_regions(&gm, false);
         assert_eq!(
             res.unwrap_err().to_string(),

--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -12,10 +12,7 @@ MACHINE = platform.machine()
 # Currently profiling with `aarch64-unknown-linux-musl` is unsupported (see
 # https://github.com/rust-lang/rustup/issues/3095#issuecomment-1280705619) therefore we profile and
 # run coverage with the `gnu` toolchains and run unit tests with the `musl` toolchains.
-TARGETS = [
-    "{}-unknown-linux-musl".format(MACHINE),
-    "{}-unknown-linux-gnu".format(MACHINE),
-]
+TARGET = "{}-unknown-linux-musl".format(MACHINE)
 
 
 @pytest.mark.timeout(600)
@@ -24,12 +21,11 @@ def test_unittests(test_fc_session_root_path):
     Run unit and doc tests for all supported targets.
     """
 
-    for target in TARGETS:
-        extra_args = "--target {} ".format(target)
-        host.cargo_test(test_fc_session_root_path, extra_args=extra_args)
+    extra_args = f"--target {TARGET}"
+    host.cargo_test(test_fc_session_root_path, extra_args=extra_args)
 
 
 def test_benchmarks_compile():
     """Checks that all benchmarks compile"""
 
-    host.cargo("bench", f"--all --no-run --target {TARGETS[0]}")
+    host.cargo("bench", f"--all --no-run --target {TARGET}")


### PR DESCRIPTION
## Changes
Removed guard pages

Initially guard pages were added as a defence mechanism to prevent guest or firecracker from accessing guest memory outside of allocated memory. Main concern was the possibility of a bug in the device emulation, that can lead to the security issue. As of right now firecracker creates guest memory backed by memfd and utilizes different forms of verification and other defence in depth mechanisms such as jailing. Additionally guard pages do not provide a generic defence mechanism.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
