### PR TITLE
doc: add fix for async engine in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@
   Fixed a bug introduced in #4047 that limited the `--level` option of logger
   to Pascal-cased values (e.g. accepting "Info", but not "info"). It now
   ignores case again.
+- [#4286](https://github.com/firecracker-microvm/firecracker/pull/4286):
+  Fixed a bug in the asynchronous virtio-block engine that rendered the device
+  non-functional after a PATCH request was issued to Firecracker for updating
+  the path to the host-side backing file of the device.
 
 ## [1.5.0]
 


### PR DESCRIPTION
## Changes

Add the fix for the async engine in the "Fixed" section of the CHANGELOG.

## Reason

Forgot to update the CHANGELOG in the initial PR.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
