### PR TITLE
chore(vhost-user-block): updated log message for init event

### DIFF
--- a/src/vmm/src/devices/virtio/vhost_user_block/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/event_handler.rs
@@ -63,7 +63,7 @@ impl MutEventSubscriber for VhostUserBlock {
         //  - on device activation (is-activated already true at this point),
         //  - on device restore from snapshot.
         if self.is_activated() {
-            error!("This a vhost backed block. Not sure why I received this event");
+            warn!("Vhost-user block: unexpected init event");
         } else {
             self.register_activate_event(ops);
         }


### PR DESCRIPTION
## Changes
Updated log message for init event because previous version could be confusing for users.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
