### PR TITLE
test: Parameterize tests that use guest features by guest kernel

### DIFF
--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -115,11 +115,11 @@ def _test_rss_memory_lower(test_microvm, stable_delta=1):
 
 
 # pylint: disable=C0103
-def test_rss_memory_lower(test_microvm_with_api):
+def test_rss_memory_lower(uvm_plain_any):
     """
     Test that inflating the balloon makes guest use less rss memory.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -136,11 +136,11 @@ def test_rss_memory_lower(test_microvm_with_api):
 
 
 # pylint: disable=C0103
-def test_inflate_reduces_free(test_microvm_with_api):
+def test_inflate_reduces_free(uvm_plain_any):
     """
     Check that the output of free in guest changes with inflate.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -225,11 +225,11 @@ def test_deflate_on_oom(test_microvm_with_api, deflate_on_oom):
 
 
 # pylint: disable=C0103
-def test_reinflate_balloon(test_microvm_with_api):
+def test_reinflate_balloon(uvm_plain_any):
     """
     Verify that repeatedly inflating and deflating the balloon works.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -286,11 +286,11 @@ def test_reinflate_balloon(test_microvm_with_api):
 
 
 # pylint: disable=C0103
-def test_size_reduction(test_microvm_with_api):
+def test_size_reduction(uvm_plain_any):
     """
     Verify that ballooning reduces RSS usage on a newly booted guest.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -328,11 +328,11 @@ def test_size_reduction(test_microvm_with_api):
 
 
 # pylint: disable=C0103
-def test_stats(test_microvm_with_api):
+def test_stats(uvm_plain_any):
     """
     Verify that balloon stats work as expected.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -386,11 +386,11 @@ def test_stats(test_microvm_with_api):
     assert inflated_stats["available_memory"] < deflated_stats["available_memory"]
 
 
-def test_stats_update(test_microvm_with_api):
+def test_stats_update(uvm_plain_any):
     """
     Verify that balloon stats update correctly.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -538,11 +538,11 @@ def test_snapshot_compatibility(microvm_factory, guest_kernel, rootfs):
     vm.snapshot_full()
 
 
-def test_memory_scrub(microvm_factory, guest_kernel, rootfs):
+def test_memory_scrub(uvm_plain_any):
     """
     Test that the memory is zeroed after deflate.
     """
-    microvm = microvm_factory.build(guest_kernel, rootfs)
+    microvm = uvm_plain_any
     microvm.spawn()
     microvm.basic_config(vcpu_count=2, mem_size_mib=256)
     microvm.add_net_iface()

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -87,17 +87,17 @@ def get_cpu_template_dir(cpu_template):
     PLATFORM != "aarch64",
     reason="This is aarch64 specific test.",
 )
-def test_default_cpu_features(microvm_factory, guest_kernel, rootfs_ubuntu_22):
+def test_default_cpu_features(uvm_plain_any):
     """
     Check the CPU features for a microvm with the specified config.
     """
 
-    vm = microvm_factory.build(guest_kernel, rootfs_ubuntu_22, monitor_memory=False)
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config()
     vm.add_net_iface()
     vm.start()
-    guest_kv = re.search(r"vmlinux-(\d+\.\d+)", guest_kernel.name).group(1)
+    guest_kv = re.search(r"vmlinux-(\d+\.\d+)", vm.kernel_file.name).group(1)
     _check_cpu_features_arm(vm, guest_kv)
 
 
@@ -106,19 +106,17 @@ def test_default_cpu_features(microvm_factory, guest_kernel, rootfs_ubuntu_22):
     reason="This is aarch64 specific test.",
 )
 @nonci_on_arm
-def test_cpu_features_with_static_template(
-    microvm_factory, guest_kernel, rootfs_ubuntu_22, cpu_template
-):
+def test_cpu_features_with_static_template(uvm_plain_any, cpu_template):
     """
     Check the CPU features for a microvm with the specified config.
     """
 
-    vm = microvm_factory.build(guest_kernel, rootfs_ubuntu_22, monitor_memory=False)
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config(cpu_template=cpu_template)
     vm.add_net_iface()
     vm.start()
-    guest_kv = re.search(r"vmlinux-(\d+\.\d+)", guest_kernel.name).group(1)
+    guest_kv = re.search(r"vmlinux-(\d+\.\d+)", vm.kernel_file.name).group(1)
     _check_cpu_features_arm(vm, guest_kv, "v1n1")
 
 
@@ -127,18 +125,16 @@ def test_cpu_features_with_static_template(
     reason="This is aarch64 specific test.",
 )
 @nonci_on_arm
-def test_cpu_features_with_custom_template(
-    microvm_factory, guest_kernel, rootfs_ubuntu_22, custom_cpu_template
-):
+def test_cpu_features_with_custom_template(uvm_plain_any, custom_cpu_template):
     """
     Check the CPU features for a microvm with the specified config.
     """
 
