### PR TITLE
Changelog for 4261 and 4242

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@
   without an error: GenericError" when exiting after encountering an emulation
   error. It now correctly prints "RunWithApiError error: MicroVMStopped *with* an
   error: GenericError".
+- [#4242](https://github.com/firecracker-microvm/firecracker/pull/4242):
+  Fixed a bug introduced in #4047 that limited the `--level` option of logger
+  to Pascal-cased values (e.g. accepting "Info", but not "info"). It now
+  ignores case again.
 
 ## [1.5.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@
 - [#4178](https://github.com/firecracker-microvm/firecracker/pull/4178):
   Fixed a bug reporting a non-zero exit code on successful shutdown when
   starting Firecracker with `--no-api`.
+- [#4261](https://github.com/firecracker-microvm/firecracker/pull/4261): Fixed
+  a bug where Firecracker would log "RunWithApiError error: MicroVMStopped
+  without an error: GenericError" when exiting after encountering an emulation
+  error. It now correctly prints "RunWithApiError error: MicroVMStopped *with* an
+  error: GenericError".
 
 ## [1.5.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@
 
 ### Fixed
 
-- Fixed a bug that ignored the `--show-log-origin` option, preventing it from
+- [#4171](https://github.com/firecracker-microvm/firecracker/pull/4171):
+  Fixed a bug that ignored the `--show-log-origin` option, preventing it from
   printing the source code file of the log messages.
 - [#4178](https://github.com/firecracker-microvm/firecracker/pull/4178):
   Fixed a bug reporting a non-zero exit code on successful shutdown when


### PR DESCRIPTION
Forgot the entry in #4261

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
