### PR TITLE
build: Move `env_logger` to `dev-dependencies` of `log-instrument`

### DIFF
--- a/src/log-instrument/Cargo.toml
+++ b/src/log-instrument/Cargo.toml
@@ -28,6 +28,8 @@ name = "five"
 name = "six"
 
 [dependencies]
-env_logger = "0.10.1"
 log = "0.4.20"
 log-instrument-macros = { path = "../log-instrument-macros" }
+
+[dev-dependencies]
+env_logger = "0.10.1"


### PR DESCRIPTION
## Changes

Moves `env_logger` from `dependencies` to `dev-dependencies` of `log-instrument`.

## Reason

Reduces dependencies in release build.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
