### PR TITLE
test(perf): omit randwrite test for vhost-user-blk

### DIFF
--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -198,7 +198,7 @@ def pin_backend(backend, cpu_id: int):
 
 @pytest.mark.nonci
 @pytest.mark.parametrize("vcpus", [1, 2], ids=["1vcpu", "2vcpu"])
-@pytest.mark.parametrize("fio_mode", ["randread", "randwrite"])
+@pytest.mark.parametrize("fio_mode", ["randread"])
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_block_vhost_user_performance(
     microvm_factory,

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -348,7 +348,7 @@ def pin_backend(backend, cpu_id: int):
 @pytest.mark.nonci
 @pytest.mark.timeout(RUNTIME_SEC * 1000)  # 1.40 hours
 @pytest.mark.parametrize("vcpus", [1, 2], ids=["1vcpu", "2vcpu"])
-@pytest.mark.parametrize("fio_mode", ["randread", "randwrite"])
+@pytest.mark.parametrize("fio_mode", ["randread"])
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_block_vhost_user_performance(
     microvm_factory,


### PR DESCRIPTION
## Changes

Omit randwrite test for vhost-user-blk and leave only randread.

## Reason

Qemu vhost-user-blk backend uses O_DIRECT when accessing the block file.
Retrieving randwrite metric for this test does not represent significant value, because it is unlikely to be used in production setups due to low performance.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- ~[ ] Any required documentation changes (code and docs) are included in this PR.~
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- ~[ ] All added/changed functionality is tested.~
- ~[ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
