### PR TITLE
[DRAFT] test(vhost-user-blk): add test for device resize

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -428,6 +428,14 @@
             {
                 "syscall": "sched_yield",
                 "comment": "Used by the rust standard library in std::sync::mpmc. Firecracker uses mpsc channels from this module for inter-thread communication"
+            },
+            {
+                "syscall": "sendmsg",
+                "comment": "Used by vhost-user frontend to communicate with the backend"
+            },
+            {
+                "syscall": "recvmsg",
+                "comment": "Used by vhost-user frontend to communicate with the backend"
             }
         ]
     },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -440,6 +440,14 @@
             {
                 "syscall": "sched_yield",
                 "comment": "Used by the rust standard library in std::sync::mpmc. Firecracker uses mpsc channels from this module for inter-thread communication"
+            },
+            {
+                "syscall": "sendmsg",
+                "comment": "Used by vhost-user frontend to communicate with the backend"
+            },
+            {
+                "syscall": "recvmsg",
+                "comment": "Used by vhost-user frontend to communicate with the backend"
             }
         ]
     },

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -64,21 +64,6 @@ pub(crate) fn parse_patch_drive(
         ));
     }
 
-    // Validate request - we need to have at least one parameter set:
-    // - path_on_host
-    // - rate_limiter
-    if block_device_update_cfg.path_on_host.is_none()
-        && block_device_update_cfg.rate_limiter.is_none()
-    {
-        METRICS.patch_api_requests.drive_fails.inc();
-        return Err(Error::Generic(
-            StatusCode::BadRequest,
-            String::from(
-                "Please specify at least one property to patch: path_on_host, rate_limiter.",
-            ),
-        ));
-    }
-
     Ok(ParsedRequest::new_sync(VmmAction::UpdateBlockDevice(
         block_device_update_cfg,
     )))

--- a/src/vmm/src/devices/virtio/vhost_user_block/device.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/device.rs
@@ -186,7 +186,7 @@ impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
                 let (_, new_config_space) = vu_handle
                     .vu
                     .get_config(
-                        VHOST_USER_CONFIG_OFFSET,
+                        0,
                         BLOCK_CONFIG_SPACE_SIZE,
                         VhostUserConfigFlags::WRITABLE,
                         &buffer,

--- a/src/vmm/src/devices/virtio/vhost_user_block/device.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/device.rs
@@ -17,7 +17,7 @@ use vhost::vhost_user::Frontend;
 
 use super::{VhostUserBlockError, NUM_QUEUES, QUEUE_SIZE};
 use crate::devices::virtio::block_common::CacheType;
-use crate::devices::virtio::device::{DeviceState, IrqTrigger, VirtioDevice};
+use crate::devices::virtio::device::{DeviceState, IrqTrigger, IrqType, VirtioDevice};
 use crate::devices::virtio::gen::virtio_blk::{
     VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_F_VERSION_1,
 };
@@ -254,6 +254,27 @@ impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
             socket: self.vu_handle.socket_path.clone(),
         }
     }
+
+    pub fn config_update(&mut self) -> Result<(), VhostUserBlockError> {
+        // This buffer is read only. Ask vhost implementation why.
+        let buffer = [0u8; BLOCK_CONFIG_SPACE_SIZE as usize];
+        let (_, new_config_space) = self
+            .vu_handle
+            .vu
+            .get_config(
+                0,
+                BLOCK_CONFIG_SPACE_SIZE,
+                VhostUserConfigFlags::WRITABLE,
+                &buffer,
+            )
+            .map_err(VhostUserBlockError::Vhost)?;
+        self.config_space = new_config_space;
+        self.irq_trigger
+            .trigger_irq(IrqType::Config)
+            .map_err(VhostUserBlockError::IrqTrigger)?;
+
+        Ok(())
+    }
 }
 
 impl<T: VhostUserHandleBackend + Send + 'static> VirtioDevice for VhostUserBlockImpl<T> {
@@ -349,11 +370,13 @@ mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
 
     use std::os::unix::net::UnixStream;
