### PR TITLE
Refactor devmetrics

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -50,8 +50,6 @@ use crate::devices::virtio::net::Net;
 use crate::devices::virtio::rng::Entropy;
 use crate::devices::virtio::vsock::{Vsock, VsockUnixBackend};
 use crate::devices::BusDevice;
-#[cfg(target_arch = "aarch64")]
-use crate::logger;
 use crate::logger::{debug, error};
 use crate::persist::{MicrovmState, MicrovmStateError};
 use crate::resources::VmResources;
@@ -711,7 +709,9 @@ fn attach_legacy_devices_aarch64(
             .map_err(VmmError::RegisterMMIODevice)?;
     }
 
-    let rtc = RTCDevice(Rtc::with_events(&logger::METRICS.rtc));
+    let rtc = RTCDevice(Rtc::with_events(
+        &crate::devices::legacy::rtc_pl031::METRICS,
+    ));
     vmm.mmio_device_manager
         .register_mmio_rtc(rtc, None)
         .map_err(VmmError::RegisterMMIODevice)

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -44,8 +44,6 @@ use crate::devices::virtio::vsock::{
     Vsock, VsockError, VsockUnixBackend, VsockUnixBackendError, TYPE_VSOCK,
 };
 use crate::devices::virtio::{TYPE_BALLOON, TYPE_BLOCK, TYPE_NET, TYPE_RNG};
-#[cfg(target_arch = "aarch64")]
-use crate::logger;
 use crate::mmds::data_store::MmdsVersion;
 use crate::resources::VmResources;
 use crate::vmm_config::mmds::MmdsConfigError;
@@ -428,7 +426,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                 }
                 if state.type_ == DeviceType::Rtc {
                     let rtc = crate::devices::legacy::RTCDevice(vm_superio::Rtc::with_events(
-                        &logger::METRICS.rtc,
+                        &crate::devices::legacy::rtc_pl031::METRICS,
                     ));
                     dev_manager
                         .address_allocator

--- a/src/vmm/src/devices/legacy/mod.rs
+++ b/src/vmm/src/devices/legacy/mod.rs
@@ -14,6 +14,8 @@ pub mod serial;
 use std::io;
 use std::ops::Deref;
 
+use serde::ser::SerializeMap;
+use serde::Serializer;
 use utils::eventfd::EventFd;
 use vm_superio::Trigger;
 
@@ -60,4 +62,11 @@ impl EventFdTrigger {
     pub fn get_event(&self) -> EventFd {
         self.0.try_clone().unwrap()
     }
+}
+
+/// Called by METRICS.flush(), this function facilitates serialization of aggregated metrics.
+pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+    let mut seq = serializer.serialize_map(Some(1))?;
+    seq.serialize_entry("i8042", &i8042::METRICS)?;
+    seq.end()
 }

--- a/src/vmm/src/devices/legacy/mod.rs
+++ b/src/vmm/src/devices/legacy/mod.rs
@@ -70,5 +70,6 @@ pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     seq.serialize_entry("i8042", &i8042::METRICS)?;
     #[cfg(target_arch = "aarch64")]
     seq.serialize_entry("rtc", &rtc_pl031::METRICS)?;
+    seq.serialize_entry("uart", &serial::METRICS)?;
     seq.end()
 }

--- a/src/vmm/src/devices/legacy/mod.rs
+++ b/src/vmm/src/devices/legacy/mod.rs
@@ -8,7 +8,7 @@
 //! Implements legacy devices (UART, RTC etc).
 mod i8042;
 #[cfg(target_arch = "aarch64")]
-mod rtc_pl031;
+pub mod rtc_pl031;
 pub mod serial;
 
 use std::io;
@@ -68,5 +68,7 @@ impl EventFdTrigger {
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let mut seq = serializer.serialize_map(Some(1))?;
     seq.serialize_entry("i8042", &i8042::METRICS)?;
+    #[cfg(target_arch = "aarch64")]
+    seq.serialize_entry("rtc", &rtc_pl031::METRICS)?;
     seq.end()
 }

