### PR TITLE
doc(vhost-user-blk): add notes about developer preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@
   [#4223](https://github.com/firecracker-microvm/firecracker/pull/4223),
   [#4247](https://github.com/firecracker-microvm/firecracker/pull/4247),
   [#4226](https://github.com/firecracker-microvm/firecracker/pull/4226):
-  Added support for vhost-user block devices. Firecracker implements
-  a vhost-user frontend. Users are free to choose from existing open source
-  backend solutions or their own implementation.
+  Added **developer preview only** (NOT for production use) support for
+  vhost-user block devices.
+  Firecracker implements a vhost-user frontend. Users are free to choose
+  from existing open source backend solutions or their own implementation.
   Known limitation: snapshotting is not currently supported for microVMs
   containing vhost-user block devices.
   See the [related doc page](./docs/api_requests/block-vhost-user.md) for details.

--- a/docs/api_requests/block-io-engine.md
+++ b/docs/api_requests/block-io-engine.md
@@ -5,8 +5,10 @@ synchronous IO engine for executing the device requests, based on blocking
 system calls.
 
 Firecracker 1.0.0 adds support for an asynchronous block device IO engine.
-Support is currently in **developer preview**. See
-[this section](#developer-preview-status) for more info.
+
+> [!WARNING]
+> Support is currently in **developer preview**. See
+> [this section](#developer-preview-status) for more info.
 
 The `Async` engine leverages [`io_uring`](https://kernel.dk/io_uring.pdf) for
 executing requests in an async manner, therefore getting overall higher

--- a/docs/api_requests/block-vhost-user.md
+++ b/docs/api_requests/block-vhost-user.md
@@ -1,5 +1,8 @@
 # Vhost-user block device
 
+Support is currently in **developer preview**. See
+[this section](#developer-preview-status) for more info.
+
 As an alternative to [file-backed block device](block-io-engine.md) `Sync` and
 `Async` engines, Firecracker supports a vhost-user block device.
 

--- a/docs/api_requests/block-vhost-user.md
+++ b/docs/api_requests/block-vhost-user.md
@@ -1,7 +1,8 @@
 # Vhost-user block device
 
-Support is currently in **developer preview**. See
-[this section](#developer-preview-status) for more info.
+> [!WARNING]
+> Support is currently in **developer preview**. See
+> [this section](#developer-preview-status) for more info.
 
 As an alternative to [file-backed block device](block-io-engine.md) `Sync` and
 `Async` engines, Firecracker supports a vhost-user block device.

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -37,9 +37,10 @@ guest workload at that particular point in time.
 
 ### Supported platforms
 
-The Firecracker snapshot feature is in [developer preview](../RELEASE_POLICY.md)
-on all CPU micro-architectures listed in [README](../../README.md#supported-platforms).
-See [this section](#developer-preview-status) for more info.
+> [!WARNING]
+> The Firecracker snapshot feature is in [developer preview](../RELEASE_POLICY.md)
+> on all CPU micro-architectures listed in [README](../../README.md#supported-platforms).
+> See [this section](#developer-preview-status) for more info.
 
 ### Overview
 

--- a/src/vmm/src/devices/virtio/vhost_user_block/device.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/device.rs
@@ -28,7 +28,7 @@ use crate::devices::virtio::vhost_user_metrics::{
     VhostUserDeviceMetrics, VhostUserMetricsPerDevice,
 };
 use crate::devices::virtio::{ActivateError, TYPE_BLOCK};
-use crate::logger::{IncMetric, StoreMetric};
+use crate::logger::{log_dev_preview_warning, IncMetric, StoreMetric};
 use crate::vmm_config::drive::BlockDeviceConfig;
 use crate::vstate::memory::GuestMemoryMmap;
 
@@ -163,6 +163,7 @@ impl<T: VhostUserHandleBackend> std::fmt::Debug for VhostUserBlockImpl<T> {
 
 impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
     pub fn new(config: VhostUserBlockConfig) -> Result<Self, VhostUserBlockError> {
+        log_dev_preview_warning("vhost-user-blk device", Option::None);
         let start_time = utils::time::get_time_us(utils::time::ClockType::Monotonic);
         let mut requested_features = AVAILABLE_FEATURES;
 


### PR DESCRIPTION
## Changes

Add notes in changelog, doc and a log message.

## Reason

vhost-user-blk feature is in developer preview

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- ~[ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
