### PR TITLE
Revert "ci: skip boottime SLA in m6i Linux 6.1"

### DIFF
--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -68,13 +68,6 @@ def test_boottime_no_network(fast_microvm, record_property, metrics):
     record_property("boottime_no_network", f"{boottime_us} us < {MAX_BOOT_TIME_US} us")
     metrics.set_dimensions(DIMENSIONS)
     metrics.put_metric("boot_time", boottime_us, unit="Microseconds")
-
-    if (
-        global_props.cpu_codename == "INTEL_ICELAKE"
-        and global_props.host_linux_version == "6.1"
-    ):
-        pytest.skip("perf regression under investigation")
-
     assert (
         boottime_us < MAX_BOOT_TIME_US
     ), f"boot time {boottime_us} cannot be greater than: {MAX_BOOT_TIME_US} us"
@@ -92,13 +85,6 @@ def test_boottime_with_network(fast_microvm, record_property, metrics):
     )
     metrics.set_dimensions(DIMENSIONS)
     metrics.put_metric("boot_time_with_net", boottime_us, unit="Microseconds")
-
-    if (
-        global_props.cpu_codename == "INTEL_ICELAKE"
-        and global_props.host_linux_version == "6.1"
-    ):
-        pytest.skip("perf regression under investigation")
-
     assert (
         boottime_us < MAX_BOOT_TIME_US
     ), f"boot time {boottime_us} cannot be greater than: {MAX_BOOT_TIME_US} us"


### PR DESCRIPTION
## Changes

revert commit e8b5a6ff46646a9e772ed3853f70bd63c37bcf2f and re-enables checking against the 150ms SLA.

## Reason

The boot time regression was resolved by another host kernel update and no changes in Firecracker.
Regression fixed in Kernel version: 6.1.61-85.141.amzn2023.x86_64

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
