### PR TITLE
Vsock metrics

### DIFF
--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -93,7 +93,8 @@ use super::super::packet::VsockPacket;
 use super::super::{VsockChannel, VsockEpollListener, VsockError};
 use super::txbuf::TxBuf;
 use super::{defs, ConnState, PendingRx, PendingRxSet, VsockCsmError};
-use crate::logger::{IncMetric, METRICS};
+use crate::devices::virtio::vsock::metrics::METRICS;
+use crate::logger::IncMetric;
 use crate::vstate::memory::GuestMemoryMmap;
 
 /// Trait that vsock connection backends need to implement.
@@ -163,7 +164,7 @@ where
         // Perform some generic initialization that is the same for any packet operation (e.g.
         // source, destination, credit, etc).
         self.init_pkt(pkt);
-        METRICS.vsock.rx_packets_count.inc();
+        METRICS.rx_packets_count.inc();
 
         // If forceful termination is pending, there's no point in checking for anything else.
         // It's dead, Jim.
@@ -238,7 +239,7 @@ where
                         // by self.peer_avail_credit(), a u32 internally.
                         pkt.set_op(uapi::VSOCK_OP_RW)
                             .set_len(u32::try_from(read_cnt).unwrap());
-                        METRICS.vsock.rx_bytes_count.add(read_cnt as u64);
+                        METRICS.rx_bytes_count.add(read_cnt as u64);
                     }
                     self.rx_cnt += Wrapping(pkt.len());
                     self.last_fwd_cnt_to_peer = self.fwd_cnt;
