### PR TITLE
[test] Allow setting the NUMA node

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,17 +236,7 @@ def uffd_handler_paths():
 
 
 @pytest.fixture()
-def fc_tmp_path(test_fc_session_root_path):
-    """A tmp_path substitute
-
-    We should use pytest's tmp_path fixture instead of this, but this can create
-    very long paths, which can run into the UDS 108 character limit.
-    """
-    return Path(tempfile.mkdtemp(dir=test_fc_session_root_path))
-
-
-@pytest.fixture()
-def microvm_factory(fc_tmp_path, request, record_property, results_dir):
+def microvm_factory(request, record_property, results_dir):
     """Fixture to create microvms simply.
 
     In order to avoid running out of space when instantiating many microvms,
@@ -262,7 +252,9 @@ def microvm_factory(fc_tmp_path, request, record_property, results_dir):
         fc_binary_path, jailer_binary_path = build_tools.get_firecracker_binaries()
     record_property("firecracker_bin", str(fc_binary_path))
 
-    uvm_factory = MicroVMFactory(fc_tmp_path, fc_binary_path, jailer_binary_path)
+    # We could override the chroot base like so
+    # jailer_kwargs={"chroot_base": "/srv/jailo"}
+    uvm_factory = MicroVMFactory(fc_binary_path, jailer_binary_path)
     yield uvm_factory
 
     # if the test failed, save fc.log in test_results for troubleshooting
@@ -276,7 +268,6 @@ def microvm_factory(fc_tmp_path, request, record_property, results_dir):
             shutil.copy(uvm.log_file, dst)
 
     uvm_factory.kill()
-    shutil.rmtree(fc_tmp_path)
 
 
 @pytest.fixture(params=firecracker_artifacts())

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -11,7 +11,6 @@ from typing import Iterator
 import packaging.version
 import pytest
 
-import host_tools.network as net_tools
 from framework.defs import ARTIFACT_DIR
 from framework.properties import global_props
 from framework.utils import get_firecracker_version_from_toml
@@ -151,29 +150,3 @@ def firecracker_artifacts():
 
     fc = working_version_as_artifact()
     yield pytest.param(fc, id=fc.name)
-
-
-@dataclass(frozen=True, repr=True)
-class NetIfaceConfig:
-    """Defines a network interface configuration."""
-
-    host_ip: str = "192.168.0.1"
-    guest_ip: str = "192.168.0.2"
-    tap_name: str = "tap0"
-    dev_name: str = "eth0"
-    netmask: int = 30
-
-    @property
-    def guest_mac(self):
-        """Return the guest MAC address."""
-        return net_tools.mac_from_ip(self.guest_ip)
-
-    @staticmethod
-    def with_id(i):
-        """Define network iface with id `i`."""
-        return NetIfaceConfig(
-            host_ip=f"192.168.{i}.1",
-            guest_ip=f"192.168.{i}.2",
-            tap_name=f"tap{i}",
-            dev_name=f"eth{i}",
-        )

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -66,7 +66,7 @@ class JailerContext:
         self.exec_file = exec_file
         self.uid = uid
         self.gid = gid
-        self.chroot_base = chroot_base
+        self.chroot_base = Path(chroot_base)
         self.netns = netns
         self.daemonize = daemonize
         self.new_pid_ns = new_pid_ns
@@ -76,6 +76,7 @@ class JailerContext:
         self.resource_limits = resource_limits
         self.cgroup_ver = cgroup_ver
         self.parent_cgroup = parent_cgroup
+        assert chroot_base is not None
 
     # Disabling 'too-many-branches' warning for this function as it needs to
     # check every argument, so the number of branches will increase
@@ -132,11 +133,7 @@ class JailerContext:
 
     def chroot_base_with_id(self):
         """Return the MicroVM chroot base + MicroVM ID."""
-        return os.path.join(
-            self.chroot_base if self.chroot_base is not None else DEFAULT_CHROOT_PATH,
-            Path(self.exec_file).name,
-            self.jailer_id,
-        )
+        return self.chroot_base / Path(self.exec_file).name / self.jailer_id
 
     def api_socket_path(self):
         """Return the MicroVM API socket path."""
@@ -178,10 +175,7 @@ class JailerContext:
 
     def setup(self):
         """Set up this jailer context."""
-        os.makedirs(
-            self.chroot_base if self.chroot_base is not None else DEFAULT_CHROOT_PATH,
-            exist_ok=True,
-        )
+        os.makedirs(self.chroot_base, exist_ok=True)
 
     def cleanup(self):
         """Clean up this jailer context."""

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -33,7 +33,6 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 import host_tools.cargo_build as build_tools
 import host_tools.network as net_tools
 from framework import utils
-from framework.artifacts import NetIfaceConfig
 from framework.defs import MAX_API_CALL_DURATION_MS
 from framework.http_api import Api
 from framework.jailer import JailerContext
@@ -102,7 +101,7 @@ class Snapshot:
         return cls(
             vmstate=src / obj["vmstate"],
             mem=src / obj["mem"],
-            net_ifaces=[NetIfaceConfig(**d) for d in obj["net_ifaces"]],
+            net_ifaces=[net_tools.NetIfaceConfig(**d) for d in obj["net_ifaces"]],
             disks={dsk: src / p for dsk, p in obj["disks"].items()},
             ssh_key=src / obj["ssh_key"],
             snapshot_type=SnapshotType(obj["snapshot_type"]),
@@ -703,7 +702,7 @@ class Microvm:
     def add_net_iface(self, iface=None, api=True, **kwargs):
         """Add a network interface"""
         if iface is None:
-            iface = NetIfaceConfig.with_id(len(self.iface))
+            iface = net_tools.NetIfaceConfig.with_id(len(self.iface))
         tap = net_tools.Tap(
             iface.tap_name, self.jailer.netns, ip=f"{iface.host_ip}/{iface.netmask}"
         )

--- a/tests/framework/microvm_helpers.py
+++ b/tests/framework/microvm_helpers.py
@@ -97,7 +97,7 @@ class MicrovmHelpers:
         This may be useful for example to get a terminal
         """
         ip = self.vm.iface["eth0"]["iface"].guest_ip
