### PR TITLE
test: A/B-ify boottime test

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -45,10 +45,9 @@ perf_test = {
         "devtool_opts": "-c 1-10 -m 0",
     },
     "memory-overhead": {
-        "label": "💾 Memory Overhead",
-        "test_path": "integration_tests/performance/test_memory_overhead.py",
+        "label": "💾 Memory Overhead and 👢 Boottime",
+        "test_path": "'integration_tests/performance/test_memory_overhead.py integration_tests/performance/test_boottime.py::test_boottime'",
         "devtool_opts": "-c 1-10 -m 0",
-        "ab_opts": "--noise-threshold 0.01",
     },
 }
 

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -173,6 +173,7 @@ def test_boottime(
     metrics.set_dimensions(
         {
             **DIMENSIONS,
+            "performance_test": "test_boottime",
             "guest_kernel": guest_kernel.name,
             "vcpus": str(vcpu_count),
             "mem_size_mib": str(mem_size_mib),

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -165,6 +165,7 @@ def find_events(log_data):
     "vcpu_count,mem_size_mib",
     [(1, 128), (1, 1024), (2, 2048), (4, 4096)],
 )
+@pytest.mark.nonci
 def test_boottime(
     microvm_factory, guest_kernel, rootfs, vcpu_count, mem_size_mib, metrics
 ):


### PR DESCRIPTION
Run the boottime test as an A/B-test post-PR so that we note changes to this key metrics other than "are we below 150ms?".

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