+    use std::sync::atomic::Ordering;
 
     use utils::tempfile::TempFile;
     use vhost::{VhostUserMemoryRegionInfo, VringConfigData};
 
     use super::*;
+    use crate::devices::virtio::mmio::VIRTIO_MMIO_INT_CONFIG;
     use crate::utilities::test_utils::create_tmp_socket;
     use crate::vstate::memory::{FileOffset, GuestAddress, GuestMemoryExtension};
 
@@ -626,6 +649,15 @@ mod tests {
         // Writing to the config does nothing
         vhost_block.write_config(0x69, &[0]);
         assert_eq!(vhost_block.config_space, vec![0x69, 0x69, 0x69]);
+
+        // Testeng [`config_update`]
+        vhost_block.config_space = vec![];
+        vhost_block.config_update().unwrap();
+        assert_eq!(vhost_block.config_space, vec![0x69, 0x69, 0x69]);
+        assert_eq!(
+            vhost_block.interrupt_status().load(Ordering::SeqCst),
+            VIRTIO_MMIO_INT_CONFIG
+        );
     }
 
     #[test]

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -811,6 +811,15 @@ impl RuntimeApiController {
         new_cfg: BlockDeviceUpdateConfig,
     ) -> Result<VmmData, VmmActionError> {
         let mut vmm = self.vmm.lock().expect("Poisoned lock");
+
+        // vhost-user-block updates
+        if new_cfg.path_on_host.is_none() && new_cfg.rate_limiter.is_none() {
+            vmm.update_vhost_user_block_config(&new_cfg.drive_id)
+                .map(|()| VmmData::Empty)
+                .map_err(DriveError::DeviceUpdate)?;
+        }
+
+        // virtio-block updates
         if let Some(new_path) = new_cfg.path_on_host {
             vmm.update_block_device_path(&new_cfg.drive_id, new_path)
                 .map(|()| VmmData::Empty)
@@ -1165,6 +1174,10 @@ mod tests {
             _: crate::rate_limiter::BucketUpdate,
             _: crate::rate_limiter::BucketUpdate,
         ) -> Result<(), VmmError> {
+            Ok(())
+        }
+
+        pub fn update_vhost_user_block_config(&mut self, _: &str) -> Result<(), VmmError> {
             Ok(())
         }
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -692,13 +692,16 @@ class Microvm:
             cache_type=cache_type,
         )
 
-    def patch_drive(self, drive_id, file):
+    def patch_drive(self, drive_id, file=None):
         """Modify/patch an existing block device."""
-        self.api.drive.patch(
-            drive_id=drive_id,
-            path_on_host=self.create_jailed_resource(file.path),
-        )
-        self.disks[drive_id] = Path(file.path)
+        if file:
+            self.api.drive.patch(
+                drive_id=drive_id,
+                path_on_host=self.create_jailed_resource(file.path),
+            )
+            self.disks[drive_id] = Path(file.path)
+        else:
+            self.api.drive.patch(drive_id=drive_id)
 
     def add_net_iface(self, iface=None, api=True, **kwargs):
         """Add a network interface"""

--- a/tests/framework/utils_drive.py
+++ b/tests/framework/utils_drive.py
@@ -50,7 +50,11 @@ CROSVM_CTR_SOCKET_NAME = "crosvm_ctr.socket"
 
 
 def spawn_vhost_user_backend(
-    vm, host_mem_path, socket_path, readonly=False, backend=VhostUserBlkBackendType.QEMU
+    vm,
+    host_mem_path,
+    socket_path,
+    readonly=False,
+    backend=VhostUserBlkBackendType.CROSVM,
 ):
     """Spawn vhost-user-blk backend."""
 

--- a/tests/integration_tests/functional/test_drive_vhost_user.py
+++ b/tests/integration_tests/functional/test_drive_vhost_user.py
@@ -7,7 +7,11 @@ import shutil
 from pathlib import Path
 
 import host_tools.drive as drive_tools
-from framework.utils_drive import partuuid_and_disk_path, spawn_vhost_user_backend
+from framework.utils_drive import (
+    partuuid_and_disk_path,
+    resize_vhost_user_drive,
+    spawn_vhost_user_backend,
+)
 from host_tools.metrics import FcDeviceMetrics
 
 
@@ -330,3 +334,51 @@ def test_partuuid_update(microvm_factory, guest_kernel, rootfs_ubuntu_22):
     }
     _check_drives(vm, assert_dict, assert_dict.keys())
     vhost_user_block_metrics.validate(vm)