-        return f"ip netns exec {self.vm.jailer.netns} ssh -o StrictHostKeyChecking=no -i {self.vm.ssh_key} root@{ip}"
+        return f"{self.vm.netns.cmd_prefix()} ssh -o StrictHostKeyChecking=no -i {self.vm.ssh_key} root@{ip}"
 
     def tmux_ssh(self):
         """Open a tmux window with an SSH session to the VM"""
@@ -133,7 +133,7 @@ class MicrovmHelpers:
           accordingly
         """
         docker_apt_install("iptables")
-        netns = self.vm.jailer.netns
+        netns = self.vm.netns.id
         vethhost = "vethhost0"
         vethhost_ip = "10.0.0.1"
         veth_net = "10.0.0.0/255.255.255.0"

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -680,7 +680,7 @@ def populate_data_store(test_microvm, data_store):
 
 def start_screen_process(screen_log, session_name, binary_path, binary_params):
     """Start binary process into a screen session."""
-    start_cmd = "screen -L -Logfile {logfile} " "-dmS {session} {binary} {params}"
+    start_cmd = "screen -L -Logfile {logfile} -dmS {session} {binary} {params}"
     start_cmd = start_cmd.format(
         logfile=screen_log,
         session=session_name,

--- a/tests/framework/utils_iperf.py
+++ b/tests/framework/utils_iperf.py
@@ -63,7 +63,7 @@ class IPerf3Test:
                 .with_arg("--affinity", assigned_cpu)
                 .build()
             )
-            utils.run_cmd(f"{self._microvm.jailer.netns_cmd_prefix()} {cmd}")
+            utils.run_cmd(f"{self._microvm.netns.cmd_prefix()} {cmd}")
             first_free_cpu += 1
 
         time.sleep(SERVER_STARTUP_TIME_SEC)

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -4,6 +4,7 @@
 
 import random
 import string
+from dataclasses import dataclass
 from pathlib import Path
 
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -182,3 +183,29 @@ class Tap:
 
     def __repr__(self):
         return f"<Tap name={self.name} netns={self.netns}>"
+
+
+@dataclass(frozen=True, repr=True)
+class NetIfaceConfig:
+    """Defines a network interface configuration."""
+
+    host_ip: str = "192.168.0.1"
+    guest_ip: str = "192.168.0.2"
+    tap_name: str = "tap0"
+    dev_name: str = "eth0"
+    netmask: int = 30
+
+    @property
+    def guest_mac(self):
+        """Return the guest MAC address."""
+        return mac_from_ip(self.guest_ip)
+
+    @staticmethod
+    def with_id(i):
+        """Define network iface with id `i`."""
+        return NetIfaceConfig(
+            host_ip=f"192.168.{i}.1",
+            guest_ip=f"192.168.{i}.2",
+            tap_name=f"tap{i}",
+            dev_name=f"eth{i}",
+        )

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -192,14 +192,14 @@ def test_net_api_put_update_pre_boot(test_microvm_with_api):
     test_microvm.spawn()
 
     first_if_name = "first_tap"
-    tap1 = net_tools.Tap(first_if_name, test_microvm.jailer.netns)
+    tap1 = net_tools.Tap(first_if_name, test_microvm.netns.id)
     test_microvm.api.network.put(
         iface_id="1", guest_mac="06:00:00:00:00:01", host_dev_name=tap1.name
     )
 
     # Adding new network interfaces is allowed.
     second_if_name = "second_tap"
-    tap2 = net_tools.Tap(second_if_name, test_microvm.jailer.netns)
+    tap2 = net_tools.Tap(second_if_name, test_microvm.netns.id)
     test_microvm.api.network.put(
         iface_id="2", guest_mac="07:00:00:00:00:01", host_dev_name=tap2.name
     )
@@ -228,7 +228,7 @@ def test_net_api_put_update_pre_boot(test_microvm_with_api):
     iface_id = "1"
     tapname = test_microvm.id[:8] + "tap" + iface_id
 
-    tap3 = net_tools.Tap(tapname, test_microvm.jailer.netns)
+    tap3 = net_tools.Tap(tapname, test_microvm.netns.id)
     test_microvm.api.network.put(
         iface_id=iface_id, host_dev_name=tap3.name, guest_mac="06:00:00:00:00:01"
     )
@@ -266,7 +266,7 @@ def test_api_mmds_config(test_microvm_with_api):
         test_microvm.api.mmds_config.put(network_interfaces=["foo"])
 
     # Attach network interface.
-    tap = net_tools.Tap("tap1", test_microvm.jailer.netns)
+    tap = net_tools.Tap("tap1", test_microvm.netns.id)
     test_microvm.api.network.put(
         iface_id="1", guest_mac="06:00:00:00:00:01", host_dev_name=tap.name
     )
@@ -485,7 +485,7 @@ def test_api_put_update_post_boot(test_microvm_with_api):
 
     iface_id = "1"
     tapname = test_microvm.id[:8] + "tap" + iface_id
-    tap1 = net_tools.Tap(tapname, test_microvm.jailer.netns)
+    tap1 = net_tools.Tap(tapname, test_microvm.netns.id)
 
     test_microvm.api.network.put(
         iface_id=iface_id, host_dev_name=tap1.name, guest_mac="06:00:00:00:00:01"
@@ -588,7 +588,7 @@ def test_rate_limiters_api_config(test_microvm_with_api):
     # Test network with tx bw rate-limiting.
     iface_id = "1"
     tapname = test_microvm.id[:8] + "tap" + iface_id
-    tap1 = net_tools.Tap(tapname, test_microvm.jailer.netns)
+    tap1 = net_tools.Tap(tapname, test_microvm.netns.id)
 
     test_microvm.api.network.put(
         iface_id=iface_id,
@@ -600,7 +600,7 @@ def test_rate_limiters_api_config(test_microvm_with_api):
     # Test network with rx bw rate-limiting.
     iface_id = "2"
     tapname = test_microvm.id[:8] + "tap" + iface_id
-    tap2 = net_tools.Tap(tapname, test_microvm.jailer.netns)
+    tap2 = net_tools.Tap(tapname, test_microvm.netns.id)
     test_microvm.api.network.put(
         iface_id=iface_id,
         guest_mac="06:00:00:00:00:02",
@@ -611,7 +611,7 @@ def test_rate_limiters_api_config(test_microvm_with_api):
     # Test network with tx and rx bw and ops rate-limiting.
     iface_id = "3"
     tapname = test_microvm.id[:8] + "tap" + iface_id
-    tap3 = net_tools.Tap(tapname, test_microvm.jailer.netns)
+    tap3 = net_tools.Tap(tapname, test_microvm.netns.id)
     test_microvm.api.network.put(
         iface_id=iface_id,
         guest_mac="06:00:00:00:00:03",
@@ -657,7 +657,7 @@ def test_api_patch_pre_boot(test_microvm_with_api):
 
     iface_id = "1"
     tapname = test_microvm.id[:8] + "tap" + iface_id
-    tap1 = net_tools.Tap(tapname, test_microvm.jailer.netns)
+    tap1 = net_tools.Tap(tapname, test_microvm.netns.id)
     test_microvm.api.network.put(
         iface_id=iface_id, host_dev_name=tap1.name, guest_mac="06:00:00:00:00:01"
     )
@@ -705,7 +705,7 @@ def test_negative_api_patch_post_boot(test_microvm_with_api):
 
     iface_id = "1"
     tapname = test_microvm.id[:8] + "tap" + iface_id
-    tap1 = net_tools.Tap(tapname, test_microvm.jailer.netns)
+    tap1 = net_tools.Tap(tapname, test_microvm.netns.id)
     test_microvm.api.network.put(
         iface_id=iface_id, host_dev_name=tap1.name, guest_mac="06:00:00:00:00:01"
     )
@@ -1220,7 +1220,7 @@ def test_get_full_config(test_microvm_with_api):
     # Add a net device.
     iface_id = "1"
     tapname = test_microvm.id[:8] + "tap" + iface_id
-    tap1 = net_tools.Tap(tapname, test_microvm.jailer.netns)
+    tap1 = net_tools.Tap(tapname, test_microvm.netns.id)
     guest_mac = "06:00:00:00:00:01"
     tx_rl = {
         "bandwidth": {"size": 1000000, "refill_time": 100, "one_time_burst": None},

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -59,11 +59,10 @@ def _configure_network_interface(test_microvm):
     """
     Create tap interface before spawning the microVM.
 
