### PR TITLE
Allow vsock device to process arbitrarily shaped descriptor chains, in anticipation of guest-side Linux 6.1 changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
+name = "smallvec"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
 name = "snapshot"
 version = "0.1.0"
 dependencies = [
@@ -1509,6 +1515,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "smallvec",
  "snapshot",
  "thiserror",
  "timerfd",

--- a/src/clippy-tracing/tests/integration_tests.rs
+++ b/src/clippy-tracing/tests/integration_tests.rs
@@ -191,7 +191,7 @@ fn exclude() {
                             lhs + rhs\n}";
 
     let dir_path = format!("/tmp/{}", Uuid::new_v4());
-    let _dir = std::fs::create_dir(&dir_path).unwrap();
+    std::fs::create_dir(&dir_path).unwrap();
 
     dbg!(&dir_path);
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -42,6 +42,7 @@ log-instrument = { path = "../log-instrument", optional = true }
 seccompiler = { path = "../seccompiler" }
 snapshot = { path = "../snapshot"}
 utils = { path = "../utils" }
+smallvec = "1.11.2"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 vm-fdt = "0.2.0"

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -444,13 +444,15 @@ impl Net {
         guest_mac: Option<MacAddr>,
         net_metrics: &NetDeviceMetrics,
     ) -> Result<bool, NetError> {
-        // Read the frame headers from the IoVecBuffer. This will return None
-        // if the frame_iovec is empty.
-        let header_len = frame_iovec.read_at(headers, 0).ok_or_else(|| {
-            error!("Received empty TX buffer");
-            net_metrics.tx_malformed_frames.inc();
-            NetError::VnetHeaderMissing
-        })?;
+        // Read the frame headers from the IoVecBuffer
+        let max_header_len = headers.len();
+        let header_len = frame_iovec
+            .read_volatile_at(&mut &mut *headers, 0, max_header_len)
+            .map_err(|err| {
+                error!("Received malformed TX buffer: {:?}", err);
+                net_metrics.tx_malformed_frames.inc();
+                NetError::VnetHeaderMissing
+            })?;
 
         let headers = frame_bytes_from_buf(&headers[..header_len]).map_err(|e| {
             error!("VNET headers missing in TX frame");
@@ -463,7 +465,9 @@ impl Net {
                 let mut frame = vec![0u8; frame_iovec.len() - vnet_hdr_len()];
                 // Ok to unwrap here, because we are passing a buffer that has the exact size
                 // of the `IoVecBuffer` minus the VNET headers.
-                frame_iovec.read_at(&mut frame, vnet_hdr_len()).unwrap();
+                frame_iovec
+                    .read_exact_volatile_at(&mut frame, vnet_hdr_len())
+                    .unwrap();
                 let _ = ns.detour_frame(&frame);
                 METRICS.mmds.rx_accepted.inc();
 
@@ -1510,7 +1514,7 @@ pub mod tests {
         let buffer = IoVecBuffer::from(&frame_buf[..frame_len]);
 
         let mut headers = vec![0; frame_hdr_len()];
-        buffer.read_at(&mut headers, 0).unwrap();
+        buffer.read_exact_volatile_at(&mut headers, 0).unwrap();
 
         // Call the code which sends the packet to the host or MMDS.
         // Validate the frame was consumed by MMDS and that the metrics reflect that.

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -589,7 +589,7 @@ impl Net {
         while let Some(head) = tx_queue.pop_or_enable_notification(mem) {
             let head_index = head.index;
             // Parse IoVecBuffer from descriptor head
-            let buffer = match IoVecBuffer::from_descriptor_chain(mem, head) {
+            let buffer = match IoVecBuffer::from_descriptor_chain(head) {
                 Ok(buffer) => buffer,
                 Err(_) => {
                     self.metrics.tx_fails.inc();

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -131,7 +131,7 @@ impl Entropy {
             let index = desc.index;
             METRICS.entropy_event_count.inc();
 
-            let bytes = match IoVecBufferMut::from_descriptor_chain(mem, desc) {
+            let bytes = match IoVecBufferMut::from_descriptor_chain(desc) {
                 Ok(mut iovec) => {
                     debug!(
                         "entropy: guest request for {} bytes of entropy",
@@ -432,13 +432,13 @@ mod tests {
         // This should succeed, we just added two descriptors
         let desc = entropy_dev.queues_mut()[RNG_QUEUE].pop(&mem).unwrap();
         assert!(matches!(
-            IoVecBufferMut::from_descriptor_chain(&mem, desc,),
+            IoVecBufferMut::from_descriptor_chain(desc),
             Err(crate::devices::virtio::iovec::IoVecError::ReadOnlyDescriptor)
         ));
 
         // This should succeed, we should have one more descriptor
         let desc = entropy_dev.queues_mut()[RNG_QUEUE].pop(&mem).unwrap();
-        let mut iovec = IoVecBufferMut::from_descriptor_chain(&mem, desc).unwrap();
+        let mut iovec = IoVecBufferMut::from_descriptor_chain(desc).unwrap();
         assert!(entropy_dev.handle_one(&mut iovec).is_ok());
     }
 

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -119,7 +119,8 @@ impl Entropy {
         })?;
 
         // It is ok to unwrap here. We are writing `iovec.len()` bytes at offset 0.
-        Ok(iovec.write_at(&rand_bytes, 0).unwrap().try_into().unwrap())
+        iovec.write_all_volatile_at(&rand_bytes, 0).unwrap();
+        Ok(iovec.len().try_into().unwrap())
     }
 
     fn process_entropy_queue(&mut self) {

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -150,7 +150,7 @@ where
             let index = head.index;
             let used_len = match VsockPacket::from_rx_virtq_head(head) {
                 Ok(mut pkt) => {
-                    if self.backend.recv_pkt(&mut pkt, mem).is_ok() {
+                    if self.backend.recv_pkt(&mut pkt).is_ok() {
                         match pkt.commit_hdr() {
                             // This addition cannot overflow, because packet length
                             // is previously validated against `MAX_PKT_BUF_SIZE`
@@ -215,7 +215,7 @@ where
                 }
             };
 
-            if self.backend.send_pkt(&pkt, mem).is_err() {
+            if self.backend.send_pkt(&pkt).is_err() {
                 self.queues[TXQ_INDEX].undo_pop();
                 break;
             }

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -147,10 +147,11 @@ where
         let mut have_used = false;
 
         while let Some(head) = self.queues[RXQ_INDEX].pop(mem) {
-            let used_len = match VsockPacket::from_rx_virtq_head(&head) {
+            let index = head.index;
+            let used_len = match VsockPacket::from_rx_virtq_head(head) {
                 Ok(mut pkt) => {
                     if self.backend.recv_pkt(&mut pkt, mem).is_ok() {
-                        match pkt.commit_hdr(mem) {
+                        match pkt.commit_hdr() {
                             // This addition cannot overflow, because packet length
                             // is previously validated against `MAX_PKT_BUF_SIZE`
                             // bound as part of `commit_hdr()`.
@@ -180,9 +181,9 @@ where
 
             have_used = true;
             self.queues[RXQ_INDEX]
-                .add_used(mem, head.index, used_len)
+                .add_used(mem, index, used_len)
                 .unwrap_or_else(|err| {
-                    error!("Failed to add available descriptor {}: {}", head.index, err)
+                    error!("Failed to add available descriptor {}: {}", index, err)
                 });
         }
 
@@ -199,15 +200,16 @@ where
         let mut have_used = false;
 
         while let Some(head) = self.queues[TXQ_INDEX].pop(mem) {
-            let pkt = match VsockPacket::from_tx_virtq_head(&head) {
+            let index = head.index;
+            let pkt = match VsockPacket::from_tx_virtq_head(head) {
                 Ok(pkt) => pkt,
                 Err(err) => {
                     error!("vsock: error reading TX packet: {:?}", err);
                     have_used = true;
                     self.queues[TXQ_INDEX]
-                        .add_used(mem, head.index, 0)
+                        .add_used(mem, index, 0)
                         .unwrap_or_else(|err| {
-                            error!("Failed to add available descriptor {}: {}", head.index, err);
+                            error!("Failed to add available descriptor {}: {}", index, err);
                         });
                     continue;
                 }
@@ -220,9 +222,9 @@ where
 
             have_used = true;
             self.queues[TXQ_INDEX]
-                .add_used(mem, head.index, 0)
+                .add_used(mem, index, 0)
                 .unwrap_or_else(|err| {
-                    error!("Failed to add available descriptor {}: {}", head.index, err);
+                    error!("Failed to add available descriptor {}: {}", index, err);
                 });
         }
 

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -266,8 +266,9 @@ mod tests {
             let mut ctx = test_ctx.create_event_handler_context();
             ctx.mock_activate(test_ctx.mem.clone());
 
-            // Invalidate the packet header descriptor, by setting its length to 0.
+            // Invalidate the descriptor chain, by setting its length to 0.
             ctx.guest_txvq.dtable[0].len.set(0);
+            ctx.guest_txvq.dtable[1].len.set(0);
             ctx.signal_txq_event();
 
             // The available descriptor should have been consumed, but no packet should have
@@ -327,8 +328,9 @@ mod tests {
             let mut ctx = test_ctx.create_event_handler_context();
             ctx.mock_activate(test_ctx.mem.clone());
 
-            // Invalidate the packet header descriptor, by setting its length to 0.
+            // Invalidate the descriptor chain, by setting its length to 0.
             ctx.guest_rxvq.dtable[0].len.set(0);
+            ctx.guest_rxvq.dtable[1].len.set(0);
 
             // The chain should've been processed, without employing the backend.
             assert!(ctx.device.process_rx());
@@ -416,7 +418,7 @@ mod tests {
             // If the descriptor chain is already declared invalid, there's no reason to assemble
             // a packet.
             if let Some(rx_desc) = ctx.device.queues[RXQ_INDEX].pop(&test_ctx.mem) {
-                assert!(VsockPacket::from_rx_virtq_head(&rx_desc).is_err());
+                assert!(VsockPacket::from_rx_virtq_head(rx_desc).is_err());
             }
         }
 
@@ -438,7 +440,7 @@ mod tests {
             ctx.guest_txvq.dtable[desc_idx].len.set(len);
 
             if let Some(tx_desc) = ctx.device.queues[TXQ_INDEX].pop(&test_ctx.mem) {
-                assert!(VsockPacket::from_tx_virtq_head(&tx_desc).is_err());
+                assert!(VsockPacket::from_tx_virtq_head(tx_desc).is_err());
             }
         }
     }
@@ -467,13 +469,13 @@ mod tests {
         {
             let mut ctx = test_ctx.create_event_handler_context();
             let rx_desc = ctx.device.queues[RXQ_INDEX].pop(&test_ctx.mem).unwrap();
-            assert!(VsockPacket::from_rx_virtq_head(&rx_desc).is_ok());
+            assert!(VsockPacket::from_rx_virtq_head(rx_desc).is_ok());
         }
 
         {
             let mut ctx = test_ctx.create_event_handler_context();
             let tx_desc = ctx.device.queues[TXQ_INDEX].pop(&test_ctx.mem).unwrap();
-            assert!(VsockPacket::from_tx_virtq_head(&tx_desc).is_ok());
+            assert!(VsockPacket::from_tx_virtq_head(tx_desc).is_ok());
         }
 
         // Let's check what happens when the header descriptor is right before the gap.

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -205,7 +205,7 @@ mod tests {
     use super::*;
     use crate::devices::virtio::vsock::packet::VSOCK_PKT_HDR_SIZE;
     use crate::devices::virtio::vsock::test_utils::{EventHandlerContext, TestContext};
-    use crate::vstate::memory::{Bytes, GuestMemoryExtension};
+    use crate::vstate::memory::{Bytes, GuestMemoryExtension, GuestMemoryMmap};
 
     #[test]
     fn test_txq_event() {

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -110,8 +110,6 @@ mod defs {
 pub enum VsockError {
     /// The vsock data/buffer virtio descriptor length is smaller than expected.
     BufDescTooSmall,
-    /// The vsock data/buffer virtio descriptor is expected, but missing.
-    BufDescMissing,
     /// Empty queue
     EmptyQueue,
     /// EventFd error: {0}

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -32,7 +32,6 @@ pub use self::device::Vsock;
 pub use self::unix::{VsockUnixBackend, VsockUnixBackendError};
 use crate::devices::virtio::iovec::IoVecError;
 use crate::devices::virtio::persist::PersistError as VirtioStateError;
-use crate::vstate::memory::GuestMemoryMmap;
 
 mod defs {
     use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
@@ -172,10 +171,10 @@ pub trait VsockEpollListener: AsRawFd {
 ///       - `send_pkt(&pkt)` will fetch data from `pkt`, and place it into the channel.
 pub trait VsockChannel {
     /// Read/receive an incoming packet from the channel.
-    fn recv_pkt(&mut self, pkt: &mut VsockPacket, mem: &GuestMemoryMmap) -> Result<(), VsockError>;
+    fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> Result<(), VsockError>;
 
     /// Write/send a packet through the channel.
-    fn send_pkt(&mut self, pkt: &VsockPacket, mem: &GuestMemoryMmap) -> Result<(), VsockError>;
+    fn send_pkt(&mut self, pkt: &VsockPacket) -> Result<(), VsockError>;
 
     /// Checks whether there is pending incoming data inside the channel, meaning that a subsequent
     /// call to `recv_pkt()` won't fail.

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -107,9 +107,10 @@ mod defs {
 
 /// Vsock device related errors.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
+#[rustfmt::skip]
 pub enum VsockError {
-    /// The vsock data/buffer virtio descriptor length is smaller than expected.
-    BufDescTooSmall,
+    /** The total length of the descriptor chain ({0}) is too short to hold a packet of length {1} + header */
+    DescChainTooShortForPacket(usize, u32),
     /// Empty queue
     EmptyQueue,
     /// EventFd error: {0}
@@ -118,8 +119,9 @@ pub enum VsockError {
     GuestMemoryMmap(GuestMemoryError),
     /// Bounds check failed on guest memory pointer.
     GuestMemoryBounds,
-    /// The vsock header descriptor length is too small: {0}
-    HdrDescTooSmall(usize),
+    /** The total length of the descriptor chain ({0}) is less than the number of bytes required\
+    to hold a vsock packet header.*/
+    DescChainTooShortForHeader(usize),
     /// The vsock header `len` field holds an invalid value: {0}
     InvalidPktLen(u32),
     /// A data fetch was attempted when no data was available.

--- a/src/vmm/src/devices/virtio/vsock/packet.rs
+++ b/src/vmm/src/devices/virtio/vsock/packet.rs
@@ -16,17 +16,13 @@
 //! to temporary buffers, before passing it on to the vsock backend.
 
 use std::fmt::Debug;
-use std::io::ErrorKind;
 
-use vm_memory::{
-    GuestMemoryError, ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile,
-};
+use vm_memory::{GuestMemoryError, ReadVolatile, WriteVolatile};
 
 use super::{defs, VsockError};
+use crate::devices::virtio::iovec::{IoVecBuffer, IoVecBufferMut};
 use crate::devices::virtio::queue::DescriptorChain;
-use crate::vstate::memory::{
-    Address, AtomicBitmap, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, BS,
-};
+use crate::vstate::memory::ByteValued;
 
 // The vsock packet header is defined by the C struct:
 //
@@ -86,151 +82,89 @@ pub const VSOCK_PKT_HDR_SIZE: u32 = 44;
 // SAFETY: `VsockPacketHeader` is a POD and contains no padding.
 unsafe impl ByteValued for VsockPacketHeader {}
 
-/// The vsock packet, implemented as a wrapper over a virtq descriptor chain:
-/// - the chain head, holding the packet header; and
-/// - (an optional) data/buffer descriptor, only present for data packets (VSOCK_OP_RW).
+/// Enum representing either a TX (e.g. read-only) or RX (e.g. write-only) buffer
+///
+/// Read and write permissions are statically enforced by using the correct `IoVecBuffer[Mut]`
+/// abstraction
+#[derive(Debug)]
+pub enum VsockPacketBuffer {
+    /// Buffer holds a read-only guest-to-host (TX) packet
+    Tx(IoVecBuffer),
+    /// Buffer holds a write-only host-to-guest (RX) packet
+    Rx(IoVecBufferMut),
+}
+
+/// Struct describing a single vsock packet.
+///
+/// Encapsulates the virtio descriptor chain containing the packet through the `IoVecBuffer[Mut]`
+/// abstractions.
 #[derive(Debug)]
 pub struct VsockPacket {
-    hdr_addr: GuestAddress,
-    // For performance purposes we hold a local copy of the Packet header.
-    // This reduces the number of calls to `vm-memory` to a minimum:
-    // 1 write for Rx and 1 read for Tx, plus 1 `check_range` call for each.
+    /// A copy of the vsock packet's 44-byte header, held in hypervisor memory
+    /// to minimize the number of accesses to guest memory. Can be written back
+    /// to geust memory using [`VsockPacket::commit_hdr`] (only for RX buffers).
     hdr: VsockPacketHeader,
-    buf_addr: Option<GuestAddress>,
-    buf_size: usize,
+    /// The raw buffer, as it is contained in guest memory (containing both
+    /// header and payload)
+    buffer: VsockPacketBuffer,
 }
 
 impl VsockPacket {
-    fn check_desc_write_only(
-        desc: &DescriptorChain,
-        expected_write_only: bool,
-    ) -> Result<(), VsockError> {
-        if desc.is_write_only() != expected_write_only {
-            return match desc.is_write_only() {
-                true => Err(VsockError::UnreadableDescriptor),
-                false => Err(VsockError::UnwritableDescriptor),
-            };
-        }
-
-        Ok(())
-    }
-
-    fn check_hdr_desc(
-        hdr_desc: &DescriptorChain,
-        expected_write_only: bool,
-    ) -> Result<(), VsockError> {
-        Self::check_desc_write_only(hdr_desc, expected_write_only)?;
-
-        // Validate the packet header address
-        if !hdr_desc
-            .mem
-            .check_range(hdr_desc.addr, VSOCK_PKT_HDR_SIZE as usize)
-        {
-            return Err(VsockError::GuestMemoryBounds);
-        }
-
-        // The packet header should fit inside the head descriptor.
-        if hdr_desc.len < VSOCK_PKT_HDR_SIZE {
-            return Err(VsockError::HdrDescTooSmall(hdr_desc.len));
-        }
-
-        Ok(())
-    }
-
-    fn init_buf(
-        &mut self,
-        hdr_desc: &DescriptorChain,
-        expected_write_only: bool,
-    ) -> Result<(), VsockError> {
-        let buf_desc = hdr_desc
-            .next_descriptor()
-            .ok_or(VsockError::BufDescMissing)?;
-        let buf_size = buf_desc.len as usize;
-
-        Self::check_desc_write_only(&buf_desc, expected_write_only)?;
-
-        // Validate the packet buf address
-        if !buf_desc
-            .mem
-            .check_range(buf_desc.addr, buf_desc.len as usize)
-        {
-            return Err(VsockError::GuestMemoryBounds);
-        }
-
-        self.buf_addr = Some(buf_desc.addr);
-        self.buf_size = buf_size;
-
-        Ok(())
-    }
-
     /// Create the packet wrapper from a TX virtq chain head.
     ///
-    /// The chain head is expected to hold valid packet header data. A following packet buffer
-    /// descriptor can optionally end the chain. Bounds and pointer checks are performed when
-    /// creating the wrapper.
-    pub fn from_tx_virtq_head(hdr_desc: &DescriptorChain) -> Result<Self, VsockError> {
-        Self::check_hdr_desc(hdr_desc, false)?;
+    /// ## Errors
+    /// Returns
+    /// - [`VsockError::UnreadableDescriptor`] if the provided descriptor chain contains any
+    ///   descriptor not marked as writable.
+    /// - [`VsockError::HdrDescTooSmall`] if the descriptor chain's total buffer length is
+    ///   insufficient to hold the 44 byte vsock header
+    /// - [`VsockError::InvalidPktLen`] if the contained vsock header describes a vsock packet whose
+    ///   length would exceed [`defs::MAX_PKT_BUR_SIZE`].
+    /// - [`VsockError::BufDescTooSmall`] if the contained vsock header describes a vsock packet
+    ///   whose length exceeds the descriptor chain's actual total buffer length.
+    pub fn from_tx_virtq_head(chain: DescriptorChain) -> Result<Self, VsockError> {
+        let buffer = IoVecBuffer::from_descriptor_chain(chain)?;
 
-        // Validate the packet header address
-        if !hdr_desc
-            .mem
-            .check_range(hdr_desc.addr, VSOCK_PKT_HDR_SIZE as usize)
-        {
-            return Err(VsockError::GuestMemoryBounds);
+        let mut hdr = VsockPacketHeader::default();
+        let header_bytes_read = buffer.read_at(hdr.as_mut_slice(), 0).unwrap_or(0);
+        if header_bytes_read < VSOCK_PKT_HDR_SIZE as usize {
+            return Err(VsockError::HdrDescTooSmall(header_bytes_read));
         }
 
-        let mut pkt = Self {
-            hdr_addr: hdr_desc.addr,
-            // On the Tx path the header is provided by the guest and is read only for Firecracker.
-            // So we read it here once and we work with the local copy from now on.
-            hdr: hdr_desc
-                .mem
-                .read_obj(hdr_desc.addr)
-                .map_err(VsockError::GuestMemoryMmap)?,
-            buf_addr: None,
-            buf_size: 0,
-        };
-
-        // No point looking for a data/buffer descriptor, if the packet is zero-lengthed.
-        if pkt.len() == 0 {
-            return Ok(pkt);
+        if hdr.len > defs::MAX_PKT_BUF_SIZE {
+            return Err(VsockError::InvalidPktLen(hdr.len));
         }
 
-        // Reject weirdly-sized packets.
-        pkt.check_len()?;
-
-        pkt.init_buf(hdr_desc, false)?;
-
-        // The data buffer should be large enough to fit the size of the data, as described by
-        // the header descriptor.
-        if pkt.buf_size < pkt.len() as usize {
+        if (hdr.len as usize) > buffer.len() - VSOCK_PKT_HDR_SIZE as usize {
             return Err(VsockError::BufDescTooSmall);
         }
 
-        Ok(pkt)
+        Ok(VsockPacket {
+            hdr,
+            buffer: VsockPacketBuffer::Tx(buffer),
+        })
     }
 
     /// Create the packet wrapper from an RX virtq chain head.
     ///
-    /// There must be two descriptors in the chain, both writable: a header descriptor and a data
-    /// descriptor. Bounds and pointer checks are performed when creating the wrapper.
-    pub fn from_rx_virtq_head(hdr_desc: &DescriptorChain) -> Result<Self, VsockError> {
-        Self::check_hdr_desc(hdr_desc, true)?;
+    /// ## Errors
+    /// Returns [`VsockError::HdrDescTooSmall`] if the descriptor chain's total buffer length is
+    /// insufficient to hold the 44 byte vsock header
+    pub fn from_rx_virtq_head(chain: DescriptorChain) -> Result<Self, VsockError> {
+        let buffer = IoVecBufferMut::from_descriptor_chain(chain)?;
 
-        let mut pkt = Self {
-            hdr_addr: hdr_desc.addr,
+        if buffer.len() < VSOCK_PKT_HDR_SIZE as usize {
+            return Err(VsockError::HdrDescTooSmall(buffer.len()));
+        }
+
+        Ok(Self {
             // On the Rx path the header has to be filled by Firecracker. The guest only provides
             // a write-only memory area that Firecracker can write the header into. So we initialize
             // the local copy with zeros, we write to it whenever we need to, and we only commit it
             // to the guest memory once, before marking the RX descriptor chain as used.
             hdr: VsockPacketHeader::default(),
-            buf_addr: None,
-            buf_size: 0,
-        };
-
-        pkt.init_buf(hdr_desc, true)?;
-
-        Ok(pkt)
+            buffer: VsockPacketBuffer::Rx(buffer),
+        })
     }
 
     /// Provides in-place access to the local copy of the vsock packet header.
@@ -239,103 +173,90 @@ impl VsockPacket {
     }
 
     /// Writes the local copy of the packet header to the guest memory.
-    pub fn commit_hdr(&self, mem: &GuestMemoryMmap) -> Result<(), VsockError> {
-        // Reject weirdly-sized packets.
-        self.check_len()?;
-
-        mem.write_obj(self.hdr, self.hdr_addr)
-            .map_err(VsockError::GuestMemoryMmap)
-    }
-
-    /// Verifies packet length against `MAX_PKT_BUF_SIZE` limit.
-    pub fn check_len(&self) -> Result<(), VsockError> {
-        if self.len() > defs::MAX_PKT_BUF_SIZE {
-            return Err(VsockError::InvalidPktLen(self.len()));
-        }
-
-        Ok(())
-    }
-
-    pub fn buf_size(&self) -> usize {
-        self.buf_size
-    }
-
-    /// Verifies that it is legal to write `count` bytes into the data descriptor of this
-    /// [`VsockPacket`] at offset `buf_offset`.
     ///
-    /// Returns a [`VolatileSlice`͘] of length `count` starting at offset `buf_offset` to the
-    /// [`GuestMemoryMmap`] backing the data descriptor of this [`VsockPacket`].
-    fn check_bounds_for_buffer_access<'a>(
-        &'a self,
-        mem: &'a GuestMemoryMmap,
-        buf_offset: usize,
-        count: usize,
-    ) -> Result<VolatileSlice<'a, BS<Option<AtomicBitmap>>>, VsockError> {
-        // Check that the desired slice is inside the buf.
-        self.buf_size
-            .checked_sub(buf_offset)
-            .and_then(|remaining_size| remaining_size.checked_sub(count))
-            .ok_or(VsockError::GuestMemoryBounds)?;
+    /// ## Errors
+    /// The function returns [`VsockError::UnwritableDescriptor`] if this [`VsockPacket`]
+    /// contains a guest-to-host (TX) packet. It returned [`VsockError::InvalidPktLen`] if the
+    /// packet's payload as described by this [`VsockPacket`] would exceed
+    /// [`defs::MAX_PKT_BUF_SIZE`].
+    pub fn commit_hdr(&mut self) -> Result<(), VsockError> {
+        match self.buffer {
+            VsockPacketBuffer::Tx(_) => Err(VsockError::UnwritableDescriptor),
+            VsockPacketBuffer::Rx(ref mut buffer) => {
+                if self.hdr.len > defs::MAX_PKT_BUF_SIZE {
+                    return Err(VsockError::InvalidPktLen(self.hdr.len));
+                }
 
-        let buf_addr = self.buf_addr.ok_or(VsockError::PktBufMissing)?;
+                let bytes_written = buffer.write_at(self.hdr.as_slice(), 0);
 
-        buf_addr
-            .checked_add(buf_offset as u64)
-            .and_then(|offset_addr| mem.get_slice(offset_addr, count).ok())
-            .and_then(|slice| {
-                // This rejects the scenario where buf_offset == buf_size and count == 0, which
-                // vm-memory would consider a valid subslice.
-                let _ = slice.offset(count.checked_sub(1)?).ok()?;
-                Some(slice)
-            })
-            .ok_or(VsockError::GuestMemoryBounds)
+                // We check the the buffer has sufficient size in from_rx_virtq_head
+                debug_assert_eq!(bytes_written, Some(VSOCK_PKT_HDR_SIZE as usize));
+
+                Ok(())
+            }
+        }
+    }
+
+    /// Returns the total length of this [`VsockPacket`]'s buffer (e.g. the amount of data bytes
+    /// contained in this packet).
+    ///
+    /// Return value will equal the total length of the underlying descriptor chain's buffers,
+    /// minus the length of the vsock header.
+    pub fn buf_size(&self) -> usize {
+        let chain_length = match self.buffer {
+            VsockPacketBuffer::Tx(ref iovec_buf) => iovec_buf.len(),
+            VsockPacketBuffer::Rx(ref iovec_buf) => iovec_buf.len(),
+        };
+        chain_length - VSOCK_PKT_HDR_SIZE as usize
     }
 
     pub fn read_at_offset_from<T: ReadVolatile + Debug>(
         &mut self,
-        mem: &GuestMemoryMmap,
-        offset: usize,
         src: &mut T,
+        offset: usize,
         count: usize,
     ) -> Result<usize, VsockError> {
-        let mut dst = self.check_bounds_for_buffer_access(mem, offset, count)?;
+        match self.buffer {
+            VsockPacketBuffer::Tx(_) => Err(VsockError::UnwritableDescriptor),
+            VsockPacketBuffer::Rx(ref mut buffer) => {
+                if count
+                    > buffer
+                        .len()
+                        .saturating_sub(VSOCK_PKT_HDR_SIZE as usize)
+                        .saturating_sub(offset)
+                {
+                    return Err(VsockError::GuestMemoryBounds);
+                }
 
-        loop {
-            match src.read_volatile(&mut dst) {
-                Err(VolatileMemoryError::IOError(err)) if err.kind() == ErrorKind::Interrupted => {
-                    continue
-                }
-                Ok(bytes_read) => return Ok(bytes_read),
-                Err(volatile_memory_error) => {
-                    return Err(VsockError::GuestMemoryMmap(GuestMemoryError::from(
-                        volatile_memory_error,
-                    )))
-                }
+                buffer
+                    .write_volatile_at(src, offset + VSOCK_PKT_HDR_SIZE as usize, count)
+                    .map_err(|err| VsockError::GuestMemoryMmap(GuestMemoryError::from(err)))
             }
         }
     }
 
     pub fn write_from_offset_to<T: WriteVolatile + Debug>(
         &self,
-        mem: &GuestMemoryMmap,
-        offset: usize,
         dst: &mut T,
+        offset: usize,
         count: usize,
     ) -> Result<usize, VsockError> {
-        let src = self.check_bounds_for_buffer_access(mem, offset, count)?;
+        match self.buffer {
+            VsockPacketBuffer::Tx(ref buffer) => {
+                if count
+                    > buffer
+                        .len()
+                        .saturating_sub(VSOCK_PKT_HDR_SIZE as usize)
+                        .saturating_sub(offset)
+                {
+                    return Err(VsockError::GuestMemoryBounds);
+                }
 
-        loop {
-            match dst.write_volatile(&src) {
-                Err(VolatileMemoryError::IOError(err)) if err.kind() == ErrorKind::Interrupted => {
-                    continue
-                }
-                Ok(bytes_written) => return Ok(bytes_written),
-                Err(volatile_memory_error) => {
-                    return Err(VsockError::GuestMemoryMmap(GuestMemoryError::from(
-                        volatile_memory_error,
-                    )))
-                }
+                buffer
+                    .read_volatile_at(dst, offset + VSOCK_PKT_HDR_SIZE as usize, count)
+                    .map_err(|err| VsockError::GuestMemoryMmap(GuestMemoryError::from(err)))
             }
+            VsockPacketBuffer::Rx(_) => Err(VsockError::UnreadableDescriptor),
         }
     }
 

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -61,11 +61,7 @@ impl Default for TestBackend {
 }
 
 impl VsockChannel for TestBackend {
-    fn recv_pkt(
-        &mut self,
-        pkt: &mut VsockPacket,
-        _mem: &GuestMemoryMmap,
-    ) -> Result<(), VsockError> {
+    fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> Result<(), VsockError> {
         let cool_buf = [0xDu8, 0xE, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF];
         match self.rx_err.take() {
             None => {
@@ -84,7 +80,7 @@ impl VsockChannel for TestBackend {
         }
     }
 
-    fn send_pkt(&mut self, _pkt: &VsockPacket, _mem: &GuestMemoryMmap) -> Result<(), VsockError> {
+    fn send_pkt(&mut self, _pkt: &VsockPacket) -> Result<(), VsockError> {
         match self.tx_err.take() {
             None => {
                 self.tx_ok_cnt += 1;

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -61,7 +61,11 @@ impl Default for TestBackend {
 }
 
 impl VsockChannel for TestBackend {
-    fn recv_pkt(&mut self, pkt: &mut VsockPacket, mem: &GuestMemoryMmap) -> Result<(), VsockError> {
+    fn recv_pkt(
+        &mut self,
+        pkt: &mut VsockPacket,
+        _mem: &GuestMemoryMmap,
+    ) -> Result<(), VsockError> {
         let cool_buf = [0xDu8, 0xE, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF];
         match self.rx_err.take() {
             None => {
@@ -70,7 +74,7 @@ impl VsockChannel for TestBackend {
                     let buf: Vec<u8> = (0..buf_size)
                         .map(|i| cool_buf[i % cool_buf.len()])
                         .collect();
-                    pkt.read_at_offset_from(mem, 0, &mut buf.as_slice(), buf_size)
+                    pkt.read_at_offset_from(&mut buf.as_slice(), 0, buf_size)
                         .unwrap();
                 }
                 self.rx_ok_cnt += 1;
@@ -155,10 +159,14 @@ impl TestContext {
         guest_rxvq.avail.idx.set(1);
 
         // Set up one available descriptor in the TX queue.
-        guest_txvq.dtable[0].set(0x0050_0000, VSOCK_PKT_HDR_SIZE, VIRTQ_DESC_F_NEXT, 1);
-        guest_txvq.dtable[1].set(0x0050_1000, 4096, 0, 0);
+        guest_txvq.dtable[0].set(0x0040_0000, VSOCK_PKT_HDR_SIZE, VIRTQ_DESC_F_NEXT, 1);
+        guest_txvq.dtable[1].set(0x0040_1000, 4096, 0, 0);
         guest_txvq.avail.ring[0].set(0);
         guest_txvq.avail.idx.set(1);
+
+        // Both descriptors above point to the same area of guest memory, to work around
+        // the fact that through the TX queue, the memory is read-only, and through the RX queue,
+        // the memory is write-only.
 
         let queues = vec![rxvq, txvq, evvq];
         EventHandlerContext {
@@ -201,9 +209,9 @@ impl<'a> EventHandlerContext<'a> {
 }
 
 #[cfg(test)]
-pub fn read_packet_data(pkt: &VsockPacket, mem: &GuestMemoryMmap, how_much: usize) -> Vec<u8> {
+pub fn read_packet_data(pkt: &VsockPacket, how_much: usize) -> Vec<u8> {
     let mut buf = vec![0; how_much];
-    pkt.write_from_offset_to(mem, 0, &mut buf.as_mut_slice(), how_much)
+    pkt.write_from_offset_to(&mut buf.as_mut_slice(), 0, how_much)
         .unwrap();
     buf
 }

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1012,7 +1012,7 @@ mod tests {
         pub fn set_vsock_device(&mut self, _: VsockDeviceConfig) -> Result<(), VsockConfigError> {
             if self.force_errors {
                 return Err(VsockConfigError::CreateVsockDevice(
-                    VsockError::BufDescMissing,
+                    VsockError::GuestMemoryBounds,
                 ));
             }
             self.vsock_set = true;
@@ -1471,7 +1471,7 @@ mod tests {
         check_preboot_request_err(
             req,
             VmmActionError::VsockConfig(VsockConfigError::CreateVsockDevice(
-                VsockError::BufDescMissing,
+                VsockError::GuestMemoryBounds,
             )),
         );
     }

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -34,14 +34,14 @@ NEGATIVE_TEST_CONNECTION_COUNT = 100
 TEST_WORKER_COUNT = 10
 
 
-def test_vsock(test_microvm_with_api, bin_vsock_path, test_fc_session_root_path):
+def test_vsock(uvm_plain_any, bin_vsock_path, test_fc_session_root_path):
     """
     Test guest and host vsock initiated connections.
 
     Check the module docstring for details on the setup.
     """
 
-    vm = test_microvm_with_api
+    vm = uvm_plain_any
     vm.spawn()
 
     vm.basic_config()


### PR DESCRIPTION
## Changes

Allow the vsock device to process arbitrarily shaped descriptor chains.

## Reason

As reported in #4284, with Linux 6.1 a linux guest will start using one virtio descriptor per vsock packet. Up until 6.0, it uses a two-descriptor descriptor chain, with the first descriptor containing the vsock packet header, and the second descriptor the payload (if it exists). 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
