### PR TITLE
doc: add vhost-user-blk documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@
   E.g. the associated metrics for vhost-user block device with endpoint
   `"/drives/rootfs"` will be available under `"vhost_user_block_rootfs"`
   in the metrics json object.
+- [#4138](https://github.com/firecracker-microvm/firecracker/pull/4138),
+  [#4170](https://github.com/firecracker-microvm/firecracker/pull/4170),
+  [#4223](https://github.com/firecracker-microvm/firecracker/pull/4223),
+  [#4226](https://github.com/firecracker-microvm/firecracker/pull/4226):
+  Added support for vhost-user block devices. Firecracker implements
+  a vhost-user frontend. Users are free to choose from existing open source
+  backend solutions or their own implementation.
+  See the [related doc page](./docs/api_requests/block-vhost-user.md) for details.
 
 ### Changed
 

--- a/docs/api_requests/block-io-engine.md
+++ b/docs/api_requests/block-io-engine.md
@@ -22,6 +22,9 @@ with the `io_engine` field taking two possible values:
 The `Sync` variant is the default, in order to provide backwards compatibility
 with older Firecracker versions.
 
+**Note** [vhost-user block device](./block-vhost-user.md) is another option
+for block IO that requires an external backend process.
+
 ## Example configuration
 
 ```bash

--- a/docs/api_requests/block-vhost-user.md
+++ b/docs/api_requests/block-vhost-user.md
@@ -1,0 +1,204 @@
+# Vhost-user block device
+
+As an alternative to [file-backed block device](block-io-engine.md) `Sync` and
+`Async` engines, Firecracker supports a vhost-user block device.
+
+There is a good introduction of how a vhost-user block device works
+in general at [FOSDEM23](https://archive.fosdem.org/2023/schedule/event/sds_vhost_user_blk).
+
+[Vhost-user](https://qemu-project.gitlab.io/qemu/interop/vhost-user.html)
+is a userspace protocol that allows to delegate Virtio queue processing
+to another userspace process on the host, as opposed to performing this task
+within Firecracker's VMM thread.
+
+In the vhost-user architecture, the VMM acts as a vhost-user frontend and
+it is responsible for:
+
+- connecting to the backend via a Unix domain socket (UDS)
+- feature negotiation with the backend and the guest
+- handling device configuration requests from the guest
+- sharing sufficient information about the guest memory and Virtio queues
+  with the backend
+
+The vhost-user backend receives the information from the frontend and performs
+handling of IO requests from the guest.
+
+The UDS socket is only used for control plane purposes
+and does not participate in the data plane.
+
+Firecracker only implements a vhost-user frontend. Users are free
+to choose from [existing open source backends](#backends) or implement their
+own.
+
+## Topology
+
+Each vhost-user device connects to its own UDS socket. There is no way for
+multiple devices to share a single socket, as there is no way to differentiate
+messages related to devices at the vhost-user protocol level.
+
+Each device can be served by a separate backend or a single backend can serve
+multiple devices.
+
+## Interactions with the backend
+
+There are three points when the vhost-user frontend communicates with
+the backend:
+
+1. Device initialisation. When a vhost-user device is created, Firecracker
+   connects to the corresponding UDS socket and negotiates Virtio and Vhost
+   features with backend and retrieves device configuration.
+1. Device activation. When the guest driver finishes setting up the device,
+   Firecracker shares memory tables and Virtio queue information with the backend.
+   As a part of this, Firecracker shares file descriptors for guest's memory
+   regions, as well as file descriptors for queue notifications.
+1. Config update. When receving a [`PATCH` request](./patch-block.md#updating-vhost-user-block-devices-after-boot)
+   on a vhost-user backed drive, Firecracker rerequests the device config
+   from the backend in order to make the new config available to the guest.
+
+## Advantages
+
+While vhost-user block is considered an optimisation to Firecracker IO, a naive
+implementation of the backend is not going to improve performance.
+
+The major advantage of using a vhost-user device is that the backend can
+implement custom processing logic. It can use intelligent algorithms to serve
+block requests, eg by fetching the block device data over the network or using
+sophisticated readahead logic. In such cases, the performance improvement will
+be coming from the fact that the custom logic is implemented in the same
+process that handles Virtio queues, which reduces the number of required
+context switches.
+
+## Backends
+
+There are a number of open source implementations of a vhost-user backend
+available for reference that can help developing a custom backend:
+
+1. [Qemu backend](https://github.com/qemu/qemu/tree/master/contrib/vhost-user-blk)
+1. [Cloud Hypervisor backend](https://github.com/cloud-hypervisor/cloud-hypervisor/tree/main/vhost_user_block)
+1. [crosvm backend](https://github.com/google/crosvm/blob/main/devices/src/virtio/vhost/user/device/block.rs)
+1. [SPDK backend](https://github.com/spdk/spdk/blob/master/lib/vhost/vhost_blk.c)
+
+## Security considerations
+
+### Guest memory sharing
+
+By design, a vhost-user frontend must share file descriptors
+of all guest memory regions to the backend. In order to achive that,
+guest memory is created as a [memfd](https://man7.org/linux/man-pages/man2/memfd_create.2.html)
+and mapped as `MAP_SHARED`.
+
+#### File descriptor in procfs
+
+An open `memfd` is reflected in `procfs` as any other open file descriptor:
+
+```shell
+$ ls -l /proc/{pid}/fd | grep memfd
+lrwx------ 1 1234 1234 64 Nov  2 13:39 32 -> /memfd:guest_mem (deleted)
+```
+
+Any process on the host that has access to this file in `procfs` will be able
+to map the file descriptor and observe runtime behaviour of the guest.
+
+At the moment, Firecracker does not close the `memfd`, because it must remain open
+until all the configured vhost-user devices have been activated and their info
+shared with the backends. This kind of tracking is not implemented in Firecracker,
+but may be implemented in the future. Meanwhile, users need to make sure that
+the access to the Firecracker's `procfs` tree is restricted to trusted processes
+on the host.
+
+On the backend side, it is advised that the backend closes
+the guest memory region file descriptors after mapping them into its own
+address space.
+
+#### Resource limit in jailer
+
+The Firecracker [jailer](../jailer.md) allows to configure resource limits
+for the Firecracker process. Specifically, it allows to set the maximum file
+size. Since `memfd` that is used to back the guest memory is considered a file,
+the file size resource limit cannot be less than the biggest guest memory
+region. This does not require any special action from a user, but needs to be
+taken into consideration.
+
+### Remote code execution in the backend
+
+It is recommended to run Firecracker using the [jailer](../jailer.md). Since
+the vhost-user backend interacts with the guest via a Virtio queue, there is
+a potential for the guest to exercise issues in the backend codebase
+to trigger undesired behaviours. Users should consider running their backend
+in a jailer or applying other adequate security measures to restrict it.
+
+**Note** [Firecracker jailer](../jailer.md) is currently only capable
+of running Firecracker as the binary. Vhost-user block device users are
+expected to use another jailer to run the backend.
+
+It is also recommended to use proactive security measures like running
+a Virtio-level fuzzer in the guest during testing to make sure that the backend
+correctly handles all possible classes of inputs (including invalid ones)
+from the guest.
+
+### Rate limiting / cgroups
+
+Virtio block device in Firecracker has a [rate limiting capability](../design.md#io-storage-networking-and-rate-limiting).
+
+In the vhost-user case, Firecracker does not participate in handling requests
+from the guest, so rate limiting becomes backend's responsibility.
+
+As an additional indirect measure, users can make use of `cgroups` settings
+(either via Firecracker jailer or independently) in order to restrict host CPU
+consumption of the guest, which would transitively limit guest's IO activity.
+
+### Protection against defects in the backend code
+
+Due to potential defects in the backend (eg mislocating Virtio queues or writes
+to a wrong location in the guest memory), the guest execution may be affected.
+It is advised that customers monitor guest's health periodically.
+
+Additionally, in order to avoid orhpaned Firecracker processes if the backend
+crashes, the backend may need to send a signal, such as `SIGBUS`,
+to the Firecracker process for it to exit as well.
+
+### Backend timeouts
+
+In order to correctly handle the case where the Firecracker process exits
+before it exchanges all the expected data with the backend, the backend may
+need to implement a timeout for how long it waits for Firecracker to connect
+and/or to exchange the data via the vhost-user protocol and exit to avoid
+resource exhaustion.
+
+## Snapshot support
+
+At the moment, [snapshotting](../snapshotting) is not supported for microVMs
+that have vhost-user devices configured. An attempt to take a snapshot of such
+a microVM will fail. It is planned to add support for that in the future.
+
+## Example configuration
+
+Run a vhost-user backend, eg Qemu backend:
+
+```bash
+vhost-user-blk --socket-path=${backend_socket} --blk-file=${drive_path}
+```
+
+Firecracker API request to add a vhost-user block device:
+
+```bash
+curl --unix-socket ${fc_socket} -i \
+     -X PUT "http://localhost/drives/scratch" \
+     -H "accept: application/json" \
+     -H "Content-Type: application/json" \
+     -d "{
+             \"drive_id\": \"scratch\",
+             \"socket\": \"${backend_socket}\",
+             \"is_root_device\": false
+         }"
+```
+
+**Note** Unlike Virtio block device, there is no way to configure a `readonly`
+vhost-user drive on the Firecracker side. Instead, this configuration belongs
+to the backend. Whenever the backend advertises the `VIRTIO_BLK_F_RO` feature,
+Firecracker will accept it, and the device will act as readonly.
+
+**Note** Whenever a `PUT` request is sent to the `/drives` endpoint for
+a vhost-user device with the `id` that already exists, Firecracker will close
+the existing connection to the backend and will open a new one. Users may need
+to restart their backend if they do so.

--- a/docs/api_requests/patch-block.md
+++ b/docs/api_requests/patch-block.md
@@ -1,5 +1,7 @@
 # Updating block devices after boot
 
+## Updating Virtio block devices after boot
+
 Firecracker offers support to update attached block devices after the microVM
 has been started. This is provided via PATCH /drives API which notifies
 Firecracker that the underlying block file has been changed on the host. It
@@ -8,7 +10,7 @@ size has been modified. It is important to note that external changes to the
 block device file do not automatically trigger a notification in Firecracker
 so the explicit PATCH API call is mandatory.
 
-## How it works
+### How it works
 
 The implementation of the PATCH /drives API does not modify the host backing
 file. It only updates the emulation layer block device properties, path and
@@ -19,7 +21,7 @@ underlying host file followed by a PATCH /drives API call is not an atomic
 operation as the guest can also modify the block file via emulation during
 the sequence, if the raw block device is mounted or accessible.
 
-## Supported use case
+### Supported use case
 
 This feature was designed to work with a cooperative guest in order to
 effectively simulate hot plug/unplug functionality for block devices.
@@ -82,14 +84,14 @@ curl --unix-socket ${socket} -i \
 # with the updated backing file.
 ```
 
-## Data integrity and other issues
+### Data integrity and other issues
 
 We do not recommend using this feature outside of its supported use case scope.
 If the required guarantees are not provided, data integrity and potential other
 issues may arise depending on the actual use case. There are two major aspects
 that need be considered here:
 
-### Atomicity of the update sequence
+#### Atomicity of the update sequence
 
 If the guest has the opportunity to perform I/O against the block device during
 the update sequence it can either read data while it is changed or can
@@ -98,9 +100,41 @@ operation can be undone if the guest issues a write for the last sector of the
 raw block device, or the guest application can become inconsistent or/and can
 create inconsistency in the block device itself.
 
-### In flight I/O requests
+#### In flight I/O requests
 
 If the atomicity of the operation is guaranteed by using methods to make the
 microVM quiescence during the update sequence (for example pausing the microVM)
 the guest itself or block device can still become incosistent from in flight
 I/O requests in the guest that will be executed after it is resumed.
+
+## Updating vhost-user block devices after boot
+
+Unlike with Virtio block device, with vhost-user block devices, Firecracker
+does not interact with the underlying block file directly (the vhost-user
+backend does). It means that changes to the file are not automatically seen
+by Firecracker. There is a mechanism in the
+[vhost-user protocol](https://qemu-project.gitlab.io/qemu/interop/vhost-user.html)
+for the backend to notify the frontend about changes in the device config
+via `VHOST_USER_BACKEND_CONFIG_CHANGE_MSG` message. This requires an extra
+UDS socket connection between the frontend and backend used for
+backend-originated messages. This mechanism **is not supported**
+by Firecracker. Instead, Firecracker makes use of the `PATCH /drives`
+API request to get notified about such changes. Such an API request
+only includes the required property (`drive_id`), because optional properties
+are not relevant to vhost-user.
+
+Example of a `PATCH` request for a vhost-user drive:
+
+```bash
+curl --unix-socket ${socket} -i \
+     -X PATCH "http://localhost/drives/scratch" \
+     -H "accept: application/json" \
+     -H "Content-Type: application/json" \
+     -d "{
+             \"drive_id\": \"scratch\"
+         }"
+```
+
+A `PATCH` request to a vhost-user drive will make Firecracker retrieve
+the new device config from the backend and send a config change notification
+to the guest.

--- a/docs/design.md
+++ b/docs/design.md
@@ -136,6 +136,8 @@ specifying token bucket configurations for ingress and egress. Each token
 bucket is defined via the bucket size, I/O cost, refill rate, maximum burst,
 and initial value. This enables the customer to define flexible rate limiters
 that support bursts or specific bandwidth/operations limitations.
+For vhost-user devices, customers should implement rate limiting on the
+side of the vhost-user backend that they provide.
 
 ### MicroVM Metadata Service
 

--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -14,91 +14,95 @@ a call to one of the [API Endpoints](#api-endpoints) will fail with a
 
 ## API Endpoints
 
-| Endpoint                  | keyboard | serial console | virtio-block | virtio-net | virtio-vsock | virtio-rng |
-| ------------------------- | :------: | :------------: | :----------: |:----------:| :----------: | :--------: |
-| `boot-source`             |    O     |       O        |      O       |     O      |      O       |      O     |
-| `cpu-config`              |    O     |       O        |      O       |     O      |      O       |      O     |
-| `drives/{id}`             |    O     |       O        |    **R**     |     O      |      O       |      O     |
-| `logger`                  |    O     |       O        |      O       |     O      |      O       |      O     |
-| `machine-config`          |    O     |       O        |      O       |     O      |      O       |      O     |
-| `metrics`                 |    O     |       O        |      O       |     O      |      O       |      O     |
-| `mmds`                    |    O     |       O        |      O       |   **R**    |      O       |      O     |
-| `mmds/config`             |    O     |       O        |      O       |   **R**    |      O       |      O     |
-| `network-interfaces/{id}` |    O     |       O        |      O       |   **R**    |      O       |      O     |
-| `snapshot/create`         |    O     |       O        |      O       |     O      |      O       |      O     |
-| `snapshot/load`           |    O     |       O        |      O       |     O      |      O       |      O     |
-| `vm`                      |    O     |       O        |      O       |     O      |      O       |      O     |
-| `vsock`                   |    O     |       O        |      O       |     O      |      O       |      O     |
-| `entropy`                 |    O     |       O        |      O       |     O      |      O       |    **R**   |
+| Endpoint                  | keyboard | serial console | virtio-block | vhost-user-block | virtio-net | virtio-vsock | virtio-rng |
+| ------------------------- | :------: | :------------: | :----------: | :--------------: | :--------: | :----------: | :--------: |
+| `boot-source`             |    O     |       O        |      O       |        O         |     O      |      O       |      O     |
+| `cpu-config`              |    O     |       O        |      O       |        O         |     O      |      O       |      O     |
+| `drives/{id}`             |    O     |       O        |    **R**     |      **R**       |     O      |      O       |      O     |
+| `logger`                  |    O     |       O        |      O       |        O         |     O      |      O       |      O     |
+| `machine-config`          |    O     |       O        |      O       |        O         |     O      |      O       |      O     |
+| `metrics`                 |    O     |       O        |      O       |        O         |     O      |      O       |      O     |
+| `mmds`                    |    O     |       O        |      O       |        O         |   **R**    |      O       |      O     |
+| `mmds/config`             |    O     |       O        |      O       |        O         |   **R**    |      O       |      O     |
+| `network-interfaces/{id}` |    O     |       O        |      O       |        O         |   **R**    |      O       |      O     |
+| `snapshot/create`         |    O     |       O        |      O       |        O         |     O      |      O       |      O     |
+| `snapshot/load`           |    O     |       O        |      O       |        O         |     O      |      O       |      O     |
+| `vm`                      |    O     |       O        |      O       |        O         |     O      |      O       |      O     |
+| `vsock`                   |    O     |       O        |      O       |        O         |     O      |      O       |      O     |
+| `entropy`                 |    O     |       O        |      O       |        O         |     O      |      O       |    **R**   |
 
 ## Input Schema
 
 All input schema fields can be found in the [Swagger](https://swagger.io)
 specification: [firecracker.yaml](./../src/api_server/swagger/firecracker.yaml).
 
-| Schema                     | Property              | keyboard | serial console | virtio-block |  virtio-net   | virtio-vsock | virtio-rng |
-|----------------------------|-----------------------| :------: | :------------: | :----------: |:-------------:| :----------: | :--------: |
-| `BootSource`               | boot_args             |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | initrd_path           |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | kernel_image_path     |    O     |       O        |      O       |       O       |      O       |      O     |
-| `CpuConfig`                | cpuid_modifiers       |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | msr_modifiers         |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | reg_modifiers         |    O     |       O        |      O       |       O       |      O       |      O     |
-| `CpuTemplate`              | enum                  |    O     |       O        |      O       |       O       |      O       |      O     |
-| `CreateSnapshotParams`     | mem_file_path         |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | snapshot_path         |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | snapshot_type         |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | version               |    O     |       O        |      O       |       O       |      O       |      O     |
-| `Drive`                    | drive_id              |    O     |       O        |    **R**     |       O       |      O       |      O     |
-|                            | is_read_only          |    O     |       O        |    **R**     |       O       |      O       |      O     |
-|                            | is_root_device        |    O     |       O        |    **R**     |       O       |      O       |      O     |
-|                            | partuuid              |    O     |       O        |    **R**     |       O       |      O       |      O     |
-|                            | path_on_host          |    O     |       O        |    **R**     |       O       |      O       |      O     |
-|                            | rate_limiter          |    O     |       O        |    **R**     |       O       |      O       |      O     |
-| `InstanceActionInfo`       | action_type           |    O     |       O        |      O       |       O       |      O       |      O     |
-| `LoadSnapshotParams`       | enable_diff_snapshots |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | mem_file_path         |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | mem_backend           |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | snapshot_path         |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | resume_vm             |    O     |       O        |      O       |       O       |      O       |      O     |
-| `Logger`                   | level                 |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | log_path              |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | show_level            |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | show_log_origin       |    O     |       O        |      O       |       O       |      O       |      O     |
-| `MachineConfiguration`     | cpu_template          |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | smt                   |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | mem_size_mib          |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | track_dirty_pages     |    O     |       O        |      O       |       O       |      O       |      O     |
-|                            | vcpu_count            |    O     |       O        |      O       |       O       |      O       |      O     |
-| `Metrics`                  | metrics_path          |    O     |       O        |      O       |       O       |      O       |      O     |
-| `MmdsConfig`               | network_interfaces    |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | version               |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | ipv4_address          |    O     |       O        |      O       |     **R**     |      O       |      O     |
-| `NetworkInterface`         | guest_mac             |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | host_dev_name         |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | iface_id              |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | rx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | tx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |      O     |
-| `PartialDrive`             | drive_id              |    O     |       O        |    **R**     |       O       |      O       |      O     |
-|                            | path_on_host          |    O     |       O        |    **R**     |       O       |      O       |      O     |
-| `PartialNetworkInterface`  | iface_id              |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | rx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | tx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |      O     |
-| `RateLimiter`              | bandwidth             |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | ops                   |    O     |       O        |    **R**     |       O       |      O       |      O     |
-| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |    **R**     |       O       |      O       |      O     |
-|                            | refill_time           |    O     |       O        |    **R**     |       O       |      O       |      O     |
-|                            | size                  |    O     |       O        |    **R**     |       O       |      O       |      O     |
-| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | refill_time           |    O     |       O        |      O       |     **R**     |      O       |      O     |
-|                            | size                  |    O     |       O        |      O       |     **R**     |      O       |      O     |
-| `Vm`                       | state                 |    O     |       O        |      O       |       O       |      O       |      O     |
-| `Vsock`                    | guest_cid             |    O     |       O        |      O       |       O       |    **R**     |      O     |
-|                            | uds_path              |    O     |       O        |      O       |       O       |    **R**     |      O     |
-|                            | vsock_id              |    O     |       O        |      O       |       O       |    **R**     |      O     |
-| `EntropyDevice`            | rate_limiter          |    O     |       O        |      O       |       O       |      O       |    **R**   |
+| Schema                     | Property              | keyboard | serial console | virtio-block | vhost-user-block |  virtio-net   | virtio-vsock | virtio-rng |
+|----------------------------|-----------------------| :------: | :------------: | :----------: | :--------------: | :-----------: | :----------: | :--------: |
+| `BootSource`               | boot_args             |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | initrd_path           |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | kernel_image_path     |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `CpuConfig`                | cpuid_modifiers       |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | msr_modifiers         |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | reg_modifiers         |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `CpuTemplate`              | enum                  |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `CreateSnapshotParams`     | mem_file_path         |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | snapshot_path         |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | snapshot_type         |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | version               |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `Drive`                    | drive_id \*           |    O     |       O        |    **R**     |      **R**       |       O       |      O       |      O     |
+|                            | is_read_only          |    O     |       O        |    **R**     |        O         |       O       |      O       |      O     |
+|                            | is_root_device \*     |    O     |       O        |    **R**     |      **R**       |       O       |      O       |      O     |
+|                            | partuuid \*           |    O     |       O        |    **R**     |      **R**       |       O       |      O       |      O     |
+|                            | path_on_host          |    O     |       O        |    **R**     |        O         |       O       |      O       |      O     |
+|                            | rate_limiter          |    O     |       O        |    **R**     |        O         |       O       |      O       |      O     |
+|                            | socket                |    O     |       O        |      O       |      **R**       |       O       |      O       |      O     |
+| `InstanceActionInfo`       | action_type           |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `LoadSnapshotParams`       | enable_diff_snapshots |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | mem_file_path         |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | mem_backend           |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | snapshot_path         |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | resume_vm             |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `Logger`                   | level                 |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | log_path              |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | show_level            |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | show_log_origin       |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `MachineConfiguration`     | cpu_template          |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | smt                   |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | mem_size_mib          |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | track_dirty_pages     |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+|                            | vcpu_count            |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `Metrics`                  | metrics_path          |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `MmdsConfig`               | network_interfaces    |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | version               |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | ipv4_address          |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+| `NetworkInterface`         | guest_mac             |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | host_dev_name         |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | iface_id              |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | rx_rate_limiter       |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | tx_rate_limiter       |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+| `PartialDrive`             | drive_id              |    O     |       O        |    **R**     |        O         |       O       |      O       |      O     |
+|                            | path_on_host          |    O     |       O        |    **R**     |        O         |       O       |      O       |      O     |
+| `PartialNetworkInterface`  | iface_id              |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | rx_rate_limiter       |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | tx_rate_limiter       |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+| `RateLimiter`              | bandwidth             |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | ops                   |    O     |       O        |    **R**     |        O         |       O       |      O       |      O     |
+| `TokenBucket` \*\*         | one_time_burst        |    O     |       O        |    **R**     |        O         |       O       |      O       |      O     |
+|                            | refill_time           |    O     |       O        |    **R**     |        O         |       O       |      O       |      O     |
+|                            | size                  |    O     |       O        |    **R**     |        O         |       O       |      O       |      O     |
+| `TokenBucket` \*\*         | one_time_burst        |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | refill_time           |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+|                            | size                  |    O     |       O        |      O       |        O         |     **R**     |      O       |      O     |
+| `Vm`                       | state                 |    O     |       O        |      O       |        O         |       O       |      O       |      O     |
+| `Vsock`                    | guest_cid             |    O     |       O        |      O       |        O         |       O       |    **R**     |      O     |
+|                            | uds_path              |    O     |       O        |      O       |        O         |       O       |    **R**     |      O     |
+|                            | vsock_id              |    O     |       O        |      O       |        O         |       O       |    **R**     |      O     |
+| `EntropyDevice`            | rate_limiter          |    O     |       O        |      O       |        O         |       O       |      O       |    **R**   |
 
-<sup>\*</sup>: The `TokenBucket` can be configured with any combination of
+\* `Drive`'s `drive_id`, `is_root_device` and `partuuid` can be configured
+by either virtio-block or vhost-user-block devices.
+
+\*\* The `TokenBucket` can be configured with any combination of
 virtio-net, virtio-block and virtio-rng devices.
 
 ## Output Schema
@@ -106,26 +110,26 @@ virtio-net, virtio-block and virtio-rng devices.
 All output schema fields can be found in the [Swagger](https://swagger.io)
 specification: [firecracker.yaml](./../src/api_server/swagger/firecracker.yaml).
 
-| Schema                 | Property          | keyboard | serial console | virtio-block | virtio-net | virtio-vsock |
-| ---------------------- | ----------------- | :------: | :------------: | :----------: | :--------: | :----------: |
-| `Error`                | fault_message     |    O     |       O        |      O       |     O      |      O       |
-| `InstanceInfo`         | app_name          |    O     |       O        |      O       |     O      |      O       |
-|                        | id                |    O     |       O        |      O       |     O      |      O       |
-|                        | state             |    O     |       O        |      O       |     O      |      O       |
-|                        | vmm_version       |    O     |       O        |      O       |     O      |      O       |
-| `MachineConfiguration` | cpu_template      |    O     |       O        |      O       |     O      |      O       |
-|                        | smt               |    O     |       O        |      O       |     O      |      O       |
-|                        | mem_size_mib      |    O     |       O        |      O       |     O      |      O       |
-|                        | track_dirty_pages |    O     |       O        |      O       |     O      |      O       |
-|                        | vcpu_count        |    O     |       O        |      O       |     O      |      O       |
+| Schema                 | Property          | keyboard | serial console | virtio-block | vhost-user-block | virtio-net | virtio-vsock |
+| ---------------------- | ----------------- | :------: | :------------: | :----------: | :--------------: | :--------: | :----------: |
+| `Error`                | fault_message     |    O     |       O        |      O       |        O         |     O      |      O       |
+| `InstanceInfo`         | app_name          |    O     |       O        |      O       |        O         |     O      |      O       |
+|                        | id                |    O     |       O        |      O       |        O         |     O      |      O       |
+|                        | state             |    O     |       O        |      O       |        O         |     O      |      O       |
+|                        | vmm_version       |    O     |       O        |      O       |        O         |     O      |      O       |
+| `MachineConfiguration` | cpu_template      |    O     |       O        |      O       |        O         |     O      |      O       |
+|                        | smt               |    O     |       O        |      O       |        O         |     O      |      O       |
+|                        | mem_size_mib      |    O     |       O        |      O       |        O         |     O      |      O       |
+|                        | track_dirty_pages |    O     |       O        |      O       |        O         |     O      |      O       |
+|                        | vcpu_count        |    O     |       O        |      O       |        O         |     O      |      O       |
 
 ## Instance Actions
 
 All instance actions can be found in the [Swagger](https://swagger.io)
 specification: [firecracker.yaml](./../src/api_server/swagger/firecracker.yaml).
 
-| Action           | keyboard | serial console | virtio-block | virtio-net | virtio-vsock |
-| ---------------- | :------: | :------------: | :----------: | :--------: | :----------: |
-| `FlushMetrics`   |    O     |       O        |      O       |     O      |      O       |
-| `InstanceStart`  |    O     |       O        |      O       |     O      |      O       |
-| `SendCtrlAltDel` |  **R**   |       O        |      O       |     O      |      O       |
+| Action           | keyboard | serial console | virtio-block | vhost-user-block | virtio-net | virtio-vsock |
+| ---------------- | :------: | :------------: | :----------: | :--------------: | :--------: | :----------: |
+| `FlushMetrics`   |    O     |       O        |      O       |        O         |     O      |      O       |
+| `InstanceStart`  |    O     |       O        |      O       |        O         |     O      |      O       |
+| `SendCtrlAltDel` |  **R**   |       O        |      O       |        O         |     O      |      O       |

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -1140,7 +1140,9 @@ definitions:
         type: string
       path_on_host:
         type: string
-        description: Host level path for the guest drive
+        description:
+          Host level path for the guest drive.
+          This field is optional for virtio-block config and should be omitted for vhost-user-block configuration.
       rate_limiter:
         $ref: "#/definitions/RateLimiter"
 


### PR DESCRIPTION
## Changes

Add documentation for the vhost-user-blk device.

## Reason

vhost-user-blk device is added in https://github.com/firecracker-microvm/firecracker/pull/4170 .

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- ~[ ] All added/changed functionality is tested.~
- ~[ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