-    The network namespace and tap interface have to be created
-    beforehand when starting the microVM from a config file.
+    The network namespace is already pre-created.
+    The tap interface has to be created beforehand when starting the microVM
+    from a config file.
     """
-    # Create network namespace.
-    utils.run_cmd(f"ip netns add {test_microvm.jailer.netns}")
 
     # Create tap device, and avoid creating it in the guest since it is already
     # specified in the JSON

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -40,7 +40,7 @@ def test_high_ingress_traffic(test_microvm_with_api):
     # If the net device breaks, iperf will freeze. We have to use a timeout.
     utils.run_cmd(
         "timeout 30 {} {} -c {} -u -V -b 1000000000 -t 30".format(
-            test_microvm.jailer.netns_cmd_prefix(),
+            test_microvm.netns.cmd_prefix(),
             IPERF_BINARY,
             guest_ip,
         ),
@@ -65,7 +65,7 @@ def test_multi_queue_unsupported(test_microvm_with_api):
     tapname = microvm.id[:8] + "tap1"
 
     utils.run_cmd(f"ip tuntap add name {tapname} mode tap multi_queue")
-    utils.run_cmd(f"ip link set {tapname} netns {microvm.jailer.netns}")
+    utils.run_cmd(f"ip link set {tapname} netns {microvm.netns.id}")
 
     expected_msg = re.escape(
         "Could not create the network device: Open tap device failed:"

--- a/tests/integration_tests/functional/test_net_config_space.py
+++ b/tests/integration_tests/functional/test_net_config_space.py
@@ -121,7 +121,7 @@ def _create_server(jailer, host_ip, port, iterations):
     cmd = 'python3 -c "{}"'.format(
         script.format(host_ip, port, iterations, PAYLOAD_DATA_SIZE)
     )
-    netns_cmd = jailer.netns_cmd_prefix() + cmd
+    netns_cmd = jailer.netns.cmd_prefix() + " " + cmd
     exit_code = subprocess.call(netns_cmd, shell=True)
     assert exit_code == 0
 

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -145,7 +145,6 @@ def test_serial_dos(test_microvm_with_api):
     # Set up the microVM with 1 vCPU and a serial console.
     microvm.basic_config(
         vcpu_count=1,
-        add_root_device=False,
         boot_args="console=ttyS0 reboot=k panic=1 pci=off",
     )
     microvm.start()

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -14,7 +14,6 @@ def test_reboot(test_microvm_with_api):
     Test reboot from guest.
     """
     vm = test_microvm_with_api
