### PR TITLE
Improve vqueue encapsulation - prerequisite for vhost work

### DIFF
--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -467,7 +467,7 @@ mod tests {
 
     use super::*;
     use crate::devices::virtio::device::VirtioDevice;
-    use crate::devices::virtio::queue::Queue;
+    use crate::devices::virtio::queue::{Queue, QueueIter, QueueIterMut};
     use crate::devices::virtio::ActivateError;
     use crate::vstate::memory::{GuestAddress, GuestMemoryExtension, GuestMemoryMmap};
     use crate::{builder, Vm};
@@ -535,12 +535,12 @@ mod tests {
             0
         }
 
-        fn queues(&self) -> &[Queue] {
-            &self.queues
+        fn queues(&self) -> QueueIter {
+            self.queues.iter()
         }
 
-        fn queues_mut(&mut self) -> &mut [Queue] {
-            &mut self.queues
+        fn queues_mut(&mut self) -> QueueIterMut {
+            self.queues.iter_mut()
         }
 
         fn queue_events(&self) -> &[EventFd] {

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -14,7 +14,6 @@ use utils::eventfd::EventFd;
 use utils::u64_to_usize;
 
 use super::super::device::{DeviceState, VirtioDevice};
-use super::super::queue::Queue;
 use super::super::{ActivateError, TYPE_BALLOON};
 use super::metrics::METRICS;
 use super::util::{compact_page_frame_numbers, remove_range};
@@ -30,6 +29,7 @@ use super::{
 use crate::devices::virtio::balloon::BalloonError;
 use crate::devices::virtio::device::{IrqTrigger, IrqType};
 use crate::devices::virtio::gen::virtio_blk::VIRTIO_F_VERSION_1;
+use crate::devices::virtio::queue::{Queue, QueueIter, QueueIterMut};
 use crate::logger::IncMetric;
 use crate::vstate::memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
 
@@ -573,12 +573,12 @@ impl VirtioDevice for Balloon {
         TYPE_BALLOON
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn queues(&self) -> QueueIter {
+        self.queues.iter()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queues_mut(&mut self) -> QueueIterMut {
+        self.queues.iter_mut()
     }
 
     fn queue_events(&self) -> &[EventFd] {

--- a/src/vmm/src/devices/virtio/balloon/persist.rs
+++ b/src/vmm/src/devices/virtio/balloon/persist.rs
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(restored_balloon.acked_features, balloon.acked_features);
         assert_eq!(restored_balloon.avail_features, balloon.avail_features);
         assert_eq!(restored_balloon.config_space, balloon.config_space);
-        assert_eq!(restored_balloon.queues(), balloon.queues());
+        assert!(restored_balloon.queues().eq(balloon.queues()));
         assert_eq!(
             restored_balloon.interrupt_status().load(Ordering::Relaxed),
             balloon.interrupt_status().load(Ordering::Relaxed)

--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 use utils::eventfd::EventFd;
 
 use super::mmio::{VIRTIO_MMIO_INT_CONFIG, VIRTIO_MMIO_INT_VRING};
-use super::queue::Queue;
 use super::ActivateError;
+use crate::devices::virtio::queue::{QueueIter, QueueIterMut};
 use crate::devices::virtio::AsAny;
 use crate::logger::{error, warn};
 use crate::vstate::memory::GuestMemoryMmap;
@@ -111,10 +111,10 @@ pub trait VirtioDevice: AsAny + Send {
     fn device_type(&self) -> u32;
 
     /// Returns the device queues.
-    fn queues(&self) -> &[Queue];
+    fn queues(&self) -> QueueIter;
 
     /// Returns a mutable reference to the device queues.
-    fn queues_mut(&mut self) -> &mut [Queue];
+    fn queues_mut(&mut self) -> QueueIterMut;
 
     /// Returns the device queues event fds.
     fn queue_events(&self) -> &[EventFd];
@@ -190,6 +190,7 @@ impl fmt::Debug for dyn VirtioDevice {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use crate::devices::virtio::queue::{QueueIter, QueueIterMut};
 
     impl IrqTrigger {
         pub fn has_pending_irq(&self, irq_type: IrqType) -> bool {
@@ -254,11 +255,11 @@ pub(crate) mod tests {
             todo!()
         }
 
-        fn queues(&self) -> &[Queue] {
+        fn queues(&self) -> QueueIter {
             todo!()
         }
 
-        fn queues_mut(&mut self) -> &mut [Queue] {
+        fn queues_mut(&mut self) -> QueueIterMut {
             todo!()
         }
 

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -2009,8 +2009,8 @@ pub mod tests {
         // Test queues count (TX and RX).
         let queues = net.queues();
         assert_eq!(queues.len(), NET_QUEUE_SIZES.len());
-        assert_eq!(queues[RX_INDEX].size, th.rxq.size());
-        assert_eq!(queues[TX_INDEX].size, th.txq.size());
+        assert_eq!(queues[RX_INDEX].size(), th.rxq.size());
+        assert_eq!(queues[TX_INDEX].size(), th.txq.size());
 
         // Test corresponding queues events.
         assert_eq!(net.queue_events().len(), NET_QUEUE_SIZES.len());
@@ -2029,7 +2029,7 @@ pub mod tests {
 
         let net = th.net();
         let queues = net.queues();
-        assert!(queues[RX_INDEX].uses_notif_suppression);
-        assert!(queues[TX_INDEX].uses_notif_suppression);
+        assert!(queues[RX_INDEX].uses_notif_suppression());
+        assert!(queues[TX_INDEX].uses_notif_suppression());
     }
 }

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -118,7 +118,7 @@ impl VirtioDeviceState {
             device_type: device.device_type(),
             avail_features: device.avail_features(),
             acked_features: device.acked_features(),
-            queues: device.queues().iter().map(Persist::save).collect(),
+            queues: device.queues().map(Persist::save).collect(),
             interrupt_status: device.interrupt_status().load(Ordering::Relaxed),
             interrupt_status_old: device.interrupt_status().load(Ordering::Relaxed) as usize,
             activated: device.is_activated(),

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -61,12 +61,12 @@ impl Persist<'_> for Queue {
 
     fn save(&self) -> Self::State {
         QueueState {
-            max_size: self.max_size,
-            size: self.size,
-            ready: self.ready,
-            desc_table: self.desc_table.0,
-            avail_ring: self.avail_ring.0,
-            used_ring: self.used_ring.0,
+            max_size: self.max_size(),
+            size: self.size(),
+            ready: self.ready(),
+            desc_table: self.desc_table().0,
+            avail_ring: self.avail_ring().0,
+            used_ring: self.used_ring().0,
             next_avail: self.next_avail,
             next_used: self.next_used,
             num_added: self.num_added,
@@ -161,7 +161,7 @@ impl VirtioDeviceState {
 
         for q in &queues {
             // Sanity check queue size and queue max size.
-            if q.max_size != expected_queue_max_size || q.size > expected_queue_max_size {
+            if q.max_size() != expected_queue_max_size || q.size() > expected_queue_max_size {
                 return Err(PersistError::InvalidInput);
             }
             // Snapshot can happen at any time, including during device configuration/activation

--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -36,6 +36,9 @@ pub enum QueueError {
     UsedRing(#[from] vm_memory::GuestMemoryError),
 }
 
+pub type QueueIter<'a> = std::slice::Iter<'a, Queue>;
+pub type QueueIterMut<'a> = std::slice::IterMut<'a, Queue>;
+
 /// A virtio descriptor constraints with C representative.
 #[repr(C)]
 #[derive(Default, Clone, Copy)]

--- a/src/vmm/src/devices/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/test_utils.rs
@@ -294,11 +294,11 @@ impl<'a> VirtQueue<'a> {
     pub fn create_queue(&self) -> Queue {
         let mut q = Queue::new(self.size());
 
-        q.size = self.size();
-        q.ready = true;
-        q.desc_table = self.dtable_start();
-        q.avail_ring = self.avail_start();
-        q.used_ring = self.used_start();
+        q.set_size(self.size());
+        q.set_ready(true);
+        *q.desc_table_mut() = self.dtable_start();
+        *q.avail_ring_mut() = self.avail_start();
+        *q.used_ring_mut() = self.used_start();
 
         q
     }

--- a/src/vmm/src/devices/virtio/vhost_user.rs
+++ b/src/vmm/src/devices/virtio/vhost_user.rs
@@ -417,18 +417,18 @@ impl<T: VhostUserHandleBackend> VhostUserHandleImpl<T> {
 
         for (queue_index, queue, queue_evt) in queues.iter() {
             let config_data = VringConfigData {
-                queue_max_size: queue.get_max_size(),
+                queue_max_size: queue.max_size(),
                 queue_size: queue.actual_size(),
                 flags: 0u32,
                 desc_table_addr: mem
-                    .get_host_address(queue.desc_table)
+                    .get_host_address(queue.desc_table())
                     .map_err(VhostUserError::DescriptorTableAddress)?
                     as u64,
                 used_ring_addr: mem
-                    .get_host_address(queue.used_ring)
+                    .get_host_address(queue.used_ring())
                     .map_err(VhostUserError::UsedAddress)? as u64,
                 avail_ring_addr: mem
-                    .get_host_address(queue.avail_ring)
+                    .get_host_address(queue.avail_ring())
                     .map_err(VhostUserError::AvailAddress)? as u64,
                 log_addr: None,
             };
@@ -910,9 +910,9 @@ mod tests {
                 queue_max_size: 69,
                 queue_size: 0,
                 flags: 0,
-                desc_table_addr: guest_memory.get_host_address(queue.desc_table).unwrap() as u64,
-                used_ring_addr: guest_memory.get_host_address(queue.used_ring).unwrap() as u64,
-                avail_ring_addr: guest_memory.get_host_address(queue.avail_ring).unwrap() as u64,
+                desc_table_addr: guest_memory.get_host_address(queue.desc_table()).unwrap() as u64,
+                used_ring_addr: guest_memory.get_host_address(queue.used_ring()).unwrap() as u64,
+                avail_ring_addr: guest_memory.get_host_address(queue.avail_ring()).unwrap() as u64,
                 log_addr: None,
             },
             base: queue.avail_idx(&guest_memory).0,

--- a/src/vmm/src/devices/virtio/vhost_user_block/device.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/device.rs
@@ -22,7 +22,7 @@ use crate::devices::virtio::gen::virtio_blk::{
     VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_F_VERSION_1,
 };
 use crate::devices::virtio::gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::{Queue, QueueIter, QueueIterMut};
 use crate::devices::virtio::vhost_user::{VhostUserHandleBackend, VhostUserHandleImpl};
 use crate::devices::virtio::vhost_user_metrics::{
     VhostUserDeviceMetrics, VhostUserMetricsPerDevice,
@@ -301,12 +301,12 @@ impl<T: VhostUserHandleBackend + Send + 'static> VirtioDevice for VhostUserBlock
         TYPE_BLOCK
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn queues(&self) -> QueueIter {
+        self.queues.iter()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queues_mut(&mut self) -> QueueIterMut {
+        self.queues.iter_mut()
     }
 
     fn queue_events(&self) -> &[EventFd] {

--- a/src/vmm/src/devices/virtio/virtio_block/device.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/device.rs
@@ -32,7 +32,7 @@ use crate::devices::virtio::gen::virtio_blk::{
     VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES, VIRTIO_F_VERSION_1,
 };
 use crate::devices::virtio::gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::{Queue, QueueIter, QueueIterMut};
 use crate::devices::virtio::virtio_block::metrics::{BlockDeviceMetrics, BlockMetricsPerDevice};
 use crate::devices::virtio::{ActivateError, TYPE_BLOCK};
 use crate::logger::{error, warn, IncMetric};
@@ -596,12 +596,12 @@ impl VirtioDevice for VirtioBlock {
         TYPE_BLOCK
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn queues(&self) -> QueueIter {
+        self.queues.iter()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queues_mut(&mut self) -> QueueIterMut {
+        self.queues.iter_mut()
     }
 
     fn queue_events(&self) -> &[EventFd] {

--- a/src/vmm/src/devices/virtio/virtio_block/persist.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/persist.rs
@@ -328,7 +328,7 @@ mod tests {
         assert_eq!(restored_block.device_type(), TYPE_BLOCK);
         assert_eq!(restored_block.avail_features(), block.avail_features());
         assert_eq!(restored_block.acked_features(), block.acked_features());
-        assert_eq!(restored_block.queues(), block.queues());
+        assert!(restored_block.queues().eq(block.queues()));
         assert_eq!(
             restored_block.interrupt_status().load(Ordering::Relaxed),
             block.interrupt_status().load(Ordering::Relaxed)

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -32,7 +32,7 @@ use super::defs::uapi;
 use super::packet::{VsockPacket, VSOCK_PKT_HDR_SIZE};
 use super::{defs, VsockBackend};
 use crate::devices::virtio::device::{DeviceState, IrqTrigger, IrqType, VirtioDevice};
-use crate::devices::virtio::queue::Queue as VirtQueue;
+use crate::devices::virtio::queue::{Queue as VirtQueue, QueueIter, QueueIterMut};
 use crate::devices::virtio::vsock::metrics::METRICS;
 use crate::devices::virtio::vsock::VsockError;
 use crate::devices::virtio::ActivateError;
@@ -276,12 +276,12 @@ where
         uapi::VIRTIO_ID_VSOCK
     }
 
-    fn queues(&self) -> &[VirtQueue] {
-        &self.queues
+    fn queues(&self) -> QueueIter {
+        self.queues.iter()
     }
 
-    fn queues_mut(&mut self) -> &mut [VirtQueue] {
-        &mut self.queues
+    fn queues_mut(&mut self) -> QueueIterMut {
+        self.queues.iter_mut()
     }
 
     fn queue_events(&self) -> &[EventFd] {


### PR DESCRIPTION
## Changes

This PR refactors `virtio.Queue` and `VirtioDevice.queues()` interfaces in order to better encapsulate the vqueue.

## Reason

This PR is part of #3707 issue, where we're trying to speed up Firecracker networking with vhost. From Firecracker point of view, Linux vhost interface is basically another implementation of virtqueue (or Virtual Queue) from Virtio spec. In order to integrate vhost into firecracker in the future we need more flexibility around vqueue implementation.

However, this is not easy. Firecracker `virtio.Queue` is deeply integrated into the code. It's imported and directly used from all the device implementations. In order to make it more plugable, we need to put some abstractions around it.

This PR creates a foundation for that. We don't change any functionality of Firecracker, just refactor the `virtio.Queue` interface a bit. These changes are necessary to create decent vhost code in the future, otherwise the spaghetti explodes fast.

We believe these changes are not controversial and generally improve the abstractions and code cleanliness.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
