### PR TITLE
test(repo): ensure CHANGELOG.md is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,7 +1052,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and to run as a daemon.
 - Enabled PATCH operations on `/drives` resources.
 
-## Changed
+### Changed
 
 - The microVM `id` supplied to the jailer may now contain alphanumeric
   characters and hyphens, up to a maximum length of 64 characters.

--- a/tests/integration_tests/style/test_repo.py
+++ b/tests/integration_tests/style/test_repo.py
@@ -3,6 +3,7 @@
 
 """Tests enforcing git repository structure"""
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -34,3 +35,25 @@ def test_repo_validate_yaml():
         if str(path).startswith("../build/"):
             continue
         yaml.safe_load(path.open(encoding="utf-8"))
+
+
+def test_repo_validate_changelog():
+    """Make sure the CHANGELOG.md file follows the Keep a Changelog format"""
+
+    changelog_path = Path("../CHANGELOG.md")
+    changelog = changelog_path.read_text(encoding="utf-8").splitlines()
+    errors = []
+    for lineno, line in enumerate(changelog, start=1):
+        if line.startswith("## "):
+            if not re.match(r"^## \[.+\]$", line):
+                msg = "Level 2 headings (versions) should be wrapped in []"
+                errors.append((lineno, msg, line))
+        if line.startswith("### "):
+            if not re.match(r"^### (Added|Changed|Deprecated|Removed|Fixed)$", line):
+                msg = "Unknown Level 3 heading"
+                errors.append((lineno, msg, line))
+
+    for lineno, msg, line in errors:
+        print(msg)
+        print(f"\t{lineno}:{line}")
+    assert len(errors) == 0


### PR DESCRIPTION
It is easy to forget to add the brackets when adding a new "Unreleased" version. Add a simple test to validate this.

Also fix a small issue the test caught.

## Changes

- Add a test to check CHANGELOG.md is valid
- Fix CHANGELOG.md

## Reason

To ensure CHANGELOG.md is always in a releasable state.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