+
+
+def test_config_change(microvm_factory, guest_kernel, rootfs):
+    """
+    Verify handling of block device resize.
+
+    We expect that the guest will start reporting the updated size
+    after Firecracker handles a PATCH request to the vhost-user block device.
+    """
+
+    orig_size = 10  # MB
+    new_sizes = [20, 10, 30]  # MB
+    vhost_user_socket = "/vub.socket"
+    mkfs_mount_cmd = "mkfs.ext4 /dev/vdb && mkdir -p /tmp/tmp && mount /dev/vdb /tmp/tmp && umount /tmp/tmp"
+
+    vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
+    vm.spawn(log_level="Info")
+    vm.basic_config()
+    vm.add_net_iface()
+
+    # Add a block device to test resizing.
+    fs = drive_tools.FilesystemFile(size=orig_size)
+    _backend = spawn_vhost_user_backend(vm, fs.path, vhost_user_socket)
+    vm.add_vhost_user_drive("scratch", vhost_user_socket)
+    vm.start()
+
+    # Check that guest reports correct original size.
+    _check_block_size(vm.ssh, "/dev/vdb", orig_size * 1024 * 1024)
+
+    # Check that we can create a filesystem and mount it
+    ret, out, err = vm.ssh.run(mkfs_mount_cmd)
+    assert ret == 0, f"{ret}, {out}, {err}"
+
+    for new_size in new_sizes:
+        # Instruct the backend to resize the device.
+        # It will both resize the file and update its device config.
+        resize_vhost_user_drive(vm, new_size)
+
+        # Instruct Firecracker to reread device config and notify
+        # the guest of a config change.
+        vm.patch_drive("scratch")
+
+        # Check that guest reports correct new size.
+        _check_block_size(vm.ssh, "/dev/vdb", new_size * 1024 * 1024)
+
+        # Check that we can create a filesystem and mount it
+        ret, out, err = vm.ssh.run(mkfs_mount_cmd)
+        assert ret == 0, f"{new_size=}, {ret=}, {out=}, {err=}"

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -23,7 +23,7 @@ from framework.utils import (
     run_cmd,
     summarize_cpu_percent,
 )
-from framework.utils_drive import spawn_vhost_user_backend
+from framework.utils_drive import VhostUserBlkBackendType, spawn_vhost_user_backend
 from integration_tests.performance.configs import defs
 
 TEST_ID = "block_performance"
@@ -370,7 +370,13 @@ def test_block_vhost_user_performance(
     # Add a secondary block device for benchmark tests.
     fs = drive_tools.FilesystemFile(size=BLOCK_DEVICE_SIZE_MB)
     vhost_user_socket = "/vub.socket"
-    backend = spawn_vhost_user_backend(vm, fs.path, vhost_user_socket, readonly=False)
+    backend = spawn_vhost_user_backend(
+        vm,
+        fs.path,
+        vhost_user_socket,
+        readonly=False,
+        backend=VhostUserBlkBackendType.QEMU,
+    )
     vm.add_vhost_user_drive("scratch", vhost_user_socket)
     vm.start()
 


### PR DESCRIPTION
This depends on:
- https://github.com/firecracker-microvm/firecracker/pull/4247 (for crosvm backend)
- https://github.com/firecracker-microvm/firecracker/pull/4223 (for config change implementation)
- some other parts that need to be included in https://github.com/firecracker-microvm/firecracker/pull/4223

## Changes

Add a test to verify disk resize support in vhost-user-blk.

## Reason

We need to test disk resize support in vhost-user-blk.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
