### PR TITLE
[1.5] Cleanup confusion arising from mixing of unix exit codes and Rust Result types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 - [#4179](https://github.com/firecracker-microvm/firecracker/pull/4179):
   Fixed a bug reporting a non-zero exit code on successful shutdown when
   starting Firecracker with `--no-api`.
+- [#4271](https://github.com/firecracker-microvm/firecracker/pull/4271): Fixed
+  a bug where Firecracker would log "RunWithApiError error: MicroVMStopped
+  without an error: GenericError" when exiting after encountering an emulation
+  error. It now correctly prints "RunWithApiError error: MicroVMStopped *with* an
+  error: GenericError".
 - [#4270](https://github.com/firecracker-microvm/firecracker/pull/4270):
   Fixed a bug introduced in #4047 that limited the `--level` option of logger
   to Pascal-cased values (e.g. accepting "Info", but not "info"). It now

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -81,7 +81,6 @@ impl From<MainError> for ExitCode {
         let exit_code = match value {
             MainError::ParseArguments(_) => FcExitCode::ArgParsing,
             MainError::InvalidLogLevel(_) => FcExitCode::BadConfiguration,
-            MainError::RunWithApi(ApiServerError::MicroVMStoppedWithoutError(code)) => code,
             MainError::RunWithApi(ApiServerError::MicroVMStoppedWithError(code)) => code,
             MainError::RunWithoutApiError(RunWithoutApiError::Shutdown(code)) => code,
             _ => FcExitCode::GenericError,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -110,7 +110,7 @@ pub mod vstate;
 use std::collections::HashMap;
 use std::io;
 use std::os::unix::io::AsRawFd;
-use std::sync::mpsc::{RecvTimeoutError, TryRecvError};
+use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{Arc, Barrier, Mutex};
 use std::time::Duration;
 
@@ -903,23 +903,27 @@ impl MutEventSubscriber for Vmm {
             // Exit event handling should never do anything more than call 'self.stop()'.
             let _ = self.vcpus_exit_evt.read();
 
-            let mut exit_code = None;
-            // Query each vcpu for their exit_code.
-            for handle in &self.vcpus_handles {
-                match handle.response_receiver().try_recv() {
-                    Ok(VcpuResponse::Exited(status)) => {
-                        exit_code = Some(status);
-                        // Just use the first encountered exit-code.
-                        break;
-                    }
-                    Ok(_response) => {} // Don't care about these, we are exiting.
-                    Err(TryRecvError::Empty) => {} // Nothing pending in channel
-                    Err(err) => {
-                        panic!("Error while looking for VCPU exit status: {}", err);
+            let exit_code = 'exit_code: {
+                // Query each vcpu for their exit_code.
+                for handle in &self.vcpus_handles {
+                    // Drain all vcpu responses that are pending from this vcpu until we find an
+                    // exit status.
+                    for response in handle.response_receiver().try_iter() {
+                        if let VcpuResponse::Exited(status) = response {
+                            // It could be that some vcpus exited successfully while others
+                            // errored out. Thus make sure that error exits from one vcpu always
+                            // takes precedence over "ok" exits
+                            if status != FcExitCode::Ok {
+                                break 'exit_code status;
+                            }
+                        }
                     }
                 }
-            }
-            self.stop(exit_code.unwrap_or(FcExitCode::Ok));
+
+                // No CPUs exited with error status code, report "Ok"
+                FcExitCode::Ok
+            };
+            self.stop(exit_code);
         } else {
             error!("Spurious EventManager event for handler: Vmm");
         }


### PR DESCRIPTION
Backport of #4261

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
