### PR TITLE
test: Fix default handling of pipeline_perf --test argument

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -91,7 +91,7 @@ parser = COMMON_PARSER
 parser.add_argument(
     "--test",
     choices=list(perf_test.keys()),
-    default=list(perf_test.keys()),
+    required=False,
     help="performance test",
     action="append",
 )
@@ -111,7 +111,7 @@ group_steps = []
 
 if RUN_TESTS:
     args = parser.parse_args()
-    tests = [perf_test[test] for test in args.test]
+    tests = [perf_test[test] for test in args.test or perf_test.keys()]
     for test_data in tests:
         test_data.setdefault("platforms", args.platforms)
         test_data.setdefault("instances", args.instances)


### PR DESCRIPTION
argparse's `action="append"` interacts unexpectedly with default arguments, in the sense that it will _always_ include the default arguments in the resulting list, and then appends any actually specified argument to the default list. This meant that doing something like `.buildkite/pipeline_perf.py --test memory-overhead` will first cause steps for _every_ performance test be added, and then another copy of the memory overhead step.

Relevant python docs: https://docs.python.org/3/library/argparse.html#action
> 'append' - This stores a list, and appends each argument value to the list. It is useful to allow an option to be specified multiple times. **If the default value is non-empty, the default elements will be present in the parsed value for the option, with any values from the command line appended after those default values**. Example usage:

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
