### PR TITLE
Cleanup of killed microVMs in the CI

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -252,6 +252,9 @@ class Microvm:
             self.expect_kill_by_signal = True
             utils.run_cmd("kill -9 {} || true".format(self.screen_pid))
 
+        # Mark the microVM as not spawned, so we avoid trying to kill twice.
+        self._spawned = False
+
         if self.time_api_requests:
             self._validate_api_response_times()
 
@@ -910,6 +913,8 @@ class MicroVMFactory:
             if len(vm.jailer.jailer_id) > 0:
                 shutil.rmtree(vm.jailer.chroot_base_with_id())
             vm.netns.cleanup()
+
+        self.vms.clear()
 
 
 class Serial:


### PR DESCRIPTION
## Changes

Mark killed microVMs as not spawned, so that we don't try to kill them twice. Also, clear the list of microVMs stored by MicroVMFactory once we call kill() on it.

## Reason

This avoids the spam we get in the CI that we are trying to kill a non-existing PID

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
