### PR TITLE
fix: environment variables dont interpolate with single quotes

### DIFF
--- a/.github/workflows/trigger_ab_tests.yml
+++ b/.github/workflows/trigger_ab_tests.yml
@@ -14,11 +14,11 @@ jobs:
           curl -X POST https://api.buildkite.com/v2/organizations/firecracker/pipelines/performance-a-b-tests/builds \
                -H 'Content-Type: application/json' \
                -H 'Authorization: Bearer ${{ secrets.BUILDKITE_TOKEN }}' \
-               -d '{
-                    "commit": "HEAD",
-                    "branch": "$GITHUB_REF_NAME",
-                    "env": {
-                      "REVISION_A": "${{ github.event.before }}",
-                      "REVISION_B": "${{ github.event.after }}"
+               -d "{
+                    \"commit\": \"HEAD\",
+                    \"branch\": \"$GITHUB_REF_NAME\",
+                    \"env\": {
+                      \"REVISION_A\": \"${{ github.event.before }}\",
+                      \"REVISION_B\": \"${{ github.event.after }}\"
                     }
-                  }'
+                  }"


### PR DESCRIPTION
This caused the triggered buildkite run to be on the literal string `"$GITHUB_REF_NAME"` instead of the value of the environment variable.

Fixes: cfc80403badbdfd71e10e668ac2c586c2a47b712

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