-    vm = microvm_factory.build(guest_kernel, rootfs_ubuntu_22, monitor_memory=False)
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config()
     vm.api.cpu_config.put(**custom_cpu_template["template"])
     vm.add_net_iface()
     vm.start()
-    guest_kv = re.search(r"vmlinux-(\d+\.\d+)", guest_kernel.name).group(1)
+    guest_kv = re.search(r"vmlinux-(\d+\.\d+)", vm.kernel_file.name).group(1)
     _check_cpu_features_arm(vm, guest_kv, custom_cpu_template["name"])

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -272,9 +272,7 @@ def get_guest_msrs(microvm, msr_index_list):
     ),
 )
 def test_cpu_config_dump_vs_actual(
-    microvm_factory,
-    guest_kernel,
-    rootfs,
+    uvm_plain_any,
     cpu_template_helper,
     tmp_path,
 ):
@@ -282,7 +280,7 @@ def test_cpu_config_dump_vs_actual(
     Verify that the dumped CPU config matches the actual CPU config inside
     guest.
     """
-    microvm = microvm_factory.build(guest_kernel, rootfs)
+    microvm = uvm_plain_any
     microvm.spawn()
     microvm.basic_config()
     vm_config_path = save_vm_config(microvm, tmp_path)

--- a/tests/integration_tests/functional/test_drive_virtio.py
+++ b/tests/integration_tests/functional/test_drive_virtio.py
@@ -23,11 +23,11 @@ def partuuid_and_disk_path_tmpfs(rootfs_ubuntu_22, tmp_path):
     disk_path.unlink()
 
 
-def test_rescan_file(test_microvm_with_api, io_engine):
+def test_rescan_file(uvm_plain_any, io_engine):
     """
     Verify that rescan works with a file-backed virtio device.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
 
     # Set up the microVM with 1 vCPUs, 256 MiB of RAM and a root file system
@@ -64,14 +64,14 @@ def test_rescan_file(test_microvm_with_api, io_engine):
     _check_block_size(test_microvm.ssh, "/dev/vdb", fs.size())
 
 
-def test_device_ordering(test_microvm_with_api, io_engine):
+def test_device_ordering(uvm_plain_any, io_engine):
     """
     Verify device ordering.
 
     The root device should correspond to /dev/vda in the guest and
     the order of the other devices should match their configuration order.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
 
     # Add first scratch block device.
@@ -112,11 +112,11 @@ def test_device_ordering(test_microvm_with_api, io_engine):
     _check_block_size(ssh_connection, "/dev/vdc", fs2.size())
 
 
-def test_rescan_dev(test_microvm_with_api, io_engine):
+def test_rescan_dev(uvm_plain_any, io_engine):
     """
     Verify that rescan works with a device-backed virtio device.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
 
     # Set up the microVM with 1 vCPUs, 256 MiB of RAM and a root file system
@@ -152,11 +152,11 @@ def test_rescan_dev(test_microvm_with_api, io_engine):
             utils.run_cmd(["losetup", "--detach", loopback_device])
 
 
-def test_non_partuuid_boot(test_microvm_with_api, io_engine):
+def test_non_partuuid_boot(uvm_plain_any, io_engine):
     """
     Test the output reported by blockdev when booting from /dev/vda.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
 
     # Sets up the microVM with 1 vCPUs, 256 MiB of RAM and a root file system
@@ -183,7 +183,7 @@ def test_non_partuuid_boot(test_microvm_with_api, io_engine):
     _check_drives(test_microvm, assert_dict, keys_array)
 
 
-def test_partuuid_boot(test_microvm_with_api, partuuid_and_disk_path_tmpfs, io_engine):
+def test_partuuid_boot(uvm_plain_any, partuuid_and_disk_path_tmpfs, io_engine):
     """
     Test the output reported by blockdev when booting with PARTUUID.
     """
@@ -191,7 +191,7 @@ def test_partuuid_boot(test_microvm_with_api, partuuid_and_disk_path_tmpfs, io_e
     partuuid = partuuid_and_disk_path_tmpfs[0]
     disk_path = partuuid_and_disk_path_tmpfs[1]
 
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
 
     # Sets up the microVM with 1 vCPUs, 256 MiB of RAM and without root file system
@@ -217,11 +217,11 @@ def test_partuuid_boot(test_microvm_with_api, partuuid_and_disk_path_tmpfs, io_e
     _check_drives(test_microvm, assert_dict, keys_array)
 
 
-def test_partuuid_update(test_microvm_with_api, io_engine):
+def test_partuuid_update(uvm_plain_any, io_engine):
     """
     Test successful switching from PARTUUID boot to /dev/vda boot.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
 
     # Set up the microVM with 1 vCPUs, 256 MiB of RAM
@@ -255,11 +255,11 @@ def test_partuuid_update(test_microvm_with_api, io_engine):
     _check_drives(test_microvm, assert_dict, keys_array)
 
 
-def test_patch_drive(test_microvm_with_api, io_engine):
+def test_patch_drive(uvm_plain_any, io_engine):
     """
     Test replacing the backing filesystem after guest boot works.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
 
     # Set up the microVM with 1 vCPUs, 256 MiB of RAM and a root file system
@@ -294,11 +294,11 @@ def test_patch_drive(test_microvm_with_api, io_engine):
     assert lines[1].strip() == size_bytes_str
 
 
-def test_no_flush(test_microvm_with_api, io_engine):
+def test_no_flush(uvm_plain_any, io_engine):
     """
     Verify default block ignores flush.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
 
     test_microvm.basic_config(vcpu_count=1, add_root_device=False)

--- a/tests/integration_tests/functional/test_feat_parity.py
+++ b/tests/integration_tests/functional/test_feat_parity.py
@@ -29,15 +29,13 @@ def inst_set_cpu_template_fxt(request):
 
 @pytest.fixture(name="vm")
 def vm_fxt(
-    microvm_factory,
+    uvm_plain_any,
     inst_set_cpu_template,
-    guest_kernel,
-    rootfs,
 ):
     """
     Create a VM, using the normal CPU templates
     """
-    vm = microvm_factory.build(guest_kernel, rootfs)
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config(vcpu_count=1, mem_size_mib=1024, cpu_template=inst_set_cpu_template)
     vm.add_net_iface()

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -86,11 +86,11 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
     assert "/root" in res
 
 
-def test_serial_console_login(test_microvm_with_api):
+def test_serial_console_login(uvm_plain_any):
     """
     Test serial console login.
     """
-    microvm = test_microvm_with_api
+    microvm = uvm_plain_any
     microvm.jailer.daemonize = False
     microvm.spawn()
 
@@ -134,11 +134,11 @@ def send_bytes(tty, bytes_count, timeout=60):
             break
 
 
-def test_serial_dos(test_microvm_with_api):
+def test_serial_dos(uvm_plain_any):
     """
     Test serial console behavior under DoS.
     """
-    microvm = test_microvm_with_api
+    microvm = uvm_plain_any
     microvm.jailer.daemonize = False
     microvm.spawn()
 
@@ -164,11 +164,11 @@ def test_serial_dos(test_microvm_with_api):
     )
 
 
