### PR TITLE
Vhost user blk metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 - [#4063](https://github.com/firecracker-microvm/firecracker/pull/4063):
   Adds source-level instrumentation based tracing. See
   [tracing](./docs/tracing.md) for more details.
+- [#4226](https://github.com/firecracker-microvm/firecracker/pull/4226):
+  Added support for vhost-user device metrics. Each vhost-user device will
+  emit metrics under the label `"vhost_user_{device}_{drive_id}"`.
+  E.g. the associated metrics for vhost-user block device with endpoint
+  `"/drives/rootfs"` will be available under `"vhost_user_block_rootfs"`
+  in the metrics json object.
 
 ### Changed
 

--- a/src/vmm/src/devices/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/mod.rs
@@ -23,6 +23,7 @@ pub mod rng;
 pub mod test_utils;
 pub mod vhost_user;
 pub mod vhost_user_block;
+pub mod vhost_user_metrics;
 pub mod virtio_block;
 pub mod vsock;
 

--- a/src/vmm/src/devices/virtio/vhost_user_block/device.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/device.rs
@@ -24,7 +24,11 @@ use crate::devices::virtio::gen::virtio_blk::{
 use crate::devices::virtio::gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use crate::devices::virtio::queue::Queue;
 use crate::devices::virtio::vhost_user::{VhostUserHandleBackend, VhostUserHandleImpl};
+use crate::devices::virtio::vhost_user_metrics::{
+    VhostUserDeviceMetrics, VhostUserMetricsPerDevice,
+};
 use crate::devices::virtio::{ActivateError, TYPE_BLOCK};
+use crate::logger::{IncMetric, StoreMetric};
 use crate::vmm_config::drive::BlockDeviceConfig;
 use crate::vstate::memory::GuestMemoryMmap;
 
@@ -127,6 +131,7 @@ pub struct VhostUserBlockImpl<T: VhostUserHandleBackend> {
     // Vhost user protocol handle
     pub vu_handle: VhostUserHandleImpl<T>,
     pub vu_acked_protocol_features: u64,
+    pub metrics: Arc<VhostUserDeviceMetrics>,
 }
 
 // Need custom implementation because otherwise `Debug` is required for `vhost::Master`
@@ -151,12 +156,14 @@ impl<T: VhostUserHandleBackend> std::fmt::Debug for VhostUserBlockImpl<T> {
                 "vu_acked_protocol_features",
                 &self.vu_acked_protocol_features,
             )
+            .field("metrics", &self.metrics)
             .finish()
     }
 }
 
 impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
     pub fn new(config: VhostUserBlockConfig) -> Result<Self, VhostUserBlockError> {
+        let start_time = utils::time::get_time_us(utils::time::ClockType::Monotonic);
         let mut requested_features = AVAILABLE_FEATURES;
 
         if config.cache_type == CacheType::Writeback {
@@ -204,6 +211,11 @@ impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
         let avail_features = acked_features;
         let acked_features = acked_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
         let read_only = acked_features & (1 << VIRTIO_BLK_F_RO) != 0;
+        let vhost_user_block_metrics_name = format!("block_{}", config.drive_id);
+
+        let metrics = VhostUserMetricsPerDevice::alloc(vhost_user_block_metrics_name);
+        let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time;
+        metrics.init_time_us.store(delta_us);
 
         Ok(Self {
             avail_features,
@@ -224,6 +236,7 @@ impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
 
             vu_handle,
             vu_acked_protocol_features: acked_protocol_features,
+            metrics,
         })
     }
 
@@ -285,6 +298,7 @@ impl<T: VhostUserHandleBackend + Send + 'static> VirtioDevice for VhostUserBlock
         let config_len = self.config_space.len() as u64;
         if offset >= config_len {
             error!("Failed to read config space");
+            self.metrics.cfg_fails.inc();
             return;
         }
         if let Some(end) = offset.checked_add(data.len() as u64) {
@@ -303,6 +317,7 @@ impl<T: VhostUserHandleBackend + Send + 'static> VirtioDevice for VhostUserBlock
     }
 
     fn activate(&mut self, mem: GuestMemoryMmap) -> Result<(), ActivateError> {
+        let start_time = utils::time::get_time_us(utils::time::ClockType::Monotonic);
         // Setting features again, because now we negotiated them
         // with guest driver as well.
         self.vu_handle
@@ -314,8 +329,13 @@ impl<T: VhostUserHandleBackend + Send + 'static> VirtioDevice for VhostUserBlock
                 &[(0, &self.queues[0], &self.queue_evts[0])],
                 &self.irq_trigger,
             )
-            .map_err(ActivateError::VhostUser)?;
+            .map_err(|err| {
+                self.metrics.activate_fails.inc();
+                ActivateError::VhostUser(err)
+            })?;
         self.device_state = DeviceState::Activated(mem);
+        let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time;
+        self.metrics.activate_time_us.store(delta_us);
         Ok(())
     }
 

--- a/src/vmm/src/devices/virtio/vhost_user_metrics.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_metrics.rs
@@ -1,0 +1,142 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the metrics system for vhost-user devices.
+//!
+//! # Metrics format
+//! The metrics are flushed in JSON when requested by vmm::logger::metrics::METRICS.write().
+//!
+//! ## JSON example with metrics:
+//! ```json
+//! {
+//!  "vhost_user_{mod}_id0": {
+//!     "activate_fails": "SharedIncMetric",
+//!     "cfg_fails": "SharedIncMetric",
+//!     "init_time_us": SharedStoreMetric,
+//!     "activate_time_us": SharedStoreMetric,
+//!  }
+//!  "vhost_user_{mod}_id1": {
+//!     "activate_fails": "SharedIncMetric",
+//!     "cfg_fails": "SharedIncMetric",
+//!     "init_time_us": SharedStoreMetric,
+//!     "activate_time_us": SharedStoreMetric,
+//!  }
+//!  ...
+//!  "vhost_user_{mod}_idN": {
+//!     "activate_fails": "SharedIncMetric",
+//!     "cfg_fails": "SharedIncMetric",
+//!     "init_time_us": SharedStoreMetric,
+//!     "activate_time_us": SharedStoreMetric,
+//!  }
+//! }
+//! ```
+//! Each `vhost_user` field in the example above is a serializable `VhostUserDeviceMetrics`
+//! structure collecting metrics such as `activate_fails`, `cfg_fails`, `init_time_us` and
+//! `activate_time_us` for the vhost_user device.
+//! For vhost-user block device having endpoint "/drives/drv0" the emitted metrics would be
+//! `vhost_user_block_drv0`.
+//! For vhost-user block device having endpoint "/drives/drvN" the emitted metrics would be
+//! `vhost_user_block_drvN`.
+//! Aggregate metrics for `vhost_user` if `not` emitted as it can be easily obtained in
+//! typical observability tools.
+//!
+//! # Design
+//! The main design goals of this system are:
+//! * To improve vhost_user device metrics by logging them at per device granularity.
+//! * `vhost_user` is a new device with no metrics emitted before so, backward compatibility doesn't
+//!   come into picture like it was in the case of block/net devices. And since, metrics can be
+//!   easily aggregated using typical observability tools, we chose not to provide aggregate
+//!   vhost_user metrics.
+//! * Rely on `serde` to provide the actual serialization for writing the metrics.
+//! * Since all metrics start at 0, we implement the `Default` trait via derive for all of them, to
+//!   avoid having to initialize everything by hand.
+//!
+//! * Follow the design of Block and Net device metrics and use a map of vhost_user device name and
+//!   corresponding metrics.
+//! * Metrics are flushed with key `vhost_user_{module_specific_name}` and each module sets an
+//!   appropriate `module_specific_name` in the format `{mod}_{id}`. e.g. vhost-user block device in
+//!   this commit set this as `format!("{}_{}", "block_", config.drive_id.clone());` This way
+//!   vhost_user_metrics stay generic while the specific vhost_user devices can have their unique
+//!   metrics.
+//!
+//! The system implements 2 type of metrics:
+//! * Shared Incremental Metrics (SharedIncMetrics) - dedicated for the metrics which need a counter
+//! (i.e the number of times activating a device failed). These metrics are reset upon flush.
+//! * Shared Store Metrics (SharedStoreMetrics) - are targeted at keeping a persistent value, it is
+//!   `not` intended to act as a counter (i.e for measure the process start up time for example).
+//! We add VhostUserDeviceMetrics entries from vhost_user_metrics::METRICS into vhost_user device
+//! instead of vhost_user device having individual separate VhostUserDeviceMetrics entries because
+//! vhost_user device is not accessible from signal handlers to flush metrics and
+//! vhost_user_metrics::METRICS is.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
+
+use crate::logger::{SharedIncMetric, SharedStoreMetric};
+
+/// map of vhost_user drive id and metrics
+/// this should be protected by a lock before accessing.
+#[allow(missing_debug_implementations)]
+pub struct VhostUserMetricsPerDevice {
+    /// used to access per vhost_user device metrics
+    pub metrics: BTreeMap<String, Arc<VhostUserDeviceMetrics>>,
+}
+
+impl VhostUserMetricsPerDevice {
+    /// Allocate `VhostUserDeviceMetrics` for vhost_user device having
+    /// id `drive_id`. Also, allocate only if it doesn't
+    /// exist to avoid overwriting previously allocated data.
+    /// lock is always initialized so it is safe the unwrap
+    /// the lock without a check.
+    pub fn alloc(drive_id: String) -> Arc<VhostUserDeviceMetrics> {
+        if METRICS.read().unwrap().metrics.get(&drive_id).is_none() {
+            METRICS.write().unwrap().metrics.insert(
+                drive_id.clone(),
+                Arc::new(VhostUserDeviceMetrics::default()),
+            );
+        }
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get(&drive_id)
+            .unwrap()
+            .clone()
+    }
+}
+
+/// Pool of vhost_user-related metrics per device behind a lock to
+/// keep things thread safe. Since the lock is initialized here
+/// it is safe to unwrap it without any check.
+static METRICS: RwLock<VhostUserMetricsPerDevice> = RwLock::new(VhostUserMetricsPerDevice {
+    metrics: BTreeMap::new(),
+});
+
+/// This function facilitates serialization of vhost_user device metrics.
+pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+    let vhost_user_metrics = METRICS.read().unwrap();
+    let metrics_len = vhost_user_metrics.metrics.len();
+    let mut seq = serializer.serialize_map(Some(metrics_len))?;
+
+    for (name, metrics) in vhost_user_metrics.metrics.iter() {
+        let devn = format!("vhost_user_{}", name);
+        seq.serialize_entry(&devn, metrics)?;
+    }
+    seq.end()
+}
+
+/// vhost_user Device associated metrics.
+#[derive(Debug, Default, Serialize)]
+pub struct VhostUserDeviceMetrics {
+    /// Number of times when activate failed on a vhost_user device.
+    pub activate_fails: SharedIncMetric,
+    /// Number of times when interacting with the space config of a vhost-user device failed.
+    pub cfg_fails: SharedIncMetric,
+    // Vhost-user init time in microseconds.
+    pub init_time_us: SharedStoreMetric,
+    // Vhost-user activate time in microseconds.
+    pub activate_time_us: SharedStoreMetric,
+}

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -73,6 +73,7 @@ use vm_superio::rtc_pl031::RtcEvents;
 
 use super::FcLineWriter;
 use crate::devices::virtio::net::metrics as net_metrics;