@@ -258,7 +259,7 @@ where
                 Err(err) => {
                     // We are not expecting any other errors when reading from the underlying
                     // stream. If any show up, we'll immediately kill this connection.
-                    METRICS.vsock.rx_read_fails.inc();
+                    METRICS.rx_read_fails.inc();
                     error!(
                         "vsock: error reading from backing stream: lp={}, pp={}, err={:?}",
                         self.local_port, self.peer_port, err
@@ -295,7 +296,7 @@ where
         // Update the peer credit information.
         self.peer_buf_alloc = pkt.buf_alloc();
         self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
-        METRICS.vsock.tx_packets_count.inc();
+        METRICS.tx_packets_count.inc();
 
         match self.state {
             // Most frequent case: this is an established connection that needs to forward some
@@ -457,7 +458,7 @@ where
             // Data can be written to the host stream. Time to flush out the TX buffer.
             //
             if self.tx_buf.is_empty() {
-                METRICS.vsock.conn_event_fails.inc();
+                METRICS.conn_event_fails.inc();
                 info!("vsock: connection received unexpected EPOLLOUT event");
                 return;
             }
@@ -465,7 +466,7 @@ where
                 .tx_buf
                 .flush_to(&mut self.stream)
                 .unwrap_or_else(|err| {
-                    METRICS.vsock.tx_flush_fails.inc();
+                    METRICS.tx_flush_fails.inc();
                     warn!(
                         "vsock: error flushing TX buf for (lp={}, pp={}): {:?}",
                         self.local_port, self.peer_port, err
@@ -482,7 +483,7 @@ where
                     0
                 });
             self.fwd_cnt += wrap_usize_to_u32(flushed);
-            METRICS.vsock.tx_bytes_count.add(flushed as u64);
+            METRICS.tx_bytes_count.add(flushed as u64);
 
             // If this connection was shutting down, but is waiting to drain the TX buffer
             // before forceful termination, the wait might be over.
@@ -628,14 +629,14 @@ where
             Err(err) => {
                 // We don't know how to handle any other write error, so we'll send it up
                 // the call chain.
-                METRICS.vsock.tx_write_fails.inc();
+                METRICS.tx_write_fails.inc();
                 return Err(err);
             }
         };
         // Move the "forwarded bytes" counter ahead by how much we were able to send out.
         // Safe to unwrap because the maximum value is pkt.len(), which is a u32.
         self.fwd_cnt += wrap_usize_to_u32(written);
-        METRICS.vsock.tx_bytes_count.add(written as u64);
+        METRICS.tx_bytes_count.add(written as u64);
 
         // If we couldn't write the whole slice, we'll need to push the remaining data to our
         // buffer.

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -34,7 +34,8 @@ use utils::epoll::EventSet;
 use super::device::{Vsock, EVQ_INDEX, RXQ_INDEX, TXQ_INDEX};
 use super::VsockBackend;
 use crate::devices::virtio::device::VirtioDevice;
-use crate::logger::{IncMetric, METRICS};
+use crate::devices::virtio::vsock::metrics::METRICS;
+use crate::logger::IncMetric;
 
 impl<B> Vsock<B>
 where
@@ -43,17 +44,17 @@ where
     pub fn handle_rxq_event(&mut self, evset: EventSet) -> bool {
         if evset != EventSet::IN {
             warn!("vsock: rxq unexpected event {:?}", evset);
-            METRICS.vsock.rx_queue_event_fails.inc();
+            METRICS.rx_queue_event_fails.inc();
             return false;
         }
 
         let mut raise_irq = false;
         if let Err(err) = self.queue_events[RXQ_INDEX].read() {
             error!("Failed to get vsock rx queue event: {:?}", err);
-            METRICS.vsock.rx_queue_event_fails.inc();
+            METRICS.rx_queue_event_fails.inc();
         } else if self.backend.has_pending_rx() {
             raise_irq |= self.process_rx();
-            METRICS.vsock.rx_queue_event_count.inc();
+            METRICS.rx_queue_event_count.inc();
         }
         raise_irq
     }
@@ -61,17 +62,17 @@ where
     pub fn handle_txq_event(&mut self, evset: EventSet) -> bool {
         if evset != EventSet::IN {
             warn!("vsock: txq unexpected event {:?}", evset);
-            METRICS.vsock.tx_queue_event_fails.inc();
+            METRICS.tx_queue_event_fails.inc();
             return false;
         }
 
         let mut raise_irq = false;
         if let Err(err) = self.queue_events[TXQ_INDEX].read() {
             error!("Failed to get vsock tx queue event: {:?}", err);
-            METRICS.vsock.tx_queue_event_fails.inc();
+            METRICS.tx_queue_event_fails.inc();
         } else {
             raise_irq |= self.process_tx();
-            METRICS.vsock.tx_queue_event_count.inc();
+            METRICS.tx_queue_event_count.inc();
             // The backend may have queued up responses to the packets we sent during
             // TX queue processing. If that happened, we need to fetch those responses
             // and place them into RX buffers.
@@ -85,13 +86,13 @@ where
     pub fn handle_evq_event(&mut self, evset: EventSet) -> bool {
         if evset != EventSet::IN {
             warn!("vsock: evq unexpected event {:?}", evset);
-            METRICS.vsock.ev_queue_event_fails.inc();
+            METRICS.ev_queue_event_fails.inc();
             return false;
         }
 
         if let Err(err) = self.queue_events[EVQ_INDEX].read() {
             error!("Failed to consume vsock evq event: {:?}", err);
-            METRICS.vsock.ev_queue_event_fails.inc();
+            METRICS.ev_queue_event_fails.inc();
         }
         false
     }

--- a/src/vmm/src/devices/virtio/vsock/metrics.rs
+++ b/src/vmm/src/devices/virtio/vsock/metrics.rs
@@ -1,0 +1,147 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the metrics system for vsock devices.
+//!
+//! # Metrics format
+//! The metrics are flushed in JSON when requested by vmm::logger::metrics::METRICS.write().
+//!
+//! ## JSON example with metrics:
+//! ```json
+//!  "vsock": {
+//!     "activate_fails": "SharedIncMetric",
+//!     "cfg_fails": "SharedIncMetric",
+//!     "rx_queue_event_fails": "SharedIncMetric",
+//!     "tx_queue_event_fails": "SharedIncMetric",
+//!     "ev_queue_event_fails": "SharedIncMetric",
+//!     "muxer_event_fails": "SharedIncMetric",
+//!     ...
+//!  }
+//! }
+//! ```
+//! Each `vsock` field in the example above is a serializable `VsockDeviceMetrics` structure
+//! collecting metrics such as `activate_fails`, `cfg_fails`, etc. for the Vsock device.
+//! Since vsock doesn't support multiple devices, there is no per device metrics and
+//! `vsock` represents the aggregate metrics for all vsock connections.
+//!
+//! # Design
+//! The main design goals of this system are:
+//! * Have a consistent approach of keeping device related metrics in the individual devices
+//!   modules.
+//! * To decouple vsock device metrics from logger module by moving VsockDeviceMetrics out of
+//!   FirecrackerDeviceMetrics.
+//! * Rely on `serde` to provide the actual serialization for writing the metrics.
+//! * Since all metrics start at 0, we implement the `Default` trait via derive for all of them, to
+//!   avoid having to initialize everything by hand.
+//!
+//! The system implements 1 type of metrics:
+//! * Shared Incremental Metrics (SharedIncMetrics) - dedicated for the metrics which need a counter
+//! (i.e the number of times an API request failed). These metrics are reset upon flush.
+
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
+
+use crate::logger::SharedIncMetric;
+
+/// Stores aggregate metrics of all Vsock connections/actions
+pub static METRICS: VsockDeviceMetrics = VsockDeviceMetrics::new();
+
+/// Called by METRICS.flush(), this function facilitates serialization of vsock device metrics.
+pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+    let mut seq = serializer.serialize_map(Some(1))?;
+    seq.serialize_entry("vsock", &METRICS)?;
+    seq.end()
+}
+
+/// Vsock-related metrics.
+#[derive(Debug, Default, Serialize)]
+pub struct VsockDeviceMetrics {
+    /// Number of times when activate failed on a vsock device.
+    pub activate_fails: SharedIncMetric,
+    /// Number of times when interacting with the space config of a vsock device failed.
+    pub cfg_fails: SharedIncMetric,
+    /// Number of times when handling RX queue events on a vsock device failed.
+    pub rx_queue_event_fails: SharedIncMetric,
+    /// Number of times when handling TX queue events on a vsock device failed.
+    pub tx_queue_event_fails: SharedIncMetric,
+    /// Number of times when handling event queue events on a vsock device failed.
+    pub ev_queue_event_fails: SharedIncMetric,
+    /// Number of times when handling muxer events on a vsock device failed.
+    pub muxer_event_fails: SharedIncMetric,
+    /// Number of times when handling connection events on a vsock device failed.
+    pub conn_event_fails: SharedIncMetric,
+    /// Number of events associated with the receiving queue.
+    pub rx_queue_event_count: SharedIncMetric,
+    /// Number of events associated with the transmitting queue.
+    pub tx_queue_event_count: SharedIncMetric,
+    /// Number of bytes received.
+    pub rx_bytes_count: SharedIncMetric,
+    /// Number of transmitted bytes.
+    pub tx_bytes_count: SharedIncMetric,
+    /// Number of packets received.
+    pub rx_packets_count: SharedIncMetric,
+    /// Number of transmitted packets.
+    pub tx_packets_count: SharedIncMetric,
+    /// Number of added connections.
+    pub conns_added: SharedIncMetric,
+    /// Number of killed connections.
+    pub conns_killed: SharedIncMetric,
+    /// Number of removed connections.
+    pub conns_removed: SharedIncMetric,
+    /// How many times the killq has been resynced.
+    pub killq_resync: SharedIncMetric,
+    /// How many flush fails have been seen.
+    pub tx_flush_fails: SharedIncMetric,
+    /// How many write fails have been seen.
+    pub tx_write_fails: SharedIncMetric,
+    /// Number of times read() has failed.
+    pub rx_read_fails: SharedIncMetric,
+}
+
+impl VsockDeviceMetrics {
+    // We need this because vsock::metrics::METRICS does not accept
+    // VsockDeviceMetrics::default()
+    pub const fn new() -> Self {
+        Self {
+            activate_fails: SharedIncMetric::new(),
+            cfg_fails: SharedIncMetric::new(),
+            rx_queue_event_fails: SharedIncMetric::new(),
+            tx_queue_event_fails: SharedIncMetric::new(),
+            ev_queue_event_fails: SharedIncMetric::new(),
+            muxer_event_fails: SharedIncMetric::new(),
+            conn_event_fails: SharedIncMetric::new(),
+            rx_queue_event_count: SharedIncMetric::new(),
+            tx_queue_event_count: SharedIncMetric::new(),
+            rx_bytes_count: SharedIncMetric::new(),
+            tx_bytes_count: SharedIncMetric::new(),
+            rx_packets_count: SharedIncMetric::new(),
+            tx_packets_count: SharedIncMetric::new(),
+            conns_added: SharedIncMetric::new(),
+            conns_killed: SharedIncMetric::new(),
+            conns_removed: SharedIncMetric::new(),
+            killq_resync: SharedIncMetric::new(),
+            tx_flush_fails: SharedIncMetric::new(),
+            tx_write_fails: SharedIncMetric::new(),
+            rx_read_fails: SharedIncMetric::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::logger::IncMetric;
+
+    #[test]
+    fn test_vsock_dev_metrics() {
+        let vsock_metrics: VsockDeviceMetrics = VsockDeviceMetrics::new();
+        let vsock_metrics_local: String = serde_json::to_string(&vsock_metrics).unwrap();
+        // the 1st serialize flushes the metrics and resets values to 0 so that
+        // we can compare the values with local metrics.
+        serde_json::to_string(&METRICS).unwrap();
+        let vsock_metrics_global: String = serde_json::to_string(&METRICS).unwrap();
+        assert_eq!(vsock_metrics_local, vsock_metrics_global);
+        vsock_metrics.conns_added.inc();
+        assert_eq!(vsock_metrics.conns_added.count(), 1);
+    }
+}

--- a/src/vmm/src/devices/virtio/vsock/metrics.rs
+++ b/src/vmm/src/devices/virtio/vsock/metrics.rs
@@ -31,8 +31,6 @@
 //! * To decouple vsock device metrics from logger module by moving VsockDeviceMetrics out of
 //!   FirecrackerDeviceMetrics.
 //! * Rely on `serde` to provide the actual serialization for writing the metrics.
-//! * Since all metrics start at 0, we implement the `Default` trait via derive for all of them, to
-//!   avoid having to initialize everything by hand.
 //!
 //! The system implements 1 type of metrics:
 //! * Shared Incremental Metrics (SharedIncMetrics) - dedicated for the metrics which need a counter
@@ -44,7 +42,7 @@ use serde::{Serialize, Serializer};
 use crate::logger::SharedIncMetric;
 
 /// Stores aggregate metrics of all Vsock connections/actions
-pub static METRICS: VsockDeviceMetrics = VsockDeviceMetrics::new();
+pub(super) static METRICS: VsockDeviceMetrics = VsockDeviceMetrics::new();
 
 /// Called by METRICS.flush(), this function facilitates serialization of vsock device metrics.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
@@ -54,8 +52,8 @@ pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
 }
 
 /// Vsock-related metrics.
-#[derive(Debug, Default, Serialize)]
-pub struct VsockDeviceMetrics {
+#[derive(Debug, Serialize)]
+pub(super) struct VsockDeviceMetrics {
     /// Number of times when activate failed on a vsock device.
     pub activate_fails: SharedIncMetric,
     /// Number of times when interacting with the space config of a vsock device failed.
@@ -101,7 +99,7 @@ pub struct VsockDeviceMetrics {
 impl VsockDeviceMetrics {
     // We need this because vsock::metrics::METRICS does not accept
     // VsockDeviceMetrics::default()
-    pub const fn new() -> Self {
+    const fn new() -> Self {
         Self {
             activate_fails: SharedIncMetric::new(),
             cfg_fails: SharedIncMetric::new(),

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -14,6 +14,7 @@
 mod csm;
 mod device;
 mod event_handler;
+pub mod metrics;
 mod packet;
 pub mod persist;
 pub mod test_utils;

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -45,7 +45,8 @@ use super::super::{VsockBackend, VsockChannel, VsockEpollListener, VsockError};
 use super::muxer_killq::MuxerKillQ;
 use super::muxer_rxq::MuxerRxQ;
 use super::{defs, MuxerConnection, VsockUnixBackendError};
-use crate::logger::{IncMetric, METRICS};
+use crate::devices::virtio::vsock::metrics::METRICS;
+use crate::logger::IncMetric;
 use crate::vstate::memory::GuestMemoryMmap;
 
 /// A unique identifier of a `MuxerConnection` object. Connections are stored in a hash map,
@@ -291,7 +292,7 @@ impl VsockEpollListener for VsockMuxer {
             }
             Err(err) => {
                 warn!("vsock: failed to consume muxer epoll event: {}", err);
-                METRICS.vsock.muxer_event_fails.inc();
+                METRICS.muxer_event_fails.inc();
             }
         }
     }
@@ -414,7 +415,7 @@ impl VsockMuxer {
                     "vsock: unexpected event: fd={:?}, evset={:?}",
                     fd, event_set
                 );
-                METRICS.vsock.muxer_event_fails.inc();
+                METRICS.muxer_event_fails.inc();
             }
         }
     }
@@ -504,7 +505,7 @@ impl VsockMuxer {
                 self.rxq.push(MuxerRx::ConnRx(key));
             }
             self.conn_map.insert(key, conn);
-            METRICS.vsock.conns_added.inc();
+            METRICS.conns_added.inc();
         })
     }
 
@@ -512,7 +513,7 @@ impl VsockMuxer {
     fn remove_connection(&mut self, key: ConnMapKey) {
         if let Some(conn) = self.conn_map.remove(&key) {
             self.remove_listener(conn.as_raw_fd());
-            METRICS.vsock.conns_removed.inc();
+            METRICS.conns_removed.inc();
         }
         self.free_local_port(key.local_port);
     }
@@ -522,7 +523,7 @@ impl VsockMuxer {
     /// it an RST packet.
     fn kill_connection(&mut self, key: ConnMapKey) {
         let mut had_rx = false;
-        METRICS.vsock.conns_killed.inc();
+        METRICS.conns_killed.inc();
 
         self.conn_map.entry(key).and_modify(|conn| {
             had_rx = conn.has_pending_rx();
@@ -715,7 +716,7 @@ impl VsockMuxer {
                                 "vsock: error updating epoll listener for (lp={}, pp={}): {:?}",
                                 key.local_port, key.peer_port, err
                             );
-                            METRICS.vsock.muxer_event_fails.inc();
+                            METRICS.muxer_event_fails.inc();
                         });
                 }
             } else {
@@ -734,7 +735,7 @@ impl VsockMuxer {
                         "vsock: error updating epoll listener for (lp={}, pp={}): {:?}",
                         key.local_port, key.peer_port, err
                     );
-                    METRICS.vsock.muxer_event_fails.inc();
+                    METRICS.muxer_event_fails.inc();
                 });
             }
         }
@@ -758,7 +759,7 @@ impl VsockMuxer {
 
         if self.killq.is_empty() && !self.killq.is_synced() {
             self.killq = MuxerKillQ::from_conn_map(&self.conn_map);
-            METRICS.vsock.killq_resync.inc();
+            METRICS.killq_resync.inc();
             // If we've just re-created the kill queue, we can sweep it again; maybe there's
             // more to kill.
             self.sweep_killq();
@@ -1003,13 +1004,13 @@ mod tests {
 
         assert_eq!(conn.get_polled_evset(), EventSet::IN);
 
-        assert_eq!(METRICS.vsock.conn_event_fails.count(), 0);
+        assert_eq!(METRICS.conn_event_fails.count(), 0);
 
         let conn_eventfd = conn.as_raw_fd();
 
         ctx.muxer.handle_event(conn_eventfd, EventSet::OUT);
 
-        assert_eq!(METRICS.vsock.conn_event_fails.count(), 1);
+        assert_eq!(METRICS.conn_event_fails.count(), 1);
     }
 
     #[test]
@@ -1308,10 +1309,10 @@ mod tests {
         let mut listener = ctx.create_local_listener(local_port);
 
         // Save metrics relevant for this test.
-        let conns_added = METRICS.vsock.conns_added.count();
-        let conns_killed = METRICS.vsock.conns_killed.count();
-        let conns_removed = METRICS.vsock.conns_removed.count();
-        let killq_resync = METRICS.vsock.killq_resync.count();
+        let conns_added = METRICS.conns_added.count();
+        let conns_killed = METRICS.conns_killed.count();
+        let conns_removed = METRICS.conns_removed.count();
+        let killq_resync = METRICS.killq_resync.count();
 
         for peer_port in peer_port_first..=peer_port_last {
             ctx.init_pkt(local_port, peer_port, uapi::VSOCK_OP_REQUEST);
@@ -1353,18 +1354,18 @@ mod tests {
         // We count +2, because there are two extra connections being
         // done outside of the loop.
         assert_eq!(
-            METRICS.vsock.conns_added.count(),
+            METRICS.conns_added.count(),
             conns_added + u64::from(defs::MUXER_KILLQ_SIZE) + 2
         );
         // Check that MUXER_KILLQ_SIZE connections were killed
         assert_eq!(
-            METRICS.vsock.conns_killed.count(),
+            METRICS.conns_killed.count(),
             conns_killed + u64::from(defs::MUXER_KILLQ_SIZE)
         );
         // No connections should be removed at this point.
-        assert_eq!(METRICS.vsock.conns_removed.count(), conns_removed);
+        assert_eq!(METRICS.conns_removed.count(), conns_removed);
 
-        assert_eq!(METRICS.vsock.killq_resync.count(), killq_resync + 1);
+        assert_eq!(METRICS.killq_resync.count(), killq_resync + 1);
         // After sweeping the kill queue, it should now be synced (assuming the RX queue is larger
         // than the kill queue, since an RST packet will be queued for each killed connection).
         assert!(ctx.muxer.killq.is_synced());
@@ -1379,7 +1380,7 @@ mod tests {
 
         // The connections should have been removed here.
         assert_eq!(
-            METRICS.vsock.conns_removed.count(),
+            METRICS.conns_removed.count(),
             conns_removed + u64::from(defs::MUXER_KILLQ_SIZE)
         );
 
@@ -1454,14 +1455,14 @@ mod tests {
     #[test]
     fn test_vsock_basic_metrics() {
         // Save the metrics values that we need tested.
-        let mut tx_packets_count = METRICS.vsock.tx_packets_count.count();
-        let mut rx_packets_count = METRICS.vsock.rx_packets_count.count();
+        let mut tx_packets_count = METRICS.tx_packets_count.count();
+        let mut rx_packets_count = METRICS.rx_packets_count.count();
 
-        let tx_bytes_count = METRICS.vsock.tx_bytes_count.count();
-        let rx_bytes_count = METRICS.vsock.rx_bytes_count.count();
+        let tx_bytes_count = METRICS.tx_bytes_count.count();
+        let rx_bytes_count = METRICS.rx_bytes_count.count();
 
-        let conns_added = METRICS.vsock.conns_added.count();
-        let conns_removed = METRICS.vsock.conns_removed.count();
+        let conns_added = METRICS.conns_added.count();
+        let conns_removed = METRICS.conns_removed.count();
 
         // Create a basic connection.
         let mut ctx = MuxerTestContext::new("vsock_basic_metrics");
@@ -1470,18 +1471,18 @@ mod tests {
 
         // Once the handshake is done, we check that the TX bytes count has
         // not been increased.
-        assert_eq!(METRICS.vsock.tx_bytes_count.count(), tx_bytes_count);
+        assert_eq!(METRICS.tx_bytes_count.count(), tx_bytes_count);
 
         // Check that one packet was sent through the handshake.
-        assert_eq!(METRICS.vsock.tx_packets_count.count(), tx_packets_count + 1);
-        tx_packets_count = METRICS.vsock.tx_packets_count.count();
+        assert_eq!(METRICS.tx_packets_count.count(), tx_packets_count + 1);
+        tx_packets_count = METRICS.tx_packets_count.count();
 
         // Check that one packet was received through the handshake.
-        assert_eq!(METRICS.vsock.rx_packets_count.count(), rx_packets_count + 1);
-        rx_packets_count = METRICS.vsock.rx_packets_count.count();
+        assert_eq!(METRICS.rx_packets_count.count(), rx_packets_count + 1);
+        rx_packets_count = METRICS.rx_packets_count.count();
 
         // Check that a new connection was added.
-        assert_eq!(METRICS.vsock.conns_added.count(), conns_added + 1);
+        assert_eq!(METRICS.conns_added.count(), conns_added + 1);
 
         // Send some data from guest to host.
         let data = [1, 2, 3, 4];
@@ -1490,12 +1491,12 @@ mod tests {
 
         // Check that tx_bytes was incremented.
         assert_eq!(
-            METRICS.vsock.tx_bytes_count.count(),
+            METRICS.tx_bytes_count.count(),
             tx_bytes_count + data.len() as u64
         );
 
         // Check that one packet was accounted for.
-        assert_eq!(METRICS.vsock.tx_packets_count.count(), tx_packets_count + 1);
+        assert_eq!(METRICS.tx_packets_count.count(), tx_packets_count + 1);
 
         // Send some data from the host to the guest.
         let data = [1, 2, 3, 4, 5, 6];
@@ -1504,11 +1505,11 @@ mod tests {
         ctx.recv();
 
         // Check that a packet was received.
-        assert_eq!(METRICS.vsock.rx_packets_count.count(), rx_packets_count + 1);
+        assert_eq!(METRICS.rx_packets_count.count(), rx_packets_count + 1);
 
         // Check that the 6 bytes have been received.
         assert_eq!(
-            METRICS.vsock.rx_bytes_count.count(),
+            METRICS.rx_bytes_count.count(),
             rx_bytes_count + data.len() as u64
         );
 
@@ -1517,6 +1518,6 @@ mod tests {
         ctx.send();
 
         // Check that the connection was removed.
-        assert_eq!(METRICS.vsock.conns_removed.count(), conns_removed + 1);
+        assert_eq!(METRICS.conns_removed.count(), conns_removed + 1);
     }
 }

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -994,8 +994,9 @@ pub struct FirecrackerMetrics {
     pub uart: SerialDeviceMetrics,
     /// Metrics related to signals.
     pub signals: SignalMetrics,
+    #[serde(flatten)]
     /// Metrics related to virtio-vsockets.
-    pub vsock: vsock_metrics::VsockDeviceMetrics,
+    pub vsock: VsockMetricsSerializeProxy,
     /// Metrics related to virtio-rng entropy device.
     pub entropy: EntropyDeviceMetrics,
 }
@@ -1023,7 +1024,7 @@ impl FirecrackerMetrics {
             vmm: VmmMetrics::new(),
             uart: SerialDeviceMetrics::new(),
             signals: SignalMetrics::new(),
-            vsock: vsock_metrics::VsockDeviceMetrics::new(),
+            vsock: VsockMetricsSerializeProxy {},
             entropy: EntropyDeviceMetrics::new(),
         }
     }

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -74,6 +74,7 @@ use vm_superio::rtc_pl031::RtcEvents;
 use super::FcLineWriter;
 use crate::devices::virtio::net::metrics as net_metrics;
 use crate::devices::virtio::virtio_block::metrics as block_metrics;
+use crate::devices::virtio::vsock::metrics as vsock_metrics;
 #[cfg(target_arch = "aarch64")]
 use crate::warn;
 
@@ -875,78 +876,6 @@ impl VmmMetrics {
     }
 }
 
-/// Vsock-related metrics.
-#[derive(Debug, Default, Serialize)]
-pub struct VsockDeviceMetrics {
-    /// Number of times when activate failed on a vsock device.
-    pub activate_fails: SharedIncMetric,
-    /// Number of times when interacting with the space config of a vsock device failed.
-    pub cfg_fails: SharedIncMetric,
-    /// Number of times when handling RX queue events on a vsock device failed.
-    pub rx_queue_event_fails: SharedIncMetric,
-    /// Number of times when handling TX queue events on a vsock device failed.
-    pub tx_queue_event_fails: SharedIncMetric,
-    /// Number of times when handling event queue events on a vsock device failed.
-    pub ev_queue_event_fails: SharedIncMetric,
-    /// Number of times when handling muxer events on a vsock device failed.
-    pub muxer_event_fails: SharedIncMetric,
-    /// Number of times when handling connection events on a vsock device failed.
-    pub conn_event_fails: SharedIncMetric,
-    /// Number of events associated with the receiving queue.
-    pub rx_queue_event_count: SharedIncMetric,
-    /// Number of events associated with the transmitting queue.
-    pub tx_queue_event_count: SharedIncMetric,
-    /// Number of bytes received.
-    pub rx_bytes_count: SharedIncMetric,
-    /// Number of transmitted bytes.
-    pub tx_bytes_count: SharedIncMetric,
-    /// Number of packets received.
-    pub rx_packets_count: SharedIncMetric,
-    /// Number of transmitted packets.
-    pub tx_packets_count: SharedIncMetric,
-    /// Number of added connections.
-    pub conns_added: SharedIncMetric,
-    /// Number of killed connections.
-    pub conns_killed: SharedIncMetric,
-    /// Number of removed connections.
-    pub conns_removed: SharedIncMetric,
-    /// How many times the killq has been resynced.
-    pub killq_resync: SharedIncMetric,
-    /// How many flush fails have been seen.
-    pub tx_flush_fails: SharedIncMetric,
-    /// How many write fails have been seen.
-    pub tx_write_fails: SharedIncMetric,
-    /// Number of times read() has failed.
-    pub rx_read_fails: SharedIncMetric,
-}
-impl VsockDeviceMetrics {
-    /// Const default construction.
-    pub const fn new() -> Self {
-        Self {
-            activate_fails: SharedIncMetric::new(),
-            cfg_fails: SharedIncMetric::new(),
-            rx_queue_event_fails: SharedIncMetric::new(),
-            tx_queue_event_fails: SharedIncMetric::new(),
-            ev_queue_event_fails: SharedIncMetric::new(),
-            muxer_event_fails: SharedIncMetric::new(),
-            conn_event_fails: SharedIncMetric::new(),
-            rx_queue_event_count: SharedIncMetric::new(),
-            tx_queue_event_count: SharedIncMetric::new(),
-            rx_bytes_count: SharedIncMetric::new(),
-            tx_bytes_count: SharedIncMetric::new(),
-            rx_packets_count: SharedIncMetric::new(),
-            tx_packets_count: SharedIncMetric::new(),
-            conns_added: SharedIncMetric::new(),
-            conns_killed: SharedIncMetric::new(),
-            conns_removed: SharedIncMetric::new(),
-            killq_resync: SharedIncMetric::new(),
-            tx_flush_fails: SharedIncMetric::new(),
-            tx_write_fails: SharedIncMetric::new(),
-            rx_read_fails: SharedIncMetric::new(),
-        }
-    }
-}
-
 #[derive(Debug, Default, Serialize)]
 pub struct EntropyDeviceMetrics {
     /// Number of device activation failures
@@ -998,37 +927,29 @@ impl Serialize for SerializeToUtcTimestampMs {
     }
 }
 
-#[derive(Default, Debug)]
-// By using the below structure in FirecrackerMetrics it is easy
-// to serialise Firecracker app_metrics as a single json object which
-// otherwise would have required extra string manipulation to pack
-// block as part of the same json object as FirecrackerMetrics.
-pub struct BlockMetricsSerializeProxy;
+macro_rules! create_serialize_proxy {
+    // By using the below structure in FirecrackerMetrics it is easy
+    // to serialise Firecracker app_metrics as a single json object which
+    // otherwise would have required extra string manipulation to pack
+    // $metric_mod as part of the same json object as FirecrackerMetrics.
+    ($proxy_struct:ident, $metric_mod:ident) => {
+        #[derive(Default, Debug)]
+        pub struct $proxy_struct;
 
-impl Serialize for BlockMetricsSerializeProxy {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        block_metrics::flush_metrics(serializer)
-    }
+        impl Serialize for $proxy_struct {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                $metric_mod::flush_metrics(serializer)
+            }
+        }
+    };
 }
 
-#[derive(Default, Debug)]
-// By using the below structure in FirecrackerMetrics it is easy
-// to serialise Firecracker app_metrics as a single json object which
-// otherwise would have required extra string manipulation to pack
-// net as part of the same json object as FirecrackerMetrics.
-pub struct NetMetricsSerializeProxy;
-
-impl Serialize for NetMetricsSerializeProxy {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        net_metrics::flush_metrics(serializer)
-    }
-}
+create_serialize_proxy!(VsockMetricsSerializeProxy, vsock_metrics);
+create_serialize_proxy!(BlockMetricsSerializeProxy, block_metrics);
+create_serialize_proxy!(NetMetricsSerializeProxy, net_metrics);
 
 /// Structure storing all metrics while enforcing serialization support on them.
 #[derive(Debug, Default, Serialize)]
@@ -1074,7 +995,7 @@ pub struct FirecrackerMetrics {
     /// Metrics related to signals.
     pub signals: SignalMetrics,
     /// Metrics related to virtio-vsockets.
-    pub vsock: VsockDeviceMetrics,
+    pub vsock: vsock_metrics::VsockDeviceMetrics,
     /// Metrics related to virtio-rng entropy device.
     pub entropy: EntropyDeviceMetrics,
 }
@@ -1102,7 +1023,7 @@ impl FirecrackerMetrics {
             vmm: VmmMetrics::new(),
             uart: SerialDeviceMetrics::new(),
             signals: SignalMetrics::new(),
-            vsock: VsockDeviceMetrics::new(),
+            vsock: vsock_metrics::VsockDeviceMetrics::new(),
             entropy: EntropyDeviceMetrics::new(),
         }
     }


### PR DESCRIPTION
## Changes

- Move vsock metrics out of logger to Vsock.
- Add check to test breaking change in vsock metrics.

## Reason

- Net and Block metrics are moved out of logger so to be consistent in having device metrics in their own modules and decouple Vsock metrics from logger.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
- ~[ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
