### PR TITLE
Vhost user blk basic config change

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -428,6 +428,14 @@
             {
                 "syscall": "sched_yield",
                 "comment": "Used by the rust standard library in std::sync::mpmc. Firecracker uses mpsc channels from this module for inter-thread communication"
+            },
+            {
+                "syscall": "sendmsg",
+                "comment": "Used by vhost-user frontend to communicate with the backend"
+            },
+            {
+                "syscall": "recvmsg",
+                "comment": "Used by vhost-user frontend to read response from the backend"
             }
         ]
     },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -440,6 +440,14 @@
             {
                 "syscall": "sched_yield",
                 "comment": "Used by the rust standard library in std::sync::mpmc. Firecracker uses mpsc channels from this module for inter-thread communication"
+            },
+            {
+                "syscall": "sendmsg",
+                "comment": "Used by vhost-user frontend to communicate with the backend"
+            },
+            {
+                "syscall": "recvmsg",
+                "comment": "Used by vhost-user frontend to read response from the backend"
             }
         ]
     },

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -64,21 +64,6 @@ pub(crate) fn parse_patch_drive(
         ));
     }
 
-    // Validate request - we need to have at least one parameter set:
-    // - path_on_host
-    // - rate_limiter
-    if block_device_update_cfg.path_on_host.is_none()
-        && block_device_update_cfg.rate_limiter.is_none()
-    {
-        METRICS.patch_api_requests.drive_fails.inc();
-        return Err(Error::Generic(
-            StatusCode::BadRequest,
-            String::from(
-                "Please specify at least one property to patch: path_on_host, rate_limiter.",
-            ),
-        ));
-    }
-
     Ok(ParsedRequest::new_sync(VmmAction::UpdateBlockDevice(
         block_device_update_cfg,
     )))
@@ -117,12 +102,12 @@ mod tests {
         let res = parse_patch_drive(&Body::new(body), Some("1000"));
         assert!(res.is_err());
 
-        // PATCH with missing path_on_host field.
+        // PATCH with only drive_id field.
         let body = r#"{
-            "drive_id": "dummy_id"
+            "drive_id": "1000"
         }"#;
-        let res = parse_patch_drive(&Body::new(body), Some("dummy_id"));
-        assert!(res.is_err());
+        let res = parse_patch_drive(&Body::new(body), Some("1000"));
+        assert!(res.is_ok());
 
         // PATCH with missing drive_id field.
         let body = r#"{

