### PR TITLE
fix(rebase-snap): Move deprecation message after version info

### DIFF
--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -13,6 +13,8 @@ use utils::u64_to_usize;
 const REBASE_SNAP_VERSION: &str = env!("CARGO_PKG_VERSION");
 const BASE_FILE: &str = "base-file";
 const DIFF_FILE: &str = "diff-file";
+const DEPRECATION_MSG: &str = "This tool is deprecated and will be removed in the future. Please \
+                               use 'snapshot-editor' instead.\n";
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 enum FileError {
@@ -115,10 +117,6 @@ fn rebase(base_file: &mut File, diff_file: &mut File) -> Result<(), FileError> {
 }
 
 fn main() -> Result<(), RebaseSnapError> {
-    println!(
-        "This tool is deprecated and will be removed in the future. Please use 'snapshot-editor' \
-         instead."
-    );
     let result = main_exec();
     if let Err(e) = result {
         eprintln!("{}", e);
@@ -139,16 +137,18 @@ fn main_exec() -> Result<(), RebaseSnapError> {
     if arguments.flag_present("help") {
         println!("Rebase_snap v{}", REBASE_SNAP_VERSION);
         println!(
-            "Tool that copies all the non-sparse sections from a diff file onto a base file\n"
+            "Tool that copies all the non-sparse sections from a diff file onto a base file.\n"
         );
+        println!("{DEPRECATION_MSG}");
         println!("{}", arg_parser.formatted_help());
         return Ok(());
     }
     if arguments.flag_present("version") {
-        println!("Rebase_snap v{}\n", REBASE_SNAP_VERSION);
+        println!("Rebase_snap v{REBASE_SNAP_VERSION}\n{DEPRECATION_MSG}");
         return Ok(());
     }
 
+    println!("{DEPRECATION_MSG}");
     let (mut base_file, mut diff_file) = get_files(arguments).map_err(RebaseSnapError::SnapFile)?;
 
     rebase(&mut base_file, &mut diff_file).map_err(RebaseSnapError::RebaseFiles)?;


### PR DESCRIPTION
## Changes

- Moves the deprecation message not to come before the version info.

## Reason

Commit ded9038aca16 ("deprecation(rebase-snap): marked rebase-snap as deprecated") breaks our release process, because it shows the deprecation message before the version info and the release script gets the version from the first line.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
