### PR TITLE
fix(test/perf/block): several minor fixes

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -8,13 +8,13 @@ from common import COMMON_PARSER, group, overlay_dict, pipeline_to_json
 
 perf_test = {
     "virtio-block": {
-        "label": "🖴 Block Performance",
+        "label": "🖴 Virtio Block Performance",
         "test_path": "integration_tests/performance/test_block_performance.py::test_block_performance",
         "devtool_opts": "-c 1-10 -m 0",
         "timeout_in_minutes": 240,
     },
     "vhost-user-block": {
-        "label": "🖴 Block Performance",
+        "label": "🖴 Vhost-user Block Performance",
         "test_path": "integration_tests/performance/test_block_performance.py::test_block_vhost_user_performance",
         "devtool_opts": "-c 1-10 -m 0",
         "timeout_in_minutes": 240,

--- a/tests/framework/utils_drive.py
+++ b/tests/framework/utils_drive.py
@@ -46,7 +46,7 @@ def spawn_vhost_user_backend(vm, host_mem_path, socket_path, readonly=False):
     uid = vm.jailer.uid
     gid = vm.jailer.gid
 
-    sp = f"{vm.chroot()}{socket_path}"
+    sp = f"{vm.chroot()}/{socket_path}"
     args = ["vhost-user-blk", "-s", sp, "-b", host_mem_path]
     if readonly:
         args.append("-r")

--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -223,7 +223,7 @@ def test_block_vhost_user_performance(
     # Add a secondary block device for benchmark tests.
     fs = drive_tools.FilesystemFile(size=BLOCK_DEVICE_SIZE_MB)
     backend = spawn_vhost_user_backend(vm, fs.path, vhost_user_socket, readonly=False)
-    vm.add_vhost_user_block("scratch", vhost_user_socket)
+    vm.add_vhost_user_drive("scratch", vhost_user_socket)
     vm.start()
 
     # Pin uVM threads to physical cores.

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -370,7 +370,7 @@ def test_block_vhost_user_performance(
     # Add a secondary block device for benchmark tests.
     fs = drive_tools.FilesystemFile(size=BLOCK_DEVICE_SIZE_MB)
     backend = spawn_vhost_user_backend(vm, fs.path, VHOST_USER_SOCKET, readonly=False)
-    vm.add_vhost_user_block("scratch", VHOST_USER_SOCKET)
+    vm.add_vhost_user_drive("scratch", VHOST_USER_SOCKET)
     vm.start()
 
     # Get names of threads in Firecracker.


### PR DESCRIPTION
## Changes

- Use correct name `add_vhost_user_drive()` in the test instead of the old name `add_vhost_user_block()`.
- Fix socket path
- Use different names for pipeline groups

## Reason

- The method name has changed in https://github.com/firecracker-microvm/firecracker/commit/1c3c411133375fd3a69cbaf42cca09fdc44090ec, but was not updated in a parallel PR during a rebase.
- Incorrect socket path
- Same name for 2 BK pipeline groups

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- ~[ ] Any required documentation changes (code and docs) are included in this PR.~
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
- ~[ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
