### PR TITLE
Replace #[doc] error comments with /// type

### DIFF
--- a/src/cpu-template-helper/src/template/verify/mod.rs
+++ b/src/cpu-template-helper/src/template/verify/mod.rs
@@ -22,8 +22,8 @@ pub use x86_64::verify;
 pub enum VerifyError {
     /// {0} not found in CPU configuration.
     KeyNotFound(String),
-    #[rustfmt::skip]
-    #[doc = "Value for {0} mismatched.\n{1}"]
+    /** Value for {0} mismatched.
+    {1} */
     ValueMismatched(String, String),
 }
 

--- a/src/vmm/src/cpu_config/x86_64/cpuid/mod.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/mod.rs
@@ -299,12 +299,12 @@ pub enum KvmGetSupportedCpuidError {
 }
 
 /// Error type for conversion from `kvm_bindings::CpuId` to `Cpuid`.
+#[rustfmt::skip]
 #[derive(Debug, thiserror::Error, displaydoc::Display, PartialEq, Eq)]
 pub enum CpuidTryFromKvmCpuid {
     /// Leaf 0 not found in the given `kvm_bindings::CpuId`.
     MissingLeaf0,
-    #[rustfmt::skip]
-    #[doc = "Unsupported CPUID manufacturer id: \"{0:?}\" (only 'GenuineIntel' and 'AuthenticAMD' are supported)."]
+    /// Unsupported CPUID manufacturer id: \"{0:?}\" (only 'GenuineIntel' and 'AuthenticAMD' are supported).
     UnsupportedVendor([u8; 12]),
 }
 

--- a/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
@@ -57,10 +57,10 @@ pub enum GetMaxCpusPerPackageError {
 }
 
 /// Error type for setting leaf b section of `IntelCpuid::normalize`.