+use crate::devices::virtio::vhost_user_metrics;
 use crate::devices::virtio::virtio_block::metrics as block_metrics;
 use crate::devices::virtio::vsock::metrics as vsock_metrics;
 #[cfg(target_arch = "aarch64")]
@@ -950,6 +951,7 @@ macro_rules! create_serialize_proxy {
 create_serialize_proxy!(VsockMetricsSerializeProxy, vsock_metrics);
 create_serialize_proxy!(BlockMetricsSerializeProxy, block_metrics);
 create_serialize_proxy!(NetMetricsSerializeProxy, net_metrics);
+create_serialize_proxy!(VhostUserMetricsSerializeProxy, vhost_user_metrics);
 
 /// Structure storing all metrics while enforcing serialization support on them.
 #[derive(Debug, Default, Serialize)]
@@ -999,6 +1001,9 @@ pub struct FirecrackerMetrics {
     pub vsock: VsockMetricsSerializeProxy,
     /// Metrics related to virtio-rng entropy device.
     pub entropy: EntropyDeviceMetrics,
+    #[serde(flatten)]
+    /// Vhost-user device related metrics.
+    pub vhost_user_ser: VhostUserMetricsSerializeProxy,
 }
 impl FirecrackerMetrics {
     /// Const default construction.
@@ -1026,6 +1031,7 @@ impl FirecrackerMetrics {
             signals: SignalMetrics::new(),
             vsock: VsockMetricsSerializeProxy {},
             entropy: EntropyDeviceMetrics::new(),
+            vhost_user_ser: VhostUserMetricsSerializeProxy {},
         }
     }
 }