-def test_serial_block(test_microvm_with_api):
+def test_serial_block(uvm_plain_any):
     """
     Test that writing to stdout never blocks the vCPU thread.
     """
-    test_microvm = test_microvm_with_api
+    test_microvm = uvm_plain_any
     test_microvm.jailer.daemonize = False
     test_microvm.spawn()
     # Set up the microVM with 1 vCPU so we make sure the vCPU thread

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -230,7 +230,7 @@ def test_load_snapshot_failure_handling(test_microvm_with_api):
     wait_process_termination(vm.firecracker_pid)
 
 
-def test_cmp_full_and_first_diff_mem(microvm_factory, guest_kernel, rootfs):
+def test_cmp_full_and_first_diff_mem(uvm_plain_any):
     """
     Compare memory of 2 consecutive full and diff snapshots.
 
@@ -241,7 +241,7 @@ def test_cmp_full_and_first_diff_mem(microvm_factory, guest_kernel, rootfs):
     """
     logger = logging.getLogger("snapshot_sequence")
 
-    vm = microvm_factory.build(guest_kernel, rootfs)
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config(
         vcpu_count=2,

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -34,14 +34,14 @@ NEGATIVE_TEST_CONNECTION_COUNT = 100
 TEST_WORKER_COUNT = 10
 
 
-def test_vsock(test_microvm_with_api, bin_vsock_path, test_fc_session_root_path):
+def test_vsock(uvm_plain_any, bin_vsock_path, test_fc_session_root_path):
     """
     Test guest and host vsock initiated connections.
 
     Check the module docstring for details on the setup.
     """
 
-    vm = test_microvm_with_api
+    vm = uvm_plain_any
     vm.spawn()
 
     vm.basic_config()
@@ -101,11 +101,11 @@ def negative_test_host_connections(vm, blob_path, blob_hash):
     validate_fc_metrics(metrics)
 
 
-def test_vsock_epipe(test_microvm_with_api, bin_vsock_path, test_fc_session_root_path):
+def test_vsock_epipe(uvm_plain_any, bin_vsock_path, test_fc_session_root_path):
     """
     Vsock negative test to validate SIGPIPE/EPIPE handling.
     """
-    vm = test_microvm_with_api
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config()
     vm.add_net_iface()


### PR DESCRIPTION
For historic reasons, a lot of our integration tests uses the test_microvm_with_api fixture, with caused them to only use a 5.10 guest kernel. For tests that meaningfully interact with the guest kernel, we instead want to test all supported guest kernels. The uvm_plain_any fixture does exactly this, so use it.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
