### PR TITLE
Fix jailer `--parent-cgroup` parameter when no cgroups specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#4309](https://github.com/firecracker-microvm/firecracker/pull/4309): The
+  jailer's option `--parent-cgroup` will move the process to that cgroup if no
+  `cgroup` options are provided.
 - Simplified and clarified the removal policy of deprecated API elements
   to follow semantic versioning 2.0.0. For more information, please refer to
   [this GitHub discussion](https://github.com/firecracker-microvm/firecracker/discussions/4135).

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -46,6 +46,8 @@ jailer --id <id> \
   the jailer will write all cgroup parameters specified through `--cgroup` in
   `/sys/fs/cgroup/<controller_name>/all_uvms/external_uvms/<id>`. By default, the
   parent cgroup is `exec-file`.
+  If there are no `--cgroup` parameters specified and `--group-version=2` was
+  passed, then the jailer will move the process to the specified cgroup.
 - `cgroup-version` is used to select which type of cgroup hierarchy to use for
   the creation of cgroups. The default value is "1" which means that cgroups
   specified with the `cgroup` argument will be created within a v1 hierarchy.

--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -161,6 +161,16 @@ impl CgroupBuilder {
             }
         }
     }
+
+    // Returns the path to the root of the hierarchy
+    pub fn get_v2_hierarchy_path(&mut self) -> Result<&PathBuf, JailerError> {
+        match self.hierarchies.entry("unified".to_string()) {
+            Occupied(entry) => Ok(entry.into_mut()),
+            Vacant(_entry) => Err(JailerError::CgroupHierarchyMissing(
+                "cgroupsv2 hierarchy missing".to_string(),
+            )),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -32,8 +32,6 @@ pub enum JailerError {
     CgroupLineNotFound(String, String),
     #[error("Cgroup invalid file: {0}")]
     CgroupInvalidFile(String),
-    #[error("Expected value {0} for {2}. Current value: {1}")]
-    CgroupWrite(String, String, String),
     #[error("Invalid format for cgroups: {0}")]
     CgroupFormat(String),
     #[error("Hierarchy not found: {0}")]
@@ -44,6 +42,8 @@ pub enum JailerError {
     CgroupInvalidVersion(String),
     #[error("Parent cgroup path is invalid. Path should not be absolute or contain '..' or '.'")]
     CgroupInvalidParentPath(),
+    #[error("Failed to write to cgroups file: {0}")]
+    CgroupWrite(io::Error),
     #[error("Failed to change owner for {0:?}: {1}")]
     ChangeFileOwner(PathBuf, io::Error),
     #[error("Failed to chdir into chroot directory: {0}")]

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -72,7 +72,7 @@ class JailerContext:
         self.new_pid_ns = new_pid_ns
         self.extra_args = extra_args
         self.api_socket_name = DEFAULT_USOCKET_NAME
-        self.cgroups = cgroups
+        self.cgroups = cgroups or []
         self.resource_limits = resource_limits
         self.cgroup_ver = cgroup_ver
         self.parent_cgroup = parent_cgroup
@@ -112,7 +112,7 @@ class JailerContext:
             jailer_param_list.extend(["--parent-cgroup", str(self.parent_cgroup)])
         if self.cgroup_ver:
             jailer_param_list.extend(["--cgroup-version", str(self.cgroup_ver)])
-        if self.cgroups is not None:
+        if self.cgroups:
             for cgroup in self.cgroups:
                 jailer_param_list.extend(["--cgroup", str(cgroup)])
         if self.resource_limits is not None:

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests that verify the jailer's behavior."""
 
-import functools
 import http.client as http_client
 import os
 import resource
@@ -196,24 +195,30 @@ def test_arbitrary_usocket_location(test_microvm_with_api):
     )
 
 
-@functools.lru_cache(maxsize=None)
-def cgroup_v2_available():
-    """Check if cgroup-v2 is enabled on the system."""
-    # https://rootlesscontaine.rs/getting-started/common/cgroup2/#checking-whether-cgroup-v2-is-already-enabled
-    return os.path.isfile("/sys/fs/cgroup/cgroup.controllers")
+class Cgroups:
+    """Helper class to work with cgroups"""
+
+    def __init__(self):
+        self.root = Path("/sys/fs/cgroup")
+        self.version = 2
+        # https://rootlesscontaine.rs/getting-started/common/cgroup2/#checking-whether-cgroup-v2-is-already-enabled
+        if not self.root.joinpath("cgroup.controllers").exists():
+            self.version = 1
+
+    def new_cgroup(self, cgname):
+        """Create a new cgroup"""
+        self.root.joinpath(cgname).mkdir(parents=True)
+
+    def move_pid(self, cgname, pid):
+        """Move a PID to a cgroup"""
+        cg_pids = self.root.joinpath(f"{cgname}/cgroup.procs")
+        cg_pids.write_text(f"{pid}\n", encoding="ascii")
 
 
 @pytest.fixture(scope="session", autouse=True)
-def sys_setup_cgroups():
-    """Configure cgroupfs in order to run the tests.
-
-    This fixture sets up the cgroups on the system to enable processes
-    spawned by the tests be able to create cgroups successfully.
-    This set-up is important to do when running from inside a Docker
-    container while the system is using cgroup-v2.
-    """
-    cgroup_version = 2 if cgroup_v2_available() else 1
-    yield cgroup_version
+def cgroups_info():
+    """Return a fixture with the cgroups available in the system"""
+    return Cgroups()
 
 
 def check_cgroups_v1(cgroups, jailer_id, parent_cgroup=FC_BINARY_NAME):
@@ -237,13 +242,12 @@ def check_cgroups_v1(cgroups, jailer_id, parent_cgroup=FC_BINARY_NAME):
 
 def check_cgroups_v2(vm):
     """Assert that every cgroupv2 in cgroups is correctly set."""
-    # We assume sysfs cgroups are mounted here.
-    cg_root = Path("/sys/fs/cgroup")
-    assert cg_root.is_dir()
+    cg = Cgroups()
+    assert cg.root.is_dir()
     parent_cgroup = vm.jailer.parent_cgroup
     if parent_cgroup is None:
         parent_cgroup = FC_BINARY_NAME
-    cg_parent = cg_root / parent_cgroup
+    cg_parent = cg.root / parent_cgroup
     cg_jail = cg_parent / vm.jailer.jailer_id
     for cgroup in vm.jailer.cgroups:
         controller = cgroup.split(".")[0]
@@ -256,7 +260,7 @@ def check_cgroups_v2(vm):
         assert all(x.isnumeric() for x in procs)
         assert str(vm.firecracker_pid) in procs
 
-        for cgroup in [cg_root, cg_parent, cg_jail]:
+        for cgroup in [cg.root, cg_parent, cg_jail]:
             assert controller in cgroup.joinpath("cgroup.controllers").read_text(
                 encoding="ascii"
             )
@@ -290,12 +294,12 @@ def check_limits(pid, no_file, fsize):
     assert hard == fsize
 
 
-def test_cgroups(test_microvm_with_api, sys_setup_cgroups):
+def test_cgroups(test_microvm_with_api, cgroups_info):
     """
     Test the cgroups are correctly set by the jailer.
     """
     test_microvm = test_microvm_with_api
-    test_microvm.jailer.cgroup_ver = sys_setup_cgroups
+    test_microvm.jailer.cgroup_ver = cgroups_info.version
     if test_microvm.jailer.cgroup_ver == 2:
         test_microvm.jailer.cgroups = ["cpu.weight.nice=10"]
     else:
@@ -318,12 +322,12 @@ def test_cgroups(test_microvm_with_api, sys_setup_cgroups):
         check_cgroups_v2(test_microvm)
 
 
-def test_cgroups_custom_parent(test_microvm_with_api, sys_setup_cgroups):
+def test_cgroups_custom_parent(test_microvm_with_api, cgroups_info):
     """
     Test cgroups when a custom parent cgroup is used.
     """
     test_microvm = test_microvm_with_api
-    test_microvm.jailer.cgroup_ver = sys_setup_cgroups
+    test_microvm.jailer.cgroup_ver = cgroups_info.version
     test_microvm.jailer.parent_cgroup = "custom_cgroup/group2"
     if test_microvm.jailer.cgroup_ver == 2:
         test_microvm.jailer.cgroups = ["cpu.weight=2"]
@@ -350,12 +354,12 @@ def test_cgroups_custom_parent(test_microvm_with_api, sys_setup_cgroups):
         check_cgroups_v2(test_microvm)
 
 
-def test_node_cgroups(test_microvm_with_api, sys_setup_cgroups):
+def test_node_cgroups(test_microvm_with_api, cgroups_info):
     """
     Test the numa node cgroups are correctly set by the jailer.
     """
     test_microvm = test_microvm_with_api
-    test_microvm.jailer.cgroup_ver = sys_setup_cgroups
+    test_microvm.jailer.cgroup_ver = cgroups_info.version
 
     # Retrieve CPUs from NUMA node 0.
     node_cpus = get_cpus(0)
@@ -371,12 +375,12 @@ def test_node_cgroups(test_microvm_with_api, sys_setup_cgroups):
         check_cgroups_v2(test_microvm)
 
 
-def test_cgroups_without_numa(test_microvm_with_api, sys_setup_cgroups):
+def test_cgroups_without_numa(test_microvm_with_api, cgroups_info):
     """
     Test the cgroups are correctly set by the jailer, without numa assignment.
     """
     test_microvm = test_microvm_with_api
-    test_microvm.jailer.cgroup_ver = sys_setup_cgroups
+    test_microvm.jailer.cgroup_ver = cgroups_info.version
     if test_microvm.jailer.cgroup_ver == 2:
         test_microvm.jailer.cgroups = ["cpu.weight=2"]
     else:
@@ -390,18 +394,15 @@ def test_cgroups_without_numa(test_microvm_with_api, sys_setup_cgroups):
         check_cgroups_v2(test_microvm)
 
 
-@pytest.mark.skipif(
-    cgroup_v2_available() is True, reason="Requires system with cgroup-v1 enabled."
-)
-def test_v1_default_cgroups(test_microvm_with_api):
+def test_v1_default_cgroups(test_microvm_with_api, cgroups_info):
     """
     Test if the jailer is using cgroup-v1 by default.
     """
+    if cgroups_info.version != 1:
+        pytest.skip(reason="Requires system with cgroup-v1 enabled.")
     test_microvm = test_microvm_with_api
     test_microvm.jailer.cgroups = ["cpu.shares=2"]
-
     test_microvm.spawn()
-
     check_cgroups_v1(test_microvm.jailer.cgroups, test_microvm.jailer.jailer_id)
 
 


### PR DESCRIPTION
## Changes

If we specify `--parent-cgroup` without any `--cgroup` option, the jailer doesn't do anything, though a user specifying it could reasonably expect it to move the process under that cgroup.

We could just error in that situation, and expect something else to launch the jailer process in a cgroup, but we risk breaking anybody that is already using it that way.

Instead, we move the process to the `--parent-cgroup` since it's the most intuitive, although the specified `--parent-cgroup` is not a parent in that case.

Closes: #4287 

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
