### PR TITLE
Fix PATCH operation in virtio-block devices backed by asynchronous engine

### DIFF
--- a/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
@@ -4,6 +4,7 @@
 use std::fmt::Debug;
 use std::fs::File;
 use std::marker::PhantomData;
+use std::os::fd::RawFd;
 use std::os::unix::io::AsRawFd;
 
 use utils::eventfd::EventFd;
@@ -13,7 +14,7 @@ use crate::devices::virtio::virtio_block::io::UserDataError;
 use crate::devices::virtio::virtio_block::IO_URING_NUM_ENTRIES;
 use crate::io_uring::operation::{Cqe, OpCode, Operation};
 use crate::io_uring::restriction::Restriction;
-use crate::io_uring::{IoUring, IoUringError};
+use crate::io_uring::{self, IoUring, IoUringError};
 use crate::logger::log_dev_preview_warning;
 use crate::vstate::memory::{GuestAddress, GuestMemory, GuestMemoryExtension, GuestMemoryMmap};
 
@@ -66,13 +67,10 @@ impl<T: Debug> WrappedUserData<T> {
 }
 
 impl<T: Debug> AsyncFileEngine<T> {
-    pub fn from_file(file: File) -> Result<AsyncFileEngine<T>, AsyncIoError> {
-        log_dev_preview_warning("Async file IO", Option::None);
-
-        let completion_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(AsyncIoError::EventFd)?;
-        let ring = IoUring::new(
+    fn new_ring(file: &File, completion_fd: RawFd) -> Result<IoUring, io_uring::IoUringError> {
+        IoUring::new(
             u32::from(IO_URING_NUM_ENTRIES),
-            vec![&file],
+            vec![file],
             vec![
                 // Make sure we only allow operations on pre-registered fds.
                 Restriction::RequireFixedFds,
@@ -81,9 +79,16 @@ impl<T: Debug> AsyncFileEngine<T> {
                 Restriction::AllowOpCode(OpCode::Write),
                 Restriction::AllowOpCode(OpCode::Fsync),
             ],
-            Some(completion_evt.as_raw_fd()),
+            Some(completion_fd),
         )
-        .map_err(AsyncIoError::IoUring)?;
+    }
+
+    pub fn from_file(file: File) -> Result<AsyncFileEngine<T>, AsyncIoError> {
+        log_dev_preview_warning("Async file IO", Option::None);
+
+        let completion_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(AsyncIoError::EventFd)?;
+        let ring =
+            Self::new_ring(&file, completion_evt.as_raw_fd()).map_err(AsyncIoError::IoUring)?;
 
         Ok(AsyncFileEngine {
             file,
@@ -91,6 +96,15 @@ impl<T: Debug> AsyncFileEngine<T> {
             completion_evt,
             phantom: PhantomData,
         })
+    }
+
+    pub fn update_file(&mut self, file: File) -> Result<(), AsyncIoError> {
+        let ring = Self::new_ring(&file, self.completion_evt.as_raw_fd())
+            .map_err(AsyncIoError::IoUring)?;
+
+        self.file = file;
+        self.ring = ring;
+        Ok(())
     }
 
     #[cfg(test)]

--- a/src/vmm/src/devices/virtio/virtio_block/io/mod.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/mod.rs
@@ -74,6 +74,15 @@ impl<T: Debug> FileEngine<T> {
         }
     }
 
+    pub fn update_file_path(&mut self, file: File) -> Result<(), BlockIoError> {
+        match self {
+            FileEngine::Async(engine) => engine.update_file(file).map_err(BlockIoError::Async)?,
+            FileEngine::Sync(engine) => engine.update_file(file),
+        };
+
+        Ok(())
+    }
+
     #[cfg(test)]
     pub fn file(&self) -> &File {
         match self {

--- a/src/vmm/src/devices/virtio/virtio_block/io/sync_io.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/sync_io.rs
@@ -34,6 +34,11 @@ impl SyncFileEngine {
         &self.file
     }
 
+    /// Update the backing file of the engine
+    pub fn update_file(&mut self, file: File) {
+        self.file = file
+    }
+
     pub fn read(
         &mut self,
         offset: u64,

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -92,7 +92,7 @@ def test_drive_io_engine(test_microvm_with_api):
     assert test_microvm.api.vm_config.get().json()["drives"][0]["io_engine"] == "Sync"
 
 
-def test_api_put_update_pre_boot(test_microvm_with_api):
+def test_api_put_update_pre_boot(test_microvm_with_api, io_engine):
     """
     Test that PUT updates are allowed before the microvm boots.
 
@@ -111,6 +111,7 @@ def test_api_put_update_pre_boot(test_microvm_with_api):
         path_on_host=test_microvm.create_jailed_resource(fs1.path),
         is_root_device=False,
         is_read_only=False,
+        io_engine=io_engine,
     )
 
     # Updates to `kernel_image_path` with an invalid path are not allowed.
@@ -132,6 +133,7 @@ def test_api_put_update_pre_boot(test_microvm_with_api):
             path_on_host="foo.bar",
             is_read_only=True,
             is_root_device=True,
+            io_engine=io_engine,
         )
 
     # Updates to `is_root_device` that result in two root block devices are not
@@ -142,6 +144,7 @@ def test_api_put_update_pre_boot(test_microvm_with_api):
             path_on_host=test_microvm.get_jailed_resource(fs1.path),
             is_read_only=False,
             is_root_device=True,
+            io_engine=io_engine,
         )
 
     # Valid updates to `path_on_host` and `is_read_only` are allowed.
@@ -151,6 +154,7 @@ def test_api_put_update_pre_boot(test_microvm_with_api):
         path_on_host=test_microvm.create_jailed_resource(fs2.path),
         is_read_only=True,
         is_root_device=False,
+        io_engine=io_engine,
     )
 
     # Valid updates to all fields in the machine configuration are allowed.
@@ -473,7 +477,7 @@ def test_api_cpu_config(test_microvm_with_api, custom_cpu_template):
     test_microvm.api.cpu_config.put(**custom_cpu_template["template"])
 
 
-def test_api_put_update_post_boot(test_microvm_with_api):
+def test_api_put_update_post_boot(test_microvm_with_api, io_engine):
     """
     Test that PUT updates are rejected after the microvm boots.
     """
@@ -520,6 +524,7 @@ def test_api_put_update_post_boot(test_microvm_with_api):
             path_on_host=test_microvm.jailer.jailed_path(test_microvm.rootfs_file),
             is_read_only=False,
             is_root_device=True,
+            io_engine=io_engine,
         )
 
     # MMDS config is not allowed post-boot.
@@ -532,7 +537,7 @@ def test_api_put_update_post_boot(test_microvm_with_api):
         test_microvm.api.mmds_config.put(**mmds_config)
 
 
-def test_rate_limiters_api_config(test_microvm_with_api):
+def test_rate_limiters_api_config(test_microvm_with_api, io_engine):
     """
     Test the IO rate limiter API config.
     """
@@ -549,6 +554,7 @@ def test_rate_limiters_api_config(test_microvm_with_api):
         is_read_only=False,
         is_root_device=False,
         rate_limiter={"bandwidth": {"size": 1000000, "refill_time": 100}},
+        io_engine=io_engine,
     )
 
     # Test drive with ops rate-limiting.
@@ -559,6 +565,7 @@ def test_rate_limiters_api_config(test_microvm_with_api):
         is_read_only=False,
         is_root_device=False,
         rate_limiter={"ops": {"size": 1, "refill_time": 100}},
+        io_engine=io_engine,
     )
 
     # Test drive with bw and ops rate-limiting.
@@ -572,6 +579,7 @@ def test_rate_limiters_api_config(test_microvm_with_api):
             "bandwidth": {"size": 1000000, "refill_time": 100},
             "ops": {"size": 1, "refill_time": 100},
         },
+        io_engine=io_engine,
     )
 
     # Test drive with 'empty' rate-limiting (same as not specifying the field)
@@ -582,6 +590,7 @@ def test_rate_limiters_api_config(test_microvm_with_api):
         is_read_only=False,
         is_root_device=False,
         rate_limiter={},
+        io_engine=io_engine,
     )
 
     # Test the NET rate limiting API.
@@ -636,7 +645,7 @@ def test_rate_limiters_api_config(test_microvm_with_api):
     )
 
 
-def test_api_patch_pre_boot(test_microvm_with_api):
+def test_api_patch_pre_boot(test_microvm_with_api, io_engine):
     """
     Test that PATCH updates are not allowed before the microvm boots.
     """
@@ -654,6 +663,7 @@ def test_api_patch_pre_boot(test_microvm_with_api):
         path_on_host=test_microvm.create_jailed_resource(fs1.path),
         is_root_device=False,
         is_read_only=False,
+        io_engine=io_engine,
     )
 
     iface_id = "1"
@@ -685,7 +695,7 @@ def test_api_patch_pre_boot(test_microvm_with_api):
         test_microvm.api.network.patch(iface_id=iface_id)
 
 
-def test_negative_api_patch_post_boot(test_microvm_with_api):
+def test_negative_api_patch_post_boot(test_microvm_with_api, io_engine):
     """
     Test PATCH updates that are not allowed after the microvm boots.
     """
@@ -702,6 +712,7 @@ def test_negative_api_patch_post_boot(test_microvm_with_api):
         path_on_host=test_microvm.create_jailed_resource(fs1.path),
         is_root_device=False,
         is_read_only=False,
+        io_engine=io_engine,
     )
 
     iface_id = "1"


### PR DESCRIPTION
## Changes

Changes the implementation along the PATCH code path for `virtio-block` devices so that, for the case of asynchronous engines (IO uring), it reuses the existing `EventFd` for getting completion callback notifications, rather than creating a knew one.

It also modifies the `virtio-block` tests to also test the asynchronous engine. It extends a test that verifies the PATCH operation works to also check that `mount`-ing an asynchronous device works.

## Reason

The asynchronous engine maintains an event file descriptor which passes to the IO uring interface when creating a new ring. IO uring uses this EventFd to notify us about completion of IO requests.

When we PATCH an async block device, we create a new asynchronous engine, including a new EventFd. However, we still monitor the old EventFd. This breaks the use of async drives post PATCH requests, because we never get notified about the results of requests we submit to the IO uring engine.

As a result, mounting a virtio-block device backed from an asynchronous file engine was blocking for ever.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