--- a/src/vmm/src/devices/virtio/mmio.rs
+++ b/src/vmm/src/devices/virtio/mmio.rs
@@ -246,14 +246,25 @@ impl MmioTransport {
                     0x34 => self.with_queue(0, |q| u32::from(q.get_max_size())),
                     0x44 => self.with_queue(0, |q| u32::from(q.ready)),
                     0x60 => {
-                        // For vhost-user backed devices we can only report
-                        // `VIRTIO_MMIO_INT_VRING` (bit 0 set) value, as any
-                        // changes to the interrupt status value cannot be propagated
-                        // back to FC from vhost-user-backend. This also means that backed should
-                        // not change device configuration as it also requires update to the
-                        // interrupt status (bit 1 set).
+                        // For vhost-user backed devices we need some additional
+                        // logic to differentiate between `VIRTIO_MMIO_INT_VRING`
+                        // and `VIRTIO_MMIO_INT_CONFIG` statuses.
+                        // Because backend cannot propagate any interrupt status
+                        // changes to the FC we always try to serve the `VIRTIO_MMIO_INT_VRING`
+                        // status. But in case when backend changes the configuration and
+                        // user triggers the manual notification, FC needs to send
+                        // `VIRTIO_MMIO_INT_CONFIG`. We know that for vhost-user devices the
+                        // interrupt status can only be 0 (no one set any bits) or
+                        // `VIRTIO_MMIO_INT_CONFIG`. Based on this knowledge we can simply
+                        // check if the current interrupt_status is equal to the
+                        // `VIRTIO_MMIO_INT_CONFIG` or not to understand if we need to send
+                        // `VIRTIO_MMIO_INT_CONFIG` or
+                        // `VIRTIO_MMIO_INT_VRING`.
+                        let is = self.interrupt_status.load(Ordering::SeqCst);
                         if !self.is_vhost_user {
-                            self.interrupt_status.load(Ordering::SeqCst)
+                            is
+                        } else if is == VIRTIO_MMIO_INT_CONFIG {
+                            VIRTIO_MMIO_INT_CONFIG
                         } else {
                             VIRTIO_MMIO_INT_VRING
                         }
@@ -539,9 +550,15 @@ pub(crate) mod tests {
         assert_eq!(read_le_u32(&buf[..]), 111);
 
         d.is_vhost_user = true;
-        d.interrupt_status.store(222, Ordering::SeqCst);
+        d.interrupt_status.store(0, Ordering::SeqCst);
         d.bus_read(0x60, &mut buf[..]);
         assert_eq!(read_le_u32(&buf[..]), VIRTIO_MMIO_INT_VRING);
+
+        d.is_vhost_user = true;
+        d.interrupt_status
+            .store(VIRTIO_MMIO_INT_CONFIG, Ordering::SeqCst);
+        d.bus_read(0x60, &mut buf[..]);
+        assert_eq!(read_le_u32(&buf[..]), VIRTIO_MMIO_INT_CONFIG);
 
         d.bus_read(0x70, &mut buf[..]);
         assert_eq!(read_le_u32(&buf[..]), 0);

--- a/src/vmm/src/devices/virtio/vhost_user_block/device.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/device.rs
@@ -17,7 +17,7 @@ use vhost::vhost_user::Frontend;
 
 use super::{VhostUserBlockError, NUM_QUEUES, QUEUE_SIZE};
 use crate::devices::virtio::block_common::CacheType;
-use crate::devices::virtio::device::{DeviceState, IrqTrigger, VirtioDevice};
+use crate::devices::virtio::device::{DeviceState, IrqTrigger, IrqType, VirtioDevice};
 use crate::devices::virtio::gen::virtio_blk::{
     VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_F_VERSION_1,
 };
@@ -181,7 +181,7 @@ impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
         // Get config from backend if CONFIG is acked or use empty buffer.
         let config_space =
             if acked_protocol_features & VhostUserProtocolFeatures::CONFIG.bits() != 0 {
-                // This buffer is read only. Ask vhost implementation why.
+                // This buffer is used for config size check in vhost crate.
                 let buffer = [0u8; BLOCK_CONFIG_SPACE_SIZE as usize];
                 let (_, new_config_space) = vu_handle
                     .vu
@@ -253,6 +253,27 @@ impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
             cache_type: self.cache_type,
             socket: self.vu_handle.socket_path.clone(),
         }
+    }
+
+    pub fn config_update(&mut self) -> Result<(), VhostUserBlockError> {
+        // This buffer is used for config size check in vhost crate.
+        let buffer = [0u8; BLOCK_CONFIG_SPACE_SIZE as usize];
+        let (_, new_config_space) = self
+            .vu_handle
+            .vu
+            .get_config(
+                0,
+                BLOCK_CONFIG_SPACE_SIZE,
+                VhostUserConfigFlags::WRITABLE,
+                &buffer,
+            )
+            .map_err(VhostUserBlockError::Vhost)?;
+        self.config_space = new_config_space;
+        self.irq_trigger
+            .trigger_irq(IrqType::Config)
+            .map_err(VhostUserBlockError::IrqTrigger)?;
+
+        Ok(())
     }
 }
 
@@ -349,11 +370,13 @@ mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
 
     use std::os::unix::net::UnixStream;
+    use std::sync::atomic::Ordering;
 
     use utils::tempfile::TempFile;
     use vhost::{VhostUserMemoryRegionInfo, VringConfigData};
 
     use super::*;
+    use crate::devices::virtio::mmio::VIRTIO_MMIO_INT_CONFIG;
     use crate::utilities::test_utils::create_tmp_socket;
     use crate::vstate::memory::{FileOffset, GuestAddress, GuestMemoryExtension};
 
@@ -626,6 +649,15 @@ mod tests {
         // Writing to the config does nothing
         vhost_block.write_config(0x69, &[0]);
         assert_eq!(vhost_block.config_space, vec![0x69, 0x69, 0x69]);
+
+        // Testing [`config_update`]
+        vhost_block.config_space = vec![];
+        vhost_block.config_update().unwrap();
+        assert_eq!(vhost_block.config_space, vec![0x69, 0x69, 0x69]);
+        assert_eq!(
+            vhost_block.interrupt_status().load(Ordering::SeqCst),
+            VIRTIO_MMIO_INT_CONFIG
+        );
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vhost_user_block/device.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/device.rs
@@ -256,6 +256,8 @@ impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
     }
 
     pub fn config_update(&mut self) -> Result<(), VhostUserBlockError> {
+        let start_time = utils::time::get_time_us(utils::time::ClockType::Monotonic);
+
         // This buffer is used for config size check in vhost crate.
         let buffer = [0u8; BLOCK_CONFIG_SPACE_SIZE as usize];
         let (_, new_config_space) = self
@@ -272,6 +274,9 @@ impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
         self.irq_trigger
             .trigger_irq(IrqType::Config)
             .map_err(VhostUserBlockError::IrqTrigger)?;
+
+        let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time;
+        self.metrics.config_change_time_us.store(delta_us);
 
         Ok(())
     }

--- a/src/vmm/src/devices/virtio/vhost_user_metrics.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_metrics.rs
@@ -14,12 +14,14 @@
 //!     "cfg_fails": "SharedIncMetric",
 //!     "init_time_us": SharedStoreMetric,
 //!     "activate_time_us": SharedStoreMetric,
+//!     "config_change_time_us": SharedStoreMetric,
 //!  }
 //!  "vhost_user_{mod}_id1": {
 //!     "activate_fails": "SharedIncMetric",
 //!     "cfg_fails": "SharedIncMetric",
 //!     "init_time_us": SharedStoreMetric,
 //!     "activate_time_us": SharedStoreMetric,
+//!     "config_change_time_us": SharedStoreMetric,
 //!  }
 //!  ...
 //!  "vhost_user_{mod}_idN": {
@@ -27,12 +29,13 @@
 //!     "cfg_fails": "SharedIncMetric",
 //!     "init_time_us": SharedStoreMetric,
 //!     "activate_time_us": SharedStoreMetric,
+//!     "config_change_time_us": SharedStoreMetric,
 //!  }
 //! }
 //! ```
 //! Each `vhost_user` field in the example above is a serializable `VhostUserDeviceMetrics`
-//! structure collecting metrics such as `activate_fails`, `cfg_fails`, `init_time_us` and
-//! `activate_time_us` for the vhost_user device.
+//! structure collecting metrics such as `activate_fails`, `cfg_fails`, `init_time_us`,
+//! `activate_time_us` and `config_change_time_us` for the vhost_user device.
 //! For vhost-user block device having endpoint "/drives/drv0" the emitted metrics would be
 //! `vhost_user_block_drv0`.
 //! For vhost-user block device having endpoint "/drives/drvN" the emitted metrics would be
@@ -139,6 +142,8 @@ pub struct VhostUserDeviceMetrics {
     pub init_time_us: SharedStoreMetric,
     // Vhost-user activate time in microseconds.
     pub activate_time_us: SharedStoreMetric,
+    // Vhost-user config change time in microseconds.
+    pub config_change_time_us: SharedStoreMetric,
 }
 
 #[cfg(test)]

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -27,7 +27,7 @@ pub enum DriveError {
     CreateVhostUserBlockDevice(VhostUserBlockError),
     /// Cannot create RateLimiter: {0}
     CreateRateLimiter(io::Error),
-    /// Unable to patch the block device: {0}
+    /// Unable to patch the block device: {0} Please verify the request arguments.
     DeviceUpdate(VmmError),
     /// A root block device already exists!
     RootBlockDeviceAlreadyAdded,

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -704,13 +704,16 @@ class Microvm:
             cache_type=cache_type,
         )
 
-    def patch_drive(self, drive_id, file):
+    def patch_drive(self, drive_id, file=None):
         """Modify/patch an existing block device."""
-        self.api.drive.patch(
-            drive_id=drive_id,
-            path_on_host=self.create_jailed_resource(file.path),
-        )
-        self.disks[drive_id] = Path(file.path)
+        if file:
+            self.api.drive.patch(
+                drive_id=drive_id,
+                path_on_host=self.create_jailed_resource(file.path),
+            )
+            self.disks[drive_id] = Path(file.path)
+        else:
+            self.api.drive.patch(drive_id=drive_id)
 
     def add_net_iface(self, iface=None, api=True, **kwargs):
         """Add a network interface"""

--- a/tests/host_tools/metrics.py
+++ b/tests/host_tools/metrics.py
@@ -446,6 +446,7 @@ def validate_fc_metrics(metrics):
                 "cfg_fails",
                 "init_time_us",
                 "activate_time_us",
+                "config_change_time_us",
             ]
             vhost_user_devices.append(metrics_name)
 


### PR DESCRIPTION
## Changes
Updated `PATCH /drive` command to trigger config update for vhost-user-block devices if no parameters set.
The config update includes reading new config from the backend and notifying the guest about the changes.
Also added new metric for vhos-user devices that measures time it took to read new config from the backend and 
notify guest about it.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