--- a/tests/host_tools/metrics.py
+++ b/tests/host_tools/metrics.py
@@ -205,221 +205,230 @@ def format_with_reduced_unit(value, unit):
 
     return f"{reduced_value:.2f}{formatted_unit}"
 
-
-FirecrackerMetrics = {
-    "api_server": [
-        "process_startup_time_us",
-        "process_startup_time_cpu_us",
-        "sync_response_fails",
-        "sync_vmm_send_timeout_count",
-    ],
-    "balloon": [
-        "activate_fails",
-        "inflate_count",
-        "stats_updates_count",
-        "stats_update_fails",
-        "deflate_count",
-        "event_fails",
-    ],
-    "block": [
-        "activate_fails",
-        "cfg_fails",
-        "no_avail_buffer",
-        "event_fails",
-        "execute_fails",
-        "invalid_reqs_count",
-        "flush_count",
-        "queue_event_count",
-        "rate_limiter_event_count",
-        "update_count",
-        "update_fails",
-        "read_bytes",
-        "write_bytes",
-        "read_count",
-        "write_count",
-        "rate_limiter_throttled_events",
-        "io_engine_throttled_events",
-    ],
-    "deprecated_api": [
-        "deprecated_http_api_calls",
-        "deprecated_cmd_line_api_calls",
-    ],
-    "get_api_requests": [
-        "instance_info_count",
-        "machine_cfg_count",
-        "mmds_count",
-        "vmm_version_count",
-    ],
-    "i8042": [
-        "error_count",
-        "missed_read_count",
-        "missed_write_count",
-        "read_count",
-        "reset_count",
-        "write_count",
-    ],
-    "latencies_us": [
-        "full_create_snapshot",
-        "diff_create_snapshot",
-        "load_snapshot",
-        "pause_vm",
-        "resume_vm",
-        "vmm_full_create_snapshot",
-        "vmm_diff_create_snapshot",
-        "vmm_load_snapshot",
-        "vmm_pause_vm",
-        "vmm_resume_vm",
-    ],
-    "logger": [
-        "missed_metrics_count",
-        "metrics_fails",
-        "missed_log_count",
-        "log_fails",
-    ],
-    "mmds": [
-        "rx_accepted",
-        "rx_accepted_err",
-        "rx_accepted_unusual",
-        "rx_bad_eth",
-        "rx_count",
-        "tx_bytes",
-        "tx_count",
-        "tx_errors",
-        "tx_frames",
-        "connections_created",
-        "connections_destroyed",
-    ],
-    "net": [
-        "activate_fails",
-        "cfg_fails",
-        "mac_address_updates",
-        "no_rx_avail_buffer",
-        "no_tx_avail_buffer",
-        "event_fails",
-        "rx_queue_event_count",
-        "rx_event_rate_limiter_count",
-        "rx_partial_writes",
-        "rx_rate_limiter_throttled",
-        "rx_tap_event_count",
-        "rx_bytes_count",
-        "rx_packets_count",
-        "rx_fails",
-        "rx_count",
-        "tap_read_fails",
-        "tap_write_fails",
-        "tx_bytes_count",
-        "tx_malformed_frames",
-        "tx_fails",
-        "tx_count",
-        "tx_packets_count",
-        "tx_partial_reads",
-        "tx_queue_event_count",
-        "tx_rate_limiter_event_count",
-        "tx_rate_limiter_throttled",
-        "tx_spoofed_mac_count",
-    ],
-    "patch_api_requests": [
-        "drive_count",
-        "drive_fails",
-        "network_count",
-        "network_fails",
-        "machine_cfg_count",
-        "machine_cfg_fails",
-        "mmds_count",
-        "mmds_fails",
-    ],
-    "put_api_requests": [
-        "actions_count",
-        "actions_fails",
-        "boot_source_count",
-        "boot_source_fails",
-        "drive_count",
-        "drive_fails",
-        "logger_count",
-        "logger_fails",
-        "machine_cfg_count",
-        "machine_cfg_fails",
-        "cpu_cfg_count",
-        "cpu_cfg_fails",
-        "metrics_count",
-        "metrics_fails",
-        "network_count",
-        "network_fails",
-        "mmds_count",
-        "mmds_fails",
-        "vsock_count",
-        "vsock_fails",
-    ],
-    "seccomp": [
-        "num_faults",
-    ],
-    "vcpu": [
-        "exit_io_in",
-        "exit_io_out",
-        "exit_mmio_read",
-        "exit_mmio_write",
-        "failures",
-    ],
-    "vmm": [
-        "device_events",
-        "panic_count",
-    ],
-    "uart": [
-        "error_count",
-        "flush_count",
-        "missed_read_count",
-        "missed_write_count",
-        "read_count",
-        "write_count",
-    ],
-    "signals": [
-        "sigbus",
-        "sigsegv",
-        "sigxfsz",
-        "sigxcpu",
-        "sigpipe",
-        "sighup",
-        "sigill",
-    ],
-    "vsock": [
-        "activate_fails",
-        "cfg_fails",
-        "rx_queue_event_fails",
-        "tx_queue_event_fails",
-        "ev_queue_event_fails",
-        "muxer_event_fails",
-        "conn_event_fails",
-        "rx_queue_event_count",
-        "tx_queue_event_count",
-        "rx_bytes_count",
-        "tx_bytes_count",
-        "rx_packets_count",
-        "tx_packets_count",
-        "conns_added",
-        "conns_killed",
-        "conns_removed",
-        "killq_resync",
-        "tx_flush_fails",
-        "tx_write_fails",
-        "rx_read_fails",
-    ],
-    "entropy": [
-        "activate_fails",
-        "entropy_event_fails",
-        "entropy_event_count",
-        "entropy_bytes",
-        "host_rng_fails",
-        "entropy_rate_limiter_throttled",
-        "rate_limiter_event_count",
-    ],
-}
-
-
 def validate_fc_metrics(metrics):
     """
     This functions makes sure that all components
     of FirecrackerMetrics struct are present.
     """