-    vm.jailer.daemonize = False
     vm.spawn()
 
     # We don't need to monitor the memory for this test because we are

--- a/tests/integration_tests/performance/test_rate_limiter.py
+++ b/tests/integration_tests/performance/test_rate_limiter.py
@@ -108,7 +108,7 @@ def test_rx_rate_limiting_cpu_load(test_microvm_with_api):
 
     # Run iperf client sending UDP traffic.
     iperf_cmd = "{} {} -u -c {} -b 1000000000 -t{} -f KBytes".format(
-        test_microvm.jailer.netns_cmd_prefix(),
+        test_microvm.netns.cmd_prefix(),
         IPERF_BINARY,
         iface.guest_ip,
         IPERF_TRANSMIT_TIME * 5,
@@ -137,7 +137,7 @@ def _check_tx_rate_limiting(test_microvm):
     eth2 = test_microvm.iface["eth2"]["iface"]
 
     # Start iperf server on the host as this is the tx rate limiting test.
-    _start_iperf_server_on_host(test_microvm.jailer.netns_cmd_prefix())
+    _start_iperf_server_on_host(test_microvm.netns.cmd_prefix())
 
     # First step: get the transfer rate when no rate limiting is enabled.
     # We are receiving the result in KBytes from iperf.
@@ -213,7 +213,7 @@ def _check_rx_rate_limiting(test_microvm):
     # Use iperf to obtain the bandwidth when there is burst to consume from,
     # send exactly BURST_SIZE packets.
     iperf_cmd = "{} {} -c {} -n {} -f KBytes -w {} -N".format(
-        test_microvm.jailer.netns_cmd_prefix(),
+        test_microvm.netns.cmd_prefix(),
         IPERF_BINARY,
         eth2.guest_ip,
         BURST_SIZE,
@@ -351,7 +351,7 @@ def _check_rx_bandwidth(test_microvm, guest_ip, expected_kbps):
 def _get_rx_bandwidth_with_duration(test_microvm, guest_ip, duration):
     """Check that the rate-limited RX bandwidth is close to what we expect."""
     iperf_cmd = "{} {} -c {} -t {} -f KBytes -w {} -N".format(
-        test_microvm.jailer.netns_cmd_prefix(),
+        test_microvm.netns.cmd_prefix(),
         IPERF_BINARY,
         guest_ip,
         duration,

--- a/tools/create_snapshot_artifact/main.py
+++ b/tools/create_snapshot_artifact/main.py
@@ -8,7 +8,6 @@ import os
 import re
 import shutil
 import sys
-import tempfile
 from pathlib import Path
 
 # Hack to be able to import testing framework functions.
@@ -16,12 +15,8 @@ sys.path.append(os.path.join(os.getcwd(), "tests"))  # noqa: E402
 
 # pylint: disable=wrong-import-position
 from framework.artifacts import disks, kernels
-from framework.defs import DEFAULT_TEST_SESSION_ROOT_PATH
 from framework.microvm import MicroVMFactory
-from framework.utils import (
-    generate_mmds_get_request,
-    generate_mmds_session_token,
-)
+from framework.utils import generate_mmds_get_request, generate_mmds_session_token
 from framework.utils_cpuid import CpuVendor, get_cpu_vendor
 from host_tools.cargo_build import get_firecracker_binaries
 
@@ -90,8 +85,7 @@ def main():
     # each guest kernel version.
     print("Cleanup")
     shutil.rmtree(SNAPSHOT_ARTIFACTS_ROOT_DIR, ignore_errors=True)
-    root_path = tempfile.mkdtemp(dir=DEFAULT_TEST_SESSION_ROOT_PATH)
-    vm_factory = MicroVMFactory(root_path, *get_firecracker_binaries())
+    vm_factory = MicroVMFactory(*get_firecracker_binaries())
 
     cpu_templates = ["None"]
     if get_cpu_vendor() == CpuVendor.INTEL:

--- a/tools/create_snapshot_artifact/main.py
+++ b/tools/create_snapshot_artifact/main.py
@@ -21,7 +21,6 @@ from framework.microvm import MicroVMFactory
 from framework.utils import (
     generate_mmds_get_request,
     generate_mmds_session_token,
-    run_cmd,
 )
 from framework.utils_cpuid import CpuVendor, get_cpu_vendor
 from host_tools.cargo_build import get_firecracker_binaries
@@ -129,8 +128,6 @@ def create_snapshots(vm, rootfs, kernel, cpu_template):
     vm.create_jailed_resource(rootfs)
     vm.create_jailed_resource(kernel)
 
-    # Create network namespace.
-    run_cmd(f"ip netns add {vm.jailer.netns}")
     for i in range(4):
         vm.add_net_iface(api=False)
 

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -72,6 +72,7 @@ RUN apt-get update \
         musl-tools \
         # needed for integration tests
         net-tools iproute2 iperf3 socat fdisk \
+        numactl \
         openssh-client \
         pkgconf \
         python3 python3-dev python3-pip \

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -65,7 +65,7 @@ else:
     bins = get_firecracker_binaries()
 
 print("This step may take a while to compile Firecracker ...")
-vmfcty = MicroVMFactory("/srv", *bins)
+vmfcty = MicroVMFactory(*bins)
 uvm = vmfcty.build(args.kernel, args.rootfs)
 uvm.help.enable_console()
 uvm.help.resize_disk(uvm.rootfs_file, args.rootfs_size)

--- a/tools/test-popular-containers/test-docker-rootfs.py
+++ b/tools/test-popular-containers/test-docker-rootfs.py
@@ -26,7 +26,7 @@ kernels = list(kernels("vmlinux-*"))
 # Use the latest guest kernel
 kernel = kernels[-1]
 
-vmfcty = MicroVMFactory("/srv", *get_firecracker_binaries())
+vmfcty = MicroVMFactory(*get_firecracker_binaries())
 # (may take a while to compile Firecracker...)
 
 for rootfs in Path(".").glob("*.ext4"):


### PR DESCRIPTION
## Changes

Some changes in the tests framework. 

- Allow setting the NUMA node in integration tests.
- Extract the Network namespace logic out of the Jailer class, for more flexibility.
- Drop the resource path concept since it is not needed.

## Reason

This is not needed for any of the current tests, but it can be useful when building new performance tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
