### PR TITLE
fix(test): do not pass network config to CPU template helper

### DIFF
--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -285,13 +285,20 @@ def test_cpu_config_dump_vs_actual(
     microvm = microvm_factory.build(guest_kernel, rootfs)
     microvm.spawn()
     microvm.basic_config()
-    microvm.add_net_iface()
     vm_config_path = save_vm_config(microvm, tmp_path)
 
     # Dump CPU config with the helper tool.
     cpu_config_path = tmp_path / "cpu_config.json"
     cpu_template_helper.template_dump(vm_config_path, cpu_config_path)
     dump_cpu_config = build_cpu_config_dict(cpu_config_path)
+
+    # Add the network interface after we dump the CPU config via
+    # the CPU template helper tool. The tool creates a microVM with
+    # the config we pass it. When we pass it network configuration, we
+    # run in some sort of race condition with TAP device creation.
+    # CPU template helper tool doesn't need the network device configuration
+    # so, add it to `microvm` after we have dumped the CPU config.
+    microvm.add_net_iface()
 
     # Retrieve actual CPU config from guest
     microvm.start()


### PR DESCRIPTION
## Changes

 Change integration test to pass a microVM configuration without a network interface to the CPU templates helper tool.

## Reason

CPU template helper tool uses a microVM configuration we pass to it to launch a VM and get it's CPU config. Our integration test that drives that needs to configure the microVM with a network interface so that it can SSH into it and run commands. However, when we pass to helper tool a configuration that includes networking, we run into a race-condition with creating/configuring a TAP device.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