--- a/src/vmm/src/devices/mod.rs
+++ b/src/vmm/src/devices/mod.rs
@@ -20,7 +20,7 @@ use log::error;
 use crate::devices::virtio::net::metrics::NetDeviceMetrics;
 use crate::devices::virtio::queue::QueueError;
 use crate::devices::virtio::vsock::VsockError;
-use crate::logger::{IncMetric, METRICS};
+use crate::logger::IncMetric;
 
 // Function used for reporting error in terms of logging
 // but also in terms of metrics of net event fails.
@@ -29,11 +29,6 @@ use crate::logger::{IncMetric, METRICS};
 pub(crate) fn report_net_event_fail(net_iface_metrics: &NetDeviceMetrics, err: DeviceError) {
     error!("{:?}", err);
     net_iface_metrics.event_fails.inc();
-}
-
-pub(crate) fn report_balloon_event_fail(err: virtio::balloon::BalloonError) {
-    error!("{:?}", err);
-    METRICS.balloon.event_fails.inc();
 }
 
 #[derive(Debug)]

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -16,6 +16,7 @@ use utils::u64_to_usize;
 use super::super::device::{DeviceState, VirtioDevice};
 use super::super::queue::Queue;
 use super::super::{ActivateError, TYPE_BALLOON};
+use super::metrics::METRICS;
 use super::util::{compact_page_frame_numbers, remove_range};
 use super::{
     BALLOON_DEV_ID, BALLOON_NUM_QUEUES, BALLOON_QUEUE_SIZES, DEFLATE_INDEX, INFLATE_INDEX,
@@ -29,7 +30,7 @@ use super::{
 use crate::devices::virtio::balloon::BalloonError;
 use crate::devices::virtio::device::{IrqTrigger, IrqType};
 use crate::devices::virtio::gen::virtio_blk::VIRTIO_F_VERSION_1;
-use crate::logger::{IncMetric, METRICS};
+use crate::logger::IncMetric;
 use crate::vstate::memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
 
 const SIZE_OF_U32: usize = std::mem::size_of::<u32>();
@@ -285,7 +286,7 @@ impl Balloon {
     pub(crate) fn process_inflate(&mut self) -> Result<(), BalloonError> {
         // This is safe since we checked in the event handler that the device is activated.
         let mem = self.device_state.mem().unwrap();
-        METRICS.balloon.inflate_count.inc();
+        METRICS.inflate_count.inc();
 
         let queue = &mut self.queues[INFLATE_INDEX];
         // The pfn buffer index used during descriptor processing.
@@ -376,7 +377,7 @@ impl Balloon {
     pub(crate) fn process_deflate_queue(&mut self) -> Result<(), BalloonError> {
         // This is safe since we checked in the event handler that the device is activated.
         let mem = self.device_state.mem().unwrap();
-        METRICS.balloon.deflate_count.inc();
+        METRICS.deflate_count.inc();
 
         let queue = &mut self.queues[DEFLATE_INDEX];
         let mut needs_interrupt = false;
@@ -398,7 +399,7 @@ impl Balloon {
     pub(crate) fn process_stats_queue(&mut self) -> Result<(), BalloonError> {
         // This is safe since we checked in the event handler that the device is activated.
         let mem = self.device_state.mem().unwrap();
-        METRICS.balloon.stats_updates_count.inc();
+        METRICS.stats_updates_count.inc();
 
         while let Some(head) = self.queues[STATS_INDEX].pop(mem) {
             if let Some(prev_stats_desc) = self.stats_desc_index {
@@ -422,7 +423,7 @@ impl Balloon {
                     .read_obj::<BalloonStat>(addr)
                     .map_err(|_| BalloonError::MalformedDescriptor)?;
                 self.latest_stats.update_with_stat(&stat).map_err(|_| {
-                    METRICS.balloon.stats_update_fails.inc();
+                    METRICS.stats_update_fails.inc();
                     BalloonError::MalformedPayload
                 })?;
             }
@@ -435,7 +436,7 @@ impl Balloon {
 
     pub(crate) fn signal_used_queue(&self) -> Result<(), BalloonError> {
         self.irq_trigger.trigger_irq(IrqType::Vring).map_err(|err| {
-            METRICS.balloon.event_fails.inc();
+            METRICS.event_fails.inc();
             BalloonError::InterruptError(err)
         })
     }
@@ -628,7 +629,7 @@ impl VirtioDevice for Balloon {
         self.device_state = DeviceState::Activated(mem);
         if self.activate_evt.write(1).is_err() {
             error!("Balloon: Cannot write to activate_evt");
-            METRICS.balloon.activate_fails.inc();
+            METRICS.activate_fails.inc();
             self.device_state = DeviceState::Inactive;
             return Err(ActivateError::BadActivate);
         }
@@ -918,7 +919,7 @@ pub(crate) mod tests {
             );
 
             check_metric_after_block!(
-                METRICS.balloon.event_fails,
+                METRICS.event_fails,
                 1,
                 balloon
                     .process_inflate_queue_event()
@@ -945,7 +946,7 @@ pub(crate) mod tests {
             );
 
             check_metric_after_block!(
-                METRICS.balloon.inflate_count,
+                METRICS.inflate_count,
                 1,
                 invoke_handler_for_queue_event(&mut balloon, INFLATE_INDEX)
             );
@@ -978,7 +979,7 @@ pub(crate) mod tests {
                 VIRTQ_DESC_F_NEXT,
             );
             check_metric_after_block!(
-                METRICS.balloon.event_fails,
+                METRICS.event_fails,
                 1,
                 balloon
                     .process_deflate_queue_event()
@@ -998,7 +999,7 @@ pub(crate) mod tests {
                 VIRTQ_DESC_F_NEXT,
             );
             check_metric_after_block!(
-                METRICS.balloon.deflate_count,
+                METRICS.deflate_count,
                 1,
                 invoke_handler_for_queue_event(&mut balloon, DEFLATE_INDEX)
             );
@@ -1026,7 +1027,7 @@ pub(crate) mod tests {
                 VIRTQ_DESC_F_NEXT,
             );
             check_metric_after_block!(
-                METRICS.balloon.event_fails,
+                METRICS.event_fails,
                 1,
                 balloon
                     .process_stats_queue_event()
@@ -1063,7 +1064,7 @@ pub(crate) mod tests {
                 2 * u32::try_from(SIZE_OF_STAT).unwrap(),
                 VIRTQ_DESC_F_NEXT,
             );
-            check_metric_after_block!(METRICS.balloon.stats_updates_count, 1, {
+            check_metric_after_block!(METRICS.stats_updates_count, 1, {
                 // Trigger the queue event.
                 balloon.queue_events()[STATS_INDEX].write(1).unwrap();
                 balloon.process_stats_queue_event().unwrap();
@@ -1082,7 +1083,7 @@ pub(crate) mod tests {
             // we could just process the timer event and it would not
             // return an error.
             std::thread::sleep(Duration::from_secs(1));
-            check_metric_after_block!(METRICS.balloon.event_fails, 0, {
+            check_metric_after_block!(METRICS.event_fails, 0, {
                 // Trigger the timer event, which consumes the stats
                 // descriptor index and signals the used queue.
                 assert!(balloon.stats_desc_index.is_some());

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -652,7 +652,7 @@ pub(crate) mod tests {
     use super::super::BALLOON_CONFIG_SPACE_SIZE;
     use super::*;
     use crate::check_metric_after_block;
-    use crate::devices::report_balloon_event_fail;
+    use crate::devices::virtio::balloon::report_balloon_event_fail;
     use crate::devices::virtio::balloon::test_utils::{
         check_request_completion, invoke_handler_for_queue_event, set_request,
     };

--- a/src/vmm/src/devices/virtio/balloon/event_handler.rs
+++ b/src/vmm/src/devices/virtio/balloon/event_handler.rs
@@ -6,8 +6,7 @@ use std::os::unix::io::AsRawFd;
 use event_manager::{EventOps, Events, MutEventSubscriber};
 use utils::epoll::EventSet;
 
-use super::{DEFLATE_INDEX, INFLATE_INDEX, STATS_INDEX};
-use crate::devices::report_balloon_event_fail;
+use super::{report_balloon_event_fail, DEFLATE_INDEX, INFLATE_INDEX, STATS_INDEX};
 use crate::devices::virtio::balloon::device::Balloon;
 use crate::devices::virtio::device::VirtioDevice;
 use crate::logger::{error, warn};

--- a/src/vmm/src/devices/virtio/balloon/metrics.rs
+++ b/src/vmm/src/devices/virtio/balloon/metrics.rs
@@ -1,0 +1,98 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the metrics system for balloon devices.
+//!
+//! # Metrics format
+//! The metrics are flushed in JSON when requested by vmm::logger::metrics::METRICS.write().
+//!
+//! ## JSON example with metrics:
+//! ```json
+//!  "balloon": {
+//!     "activate_fails": "SharedIncMetric",
+//!     "inflate_count": "SharedIncMetric",
+//!     "stats_updates_count": "SharedIncMetric",
+//!     ...
+//!  }
+//! }
+//! ```
+//! Each `balloon` field in the example above is a serializable `BalloonDeviceMetrics` structure
+//! collecting metrics such as `activate_fails`, `inflate_count` etc. for the balloon device.
+//! Since balloon doesn't support multiple devices, there is no per device metrics and
+//! `balloon` represents the aggregate balloon metrics.
+//!
+//! # Design
+//! The main design goals of this system are:
+//! * Have a consistent approach of keeping device related metrics in the individual devices
+//!   modules.
+//! * To decouple balloon device metrics from logger module by moving BalloonDeviceMetrics out of
+//!   FirecrackerDeviceMetrics.
+//! * Rely on `serde` to provide the actual serialization for writing the metrics.
+//!
+//! The system implements 1 type of metrics:
+//! * Shared Incremental Metrics (SharedIncMetrics) - dedicated for the metrics which need a counter
+//! (i.e the number of times an API request failed). These metrics are reset upon flush.
+
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
+
+use crate::logger::SharedIncMetric;
+
+/// Stores aggregated balloon metrics
+pub(super) static METRICS: BalloonDeviceMetrics = BalloonDeviceMetrics::new();
+
+/// Called by METRICS.flush(), this function facilitates serialization of balloon device metrics.
+pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+    let mut seq = serializer.serialize_map(Some(1))?;
+    seq.serialize_entry("balloon", &METRICS)?;
+    seq.end()
+}
+
+/// Balloon Device associated metrics.
+#[derive(Debug, Serialize)]
+pub(super) struct BalloonDeviceMetrics {
+    /// Number of times when activate failed on a balloon device.
+    pub activate_fails: SharedIncMetric,
+    /// Number of balloon device inflations.
+    pub inflate_count: SharedIncMetric,
+    // Number of balloon statistics updates from the driver.
+    pub stats_updates_count: SharedIncMetric,
+    // Number of balloon statistics update failures.
+    pub stats_update_fails: SharedIncMetric,
+    /// Number of balloon device deflations.
+    pub deflate_count: SharedIncMetric,
+    /// Number of times when handling events on a balloon device failed.
+    pub event_fails: SharedIncMetric,
+}
+impl BalloonDeviceMetrics {
+    /// Const default construction.
+    const fn new() -> Self {
+        Self {
+            activate_fails: SharedIncMetric::new(),
+            inflate_count: SharedIncMetric::new(),
+            stats_updates_count: SharedIncMetric::new(),
+            stats_update_fails: SharedIncMetric::new(),
+            deflate_count: SharedIncMetric::new(),
+            event_fails: SharedIncMetric::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::logger::IncMetric;
+
+    #[test]
+    fn test_balloon_dev_metrics() {
+        let balloon_metrics: BalloonDeviceMetrics = BalloonDeviceMetrics::new();
+        let balloon_metrics_local: String = serde_json::to_string(&balloon_metrics).unwrap();
+        // the 1st serialize flushes the metrics and resets values to 0 so that
+        // we can compare the values with local metrics.
+        serde_json::to_string(&METRICS).unwrap();
+        let balloon_metrics_global: String = serde_json::to_string(&METRICS).unwrap();
+        assert_eq!(balloon_metrics_local, balloon_metrics_global);
+        balloon_metrics.inflate_count.inc();
+        assert_eq!(balloon_metrics.inflate_count.count(), 1);
+    }
+}

--- a/src/vmm/src/devices/virtio/balloon/mod.rs
+++ b/src/vmm/src/devices/virtio/balloon/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod device;
 mod event_handler;
+pub mod metrics;
 pub mod persist;
 pub mod test_utils;
 mod util;
@@ -14,8 +15,9 @@ use vm_memory::GuestMemoryError;
 
 pub use self::device::{Balloon, BalloonConfig, BalloonStats};
 use super::queue::QueueError;
+use crate::devices::virtio::balloon::metrics::METRICS;
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
-use crate::logger::{IncMetric, METRICS};
+use crate::logger::IncMetric;
 
 /// Device ID used in MMIO device identification.
 /// Because Balloon is unique per-vm, this ID can be hardcoded.
@@ -109,5 +111,5 @@ pub enum RemoveRegionError {
 
 pub(super) fn report_balloon_event_fail(err: BalloonError) {
     error!("{:?}", err);
-    METRICS.balloon.event_fails.inc();
+    METRICS.event_fails.inc();
 }

--- a/src/vmm/src/devices/virtio/balloon/mod.rs
+++ b/src/vmm/src/devices/virtio/balloon/mod.rs
@@ -9,11 +9,13 @@ pub mod persist;
 pub mod test_utils;
 mod util;
 
+use log::error;
 use vm_memory::GuestMemoryError;
 
 pub use self::device::{Balloon, BalloonConfig, BalloonStats};
 use super::queue::QueueError;
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
+use crate::logger::{IncMetric, METRICS};
 
 /// Device ID used in MMIO device identification.
 /// Because Balloon is unique per-vm, this ID can be hardcoded.
@@ -103,4 +105,9 @@ pub enum RemoveRegionError {
     MadviseFail(std::io::Error),
     MmapFail(std::io::Error),
     RegionNotFound,
+}
+
+pub(super) fn report_balloon_event_fail(err: BalloonError) {
+    error!("{:?}", err);
+    METRICS.balloon.event_fails.inc();
 }

--- a/src/vmm/src/devices/virtio/rng/metrics.rs
+++ b/src/vmm/src/devices/virtio/rng/metrics.rs
@@ -1,0 +1,100 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the metrics system for entropy devices.
+//!
+//! # Metrics format
+//! The metrics are flushed in JSON when requested by vmm::logger::metrics::METRICS.write().
+//!
+//! ## JSON example with metrics:
+//! ```json
+//!  "entropy": {
+//!     "activate_fails": "SharedIncMetric",
+//!     "entropy_event_fails": "SharedIncMetric",
+//!     "entropy_event_count": "SharedIncMetric",
+//!     ...
+//!  }
+//! }
+//! ```
+//! Each `entropy` field in the example above is a serializable `EntropyDeviceMetrics` structure
+//! collecting metrics such as `activate_fails`, `entropy_event_fails` etc. for the entropy device.
+//! Since entropy doesn't support multiple devices, there is no per device metrics and
+//! `entropy` represents the aggregate entropy metrics.
+//!
+//! # Design
+//! The main design goals of this system are:
+//! * Have a consistent approach of keeping device related metrics in the individual devices
+//!   modules.
+//! * To decouple entropy device metrics from logger module by moving EntropyDeviceMetrics out of
+//!   FirecrackerDeviceMetrics.
+//! * Rely on `serde` to provide the actual serialization for writing the metrics.
+//!
+//! The system implements 1 type of metrics:
+//! * Shared Incremental Metrics (SharedIncMetrics) - dedicated for the metrics which need a counter
+//! (i.e the number of times an API request failed). These metrics are reset upon flush.
+
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
+
+use crate::logger::SharedIncMetric;
+
+/// Stores aggregated entropy metrics
+pub(super) static METRICS: EntropyDeviceMetrics = EntropyDeviceMetrics::new();
+
+/// Called by METRICS.flush(), this function facilitates serialization of entropy device metrics.
+pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+    let mut seq = serializer.serialize_map(Some(1))?;
+    seq.serialize_entry("entropy", &METRICS)?;
+    seq.end()
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct EntropyDeviceMetrics {
+    /// Number of device activation failures
+    pub activate_fails: SharedIncMetric,
+    /// Number of entropy queue event handling failures
+    pub entropy_event_fails: SharedIncMetric,
+    /// Number of entropy requests handled
+    pub entropy_event_count: SharedIncMetric,
+    /// Number of entropy bytes provided to guest
+    pub entropy_bytes: SharedIncMetric,
+    /// Number of errors while getting random bytes on host
+    pub host_rng_fails: SharedIncMetric,
+    /// Number of times an entropy request was rate limited
+    pub entropy_rate_limiter_throttled: SharedIncMetric,
+    /// Number of events associated with the rate limiter
+    pub rate_limiter_event_count: SharedIncMetric,
+}
+impl EntropyDeviceMetrics {
+    /// Const default construction.
+    const fn new() -> Self {
+        Self {
+            activate_fails: SharedIncMetric::new(),
+            entropy_event_fails: SharedIncMetric::new(),
+            entropy_event_count: SharedIncMetric::new(),
+            entropy_bytes: SharedIncMetric::new(),
+            host_rng_fails: SharedIncMetric::new(),
+            entropy_rate_limiter_throttled: SharedIncMetric::new(),
+            rate_limiter_event_count: SharedIncMetric::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::logger::IncMetric;
+
+    #[test]
+    fn test_entropy_dev_metrics() {
+        let entropy_metrics: EntropyDeviceMetrics = EntropyDeviceMetrics::new();
+        let entropy_metrics_local: String = serde_json::to_string(&entropy_metrics).unwrap();
+        // the 1st serialize flushes the metrics and resets values to 0 so that
+        // we can compare the values with local metrics.
+        serde_json::to_string(&METRICS).unwrap();
+        let entropy_metrics_global: String = serde_json::to_string(&METRICS).unwrap();
+        assert_eq!(entropy_metrics_local, entropy_metrics_global);
+        entropy_metrics.entropy_event_count.inc();
+        assert_eq!(entropy_metrics.entropy_event_count.count(), 1);
+    }
+}

--- a/src/vmm/src/devices/virtio/rng/mod.rs
+++ b/src/vmm/src/devices/virtio/rng/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod device;
 mod event_handler;
+pub mod metrics;
 pub mod persist;
 
 pub use self::device::{Entropy, EntropyError};

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -656,36 +656,6 @@ impl SeccompMetrics {
     }
 }
 
-/// Metrics specific to the UART device.
-#[derive(Debug, Default, Serialize)]
-pub struct SerialDeviceMetrics {
-    /// Errors triggered while using the UART device.
-    pub error_count: SharedIncMetric,
-    /// Number of flush operations.
-    pub flush_count: SharedIncMetric,
-    /// Number of read calls that did not trigger a read.
-    pub missed_read_count: SharedIncMetric,
-    /// Number of write calls that did not trigger a write.
-    pub missed_write_count: SharedIncMetric,
-    /// Number of succeeded read calls.
-    pub read_count: SharedIncMetric,
-    /// Number of succeeded write calls.
-    pub write_count: SharedIncMetric,
-}
-impl SerialDeviceMetrics {
-    /// Const default construction.
-    pub const fn new() -> Self {
-        Self {
-            error_count: SharedIncMetric::new(),
-            flush_count: SharedIncMetric::new(),
-            missed_read_count: SharedIncMetric::new(),
-            missed_write_count: SharedIncMetric::new(),
-            read_count: SharedIncMetric::new(),
-            write_count: SharedIncMetric::new(),
-        }
-    }
-}
-
 /// Metrics related to signals.
 /// Deadly signals must be of `SharedStoreMetric` type, since they can ever be either 0 or 1.
 /// This avoids a tricky race condition caused by the unatomic serialize method of
@@ -852,8 +822,6 @@ pub struct FirecrackerMetrics {
     pub vcpu: VcpuMetrics,
     /// Metrics related to the virtual machine manager.
     pub vmm: VmmMetrics,
-    /// Metrics related to the UART device.
-    pub uart: SerialDeviceMetrics,
     /// Metrics related to signals.
     pub signals: SignalMetrics,
     #[serde(flatten)]
@@ -886,7 +854,6 @@ impl FirecrackerMetrics {
             seccomp: SeccompMetrics::new(),
             vcpu: VcpuMetrics::new(),
             vmm: VmmMetrics::new(),
-            uart: SerialDeviceMetrics::new(),
             signals: SignalMetrics::new(),
             vsock: VsockMetricsSerializeProxy {},
             entropy_ser: EntropyMetricsSerializeProxy {},

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -826,7 +826,7 @@ pub struct FirecrackerMetrics {
     pub signals: SignalMetrics,
     #[serde(flatten)]
     /// Metrics related to virtio-vsockets.
-    pub vsock: VsockMetricsSerializeProxy,
+    pub vsock_ser: VsockMetricsSerializeProxy,
     #[serde(flatten)]
     /// Metrics related to virtio-rng entropy device.
     pub entropy_ser: EntropyMetricsSerializeProxy,
@@ -855,7 +855,7 @@ impl FirecrackerMetrics {
             vcpu: VcpuMetrics::new(),
             vmm: VmmMetrics::new(),
             signals: SignalMetrics::new(),
-            vsock: VsockMetricsSerializeProxy {},
+            vsock_ser: VsockMetricsSerializeProxy {},
             entropy_ser: EntropyMetricsSerializeProxy {},
             vhost_user_ser: VhostUserMetricsSerializeProxy {},
         }

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -72,6 +72,7 @@ use serde::{Serialize, Serializer};
 use vm_superio::rtc_pl031::RtcEvents;
 
 use super::FcLineWriter;
+use crate::devices::virtio::balloon::metrics as balloon_metrics;
 use crate::devices::virtio::net::metrics as net_metrics;
 use crate::devices::virtio::vhost_user_metrics;
 use crate::devices::virtio::rng::metrics as entropy_metrics;
@@ -525,36 +526,6 @@ impl DeprecatedApiMetrics {
     }
 }
 
-/// Balloon Device associated metrics.
-#[derive(Debug, Default, Serialize)]
-pub struct BalloonDeviceMetrics {
-    /// Number of times when activate failed on a balloon device.
-    pub activate_fails: SharedIncMetric,
-    /// Number of balloon device inflations.
-    pub inflate_count: SharedIncMetric,
-    // Number of balloon statistics updates from the driver.
-    pub stats_updates_count: SharedIncMetric,
-    // Number of balloon statistics update failures.
-    pub stats_update_fails: SharedIncMetric,
-    /// Number of balloon device deflations.
-    pub deflate_count: SharedIncMetric,
-    /// Number of times when handling events on a balloon device failed.
-    pub event_fails: SharedIncMetric,
-}
-impl BalloonDeviceMetrics {
-    /// Const default construction.
-    pub const fn new() -> Self {
-        Self {
-            activate_fails: SharedIncMetric::new(),
-            inflate_count: SharedIncMetric::new(),
-            stats_updates_count: SharedIncMetric::new(),
-            stats_update_fails: SharedIncMetric::new(),
-            deflate_count: SharedIncMetric::new(),
-            event_fails: SharedIncMetric::new(),
-        }
-    }
-}
-
 /// Metrics specific to the i8042 device.
 #[derive(Debug, Default, Serialize)]
 pub struct I8042DeviceMetrics {
@@ -917,11 +888,12 @@ macro_rules! create_serialize_proxy {
     };
 }
 
-create_serialize_proxy!(VsockMetricsSerializeProxy, vsock_metrics);
 create_serialize_proxy!(BlockMetricsSerializeProxy, block_metrics);
 create_serialize_proxy!(NetMetricsSerializeProxy, net_metrics);
 create_serialize_proxy!(VhostUserMetricsSerializeProxy, vhost_user_metrics);
+create_serialize_proxy!(BalloonMetricsSerializeProxy, balloon_metrics);
 create_serialize_proxy!(EntropyMetricsSerializeProxy, entropy_metrics);
+create_serialize_proxy!(VsockMetricsSerializeProxy, vsock_metrics);
 
 /// Structure storing all metrics while enforcing serialization support on them.
 #[derive(Debug, Default, Serialize)]
@@ -929,8 +901,9 @@ pub struct FirecrackerMetrics {
     utc_timestamp_ms: SerializeToUtcTimestampMs,
     /// API Server related metrics.
     pub api_server: ApiServerMetrics,
+    #[serde(flatten)]
     /// A balloon device's related metrics.
-    pub balloon: BalloonDeviceMetrics,
+    pub balloon_ser: BalloonMetricsSerializeProxy,
     #[serde(flatten)]
     /// A block device's related metrics.
     pub block_ser: BlockMetricsSerializeProxy,
@@ -982,7 +955,7 @@ impl FirecrackerMetrics {
         Self {
             utc_timestamp_ms: SerializeToUtcTimestampMs::new(),
             api_server: ApiServerMetrics::new(),
-            balloon: BalloonDeviceMetrics::new(),
+            balloon_ser: BalloonMetricsSerializeProxy {},
             block_ser: BlockMetricsSerializeProxy {},
             deprecated_api: DeprecatedApiMetrics::new(),
             get_api_requests: GetRequestsMetrics::new(),

--- a/src/vmm/src/logger/mod.rs
+++ b/src/vmm/src/logger/mod.rs
@@ -15,8 +15,8 @@ pub use logging::{
     DEFAULT_INSTANCE_ID, DEFAULT_LEVEL, INSTANCE_ID, LOGGER,
 };
 pub use metrics::{
-    IncMetric, MetricsError, ProcessTimeReporter, SerialDeviceMetrics, SharedIncMetric,
-    SharedStoreMetric, StoreMetric, METRICS,
+    IncMetric, MetricsError, ProcessTimeReporter, SharedIncMetric, SharedStoreMetric, StoreMetric,
+    METRICS,
 };
 
 /// Alias for `std::io::LineWriter<std::fs::File>`.

--- a/src/vmm/src/logger/mod.rs
+++ b/src/vmm/src/logger/mod.rs
@@ -14,8 +14,6 @@ pub use logging::{
     LevelFilter, LevelFilterFromStrError, LoggerConfig, LoggerInitError, LoggerUpdateError,
     DEFAULT_INSTANCE_ID, DEFAULT_LEVEL, INSTANCE_ID, LOGGER,
 };
-#[cfg(target_arch = "aarch64")]
-pub use metrics::RTCDeviceMetrics;
 pub use metrics::{
     IncMetric, MetricsError, ProcessTimeReporter, SerialDeviceMetrics, SharedIncMetric,
     SharedStoreMetric, StoreMetric, METRICS,


### PR DESCRIPTION
## Changes

Move Virtio and legacy device metrics out of logger to their respective modules.

## Reason

To be consistent in approach to move device metrics to their own modules.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
