### PR TITLE
fix: Trigger A/B-Test runs by $GITHUB_REF_NAME

### DIFF
--- a/.github/workflows/trigger_ab_tests.yml
+++ b/.github/workflows/trigger_ab_tests.yml
@@ -16,7 +16,7 @@ jobs:
                -H 'Authorization: Bearer ${{ secrets.BUILDKITE_TOKEN }}' \
                -d '{
                     "commit": "HEAD",
-                    "branch": "${{ github.event.ref }}",
+                    "branch": "$GITHUB_REF_NAME",
                     "env": {
                       "REVISION_A": "${{ github.event.before }}",
                       "REVISION_B": "${{ github.event.after }}"


### PR DESCRIPTION
Currently, our runs get triggered on `/ref/heads/main`. For consistency with other pipelines, normalize that to just `main`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
