### PR TITLE
doc: clean up limitation section on the main readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,6 @@ We test all combinations of:
 
 ## Known issues and Limitations
 
-- If a CPU template is not used on x86_64, overwrites of `MSR_IA32_TSX_CTRL` MSR
-  value will not be preserved after restoring from a snapshot.
 - The `pl031` RTC device on aarch64 does not support interrupts, so guest
   programs which use an RTC alarm (e.g. `hwclock`) will not work.
 - Issues and limitations related to snapshots are described in a [separate document](docs/snapshotting/snapshot-support.md#limitations).

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ We test all combinations of:
 
 - The `pl031` RTC device on aarch64 does not support interrupts, so guest
   programs which use an RTC alarm (e.g. `hwclock`) will not work.
-- Issues and limitations related to snapshots are described in a [separate document](docs/snapshotting/snapshot-support.md#limitations).
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,6 @@ We test all combinations of:
 
 ## Known issues and Limitations
 
-- The [SendCtrlAltDel](docs/api_requests/actions.md#sendctrlaltdel) API request
-  is not supported for aarch64 enabled microVMs.
 - If a CPU template is not used on x86_64, overwrites of `MSR_IA32_TSX_CTRL` MSR
   value will not be preserved after restoring from a snapshot.
 - The `pl031` RTC device on aarch64 does not support interrupts, so guest

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -149,6 +149,9 @@ The snapshot functionality is still in developer preview due to the following:
   Please see [Vsock device limitation](#vsock-device-limitation).
 - Snapshotting on arm64 works for both GICv2 and GICv3 enabled guests.
   However, restoring between different GIC version is not possible.
+- If a [CPU template](../cpu_templates/cpu-templates.md) is not used on x86_64,
+  overwrites of `MSR_IA32_TSX_CTRL` MSR value will not be preserved after
+  restoring from a snapshot.
 
 ## Firecracker Snapshotting characteristics
 


### PR DESCRIPTION
## Changes

Re(move) topic-specific issues and limitations from the main README page.
Only one limitation remains there that does not have a better location as of now.

## Reason

We have a number of topic-specific limitations listed on the main README page that cause confusion about where a new limitation needs to be added, to the main README or elsewhere.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- ~[ ] All added/changed functionality is tested.~
- ~[ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
