### PR TITLE
Marked `rebase-snap` as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 
 ### Deprecated
 
+- [#4209](https://github.com/firecracker-microvm/firecracker/pull/4209):
+  `rebase-snap` tool is now deprecated. Users should use `snapshot-editor`
+  for rebasing diff snapshots.
+
 ### Fixed
 
 - Fixed a bug that ignored the `--show-log-origin` option, preventing it from

--- a/docs/snapshotting/snapshot-editor.md
+++ b/docs/snapshotting/snapshot-editor.md
@@ -20,7 +20,7 @@ This command is used to merge a `diff` snapshot memory file on
 top of a base memory file.
 
 **Note**
-You can also use `rebase-snap` tool for this.
+You can also use `rebase-snap` (deprecated) tool for this.
 
 Arguments:
 

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -249,10 +249,10 @@ created by a subsequent `/snapshot/create` API call. The order in which the
 snapshots were created matters and they should be merged in the same order
 in which they were created. To merge a `diff` snapshot memory file on
 top of a base, users should copy its content over the base. This can be done
-using the `rebase-snap` or `snapshot-editor` tools provided with the
+using the `rebase-snap` (deprecated) or `snapshot-editor` tools provided with the
 firecracker release:
 
-`rebase-snap` example:
+`rebase-snap` (deprecated) example:
 
 ```bash
 rebase-snap --base-file path/to/base --diff-file path/to/layer

--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -115,6 +115,10 @@ fn rebase(base_file: &mut File, diff_file: &mut File) -> Result<(), FileError> {
 }
 
 fn main() -> Result<(), RebaseSnapError> {
+    println!(
+        "This tool is deprecated and will be removed in the future. Please use 'snapshot-editor' \
+         instead."
+    );
     let result = main_exec();
     if let Err(e) = result {
         eprintln!("{}", e);


### PR DESCRIPTION
## Changes
Marked `rebase-snap` as deprecated in favour of `snapshot-editor`

## Reason
We have `snapshot-editor` which is a newer tool with more options.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
