### PR TITLE
chore(logs): removed redundant `debug!` logs

### DIFF
--- a/src/vmm/src/devices/virtio/balloon/event_handler.rs
+++ b/src/vmm/src/devices/virtio/balloon/event_handler.rs
@@ -10,7 +10,7 @@ use super::{DEFLATE_INDEX, INFLATE_INDEX, STATS_INDEX};
 use crate::devices::report_balloon_event_fail;
 use crate::devices::virtio::balloon::device::Balloon;
 use crate::devices::virtio::device::VirtioDevice;
-use crate::logger::{debug, error, warn};
+use crate::logger::{error, warn};
 
 impl Balloon {
     fn register_runtime_events(&self, ops: &mut EventOps) {
@@ -37,7 +37,6 @@ impl Balloon {
     }
 
     fn process_activate_event(&self, ops: &mut EventOps) {
-        debug!("balloon: activate event");
         if let Err(err) = self.activate_evt.read() {
             error!("Failed to consume balloon activate event: {:?}", err);
         }

--- a/src/vmm/src/devices/virtio/net/event_handler.rs
+++ b/src/vmm/src/devices/virtio/net/event_handler.rs
@@ -9,7 +9,7 @@ use utils::epoll::EventSet;
 use crate::devices::virtio::device::VirtioDevice;
 use crate::devices::virtio::net::device::Net;
 use crate::devices::virtio::net::{RX_INDEX, TX_INDEX};
-use crate::logger::{debug, error, warn, IncMetric};
+use crate::logger::{error, warn, IncMetric};
 
 impl Net {
     fn register_runtime_events(&self, ops: &mut EventOps) {
@@ -40,7 +40,6 @@ impl Net {
     }
 
     fn process_activate_event(&self, ops: &mut EventOps) {
-        debug!("net: activate event");
         if let Err(err) = self.activate_evt.read() {
             error!("Failed to consume net activate event: {:?}", err);
         }

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -82,7 +82,6 @@ impl Entropy {
     }
 
     fn signal_used_queue(&self) -> Result<(), DeviceError> {
-        debug!("entropy: raising IRQ");
         self.irq_trigger
             .trigger_irq(IrqType::Vring)
             .map_err(DeviceError::FailedSignalingIrq)

--- a/src/vmm/src/devices/virtio/virtio_block/event_handler.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/event_handler.rs
@@ -8,7 +8,7 @@ use utils::epoll::EventSet;
 use super::io::FileEngine;
 use crate::devices::virtio::device::VirtioDevice;
 use crate::devices::virtio::virtio_block::device::VirtioBlock;
-use crate::logger::{debug, error, warn};
+use crate::logger::{error, warn};
 
 impl VirtioBlock {
     fn register_runtime_events(&self, ops: &mut EventOps) {
@@ -32,7 +32,6 @@ impl VirtioBlock {
     }
 
     fn process_activate_event(&self, ops: &mut EventOps) {
-        debug!("block: activate event");
         if let Err(err) = self.activate_evt.read() {
             error!("Failed to consume block activate event: {:?}", err);
         }

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
-use log::{debug, error, warn};
+use log::{error, warn};
 use utils::byte_order;
 use utils::eventfd::EventFd;
 
@@ -131,7 +131,6 @@ where
     /// Signal the guest driver that we've used some virtio buffers that it had previously made
     /// available.
     pub fn signal_used_queue(&self) -> Result<(), DeviceError> {
-        debug!("vsock: raising IRQ");
         self.irq_trigger
             .trigger_irq(IrqType::Vring)
             .map_err(DeviceError::FailedSignalingIrq)
@@ -141,7 +140,6 @@ where
     /// have pending. Return `true` if descriptors have been added to the used ring, and `false`
     /// otherwise.
     pub fn process_rx(&mut self) -> bool {
-        debug!("vsock: process_rx()");
         // This is safe since we checked in the event handler that the device is activated.
         let mem = self.device_state.mem().unwrap();
 
@@ -194,7 +192,6 @@ where
     /// to the backend for processing. Return `true` if descriptors have been added to the used
     /// ring, and `false` otherwise.
     pub fn process_tx(&mut self) -> bool {
-        debug!("vsock::process_tx()");
         // This is safe since we checked in the event handler that the device is activated.
         let mem = self.device_state.mem().unwrap();
 

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -28,7 +28,7 @@ use std::fmt::Debug;
 use std::os::unix::io::AsRawFd;
 
 use event_manager::{EventOps, Events, MutEventSubscriber};
-use log::{debug, error, warn};
+use log::{error, warn};
 use utils::epoll::EventSet;
 
 use super::device::{Vsock, EVQ_INDEX, RXQ_INDEX, TXQ_INDEX};
@@ -41,8 +41,6 @@ where
     B: Debug + VsockBackend + 'static,
 {
     pub fn handle_rxq_event(&mut self, evset: EventSet) -> bool {
-        debug!("vsock: RX queue event");
-
         if evset != EventSet::IN {
             warn!("vsock: rxq unexpected event {:?}", evset);
             METRICS.vsock.rx_queue_event_fails.inc();
@@ -61,8 +59,6 @@ where
     }
 
     pub fn handle_txq_event(&mut self, evset: EventSet) -> bool {
-        debug!("vsock: TX queue event");
-
         if evset != EventSet::IN {
             warn!("vsock: txq unexpected event {:?}", evset);
             METRICS.vsock.tx_queue_event_fails.inc();
@@ -87,8 +83,6 @@ where
     }
 
     pub fn handle_evq_event(&mut self, evset: EventSet) -> bool {
-        debug!("vsock: event queue event");
-
         if evset != EventSet::IN {
             warn!("vsock: evq unexpected event {:?}", evset);
             METRICS.vsock.ev_queue_event_fails.inc();
@@ -104,8 +98,6 @@ where
 
     /// Notify backend of new events.
     pub fn notify_backend(&mut self, evset: EventSet) -> bool {
-        debug!("vsock: backend event");
-
         self.backend.notify(evset);
         // After the backend has been kicked, it might've freed up some resources, so we
         // can attempt to send it more data to process.
@@ -141,7 +133,6 @@ where
     }
 
     fn handle_activate_event(&self, ops: &mut EventOps) {
-        debug!("vsock: activate event");
         if let Err(err) = self.activate_evt.read() {
             error!("Failed to consume net activate event: {:?}", err);
         }

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -276,8 +276,6 @@ impl VsockEpollListener for VsockMuxer {
 
     /// Notify the muxer about a pending event having occured under its nested epoll FD.
     fn notify(&mut self, _: EventSet) {
-        debug!("vsock: muxer received kick");
-
         let mut epoll_events = vec![EpollEvent::new(EventSet::empty(), 0); 32];
         match self.epoll.wait(0, epoll_events.as_mut_slice()) {
             Ok(ev_cnt) => {


### PR DESCRIPTION
## Changes
Removed redundant `debug!` logs. These logs were used to trace execution of the FC, but it is better to use tracing tools for this.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
