### PR TITLE
Upgrade Rust toolchain to 1.73.0

### DIFF
--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::fmt::Debug;
+use std::fmt::{Debug, Write};
 
 use kvm_bindings::*;
 use kvm_ioctls::*;
@@ -285,8 +285,10 @@ impl Debug for VcpuState {
                 reg.as_slice()
                     .iter()
                     .rev()
-                    .map(|b| format!("{b:x}"))
-                    .collect::<String>()
+                    .fold(String::new(), |mut output, b| {
+                        let _ = write!(output, "{b:x}");
+                        output
+                    })
             )?;
         }
         Ok(())

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 # The Rust toolchain layer will get updated most frequently, but we could keep the system
 # dependencies layer intact for much longer.
 
-ARG RUST_TOOLCHAIN="1.70.0"
+ARG RUST_TOOLCHAIN="1.73.0"
 ARG TMP_BUILD_DIR=/tmp/build
 ARG FIRECRACKER_SRC_DIR="/firecracker"
 ARG FIRECRACKER_BUILD_DIR="$FIRECRACKER_SRC_DIR/build"
@@ -91,6 +91,8 @@ RUN apt-get update \
         libglib2.0-dev \
         # for crosvm (vhost-user-blk backend)
         libcap2 \
+        # for debugging
+        gdb strace \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --upgrade pip poetry \
     && gem install mdl

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v67}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v68}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -101,6 +101,7 @@ VERSION=$(get-firecracker-version)
 PROFILE_DIR=$(get-profile-dir "$PROFILE")
 CARGO_TARGET=$ARCH-unknown-linux-$LIBC
 CARGO_TARGET_DIR=build/cargo_target/$CARGO_TARGET/$PROFILE_DIR
+RUST_TOOLCHAIN=$(cargo version | cut -f2 -d ' ')
 
 CARGO_REGISTRY_DIR="build/cargo_registry"
 CARGO_GIT_REGISTRY_DIR="build/cargo_git_registry"
@@ -124,7 +125,7 @@ if [ "$LIBC" == "gnu" ]; then
     ARTIFACTS=(firecracker seccompiler-bin rebase-snap cpu-template-helper snapshot-editor)
 fi
 
-say "Building version=$VERSION, profile=$PROFILE, target=$CARGO_TARGET..."
+say "Building version=$VERSION, profile=$PROFILE, target=$CARGO_TARGET, Rust toolchain=${RUST_TOOLCHAIN}..."
 # shellcheck disable=SC2086
 cargo build --target "$CARGO_TARGET" $CARGO_OPTS --workspace
 


### PR DESCRIPTION
## Changes

Upgrade Rust toolchain to 1.73.0

## Reason

Use latest toolchain

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