+
+
+    FirecrackerMetrics = {
+        "api_server": [
+            "process_startup_time_us",
+            "process_startup_time_cpu_us",
+            "sync_response_fails",
+            "sync_vmm_send_timeout_count",
+        ],
+        "balloon": [
+            "activate_fails",
+            "inflate_count",
+            "stats_updates_count",
+            "stats_update_fails",
+            "deflate_count",
+            "event_fails",
+        ],
+        "block": [
+            "activate_fails",
+            "cfg_fails",
+            "no_avail_buffer",
+            "event_fails",
+            "execute_fails",
+            "invalid_reqs_count",
+            "flush_count",
+            "queue_event_count",
+            "rate_limiter_event_count",
+            "update_count",
+            "update_fails",
+            "read_bytes",
+            "write_bytes",
+            "read_count",
+            "write_count",
+            "rate_limiter_throttled_events",
+            "io_engine_throttled_events",
+        ],
+        "deprecated_api": [
+            "deprecated_http_api_calls",
+            "deprecated_cmd_line_api_calls",
+        ],
+        "get_api_requests": [
+            "instance_info_count",
+            "machine_cfg_count",
+            "mmds_count",
+            "vmm_version_count",
+        ],
+        "i8042": [
+            "error_count",
+            "missed_read_count",
+            "missed_write_count",
+            "read_count",
+            "reset_count",
+            "write_count",
+        ],
+        "latencies_us": [
+            "full_create_snapshot",
+            "diff_create_snapshot",
+            "load_snapshot",
+            "pause_vm",
+            "resume_vm",
+            "vmm_full_create_snapshot",
+            "vmm_diff_create_snapshot",
+            "vmm_load_snapshot",
+            "vmm_pause_vm",
+            "vmm_resume_vm",
+        ],
+        "logger": [
+            "missed_metrics_count",
+            "metrics_fails",
+            "missed_log_count",
+            "log_fails",
+        ],
+        "mmds": [
+            "rx_accepted",
+            "rx_accepted_err",
+            "rx_accepted_unusual",
+            "rx_bad_eth",
+            "rx_count",
+            "tx_bytes",
+            "tx_count",
+            "tx_errors",
+            "tx_frames",
+            "connections_created",
+            "connections_destroyed",
+        ],
+        "net": [
+            "activate_fails",
+            "cfg_fails",
+            "mac_address_updates",
+            "no_rx_avail_buffer",
+            "no_tx_avail_buffer",
+            "event_fails",
+            "rx_queue_event_count",
+            "rx_event_rate_limiter_count",
+            "rx_partial_writes",
+            "rx_rate_limiter_throttled",
+            "rx_tap_event_count",
+            "rx_bytes_count",
+            "rx_packets_count",
+            "rx_fails",
+            "rx_count",
+            "tap_read_fails",
+            "tap_write_fails",
+            "tx_bytes_count",
+            "tx_malformed_frames",
+            "tx_fails",
+            "tx_count",
+            "tx_packets_count",
+            "tx_partial_reads",
+            "tx_queue_event_count",
+            "tx_rate_limiter_event_count",
+            "tx_rate_limiter_throttled",
+            "tx_spoofed_mac_count",
+        ],
+        "patch_api_requests": [
+            "drive_count",
+            "drive_fails",
+            "network_count",
+            "network_fails",
+            "machine_cfg_count",
+            "machine_cfg_fails",
+            "mmds_count",
+            "mmds_fails",
+        ],
+        "put_api_requests": [
+            "actions_count",
+            "actions_fails",
+            "boot_source_count",
+            "boot_source_fails",
+            "drive_count",
+            "drive_fails",
+            "logger_count",
+            "logger_fails",
+            "machine_cfg_count",
+            "machine_cfg_fails",
+            "cpu_cfg_count",
+            "cpu_cfg_fails",
+            "metrics_count",
+            "metrics_fails",
+            "network_count",
+            "network_fails",
+            "mmds_count",
+            "mmds_fails",
+            "vsock_count",
+            "vsock_fails",
+        ],
+        "seccomp": [
+            "num_faults",
+        ],
+        "vcpu": [
+            "exit_io_in",
+            "exit_io_out",
+            "exit_mmio_read",
+            "exit_mmio_write",
+            "failures",
+        ],
+        "vmm": [
+            "device_events",
+            "panic_count",
+        ],
+        "uart": [
+            "error_count",
+            "flush_count",
+            "missed_read_count",
+            "missed_write_count",
+            "read_count",
+            "write_count",
+        ],
+        "signals": [
+            "sigbus",
+            "sigsegv",
+            "sigxfsz",
+            "sigxcpu",
+            "sigpipe",
+            "sighup",
+            "sigill",
+        ],
+        "vsock": [
+            "activate_fails",
+            "cfg_fails",
+            "rx_queue_event_fails",
+            "tx_queue_event_fails",
+            "ev_queue_event_fails",
+            "muxer_event_fails",
+            "conn_event_fails",
+            "rx_queue_event_count",
+            "tx_queue_event_count",
+            "rx_bytes_count",
+            "tx_bytes_count",
+            "rx_packets_count",
+            "tx_packets_count",
+            "conns_added",
+            "conns_killed",
+            "conns_removed",
+            "killq_resync",
+            "tx_flush_fails",
+            "tx_write_fails",
+            "rx_read_fails",
+        ],
+        "entropy": [
+            "activate_fails",
+            "entropy_event_fails",
+            "entropy_event_count",
+            "entropy_bytes",
+            "host_rng_fails",
+            "entropy_rate_limiter_throttled",
+            "rate_limiter_event_count",
+        ],
+    }
+
+    # validate timestamp before jsonschema validation which some more time
+    utc_time = datetime.datetime.now(datetime.timezone.utc)
+    utc_timestamp_ms = math.floor(utc_time.timestamp() * 1000)
+
+    # Assert that the absolute difference is less than 1 second, to check that
+    # the reported utc_timestamp_ms is actually a UTC timestamp from the Unix
+    # Epoch.Regression test for:
+    # https://github.com/firecracker-microvm/firecracker/issues/2639
+    assert abs(utc_timestamp_ms - metrics["utc_timestamp_ms"]) < 1000
 
     if platform.machine() == "aarch64":
         FirecrackerMetrics["rtc"] = [
@@ -447,37 +456,33 @@ def validate_fc_metrics(metrics):
 
     jsonschema.validate(instance=metrics, schema=firecracker_metrics_schema)
 
-    # remove some metrics and confirm that fields and not just top level metrics
-    # are validated.
-    temp_pop_metrics = metrics["api_server"].pop("process_startup_time_us")
-    try:
-        jsonschema.validate(instance=metrics, schema=firecracker_metrics_schema)
-    except jsonschema.exceptions.ValidationError as error:
-        if error.message.strip() == "'process_startup_time_us' is a required property":
-            pass
-        else:
-            raise error
-    metrics["api_server"]["process_startup_time_us"] = temp_pop_metrics
-
-    if platform.machine() == "aarch64":
-        temp_pop_metrics = metrics["rtc"].pop("error_count")
+    def validate_missing_metrics(metrics):
+        # remove some metrics and confirm that fields and not just top level metrics
+        # are validated.
+        temp_pop_metrics = metrics["api_server"].pop("process_startup_time_us")
         try:
             jsonschema.validate(instance=metrics, schema=firecracker_metrics_schema)
         except jsonschema.exceptions.ValidationError as error:
-            if error.message.strip() == "'error_count' is a required property":
+            if (
+                error.message.strip()
+                == "'process_startup_time_us' is a required property"
+            ):
                 pass
             else:
                 raise error
-        metrics["rtc"]["error_count"] = temp_pop_metrics
+        metrics["api_server"]["process_startup_time_us"] = temp_pop_metrics
 
-    utc_time = datetime.datetime.now(datetime.timezone.utc)
-    utc_timestamp_ms = math.floor(utc_time.timestamp() * 1000)
-
-    # Assert that the absolute difference is less than 1 second, to check that
-    # the reported utc_timestamp_ms is actually a UTC timestamp from the Unix
-    # Epoch.Regression test for:
-    # https://github.com/firecracker-microvm/firecracker/issues/2639
-    assert abs(utc_timestamp_ms - metrics["utc_timestamp_ms"]) < 1000
+        if platform.machine() == "aarch64":
+            temp_pop_metrics = metrics["rtc"].pop("error_count")
+            try:
+                jsonschema.validate(instance=metrics, schema=firecracker_metrics_schema)
+            except jsonschema.exceptions.ValidationError as error:
+                if error.message.strip() == "'error_count' is a required property":
+                    pass
+                else:
+                    raise error
+            metrics["rtc"]["error_count"] = temp_pop_metrics
+    validate_missing_metrics(metrics)
 
 
 class FcDeviceMetrics:
@@ -502,7 +507,6 @@ class FcDeviceMetrics:
         # make sure "{self.name}" is aggregate of "{self.name}_*"
         # and that there are only {num_dev} entries of "{self.name}_*"
         self.validate_aggregation(fc_metrics)
-        print(f"\nsuccessfully validated aggregate of {self.dev_name} metrics")
 
     def validate_aggregation(self, fc_metrics):
         """
@@ -511,14 +515,13 @@ class FcDeviceMetrics:
         metrics_aggregate = fc_metrics[self.dev_name]
         metrics_calculated = {}
         actual_num_devices = 0
-        print(f"In aggregation of {self.dev_name} expected {self.num_dev=}")
         for component_metric_names, component_metric_values in fc_metrics.items():
             if f"{self.dev_name}_" in component_metric_names:
-                print(f"found {component_metric_names} during aggr of {self.dev_name}")
                 actual_num_devices += 1
                 for metrics_name, metric_value in component_metric_values.items():
                     if metrics_name not in metrics_calculated:
                         metrics_calculated[metrics_name] = 0
                     metrics_calculated[metrics_name] += metric_value
+
         assert metrics_aggregate == metrics_calculated
         assert self.num_dev == actual_num_devices


### PR DESCRIPTION
## Changes

- Add below metrics for vhost user device: 
    1. to report activate failures.
    2. to report failure to read config space.
    3. to report time taken to init the device in micro seconds.
    4. to report time taken to activate the device in micro seconds.
- Add test to validate breaking change in vhost device metrics.

## Reason

Vhost user block is a new device which doesn't have any metrics.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
