### PR TITLE
Fixes to handle more instances with existing CPUs

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -25,7 +25,7 @@ def select_supported_kernels():
     hlv = packaging.version.parse(global_props.host_linux_version)
     supported_kernels = [r"vmlinux-4.14.\d+"]
     if (
-        global_props.instance == "c7g.metal"
+        global_props.cpu_model == "ARM_NEOVERSE_V1"
         and global_props.host_linux_version == "4.14"
     ):
         supported_kernels.append(r"vmlinux-5.10-no-sve.bin")
@@ -33,7 +33,7 @@ def select_supported_kernels():
         supported_kernels.append(r"vmlinux-5.10.\d+")
 
     # Support Linux 6.1 guest in a limited fashion
-    if global_props.instance == "c7g.metal" and (hlv.major, hlv.minor) >= (6, 1):
+    if global_props.cpu_model == "ARM_NEOVERSE_V1" and (hlv.major, hlv.minor) >= (6, 1):
         supported_kernels.append(r"vmlinux-6.1.\d+")
 
     return supported_kernels

--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -26,8 +26,8 @@ def get_supported_cpu_templates():
     match cpuid_utils.get_cpu_vendor():
         case cpuid_utils.CpuVendor.INTEL:
             # T2CL template is only supported on Cascade Lake and newer CPUs.
-            skylake_model = "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz"
-            if global_props.cpu_model == skylake_model:
+
+            if global_props.cpu_codename == cpuid_utils.CpuModel.INTEL_SKYLAKE:
                 return sorted(set(INTEL_TEMPLATES) - set(["T2CL"]))
             return INTEL_TEMPLATES
         case cpuid_utils.CpuVendor.AMD:

--- a/tests/framework/utils_cpuid.py
+++ b/tests/framework/utils_cpuid.py
@@ -33,6 +33,7 @@ class CpuModel(str, Enum):
 CPU_DICT = {
     CpuVendor.INTEL: {
         "Intel(R) Xeon(R) Platinum 8175M CPU": "INTEL_SKYLAKE",
+        "Intel(R) Xeon(R) Platinum 8124M CPU": "INTEL_SKYLAKE",
         "Intel(R) Xeon(R) Platinum 8259CL CPU": "INTEL_CASCADELAKE",
         "Intel(R) Xeon(R) Platinum 8375C CPU": "INTEL_ICELAKE",
     },


### PR DESCRIPTION
## Changes

Changes to depend less on exact instances and more on the CPU model.

## Reason

This is useful to make the tests work in other instances that have the same CPUs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
