### PR TITLE
Use the double fork method to daemonize jailer

### DIFF
--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -271,10 +271,6 @@ Note: default value for `<api-sock>` is `/run/firecracker.socket`.
   binary file in a new PID namespace, in order to become a pseudo-init process.
   Alternatively, the user can spawn the jailer in a new PID namespace via a
   combination of `clone()` with the `CLONE_NEWPID` flag and `exec()`.
-- When running with `--daemonize`, the jailer will fail to start if it's a
-  process group leader, because `setsid()` returns an error in this case.
-  Spawning the jailer via `clone()` and `exec()` also ensures it cannot be a
-  process group leader.
 - We run the jailer as the `root` user; it actually requires a more restricted
   set of capabilities, but that's to be determined as features stabilize.
 - The jailer can only log messages to stdout/err for now, which is why the

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -64,6 +64,8 @@ pub enum JailerError {
     CreateDir(PathBuf, io::Error),
     #[error("Encountered interior \\0 while parsing a string")]
     CStringParsing(NulError),
+    #[error("Failed to daemonize: {0}")]
+    Daemonize(io::Error),
     #[error("Failed to open directory {0}: {1}")]
     DirOpen(String, String),
     #[error("Failed to duplicate fd: {0}")]


### PR DESCRIPTION
## Changes

- Use the double fork method to daemonize jailer as suggested in https://0xjet.github.io/3OHA/2022/04/11/post.html
1st fork to make sure setsid doesn't fail and 2nd fork is to
make sure the daemon code cannot reacquire a controlling terminal.

In addition to the CI tried running --daemonize manually as per steps mentioned in https://github.com/firecracker-microvm/firecracker/issues/4140 and didn't see the setsid error.

## Reason

- When running jailer with --daemonize, the jailer used to fail
to start if it was started a process group leader, because setsid()
returns an error if the calling process is already a process group
leader.
This was a common reported issue by users running jailer manually.
Compared to maintaining a document which was rather difficult to
understand and explain, it is easier to handle this case in jailer by not
calling setsid when process id is same as process groud id (i.e. when 
jailer is not the process group leader).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
