### PR TITLE
refactor(errors): updated error enums with proper derives

### DIFF
--- a/src/utils/src/kernel_version.rs
+++ b/src/utils/src/kernel_version.rs
@@ -6,12 +6,16 @@ use std::result::Result;
 
 use libc::{uname, utsname};
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum Error {
-    Uname(IoError),
-    InvalidUtf8(std::string::FromUtf8Error),
+    /// Error calling uname: {0}
+    Uname(#[from] IoError),
+    /// Invalid utf-8: {0}
+    InvalidUtf8(#[from] std::string::FromUtf8Error),
+    /// Invalid kernel version format
     InvalidFormat,
-    InvalidInt(std::num::ParseIntError),
+    /// Invalid integer: {0}
+    InvalidInt(#[from] std::num::ParseIntError),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd)]

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -53,12 +53,14 @@ pub trait DeviceInfoForFDT {
 }
 
 /// Errors thrown while configuring the Flattened Device Tree for aarch64.
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum FdtError {
-    CreateFdt(VmFdtError),
+    /// Create FDT error: {0}
+    CreateFdt(#[from] VmFdtError),
+    /// Read cache info error: {0}
     ReadCacheInfo(String),
     /// Failure in writing FDT in memory.
-    WriteFdtToMemory(GuestMemoryError),
+    WriteFdtToMemory(#[from] GuestMemoryError),
 }
 
 /// Creates the flattened device tree for this aarch64 microVM.

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -23,10 +23,10 @@ use crate::arch::DeviceType;
 use crate::vstate::memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 /// Errors thrown while configuring aarch64 system.
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum ConfigurationError {
     /// Failed to create a Flattened Device Tree for this aarch64 microVM.
-    SetupFDT(fdt::FdtError),
+    SetupFDT(#[from] fdt::FdtError),
     /// Failed to compute the initrd address.
     InitrdAddress,
 }

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -35,12 +35,12 @@ const E820_RAM: u32 = 1;
 const E820_RESERVED: u32 = 2;
 
 /// Errors thrown while configuring x86_64 system.
-#[derive(Debug, PartialEq, Eq, derive_more::From)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum ConfigurationError {
     /// Invalid e820 setup params.
     E820Configuration,
-    /// Error writing MP table to memory.
-    MpTableSetup(mptable::MptableError),
+    /// Error writing MP table to memory: {0}
+    MpTableSetup(#[from] mptable::MptableError),
     /// Error writing the zero page of guest memory.
     ZeroPageSetup,
     /// Failed to compute initrd address.

--- a/src/vmm/src/arch/x86_64/mptable.rs
+++ b/src/vmm/src/arch/x86_64/mptable.rs
@@ -36,7 +36,7 @@ unsafe impl ByteValued for mpspec::mpf_intel {}
 // MPTABLE, describing VCPUS.
 const MPTABLE_START: u64 = 0x9fc00;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum MptableError {
     /// There was too little guest memory to store the entire MP table.
     NotEnoughMemory,

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -65,84 +65,54 @@ use crate::vstate::vm::Vm;
 use crate::{device_manager, EventManager, RestoreVcpusError, Vmm, VmmError};
 
 /// Errors associated with starting the instance.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum StartMicrovmError {
-    /// Unable to attach block device to Vmm.
-    #[error("Unable to attach block device to Vmm: {0}")]
+    /// Unable to attach block device to Vmm: {0}
     AttachBlockDevice(io::Error),
-    /// This error is thrown by the minimal boot loader implementation.
-    #[error("System configuration error: {0:?}")]
+    /// System configuration error: {0}
     ConfigureSystem(crate::arch::ConfigurationError),
-    /// Error using CPU template to configure vCPUs
-    #[error("Failed to create guest config: {0:?}")]
+    /// Failed to create guest config: {0}
     CreateGuestConfig(#[from] GuestConfigError),
-    /// Internal errors are due to resource exhaustion.
-    #[error("Cannot create network device. {}", format!("{:?}", .0).replace('\"', ""))]
+    /// Cannot create network device: {0}
     CreateNetDevice(crate::devices::virtio::net::NetError),
-    /// Failed to create a `RateLimiter` object.
-    #[error("Cannot create RateLimiter: {0}")]
+    /// Cannot create RateLimiter: {0}
     CreateRateLimiter(io::Error),
-    /// Legacy devices work with Event file descriptors and the creation can fail because
-    /// of resource exhaustion.
+    /// Error creating legacy device: {0}
     #[cfg(target_arch = "x86_64")]
-    #[error("Error creating legacy device: {0}")]
     CreateLegacyDevice(device_manager::legacy::LegacyDeviceError),
-    /// Memory regions are overlapping or mmap fails.
-    #[error("Invalid Memory Configuration: {}", format!("{:?}", .0).replace('\"', ""))]
+    /// Invalid Memory Configuration: {0}
     GuestMemory(crate::vstate::memory::MemoryError),
     /// Cannot load initrd due to an invalid memory configuration.
-    #[error("Cannot load initrd due to an invalid memory configuration.")]
     InitrdLoad,
-    /// Cannot load initrd due to an invalid image.
-    #[error("Cannot load initrd due to an invalid image: {0}")]
+    /// Cannot load initrd due to an invalid image: {0}
     InitrdRead(io::Error),
-    /// Internal error encountered while starting a microVM.
-    #[error("Internal error while starting microVM: {0}")]
+    /// Internal error while starting microVM: {0}
     Internal(VmmError),
-    /// Failed to get CPU template.
-    #[error("Failed to get CPU template: {0}")]
+    /// Failed to get CPU template: {0}
     GetCpuTemplate(#[from] GetCpuTemplateError),
-    /// The kernel command line is invalid.
-    #[error("Invalid kernel command line: {0}")]
+    /// Invalid kernel command line: {0}
     KernelCmdline(String),
-    /// Cannot load kernel due to invalid memory configuration or invalid kernel image.
-    #[error(
-        "Cannot load kernel due to invalid memory configuration or invalid kernel image: {}",
-        format!("{}", .0).replace('\"', "")
-    )]
+    /// Cannot load kernel due to invalid memory configuration or invalid kernel image: {0}
     KernelLoader(linux_loader::loader::Error),
-    /// Cannot load command line string.
-    #[error("Cannot load command line string: {}", format!("{}", .0).replace('\"', ""))]
+    /// Cannot load command line string: {0}
     LoadCommandline(linux_loader::loader::Error),
-    /// Cannot start the VM because the kernel builder was not configured.
-    #[error("Cannot start microvm without kernel configuration.")]
+    /// Cannot start microvm without kernel configuration.
     MissingKernelConfig,
-    /// Cannot start the VM because the size of the guest memory  was not specified.
-    #[error("Cannot start microvm without guest mem_size config.")]
+    /// Cannot start microvm without guest mem_size config.
     MissingMemSizeConfig,
-    /// The seccomp filter map is missing a key.
-    #[error("No seccomp filter for thread category: {0}")]
+    /// No seccomp filter for thread category: {0}
     MissingSeccompFilters(String),
     /// The net device configuration is missing the tap device.
-    #[error("The net device configuration is missing the tap device.")]
     NetDeviceNotConfigured,
-    /// Cannot open the block device backing file.
-    #[error("Cannot open the block device backing file: {}", format!("{:?}", .0).replace('\"', ""))]
+    /// Cannot open the block device backing file: {0}
     OpenBlockDevice(io::Error),
-    /// Cannot initialize a MMIO Device or add a device to the MMIO Bus or cmdline.
-    #[error(
-        "Cannot initialize a MMIO Device or add a device to the MMIO Bus or cmdline: {}",
-        format!("{}", .0).replace('\"', "")
-    )]
+    /// Cannot initialize a MMIO Device or add a device to the MMIO Bus or cmdline: {0}
     RegisterMmioDevice(device_manager::mmio::MmioError),
-    /// Cannot restore microvm state.
-    #[error("Cannot restore microvm state: {0}")]
+    /// Cannot restore microvm state: {0}
     RestoreMicrovmState(MicrovmStateError),
-    /// Unable to set VmResources.
-    #[error("Cannot set vm resources: {0}")]
+    /// Cannot set vm resources: {0}
     SetVmResources(VmConfigError),
-    /// Failed to create an Entropy device
-    #[error("Cannot create the entropy device: {0}")]
+    /// Cannot create the entropy device: {0}
     CreateEntropyDevice(crate::devices::virtio::rng::EntropyError),
 }
 

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -51,20 +51,31 @@ use crate::vstate::memory::GuestMemoryMmap;
 use crate::EventManager;
 
 /// Errors for (de)serialization of the MMIO device manager.
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum DevicePersistError {
-    Balloon(BalloonError),
-    VirtioBlock(VirtioBlockError),
-    VhostUserBlock(VhostUserBlockError),
-    DeviceManager(super::mmio::MmioError),
+    /// Balloon: {0}
+    Balloon(#[from] BalloonError),
+    /// VirtioBlock: {0}
+    VirtioBlock(#[from] VirtioBlockError),
+    /// VhostUserBlock: {0}
+    VhostUserBlock(#[from] VhostUserBlockError),
+    /// Device manager: {0}
+    DeviceManager(#[from] super::mmio::MmioError),
+    /// Mmio transport
     MmioTransport,
     #[cfg(target_arch = "aarch64")]
-    Legacy(crate::VmmError),
-    Net(NetError),
-    Vsock(VsockError),
-    VsockUnixBackend(VsockUnixBackendError),
-    MmdsConfig(MmdsConfigError),
-    Entropy(EntropyError),
+    /// Legacy: {0}
+    Legacy(#[from] crate::VmmError),
+    /// Net: {0}
+    Net(#[from] NetError),
+    /// Vsock: {0}
+    Vsock(#[from] VsockError),
+    /// VsockUnixBackend: {0}
+    VsockUnixBackend(#[from] VsockUnixBackendError),
+    /// MmdsConfig: {0}
+    MmdsConfig(#[from] MmdsConfigError),
+    /// Entropy: {0}
+    Entropy(#[from] EntropyError),
 }
 
 /// Holds the state of a balloon device connected to the MMIO space.

--- a/src/vmm/src/devices/legacy/serial.rs
+++ b/src/vmm/src/devices/legacy/serial.rs
@@ -60,8 +60,9 @@ impl SerialDeviceMetrics {
 /// Stores aggregated metrics
 pub(super) static METRICS: SerialDeviceMetrics = SerialDeviceMetrics::new();
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum RawIOError {
+    /// Serial error: {0:?}
     Serial(SerialError<io::Error>),
 }
 

--- a/src/vmm/src/devices/mod.rs
+++ b/src/vmm/src/devices/mod.rs
@@ -31,20 +31,20 @@ pub(crate) fn report_net_event_fail(net_iface_metrics: &NetDeviceMetrics, err: D
     net_iface_metrics.event_fails.inc();
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum DeviceError {
     /// Failed to read from the TAP device.
     FailedReadTap,
-    /// Failed to signal irq.
+    /// Failed to signal irq: {0}
     FailedSignalingIrq(io::Error),
-    /// IO error.
+    /// IO error: {0}
     IoError(io::Error),
     /// Device received malformed payload.
     MalformedPayload,
     /// Device received malformed descriptor.
     MalformedDescriptor,
-    /// Error during queue processing.
+    /// Error during queue processing: {0}
     QueueError(QueueError),
-    /// Vsock device error.
+    /// Vsock device error: {0}
     VsockError(VsockError),
 }

--- a/src/vmm/src/devices/virtio/balloon/mod.rs
+++ b/src/vmm/src/devices/virtio/balloon/mod.rs
@@ -66,19 +66,19 @@ const VIRTIO_BALLOON_S_HTLB_PGALLOC: u16 = 8;
 const VIRTIO_BALLOON_S_HTLB_PGFAIL: u16 = 9;
 
 /// Balloon device related errors.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum BalloonError {
-    /// Activation error.
+    /// Activation error: {0}
     Activate(super::ActivateError),
     /// No balloon device found.
     DeviceNotFound,
     /// Device not activated yet.
     DeviceNotActive,
-    /// EventFd error.
+    /// EventFd error: {0}
     EventFd(std::io::Error),
-    /// Guest gave us bad memory addresses.
+    /// Guest gave us bad memory addresses: {0}
     GuestMemory(GuestMemoryError),
-    /// Received error while sending an interrupt.
+    /// Received error while sending an interrupt: {0}
     InterruptError(std::io::Error),
     /// Guest gave us a malformed descriptor.
     MalformedDescriptor,
@@ -92,20 +92,25 @@ pub enum BalloonError {
     StatisticsStateChange,
     /// Amount of pages requested cannot fit in `u32`.
     TooManyPagesRequested,
-    /// Error while processing the virt queues.
+    /// Error while processing the virt queues: {0}
     Queue(QueueError),
-    /// Error removing a memory region at inflate time.
+    /// Error removing a memory region at inflate time: {0}
     RemoveMemoryRegion(RemoveRegionError),
-    /// Error creating the statistics timer.
+    /// Error creating the statistics timer: {0}
     Timer(std::io::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum RemoveRegionError {
+    /// Address translation error.
     AddressTranslation,
+    /// Malformed guest address range.
     MalformedRange,
+    /// Error calling madvise: {0}
     MadviseFail(std::io::Error),
+    /// Error calling mmap: {0}
     MmapFail(std::io::Error),
+    /// Region not found.
     RegionNotFound,
 }
 

--- a/src/vmm/src/devices/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/mod.rs
@@ -60,7 +60,7 @@ pub const TYPE_BALLOON: u32 = 5;
 pub const NOTIFY_REG_OFFSET: u32 = 0x50;
 
 /// Errors triggered when activating a VirtioDevice.
-#[derive(Debug, displaydoc::Display)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum ActivateError {
     /// Epoll error.
     EpollCtl(IOError),

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -46,12 +46,17 @@ use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap};
 
 const FRAME_HEADER_MAX_LEN: usize = PAYLOAD_OFFSET + ETH_IPV4_FRAME_LEN;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 enum FrontendError {
+    /// Add user.
     AddUsed,
+    /// Descriptor chain too mall.
     DescriptorChainTooSmall,
+    /// Empty queue.
     EmptyQueue,
+    /// Guest memory error: {0}
     GuestMemory(GuestMemoryError),
+    /// Read only descriptor.
     ReadOnlyDescriptor,
 }
 

--- a/src/vmm/src/devices/virtio/net/persist.rs
+++ b/src/vmm/src/devices/virtio/net/persist.rs
@@ -78,14 +78,14 @@ pub struct NetConstructorArgs {
 }
 
 /// Errors triggered when trying to construct a network device at resume time.
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum NetPersistError {
-    /// Failed to create a network device.
-    CreateNet(super::NetError),
-    /// Failed to create a rate limiter.
-    CreateRateLimiter(io::Error),
-    /// Failed to re-create the virtio state (i.e queues etc).
-    VirtioState(VirtioStateError),
+    /// Failed to create a network device: {0}
+    CreateNet(#[from] super::NetError),
+    /// Failed to create a rate limiter: {0}
+    CreateRateLimiter(#[from] io::Error),
+    /// Failed to re-create the virtio state (i.e queues etc): {0}
+    VirtioState(#[from] VirtioStateError),
     /// Indicator that no MMDS is associated with this device.
     NoMmdsDataStore,
 }

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -18,7 +18,7 @@ use crate::devices::virtio::queue::Queue;
 use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
 
 /// Errors thrown during restoring virtio state.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum PersistError {
     /// Snapshot state contains invalid queue info.
     InvalidInput,

--- a/src/vmm/src/devices/virtio/rng/persist.rs
+++ b/src/vmm/src/devices/virtio/rng/persist.rs
@@ -30,11 +30,14 @@ impl EntropyConstructorArgs {
     }
 }
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum EntropyPersistError {
-    CreateEntropy(EntropyError),
-    VirtioState(VirtioStateError),
-    RestoreRateLimiter(std::io::Error),
+    /// Create entropy: {0}
+    CreateEntropy(#[from] EntropyError),
+    /// Virtio state: {0}
+    VirtioState(#[from] VirtioStateError),
+    /// Restore rate limiter: {0}
+    RestoreRateLimiter(#[from] std::io::Error),
 }
 
 impl Persist<'_> for Entropy {

--- a/src/vmm/src/devices/virtio/vhost_user.rs
+++ b/src/vmm/src/devices/virtio/vhost_user.rs
@@ -7,7 +7,6 @@
 use std::os::fd::AsRawFd;
 use std::os::unix::net::UnixStream;
 
-use thiserror::Error;
 use utils::eventfd::EventFd;
 use vhost::vhost_user::message::*;
 use vhost::vhost_user::{Frontend, VhostUserFrontend};
@@ -19,7 +18,7 @@ use crate::devices::virtio::queue::Queue;
 use crate::vstate::memory::GuestMemoryMmap;
 
 /// vhost-user error.
-#[derive(Error, Debug, displaydoc::Display)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum VhostUserError {
     /// Invalid available address
     AvailAddress(GuestMemoryError),

--- a/src/vmm/src/devices/virtio/vhost_user_block/mod.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/mod.rs
@@ -15,11 +15,11 @@ pub const NUM_QUEUES: u64 = 1;
 pub const QUEUE_SIZE: u16 = 256;
 
 /// Vhost-user block device error.
-#[derive(Debug, displaydoc::Display)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum VhostUserBlockError {
     /// Cannot create config
     Config,
-    /// Persistence error: {0:?}
+    /// Persistence error: {0}
     Persist(crate::devices::virtio::persist::PersistError),
     /// Vhost-user error: {0}
     VhostUser(VhostUserError),

--- a/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
@@ -18,13 +18,19 @@ use crate::io_uring::{self, IoUring, IoUringError};
 use crate::logger::log_dev_preview_warning;
 use crate::vstate::memory::{GuestAddress, GuestMemory, GuestMemoryExtension, GuestMemoryMmap};
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum AsyncIoError {
+    /// IO: {0}
     IO(std::io::Error),
+    /// IoUring: {0}
     IoUring(IoUringError),
+    /// Submit: {0}
     Submit(std::io::Error),
+    /// SyncAll: {0}
     SyncAll(std::io::Error),
+    /// EventFd: {0}
     EventFd(std::io::Error),
+    /// GuestMemory: {0}
     GuestMemory(GuestMemoryError),
 }
 

--- a/src/vmm/src/devices/virtio/virtio_block/io/mod.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/mod.rs
@@ -24,11 +24,15 @@ pub enum FileEngineOk<T> {
     Executed(UserDataOk<T>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum BlockIoError {
+    /// Sync error: {0}
     Sync(SyncIoError),
+    /// Async error: {0}
     Async(AsyncIoError),
+    /// Unsupported engine type: {0:?}
     UnsupportedEngine(FileEngineType),
+    /// Could not get kernel version: {0}
     GetKernelVersion(utils::kernel_version::Error),
 }
 

--- a/src/vmm/src/devices/virtio/virtio_block/io/sync_io.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/sync_io.rs
@@ -8,11 +8,15 @@ use vm_memory::{GuestMemoryError, ReadVolatile, WriteVolatile};
 
 use crate::vstate::memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum SyncIoError {
+    /// Flush: {0}
     Flush(std::io::Error),
+    /// Seek: {0}
     Seek(std::io::Error),
+    /// SyncAll: {0}
     SyncAll(std::io::Error),
+    /// Transfer: {0}
     Transfer(GuestMemoryError),
 }
 

--- a/src/vmm/src/devices/virtio/virtio_block/mod.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/mod.rs
@@ -34,7 +34,7 @@ pub const BLOCK_QUEUE_SIZES: [u16; BLOCK_NUM_QUEUES] = [FIRECRACKER_MAX_QUEUE_SI
 pub const IO_URING_NUM_ENTRIES: u16 = 128;
 
 /// Errors the block device can trigger.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum VirtioBlockError {
     /// Cannot create config
     Config,
@@ -54,16 +54,16 @@ pub enum VirtioBlockError {
     UnexpectedReadOnlyDescriptor,
     /// Guest gave us a write only descriptor that protocol says to read from.
     UnexpectedWriteOnlyDescriptor,
-    // Error coming from the IO engine.
+    /// Error coming from the IO engine: {0}
     FileEngine(io::BlockIoError),
-    // Error manipulating the backing file.
+    /// Error manipulating the backing file: {0} {1}
     BackingFile(std::io::Error, String),
-    /// Error opening eventfd.
+    /// Error opening eventfd: {0}
     EventFd(std::io::Error),
-    /// Error creating an irqfd.
+    /// Error creating an irqfd: {0}
     IrqTrigger(std::io::Error),
-    /// Error coming from the rate limiter.
+    /// Error coming from the rate limiter: {0}
     RateLimiter(std::io::Error),
-    // Persistence error.
+    /// Persistence error: {0}
     Persist(crate::devices::virtio::persist::PersistError),
 }

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -106,7 +106,7 @@ mod defs {
 }
 
 /// Vsock device related errors.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum VsockError {
     /// The vsock data/buffer virtio descriptor length is smaller than expected.
     BufDescTooSmall,
@@ -114,15 +114,15 @@ pub enum VsockError {
     BufDescMissing,
     /// Empty queue
     EmptyQueue,
-    /// EventFd error
+    /// EventFd error: {0}
     EventFd(std::io::Error),
-    /// Chained GuestMemoryMmap error.
+    /// Chained GuestMemoryMmap error: {0}
     GuestMemoryMmap(GuestMemoryError),
     /// Bounds check failed on guest memory pointer.
     GuestMemoryBounds,
-    /// The vsock header descriptor length is too small.
+    /// The vsock header descriptor length is too small: {0}
     HdrDescTooSmall(u32),
-    /// The vsock header `len` field holds an invalid value.
+    /// The vsock header `len` field holds an invalid value: {0}
     InvalidPktLen(u32),
     /// A data fetch was attempted when no data was available.
     NoData,
@@ -132,8 +132,9 @@ pub enum VsockError {
     UnreadableDescriptor,
     /// Encountered an unexpected read-only virtio descriptor.
     UnwritableDescriptor,
-    /// Invalid virtio configuration.
+    /// Invalid virtio configuration: {0}
     VirtioState(VirtioStateError),
+    /// Vsock uds backend error: {0}
     VsockUdsBackend(VsockUnixBackendError),
 }
 

--- a/src/vmm/src/devices/virtio/vsock/unix/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/mod.rs
@@ -27,21 +27,21 @@ mod defs {
 }
 
 /// Vsock backend related errors.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum VsockUnixBackendError {
-    /// Error registering a new epoll-listening FD.
+    /// Error registering a new epoll-listening FD: {0}
     EpollAdd(std::io::Error),
-    /// Error creating an epoll FD.
+    /// Error creating an epoll FD: {0}
     EpollFdCreate(std::io::Error),
     /// The host made an invalid vsock port connection request.
     InvalidPortRequest,
-    /// Error accepting a new connection from the host-side Unix socket.
+    /// Error accepting a new connection from the host-side Unix socket: {0}
     UnixAccept(std::io::Error),
-    /// Error binding to the host-side Unix socket.
+    /// Error binding to the host-side Unix socket: {0}
     UnixBind(std::io::Error),
-    /// Error connecting to a host-side Unix socket.
+    /// Error connecting to a host-side Unix socket: {0}
     UnixConnect(std::io::Error),
-    /// Error reading from host-side Unix socket.
+    /// Error reading from host-side Unix socket: {0}
     UnixRead(std::io::Error),
     /// Muxer connection limit reached.
     TooManyConnections,

--- a/src/vmm/src/dumbo/pdu/arp.rs
+++ b/src/vmm/src/dumbo/pdu/arp.rs
@@ -45,7 +45,7 @@ const ETH_IPV4_TPA_OFFSET: usize = 24;
 const IPV4_ADDR_LEN: u8 = 4;
 
 /// Represents errors which may occur while parsing or writing a frame.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum Error {
     /// Invalid hardware address length.
     HLen,

--- a/src/vmm/src/dumbo/pdu/ethernet.rs
+++ b/src/vmm/src/dumbo/pdu/ethernet.rs
@@ -27,7 +27,7 @@ pub const ETHERTYPE_ARP: u16 = 0x0806;
 pub const ETHERTYPE_IPV4: u16 = 0x0800;
 
 /// Describes the errors which may occur when handling Ethernet frames.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum Error {
     /// The specified byte sequence is shorter than the Ethernet header length.
     SliceTooShort,

--- a/src/vmm/src/dumbo/pdu/ipv4.rs
+++ b/src/vmm/src/dumbo/pdu/ipv4.rs
@@ -39,7 +39,7 @@ pub const PROTOCOL_TCP: u8 = 0x06;
 pub const PROTOCOL_UDP: u8 = 0x11;
 
 /// Describes the errors which may occur while handling IPv4 packets.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum Error {
     /// The header checksum is invalid.
     Checksum,

--- a/src/vmm/src/dumbo/pdu/tcp.rs
+++ b/src/vmm/src/dumbo/pdu/tcp.rs
@@ -73,7 +73,7 @@ bitflags! {
 }
 
 /// Describes the errors which may occur while handling TCP segments.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum Error {
     /// Invalid checksum.
     Checksum,

--- a/src/vmm/src/dumbo/pdu/udp.rs
+++ b/src/vmm/src/dumbo/pdu/udp.rs
@@ -29,14 +29,13 @@ pub const UDP_HEADER_SIZE: usize = 8;
 const IPV4_MAX_UDP_PACKET_SIZE: u16 = 65507;
 
 /// Represents errors which may occur while parsing or writing a datagram.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum Error {
     /// Invalid checksum.
     Checksum,
     /// The specified byte sequence is shorter than the Ethernet header length.
     DatagramTooShort,
-    /// The payload to be added to the UDP packet exceeds the size allowed
-    /// by the used IP version.
+    /// The payload to be added to the UDP packet exceeds the size allowed by the used IP version.
     PayloadTooBig,
 }
 

--- a/src/vmm/src/dumbo/tcp/handler.rs
+++ b/src/vmm/src/dumbo/tcp/handler.rs
@@ -57,12 +57,12 @@ pub enum WriteEvent {
 ///
 /// [`receive_packet`]: struct.TcpIPv4Handler.html#method.receive_packet
 /// [`TcpIPv4Handler`]: struct.TcpIPv4Handler.html
-#[derive(Debug, PartialEq, Eq, derive_more::From)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum RecvError {
     /// The inner segment has an invalid destination port.
     InvalidPort,
-    /// The handler encountered an error while parsing the inner TCP segment.
-    TcpSegment(TcpSegmentError),
+    /// The handler encountered an error while parsing the inner TCP segment: {0}
+    TcpSegment(#[from] TcpSegmentError),
 }
 
 /// Describes errors which may be encountered by the [`write_next_packet`] method from
@@ -70,12 +70,12 @@ pub enum RecvError {
 ///
 /// [`write_next_packet`]: struct.TcpIPv4Handler.html#method.write_next_packet
 /// [`TcpIPv4Handler`]: struct.TcpIPv4Handler.html
-#[derive(Debug, PartialEq, Eq, derive_more::From)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum WriteNextError {
-    /// There was an error while writing the contents of the IPv4 packet.
-    IPv4Packet(IPv4PacketError),
-    /// There was an error while writing the contents of the inner TCP segment.
-    TcpSegment(TcpSegmentError),
+    /// There was an error while writing the contents of the IPv4 packet: {0}
+    IPv4Packet(#[from] IPv4PacketError),
+    /// There was an error while writing the contents of the inner TCP segment: {0}
+    TcpSegment(#[from] TcpSegmentError),
 }
 
 // Generally speaking, a TCP/IPv4 connection is identified using the four-tuple (src_addr, src_port,

--- a/src/vmm/src/io_uring/mod.rs
+++ b/src/vmm/src/io_uring/mod.rs
@@ -31,38 +31,38 @@ const REQUIRED_OPS: [OpCode; 2] = [OpCode::Read, OpCode::Write];
 // Taken from linux/fs/io_uring.c
 const IORING_MAX_FIXED_FILES: usize = 1 << 15;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 /// IoUring Error.
 pub enum IoUringError {
-    /// Error originating in the completion queue.
+    /// Error originating in the completion queue: {0}
     CQueue(CQueueError),
-    /// Could not enable the ring.
+    /// Could not enable the ring: {0}
     Enable(IOError),
-    /// A FamStructWrapper operation has failed.
+    /// A FamStructWrapper operation has failed: {0}
     Fam(utils::fam::Error),
     /// The number of ops in the ring is >= CQ::count
     FullCQueue,
-    /// Fd was not registered.
+    /// Fd was not registered: {0}
     InvalidFixedFd(FixedFd),
     /// There are no registered fds.
     NoRegisteredFds,
-    /// Error probing the io_uring subsystem.
+    /// Error probing the io_uring subsystem: {0}
     Probe(IOError),
-    /// Could not register eventfd.
+    /// Could not register eventfd: {0}
     RegisterEventfd(IOError),
-    /// Could not register file.
+    /// Could not register file: {0}
     RegisterFile(IOError),
     /// Attempted to register too many files.
     RegisterFileLimitExceeded,
-    /// Could not register restrictions.
+    /// Could not register restrictions: {0}
     RegisterRestrictions(IOError),
-    /// Error calling io_uring_setup.
+    /// Error calling io_uring_setup: {0}
     Setup(IOError),
-    /// Error originating in the submission queue.
+    /// Error originating in the submission queue: {0}
     SQueue(SQueueError),
-    /// Required feature is not supported on the host kernel.
+    /// Required feature is not supported on the host kernel: {0}
     UnsupportedFeature(&'static str),
-    /// Required operation is not supported on the host kernel.
+    /// Required operation is not supported on the host kernel: {0}
     UnsupportedOperation(&'static str),
 }
 

--- a/src/vmm/src/io_uring/queue/completion.rs
+++ b/src/vmm/src/io_uring/queue/completion.rs
@@ -13,13 +13,13 @@ use crate::io_uring::bindings;
 use crate::io_uring::operation::Cqe;
 use crate::vstate::memory::MmapRegion;
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 /// CQueue Error.
 pub enum CQueueError {
-    /// Error mapping the ring.
-    Mmap(MmapError),
-    /// Error reading/writing volatile memory.
-    VolatileMemory(VolatileMemoryError),
+    /// Error mapping the ring: {0}
+    Mmap(#[from] MmapError),
+    /// Error reading/writing volatile memory: {0}
+    VolatileMemory(#[from] VolatileMemoryError),
 }
 
 #[derive(Debug)]

--- a/src/vmm/src/io_uring/queue/mmap.rs
+++ b/src/vmm/src/io_uring/queue/mmap.rs
@@ -8,9 +8,11 @@ use vm_memory::mmap::MmapRegionError;
 
 use crate::vstate::memory::MmapRegion;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum MmapError {
+    /// Os: {0}
     Os(IOError),
+    /// BuildMmapRegion: {0}
     BuildMmapRegion(MmapRegionError),
 }
 

--- a/src/vmm/src/io_uring/queue/submission.rs
+++ b/src/vmm/src/io_uring/queue/submission.rs
@@ -16,17 +16,17 @@ use crate::io_uring::bindings;
 use crate::io_uring::operation::Sqe;
 use crate::vstate::memory::{Bytes, MmapRegion};
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 /// SQueue Error.
 pub enum SQueueError {
     /// The queue is full.
     FullQueue,
-    /// Error mapping the ring.
-    Mmap(MmapError),
-    /// Error reading/writing volatile memory.
-    VolatileMemory(VolatileMemoryError),
-    /// Error returned by `io_uring_enter`.
-    Submit(IOError),
+    /// Error mapping the ring: {0}
+    Mmap(#[from] MmapError),
+    /// Error reading/writing volatile memory: {0}
+    VolatileMemory(#[from] VolatileMemoryError),
+    /// Error returned by `io_uring_enter`: {0}
+    Submit(#[from] IOError),
 }
 
 #[derive(Debug)]

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -201,7 +201,7 @@ pub enum VmmError {
     #[cfg(target_arch = "aarch64")]
     /// Invalid command line error.
     Cmdline,
-    /// {0}
+    /// Device manager error: {0}
     DeviceManager(device_manager::mmio::MmioError),
     /// Error getting the KVM dirty bitmap. {0}
     DirtyBitmap(kvm_ioctls::Error),
@@ -263,17 +263,17 @@ pub(crate) fn mem_size_mib(guest_memory: &GuestMemoryMmap) -> u64 {
     guest_memory.iter().map(|region| region.len()).sum::<u64>() >> 20
 }
 
-/// Error type for [`Vmm::emulate_serial_init`].
-#[derive(Debug, derive_more::From, thiserror::Error)]
-#[error("Emulate serial init error: {0}")]
-pub struct EmulateSerialInitError(std::io::Error);
+// Error type for [`Vmm::emulate_serial_init`].
+/// Emulate serial init error: {0}
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub struct EmulateSerialInitError(#[from] std::io::Error);
 
 /// Error type for [`Vmm::start_vcpus`].
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum StartVcpusError {
-    /// {0}
+    /// VMM observer init error: {0}
     VmmObserverInit(#[from] utils::errno::Error),
-    /// {0}
+    /// Vcpu handle error: {0}
     VcpuHandle(#[from] StartThreadedError),
 }
 

--- a/src/vmm/src/mmds/ns.rs
+++ b/src/vmm/src/mmds/ns.rs
@@ -36,19 +36,26 @@ const DEFAULT_TCP_PORT: u16 = 80;
 const DEFAULT_MAX_CONNECTIONS: usize = 30;
 const DEFAULT_MAX_PENDING_RESETS: usize = 100;
 
-#[derive(Debug, PartialEq, derive_more::From)]
+#[derive(Debug, PartialEq, thiserror::Error, displaydoc::Display)]
 enum WriteArpFrameError {
+    /// NoPendingArpReply
     NoPendingArpReply,
-    Arp(ArpFrameError),
-    Ethernet(EthernetFrameError),
+    /// ARP error: {0}
+    Arp(#[from] ArpFrameError),
+    /// Ethernet error: {0}
+    Ethernet(#[from] EthernetFrameError),
 }
 
-#[derive(Debug, PartialEq, derive_more::From)]
+#[derive(Debug, PartialEq, thiserror::Error, displaydoc::Display)]
 enum WritePacketError {
-    IPv4Packet(IPv4PacketError),
-    Ethernet(EthernetFrameError),
-    TcpSegment(TcpSegmentError),
-    WriteNext(WriteNextError),
+    /// IPv4Packet error: {0}
+    IPv4Packet(#[from] IPv4PacketError),
+    /// Ethernet error: {0}
+    Ethernet(#[from] EthernetFrameError),
+    /// TcpSegment error: {0}
+    TcpSegment(#[from] TcpSegmentError),
+    /// WriteNext error: {0}
+    WriteNext(#[from] WriteNextError),
 }
 
 #[derive(Debug)]

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -11,10 +11,10 @@ use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 
 pub mod persist;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 /// Describes the errors that may occur while handling rate limiter events.
 pub enum Error {
-    /// The event handler was called spuriously.
+    /// The event handler was called spuriously: {0}
     SpuriousRateLimiterEvent(&'static str),
 }
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -30,34 +30,34 @@ use crate::vmm_config::net::*;
 use crate::vmm_config::vsock::*;
 
 /// Errors encountered when configuring microVM resources.
-#[derive(Debug, thiserror::Error, displaydoc::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum ResourcesError {
     /// Balloon device error: {0}
-    BalloonDevice(BalloonConfigError),
+    BalloonDevice(#[from] BalloonConfigError),
     /// Block device error: {0}
-    BlockDevice(DriveError),
+    BlockDevice(#[from] DriveError),
     /// Boot source error: {0}
-    BootSource(BootSourceConfigError),
+    BootSource(#[from] BootSourceConfigError),
     /// File operation error: {0}
-    File(std::io::Error),
+    File(#[from] std::io::Error),
     /// Invalid JSON: {0}
-    InvalidJson(serde_json::Error),
+    InvalidJson(#[from] serde_json::Error),
     /// Logger error: {0}
-    Logger(crate::logger::LoggerUpdateError),
+    Logger(#[from] crate::logger::LoggerUpdateError),
     /// Metrics error: {0}
-    Metrics(MetricsConfigError),
+    Metrics(#[from] MetricsConfigError),
     /// MMDS error: {0}
-    Mmds(mmds::data_store::Error),
+    Mmds(#[from] mmds::data_store::Error),
     /// MMDS config error: {0}
-    MmdsConfig(MmdsConfigError),
+    MmdsConfig(#[from] MmdsConfigError),
     /// Network device error: {0}
-    NetDevice(NetworkInterfaceError),
+    NetDevice(#[from] NetworkInterfaceError),
     /// VM config error: {0}
-    VmConfig(VmConfigError),
+    VmConfig(#[from] VmConfigError),
     /// Vsock device error: {0}
-    VsockDevice(VsockConfigError),
+    VsockDevice(#[from] VsockConfigError),
     /// Entropy device error: {0}
-    EntropyDevice(EntropyDeviceError),
+    EntropyDevice(#[from] EntropyDeviceError),
 }
 
 /// Used for configuring a vmm from one single json passed to the Firecracker process.

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -131,50 +131,50 @@ pub enum VmmAction {
 }
 
 /// Wrapper for all errors associated with VMM actions.
-#[derive(Debug, thiserror::Error, displaydoc::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum VmmActionError {
-    /// {0}
-    BalloonConfig(BalloonConfigError),
-    /// {0}
-    BootSource(BootSourceConfigError),
-    /// {0}
-    CreateSnapshot(CreateSnapshotError),
-    /// {0}
-    ConfigureCpu(GuestConfigError),
-    /// {0}
-    DriveConfig(DriveError),
-    /// {0}
-    EntropyDevice(EntropyDeviceError),
-    /// Internal Vmm error: {0}
-    InternalVmm(VmmError),
-    /// Load microVM snapshot error: {0}
-    LoadSnapshot(LoadSnapshotError),
-    /// {0}
-    Logger(crate::logger::LoggerUpdateError),
-    /// {0}
-    MachineConfig(VmConfigError),
-    /// {0}
-    Metrics(MetricsConfigError),
+    /// Balloon config error: {0}
+    BalloonConfig(#[from] BalloonConfigError),
+    /// Boot source error: {0}
+    BootSource(#[from] BootSourceConfigError),
+    /// Create snapshot error: {0}
+    CreateSnapshot(#[from] CreateSnapshotError),
+    /// Configure CPU error: {0}
+    ConfigureCpu(#[from] GuestConfigError),
+    /// Drive config error: {0}
+    DriveConfig(#[from] DriveError),
+    /// Entropy device error: {0}
+    EntropyDevice(#[from] EntropyDeviceError),
+    /// Internal VMM error: {0}
+    InternalVmm(#[from] VmmError),
+    /// Load snapshot error: {0}
+    LoadSnapshot(#[from] LoadSnapshotError),
+    /// Logger error: {0}
+    Logger(#[from] crate::logger::LoggerUpdateError),
+    /// Machine config error: {0}
+    MachineConfig(#[from] VmConfigError),
+    /// Metrics error: {0}
+    Metrics(#[from] MetricsConfigError),
     #[from(ignore)]
-    /// {0}
-    Mmds(data_store::Error),
-    /// {0}
-    MmdsConfig(MmdsConfigError),
+    /// MMDS error: {0}
+    Mmds(#[from] data_store::Error),
+    /// MMMDS config error: {0}
+    MmdsConfig(#[from] MmdsConfigError),
     #[from(ignore)]
-    /// {0}
+    /// MMDS limit exceeded error: {0}
     MmdsLimitExceeded(data_store::Error),
-    /// {0}
-    NetworkConfig(NetworkInterfaceError),
+    /// Network config error: {0}
+    NetworkConfig(#[from] NetworkInterfaceError),
     /// The requested operation is not supported: {0}
     NotSupported(String),
     /// The requested operation is not supported after starting the microVM.
     OperationNotSupportedPostBoot,
     /// The requested operation is not supported before starting the microVM.
     OperationNotSupportedPreBoot,
-    /// {0}
-    StartMicrovm(StartMicrovmError),
-    /// {0}
-    VsockConfig(VsockConfigError),
+    /// Start microvm error: {0}
+    StartMicrovm(#[from] StartMicrovmError),
+    /// Vsock config error: {0}
+    VsockConfig(#[from] VsockConfigError),
 }
 
 /// The enum represents the response sent by the VMM in case of success. The response is either

--- a/src/vmm/src/vmm_config/metrics.rs
+++ b/src/vmm/src/vmm_config/metrics.rs
@@ -17,10 +17,9 @@ pub struct MetricsConfig {
 }
 
 /// Errors associated with actions on the `MetricsConfig`.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum MetricsConfigError {
-    /// Cannot initialize the metrics system due to bad user input.
-    #[error("{}", format!("{:?}", .0).replace('\"', ""))]
+    /// Cannot initialize the metrics system due to bad user input: {0}
     InitializationFailure(String),
 }
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -29,78 +29,54 @@ use crate::cpu_config::templates::KvmCapability;
 use crate::vstate::memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 
 /// Errors associated with the wrappers over KVM ioctls.
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+/// Needs `rustfmt::skip` to make multiline comments work
+#[rustfmt::skip]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
 pub enum VmError {
-    /// The host kernel reports an invalid KVM API version.
-    #[error("The host kernel reports an invalid KVM API version: {0}")]
+    /// The host kernel reports an invalid KVM API version: {0}
     ApiVersion(i32),
-    /// Cannot initialize the KVM context due to missing capabilities.
-    #[error("Missing KVM capabilities: {0:x?}")]
+    /// Missing KVM capabilities: {0:x?}
     Capabilities(u32),
-    /// Cannot initialize the KVM context.
-    #[error("{}", ({
-        if .0.errno() == libc::EACCES {
-            format!(
-                "Error creating KVM object. [{}]\nMake sure the user \
-                launching the firecracker process is configured on the /dev/kvm file's ACL.",
-                .0
-            )
-        } else {
-            format!("Error creating KVM object. [{}]", .0)
-        }
-    }))]
+    /**  Error creating KVM object: {0} Make sure the user launching the firecracker process is \
+    configured on the /dev/kvm file's ACL. */
     Kvm(kvm_ioctls::Error),
     #[cfg(target_arch = "x86_64")]
-    /// Failed to get MSR index list to save into snapshots.
-    #[error("Failed to get MSR index list to save into snapshots: {0}")]
+    /// Failed to get MSR index list to save into snapshots: {0}
     GetMsrsToSave(#[from] crate::arch::x86_64::msr::MsrError),
-    /// The number of configured slots is bigger than the maximum reported by KVM.
-    #[error("The number of configured slots is bigger than the maximum reported by KVM")]
+    /// The number of configured slots is bigger than the maximum reported by KVM
     NotEnoughMemorySlots,
-    /// Cannot set the memory regions.
-    #[error("Cannot set the memory regions: {0}")]
+    /// Cannot set the memory regions: {0}
     SetUserMemoryRegion(kvm_ioctls::Error),
     #[cfg(target_arch = "aarch64")]
-    /// Cannot create the global interrupt controller.
-    #[error("Error creating the global interrupt controller: {0:?}")]
+    /// Error creating the global interrupt controller: {0}
     VmCreateGIC(crate::arch::aarch64::gic::GicError),
-    /// Cannot open the VM file descriptor.
-    #[error("Cannot open the VM file descriptor: {0}")]
+    /// Cannot open the VM file descriptor: {0}
     VmFd(kvm_ioctls::Error),
     #[cfg(target_arch = "x86_64")]
-    /// Failed to get KVM vm pit state.
-    #[error("Failed to get KVM vm pit state: {0}")]
+    /// Failed to get KVM vm pit state: {0}
     VmGetPit2(kvm_ioctls::Error),
     #[cfg(target_arch = "x86_64")]
-    /// Failed to get KVM vm clock.
-    #[error("Failed to get KVM vm clock: {0}")]
+    /// Failed to get KVM vm clock: {0}
     VmGetClock(kvm_ioctls::Error),
     #[cfg(target_arch = "x86_64")]
-    /// Failed to get KVM vm irqchip.
-    #[error("Failed to get KVM vm irqchip: {0}")]
+    /// Failed to get KVM vm irqchip: {0}
     VmGetIrqChip(kvm_ioctls::Error),
     #[cfg(target_arch = "x86_64")]
-    /// Failed to set KVM vm pit state.
-    #[error("Failed to set KVM vm pit state: {0}")]
+    /// Failed to set KVM vm pit state: {0}
     VmSetPit2(kvm_ioctls::Error),
     #[cfg(target_arch = "x86_64")]
-    /// Failed to set KVM vm clock.
-    #[error("Failed to set KVM vm clock: {0}")]
+    /// Failed to set KVM vm clock: {0}
     VmSetClock(kvm_ioctls::Error),
     #[cfg(target_arch = "x86_64")]
-    /// Failed to set KVM vm irqchip.
-    #[error("Failed to set KVM vm irqchip: {0}")]
+    /// Failed to set KVM vm irqchip: {0}
     VmSetIrqChip(kvm_ioctls::Error),
-    /// Cannot configure the microvm.
-    #[error("Cannot configure the microvm: {0}")]
+    /// Cannot configure the microvm: {0}
     VmSetup(kvm_ioctls::Error),
     #[cfg(target_arch = "aarch64")]
-    /// Failed to save the VM's GIC state.
-    #[error("Failed to save the VM's GIC state: {0:?}")]
+    /// Failed to save the VM's GIC state: {0}
     SaveGic(crate::arch::aarch64::gic::GicError),
     #[cfg(target_arch = "aarch64")]
-    /// Failed to restore the VM's GIC state.
-    #[error("Failed to restore the VM's GIC state: {0:?}")]
+    /// Failed to restore the VM's GIC state: {0}
     RestoreGic(crate::arch::aarch64::gic::GicError),
 }
 
@@ -109,17 +85,17 @@ pub enum VmError {
 #[cfg(target_arch = "x86_64")]
 #[derive(Debug, thiserror::Error, displaydoc::Display, PartialEq, Eq)]
 pub enum RestoreStateError {
-    /// {0}
+    /// Set PIT2 error: {0}
     SetPit2(kvm_ioctls::Error),
-    /// {0}
+    /// Set clock error: {0}
     SetClock(kvm_ioctls::Error),
-    /// {0}
+    /// Set IrqChipPicMaster error: {0}
     SetIrqChipPicMaster(kvm_ioctls::Error),
-    /// {0}
+    /// Set IrqChipPicSlave error: {0}
     SetIrqChipPicSlave(kvm_ioctls::Error),
-    /// {0}
+    /// Set IrqChipIoAPIC error: {0}
     SetIrqChipIoAPIC(kvm_ioctls::Error),
-    /// {0}
+    /// VM error: {0}
     VmError(VmError),
 }
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -75,8 +75,7 @@ def test_drive_io_engine(test_microvm_with_api):
             test_microvm.api.drive.put(io_engine="Async", **kwargs)
         # The Async engine is not supported for older kernels.
         test_microvm.check_log_message(
-            "Received Error. Status code: 400 Bad Request. Message: Unable"
-            " to create the virtio block device: FileEngine(UnsupportedEngine(Async))"
+            "Received Error. Status code: 400 Bad Request. Message: Drive config error: Unable to create the virtio block device: FileEngine(UnsupportedEngine(Async))"
         )
 
         # Now configure the default engine type and check that it works.
@@ -394,7 +393,7 @@ def test_api_machine_config(test_microvm_with_api):
     test_microvm.api.machine_config.patch(mem_size_mib=bad_size)
 
     fail_msg = re.escape(
-        "Invalid Memory Configuration: MemfdSetLen(Custom { kind: InvalidInput, error: TryFromIntError(()) })"
+        "Invalid Memory Configuration: Cannot resize memfd file: Custom { kind: InvalidInput, error: TryFromIntError(()) }"
     )
     with pytest.raises(RuntimeError, match=fail_msg):
         test_microvm.start()
@@ -852,8 +851,8 @@ def _drive_patch(test_microvm):
 
     # Updates to `path_on_host` with an invalid path are not allowed.
     expected_msg = (
-        "Unable to patch the block device: BackingFile(Os { code: 2, "
-        f'kind: NotFound, message: "No such file or directory" }}, "{drive_path}")'
+        "Unable to patch the block device: Device manager error: BackingFile(Os { code: 2, "
+        f'kind: NotFound, message: "No such file or directory" }}, "{drive_path}") Please verify the request arguments.'
     )
     with pytest.raises(RuntimeError, match=re.escape(expected_msg)):
         test_microvm.api.drive.patch(drive_id="scratch", path_on_host=drive_path)

--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -158,9 +158,7 @@ def test_api_requests_logs(test_microvm_with_api):
 
     # Check that the fault message return by the client is also logged in the
     # FIFO.
-    fault_msg = (
-        "The kernel file cannot be opened: No such file or directory (os error 2)"
-    )
+    fault_msg = "Boot source error: The kernel file cannot be opened: No such file or directory (os error 2)"
     with pytest.raises(RuntimeError, match=re.escape(fault_msg)):
         microvm.api.boot.put(kernel_image_path="inexistent_path")
     microvm.check_log_message(

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -219,7 +219,7 @@ def test_load_snapshot_failure_handling(test_microvm_with_api):
 
     # Load the snapshot
     expected_msg = (
-        "Load microVM snapshot error: Failed to restore from snapshot: Failed to get snapshot "
+        "Load snapshot error: Failed to restore from snapshot: Failed to get snapshot "
         "state from file: Failed to load snapshot state from file: Snapshot file is smaller "
         "than CRC length."
     )
@@ -327,7 +327,7 @@ def test_negative_snapshot_permissions(uvm_plain_rw, microvm_factory):
     microvm.spawn()
 
     expected_err = re.escape(
-        "Load microVM snapshot error: Failed to restore from snapshot: Failed to load guest "
+        "Load snapshot error: Failed to restore from snapshot: Failed to load guest "
         "memory: Error creating guest memory from file: Failed to load guest memory: "
         "Permission denied (os error 13)"
     )
@@ -341,7 +341,7 @@ def test_negative_snapshot_permissions(uvm_plain_rw, microvm_factory):
     microvm.spawn()
 
     expected_err = re.escape(
-        "Load microVM snapshot error: Failed to restore from snapshot: Failed to get snapshot "
+        "Load snapshot error: Failed to restore from snapshot: Failed to get snapshot "
         "state from file: Failed to open snapshot file: Permission denied (os error 13)"
     )
     with pytest.raises(RuntimeError, match=expected_err):

--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -65,7 +65,7 @@ def test_bad_socket_path(uvm_plain, snapshot):
     jailed_vmstate = vm.create_jailed_resource(snapshot.vmstate)
 
     expected_msg = re.escape(
-        "Load microVM snapshot error: Failed to restore from snapshot: Failed to load guest "
+        "Load snapshot error: Failed to restore from snapshot: Failed to load guest "
         "memory: Error creating guest memory from uffd: Failed to connect to UDS Unix stream: No "
         "such file or directory (os error 2)"
     )
@@ -89,7 +89,7 @@ def test_unbinded_socket(uvm_plain, snapshot):
     jailed_sock_path = vm.create_jailed_resource(socket_path)
 
     expected_msg = re.escape(
-        "Load microVM snapshot error: Failed to restore from snapshot: Failed to load guest "
+        "Load snapshot error: Failed to restore from snapshot: Failed to load guest "
         "memory: Error creating guest memory from uffd: Failed to connect to UDS Unix stream: "
         "Connection refused (os error 111)"
     )


### PR DESCRIPTION
## Changes
Updated error enums with proper derives. This is done, because the issue of printing/formatting errors occur frequently during code modifications. This PR tries to fix all error enums in `vmm` crate.

Main changes are:
- Adding `thiserror::Error` and `displaydoc::Display` for all errors
- Removing of `derive_more::From` for errors as `thiserror::Error` can do the same
- Minor modification of error messages (`Some error: {0}` instead of just `{0}`)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
