### PR TITLE
ci: Disable A/B tests failing on m6i.metal 5.10

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -49,6 +49,11 @@ IGNORED = [
         "host_kernel": "linux-5.10",
         "vcpus": "1",
     },
+    # High volatility due to AMI.
+    {
+        "instance": "m6i.metal",
+        "host_kernel": "linux-5.10",
+    },
 ]
 
 


### PR DESCRIPTION
## Changes

This commit disables failing on this configuration to avoid spurious failures until the AMI is updated and the volatility has subsided.

## Reason

An AMI update in CI introduced high volatility on m6i.metal 5.10 affecting a large number of performance.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