+#[rustfmt::skip]
 #[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
 pub enum ExtendedTopologyError {
-    #[rustfmt::skip]
-    #[doc = "Failed to set `Number of bits to shift right on x2APIC ID to get a unique topology ID of the next level type`: {0}"]
+    /// Failed to set `Number of bits to shift right on x2APIC ID to get a unique topology ID of the next level type`: {0}
     ApicId(CheckedAssignError),
     /// Failed to set `Number of logical processors at this level type`: {0}
     LogicalProcessors(CheckedAssignError),

--- a/src/vmm/src/devices/virtio/net/tap.rs
+++ b/src/vmm/src/devices/virtio/net/tap.rs
@@ -24,14 +24,14 @@ use crate::devices::virtio::net::test_utils::Mocks;
 const IFACE_NAME_MAX_LEN: usize = 16;
 
 /// List of errors the tap implementation can throw.
+#[rustfmt::skip]
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum TapError {
     /// Couldn't open /dev/net/tun: {0}
     OpenTun(IoError),
     /// Invalid interface name
     InvalidIfname,
-    #[rustfmt::skip]
-    #[doc = "Error while creating ifreq structure: {0}. Invalid TUN/TAP Backend provided by {1}. Check our documentation on setting up the network devices."]
+    /// Error while creating ifreq structure: {0}. Invalid TUN/TAP Backend provided by {1}. Check our documentation on setting up the network devices.
     IfreqExecuteError(IoError, String),
     /// Error while setting the offload flags: {0}
     SetOffloadFlags(IoError),

--- a/src/vmm/src/mmds/mod.rs
+++ b/src/vmm/src/mmds/mod.rs
@@ -23,6 +23,7 @@ use crate::mmds::data_store::{Error as MmdsError, Mmds, MmdsVersion, OutputForma
 use crate::mmds::token::PATH_TO_TOKEN;
 use crate::mmds::token_headers::REJECTED_HEADER;
 
+#[rustfmt::skip]
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 /// MMDS token errors
 pub enum Error {
@@ -34,8 +35,7 @@ pub enum Error {
     MethodNotAllowed,
     /// No MMDS token provided. Use `X-metadata-token` header to specify the session token.
     NoTokenProvided,
-    #[rustfmt::skip]
-    #[doc = "Token time to live value not found. Use `X-metadata-token-ttl-seconds` header to specify the token's lifetime."]
+    /// Token time to live value not found. Use `X-metadata-token-ttl-seconds` header to specify the token's lifetime.
     NoTtlProvided,
     /// Resource not found: {0}.
     ResourceNotFound(String),

--- a/src/vmm/src/mmds/token.rs
+++ b/src/vmm/src/mmds/token.rs
@@ -45,6 +45,7 @@ const TOKEN_LENGTH_LIMIT: usize = 70;
 /// too much memory when deserializing tokens.
 const DESERIALIZATION_BYTES_LIMIT: usize = std::mem::size_of::<Token>();
 
+#[rustfmt::skip]
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum Error {
     /// Failed to extract entropy from /dev/urandom entropy pool: {0}.
@@ -53,8 +54,7 @@ pub enum Error {
     ExpiryExtraction,
     /// Invalid token authority state.
     InvalidState,
-    #[rustfmt::skip]
-    #[doc= "Invalid time to live value provided for token: {0}. Please provide a value between {MIN_TOKEN_TTL_SECONDS:} and {MAX_TOKEN_TTL_SECONDS:}."]
+    /// Invalid time to live value provided for token: {0}. Please provide a value between {MIN_TOKEN_TTL_SECONDS:} and {MAX_TOKEN_TTL_SECONDS:}.
     InvalidTtlValue(u32),
     /// Bincode serialization failed: {0}.
     Serialization(#[from] BincodeError),

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -153,12 +153,12 @@ pub enum MicrovmStateError {
 }
 
 /// Errors associated with creating a snapshot.
+#[rustfmt::skip]
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum CreateSnapshotError {
     /// Cannot get dirty bitmap: {0}
     DirtyBitmap(VmmError),
-    #[rustfmt::skip]
-    #[doc = "The virtio devices use a features that is incompatible with older versions of Firecracker: {0}"]
+    /// The virtio devices use a features that is incompatible with older versions of Firecracker: {0}
     IncompatibleVirtioFeature(&'static str),
     /// Invalid microVM version format
     InvalidVersionFormat,
@@ -174,12 +174,10 @@ pub enum CreateSnapshotError {
     SerializeMicrovmState(snapshot::Error),
     /// Cannot perform {0} on the snapshot backing file: {1}
     SnapshotBackingFile(&'static str, io::Error),
-    #[rustfmt::skip]
-    #[doc = "Size mismatch when writing diff snapshot on top of base layer: base layer size is {0} but diff layer is size {1}."]
+    /// Size mismatch when writing diff snapshot on top of base layer: base layer size is {0} but diff layer is size {1}.
     SnapshotBackingFileLengthMismatch(u64, u64),
     #[cfg(target_arch = "x86_64")]
-    #[rustfmt::skip]
-    #[doc = "Too many devices attached: {0}. The maximum number allowed for the snapshot data version requested is {FC_V0_23_MAX_DEVICES:}."]
+    /// Too many devices attached: {0}. The maximum number allowed for the snapshot data version requested is {FC_V0_23_MAX_DEVICES:}.
     TooManyDevices(usize),
 }
 

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -13,17 +13,16 @@ pub const DEFAULT_MEM_SIZE_MIB: usize = 128;
 pub const MAX_SUPPORTED_VCPUS: u8 = 32;
 
 /// Errors associated with configuring the microVM.
+#[rustfmt::skip]
 #[derive(Debug, thiserror::Error, displaydoc::Display, PartialEq, Eq)]
 pub enum VmConfigError {
     /// The memory size (MiB) is smaller than the previously set balloon device target size.
     IncompatibleBalloonSize,
     /// The memory size (MiB) is invalid.
     InvalidMemorySize,
-    #[rustfmt::skip]
-    #[doc = "The vCPU number is invalid! The vCPU number can only be 1 or an even number when SMT is enabled."]
+    /// The vCPU number is invalid! The vCPU number can only be 1 or an even number when SMT is enabled.
     InvalidVcpuCount,
-    #[rustfmt::skip]
-    #[doc = "Could not get the configuration of the previously installed balloon device to validate the memory size."]
+    /// Could not get the configuration of the previously installed balloon device to validate the memory size.
     InvalidVmState,
 }
 

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -39,14 +39,14 @@ impl MmdsConfig {
 }
 
 /// MMDS configuration related errors.
+#[rustfmt::skip]
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum MmdsConfigError {
     /// The list of network interface IDs that allow forwarding MMDS requests is empty.
     EmptyNetworkIfaceList,
     /// The MMDS IPv4 address is not link local.
     InvalidIpv4Addr,
-    #[rustfmt::skip]
-    #[doc = "The list of network interface IDs provided contains at least one ID that does not correspond to any existing network interface."]
+    /// The list of network interface IDs provided contains at least one ID that does not correspond to any existing network interface.
     InvalidNetworkInterfaceId,
     /// The MMDS could not be configured to version {0}: {1}
     MmdsVersion(MmdsVersion, data_store::Error),


### PR DESCRIPTION
Fixed issue #4313, 12 comments changed

## Changes
This commit updates error doc comments with /** */.
It also moves or removes extraneous skip attributes.

    modified:   src/cpu-template-helper/src/template/verify/mod.rs
    modified:   src/vmm/src/cpu_config/x86_64/cpuid/mod.rs        
    modified:   src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs  
    modified:   src/vmm/src/devices/virtio/net/tap.rs
    modified:   src/vmm/src/mmds/mod.rs
    modified:   src/vmm/src/mmds/token.rs
    modified:   src/vmm/src/persist.rs
    modified:   src/vmm/src/vmm_config/machine_config.rs
    modified:   src/vmm/src/vmm_config/mmds.rs

## Reason

Issue #4313 requested changes to error comment types across the codebase.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [X] If a specific issue led to this PR, this PR closes the issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
