### PR TITLE
doc: Add kernel pre-requisites for vsock

### DIFF
--- a/docs/vsock.md
+++ b/docs/vsock.md
@@ -17,6 +17,22 @@ Firecracker, check out the [getting started guide](getting-started.md).
 Familiarity with socket programming, in particular Unix sockets, is also
 assumed.
 
+### Kernel configs
+
+- Host kernel config has: `CONFIG_VHOST_VSOCK=m`
+- Guest kernel config has: `CONFIG_VIRTIO_VSOCKETS=y`
+
+To confirm that vsock can be used, run below command inside guest:
+
+```bash
+ls /dev/vsock
+```
+
+and confirm that the `/dev/vsock` device is available.
+
+Reference the guest kernel configuration that Firecracker is
+using in its CI can be found [here](../resources/guest_configs/).
+
 ## Firecracker Virtio-vsock Design
 
 The Firecracker vsock device aims to provide full virtio-vsock support to


### PR DESCRIPTION

Related to issues/#3872.

## Changes

Add some more details to make debugging vsock issues easier for users.
We have `CONFIG_VIRTIO_VSOCKETS=y` in our guest configurations however, if customers want to keep it `CONFIG_VIRTIO_VSOCKETS=m` then they would have to load `vmw_vsock_virtio_transport` manually.

Not adding the description or steps to load `vmw_vsock_virtio_transport` to keep the steps are short and simple and also because we don't do that in our CI.

## Reason

One step forward in helping customers with debugging vsock related issues.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- ~~[ ] All added/changed functionality is tested.~~
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
