### PR TITLE
test(vhost-user-blk): move backend management to microvm class

### DIFF
--- a/tests/framework/utils_drive.py
+++ b/tests/framework/utils_drive.py
@@ -6,6 +6,7 @@
 import os
 import subprocess
 import time
+from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 from subprocess import check_output
@@ -46,35 +47,119 @@ def partuuid_and_disk_path(rootfs_ubuntu_22, disk_path):
     return (partuuid, disk_path)
 
 
-CROSVM_CTR_SOCKET_NAME = "crosvm_ctr.socket"
+class VhostUserBlkBackend(ABC):
+    """vhost-user-blk backend base class"""
+
+    @classmethod
+    def get_all_subclasses(cls):
+        """Get all subclasses of the class."""
+        subclasses = {}
+        for subclass in cls.__subclasses__():
+            subclasses[subclass.__name__] = subclass
+            subclasses.update(subclass.get_all_subclasses())
+        return subclasses
+
+    @classmethod
+    def with_backend(cls, backend: VhostUserBlkBackendType, *args, **kwargs):
+        """Get a backend of a specific type."""
+        subclasses = cls.get_all_subclasses()
+        return subclasses[backend.value + cls.__name__](*args, **kwargs)
+
+    def __init__(
+        self,
+        host_mem_path,
+        chroot,
+        backend_id,
+        readonly,
+    ):
+        self.host_mem_path = host_mem_path
+        self.socket_path = Path(chroot) / f"{backend_id}_vhost_user.sock"
+        self.readonly = readonly
+        self.proc = None
+
+    def spawn(self, uid, gid):
+        """
+        Spawn a backend.
+
+        Return socket path in the jail that can be used with FC API.
+        """
+        assert not self.proc, "backend already spawned"
+        args = self._spawn_cmd()
+        proc = subprocess.Popen(args)
+
+        # Give the backend time to initialise.
+        time.sleep(1)
+
+        assert proc is not None and proc.poll() is None, "backend is not up"
+        assert self.socket_path.exists()
+
+        os.chown(self.socket_path, uid, gid)
+
+        self.proc = proc
+
+        return str(Path("/") / os.path.basename(self.socket_path))
+
+    @abstractmethod
+    def _spawn_cmd(self):
+        """Return a spawn command for the backend"""
+        return ""
+
+    @abstractmethod
+    def resize(self, new_size):
+        """Resize the vhost-user-backed drive"""
+
+    def pin(self, cpu_id: int):
+        """Pin the vhost-user backend to a CPU list."""
+        return utils.ProcessManager.set_cpu_affinity(self.proc.pid, [cpu_id])
+
+    def kill(self):
+        """Kill the backend"""
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            self.proc.wait()
+            os.remove(self.socket_path)
+        assert not os.path.exists(self.socket_path)
 
 
-def spawn_vhost_user_backend(
-    vm,
-    host_mem_path,
-    socket_path,
-    readonly=False,
-    backend=VhostUserBlkBackendType.CROSVM,
-):
-    """Spawn vhost-user-blk backend."""
+class QemuVhostUserBlkBackend(VhostUserBlkBackend):
+    """vhost-user-blk backend implementaiton for Qemu backend"""
 
-    uid = vm.jailer.uid
-    gid = vm.jailer.gid
-    host_vhost_user_socket_path = Path(vm.chroot()) / socket_path.strip("/")
-
-    if backend == VhostUserBlkBackendType.QEMU:
+    def _spawn_cmd(self):
         args = [
             "vhost-user-blk",
             "--socket-path",
-            host_vhost_user_socket_path,
+            self.socket_path,
             "--blk-file",
-            host_mem_path,
+            self.host_mem_path,
         ]
-        if readonly:
+        if self.readonly:
             args.append("--read-only")
-    elif backend == VhostUserBlkBackendType.CROSVM:
-        crosvm_ctr_socket_path = Path(vm.chroot()) / CROSVM_CTR_SOCKET_NAME.strip("/")
-        ro = ",ro" if readonly else ""
+        return args
+
+    def resize(self, new_size):
+        raise NotImplementedError("not supported for Qemu backend")
+
+
+class CrosvmVhostUserBlkBackend(VhostUserBlkBackend):
+    """vhost-user-blk backend implementaiton for crosvm backend"""
+
+    def __init__(
+        self,
+        host_mem_path,
+        chroot,
+        backend_id,
+        readonly=False,
+    ):
+        super().__init__(
+            host_mem_path,
+            chroot,
+            backend_id,
+            readonly,
+        )
+        self.ctr_socket_path = Path(chroot) / f"{backend_id}_ctr.sock"
+
+    def _spawn_cmd(self):
+        ro = ",ro" if self.readonly else ""
         args = [
             "crosvm",
             "--log-level",
@@ -82,42 +167,22 @@ def spawn_vhost_user_backend(
             "devices",
             "--disable-sandbox",
             "--control-socket",
-            crosvm_ctr_socket_path,
+            self.ctr_socket_path,
             "--block",
-            f"vhost={host_vhost_user_socket_path},path={host_mem_path}{ro}",
+            f"vhost={self.socket_path},path={self.host_mem_path}{ro}",
         ]
-        if os.path.exists(crosvm_ctr_socket_path):
-            os.remove(crosvm_ctr_socket_path)
-    else:
-        assert False, f"unknown vhost-user-blk backend `{backend}`"
-    proc = subprocess.Popen(args)
+        return args
 
-    # Give the backend time to initialise.
-    time.sleep(1)
+    def resize(self, new_size):
+        assert self.proc, "backend is not spawned"
+        assert self.ctr_socket_path.exists()
 
-    assert proc is not None and proc.poll() is None, "backend is not up"
+        utils.run_cmd(
+            f"crosvm disk resize 0 {new_size * 1024 * 1024} {self.ctr_socket_path}"
+        )
 
-    with utils.chroot(vm.chroot()):
-        # The backend will create the socket path with root rights.
-        # Change rights to the jailer's.
-        os.chown(socket_path, uid, gid)
-
-    return proc
-
-
-def resize_vhost_user_drive(vm, new_size):
-    """
-    Resize vhost-user-blk drive and send config change notification.
-
-    This only works with the crosvm vhost-user-blk backend.
-    New size is in MB.
-    """
-
-    crosvm_ctr_socket_path = Path(vm.chroot()) / CROSVM_CTR_SOCKET_NAME.strip("/")
-    assert os.path.exists(
-        crosvm_ctr_socket_path
-    ), "crosvm backend must be spawned first"
-
-    utils.run_cmd(
-        f"crosvm disk resize 0 {new_size * 1024 * 1024} {crosvm_ctr_socket_path}"
-    )
+    def kill(self):
+        super().kill()
+        assert self.proc.poll() is not None
+        os.remove(self.ctr_socket_path)
+        assert not os.path.exists(self.ctr_socket_path)


### PR DESCRIPTION
## Changes

This change creates separate classes for Qemu and crosvm backends and moves management of backend processes to the Microvm class.

## Reason

The following problems are being solved by this change:
- proper cleanup of sockets related to vhost-user-blk
- fixing name conflict for crosvm backend socket

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- ~[ ] Any required documentation changes (code and docs) are included in this PR.~
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
