### PR TITLE
Disable CPU idle states when running performance tests in CI

### DIFF
--- a/.buildkite/pipeline_ab.py
+++ b/.buildkite/pipeline_ab.py
@@ -62,7 +62,7 @@ def build_group(test):
     test_path = test.pop("test_path")
     return group(
         label=test.pop("label"),
-        command=f"./tools/devtool -y test --ab {devtool_opts} -- {REVISION_A} {REVISION_B} --test {test_path}",
+        command=f"./tools/devtool -y test --performance --ab {devtool_opts} -- {REVISION_A} {REVISION_B} --test {test_path}",
         artifacts=["./test_results/*"],
         instances=test.pop("instances"),
         platforms=test.pop("platforms"),

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -6,6 +6,11 @@
 
 from common import COMMON_PARSER, group, overlay_dict, pipeline_to_json
 
+# In `devtool_opts`, we restrict both the set of CPUs on which the docker container's threads can run,
+# and its memory node. For the cpuset, we pick a continuous set of CPUs from a single NUMA node
+# that is large enough so that every firecracker thread can get its own core. We exclude core #0, as
+# the operating system sometimes uses it for book-keeping tasks. The memory node (-m parameter)
+# has to be the node associated with the NUMA node from which we picked CPUs.
 perf_test = {
     "virtio-block": {
         "label": "🖴 Virtio Block Performance",

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -57,7 +57,7 @@ def build_group(test):
     retries = test.pop("retries")
     return group(
         label=test.pop("label"),
-        command=f"./tools/devtool -y test {devtool_opts} -- -m nonci --reruns {retries} --perf-fail {test_path}",
+        command=f"./tools/devtool -y test --performance {devtool_opts} -- -m nonci --reruns {retries} --perf-fail {test_path}",
         artifacts=["./test_results/*"],
         instances=test.pop("instances"),
         platforms=test.pop("platforms"),

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -77,7 +77,7 @@ defaults_for_performance = overlay_dict(
 
 performance_grp = group(
     "⏱ Performance",
-    "./tools/devtool -y test -c 1-10 -m 0 -- ../tests/integration_tests/performance/",
+    "./tools/devtool -y test --performance -c 1-10 -m 0 -- ../tests/integration_tests/performance/",
     **defaults_for_performance,
 )
 

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -77,7 +77,7 @@ defaults_for_performance = overlay_dict(
 
 performance_grp = group(
     "⏱ Performance",
-    "./tools/devtool -y test -- ../tests/integration_tests/performance/",
+    "./tools/devtool -y test -c 1-10 -m 0 -- ../tests/integration_tests/performance/",
     **defaults_for_performance,
 )
 

--- a/.buildkite/pipeline_pr_no_block.py
+++ b/.buildkite/pipeline_pr_no_block.py
@@ -33,7 +33,7 @@ defaults = overlay_dict(defaults, args.step_param)
 
 optional_grp = group(
     "❓ Optional",
-    "./tools/devtool -y test -c 1-10 -m 0 -- ../tests/integration_tests/ -m 'no_block_pr and not nonci' --log-cli-level=INFO",
+    "./tools/devtool -y test --performance -c 1-10 -m 0 -- ../tests/integration_tests/ -m 'no_block_pr and not nonci' --log-cli-level=INFO",
     **defaults,
 )
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -456,6 +456,24 @@ class Microvm:
             return True
         return False
 
+    def pin_threads(self, first_cpu):
+        """
+        Pins all microvm threads (VMM, API and vCPUs) to consecutive physical cpu core, starting with "first_cpu"
+        """
+        for vcpu, pcpu in enumerate(range(first_cpu, first_cpu + self.vcpus_count)):
+            assert self.pin_vcpu(
+                vcpu, pcpu
+            ), f"Failed to pin fc_vcpu {vcpu} thread to core {pcpu}."
+        # The cores first_cpu,...,first_cpu + self.vcpus_count - 1 are assigned to the individual vCPU threads,
+        # So the remaining two threads (VMM and API) get first_cpu + self.vcpus_count
+        # and first_cpu + self.vcpus_count + 1
+        assert self.pin_vmm(
+            first_cpu + self.vcpus_count
+        ), "Failed to pin firecracker thread."
+        assert self.pin_api(
+            first_cpu + self.vcpus_count + 1
+        ), "Failed to pin fc_api thread."
+
     def spawn(
         self,
         log_file="fc.log",

--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -166,12 +166,7 @@ def test_block_performance(
     )
     vm.add_drive("scratch", fs.path, io_engine=io_engine)
     vm.start()
-
-    # Pin uVM threads to physical cores.
-    assert vm.pin_vmm(0), "Failed to pin firecracker thread."
-    assert vm.pin_api(1), "Failed to pin fc_api thread."
-    for i in range(vm.vcpus_count):
-        assert vm.pin_vcpu(i, i + 2), f"Failed to pin fc_vcpu {i} thread."
+    vm.pin_threads(0)
 
     logs_dir, cpu_load = run_fio(vm, fio_mode, fio_block_size)
 
@@ -225,13 +220,9 @@ def test_block_vhost_user_performance(
     backend = spawn_vhost_user_backend(vm, fs.path, vhost_user_socket, readonly=False)
     vm.add_vhost_user_drive("scratch", vhost_user_socket)
     vm.start()
+    vm.pin_threads(0)
 
-    # Pin uVM threads to physical cores.
-    assert vm.pin_vmm(0), "Failed to pin firecracker thread."
-    assert vm.pin_api(1), "Failed to pin fc_api thread."
-    pin_backend(backend, 2)
-    for i in range(vm.vcpus_count):
-        assert vm.pin_vcpu(i, i + 3), f"Failed to pin fc_vcpu {i} thread."
+    pin_backend(backend, vm.vcpus_count + 2)
 
     logs_dir, cpu_load = run_fio(vm, fio_mode, fio_block_size)
 

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -152,6 +152,7 @@ def _configure_and_run_vm(microvm, network=False, initrd=False):
     if network:
         microvm.add_net_iface()
     microvm.start()
+    microvm.pin_threads(0)
 
 
 def find_events(log_data):
@@ -202,6 +203,7 @@ def test_boottime(
         )
         vm.add_net_iface()
         vm.start()
+        vm.pin_threads(0)
         boottime_us = _get_microvm_boottime(vm)
         metrics.put_metric("boot_time", boottime_us, unit="Microseconds")
         timestamps = find_events(vm.log_data)

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -54,12 +54,7 @@ def network_microvm(request, microvm_factory, guest_kernel, rootfs):
     vm.basic_config(vcpu_count=request.param, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()
     vm.start()
-
-    # Pin uVM threads to physical cores.
-    assert vm.pin_vmm(0), "Failed to pin firecracker thread."
-    assert vm.pin_api(1), "Failed to pin fc_api thread."
-    for i in range(vm.vcpus_count):
-        assert vm.pin_vcpu(i, i + 2), f"Failed to pin fc_vcpu {i} thread."
+    vm.pin_threads(0)
 
     return vm
 

--- a/tests/integration_tests/performance/test_vsock_ab.py
+++ b/tests/integration_tests/performance/test_vsock_ab.py
@@ -92,12 +92,7 @@ def test_vsock_throughput(
     # Create a vsock device
     vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path="/" + VSOCK_UDS_PATH)
     vm.start()
-
-    # Pin uVM threads to physical cores.
-    assert vm.pin_vmm(0), "Failed to pin firecracker thread."
-    assert vm.pin_api(1), "Failed to pin fc_api thread."
-    for i in range(vm.vcpus_count):
-        assert vm.pin_vcpu(i, i + 2), f"Failed to pin fc_vcpu {i} thread."
+    vm.pin_threads(0)
 
     test = VsockIPerf3Test(vm, mode, payload_length)
     data = test.run_test(vm.vcpus_count + 2)

--- a/tools/devtool
+++ b/tools/devtool
@@ -582,9 +582,22 @@ apply_linux_61_tweaks() {
 
 
 apply_performance_tweaks() {
-  # Disable turbo boost. Some of our tests are performance tests, and we want minimum variability wrt processor frequency
-  # See also https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html
-  echo 1 |sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo &> /dev/null
+  # m6a instances do not support the amd_pstate driver (yet), so nothing we can do there
+  if [[ -d /sys/devices/system/cpu/intel_pstate ]]; then
+    # Disable turbo boost. Some of our tests are performance tests, and we want minimum variability wrt processor frequency
+    # See also https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html
+    echo 1 |sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo &> /dev/null
+
+    # Save old values to restore later
+    MIN_PERF_PCT=$(cat /sys/devices/system/cpu/intel_pstate/min_perf_pct)
+    MAX_PERF_PCT=$(cat /sys/devices/system/cpu/intel_pstate/max_perf_pct)
+
+    # Force the CPU to continuously stay in the highest, non-turbo P-state. The P-state will determine the
+    # CPU's clock frequency.
+    # https://www.kernel.org/doc/html/v4.12/admin-guide/pm/intel_pstate.html
+    echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/min_perf_pct
+    echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct
+  fi
 
   # The governor is a linux component that can adjust CPU frequency. "performance" tells it to always run CPUs at
   # their maximum safe frequency. It seems to be the default for Amazon Linux, but it doesn't hurt to make this explicit.
@@ -602,14 +615,20 @@ apply_performance_tweaks() {
 }
 
 unapply_performance_tweaks() {
-  # reenable turbo boost
-  echo 0 |sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo &> /dev/null
+  if [[ -d /sys/devices/system/cpu/intel_pstate ]]; then
+    # reenable turbo boost
+    echo 0 |sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo &> /dev/null
+
+    # restore p-state limits
+    echo $MIN_PERF_PCT |sudo tee /sys/devices/system/cpu/intel_pstate/min_perf_pct &> /dev/null
+    echo $MAX_PERF_PCT |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct &> /dev/null
+  fi
+
+  # reenable deeper sleep states
+  echo 0 | sudo tee /sys/devices/system/cpu/cpu*/cpuidle/state*/disable &>/dev/null
 
   # We do not reset the governor, as keeping track of each CPUs configured governor is not trivial here. On our CI
   # instances, the performance governor is current the default anyway (2023/11/14)
-
-  # reenable deeper sleep states
-  echo 0 |sudo tee /sys/devices/system/cpu/cpu*/cpuidle/state*/disable &> /dev/null
 }
 
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -581,6 +581,38 @@ apply_linux_61_tweaks() {
 }
 
 
+apply_performance_tweaks() {
+  # Disable turbo boost. Some of our tests are performance tests, and we want minimum variability wrt processor frequency
+  # See also https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html
+  echo 1 |sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo &> /dev/null
+
+  # The governor is a linux component that can adjust CPU frequency. "performance" tells it to always run CPUs at
+  # their maximum safe frequency. It seems to be the default for Amazon Linux, but it doesn't hurt to make this explicit.
+  # See also https://wiki.archlinux.org/title/CPU_frequency_scaling
+  echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor &> /dev/null
+
+  # When a CPU core has nothing to do, it enters an idle state, also called "C-state". These are enumerated, with C0
+  # being the shallowest idle state (corresponding to "currently executing instructions", aka "not actually idling"),
+  # and higher numbers being deeper sleep states (how many there are depends on the specific processor). The deeper
+  # a C-state a CPU core enters, the higher the latency to wake it up again. We can disable deeper C-states altogether
+  # by forcing each CPU core to constantly stay in C-0 (e.g. have them actively poll for new things to do).
+  # See also https://www.kernel.org/doc/html/v5.0/admin-guide/pm/cpuidle.html.
+  # The below also set "disable=1" on "state0", but this does not do anything (as disabling C-0 makes no sense).
+  echo 1 |sudo tee /sys/devices/system/cpu/cpu*/cpuidle/state*/disable &> /dev/null
+}
+
+unapply_performance_tweaks() {
+  # reenable turbo boost
+  echo 0 |sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo &> /dev/null
+
+  # We do not reset the governor, as keeping track of each CPUs configured governor is not trivial here. On our CI
+  # instances, the performance governor is current the default anyway (2023/11/14)
+
+  # reenable deeper sleep states
+  echo 0 |sudo tee /sys/devices/system/cpu/cpu*/cpuidle/state*/disable &> /dev/null
+}
+
+
 # `$0 test` - run integration tests
 # Please see `$0 help` for more information.
 #
@@ -621,26 +653,19 @@ cmd_test() {
     say "Kernel version: $(uname -r)"
     say "$(sed '/^processor.*: 0$/,/^processor.*: 1$/!d; /^processor.*: 1$/d' /proc/cpuinfo)"
     say "RPM microcode_ctl version: $(rpm -q microcode_ctl)"
-    say "Starting test run ..."
 
     # Testing (running Firecracker via the jailer) needs root access,
     # in order to set-up the Firecracker jail (manipulating cgroups, net
     # namespaces, etc).
     # We need to run a privileged container to get that kind of access.
     env |grep -P "^(AWS_EMF_|BUILDKITE|CODECOV_)" > env.list
+    if [[ "$BUILDKITE" == "true" ]] && [[ "$(uname --machine)" == "x86_64" ]]; then
+      say "Detected CI and performance tests, tuning CPU frequency scaling and idle states for reduced variability"
 
-    if [[ "$BUILDKITE" = "true" ]]; then
-      # Disable turbo boost. Some of our tests are performance tests, and we want minimum variability wrt processor frequency
-      # See also https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html
-      sudo sh -c "echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo" &> /dev/null
-
-      # The governor is a linux component that can adjust CPU frequency. "performance" tells it to always run CPUs at
-      # their maximum safe frequency. It seems to be the default for Amazon Linux, but it doesn't hurt to make this explicit.
-      # See also https://wiki.archlinux.org/title/CPU_frequency_scaling
-      sudo sh -c "echo "performance" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor" &> /dev/null
-
-      say "Detected CI, tuning CPU frequency scaling for reduced variability"
+      apply_performance_tweaks
     fi
+
+    say "Starting test run ..."
 
     test_script="./tools/test.sh"
 
@@ -668,6 +693,11 @@ cmd_test() {
     # Running as root would have created some root-owned files under the build
     # dir. Let's fix that.
     cmd_fix_perms
+
+    # undo performance tweaks (in case the instance gets recycled for a non-perf test)
+    if [[ "$BUILDKITE" == "true" ]] && [[ "$(uname --machine)" == "x86_64" ]]; then
+      unapply_performance_tweaks
+    fi
 
     # do not leave behind env.list file
     rm env.list

--- a/tools/devtool
+++ b/tools/devtool
@@ -603,7 +603,7 @@ apply_performance_tweaks() {
     # https://www.kernel.org/doc/html/v4.12/admin-guide/pm/intel_pstate.html
     echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/min_perf_pct &> /dev/null
     echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct &> /dev/null
-  elif [[ -f /sys/devices/system/cpu/cpufreq/boost ]]; then
+  elif [[ -f /sys/devices/system/cpu/cpufreq/boost ]] && [ ! $(uname -r | grep 4.14) ]; then
     echo 0 |sudo tee /sys/devices/system/cpu/cpufreq/boost &> /dev/null
   fi
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -583,6 +583,7 @@ apply_linux_61_tweaks() {
 
 # Modifies the processors C- and P-state configuration (x86_64 only) for consistent performance. This means
 # - Disable turbo boost (Intel only) by writing 1 to /sys/devices/system/cpu/intel_pstate/no_turbo
+# - Disable turbo boost (AMD only) by writing 0 to /sys/devices/system/cpu/cpufreq/boost
 # - Lock the CPUs' P-state to the highest non-turbo one (Intel only) by writing 100 to /sys/devices/system/cpu/intel_pstate/{min,max}_perf_pct
 # - Disable all idle C-states, meaning all CPu cores will idle by polling (busy looping) by writing 1 to /sys/devices/system/cpu/cpu*/cpuidle/state*/disable
 # - Set the cpu frequency governor to performance by writing "performance" to /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
@@ -600,8 +601,10 @@ apply_performance_tweaks() {
     # Force the CPU to continuously stay in the highest, non-turbo P-state. The P-state will determine the
     # CPU's clock frequency.
     # https://www.kernel.org/doc/html/v4.12/admin-guide/pm/intel_pstate.html
-    echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/min_perf_pct
-    echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct
+    echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/min_perf_pct &> /dev/null
+    echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct &> /dev/null
+  elif [[ -f /sys/devices/system/cpu/cpufreq/boost ]]; then
+    echo 0 |sudo tee /sys/devices/system/cpu/cpufreq/boost &> /dev/null
   fi
 
   # The governor is a linux component that can adjust CPU frequency. "performance" tells it to always run CPUs at
@@ -627,6 +630,8 @@ unapply_performance_tweaks() {
     # restore p-state limits
     echo $MIN_PERF_PCT |sudo tee /sys/devices/system/cpu/intel_pstate/min_perf_pct &> /dev/null
     echo $MAX_PERF_PCT |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct &> /dev/null
+  elif [[ -f /sys/devices/system/cpu/cpufreq/boost ]]; then
+    echo 1 | sudo tee /sys/devices/system/cpu/cpufreq/boost &> /dev/null
   fi
 
   # reenable deeper sleep states

--- a/tools/devtool
+++ b/tools/devtool
@@ -686,10 +686,6 @@ cmd_test() {
     say "$(sed '/^processor.*: 0$/,/^processor.*: 1$/!d; /^processor.*: 1$/d' /proc/cpuinfo)"
     say "RPM microcode_ctl version: $(rpm -q microcode_ctl)"
 
-    # Testing (running Firecracker via the jailer) needs root access,
-    # in order to set-up the Firecracker jail (manipulating cgroups, net
-    # namespaces, etc).
-    # We need to run a privileged container to get that kind of access.
     env |grep -P "^(AWS_EMF_|BUILDKITE|CODECOV_)" > env.list
     if [[ $performance_tweaks -eq 1 ]] && [[ "$(uname --machine)" == "x86_64" ]]; then
       say "Detected CI and performance tests, tuning CPU frequency scaling and idle states for reduced variability"
@@ -705,6 +701,10 @@ cmd_test() {
       test_script="./tools/ab_test.py"
     fi
 
+    # Testing (running Firecracker via the jailer) needs root access,
+    # in order to set-up the Firecracker jail (manipulating cgroups, net
+    # namespaces, etc).
+    # We need to run a privileged container to get that kind of access.
     run_devctr \
         --privileged \
         --security-opt seccomp=unconfined \

--- a/tools/devtool
+++ b/tools/devtool
@@ -581,6 +581,11 @@ apply_linux_61_tweaks() {
 }
 
 
+# Modifies the processors C- and P-state configuration (x86_64 only) for consistent performance. This means
+# - Disable turbo boost (Intel only) by writing 1 to /sys/devices/system/cpu/intel_pstate/no_turbo
+# - Lock the CPUs' P-state to the highest non-turbo one (Intel only) by writing 100 to /sys/devices/system/cpu/intel_pstate/{min,max}_perf_pct
+# - Disable all idle C-states, meaning all CPu cores will idle by polling (busy looping) by writing 1 to /sys/devices/system/cpu/cpu*/cpuidle/state*/disable
+# - Set the cpu frequency governor to performance by writing "performance" to /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 apply_performance_tweaks() {
   # m6a instances do not support the amd_pstate driver (yet), so nothing we can do there
   if [[ -d /sys/devices/system/cpu/intel_pstate ]]; then
@@ -649,6 +654,9 @@ cmd_test() {
                 shift
                 local cpuset_mems="$1"
                 ;;
+            "--performance")
+                local performance_tweaks=1;
+                ;;
             "--ab")
                 do_ab_test=1
                 ;;
@@ -678,7 +686,7 @@ cmd_test() {
     # namespaces, etc).
     # We need to run a privileged container to get that kind of access.
     env |grep -P "^(AWS_EMF_|BUILDKITE|CODECOV_)" > env.list
-    if [[ "$BUILDKITE" == "true" ]] && [[ "$(uname --machine)" == "x86_64" ]]; then
+    if [[ $performance_tweaks -eq 1 ]] && [[ "$(uname --machine)" == "x86_64" ]]; then
       say "Detected CI and performance tests, tuning CPU frequency scaling and idle states for reduced variability"
 
       apply_performance_tweaks
@@ -714,7 +722,7 @@ cmd_test() {
     cmd_fix_perms
 
     # undo performance tweaks (in case the instance gets recycled for a non-perf test)
-    if [[ "$BUILDKITE" == "true" ]] && [[ "$(uname --machine)" == "x86_64" ]]; then
+    if [[ $performance_tweaks -eq 1 ]] && [[ "$(uname --machine)" == "x86_64" ]]; then
       unapply_performance_tweaks
     fi
 


### PR DESCRIPTION
## Changes

- Disable idle states when running performance tests in CI
- Limit P-states to the highest p-state at which the processor can continuously operate safely.
- Disable turbo boost also on non-intel instances (if they support turbo boost in the first place)

## Reason

Consolidate performance tweaks in one location

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
