### PR TITLE
Make ab_test.py print relative delta of changes

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -327,7 +327,12 @@ if __name__ == "__main__":
         type=float,
         default=0.0,
     )
-    parser.add_argument("--noise-threshold", type=float, default=0.05)
+    parser.add_argument(
+        "--noise-threshold",
+        help="The minimal delta which a metric has to regress on average across all tests that emit it before the regressions will be considered valid.",
+        type=float,
+        default=0.05,
+    )
     args = parser.parse_args()
 
     ab_performance_test(

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -275,20 +275,25 @@ def ab_performance_test(
         ):
             failures.append((dimension_set, metric, result, unit))
 
-    failure_report = "\n".join(
-        f"\033[0;32m[Firecracker A/B-Test Runner]\033[0m A/B-testing shows a change of "
-        f"\033[0;31m\033[1m{format_with_reduced_unit(result.statistic, unit)}\033[0m "
-        f"(from {format_with_reduced_unit(statistics.mean(processed_emf_a[dimension_set][metric][0]), unit)} "
-        f"to {format_with_reduced_unit(statistics.mean(processed_emf_b[dimension_set][metric][0]), unit)}) "
-        f"for metric \033[1m{metric}\033[0m with \033[0;31m\033[1mp={result.pvalue}\033[0m. "
-        f"This means that observing a change of this magnitude or worse, assuming that performance "
-        f"characteristics did not change across the tested commits, has a probability of {result.pvalue:.2%}. "
-        f"Tested Dimensions:\n{json.dumps(dict(dimension_set), indent=2)}"
-        for (dimension_set, metric, result, unit) in failures
+    messages = []
+    for dimension_set, metric, result, unit in failures:
         # Sanity check as described above
-        if abs(statistics.mean(relative_changes_by_metric[metric])) > noise_threshold
-    )
-    assert not failure_report, "\n" + failure_report
+        if abs(statistics.mean(relative_changes_by_metric[metric])) > noise_threshold:
+            old_mean = statistics.mean(processed_emf_a[dimension_set][metric][0])
+            new_mean = statistics.mean(processed_emf_b[dimension_set][metric][0])
+
+            msg = (
+                f"\033[0;32m[Firecracker A/B-Test Runner]\033[0m A/B-testing shows a change of "
+                f"{format_with_reduced_unit(result.statistic, unit)}, or {result.statistic / old_mean:.2%}, "
+                f"(from {format_with_reduced_unit(old_mean, unit)} to {format_with_reduced_unit(new_mean, unit)}"
+                f"for metric \033[1m{metric}\033[0m with \033[0;31m\033[1mp={result.pvalue}\033[0m. "
+                f"This means that observing a change of this magnitude or worse, assuming that performance "
+                f"characteristics did not change across the tested commits, has a probability of {result.pvalue:.2%}. "
+                f"Tested Dimensions:\n{json.dumps(dict(dimension_set), indent=2)}"
+            )
+            messages.append(msg)
+
+    assert not messages, "\n" + "\n".join(messages)
     print("No regressions detected!")
 
 


### PR DESCRIPTION
In addition to the absolute change, also make it print the relative change compared to the old value

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
