### PR TITLE
fix(drive): made FileEngineType optional

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1006,7 +1006,7 @@ pub mod tests {
     use crate::mmds::ns::MmdsNetworkStack;
     use crate::vmm_config::balloon::{BalloonBuilder, BalloonDeviceConfig, BALLOON_DEV_ID};
     use crate::vmm_config::boot_source::DEFAULT_KERNEL_CMDLINE;
-    use crate::vmm_config::drive::{BlockBuilder, BlockDeviceConfig, FileEngineType};
+    use crate::vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
     use crate::vmm_config::entropy::{EntropyDeviceBuilder, EntropyDeviceConfig};
     use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
     use crate::vmm_config::vsock::tests::default_config;
@@ -1154,7 +1154,7 @@ pub mod tests {
                         .to_string(),
                 ),
                 rate_limiter: None,
-                file_engine_type: FileEngineType::default(),
+                file_engine_type: None,
 
                 socket: None,
             };

--- a/src/vmm/src/devices/virtio/vhost_user_block/device.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/device.rs
@@ -72,6 +72,7 @@ impl TryFrom<&BlockDeviceConfig> for VhostUserBlockConfig {
             && value.is_read_only.is_none()
             && value.path_on_host.is_none()
             && value.rate_limiter.is_none()
+            && value.file_engine_type.is_none()
         {
             Ok(Self {
                 drive_id: value.drive_id.clone(),
@@ -98,7 +99,7 @@ impl From<VhostUserBlockConfig> for BlockDeviceConfig {
             is_read_only: None,
             path_on_host: None,
             rate_limiter: None,
-            file_engine_type: Default::default(),
+            file_engine_type: None,
 
             socket: Some(value.socket),
         }
@@ -382,6 +383,7 @@ mod tests {
 
     use super::*;
     use crate::devices::virtio::mmio::VIRTIO_MMIO_INT_CONFIG;
+    use crate::devices::virtio::virtio_block::device::FileEngineType;
     use crate::utilities::test_utils::create_tmp_socket;
     use crate::vstate::memory::{FileOffset, GuestAddress, GuestMemoryExtension};
 
@@ -396,7 +398,7 @@ mod tests {
             is_read_only: None,
             path_on_host: None,
             rate_limiter: None,
-            file_engine_type: Default::default(),
+            file_engine_type: None,
 
             socket: Some("sock".to_string()),
         };
@@ -411,7 +413,7 @@ mod tests {
             is_read_only: Some(true),
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
-            file_engine_type: Default::default(),
+            file_engine_type: Some(FileEngineType::Sync),
 
             socket: None,
         };
@@ -426,7 +428,7 @@ mod tests {
             is_read_only: Some(true),
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
-            file_engine_type: Default::default(),
+            file_engine_type: Some(FileEngineType::Sync),
 
             socket: Some("sock".to_string()),
         };

--- a/src/vmm/src/devices/virtio/virtio_block/device.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/device.rs
@@ -195,7 +195,7 @@ impl TryFrom<&BlockDeviceConfig> for VirtioBlockConfig {
                 is_read_only: value.is_read_only.unwrap_or(false),
                 path_on_host: value.path_on_host.as_ref().unwrap().clone(),
                 rate_limiter: value.rate_limiter,
-                file_engine_type: value.file_engine_type,
+                file_engine_type: value.file_engine_type.unwrap_or_default(),
             })
         } else {
             Err(VirtioBlockError::Config)
@@ -214,7 +214,7 @@ impl From<VirtioBlockConfig> for BlockDeviceConfig {
             is_read_only: Some(value.is_read_only),
             path_on_host: Some(value.path_on_host),
             rate_limiter: value.rate_limiter,
-            file_engine_type: value.file_engine_type,
+            file_engine_type: Some(value.file_engine_type),
 
             socket: None,
         }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -487,7 +487,7 @@ mod tests {
     use crate::vmm_config::boot_source::{
         BootConfig, BootSource, BootSourceConfig, DEFAULT_KERNEL_CMDLINE,
     };
-    use crate::vmm_config::drive::{BlockBuilder, BlockDeviceConfig, FileEngineType};
+    use crate::vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
     use crate::vmm_config::machine_config::{MachineConfig, VmConfigError};
     use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
     use crate::vmm_config::vsock::tests::default_config;
@@ -530,7 +530,7 @@ mod tests {
                 is_read_only: Some(false),
                 path_on_host: Some(tmp_file.as_path().to_str().unwrap().to_string()),
                 rate_limiter: Some(RateLimiterConfig::default()),
-                file_engine_type: FileEngineType::default(),
+                file_engine_type: None,
 
                 socket: None,
             },
@@ -1148,7 +1148,8 @@ mod tests {
                             "drive_id": "rootfs",
                             "path_on_host": "{}",
                             "is_root_device": true,
-                            "is_read_only": false
+                            "is_read_only": false,
+                            "io_engine": "Sync"
                         }}
                     ],
                     "network-interfaces": [
@@ -1222,7 +1223,8 @@ mod tests {
                             "drive_id": "rootfs",
                             "path_on_host": "{}",
                             "is_root_device": true,
-                            "is_read_only": false
+                            "is_read_only": false,
+                            "io_engine": "Sync"
                         }}
                     ],
                     "network-interfaces": [
@@ -1281,7 +1283,8 @@ mod tests {
                             "drive_id": "rootfs",
                             "path_on_host": "{}",
                             "is_root_device": true,
-                            "is_read_only": false
+                            "is_read_only": false,
+                            "io_engine": "Sync"
                         }}
                     ],
                     "network-interfaces": [

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -878,7 +878,6 @@ mod tests {
     use crate::devices::virtio::vsock::VsockError;
     use crate::mmds::data_store::MmdsVersion;
     use crate::vmm_config::balloon::BalloonBuilder;
-    use crate::vmm_config::drive::FileEngineType;
     use crate::vmm_config::machine_config::VmConfig;
     use crate::vmm_config::snapshot::{MemBackendConfig, MemBackendType};
     use crate::vmm_config::vsock::VsockBuilder;
@@ -1406,7 +1405,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(String::new()),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -2086,7 +2085,7 @@ mod tests {
                 is_read_only: Some(false),
                 path_on_host: Some(String::new()),
                 rate_limiter: None,
-                file_engine_type: FileEngineType::default(),
+                file_engine_type: None,
 
                 socket: None,
             }),
@@ -2196,7 +2195,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(String::new()),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -60,9 +60,11 @@ pub struct BlockDeviceConfig {
     /// Rate Limiter for I/O operations.
     pub rate_limiter: Option<RateLimiterConfig>,
     /// The type of IO engine used by the device.
-    #[serde(default)]
+    // #[serde(default)]
+    // #[serde(rename = "io_engine")]
+    // pub file_engine_type: FileEngineType,
     #[serde(rename = "io_engine")]
-    pub file_engine_type: FileEngineType,
+    pub file_engine_type: Option<FileEngineType>,
 
     // VhostUserBlock specific fields
     /// Path to the vhost-user socket.
@@ -271,7 +273,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -310,7 +312,7 @@ mod tests {
             is_read_only: Some(true),
             path_on_host: Some(dummy_path),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -346,7 +348,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -362,7 +364,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -389,7 +391,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -405,7 +407,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -421,7 +423,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_3),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -468,7 +470,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -484,7 +486,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -500,7 +502,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_3),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -548,7 +550,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_1.clone()),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -564,7 +566,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_2.clone()),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -631,7 +633,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -647,7 +649,7 @@ mod tests {
             is_read_only: Some(false),
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: None,
 
             socket: None,
         };
@@ -678,7 +680,7 @@ mod tests {
             is_read_only: Some(true),
             path_on_host: Some(dummy_file.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
-            file_engine_type: FileEngineType::default(),
+            file_engine_type: Some(FileEngineType::Sync),
 
             socket: None,
         };

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -930,7 +930,7 @@ def _drive_patch(test_microvm):
             "is_read_only": None,
             "path_on_host": None,
             "rate_limiter": None,
-            "io_engine": "Sync",
+            "io_engine": None,
             "socket": "/vub.socket",
         },
     ]


### PR DESCRIPTION
## Changes

Updated `BlockDeviceConfig` to have `file_engine_type` as an optional filed, instead of a filed with default value. This is done, because for vhost-user-block this field is not used, but it would still be have some value when user would request the block config.
With this change config for vhost-user-block will return `None` for `file_engine_type`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
