### PR TITLE
chore: support ppc64le and riscv64

### DIFF
--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -43,6 +43,12 @@ const BASE_MAGIC_ID: u64 = 0x0710_1984_8664_0000u64;
 #[cfg(target_arch = "aarch64")]
 const BASE_MAGIC_ID: u64 = 0x0710_1984_AAAA_0000u64;
 
+#[cfg(target_arch = "powerpc64")]
+const BASE_MAGIC_ID: u64 = 0x0710_1984_CC64_0000u64;
+
+#[cfg(target_arch = "riscv64")]
+const BASE_MAGIC_ID: u64 = 0x0710_1984_C564_0000u64;
+
 /// Error definitions for the Snapshot API.
 #[derive(Debug, thiserror::Error, displaydoc::Display, PartialEq)]
 pub enum Error {
@@ -326,6 +332,10 @@ mod tests {
         let good_magic_id = 0x0710_1984_8664_0001u64;
         #[cfg(target_arch = "aarch64")]
         let good_magic_id = 0x0710_1984_AAAA_0001u64;
+        #[cfg(target_arch = "powerpc64")]
+        let good_magic_id = 0x0710_1984_CC64_0001u64;
+        #[cfg(target_arch = "riscv64")]
+        let good_magic_id = 0x0710_1984_C564_0001u64;
 
         assert_eq!(get_format_version(good_magic_id).unwrap(), 1u16);
 
@@ -550,6 +560,10 @@ mod tests {
         let expected_err = Error::Crc64(0x1960_4E6A_A13F_6615);
         #[cfg(target_arch = "x86_64")]
         let expected_err = Error::Crc64(0x103F_8F52_8F51_20B1);
+        #[cfg(target_arch = "powerpc64")]
+        let expected_err = Error::Crc64(0x33D0_CCE5_DA3C_CCEA);
+        #[cfg(target_arch = "riscv64")]
+        let expected_err = Error::Crc64(0xFAC5_E225_5586_9011);
 
         let load_result: Result<(Test1, _), Error> =
             Snapshot::load(&mut snapshot_mem.as_slice(), 38, vm);

--- a/src/snapshot/tests/test.rs
+++ b/src/snapshot/tests/test.rs
@@ -53,6 +53,14 @@ fn test_hardcoded_snapshot_deserialization() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
@@ -75,10 +83,19 @@ fn test_hardcoded_snapshot_deserialization() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
-        0x86, 0x84, 0x19, 0x10, 0x07,
+        0x86,
+        0x84, 0x19, 0x10, 0x07,
         // Version 2 +
         0x02, 0x00,
         // `a` field +
@@ -129,6 +146,14 @@ fn test_invalid_format_version() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
@@ -156,6 +181,14 @@ fn test_invalid_format_version() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
@@ -185,6 +218,14 @@ fn test_invalid_data_version() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
@@ -211,6 +252,14 @@ fn test_invalid_data_version() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
## Changes

Add `BASE_MAGIC_ID` in `ppc64le` and `riscv64` arches to support using `snapshot` in `ppc64le` and `riscv64`.

## Reason
Ref:https://github.com/firecracker-microvm/firecracker/issues/4162 https://github.com/kata-containers/dbs-snapshot/pull/5 https://github.com/dragonflyoss/nydus/pull/1510 

Our project depends on firecracker's [snapshot](https://github.com/firecracker-microvm/firecracker/tree/main/src/snapshot) crate, we need to work on different arches like `ppc64le` and `riscv64`. I think many other projects must also work on `ppc64le` and `riscv64`.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
