### PR TITLE
test: Update test parallelism

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -61,7 +61,7 @@ build_grp = group(
 
 functional_grp = group(
     "⚙ Functional and security 🔒",
-    "./tools/devtool -y test -- -n 8 --dist worksteal integration_tests/{{functional,security}}",
+    "./tools/devtool -y test -- -n 32 --dist worksteal integration_tests/{{functional,security}}",
     **defaults,
 )
 

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -61,7 +61,7 @@ build_grp = group(
 
 functional_grp = group(
     "⚙ Functional and security 🔒",
-    "./tools/devtool -y test -- -n 32 --dist worksteal integration_tests/{{functional,security}}",
+    "./tools/devtool -y test -- --timeout 60 -n 32 --dist worksteal integration_tests/{{functional,security}}",
     **defaults,
 )
 


### PR DESCRIPTION
## Changes

Increase parallelism from 8 to 32.

## Reason

Tests are run on instances with upwards of 96 cores, we should be able to significantly speed up testing by increasing parallelism from 8 to 32.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
