### PR TITLE
doc(changelog): deduplicate vhost-user-blk entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,20 +22,18 @@
 - [#4063](https://github.com/firecracker-microvm/firecracker/pull/4063):
   Adds source-level instrumentation based tracing. See
   [tracing](./docs/tracing.md) for more details.
-- [#4226](https://github.com/firecracker-microvm/firecracker/pull/4226):
-  Added support for vhost-user device metrics. Each vhost-user device will
-  emit metrics under the label `"vhost_user_{device}_{drive_id}"`.
-  E.g. the associated metrics for vhost-user block device with endpoint
-  `"/drives/rootfs"` will be available under `"vhost_user_block_rootfs"`
-  in the metrics json object.
 - [#4138](https://github.com/firecracker-microvm/firecracker/pull/4138),
   [#4170](https://github.com/firecracker-microvm/firecracker/pull/4170),
   [#4223](https://github.com/firecracker-microvm/firecracker/pull/4223),
+  [#4247](https://github.com/firecracker-microvm/firecracker/pull/4247),
   [#4226](https://github.com/firecracker-microvm/firecracker/pull/4226):
   Added support for vhost-user block devices. Firecracker implements
   a vhost-user frontend. Users are free to choose from existing open source
   backend solutions or their own implementation.
+  Known limitation: snapshotting is not currently supported for microVMs
+  containing vhost-user block devices.
   See the [related doc page](./docs/api_requests/block-vhost-user.md) for details.
+  The device emits metrics under the label `"vhost_user_{device}_{drive_id}"`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   a readable format. Also made the `vcpu-states` subcommand available on
   x86_64.
 - [#4063](https://github.com/firecracker-microvm/firecracker/pull/4063):
-  Adds source-level instrumentation based tracing. See
+  Added source-level instrumentation based tracing. See
   [tracing](./docs/tracing.md) for more details.
 - [#4138](https://github.com/firecracker-microvm/firecracker/pull/4138),
   [#4170](https://github.com/firecracker-microvm/firecracker/pull/4170),


### PR DESCRIPTION
## Changes

- Merge the item about metrics with the main one
- Mention snapshotting limitaion
- Add PR 4247 that removes device config offset

## Reason

Changelog contains 2 entries related to a newly added device (vhost-user-blk). Having a separate entry for metrics does not make sense, because users didn't have a chance to experience the device without metrics.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- ~[ ] All added/changed functionality is tested.~
- ~[ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
