### PR TITLE
chore: Eliminate use of `assert!((...).is_ok())`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -11,6 +11,7 @@ rustflags = [
   "-Wmissing_debug_implementations",
   "-Wclippy::exit",
   "-Wclippy::tests_outside_test_module",
+  "-Wclippy::assertions_on_result_states"
 ]
 
 [net]

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -323,7 +323,7 @@ mod tests {
                 }",
             )
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
         let response = api_server.handle_request(&req, 0);
         assert_eq!(response.status(), StatusCode::BadRequest);
@@ -335,7 +335,7 @@ mod tests {
             ))))
             .unwrap();
         sender.write_all(b"GET / HTTP/1.1\r\n\r\n").unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
         let response = api_server.handle_request(&req, 0);
         assert_eq!(response.status(), StatusCode::OK);
@@ -348,7 +348,7 @@ mod tests {
                 Content-Length: 2\r\n\r\n{}",
             )
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
         let response = api_server.handle_request(&req, 0);
         assert_eq!(response.status(), StatusCode::BadRequest);
@@ -358,7 +358,6 @@ mod tests {
     fn test_handle_request_logging() {
         let cpu_template_json = TEST_UNESCAPED_JSON_TEMPLATE;
         let result = parse_put_cpu_config(&Body::new(cpu_template_json.as_bytes()));
-        assert!(result.is_err());
         let result_error = result.unwrap_err();
         let err_msg = format!("{}", result_error);
         assert_ne!(
@@ -410,12 +409,12 @@ mod tests {
         let mut sock = UnixStream::connect(PathBuf::from(path_to_socket)).unwrap();
 
         // Send a GET InstanceInfo request.
-        assert!(sock.write_all(b"GET / HTTP/1.1\r\n\r\n").is_ok());
+        sock.write_all(b"GET / HTTP/1.1\r\n\r\n").unwrap();
         let mut buf: [u8; 100] = [0; 100];
         assert!(sock.read(&mut buf[..]).unwrap() > 0);
 
         // Send an erroneous request.
-        assert!(sock.write_all(b"OPTIONS / HTTP/1.1\r\n\r\n").is_ok());
+        sock.write_all(b"OPTIONS / HTTP/1.1\r\n\r\n").unwrap();
         let mut buf: [u8; 100] = [0; 100];
         assert!(sock.read(&mut buf[..]).unwrap() > 0);
     }
@@ -448,12 +447,11 @@ mod tests {
         let mut sock = UnixStream::connect(PathBuf::from(path_to_socket)).unwrap();
 
         // Send a GET mmds request.
-        assert!(sock
-            .write_all(
-                b"PUT http://localhost/home HTTP/1.1\r\n\
-                  Content-Length: 50000\r\n\r\naaaaaa"
-            )
-            .is_ok());
+        sock.write_all(
+            b"PUT http://localhost/home HTTP/1.1\r\n\
+                  Content-Length: 50000\r\n\r\naaaaaa",
+        )
+        .unwrap();
         let mut buf: [u8; 265] = [0; 265];
         assert!(sock.read(&mut buf[..]).unwrap() > 0);
         let error_message = b"HTTP/1.1 400 \r\n\

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -403,16 +403,16 @@ pub mod tests {
         sender
             .write_all(http_request("GET", "none", Some("body")).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
 
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_err());
+        ParsedRequest::try_from(&req).unwrap_err();
     }
 
     #[test]
     fn test_checked_id() {
-        assert!(checked_id("dummy").is_ok());
-        assert!(checked_id("dummy_1").is_ok());
+        checked_id("dummy").unwrap();
+        checked_id("dummy_1").unwrap();
 
         assert_eq!(
             format!("{}", checked_id("").unwrap_err()),
@@ -431,7 +431,7 @@ pub mod tests {
         sender
             .write_all(http_request("GET", "/mmds", Some("body")).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
         let parsed_request = ParsedRequest::try_from(&req);
         assert!(matches!(
@@ -447,7 +447,7 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/mmds", None).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
         let parsed_request = ParsedRequest::try_from(&req);
         assert!(matches!(
@@ -463,7 +463,7 @@ pub mod tests {
         sender
             .write_all(http_request("PATCH", "/mmds", None).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
         let parsed_request = ParsedRequest::try_from(&req);
         assert!(matches!(
@@ -478,7 +478,7 @@ pub mod tests {
         let mut buf = Cursor::new(vec![0]);
         let response: Response =
             Error::Generic(StatusCode::BadRequest, "message".to_string()).into();
-        assert!(response.write_all(&mut buf).is_ok());
+        response.write_all(&mut buf).unwrap();
         let body = ApiServer::json_fault_message("message");
         let expected_response = http_response(&body, 400);
         assert_eq!(buf.into_inner(), expected_response.as_bytes());
@@ -486,7 +486,7 @@ pub mod tests {
         // Empty ID error.
         let mut buf = Cursor::new(vec![0]);
         let response: Response = Error::EmptyID.into();
-        assert!(response.write_all(&mut buf).is_ok());
+        response.write_all(&mut buf).unwrap();
         let body = ApiServer::json_fault_message("The ID cannot be empty.");
         let expected_response = http_response(&body, 400);
         assert_eq!(buf.into_inner(), expected_response.as_bytes());
@@ -494,7 +494,7 @@ pub mod tests {
         // Invalid ID error.
         let mut buf = Cursor::new(vec![0]);
         let response: Response = Error::InvalidID.into();
-        assert!(response.write_all(&mut buf).is_ok());
+        response.write_all(&mut buf).unwrap();
         let body = ApiServer::json_fault_message(
             "API Resource IDs can only contain alphanumeric characters and underscores.",
         );
@@ -504,7 +504,7 @@ pub mod tests {
         // Invalid path or method error.
         let mut buf = Cursor::new(vec![0]);
         let response: Response = Error::InvalidPathMethod("path".to_string(), Method::Get).into();
-        assert!(response.write_all(&mut buf).is_ok());
+        response.write_all(&mut buf).unwrap();
         let body = ApiServer::json_fault_message(format!(
             "Invalid request method and/or path: {} {}.",
             std::str::from_utf8(Method::Get.raw()).unwrap(),
@@ -517,7 +517,7 @@ pub mod tests {
         let mut buf = Cursor::new(vec![0]);
         let serde_error = serde_json::Value::from_str("").unwrap_err();
         let response: Response = Error::SerdeJson(serde_error).into();
-        assert!(response.write_all(&mut buf).is_ok());
+        response.write_all(&mut buf).unwrap();
         let body = ApiServer::json_fault_message(
             "An error occurred when deserializing the json body of a request: EOF while parsing a \
              value at line 1 column 0.",
@@ -573,7 +573,7 @@ pub mod tests {
                 ),
             };
             let response = ParsedRequest::convert_to_response(&data);
-            assert!(response.write_all(&mut buf).is_ok());
+            response.write_all(&mut buf).unwrap();
             assert_eq!(buf.into_inner(), expected_response.as_bytes());
         };
 
@@ -608,9 +608,9 @@ pub mod tests {
         sender
             .write_all(http_request("GET", "/", None).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -620,9 +620,9 @@ pub mod tests {
         sender
             .write_all(http_request("GET", "/balloon", None).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -632,9 +632,9 @@ pub mod tests {
         sender
             .write_all(http_request("GET", "/balloon/statistics", None).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -644,9 +644,9 @@ pub mod tests {
         sender
             .write_all(http_request("GET", "/machine-config", None).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -656,9 +656,9 @@ pub mod tests {
         sender
             .write_all(http_request("GET", "/mmds", None).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -668,9 +668,9 @@ pub mod tests {
         sender
             .write_all(http_request("GET", "/version", None).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -681,9 +681,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/actions", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -695,9 +695,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/balloon", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -710,9 +710,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/entropy", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -723,9 +723,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/boot-source", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -740,9 +740,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/drives/string", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -754,9 +754,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/logger", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -767,9 +767,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/machine-config", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -780,9 +780,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/metrics", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -794,26 +794,26 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/mmds", Some("{}")).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
 
         let body = "{\"foo\":\"bar\"}";
         sender
             .write_all(http_request("PUT", "/mmds", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
 
         // `/mmds/config`
         let body = "{ \"ipv4_address\": \"169.254.170.2\", \"network_interfaces\": [\"iface0\"] }";
         sender
             .write_all(http_request("PUT", "/mmds/config", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -830,9 +830,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/network-interfaces/string", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -843,9 +843,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/snapshot/create", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
 
         let body = "{ \"snapshot_path\": \"foo\", \"mem_backend\": { \"backend_type\": \"File\", \
                     \"backend_path\": \"bar\" }, \"enable_diff_snapshots\": true }";
@@ -853,9 +853,9 @@ pub mod tests {
             .write_all(http_request("PUT", "/snapshot/load", Some(body)).as_bytes())
             .unwrap();
 
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
 
         let body =
             "{ \"snapshot_path\": \"foo\", \"mem_file_path\": \"bar\", \"resume_vm\": true }";
@@ -863,9 +863,9 @@ pub mod tests {
             .write_all(http_request("PUT", "/snapshot/load", Some(body)).as_bytes())
             .unwrap();
 
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -876,9 +876,9 @@ pub mod tests {
         sender
             .write_all(http_request("PATCH", "/vm", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -889,9 +889,9 @@ pub mod tests {
         sender
             .write_all(http_request("PUT", "/vsock", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -902,16 +902,16 @@ pub mod tests {
         sender
             .write_all(http_request("PATCH", "/balloon", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
         let body = "{ \"stats_polling_interval_s\": 1 }";
         sender
             .write_all(http_request("PATCH", "/balloon/statistics", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -922,9 +922,9 @@ pub mod tests {
         sender
             .write_all(http_request("PATCH", "/drives/string", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -935,20 +935,20 @@ pub mod tests {
         sender
             .write_all(http_request("PATCH", "/machine-config", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
         let body =
             "{ \"vcpu_count\": 1, \"mem_size_mib\": 1, \"smt\": false, \"cpu_template\": \"C3\" }";
         sender
             .write_all(http_request("PATCH", "/machine-config", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
         #[cfg(target_arch = "x86_64")]
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
         #[cfg(target_arch = "aarch64")]
-        assert!(ParsedRequest::try_from(&req).is_err());
+        ParsedRequest::try_from(&req).unwrap_err();
     }
 
     #[test]
@@ -965,8 +965,8 @@ pub mod tests {
         let cpu_config_json = cpu_config_json_result.unwrap();
         let result =
             sender.write_all(http_request("PUT", "/cpu-config", Some(&cpu_config_json)).as_bytes());
-        assert!(result.is_ok());
-        assert!(connection.try_read().is_ok());
+        result.unwrap();
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
         let request_result = ParsedRequest::try_from(&req);
         assert!(request_result.is_ok(), "{}", request_result.err().unwrap());
@@ -979,9 +979,9 @@ pub mod tests {
         sender
             .write_all(http_request("PATCH", "/mmds", Some("{}")).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 
     #[test]
@@ -992,8 +992,8 @@ pub mod tests {
         sender
             .write_all(http_request("PATCH", "/network-interfaces/string", Some(body)).as_bytes())
             .unwrap();
-        assert!(connection.try_read().is_ok());
+        connection.try_read().unwrap();
         let req = connection.pop_parsed_request().unwrap();
-        assert!(ParsedRequest::try_from(&req).is_ok());
+        ParsedRequest::try_from(&req).unwrap();
     }
 }

--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn test_parse_put_actions_request() {
         {
-            assert!(parse_put_actions(&Body::new("invalid_body")).is_err());
+            parse_put_actions(&Body::new("invalid_body")).unwrap_err();
 
             let json = r#"{
                 "action_type": "InstanceStart"
@@ -67,8 +67,7 @@ mod tests {
 
             let req: ParsedRequest = ParsedRequest::new_sync(VmmAction::StartMicroVm);
             let result = parse_put_actions(&Body::new(json));
-            assert!(result.is_ok());
-            assert!(result.unwrap().eq(&req));
+            assert_eq!(result.unwrap(), req);
         }
 
         #[cfg(target_arch = "x86_64")]
@@ -79,8 +78,7 @@ mod tests {
 
             let req: ParsedRequest = ParsedRequest::new_sync(VmmAction::SendCtrlAltDel);
             let result = parse_put_actions(&Body::new(json));
-            assert!(result.is_ok());
-            assert!(result.unwrap().eq(&req));
+            assert_eq!(result.unwrap(), req);
         }
 
         #[cfg(target_arch = "aarch64")]
@@ -90,7 +88,7 @@ mod tests {
             }"#;
 
             let result = parse_put_actions(&Body::new(json));
-            assert!(result.is_err());
+            result.unwrap_err();
         }
 
         {
@@ -100,8 +98,7 @@ mod tests {
 
             let req: ParsedRequest = ParsedRequest::new_sync(VmmAction::FlushMetrics);
             let result = parse_put_actions(&Body::new(json));
-            assert!(result.is_ok());
-            assert!(result.unwrap().eq(&req));
+            assert_eq!(result.unwrap(), req);
         }
     }
 }

--- a/src/api_server/src/request/balloon.rs
+++ b/src/api_server/src/request/balloon.rs
@@ -56,23 +56,23 @@ mod tests {
 
     #[test]
     fn test_parse_get_balloon_request() {
-        assert!(parse_get_balloon(None).is_ok());
+        parse_get_balloon(None).unwrap();
 
-        assert!(parse_get_balloon(Some("unrelated")).is_err());
+        parse_get_balloon(Some("unrelated")).unwrap_err();
 
-        assert!(parse_get_balloon(Some("statistics")).is_ok());
+        parse_get_balloon(Some("statistics")).unwrap();
     }
 
     #[test]
     fn test_parse_patch_balloon_request() {
-        assert!(parse_patch_balloon(&Body::new("invalid_payload"), None).is_err());
+        parse_patch_balloon(&Body::new("invalid_payload"), None).unwrap_err();
 
         // PATCH with invalid fields.
         let body = r#"{
             "amount_mib": "bar",
             "foo": "bar"
         }"#;
-        assert!(parse_patch_balloon(&Body::new(body), None).is_err());
+        parse_patch_balloon(&Body::new(body), None).unwrap_err();
 
         // PATCH with invalid types on fields. Adding a polling interval as string instead of bool.
         let body = r#"{
@@ -80,7 +80,7 @@ mod tests {
             "stats_polling_interval_s": "false"
         }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
-        assert!(res.is_err());
+        res.unwrap_err();
 
         // PATCH with invalid types on fields. Adding a amount_mib as a negative number.
         let body = r#"{
@@ -88,21 +88,21 @@ mod tests {
             "stats_polling_interval_s": true
         }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
-        assert!(res.is_err());
+        res.unwrap_err();
 
         // PATCH on statistics with missing ppolling interval field.
         let body = r#"{
             "amount_mib": 100
         }"#;
         let res = parse_patch_balloon(&Body::new(body), Some("statistics"));
-        assert!(res.is_err());
+        res.unwrap_err();
 
         // PATCH with missing amount_mib field.
         let body = r#"{
             "stats_polling_interval_s": 0
         }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
-        assert!(res.is_err());
+        res.unwrap_err();
 
         // PATCH that tries to update something else other than allowed fields.
         let body = r#"{
@@ -110,19 +110,19 @@ mod tests {
             "stats_polling_interval_s": "dummy_host"
         }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
-        assert!(res.is_err());
+        res.unwrap_err();
 
         // PATCH with payload that is not a json.
         let body = r#"{
             "fields": "dummy_field"
         }"#;
-        assert!(parse_patch_balloon(&Body::new(body), None).is_err());
+        parse_patch_balloon(&Body::new(body), None).unwrap_err();
 
         // PATCH on unrecognized path.
         let body = r#"{
             "fields": "dummy_field"
         }"#;
-        assert!(parse_patch_balloon(&Body::new(body), Some("config")).is_err());
+        parse_patch_balloon(&Body::new(body), Some("config")).unwrap_err();
 
         let body = r#"{
             "amount_mib": 1
@@ -149,14 +149,14 @@ mod tests {
 
     #[test]
     fn test_parse_put_balloon_request() {
-        assert!(parse_put_balloon(&Body::new("invalid_payload")).is_err());
+        parse_put_balloon(&Body::new("invalid_payload")).unwrap_err();
 
         // PUT with invalid fields.
         let body = r#"{
             "amount_mib": "bar",
             "is_read_only": false
         }"#;
-        assert!(parse_put_balloon(&Body::new(body)).is_err());
+        parse_put_balloon(&Body::new(body)).unwrap_err();
 
         // PUT with valid input fields.
         let body = r#"{
@@ -164,6 +164,6 @@ mod tests {
             "deflate_on_oom": true,
             "stats_polling_interval_s": 0
         }"#;
-        assert!(parse_put_balloon(&Body::new(body)).is_ok());
+        parse_put_balloon(&Body::new(body)).unwrap();
     }
 }

--- a/src/api_server/src/request/boot_source.rs
+++ b/src/api_server/src/request/boot_source.rs
@@ -24,7 +24,7 @@ mod tests {
 
     #[test]
     fn test_parse_boot_request() {
-        assert!(parse_put_boot_source(&Body::new("invalid_payload")).is_err());
+        parse_put_boot_source(&Body::new("invalid_payload")).unwrap_err();
 
         let body = r#"{
             "kernel_image_path": "/foo/bar",
@@ -36,10 +36,11 @@ mod tests {
             initrd_path: Some(String::from("/bar/foo")),
             boot_args: Some(String::from("foobar")),
         };
-        let result = parse_put_boot_source(&Body::new(body));
-        assert!(result.is_ok());
-        let parsed_req = result.unwrap_or_else(|_e| panic!("Failed test."));
+        let parsed_req = parse_put_boot_source(&Body::new(body)).unwrap();
 
-        assert!(parsed_req == ParsedRequest::new_sync(VmmAction::ConfigureBootSource(same_body)));
+        assert_eq!(
+            parsed_req,
+            ParsedRequest::new_sync(VmmAction::ConfigureBootSource(same_body))
+        );
     }
 }

--- a/src/api_server/src/request/cpu_configuration.rs
+++ b/src/api_server/src/request/cpu_configuration.rs
@@ -68,7 +68,7 @@ mod tests {
         // Test case for invalid payload
         let unparsable_cpu_config_result =
             parse_put_cpu_config(&Body::new("<unparseable_payload>"));
-        assert!(unparsable_cpu_config_result.is_err());
+        unparsable_cpu_config_result.unwrap_err();
         assert_eq!(
             METRICS.put_api_requests.cpu_cfg_fails.count(),
             expected_err_count
@@ -78,11 +78,14 @@ mod tests {
         let invalid_put_result = parse_put_cpu_config(&Body::new(TEST_INVALID_TEMPLATE_JSON));
         expected_err_count += 1;
 
-        assert!(invalid_put_result.is_err());
         assert_eq!(
             METRICS.put_api_requests.cpu_cfg_fails.count(),
             expected_err_count
         );
-        assert!(matches!(invalid_put_result, Err(Error::SerdeJson(_))));
+        assert!(
+            matches!(invalid_put_result, Err(Error::SerdeJson(_))),
+            "{:?}",
+            invalid_put_result
+        );
     }
 }

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -76,15 +76,15 @@ mod tests {
 
     #[test]
     fn test_parse_patch_drive_request() {
-        assert!(parse_patch_drive(&Body::new("invalid_payload"), None).is_err());
-        assert!(parse_patch_drive(&Body::new("invalid_payload"), Some("id")).is_err());
+        parse_patch_drive(&Body::new("invalid_payload"), None).unwrap_err();
+        parse_patch_drive(&Body::new("invalid_payload"), Some("id")).unwrap_err();
 
         // PATCH with invalid fields.
         let body = r#"{
             "drive_id": "bar",
             "is_read_only": false
         }"#;
-        assert!(parse_patch_drive(&Body::new(body), Some("2")).is_err());
+        parse_patch_drive(&Body::new(body), Some("2")).unwrap_err();
 
         // PATCH with invalid types on fields. Adding a drive_id as number instead of string.
         let body = r#"{
@@ -92,7 +92,7 @@ mod tests {
             "path_on_host": "dummy"
         }"#;
         let res = parse_patch_drive(&Body::new(body), Some("1000"));
-        assert!(res.is_err());
+        res.unwrap_err();
 
         // PATCH with invalid types on fields. Adding a path_on_host as bool instead of string.
         let body = r#"{
@@ -100,21 +100,21 @@ mod tests {
             "path_on_host": true
         }"#;
         let res = parse_patch_drive(&Body::new(body), Some("1000"));
-        assert!(res.is_err());
+        res.unwrap_err();
 
         // PATCH with only drive_id field.
         let body = r#"{
             "drive_id": "1000"
         }"#;
         let res = parse_patch_drive(&Body::new(body), Some("1000"));
-        assert!(res.is_ok());
+        res.unwrap();
 
         // PATCH with missing drive_id field.
         let body = r#"{
             "path_on_host": true
         }"#;
         let res = parse_patch_drive(&Body::new(body), Some("1000"));
-        assert!(res.is_err());
+        res.unwrap_err();
 
         // PATCH that tries to update something else other than path_on_host.
         let body = r#"{
@@ -123,13 +123,13 @@ mod tests {
             "is_read_only": false
         }"#;
         let res = parse_patch_drive(&Body::new(body), Some("1234"));
-        assert!(res.is_err());
+        res.unwrap_err();
 
         // PATCH with payload that is not a json.
         let body = r#"{
             "fields": "dummy_field"
         }"#;
-        assert!(parse_patch_drive(&Body::new(body), Some("1234")).is_err());
+        parse_patch_drive(&Body::new(body), Some("1234")).unwrap_err();
 
         let body = r#"{
             "drive_id": "foo",
@@ -150,7 +150,7 @@ mod tests {
             "path_on_host": "dummy"
         }"#;
         // Must fail since the drive id differs from id_from_path (foo vs bar).
-        assert!(parse_patch_drive(&Body::new(body), Some("bar")).is_err());
+        parse_patch_drive(&Body::new(body), Some("bar")).unwrap_err();
 
         let body = r#"{
             "drive_id": "foo",
@@ -166,7 +166,7 @@ mod tests {
             }
         }"#;
         // Validate that updating just the ratelimiter works.
-        assert!(parse_patch_drive(&Body::new(body), Some("foo")).is_ok());
+        parse_patch_drive(&Body::new(body), Some("foo")).unwrap();
 
         let body = r#"{
             "drive_id": "foo",
@@ -183,7 +183,7 @@ mod tests {
             }
         }"#;
         // Validate that updating both path and rate limiter succeds.
-        assert!(parse_patch_drive(&Body::new(body), Some("foo")).is_ok());
+        parse_patch_drive(&Body::new(body), Some("foo")).unwrap();
 
         let body = r#"{
             "drive_id": "foo",
@@ -195,20 +195,20 @@ mod tests {
             }
         }"#;
         // Validate that parse_patch_drive fails for invalid rate limiter cfg.
-        assert!(parse_patch_drive(&Body::new(body), Some("foo")).is_err());
+        parse_patch_drive(&Body::new(body), Some("foo")).unwrap_err();
     }
 
     #[test]
     fn test_parse_put_drive_request() {
-        assert!(parse_put_drive(&Body::new("invalid_payload"), None).is_err());
-        assert!(parse_put_drive(&Body::new("invalid_payload"), Some("id")).is_err());
+        parse_put_drive(&Body::new("invalid_payload"), None).unwrap_err();
+        parse_put_drive(&Body::new("invalid_payload"), Some("id")).unwrap_err();
 
         // PUT with invalid fields.
         let body = r#"{
             "drive_id": "bar",
             "is_read_only": false
         }"#;
-        assert!(parse_put_drive(&Body::new(body), Some("2")).is_err());
+        parse_put_drive(&Body::new(body), Some("2")).unwrap_err();
 
         // PUT with missing all optional fields.
         let body = r#"{
@@ -217,10 +217,10 @@ mod tests {
             "is_root_device": true,
             "is_read_only": true
         }"#;
-        assert!(parse_put_drive(&Body::new(body), Some("1000")).is_ok());
+        parse_put_drive(&Body::new(body), Some("1000")).unwrap();
 
         // PUT with invalid types on fields. Adding a drive_id as number instead of string.
-        assert!(parse_put_drive(&Body::new(body), Some("foo")).is_err());
+        parse_put_drive(&Body::new(body), Some("foo")).unwrap_err();
 
         // PUT with the complete configuration.
         let body = r#"{
@@ -244,6 +244,6 @@ mod tests {
                 }
             }
         }"#;
-        assert!(parse_put_drive(&Body::new(body), Some("1000")).is_ok());
+        parse_put_drive(&Body::new(body), Some("1000")).unwrap();
     }
 }

--- a/src/api_server/src/request/entropy.rs
+++ b/src/api_server/src/request/entropy.rs
@@ -18,16 +18,16 @@ mod tests {
 
     #[test]
     fn test_parse_put_entropy_request() {
-        assert!(parse_put_entropy(&Body::new("invalid_payload")).is_err());
+        parse_put_entropy(&Body::new("invalid_payload")).unwrap_err();
 
         // PUT with invalid fields.
         let body = r#"{
             "some_id": 4
         }"#;
-        assert!(parse_put_entropy(&Body::new(body)).is_err());
+        parse_put_entropy(&Body::new(body)).unwrap_err();
 
         // PUT with valid fields.
         let body = r#"{}"#;
-        assert!(parse_put_entropy(&Body::new(body)).is_ok());
+        parse_put_entropy(&Body::new(body)).unwrap();
     }
 }

--- a/src/api_server/src/request/logger.rs
+++ b/src/api_server/src/request/logger.rs
@@ -72,6 +72,6 @@ mod tests {
             "show_level": false,
             "show_log_origin": false
         }"#;
-        assert!(parse_put_logger(&Body::new(invalid_body)).is_err());
+        parse_put_logger(&Body::new(invalid_body)).unwrap_err();
     }
 }

--- a/src/api_server/src/request/machine_configuration.rs
+++ b/src/api_server/src/request/machine_configuration.rs
@@ -80,26 +80,26 @@ mod tests {
 
     #[test]
     fn test_parse_get_machine_config_request() {
-        assert!(parse_get_machine_config().is_ok());
+        parse_get_machine_config().unwrap();
         assert!(METRICS.get_api_requests.machine_cfg_count.count() > 0);
     }
 
     #[test]
     fn test_parse_put_machine_config_request() {
         // 1. Test case for invalid payload.
-        assert!(parse_put_machine_config(&Body::new("invalid_payload")).is_err());
+        parse_put_machine_config(&Body::new("invalid_payload")).unwrap_err();
         assert!(METRICS.put_api_requests.machine_cfg_fails.count() > 0);
 
         // 2. Test case for mandatory fields.
         let body = r#"{
             "mem_size_mib": 1024
         }"#;
-        assert!(parse_put_machine_config(&Body::new(body)).is_err());
+        parse_put_machine_config(&Body::new(body)).unwrap_err();
 
         let body = r#"{
             "vcpu_count": 8
         }"#;
-        assert!(parse_put_machine_config(&Body::new(body)).is_err());
+        parse_put_machine_config(&Body::new(body)).unwrap_err();
 
         // 3. Test case for success scenarios for both architectures.
         let body = r#"{
@@ -177,7 +177,7 @@ mod tests {
         }
         #[cfg(target_arch = "aarch64")]
         {
-            assert!(parse_put_machine_config(&Body::new(body)).is_err());
+            parse_put_machine_config(&Body::new(body)).unwrap_err();
         }
 
         // 5. Test that setting `smt: true` is successful on x86_64 while on aarch64, it is not.
@@ -203,35 +203,35 @@ mod tests {
         }
         #[cfg(target_arch = "aarch64")]
         {
-            assert!(parse_put_machine_config(&Body::new(body)).is_err());
+            parse_put_machine_config(&Body::new(body)).unwrap_err();
         }
     }
 
     #[test]
     fn test_parse_patch_machine_config_request() {
         // 1. Test cases for invalid payload.
-        assert!(parse_patch_machine_config(&Body::new("invalid_payload")).is_err());
+        parse_patch_machine_config(&Body::new("invalid_payload")).unwrap_err();
 
         // 2. Check currently supported fields that can be patched.
         let body = r#"{
             "track_dirty_pages": true
         }"#;
-        assert!(parse_patch_machine_config(&Body::new(body)).is_ok());
+        parse_patch_machine_config(&Body::new(body)).unwrap();
 
         // On aarch64, CPU template is also not patch compatible.
         let body = r#"{
             "cpu_template": "T2"
         }"#;
         #[cfg(target_arch = "aarch64")]
-        assert!(parse_patch_machine_config(&Body::new(body)).is_err());
+        parse_patch_machine_config(&Body::new(body)).unwrap_err();
         #[cfg(target_arch = "x86_64")]
-        assert!(parse_patch_machine_config(&Body::new(body)).is_ok());
+        parse_patch_machine_config(&Body::new(body)).unwrap();
 
         let body = r#"{
             "vcpu_count": 8,
             "mem_size_mib": 1024
         }"#;
-        assert!(parse_patch_machine_config(&Body::new(body)).is_ok());
+        parse_patch_machine_config(&Body::new(body)).unwrap();
 
         // On aarch64, we allow `smt` to be configured to `false` but not `true`.
         let body = r#"{
@@ -239,11 +239,11 @@ mod tests {
             "mem_size_mib": 1024,
             "smt": false
         }"#;
-        assert!(parse_patch_machine_config(&Body::new(body)).is_ok());
+        parse_patch_machine_config(&Body::new(body)).unwrap();
 
         // 3. Check to see if an empty body returns an error.
         let body = r#"{}"#;
-        assert!(parse_patch_machine_config(&Body::new(body)).is_err());
+        parse_patch_machine_config(&Body::new(body)).unwrap_err();
     }
 
     #[test]

--- a/src/api_server/src/request/metrics.rs
+++ b/src/api_server/src/request/metrics.rs
@@ -41,6 +41,6 @@ mod tests {
         let invalid_body = r#"{
             "invalid_field": "metrics"
         }"#;
-        assert!(parse_put_metrics(&Body::new(invalid_body)).is_err());
+        parse_put_metrics(&Body::new(invalid_body)).unwrap_err();
     }
 }

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn test_parse_get_mmds_request() {
-        assert!(parse_get_mmds().is_ok());
+        parse_get_mmds().unwrap();
         assert!(METRICS.get_api_requests.mmds_count.count() > 0);
     }
 
@@ -84,10 +84,10 @@ mod tests {
         let body = r#"{
             "foo": "bar"
         }"#;
-        assert!(parse_put_mmds(&Body::new(body), None).is_ok());
+        parse_put_mmds(&Body::new(body), None).unwrap();
 
         let invalid_body = "invalid_body";
-        assert!(parse_put_mmds(&Body::new(invalid_body), None).is_err());
+        parse_put_mmds(&Body::new(invalid_body), None).unwrap_err();
         assert!(METRICS.put_api_requests.mmds_fails.count() > 0);
 
         // Test `config` path.
@@ -97,37 +97,37 @@ mod tests {
             "network_interfaces": []
         }"#;
         let config_path = "config";
-        assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_ok());
+        parse_put_mmds(&Body::new(body), Some(config_path)).unwrap();
 
         let body = r#"{
             "network_interfaces": []
         }"#;
-        assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_ok());
+        parse_put_mmds(&Body::new(body), Some(config_path)).unwrap();
 
         let body = r#"{
             "version": "foo",
             "ipv4_address": "169.254.170.2",
             "network_interfaces": []
         }"#;
-        assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_err());
+        parse_put_mmds(&Body::new(body), Some(config_path)).unwrap_err();
 
         let body = r#"{
             "version": "V2"
         }"#;
-        assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_err());
+        parse_put_mmds(&Body::new(body), Some(config_path)).unwrap_err();
 
         let body = r#"{
             "ipv4_address": "",
             "network_interfaces": []
         }"#;
-        assert!(parse_put_mmds(&Body::new(body), Some(config_path)).is_err());
+        parse_put_mmds(&Body::new(body), Some(config_path)).unwrap_err();
 
         let invalid_config_body = r#"{
             "invalid_config": "invalid_value"
         }"#;
-        assert!(parse_put_mmds(&Body::new(invalid_config_body), Some(config_path)).is_err());
-        assert!(parse_put_mmds(&Body::new(body), Some("invalid_path")).is_err());
-        assert!(parse_put_mmds(&Body::new(invalid_body), Some(config_path)).is_err());
+        parse_put_mmds(&Body::new(invalid_config_body), Some(config_path)).unwrap_err();
+        parse_put_mmds(&Body::new(body), Some("invalid_path")).unwrap_err();
+        parse_put_mmds(&Body::new(invalid_body), Some(config_path)).unwrap_err();
     }
 
     #[test]
@@ -169,9 +169,9 @@ mod tests {
         let body = r#"{
             "foo": "bar"
         }"#;
-        assert!(parse_patch_mmds(&Body::new(body)).is_ok());
+        parse_patch_mmds(&Body::new(body)).unwrap();
         assert!(METRICS.patch_api_requests.mmds_count.count() > 0);
-        assert!(parse_patch_mmds(&Body::new("invalid_body")).is_err());
+        parse_patch_mmds(&Body::new("invalid_body")).unwrap_err();
         assert!(METRICS.patch_api_requests.mmds_fails.count() > 0);
     }
 }

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -86,9 +86,9 @@ mod tests {
             "guest_mac": "12:34:56:78:9A:BC"
         }"#;
         // 1. Exercise infamous "The id from the path does not match id from the body!".
-        assert!(parse_put_net(&Body::new(body), Some("bar")).is_err());
+        parse_put_net(&Body::new(body), Some("bar")).unwrap_err();
         // 2. The `id_from_path` cannot be None.
-        assert!(parse_put_net(&Body::new(body), None).is_err());
+        parse_put_net(&Body::new(body), None).unwrap_err();
 
         // 3. Success case.
         let expected_config = serde_json::from_str::<NetworkInterfaceConfig>(body).unwrap();
@@ -113,7 +113,7 @@ mod tests {
                 }
             }
         }"#;
-        assert!(parse_put_net(&Body::new(body), Some("foo")).is_err());
+        parse_put_net(&Body::new(body), Some("foo")).unwrap_err();
     }
 
     #[test]
@@ -124,9 +124,9 @@ mod tests {
             "tx_rate_limiter": {}
         }"#;
         // 1. Exercise infamous "The id from the path does not match id from the body!".
-        assert!(parse_patch_net(&Body::new(body), Some("bar")).is_err());
+        parse_patch_net(&Body::new(body), Some("bar")).unwrap_err();
         // 2. The `id_from_path` cannot be None.
-        assert!(parse_patch_net(&Body::new(body), None).is_err());
+        parse_patch_net(&Body::new(body), None).unwrap_err();
 
         // 3. Success case.
         let expected_config = serde_json::from_str::<NetworkInterfaceUpdateConfig>(body).unwrap();
@@ -151,6 +151,6 @@ mod tests {
                 }
             }
         }"#;
-        assert!(parse_patch_net(&Body::new(body), Some("foo")).is_err());
+        parse_patch_net(&Body::new(body), Some("foo")).unwrap_err();
     }
 }

--- a/src/api_server/src/request/snapshot.rs
+++ b/src/api_server/src/request/snapshot.rs
@@ -158,7 +158,7 @@ mod tests {
             "invalid_field": "foo",
             "mem_file_path": "bar"
         }"#;
-        assert!(parse_put_snapshot(&Body::new(invalid_body), Some("create")).is_err());
+        parse_put_snapshot(&Body::new(invalid_body), Some("create")).unwrap_err();
 
         let body = r#"{
             "snapshot_path": "foo",
@@ -331,8 +331,8 @@ mod tests {
             "An error occurred when deserializing the json body of a request: missing field \
              `snapshot_path` at line 6 column 9."
         );
-        assert!(parse_put_snapshot(&Body::new(body), Some("invalid")).is_err());
-        assert!(parse_put_snapshot(&Body::new(body), None).is_err());
+        parse_put_snapshot(&Body::new(body), Some("invalid")).unwrap_err();
+        parse_put_snapshot(&Body::new(body), None).unwrap_err();
     }
 
     #[test]
@@ -354,6 +354,6 @@ mod tests {
         let invalid_body = r#"{
             "invalid": "Paused"
         }"#;
-        assert!(parse_patch_vm_state(&Body::new(invalid_body)).is_err());
+        parse_patch_vm_state(&Body::new(invalid_body)).unwrap_err();
     }
 }

--- a/src/api_server/src/request/vsock.rs
+++ b/src/api_server/src/request/vsock.rs
@@ -44,13 +44,13 @@ mod tests {
             "guest_cid": 42,
             "uds_path": "vsock.sock"
         }"#;
-        assert!(parse_put_vsock(&Body::new(body)).is_ok());
+        parse_put_vsock(&Body::new(body)).unwrap();
 
         let body = r#"{
             "guest_cid": 42,
             "invalid_field": false
         }"#;
-        assert!(parse_put_vsock(&Body::new(body)).is_err());
+        parse_put_vsock(&Body::new(body)).unwrap_err();
     }
 
     #[test]

--- a/src/cpu-template-helper/src/template/dump/mod.rs
+++ b/src/cpu-template-helper/src/template/dump/mod.rs
@@ -47,6 +47,6 @@ mod tests {
             generate_config(&kernel_image_path, tmp_file.as_path().to_str().unwrap());
         let (vmm, _) = build_microvm_from_config(&valid_config).unwrap();
 
-        assert!(dump(vmm).is_ok());
+        dump(vmm).unwrap();
     }
 }

--- a/src/firecracker/src/seccomp.rs
+++ b/src/firecracker/src/seccomp.rs
@@ -139,7 +139,7 @@ mod tests {
 
         let file = TempFile::new().unwrap().into_file();
 
-        assert!(get_filters(SeccompConfig::Custom(file)).is_err());
+        get_filters(SeccompConfig::Custom(file)).unwrap_err();
     }
 
     #[test]

--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -179,7 +179,7 @@ pub struct CgroupV1 {
 #[derive(Debug)]
 pub struct CgroupV2(CgroupBase);
 
-pub trait Cgroup {
+pub trait Cgroup: Debug {
     // Write the cgroup value into the cgroup property file.
     fn write_value(&self) -> Result<(), JailerError>;
 
@@ -559,46 +559,46 @@ mod tests {
     #[test]
     fn test_cgroup_builder_no_mounts() {
         let builder = CgroupBuilder::new(1);
-        assert!(builder.is_err());
+        builder.unwrap_err();
     }
 
     #[test]
     fn test_cgroup_builder_v1() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
         let builder = CgroupBuilder::new(1);
-        assert!(builder.is_ok());
+        builder.unwrap();
     }
 
     #[test]
     fn test_cgroup_builder_v2() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v2_mounts().is_ok());
+        mock_cgroups.add_v2_mounts().unwrap();
         let builder = CgroupBuilder::new(2);
-        assert!(builder.is_ok());
+        builder.unwrap();
     }
 
     #[test]
     fn test_cgroup_builder_v2_with_v1_mounts() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
         let builder = CgroupBuilder::new(2);
-        assert!(builder.is_err());
+        builder.unwrap_err();
     }
 
     #[test]
     fn test_cgroup_builder_v1_with_v2_mounts() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v2_mounts().is_ok());
+        mock_cgroups.add_v2_mounts().unwrap();
         let builder = CgroupBuilder::new(1);
-        assert!(builder.is_err());
+        builder.unwrap_err();
     }
 
     #[test]
     fn test_cgroup_build() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
-        assert!(mock_cgroups.add_v2_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
+        mock_cgroups.add_v2_mounts().unwrap();
 
         for v in &[1, 2] {
             let mut builder = CgroupBuilder::new(*v).unwrap();
@@ -609,15 +609,15 @@ mod tests {
                 "101",
                 Path::new("fc_test_cg"),
             );
-            assert!(cg.is_ok());
+            cg.unwrap();
         }
     }
 
     #[test]
     fn test_cgroup_build_invalid() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
-        assert!(mock_cgroups.add_v2_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
+        mock_cgroups.add_v2_mounts().unwrap();
 
         for v in &[1, 2] {
             let mut builder = CgroupBuilder::new(*v).unwrap();
@@ -627,16 +627,16 @@ mod tests {
                 "101",
                 Path::new("fc_test_cg"),
             );
-            assert!(cg.is_err());
+            cg.unwrap_err();
         }
     }
 
     #[test]
     fn test_cgroup_v2_write_value() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v2_mounts().is_ok());
+        mock_cgroups.add_v2_mounts().unwrap();
         let builder = CgroupBuilder::new(2);
-        assert!(builder.is_ok());
+        builder.unwrap();
 
         let mut builder = CgroupBuilder::new(2).unwrap();
         let cg = builder.new_cgroup(
@@ -645,7 +645,6 @@ mod tests {
             "101",
             Path::new("fc_test_cgv2"),
         );
-        assert!(cg.is_ok());
         let cg = cg.unwrap();
 
         let cg_root = PathBuf::from(format!("{}/unified", MockCgroupFs::MOCK_SYS_CGROUPS_DIR));
@@ -664,7 +663,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(cg.write_value().is_ok());
+        cg.write_value().unwrap();
 
         // check that the value was written correctly
         assert!(cg_root.join("fc_test_cgv2/101/cpuset.mems").exists());
@@ -699,8 +698,11 @@ mod tests {
         let dir2 = TempDir::new_in(dir.as_path()).expect("Cannot create temporary directory.");
         let mut path2 = PathBuf::from(dir2.as_path());
         let result = inherit_from_parent(&mut PathBuf::from(&path2), "inexistent", 1);
-        assert!(result.is_err());
-        assert!(format!("{:?}", result).contains("ReadToString"));
+        assert!(
+            matches!(result, Err(JailerError::ReadToString(_, _))),
+            "{:?}",
+            result
+        );
 
         // 2. If parent file exists and is empty, will go one level up, and return error because
         // the grandparent file does not exist.
@@ -710,8 +712,11 @@ mod tests {
             named_file.as_path().to_str().unwrap(),
             1,
         );
-        assert!(result.is_err());
-        assert!(format!("{:?}", result).contains("CgroupInheritFromParent"));
+        assert!(
+            matches!(result, Err(JailerError::CgroupInheritFromParent(_, _))),
+            "{:?}",
+            result
+        );
 
         let child_file = dir2.as_path().join(named_file.as_path().to_str().unwrap());
 
@@ -720,7 +725,7 @@ mod tests {
         let some_line = "Parent line";
         writeln!(named_file.as_file(), "{}", some_line).expect("Cannot write to file.");
         let result = inherit_from_parent(&mut path2, named_file.as_path().to_str().unwrap(), 1);
-        assert!(result.is_ok());
+        result.unwrap();
         let res = readln_special(&child_file).expect("Cannot read from file.");
         assert!(res == some_line);
     }
@@ -731,25 +736,37 @@ mod tests {
 
         // Check valid file.
         let mut result = get_controller_from_filename(file);
-        assert!(result.is_ok());
-        assert!(matches!(result, Ok(ctrl) if ctrl == "cpuset"));
+        assert!(
+            matches!(result, Ok(ctrl) if ctrl == "cpuset"),
+            "{:?}",
+            result
+        );
 
         // Check valid file with multiple '.'.
         file = "memory.swap.high";
         result = get_controller_from_filename(file);
-        assert!(result.is_ok());
-        assert!(matches!(result, Ok(ctrl) if ctrl == "memory"));
+        assert!(
+            matches!(result, Ok(ctrl) if ctrl == "memory"),
+            "{:?}",
+            result
+        );
 
         // Check invalid file
         file = "cpusetcpu";
         result = get_controller_from_filename(file);
-        assert!(result.is_err());
-        assert!(format!("{:?}", result).contains("CgroupInvalidFile"));
+        assert!(
+            matches!(result, Err(JailerError::CgroupInvalidFile(_))),
+            "{:?}",
+            result
+        );
 
         // Check empty file
         file = "";
         result = get_controller_from_filename(file);
-        assert!(result.is_err());
-        assert!(format!("{:?}", result).contains("CgroupInvalidFile"));
+        assert!(
+            matches!(result, Err(JailerError::CgroupInvalidFile(_))),
+            "{:?}",
+            result
+        );
     }
 }

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -850,7 +850,7 @@ mod tests {
     #[test]
     fn test_new_env() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
 
         let good_arg_vals = ArgVals::new();
         let arg_parser = build_arg_parser();
@@ -901,7 +901,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         let invalid_res_limit_arg_vals = ArgVals {
             resource_limits: vec!["zzz"],
@@ -911,7 +911,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_res_limit_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         let invalid_id_arg_vals = ArgVals {
             id: "/ad./sa12",
@@ -921,7 +921,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_id_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         let inexistent_exec_file_arg_vals = ArgVals {
             exec_file: "/this!/file!/should!/not!/exist!/",
@@ -932,7 +932,7 @@ mod tests {
         args = arg_parser.arguments().clone();
         args.parse(&make_args(&inexistent_exec_file_arg_vals))
             .unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         let invalid_uid_arg_vals = ArgVals {
             uid: "zzz",
@@ -942,7 +942,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_uid_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         let invalid_gid_arg_vals = ArgVals {
             gid: "zzz",
@@ -952,7 +952,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_gid_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         let invalid_parent_cg_vals = ArgVals {
             parent_cgroup: Some("/root"),
@@ -962,7 +962,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_parent_cg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         let invalid_controller_pt = ArgVals {
             cgroups: vec!["../file_name=1", "./root=1", "/home=1"],
@@ -971,7 +971,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_controller_pt)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         let invalid_format = ArgVals {
             cgroups: vec!["./root/", "../root"],
@@ -980,7 +980,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_format)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         // The chroot-base-dir param is not validated by Env::new, but rather in run, when we
         // actually attempt to create the folder structure (the same goes for netns).
@@ -1000,7 +1000,7 @@ mod tests {
     fn test_validate_exec_file() {
         // Success case
         File::create(PSEUDO_EXEC_FILE_PATH).unwrap();
-        assert!(Env::validate_exec_file(PSEUDO_EXEC_FILE_PATH).is_ok());
+        Env::validate_exec_file(PSEUDO_EXEC_FILE_PATH).unwrap();
 
         // Error case 1: No such file exists
         std::fs::remove_file(PSEUDO_EXEC_FILE_PATH).unwrap();
@@ -1042,7 +1042,7 @@ mod tests {
     #[test]
     fn test_setup_jailed_folder() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
         let env = create_env();
 
         // Error case: non UTF-8 paths.
@@ -1063,7 +1063,7 @@ mod tests {
 
         // Success case.
         let foo_dir = TempDir::new().unwrap().as_path().to_owned();
-        assert!(env.setup_jailed_folder(foo_dir.as_path()).is_ok());
+        env.setup_jailed_folder(foo_dir.as_path()).unwrap();
 
         let metadata = fs::metadata(&foo_dir).unwrap();
         // The mode bits will also have S_IFDIR set because the path belongs to a directory.
@@ -1113,7 +1113,7 @@ mod tests {
     #[test]
     fn test_mknod_and_own_dev() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
         let env = create_env();
 
         // Ensure device nodes are created with correct major/minor numbers and permissions.
@@ -1142,7 +1142,7 @@ mod tests {
     #[test]
     fn test_userfaultfd_dev() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
         let env = create_env();
 
         if !Path::new(DEV_UFFD_PATH).exists() {
@@ -1158,7 +1158,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         let mut args = arg_parser.arguments().clone();
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
 
         // Create tmp resources for `exec_file` and `chroot_base`.
         File::create(PSEUDO_EXEC_FILE_PATH).unwrap();
@@ -1233,7 +1233,7 @@ mod tests {
         let arg_parser = build_arg_parser();
         let good_arg_vals = ArgVals::new();
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
 
         // Cases that should fail
 
@@ -1244,7 +1244,7 @@ mod tests {
             ..good_arg_vals.clone()
         };
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         // Check empty string
         let mut args = arg_parser.arguments().clone();
@@ -1253,7 +1253,7 @@ mod tests {
             ..good_arg_vals.clone()
         };
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         // Check valid file empty value
         let mut args = arg_parser.arguments().clone();
@@ -1262,7 +1262,7 @@ mod tests {
             ..good_arg_vals.clone()
         };
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         // Check valid file no value
         let mut args = arg_parser.arguments().clone();
@@ -1271,7 +1271,7 @@ mod tests {
             ..good_arg_vals.clone()
         };
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
+        Env::new(&args, 0, 0).unwrap_err();
 
         // Cases that should succeed
 
@@ -1282,7 +1282,7 @@ mod tests {
             ..good_arg_vals.clone()
         };
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_ok());
+        Env::new(&args, 0, 0).unwrap();
 
         // Check valid case
         let mut args = arg_parser.arguments().clone();
@@ -1291,7 +1291,7 @@ mod tests {
             ..good_arg_vals.clone()
         };
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_ok());
+        Env::new(&args, 0, 0).unwrap();
 
         // Check file with multiple "."
         let mut args = arg_parser.arguments().clone();
@@ -1300,7 +1300,7 @@ mod tests {
             ..good_arg_vals.clone()
         };
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_ok());
+        Env::new(&args, 0, 0).unwrap();
     }
 
     #[test]
@@ -1372,22 +1372,22 @@ mod tests {
     #[cfg(target_arch = "aarch64")]
     fn test_copy_cache_info() {
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
 
         let env = create_env();
 
         // Create the required chroot dir hierarchy.
         fs::create_dir_all(env.chroot_dir()).expect("Could not create dir hierarchy.");
 
-        assert!(env.copy_cache_info().is_ok());
+        env.copy_cache_info().unwrap();
 
         // Make sure that the needed files truly exist.
         const JAILER_CACHE_INFO: &str = "sys/devices/system/cpu/cpu0/cache";
 
         let dest_path = env.chroot_dir.join(JAILER_CACHE_INFO);
-        assert!(fs::metadata(&dest_path).is_ok());
+        fs::metadata(&dest_path).unwrap();
         let index_dest_path = dest_path.join("index0");
-        assert!(fs::metadata(&index_dest_path).is_ok());
+        fs::metadata(&index_dest_path).unwrap();
         let entries = fs::read_dir(&index_dest_path).unwrap();
         assert_eq!(entries.enumerate().count(), 6);
     }
@@ -1399,7 +1399,7 @@ mod tests {
         let pid = 1;
 
         let mut mock_cgroups = MockCgroupFs::new().unwrap();
-        assert!(mock_cgroups.add_v1_mounts().is_ok());
+        mock_cgroups.add_v1_mounts().unwrap();
 
         let mut env = create_env();
         env.save_exec_file_pid(pid, PathBuf::from(exec_file_name))

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -400,23 +400,22 @@ mod tests {
             "/tmp/jailer/tests/close_fds/_{}",
             rand::rand_alphanumerics(4).into_string().unwrap()
         );
-        assert!(fs::create_dir_all(&tmp_dir_path).is_ok());
+        fs::create_dir_all(&tmp_dir_path).unwrap();
 
         let mut fds = Vec::new();
         for i in 0..n {
             let maybe_file = File::create(format!("{}/{}", &tmp_dir_path, i));
-            assert!(maybe_file.is_ok());
             fds.push(maybe_file.unwrap().into_raw_fd());
         }
 
-        assert!(test_fn().is_ok());
+        test_fn().unwrap();
 
         for fd in fds {
             let is_fd_opened = unsafe { libc::fcntl(fd, libc::F_GETFD) } == 0;
             assert!(!is_fd_opened);
         }
 
-        assert!(fs::remove_dir_all(tmp_dir_path).is_ok());
+        fs::remove_dir_all(tmp_dir_path).unwrap();
     }
 
     #[test]

--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -237,7 +237,7 @@ mod tests {
                 .as_ref(),
             )
             .unwrap();
-        assert!(get_files(arguments).is_ok());
+        get_files(arguments).unwrap();
     }
 
     fn check_file_content(file: &mut File, expected_content: &[u8]) {

--- a/src/seccompiler/src/backend.rs
+++ b/src/seccompiler/src/backend.rs
@@ -1389,7 +1389,7 @@ mod tests {
     // Checks that rule gets translated correctly into BPF statements.
     #[test]
     fn test_rule_bpf_output() {
-        assert!(Cond::new(6, ArgLen::Qword, Eq, 1).is_err());
+        Cond::new(6, ArgLen::Qword, Eq, 1).unwrap_err();
 
         // Builds rule.
         let rule = SeccompRule::new(
@@ -1515,7 +1515,7 @@ mod tests {
         {
             let mut empty_rule_map = BTreeMap::new();
             empty_rule_map.insert(1, vec![]);
-            assert!(SeccompFilter::new(empty_rule_map, SeccompAction::Allow, ARCH).is_err());
+            SeccompFilter::new(empty_rule_map, SeccompAction::Allow, ARCH).unwrap_err();
         }
 
         let filter = create_test_bpf_filter(ArgLen::Dword);
@@ -1566,7 +1566,7 @@ mod tests {
         {
             let mut empty_rule_map = BTreeMap::new();
             empty_rule_map.insert(1, vec![]);
-            assert!(SeccompFilter::new(empty_rule_map, SeccompAction::Allow, ARCH).is_err());
+            SeccompFilter::new(empty_rule_map, SeccompAction::Allow, ARCH).unwrap_err();
         }
 
         let filter = create_test_bpf_filter(ArgLen::Qword);
@@ -1767,7 +1767,7 @@ mod tests {
         );
 
         // Valid argument number
-        assert!(Cond::new(0, ArgLen::Dword, Eq, 65).is_ok());
+        Cond::new(0, ArgLen::Dword, Eq, 65).unwrap();
     }
 
     #[test]

--- a/src/seccompiler/src/compiler.rs
+++ b/src/seccompiler/src/compiler.rs
@@ -506,11 +506,11 @@ mod tests {
         // We don't test the BPF compilation in this module.
         // This is done in the seccomp/lib.rs module.
         // Here, we only test the (Filter -> SeccompFilter) transformations. (High-level -> IR)
-        assert!(compiler
+        compiler
             .compile_blob(correct_filters.clone(), false)
-            .is_ok());
+            .unwrap();
         // Also test with basic filtering on.
-        assert!(compiler.compile_blob(correct_filters, true).is_ok());
+        compiler.compile_blob(correct_filters, true).unwrap();
     }
 
     #[test]

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -140,7 +140,7 @@ mod tests {
         // Malformed bincode binary.
         {
             let data = "adassafvc".to_string();
-            assert!(deserialize_binary(data.as_bytes(), None).is_err());
+            deserialize_binary(data.as_bytes(), None).unwrap_err();
         }
 
         // Test that the binary deserialization is correct, and that the thread keys

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -500,7 +500,7 @@ mod tests {
                 .as_ref(),
             )
             .unwrap();
-        assert!(get_argument_values(arguments).is_err());
+        get_argument_values(arguments).unwrap_err();
 
         // invalid value supplied to --basic
         let arguments = &mut arg_parser.arguments().clone();
@@ -561,7 +561,7 @@ mod tests {
             };
 
             // do the compilation & check for errors
-            assert!(compile(&arguments).is_ok());
+            compile(&arguments).unwrap();
 
             // also check with is_basic: true
             let arguments = Arguments {
@@ -572,7 +572,7 @@ mod tests {
             };
 
             // do the compilation & check for errors
-            assert!(compile(&arguments).is_ok());
+            compile(&arguments).unwrap();
         }
     }
 }

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -642,7 +642,7 @@ mod tests {
             .map(String::from)
             .collect::<Vec<String>>();
 
-        assert!(arguments.parse(&args).is_ok());
+        arguments.parse(&args).unwrap();
         assert!(arguments.args.contains_key("help"));
 
         arguments = arg_parser.arguments().clone();
@@ -652,7 +652,7 @@ mod tests {
             .map(String::from)
             .collect::<Vec<String>>();
 
-        assert!(arguments.parse(&args).is_ok());
+        arguments.parse(&args).unwrap();
         assert!(arguments.args.contains_key("version"));
 
         arguments = arg_parser.arguments().clone();
@@ -917,7 +917,7 @@ mod tests {
         .map(String::from)
         .collect::<Vec<String>>();
 
-        assert!(arguments.parse(&args).is_ok());
+        arguments.parse(&args).unwrap();
         assert!(arguments.extra_args.contains(&"--extra-flag".to_string()));
     }
 
@@ -1017,7 +1017,7 @@ mod tests {
             .map(String::from)
             .collect::<Vec<String>>();
 
-        assert!(arguments.parse(&args).is_ok());
+        arguments.parse(&args).unwrap();
 
         arguments = arg_parser.arguments().clone();
 
@@ -1027,7 +1027,7 @@ mod tests {
             .map(String::from)
             .collect::<Vec<String>>();
 
-        assert!(arguments.parse(&args).is_ok());
+        arguments.parse(&args).unwrap();
 
         // Check dulicates require a value
         let args = vec!["binary-name", "--multiple", "--multiple", "2"]

--- a/src/utils/src/kernel_version.rs
+++ b/src/utils/src/kernel_version.rs
@@ -112,7 +112,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_get() {
-        assert!(KernelVersion::get().is_ok());
+        KernelVersion::get().unwrap();
     }
 
     #[test]
@@ -133,12 +133,12 @@ mod tests {
 
     #[test]
     fn test_parse_invalid() {
-        assert!(KernelVersion::parse("".to_string()).is_err());
-        assert!(KernelVersion::parse("ffff".to_string()).is_err());
-        assert!(KernelVersion::parse("ffff.55.0".to_string()).is_err());
-        assert!(KernelVersion::parse("5.10.".to_string()).is_err());
-        assert!(KernelVersion::parse("5.0".to_string()).is_err());
-        assert!(KernelVersion::parse("5.0fff".to_string()).is_err());
+        KernelVersion::parse("".to_string()).unwrap_err();
+        KernelVersion::parse("ffff".to_string()).unwrap_err();
+        KernelVersion::parse("ffff.55.0".to_string()).unwrap_err();
+        KernelVersion::parse("5.10.".to_string()).unwrap_err();
+        KernelVersion::parse("5.0".to_string()).unwrap_err();
+        KernelVersion::parse("5.0fff".to_string()).unwrap_err();
     }
 
     #[test]

--- a/src/utils/src/net/mac.rs
+++ b/src/utils/src/net/mac.rs
@@ -149,16 +149,16 @@ mod tests {
     #[test]
     fn test_mac_addr() {
         // too long
-        assert!(MacAddr::from_str("aa:aa:aa:aa:aa:aa:aa").is_err());
+        MacAddr::from_str("aa:aa:aa:aa:aa:aa:aa").unwrap_err();
 
         // invalid hex
-        assert!(MacAddr::from_str("aa:aa:aa:aa:aa:ax").is_err());
+        MacAddr::from_str("aa:aa:aa:aa:aa:ax").unwrap_err();
 
         // single digit mac address component should be invalid
-        assert!(MacAddr::from_str("aa:aa:aa:aa:aa:b").is_err());
+        MacAddr::from_str("aa:aa:aa:aa:aa:b").unwrap_err();
 
         // components with more than two digits should also be invalid
-        assert!(MacAddr::from_str("aa:aa:aa:aa:aa:bbb").is_err());
+        MacAddr::from_str("aa:aa:aa:aa:aa:bbb").unwrap_err();
 
         let mac = MacAddr::from_str("12:34:56:78:9a:BC").unwrap();
 

--- a/src/utils/src/validators.rs
+++ b/src/utils/src/validators.rs
@@ -42,7 +42,7 @@ mod tests {
             format!("{}", validate_instance_id("").unwrap_err()),
             "Invalid len (0);  the length must be between 1 and 64"
         );
-        assert!(validate_instance_id("12-3aa").is_ok());
+        validate_instance_id("12-3aa").unwrap();
         assert_eq!(
             format!("{}", validate_instance_id("12_3aa").unwrap_err()),
             "Invalid char (_) at position 2"

--- a/src/vmm/src/arch/aarch64/cache_info.rs
+++ b/src/vmm/src/arch/aarch64/cache_info.rs
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_mask_str2bit_count() {
-        assert!(mask_str2bit_count("00000000,00000001").is_ok());
+        mask_str2bit_count("00000000,00000001").unwrap();
         let res = mask_str2bit_count("00000000,00000000");
 
         assert!(
@@ -392,8 +392,8 @@ mod tests {
 
     #[test]
     fn test_to_bytes() {
-        assert!(to_bytes(&mut "64K".to_string()).is_ok());
-        assert!(to_bytes(&mut "64M".to_string()).is_ok());
+        to_bytes(&mut "64K".to_string()).unwrap();
+        to_bytes(&mut "64M".to_string()).unwrap();
 
         match to_bytes(&mut "64KK".to_string()) {
             Err(err) => assert_eq!(
@@ -426,13 +426,11 @@ mod tests {
         map1.remove("index0/type");
         let engine = CacheEngine::new(&map1);
         let res = CacheEntry::from_index(0, engine.store.as_ref());
-        assert!(res.is_err());
         // We did create the level file but we still do not have the type file.
         assert!(matches!(res.unwrap_err(), CacheInfoError::MissingCacheType));
 
         let engine = CacheEngine::new(&default_map);
         let res = CacheEntry::from_index(0, engine.store.as_ref());
-        assert!(res.is_err());
         assert_eq!(
             format!("{}", res.unwrap_err()),
             "shared cpu map, coherency line size, size, number of sets",
@@ -572,7 +570,7 @@ mod tests {
         let mut l1_caches: Vec<CacheEntry> = Vec::new();
         let mut non_l1_caches: Vec<CacheEntry> = Vec::new();
         // We use sysfs for extracting the cache information.
-        assert!(read_cache_config(&mut l1_caches, &mut non_l1_caches).is_ok());
+        read_cache_config(&mut l1_caches, &mut non_l1_caches).unwrap();
         assert_eq!(l1_caches.len(), 2);
         assert_eq!(l1_caches.len(), 2);
     }

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -487,7 +487,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let gic = create_gic(&vm, 1, None).unwrap();
-        assert!(create_fdt(
+        create_fdt(
             &mem,
             vec![0],
             CString::new("console=tty0").unwrap(),
@@ -495,7 +495,7 @@ mod tests {
             &gic,
             &None,
         )
-        .is_ok())
+        .unwrap();
     }
 
     #[test]

--- a/src/vmm/src/arch/aarch64/gic/gicv2/regs/dist_regs.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv2/regs/dist_regs.rs
@@ -147,19 +147,17 @@ mod tests {
         };
 
         let res = get_dist_regs(gic_fd.device_fd());
-        assert!(res.is_ok());
         let state = res.unwrap();
         assert_eq!(state.len(), 7);
         // Check GICD_CTLR size.
         assert_eq!(state[0].chunks.len(), 1);
 
         let res = set_dist_regs(gic_fd.device_fd(), &state);
-        assert!(res.is_ok());
+        res.unwrap();
 
         unsafe { libc::close(gic_fd.device_fd().as_raw_fd()) };
 
         let res = get_dist_regs(gic_fd.device_fd());
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), false, 1)"

--- a/src/vmm/src/arch/aarch64/gic/gicv2/regs/icc_regs.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv2/regs/icc_regs.rs
@@ -102,25 +102,21 @@ mod tests {
 
         let cpu_id = 0;
         let res = get_icc_regs(gic_fd.device_fd(), cpu_id);
-        assert!(res.is_ok());
-
         let state = res.unwrap();
         assert_eq!(state.main_icc_regs.len(), 8);
         assert_eq!(state.ap_icc_regs.len(), 0);
 
-        assert!(set_icc_regs(gic_fd.device_fd(), cpu_id, &state).is_ok());
+        set_icc_regs(gic_fd.device_fd(), cpu_id, &state).unwrap();
 
         unsafe { libc::close(gic_fd.device_fd().as_raw_fd()) };
 
         let res = set_icc_regs(gic_fd.device_fd(), cpu_id, &state);
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), true, 2)"
         );
 
         let res = get_icc_regs(gic_fd.device_fd(), cpu_id);
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), false, 2)"

--- a/src/vmm/src/arch/aarch64/gic/gicv2/regs/mod.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv2/regs/mod.rs
@@ -59,7 +59,6 @@ mod tests {
         let mpidr = vec![0];
         let res = save_state(gic_fd.device_fd(), &mpidr);
         // We will receive an error if trying to call before creating vcpu.
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(22), false, 2)"
@@ -89,6 +88,6 @@ mod tests {
 
         assert_eq!(gicd_statusr.chunks[0], val);
         assert_eq!(vm_state.dist.len(), 7);
-        assert!(restore_state(gic_fd, &mpidr, &vm_state).is_ok());
+        restore_state(gic_fd, &mpidr, &vm_state).unwrap();
     }
 }

--- a/src/vmm/src/arch/aarch64/gic/gicv3/mod.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv3/mod.rs
@@ -211,12 +211,11 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let gic = create_gic(&vm, 1, Some(GICVersion::GICV3)).expect("Cannot create gic");
-        assert!(save_pending_tables(gic.device_fd()).is_ok());
+        save_pending_tables(gic.device_fd()).unwrap();
 
         unsafe { libc::close(gic.device_fd().as_raw_fd()) };
 
         let res = save_pending_tables(gic.device_fd());
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), true, 4)"

--- a/src/vmm/src/arch/aarch64/gic/gicv3/regs/dist_regs.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv3/regs/dist_regs.rs
@@ -145,19 +145,17 @@ mod tests {
         let gic_fd = create_gic(&vm, 1, Some(GICVersion::GICV3)).expect("Cannot create gic");
 
         let res = get_dist_regs(gic_fd.device_fd());
-        assert!(res.is_ok());
         let state = res.unwrap();
         assert_eq!(state.len(), 12);
         // Check GICD_CTLR size.
         assert_eq!(state[0].chunks.len(), 1);
 
         let res = set_dist_regs(gic_fd.device_fd(), &state);
-        assert!(res.is_ok());
+        res.unwrap();
 
         unsafe { libc::close(gic_fd.device_fd().as_raw_fd()) };
 
         let res = get_dist_regs(gic_fd.device_fd());
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), false, 1)"

--- a/src/vmm/src/arch/aarch64/gic/gicv3/regs/icc_regs.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv3/regs/icc_regs.rs
@@ -183,31 +183,27 @@ mod tests {
 
         let gicr_typer = 123;
         let res = get_icc_regs(gic_fd.device_fd(), gicr_typer);
-        assert!(res.is_ok());
         let mut state = res.unwrap();
         assert_eq!(state.main_icc_regs.len(), 7);
         assert_eq!(state.ap_icc_regs.len(), 8);
 
-        assert!(set_icc_regs(gic_fd.device_fd(), gicr_typer, &state).is_ok());
+        set_icc_regs(gic_fd.device_fd(), gicr_typer, &state).unwrap();
 
         for reg in state.ap_icc_regs.iter_mut() {
             *reg = None;
         }
         let res = set_icc_regs(gic_fd.device_fd(), gicr_typer, &state);
-        assert!(res.is_err());
         assert_eq!(format!("{:?}", res.unwrap_err()), "InvalidVgicSysRegState");
 
         unsafe { libc::close(gic_fd.device_fd().as_raw_fd()) };
 
         let res = set_icc_regs(gic_fd.device_fd(), gicr_typer, &state);
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), true, 6)"
         );
 
         let res = get_icc_regs(gic_fd.device_fd(), gicr_typer);
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), false, 6)"

--- a/src/vmm/src/arch/aarch64/gic/gicv3/regs/mod.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv3/regs/mod.rs
@@ -61,7 +61,6 @@ mod tests {
         let mpidr = vec![1];
         let res = save_state(gic_fd, &mpidr);
         // We will receive an error if trying to call before creating vcpu.
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(22), false, 5)"
@@ -91,7 +90,7 @@ mod tests {
 
         assert_eq!(gicd_statusr.chunks[0], val);
         assert_eq!(vm_state.dist.len(), 12);
-        assert!(restore_state(gic_fd, &mpidr, &vm_state).is_ok());
-        assert!(restore_state(gic_fd, &[1, 2], &vm_state).is_err());
+        restore_state(gic_fd, &mpidr, &vm_state).unwrap();
+        restore_state(gic_fd, &[1, 2], &vm_state).unwrap_err();
     }
 }

--- a/src/vmm/src/arch/aarch64/gic/gicv3/regs/redist_regs.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv3/regs/redist_regs.rs
@@ -104,23 +104,20 @@ mod tests {
 
         let gicr_typer = 123;
         let res = get_redist_regs(gic_fd.device_fd(), gicr_typer);
-        assert!(res.is_ok());
         let state = res.unwrap();
         assert_eq!(state.len(), 14);
 
-        assert!(set_redist_regs(gic_fd.device_fd(), gicr_typer, &state).is_ok());
+        set_redist_regs(gic_fd.device_fd(), gicr_typer, &state).unwrap();
 
         unsafe { libc::close(gic_fd.device_fd().as_raw_fd()) };
 
         let res = set_redist_regs(gic_fd.device_fd(), gicr_typer, &state);
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), true, 5)"
         );
 
         let res = get_redist_regs(gic_fd.device_fd(), gicr_typer);
-        assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), false, 5)"

--- a/src/vmm/src/arch/aarch64/gic/mod.rs
+++ b/src/vmm/src/arch/aarch64/gic/mod.rs
@@ -175,6 +175,6 @@ mod tests {
     fn test_create_gic() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
-        assert!(create_gic(&vm, 1, None).is_ok());
+        create_gic(&vm, 1, None).unwrap();
     }
 }

--- a/src/vmm/src/arch/aarch64/regs.rs
+++ b/src/vmm/src/arch/aarch64/regs.rs
@@ -605,9 +605,8 @@ mod tests {
         let mut buf = vec![0; 10000];
         let version_map = VersionMap::new();
 
-        assert!(v
-            .serialize(&mut buf.as_mut_slice(), &version_map, 1)
-            .is_ok());
+        v.serialize(&mut buf.as_mut_slice(), &version_map, 1)
+            .unwrap();
         let restored =
             <Aarch64RegisterVec as Versionize>::deserialize(&mut buf.as_slice(), &version_map, 1)
                 .unwrap();
@@ -636,18 +635,13 @@ mod tests {
         let mut buf = vec![0; 10000];
         let version_map = VersionMap::new();
 
-        assert!(v
-            .serialize(&mut buf.as_mut_slice(), &version_map, 1)
-            .is_ok());
+        v.serialize(&mut buf.as_mut_slice(), &version_map, 1)
+            .unwrap();
 
         // Total size of registers according IDs are 16 + 16 = 32,
         // but actual data size is 8 + 16 = 24.
-        assert!(<Aarch64RegisterVec as Versionize>::deserialize(
-            &mut buf.as_slice(),
-            &version_map,
-            1
-        )
-        .is_err());
+        <Aarch64RegisterVec as Versionize>::deserialize(&mut buf.as_slice(), &version_map, 1)
+            .unwrap_err();
     }
 
     #[test]
@@ -667,17 +661,12 @@ mod tests {
         let mut buf = vec![0; 10000];
         let version_map = VersionMap::new();
 
-        assert!(v
-            .serialize(&mut buf.as_mut_slice(), &version_map, 1)
-            .is_ok());
+        v.serialize(&mut buf.as_mut_slice(), &version_map, 1)
+            .unwrap();
 
         // 4096 bit wide registers are not supported.
-        assert!(<Aarch64RegisterVec as Versionize>::deserialize(
-            &mut buf.as_slice(),
-            &version_map,
-            1
-        )
-        .is_err());
+        <Aarch64RegisterVec as Versionize>::deserialize(&mut buf.as_slice(), &version_map, 1)
+            .unwrap_err();
     }
 
     #[test]
@@ -852,7 +841,7 @@ mod tests {
         };
 
         let reg_ref: Result<Aarch64RegisterRef, _> = (&old_reg).try_into();
-        assert!(reg_ref.is_err());
+        reg_ref.unwrap_err();
 
         // 4096 bit wide reg ID.
         let old_reg = Aarch64RegisterOld {
@@ -861,7 +850,7 @@ mod tests {
         };
 
         let reg_ref: Result<Aarch64RegisterRef, _> = (&old_reg).try_into();
-        assert!(reg_ref.is_err());
+        reg_ref.unwrap_err();
     }
 
     #[test]
@@ -876,6 +865,6 @@ mod tests {
         let reg_ref = Aarch64RegisterRef::new(KVM_REG_SIZE_U256, &[0_u8; 32]);
 
         let reg: Result<Aarch64RegisterOld, _> = reg_ref.try_into();
-        assert!(reg.is_err());
+        reg.unwrap_err();
     }
 }

--- a/src/vmm/src/arch/aarch64/vcpu.rs
+++ b/src/vmm/src/arch/aarch64/vcpu.rs
@@ -222,7 +222,7 @@ mod tests {
         vm.get_preferred_target(&mut kvi).unwrap();
         vcpu.vcpu_init(&kvi).unwrap();
 
-        assert!(setup_boot_regs(&vcpu, 0, 0x0, &mem).is_ok());
+        setup_boot_regs(&vcpu, 0, 0x0, &mem).unwrap();
     }
 
     #[test]
@@ -273,15 +273,14 @@ mod tests {
         vm.get_preferred_target(&mut kvi).unwrap();
 
         let res = get_mpstate(&vcpu);
-        assert!(res.is_ok());
-        assert!(set_mpstate(&vcpu, res.unwrap()).is_ok());
+        set_mpstate(&vcpu, res.unwrap()).unwrap();
 
         unsafe { libc::close(vcpu.as_raw_fd()) };
 
         let res = get_mpstate(&vcpu);
-        assert!(matches!(res.unwrap_err(), VcpuError::GetMp(_)));
+        assert!(matches!(res, Err(VcpuError::GetMp(_))), "{:?}", res);
 
         let res = set_mpstate(&vcpu, kvm_mp_state::default());
-        assert!(matches!(res.unwrap_err(), VcpuError::SetMp(_)));
+        assert!(matches!(res, Err(VcpuError::SetMp(_))), "{:?}", res);
     }
 }

--- a/src/vmm/src/arch/x86_64/interrupts.rs
+++ b/src/vmm/src/arch/x86_64/interrupts.rs
@@ -117,7 +117,7 @@ mod tests {
         assert!(kvm.check_extension(kvm_ioctls::Cap::Irqchip));
         let vm = kvm.create_vm().unwrap();
         // the get_lapic ioctl will fail if there is no irqchip created beforehand.
-        assert!(vm.create_irq_chip().is_ok());
+        vm.create_irq_chip().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let klapic_before: kvm_lapic_state = vcpu.get_lapic().unwrap();
 
@@ -144,6 +144,6 @@ mod tests {
         let vcpu = vm.create_vcpu(0).unwrap();
         // 'get_lapic' ioctl triggered by the 'set_lint' function will fail if there is no
         // irqchip created beforehand.
-        assert!(set_lint(&vcpu).is_err());
+        set_lint(&vcpu).unwrap_err();
     }
 }

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -233,7 +233,6 @@ mod tests {
         let no_vcpus = 4;
         let gm = GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), 0x10000)], false).unwrap();
         let config_err = configure_system(&gm, GuestAddress(0), 0, &None, 1);
-        assert!(config_err.is_err());
         assert_eq!(
             config_err.unwrap_err(),
             super::ConfigurationError::MpTableSetup(mptable::MptableError::NotEnoughMemory)

--- a/src/vmm/src/arch/x86_64/mptable.rs
+++ b/src/vmm/src/arch/x86_64/mptable.rs
@@ -324,7 +324,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(setup_mptable(&mem, num_cpus).is_err());
+        setup_mptable(&mem, num_cpus).unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/arch/x86_64/msr.rs
+++ b/src/vmm/src/arch/x86_64/msr.rs
@@ -576,7 +576,7 @@ mod tests {
             data: 0,
             ..Default::default()
         }];
-        assert!(set_msrs(&vcpu, &msr_entries).is_ok());
+        set_msrs(&vcpu, &msr_entries).unwrap();
     }
 
     #[test]

--- a/src/vmm/src/arch/x86_64/regs.rs
+++ b/src/vmm/src/arch/x86_64/regs.rs
@@ -337,7 +337,7 @@ mod tests {
         let vcpu = vm.create_vcpu(0).unwrap();
         let gm = create_guest_mem(None);
 
-        assert!(vcpu.set_sregs(&Default::default()).is_ok());
+        vcpu.set_sregs(&Default::default()).unwrap();
         setup_sregs(&gm, &vcpu).unwrap();
 
         let mut sregs: kvm_sregs = vcpu.get_sregs().unwrap();
@@ -359,7 +359,7 @@ mod tests {
             gdt_entry(0xc093, 0, 0xfffff), // DATA
             gdt_entry(0x808b, 0, 0xfffff), // TSS
         ];
-        assert!(write_gdt_table(&gdt_table, &gm).is_err());
+        write_gdt_table(&gdt_table, &gm).unwrap_err();
 
         // We allocate exactly the amount needed to write four u64 to `BOOT_GDT_OFFSET`.
         let gm = create_guest_mem(Some(
@@ -372,7 +372,7 @@ mod tests {
             gdt_entry(0xc093, 0, 0xfffff), // DATA
             gdt_entry(0x808b, 0, 0xfffff), // TSS
         ];
-        assert!(write_gdt_table(&gdt_table, &gm).is_ok());
+        write_gdt_table(&gdt_table, &gm).unwrap();
     }
 
     #[test]
@@ -380,11 +380,11 @@ mod tests {
         // Not enough memory for the a u64 value to fit.
         let gm = create_guest_mem(Some(BOOT_IDT_OFFSET));
         let val = 0x100;
-        assert!(write_idt_value(val, &gm).is_err());
+        write_idt_value(val, &gm).unwrap_err();
 
         let gm = create_guest_mem(Some(BOOT_IDT_OFFSET + mem::size_of::<u64>() as u64));
         // We have allocated exactly the amount neded to write an u64 to `BOOT_IDT_OFFSET`.
-        assert!(write_idt_value(val, &gm).is_ok());
+        write_idt_value(val, &gm).unwrap();
     }
 
     #[test]
@@ -400,13 +400,13 @@ mod tests {
     fn test_setup_page_tables() {
         let mut sregs: kvm_sregs = Default::default();
         let gm = create_guest_mem(Some(PML4_START));
-        assert!(setup_page_tables(&gm, &mut sregs).is_err());
+        setup_page_tables(&gm, &mut sregs).unwrap_err();
 
         let gm = create_guest_mem(Some(PDPTE_START));
-        assert!(setup_page_tables(&gm, &mut sregs).is_err());
+        setup_page_tables(&gm, &mut sregs).unwrap_err();
 
         let gm = create_guest_mem(Some(PDE_START));
-        assert!(setup_page_tables(&gm, &mut sregs).is_err());
+        setup_page_tables(&gm, &mut sregs).unwrap_err();
 
         let gm = create_guest_mem(None);
         setup_page_tables(&gm, &mut sregs).unwrap();

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1152,7 +1152,7 @@ pub mod tests {
         net_builder.build(net_config).unwrap();
 
         let res = attach_net_devices(vmm, cmdline, net_builder.iter(), event_manager);
-        assert!(res.is_ok());
+        res.unwrap();
     }
 
     pub(crate) fn insert_net_device_with_mmds(
@@ -1185,7 +1185,7 @@ pub mod tests {
         let vsock = VsockBuilder::create_unixsock_vsock(vsock_config).unwrap();
         let vsock = Arc::new(Mutex::new(vsock));
 
-        assert!(attach_unixsock_vsock_device(vmm, cmdline, &vsock, event_manager).is_ok());
+        attach_unixsock_vsock_device(vmm, cmdline, &vsock, event_manager).unwrap();
 
         assert!(vmm
             .mmio_device_manager
@@ -1202,7 +1202,7 @@ pub mod tests {
         let mut builder = EntropyDeviceBuilder::new();
         let entropy = builder.build(entropy_config).unwrap();
 
-        assert!(attach_entropy_device(vmm, cmdline, &entropy, event_manager).is_ok());
+        attach_entropy_device(vmm, cmdline, &entropy, event_manager).unwrap();
 
         assert!(vmm
             .mmio_device_manager
@@ -1217,10 +1217,10 @@ pub mod tests {
         balloon_config: BalloonDeviceConfig,
     ) {
         let mut builder = BalloonBuilder::new();
-        assert!(builder.set(balloon_config).is_ok());
+        builder.set(balloon_config).unwrap();
         let balloon = builder.get().unwrap();
 
-        assert!(attach_balloon_device(vmm, cmdline, balloon, event_manager).is_ok());
+        attach_balloon_device(vmm, cmdline, balloon, event_manager).unwrap();
 
         assert!(vmm
             .mmio_device_manager
@@ -1265,7 +1265,6 @@ pub mod tests {
         let gm = create_guest_mem_with_size(mem_size + crate::arch::aarch64::layout::FDT_MAX_SIZE);
 
         let res = load_initrd(&gm, &mut tempfile);
-        assert!(res.is_ok());
         let initrd = res.unwrap();
         assert!(gm.address_in_range(initrd.address));
         assert_eq!(initrd.size, image.len());
@@ -1279,10 +1278,10 @@ pub mod tests {
         let mut tempfile = tempfile.into_file();
         tempfile.write_all(&image).unwrap();
         let res = load_initrd(&gm, &mut tempfile);
-        assert!(res.is_err());
-        assert_eq!(
-            StartMicrovmError::InitrdLoad.to_string(),
-            res.err().unwrap().to_string()
+        assert!(
+            matches!(res, Err(StartMicrovmError::InitrdLoad)),
+            "{:?}",
+            res
         );
     }
 
@@ -1298,10 +1297,10 @@ pub mod tests {
         );
 
         let res = load_initrd(&gm, &mut tempfile);
-        assert!(res.is_err());
-        assert_eq!(
-            StartMicrovmError::InitrdLoad.to_string(),
-            res.err().unwrap().to_string()
+        assert!(
+            matches!(res, Err(StartMicrovmError::InitrdLoad)),
+            "{:?}",
+            res
         );
     }
 
@@ -1362,7 +1361,7 @@ pub mod tests {
 
         // We can not attach it once more.
         let mut net_builder = NetBuilder::new();
-        assert!(net_builder.build(network_interface).is_err());
+        net_builder.build(network_interface).unwrap_err();
     }
 
     #[test]
@@ -1549,7 +1548,7 @@ pub mod tests {
         let request_ts = TimestampUs::default();
 
         let res = attach_boot_timer_device(&mut vmm, request_ts);
-        assert!(res.is_ok());
+        res.unwrap();
         assert!(vmm
             .mmio_device_manager
             .get_device(DeviceType::BootTimer, &DeviceType::BootTimer.to_string())

--- a/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs
+++ b/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs
@@ -204,7 +204,7 @@ mod tests {
                     ]
                 }"#,
         );
-        assert!(cpu_config_result.is_ok());
+        cpu_config_result.unwrap();
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod tests {
                     "vcpu_features":[{"index":0,"bitmap":"0b1100000"}]
                 }"#,
         );
-        assert!(cpu_config_result.is_err());
+        cpu_config_result.unwrap_err();
 
         // Malformed vcpu features
         let cpu_config_result = serde_json::from_str::<CustomCpuTemplate>(
@@ -225,7 +225,7 @@ mod tests {
                     "vcpu_features":[{"index":0,"bitmap":"0b11abc00"}]
                 }"#,
         );
-        assert!(cpu_config_result.is_err());
+        cpu_config_result.unwrap_err();
 
         // Malformed register address
         let cpu_config_result = serde_json::from_str::<CustomCpuTemplate>(
@@ -238,7 +238,6 @@ mod tests {
                     ]
                 }"#,
         );
-        assert!(cpu_config_result.is_err());
         let error_msg: String = cpu_config_result.unwrap_err().to_string();
         // Formatted error expected clarifying the number system prefix is missing
         assert!(
@@ -258,7 +257,6 @@ mod tests {
                     ]
                 }"#,
         );
-        assert!(cpu_config_result.is_err());
         assert!(cpu_config_result
             .unwrap_err()
             .to_string()
@@ -275,7 +273,6 @@ mod tests {
                     ]
                 }"#,
         );
-        assert!(cpu_config_result.is_err());
         assert!(cpu_config_result.unwrap_err().to_string().contains(
             "Failed to parse string [0bx0?1_0_0x_?x1xxxx00xxx1xxxxxxxxxxx1] as a bitmap"
         ));
@@ -291,7 +288,6 @@ mod tests {
                     ]
                 }"#,
         );
-        assert!(cpu_config_result.is_err());
         assert!(cpu_config_result
             .unwrap_err()
             .to_string()
@@ -309,11 +305,9 @@ mod tests {
     fn test_serialization_lifecycle() {
         let template = build_test_template();
         let template_json_str_result = serde_json::to_string_pretty(&template);
-        assert!(&template_json_str_result.is_ok());
         let template_json = template_json_str_result.unwrap();
 
         let deserialization_result = serde_json::from_str::<CustomCpuTemplate>(&template_json);
-        assert!(deserialization_result.is_ok());
         assert_eq!(template, deserialization_result.unwrap());
     }
 
@@ -376,7 +370,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        assert!(template.validate().is_ok());
+        template.validate().unwrap();
 
         // 32 bit reg with too long filter
         let template = CustomCpuTemplate {
@@ -389,7 +383,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        assert!(template.validate().is_err());
+        template.validate().unwrap_err();
 
         // 32 bit reg with too long value
         let template = CustomCpuTemplate {
@@ -402,7 +396,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        assert!(template.validate().is_err());
+        template.validate().unwrap_err();
 
         // 16 bit unsupporteed reg
         let template = CustomCpuTemplate {
@@ -415,6 +409,6 @@ mod tests {
             }],
             ..Default::default()
         };
-        assert!(template.validate().is_err());
+        template.validate().unwrap_err();
     }
 }

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -359,10 +359,10 @@ mod tests {
 
         let serialized = "\"0b0_xϽ1_xx_xx\"";
         let deserialized: Result<RegisterValueFilter<u8>, _> = serde_json::from_str(serialized);
-        assert!(deserialized.is_err());
+        deserialized.unwrap_err();
 
         let serialized = "\"0b0000_0000_0\"";
         let deserialized: Result<RegisterValueFilter<u8>, _> = serde_json::from_str(serialized);
-        assert!(deserialized.is_err());
+        deserialized.unwrap_err();
     }
 }

--- a/src/vmm/src/cpu_config/templates_serde.rs
+++ b/src/vmm/src/cpu_config/templates_serde.rs
@@ -61,23 +61,21 @@ mod tests {
         let valid_string = "0b1000101";
         let deserializer: StrDeserializer<Error> = valid_string.into_deserializer();
         let valid_value = deserialize_from_str_u32(deserializer);
-        assert!(valid_value.is_ok());
         assert_eq!(valid_value.unwrap(), 69);
 
         let valid_string = "0x0045";
         let deserializer: StrDeserializer<Error> = valid_string.into_deserializer();
         let valid_value = deserialize_from_str_u32(deserializer);
-        assert!(valid_value.is_ok());
         assert_eq!(valid_value.unwrap(), 69);
 
         let invalid_string = "xϽ69";
         let deserializer: StrDeserializer<Error> = invalid_string.into_deserializer();
         let invalid_value = deserialize_from_str_u32(deserializer);
-        assert!(invalid_value.is_err());
+        invalid_value.unwrap_err();
 
         let invalid_string = "69";
         let deserializer: StrDeserializer<Error> = invalid_string.into_deserializer();
         let invalid_value = deserialize_from_str_u32(deserializer);
-        assert!(invalid_value.is_err());
+        invalid_value.unwrap_err();
     }
 }

--- a/src/vmm/src/cpu_config/x86_64/cpuid/amd/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/amd/normalize.rs
@@ -447,7 +447,7 @@ mod tests {
                 },
             },
         )]));
-        assert!(cpuid.update_structured_extended_entry().is_ok());
+        cpuid.update_structured_extended_entry().unwrap();
         assert_eq!(
             cpuid
                 .get(&CpuidKey {

--- a/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
@@ -583,7 +583,7 @@ mod tests {
             cpu_bits,
             cpus_per_core,
         );
-        assert!(result.is_ok());
+        result.unwrap();
         assert!(intel_cpuid.inner().contains_key(&CpuidKey {
             leaf: 0xb,
             subleaf: 0x1
@@ -607,7 +607,7 @@ mod tests {
         )])));
         let result =
             amd_cpuid.update_extended_topology_entry(cpu_index, cpu_count, cpu_bits, cpus_per_core);
-        assert!(result.is_ok());
+        result.unwrap();
         assert!(amd_cpuid.inner().contains_key(&CpuidKey {
             leaf: 0xb,
             subleaf: 0x1

--- a/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
+++ b/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
@@ -389,7 +389,6 @@ mod tests {
                     ],
                 }"#,
         );
-        assert!(cpu_template_result.is_err());
         assert!(cpu_template_result
             .unwrap_err()
             .to_string()
@@ -406,7 +405,6 @@ mod tests {
                     ]
                 }"#,
         );
-        assert!(cpu_template_result.is_err());
         let error_msg: String = cpu_template_result.unwrap_err().to_string();
         // Formatted error expected clarifying the number system prefix is missing
         assert!(
@@ -433,7 +431,6 @@ mod tests {
                     ],
                 }"#,
         );
-        assert!(cpu_template_result.is_err());
         let error_msg: String = cpu_template_result.unwrap_err().to_string();
         // Formatted error expected clarifying the number system prefix is missing
         assert!(
@@ -452,7 +449,6 @@ mod tests {
                     ]
                 }"#,
         );
-        assert!(cpu_template_result.is_err());
         assert!(cpu_template_result.unwrap_err().to_string().contains(
             "Failed to parse string [0bx0?1_0_0x_?x1xxxx00xxx1xxxxxxxxxxx1] as a bitmap"
         ));
@@ -467,7 +463,6 @@ mod tests {
                     ]
                 }"#,
         );
-        assert!(cpu_template_result.is_err());
         assert!(cpu_template_result
             .unwrap_err()
             .to_string()
@@ -486,11 +481,9 @@ mod tests {
     fn test_serialization_lifecycle() {
         let template = build_test_template();
         let template_json_str_result = serde_json::to_string_pretty(&template);
-        assert!(&template_json_str_result.is_ok());
         let template_json = template_json_str_result.unwrap();
 
         let deserialization_result = serde_json::from_str::<CustomCpuTemplate>(&template_json);
-        assert!(deserialization_result.is_ok());
         assert_eq!(template, deserialization_result.unwrap());
     }
 

--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -196,6 +196,6 @@ mod tests {
             EventFd::new(libc::EFD_NONBLOCK).unwrap(),
         )
         .unwrap();
-        assert!(ldm.register_devices(vm.fd()).is_ok());
+        ldm.register_devices(vm.fd()).unwrap();
     }
 }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -600,13 +600,13 @@ mod tests {
         let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         let dummy = Arc::new(Mutex::new(DummyDevice::new()));
         #[cfg(target_arch = "x86_64")]
-        assert!(builder::setup_interrupt_controller(&mut vm).is_ok());
+        builder::setup_interrupt_controller(&mut vm).unwrap();
         #[cfg(target_arch = "aarch64")]
-        assert!(builder::setup_interrupt_controller(&mut vm, 1).is_ok());
+        builder::setup_interrupt_controller(&mut vm, 1).unwrap();
 
-        assert!(device_manager
+        device_manager
             .register_virtio_test_device(vm.fd(), guest_mem, dummy, &mut cmdline, "dummy")
-            .is_ok());
+            .unwrap();
     }
 
     #[test]
@@ -629,9 +629,9 @@ mod tests {
 
         let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         #[cfg(target_arch = "x86_64")]
-        assert!(builder::setup_interrupt_controller(&mut vm).is_ok());
+        builder::setup_interrupt_controller(&mut vm).unwrap();
         #[cfg(target_arch = "aarch64")]
-        assert!(builder::setup_interrupt_controller(&mut vm, 1).is_ok());
+        builder::setup_interrupt_controller(&mut vm, 1).unwrap();
 
         for _i in crate::arch::IRQ_BASE..=crate::arch::IRQ_MAX {
             device_manager
@@ -684,9 +684,9 @@ mod tests {
         let mem_clone = guest_mem.clone();
 
         #[cfg(target_arch = "x86_64")]
-        assert!(builder::setup_interrupt_controller(&mut vm).is_ok());
+        builder::setup_interrupt_controller(&mut vm).unwrap();
         #[cfg(target_arch = "aarch64")]
-        assert!(builder::setup_interrupt_controller(&mut vm, 1).is_ok());
+        builder::setup_interrupt_controller(&mut vm, 1).unwrap();
 
         let mut device_manager = MMIODeviceManager::new(
             0xd000_0000,
@@ -776,6 +776,6 @@ mod tests {
             "Failed to allocate requested resource: The requested resource is not available."
                 .to_string()
         );
-        assert!(device_manager.allocate_mmio_resources(0).is_ok());
+        device_manager.allocate_mmio_resources(0).unwrap();
     }
 }

--- a/src/vmm/src/devices/bus.rs
+++ b/src/vmm/src/devices/bus.rs
@@ -316,34 +316,33 @@ mod tests {
         let mut bus = Bus::new();
         let dummy = Arc::new(Mutex::new(BusDevice::Dummy(DummyDevice)));
         // Insert len should not be 0.
-        assert!(bus.insert(dummy.clone(), 0x10, 0).is_err());
-        assert!(bus.insert(dummy.clone(), 0x10, 0x10).is_ok());
+        bus.insert(dummy.clone(), 0x10, 0).unwrap_err();
+        bus.insert(dummy.clone(), 0x10, 0x10).unwrap();
 
         let result = bus.insert(dummy.clone(), 0x0f, 0x10);
         // This overlaps the address space of the existing bus device at 0x10.
-        assert!(result.is_err());
-        assert_eq!(format!("{:?}", result), "Err(Overlap)");
+        assert!(matches!(result, Err(BusError::Overlap)), "{:?}", result);
 
         // This overlaps the address space of the existing bus device at 0x10.
-        assert!(bus.insert(dummy.clone(), 0x10, 0x10).is_err());
+        bus.insert(dummy.clone(), 0x10, 0x10).unwrap_err();
         // This overlaps the address space of the existing bus device at 0x10.
-        assert!(bus.insert(dummy.clone(), 0x10, 0x15).is_err());
+        bus.insert(dummy.clone(), 0x10, 0x15).unwrap_err();
         // This overlaps the address space of the existing bus device at 0x10.
-        assert!(bus.insert(dummy.clone(), 0x12, 0x15).is_err());
+        bus.insert(dummy.clone(), 0x12, 0x15).unwrap_err();
         // This overlaps the address space of the existing bus device at 0x10.
-        assert!(bus.insert(dummy.clone(), 0x12, 0x01).is_err());
+        bus.insert(dummy.clone(), 0x12, 0x01).unwrap_err();
         // This overlaps the address space of the existing bus device at 0x10.
-        assert!(bus.insert(dummy.clone(), 0x0, 0x20).is_err());
-        assert!(bus.insert(dummy.clone(), 0x20, 0x05).is_ok());
-        assert!(bus.insert(dummy.clone(), 0x25, 0x05).is_ok());
-        assert!(bus.insert(dummy, 0x0, 0x10).is_ok());
+        bus.insert(dummy.clone(), 0x0, 0x20).unwrap_err();
+        bus.insert(dummy.clone(), 0x20, 0x05).unwrap();
+        bus.insert(dummy.clone(), 0x25, 0x05).unwrap();
+        bus.insert(dummy, 0x0, 0x10).unwrap();
     }
 
     #[test]
     fn bus_read_write() {
         let mut bus = Bus::new();
         let dummy = Arc::new(Mutex::new(BusDevice::Dummy(DummyDevice)));
-        assert!(bus.insert(dummy, 0x10, 0x10).is_ok());
+        bus.insert(dummy, 0x10, 0x10).unwrap();
         assert!(bus.read(0x10, &mut [0, 0, 0, 0]));
         assert!(bus.write(0x10, &[0, 0, 0, 0]));
         assert!(bus.read(0x11, &mut [0, 0, 0, 0]));
@@ -360,7 +359,7 @@ mod tests {
     fn bus_read_write_values() {
         let mut bus = Bus::new();
         let dummy = Arc::new(Mutex::new(BusDevice::Constant(ConstantDevice)));
-        assert!(bus.insert(dummy, 0x10, 0x10).is_ok());
+        bus.insert(dummy, 0x10, 0x10).unwrap();
 
         let mut values = [0, 1, 2, 3];
         assert!(bus.read(0x10, &mut values));
@@ -381,13 +380,12 @@ mod tests {
 
         let mut bus = Bus::new();
         let mut data = [1, 2, 3, 4];
-        assert!(bus
-            .insert(
-                Arc::new(Mutex::new(BusDevice::Dummy(DummyDevice))),
-                0x10,
-                0x10
-            )
-            .is_ok());
+        bus.insert(
+            Arc::new(Mutex::new(BusDevice::Dummy(DummyDevice))),
+            0x10,
+            0x10,
+        )
+        .unwrap();
         assert!(bus.write(0x10, &data));
         let bus_clone = bus.clone();
         assert!(bus.read(0x10, &mut data));

--- a/src/vmm/src/devices/legacy/i8042.rs
+++ b/src/vmm/src/devices/legacy/i8042.rs
@@ -366,7 +366,7 @@ mod tests {
         // Check if reset works.
         // Write 1 to the reset event fd, so that read doesn't block in case the event fd
         // counter doesn't change (for 0 it blocks).
-        assert!(reset_evt.write(1).is_ok());
+        reset_evt.write(1).unwrap();
         let mut data = [CMD_RESET_CPU];
         i8042.bus_write(OFS_STATUS, &data);
         assert_eq!(reset_evt.read().unwrap(), 2);

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -841,7 +841,7 @@ pub(crate) mod tests {
 
         // Fill the second page with non-zero bytes.
         for i in 0..0x1000 {
-            assert!(mem.write_obj::<u8>(1, GuestAddress((1 << 12) + i)).is_ok());
+            mem.write_obj::<u8>(1, GuestAddress((1 << 12) + i)).unwrap();
         }
 
         // Will write the page frame number of the affected frame at this
@@ -899,7 +899,7 @@ pub(crate) mod tests {
 
         // Fill the third page with non-zero bytes.
         for i in 0..0x1000 {
-            assert!(mem.write_obj::<u8>(1, GuestAddress((1 << 12) + i)).is_ok());
+            mem.write_obj::<u8>(1, GuestAddress((1 << 12) + i)).unwrap();
         }
 
         // Will write the page frame number of the affected frame at this
@@ -1087,7 +1087,7 @@ pub(crate) mod tests {
                 // Trigger the timer event, which consumes the stats
                 // descriptor index and signals the used queue.
                 assert!(balloon.stats_desc_index.is_some());
-                assert!(balloon.process_stats_timer_event().is_ok());
+                balloon.process_stats_timer_event().unwrap();
                 assert!(balloon.stats_desc_index.is_none());
                 assert!(balloon.irq_trigger.has_pending_irq(IrqType::Vring));
             });
@@ -1117,7 +1117,7 @@ pub(crate) mod tests {
             format!("{:?}", balloon.update_stats_polling_interval(1)),
             "Err(StatisticsStateChange)"
         );
-        assert!(balloon.update_stats_polling_interval(0).is_ok());
+        balloon.update_stats_polling_interval(0).unwrap();
 
         let mut balloon = Balloon::new(0, true, 1, false).unwrap();
         let mem = default_mem();
@@ -1126,15 +1126,15 @@ pub(crate) mod tests {
             format!("{:?}", balloon.update_stats_polling_interval(0)),
             "Err(StatisticsStateChange)"
         );
-        assert!(balloon.update_stats_polling_interval(1).is_ok());
-        assert!(balloon.update_stats_polling_interval(2).is_ok());
+        balloon.update_stats_polling_interval(1).unwrap();
+        balloon.update_stats_polling_interval(2).unwrap();
     }
 
     #[test]
     fn test_num_pages() {
         let mut balloon = Balloon::new(0, true, 0, false).unwrap();
         // Assert that we can't update an inactive device.
-        assert!(balloon.update_size(1).is_err());
+        balloon.update_size(1).unwrap_err();
         // Switch the state to active.
         balloon.device_state = DeviceState::Activated(
             GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0x0), 0x1)], false).unwrap(),
@@ -1147,7 +1147,7 @@ pub(crate) mod tests {
         balloon.update_actual_pages(0x1234);
         balloon.update_num_pages(0x100);
         assert_eq!(balloon.num_pages(), 0x100);
-        assert!(balloon.update_size(16).is_ok());
+        balloon.update_size(16).unwrap();
 
         let mut actual_config = vec![0; BALLOON_CONFIG_SPACE_SIZE];
         balloon.read_config(0, &mut actual_config);

--- a/src/vmm/src/devices/virtio/balloon/util.rs
+++ b/src/vmm/src/devices/virtio/balloon/util.rs
@@ -187,7 +187,7 @@ mod tests {
         mem.write(&ones[..], GuestAddress(0)).unwrap();
 
         // Remove the first page.
-        assert!(remove_range(&mem, (GuestAddress(0), page_size as u64), false).is_ok());
+        remove_range(&mem, (GuestAddress(0), page_size as u64), false).unwrap();
 
         // Check that the first page is zeroed.
         let mut actual_page = vec![0u8; page_size];
@@ -228,7 +228,7 @@ mod tests {
         mem.write(&ones[..], GuestAddress(0)).unwrap();
 
         // Remove the first page.
-        assert!(remove_range(&mem, (GuestAddress(0), page_size as u64), true).is_ok());
+        remove_range(&mem, (GuestAddress(0), page_size as u64), true).unwrap();
 
         // Check that the first page is zeroed.
         let mut actual_page = vec![0u8; page_size];

--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -228,8 +228,8 @@ pub(crate) mod tests {
 
         // Check trigger_irq() failure case (irq_evt is full).
         irq_trigger.irq_evt.write(u64::MAX - 1).unwrap();
-        assert!(irq_trigger.trigger_irq(IrqType::Config).is_err());
-        assert!(irq_trigger.trigger_irq(IrqType::Vring).is_err());
+        irq_trigger.trigger_irq(IrqType::Config).unwrap_err();
+        irq_trigger.trigger_irq(IrqType::Vring).unwrap_err();
     }
 
     #[derive(Debug)]

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -429,11 +429,11 @@ mod tests {
 
         let (mut q, _) = write_only_chain(&mem);
         let head = q.pop(&mem).unwrap();
-        assert!(IoVecBuffer::from_descriptor_chain(head).is_err());
+        IoVecBuffer::from_descriptor_chain(head).unwrap_err();
 
         let (mut q, _) = read_only_chain(&mem);
         let head = q.pop(&mem).unwrap();
-        assert!(IoVecBufferMut::from_descriptor_chain(head).is_err());
+        IoVecBufferMut::from_descriptor_chain(head).unwrap_err();
 
         let (mut q, _) = write_only_chain(&mem);
         let head = q.pop(&mem).unwrap();

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -1496,7 +1496,7 @@ pub mod tests {
         let arp_request =
             EthIPv4ArpFrame::write_request(frame.payload_mut(), src_mac, src_ip, dst_mac, dst_ip);
         // Validate success.
-        assert!(arp_request.is_ok());
+        arp_request.unwrap();
 
         (frame_buf, frame_len)
     }

--- a/src/vmm/src/devices/virtio/net/metrics.rs
+++ b/src/vmm/src/devices/virtio/net/metrics.rs
@@ -271,8 +271,8 @@ pub mod tests {
         // we have 5-23 irq for net devices so max 19 net devices.
         const MAX_NET_DEVICES: usize = 19;
 
-        assert!(METRICS.read().is_ok());
-        assert!(METRICS.write().is_ok());
+        drop(METRICS.read().unwrap());
+        drop(METRICS.write().unwrap());
 
         for i in 0..MAX_NET_DEVICES {
             let devn: String = format!("eth{}", i);
@@ -346,11 +346,10 @@ pub mod tests {
         // `test_net_dev_metrics` which also uses the same name.
         let devn = "eth0";
 
-        assert!(METRICS.read().is_ok());
-        assert!(METRICS.write().is_ok());
+        drop(METRICS.read().unwrap());
+        drop(METRICS.write().unwrap());
 
         NetMetricsPerDevice::alloc(String::from(devn));
-        assert!(METRICS.read().is_ok());
         assert!(METRICS.read().unwrap().metrics.get(devn).is_some());
 
         METRICS

--- a/src/vmm/src/devices/virtio/net/tap.rs
+++ b/src/vmm/src/devices/virtio/net/tap.rs
@@ -316,7 +316,7 @@ pub mod tests {
         tap_traffic_simulator.push_tx_packet(packet.as_bytes());
 
         let mut buf = [0u8; PACKET_SIZE];
-        assert!(tap.read(&mut buf).is_ok());
+        assert_eq!(tap.read(&mut buf).unwrap(), PAYLOAD_SIZE + VNET_HDR_SIZE);
         assert_eq!(
             &buf[VNET_HDR_SIZE..packet.len() + VNET_HDR_SIZE],
             packet.as_bytes()
@@ -333,7 +333,7 @@ pub mod tests {
         let payload = utils::rand::rand_alphanumerics(PAYLOAD_SIZE);
         packet[gen::ETH_HLEN as usize..payload.len() + gen::ETH_HLEN as usize]
             .copy_from_slice(payload.as_bytes());
-        assert!(tap.write(&packet).is_ok());
+        assert_eq!(tap.write(&packet).unwrap(), PACKET_SIZE);
 
         let mut read_buf = [0u8; PACKET_SIZE];
         assert!(tap_traffic_simulator.pop_rx_packet(&mut read_buf));
@@ -361,7 +361,7 @@ pub mod tests {
             fragment3.as_slice(),
         ]);
 
-        assert!(tap.write_iovec(&scattered).is_ok());
+        tap.write_iovec(&scattered).unwrap();
 
         let mut read_buf = vec![0u8; scattered.len()];
         assert!(tap_traffic_simulator.pop_rx_packet(&mut read_buf));

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -440,7 +440,7 @@ mod tests {
         // This should succeed, we should have one more descriptor
         let desc = entropy_dev.queues_mut()[RNG_QUEUE].pop(&mem).unwrap();
         let mut iovec = IoVecBufferMut::from_descriptor_chain(desc).unwrap();
-        assert!(entropy_dev.handle_one(&mut iovec).is_ok());
+        entropy_dev.handle_one(&mut iovec).unwrap();
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/test_utils.rs
@@ -151,18 +151,16 @@ impl<'a> VirtqDesc<'a> {
     pub fn set_data(&mut self, data: &[u8]) {
         assert!(self.len.get() as usize >= data.len());
         let mem = self.addr.mem;
-        assert!(mem
-            .write_slice(data, GuestAddress::new(self.addr.get()))
-            .is_ok());
+        mem.write_slice(data, GuestAddress::new(self.addr.get()))
+            .unwrap();
     }
 
     pub fn check_data(&self, expected_data: &[u8]) {
         assert!(self.len.get() as usize >= expected_data.len());
         let mem = self.addr.mem;
         let mut buf = vec![0; expected_data.len()];
-        assert!(mem
-            .read_slice(&mut buf, GuestAddress::new(self.addr.get()))
-            .is_ok());
+        mem.read_slice(&mut buf, GuestAddress::new(self.addr.get()))
+            .unwrap();
         assert_eq!(buf.as_slice(), expected_data);
     }
 }

--- a/src/vmm/src/devices/virtio/vhost_user_block/device.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_block/device.rs
@@ -403,7 +403,7 @@ mod tests {
 
             socket: Some("sock".to_string()),
         };
-        assert!(VhostUserBlockConfig::try_from(&block_config).is_ok());
+        VhostUserBlockConfig::try_from(&block_config).unwrap();
 
         let block_config = BlockDeviceConfig {
             drive_id: "".to_string(),
@@ -418,7 +418,7 @@ mod tests {
 
             socket: None,
         };
-        assert!(VhostUserBlockConfig::try_from(&block_config).is_err());
+        VhostUserBlockConfig::try_from(&block_config).unwrap_err();
 
         let block_config = BlockDeviceConfig {
             drive_id: "".to_string(),
@@ -433,7 +433,7 @@ mod tests {
 
             socket: Some("sock".to_string()),
         };
-        assert!(VhostUserBlockConfig::try_from(&block_config).is_err());
+        VhostUserBlockConfig::try_from(&block_config).unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/virtio_block/io/mod.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/mod.rs
@@ -358,9 +358,9 @@ pub mod tests {
         assert_eq!(buf, data.as_slice());
 
         // Check other ops
-        assert!(engine.flush(()).is_ok());
-        assert!(engine.drain(true).is_ok());
-        assert!(engine.drain_and_flush(true).is_ok());
+        engine.flush(()).unwrap();
+        engine.drain(true).unwrap();
+        engine.drain_and_flush(true).unwrap();
     }
 
     #[test]
@@ -369,7 +369,7 @@ pub mod tests {
 
         // Check invalid file
         let file = unsafe { File::from_raw_fd(-2) };
-        assert!(FileEngine::<()>::from_file(file, FileEngineType::Async).is_err());
+        FileEngine::<()>::from_file(file, FileEngineType::Async).unwrap_err();
 
         // Create backing file.
         let file = TempFile::new().unwrap().into_file();
@@ -423,7 +423,7 @@ pub mod tests {
         assert_queued!(engine.flush(()));
         assert_async_execution(&mem, &mut engine, 0);
 
-        assert!(engine.drain(true).is_ok());
-        assert!(engine.drain_and_flush(true).is_ok());
+        engine.drain(true).unwrap();
+        engine.drain_and_flush(true).unwrap();
     }
 }

--- a/src/vmm/src/devices/virtio/virtio_block/metrics.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/metrics.rs
@@ -232,8 +232,8 @@ pub mod tests {
         const MAX_BLOCK_DEVICES: usize = 19;
 
         // This is to make sure that RwLock for block::metrics::METRICS is good.
-        assert!(METRICS.read().is_ok());
-        assert!(METRICS.write().is_ok());
+        drop(METRICS.read().unwrap());
+        drop(METRICS.write().unwrap());
 
         // block::metrics::METRICS is in short RwLock on Vec of BlockDeviceMetrics.
         // Normally, pointer to unique entries of block::metrics::METRICS are stored
@@ -281,8 +281,8 @@ pub mod tests {
         let devn = "drv0";
 
         // This is to make sure that RwLock for block::metrics::METRICS is good.
-        assert!(METRICS.read().is_ok());
-        assert!(METRICS.write().is_ok());
+        drop(METRICS.read().unwrap());
+        drop(METRICS.write().unwrap());
 
         let test_metrics = BlockMetricsPerDevice::alloc(String::from(devn));
         // Test to update IncMetrics

--- a/src/vmm/src/devices/virtio/virtio_block/persist.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/persist.rs
@@ -214,13 +214,13 @@ mod tests {
         let mut mem = vec![0; 4096];
         let version_map = VersionMap::new();
 
-        assert!(<VirtioBlock as Persist>::save(&block)
+        <VirtioBlock as Persist>::save(&block)
             .serialize(&mut mem.as_mut_slice(), &version_map, 2)
-            .is_ok());
+            .unwrap();
 
-        assert!(<VirtioBlock as Persist>::save(&block)
+        <VirtioBlock as Persist>::save(&block)
             .serialize(&mut mem.as_mut_slice(), &version_map, 3)
-            .is_ok());
+            .unwrap();
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/virtio_block/request.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/request.rs
@@ -450,7 +450,7 @@ mod tests {
 
         // Test that trying to read a request header that goes outside of the
         // memory boundary fails.
-        assert!(RequestHeader::read_from(&mem, GuestAddress(0x1000)).is_err());
+        RequestHeader::read_from(&mem, GuestAddress(0x1000)).unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -418,7 +418,7 @@ mod tests {
             // If the descriptor chain is already declared invalid, there's no reason to assemble
             // a packet.
             if let Some(rx_desc) = ctx.device.queues[RXQ_INDEX].pop(&test_ctx.mem) {
-                assert!(VsockPacket::from_rx_virtq_head(rx_desc).is_err());
+                VsockPacket::from_rx_virtq_head(rx_desc).unwrap_err();
             }
         }
 
@@ -440,7 +440,7 @@ mod tests {
             ctx.guest_txvq.dtable[desc_idx].len.set(len);
 
             if let Some(tx_desc) = ctx.device.queues[TXQ_INDEX].pop(&test_ctx.mem) {
-                assert!(VsockPacket::from_tx_virtq_head(tx_desc).is_err());
+                VsockPacket::from_tx_virtq_head(tx_desc).unwrap_err();
             }
         }
     }
@@ -469,13 +469,13 @@ mod tests {
         {
             let mut ctx = test_ctx.create_event_handler_context();
             let rx_desc = ctx.device.queues[RXQ_INDEX].pop(&test_ctx.mem).unwrap();
-            assert!(VsockPacket::from_rx_virtq_head(rx_desc).is_ok());
+            VsockPacket::from_rx_virtq_head(rx_desc).unwrap();
         }
 
         {
             let mut ctx = test_ctx.create_event_handler_context();
             let tx_desc = ctx.device.queues[TXQ_INDEX].pop(&test_ctx.mem).unwrap();
-            assert!(VsockPacket::from_tx_virtq_head(tx_desc).is_ok());
+            VsockPacket::from_tx_virtq_head(tx_desc).unwrap();
         }
 
         // Let's check what happens when the header descriptor is right before the gap.

--- a/src/vmm/src/devices/virtio/vsock/packet.rs
+++ b/src/vmm/src/devices/virtio/vsock/packet.rs
@@ -672,12 +672,10 @@ mod tests {
         ];
         let mut buf = vec![0; pkt.buf_size()];
         for (offset, count) in oob_cases {
-            assert!(pkt
-                .read_at_offset_from(&mut data.as_slice(), offset, count)
-                .is_err());
-            assert!(pkt2
-                .write_from_offset_to(&mut buf.as_mut_slice(), offset, count)
-                .is_err());
+            let res = pkt.read_at_offset_from(&mut data.as_slice(), offset, count);
+            assert!(matches!(res, Err(VsockError::GuestMemoryBounds)));
+            let res = pkt2.write_from_offset_to(&mut buf.as_mut_slice(), offset, count);
+            assert!(matches!(res, Err(VsockError::GuestMemoryBounds)));
         }
     }
 }

--- a/src/vmm/src/dumbo/pdu/arp.rs
+++ b/src/vmm/src/dumbo/pdu/arp.rs
@@ -420,7 +420,7 @@ mod tests {
             tpa,
         )
         .unwrap();
-        assert!(EthIPv4ArpFrame::request_from_bytes(&a[..ETH_IPV4_FRAME_LEN]).is_ok());
+        EthIPv4ArpFrame::request_from_bytes(&a[..ETH_IPV4_FRAME_LEN]).unwrap();
 
         // Now we start writing invalid requests. We've already tried with an invalid operation.
 

--- a/src/vmm/src/dumbo/pdu/ethernet.rs
+++ b/src/vmm/src/dumbo/pdu/ethernet.rs
@@ -301,7 +301,7 @@ mod kani_proofs {
             assert_eq!(ethernet.len(), slice_length);
             assert_eq!(ethernet.payload().len(), slice_length - PAYLOAD_OFFSET);
         } else {
-            assert!(ethernet.is_err());
+            ethernet.unwrap_err();
         }
     }
 

--- a/src/vmm/src/dumbo/pdu/ipv4.rs
+++ b/src/vmm/src/dumbo/pdu/ipv4.rs
@@ -562,7 +562,7 @@ mod tests {
             // The mutable borrow of buf will end here.
         }
 
-        assert!(IPv4Packet::from_bytes(buf.as_ref(), true).is_ok());
+        IPv4Packet::from_bytes(buf.as_ref(), true).unwrap();
 
         // Now let's check some error conditions.
 

--- a/src/vmm/src/io_uring/mod.rs
+++ b/src/vmm/src/io_uring/mod.rs
@@ -393,7 +393,7 @@ mod tests {
 
     fn drain_cqueue(ring: &mut IoUring) {
         while let Some(entry) = unsafe { ring.pop::<u32>().unwrap() } {
-            assert!(entry.result().is_ok());
+            entry.result().unwrap();
 
             // Assert that there were no partial writes.
             let count = entry.result().unwrap();

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -889,13 +889,13 @@ mod tests {
         assert!(res.is_ok() && !res.unwrap());
 
         let f = TempFile::new().expect("Failed to create temporary metrics file");
-        assert!(m.init(LineWriter::new(f.into_file())).is_ok());
+        m.init(LineWriter::new(f.into_file())).unwrap();
 
-        assert!(m.write().is_ok());
+        m.write().unwrap();
 
         let f = TempFile::new().expect("Failed to create temporary metrics file");
 
-        assert!(m.init(LineWriter::new(f.into_file())).is_err());
+        m.init(LineWriter::new(f.into_file())).unwrap_err();
     }
 
     #[test]
@@ -944,7 +944,7 @@ mod tests {
     #[test]
     fn test_serialize() {
         let s = serde_json::to_string(&FirecrackerMetrics::default());
-        assert!(s.is_ok());
+        s.unwrap();
     }
 
     #[test]

--- a/src/vmm/src/mmds/data_store.rs
+++ b/src/vmm/src/mmds/data_store.rs
@@ -321,7 +321,7 @@ mod tests {
 
         mmds.put_data(serde_json::from_str(mmds_json).unwrap())
             .unwrap();
-        assert!(mmds.check_data_store_initialized().is_ok());
+        mmds.check_data_store_initialized().unwrap();
 
         assert_eq!(mmds.get_data_str(), mmds_json);
 
@@ -512,7 +512,7 @@ mod tests {
             "age": "100"
         }"#;
         let data_store: Value = serde_json::from_str(data).unwrap();
-        assert!(mmds.patch_data(data_store).is_ok());
+        mmds.patch_data(data_store).unwrap();
 
         let data = r#"{
             "name": {
@@ -532,13 +532,13 @@ mod tests {
             "age": "43"
         }"#;
         let data_store: Value = serde_json::from_str(data).unwrap();
-        assert!(mmds.patch_data(data_store).is_ok());
+        mmds.patch_data(data_store).unwrap();
 
         let filling = (0..51151).map(|_| "X").collect::<String>();
         let data = "{\"new_key\": \"".to_string() + &filling + "\"}";
 
         let data_store: Value = serde_json::from_str(&data).unwrap();
-        assert!(mmds.patch_data(data_store).is_ok());
+        mmds.patch_data(data_store).unwrap();
 
         let data = "{\"new_key2\" : \"smth\"}";
         let data_store: Value = serde_json::from_str(data).unwrap();
@@ -550,13 +550,13 @@ mod tests {
 
         let data = "{\"new_key\" : \"smth\"}";
         let data_store: Value = serde_json::from_str(data).unwrap();
-        assert!(mmds.patch_data(data_store).is_ok());
+        mmds.patch_data(data_store).unwrap();
         assert!(mmds.get_data_str().contains("smth"));
         assert_eq!(mmds.get_data_str().len(), 53);
 
         let data = "{\"new_key2\" : \"smth2\"}";
         let data_store: Value = serde_json::from_str(data).unwrap();
-        assert!(mmds.patch_data(data_store).is_ok());
+        mmds.patch_data(data_store).unwrap();
         assert!(mmds.get_data_str().contains("smth2"));
         assert_eq!(mmds.get_data_str().len(), 72);
     }

--- a/src/vmm/src/mmds/token.rs
+++ b/src/vmm/src/mmds/token.rs
@@ -436,7 +436,7 @@ mod tests {
 
         // Decode invalid base64 bytes sequence.
         encoded_token.push('x');
-        assert!(Token::base64_decode(&encoded_token).is_err());
+        Token::base64_decode(&encoded_token).unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -945,7 +945,7 @@ pub(crate) mod tests {
         assert!(l.consume(u64::max_value(), TokenType::Ops));
         assert!(l.consume(u64::max_value(), TokenType::Bytes));
         // calling the handler without there having been an event should error
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert_eq!(
             format!("{:?}", l.event_handler().err().unwrap()),
             "SpuriousRateLimiterEvent(\"Rate limiter event handler called without a present \
@@ -1017,7 +1017,7 @@ pub(crate) mod tests {
         // wait the other half of the timer period
         thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!l.is_blocked());
         // try and succeed on another 100 bytes this time
@@ -1050,7 +1050,7 @@ pub(crate) mod tests {
         // wait the other half of the timer period
         thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!l.is_blocked());
         // try and succeed on another 100 ops this time
@@ -1084,7 +1084,7 @@ pub(crate) mod tests {
         // wait the other half of the timer period
         thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!l.is_blocked());
         // try and succeed on another 100 ops this time
@@ -1105,13 +1105,13 @@ pub(crate) mod tests {
         // check that even after a whole second passes, the rate limiter
         // is still blocked
         thread::sleep(Duration::from_millis(1000));
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert!(l.is_blocked());
 
         // after 1.5x the replenish time has passed, the rate limiter
         // is available again
         thread::sleep(Duration::from_millis(500));
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         assert!(!l.is_blocked());
 
         // reset the rate limiter
@@ -1125,27 +1125,27 @@ pub(crate) mod tests {
         // check that after more than the minimum refill time,
         // the rate limiter is still blocked
         thread::sleep(Duration::from_millis(200));
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert!(l.is_blocked());
 
         // try to consume some tokens, which should fail as the timer
         // is still active
         assert!(!l.consume(100, TokenType::Bytes));
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert!(l.is_blocked());
 
         // check that after the minimum refill time, the timer was not
         // overwritten and the rate limiter is still blocked from the
         // borrowing we performed earlier
         thread::sleep(Duration::from_millis(100));
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert!(l.is_blocked());
         assert!(!l.consume(100, TokenType::Bytes));
 
         // after waiting out the full duration, rate limiter should be
         // availale again
         thread::sleep(Duration::from_millis(200));
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         assert!(!l.is_blocked());
         assert!(l.consume(100, TokenType::Bytes));
     }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -740,21 +740,21 @@ mod tests {
         );
 
         #[cfg(target_arch = "x86_64")]
-        assert!(VmResources::from_json(
+        VmResources::from_json(
             json.as_str(),
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
-            None
+            None,
         )
-        .is_ok());
+        .unwrap();
         #[cfg(target_arch = "aarch64")]
-        assert!(VmResources::from_json(
+        VmResources::from_json(
             json.as_str(),
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
-            None
+            None,
         )
-        .is_err());
+        .unwrap_err();
 
         // Valid config for x86 but invalid on aarch64 since it uses cpu_template.
         json = format!(
@@ -781,21 +781,21 @@ mod tests {
             rootfs_file.as_path().to_str().unwrap()
         );
         #[cfg(target_arch = "x86_64")]
-        assert!(VmResources::from_json(
+        VmResources::from_json(
             json.as_str(),
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
-            None
+            None,
         )
-        .is_ok());
+        .unwrap();
         #[cfg(target_arch = "aarch64")]
-        assert!(VmResources::from_json(
+        VmResources::from_json(
             json.as_str(),
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
-            None
+            None,
         )
-        .is_err());
+        .unwrap_err();
 
         // Invalid memory size.
         json = format!(
@@ -976,13 +976,13 @@ mod tests {
             kernel_file.as_path().to_str().unwrap(),
             rootfs_file.as_path().to_str().unwrap(),
         );
-        assert!(VmResources::from_json(
+        VmResources::from_json(
             json.as_str(),
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
-            None
+            None,
         )
-        .is_ok());
+        .unwrap();
 
         // Test all configuration, this time trying to set default configuration
         // for version and IPv4 address.
@@ -1385,7 +1385,7 @@ mod tests {
 
         // mem_size_mib compatible with balloon size.
         aux_vm_config.mem_size_mib = Some(256);
-        assert!(vm_resources.update_vm_config(&aux_vm_config).is_ok());
+        vm_resources.update_vm_config(&aux_vm_config).unwrap();
     }
 
     #[test]
@@ -1416,7 +1416,9 @@ mod tests {
         let mut vm_resources = default_vm_resources();
         vm_resources.balloon = BalloonBuilder::new();
         new_balloon_cfg.amount_mib = 256;
-        assert!(vm_resources.set_balloon_device(new_balloon_cfg).is_err());
+        vm_resources
+            .set_balloon_device(new_balloon_cfg)
+            .unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -184,11 +184,11 @@ mod tests {
     #[test]
     fn test_signal_handler() {
         let child = thread::spawn(move || {
-            assert!(register_signal_handlers().is_ok());
+            register_signal_handlers().unwrap();
 
             let filter = make_test_seccomp_bpf_filter();
 
-            assert!(seccompiler::apply_filter(&filter).is_ok());
+            seccompiler::apply_filter(&filter).unwrap();
             assert_eq!(METRICS.seccomp.num_faults.fetch(), 0);
 
             // Call the forbidden `SYS_mkdirat`.
@@ -236,7 +236,7 @@ mod tests {
                 syscall(libc::SYS_kill, process::id(), SIGILL);
             }
         });
-        assert!(child.join().is_ok());
+        child.join().unwrap();
 
         assert!(METRICS.seccomp.num_faults.fetch() >= 1);
         assert!(METRICS.signals.sigbus.fetch() >= 1);

--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -125,7 +125,7 @@ impl BalloonBuilder {
 impl Default for BalloonBuilder {
     fn default() -> BalloonBuilder {
         let mut balloon = BalloonBuilder::new();
-        assert!(balloon.set(BalloonDeviceConfig::default()).is_ok());
+        balloon.set(BalloonDeviceConfig::default()).unwrap();
         balloon
     }
 }

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -279,7 +279,7 @@ mod tests {
         };
 
         let mut block_devs = BlockBuilder::new();
-        assert!(block_devs.insert(dummy_block_device.clone()).is_ok());
+        block_devs.insert(dummy_block_device.clone()).unwrap();
 
         assert!(!block_devs.has_root_device());
         assert_eq!(block_devs.devices.len(), 1);
@@ -318,7 +318,7 @@ mod tests {
         };
 
         let mut block_devs = BlockBuilder::new();
-        assert!(block_devs.insert(dummy_block_device.clone()).is_ok());
+        block_devs.insert(dummy_block_device.clone()).unwrap();
 
         assert!(block_devs.has_root_device());
         assert_eq!(block_devs.devices.len(), 1);
@@ -370,7 +370,7 @@ mod tests {
         };
 
         let mut block_devs = BlockBuilder::new();
-        assert!(block_devs.insert(root_block_device_1).is_ok());
+        block_devs.insert(root_block_device_1).unwrap();
         assert_eq!(
             block_devs.insert(root_block_device_2).unwrap_err(),
             DriveError::RootBlockDeviceAlreadyAdded
@@ -429,9 +429,9 @@ mod tests {
         };
 
         let mut block_devs = BlockBuilder::new();
-        assert!(block_devs.insert(dummy_block_dev_2.clone()).is_ok());
-        assert!(block_devs.insert(dummy_block_dev_3.clone()).is_ok());
-        assert!(block_devs.insert(root_block_device.clone()).is_ok());
+        block_devs.insert(dummy_block_dev_2.clone()).unwrap();
+        block_devs.insert(dummy_block_dev_3.clone()).unwrap();
+        block_devs.insert(root_block_device.clone()).unwrap();
 
         assert_eq!(block_devs.devices.len(), 3);
 
@@ -508,9 +508,9 @@ mod tests {
         };
 
         let mut block_devs = BlockBuilder::new();
-        assert!(block_devs.insert(dummy_block_dev_2.clone()).is_ok());
-        assert!(block_devs.insert(dummy_block_dev_3.clone()).is_ok());
-        assert!(block_devs.insert(root_block_device.clone()).is_ok());
+        block_devs.insert(dummy_block_dev_2.clone()).unwrap();
+        block_devs.insert(dummy_block_dev_3.clone()).unwrap();
+        block_devs.insert(root_block_device.clone()).unwrap();
 
         assert_eq!(block_devs.devices.len(), 3);
 
@@ -574,8 +574,8 @@ mod tests {
         let mut block_devs = BlockBuilder::new();
 
         // Add 2 block devices.
-        assert!(block_devs.insert(root_block_device).is_ok());
-        assert!(block_devs.insert(dummy_block_device_2.clone()).is_ok());
+        block_devs.insert(root_block_device).unwrap();
+        block_devs.insert(dummy_block_device_2.clone()).unwrap();
 
         // Get index zero.
         assert_eq!(
@@ -595,7 +595,7 @@ mod tests {
             .is_some());
         // Update OK.
         dummy_block_device_2.is_read_only = Some(true);
-        assert!(block_devs.insert(dummy_block_device_2.clone()).is_ok());
+        block_devs.insert(dummy_block_device_2.clone()).unwrap();
 
         let index = block_devs
             .get_index_of_drive_id(&dummy_block_device_2.drive_id)
@@ -654,9 +654,9 @@ mod tests {
             socket: None,
         };
 
-        assert!(block_devs.insert(root_block_device_old).is_ok());
+        block_devs.insert(root_block_device_old).unwrap();
         let root_block_id = root_block_device_new.drive_id.clone();
-        assert!(block_devs.insert(root_block_device_new).is_ok());
+        block_devs.insert(root_block_device_new).unwrap();
         assert!(block_devs.has_root_device());
         // Verify it's been moved to the first position.
         match block_devs.devices[0] {
@@ -686,7 +686,7 @@ mod tests {
         };
 
         let mut block_devs = BlockBuilder::new();
-        assert!(block_devs.insert(dummy_block_device.clone()).is_ok());
+        block_devs.insert(dummy_block_device.clone()).unwrap();
 
         let configs = block_devs.configs();
         assert_eq!(configs.len(), 1);

--- a/src/vmm/src/vmm_config/metrics.rs
+++ b/src/vmm/src/vmm_config/metrics.rs
@@ -46,7 +46,7 @@ mod tests {
         let desc = MetricsConfig {
             metrics_path: PathBuf::from("not_found_file_metrics"),
         };
-        assert!(init_metrics(desc).is_err());
+        init_metrics(desc).unwrap_err();
 
         // Initializing metrics with valid pipe is ok.
         let metrics_file = TempFile::new().unwrap();
@@ -54,7 +54,7 @@ mod tests {
             metrics_path: metrics_file.as_path().to_path_buf(),
         };
 
-        assert!(init_metrics(desc.clone()).is_ok());
-        assert!(init_metrics(desc).is_err());
+        init_metrics(desc.clone()).unwrap();
+        init_metrics(desc).unwrap_err();
     }
 }

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -224,20 +224,20 @@ mod tests {
 
         // Test create.
         let netif_1 = create_netif(id_1, host_dev_name_1, guest_mac_1);
-        assert!(net_builder.build(netif_1).is_ok());
+        net_builder.build(netif_1).unwrap();
         assert_eq!(net_builder.net_devices.len(), 1);
 
         // Test update mac address (this test does not modify the tap).
         guest_mac_1 = "01:23:45:67:89:0b";
         let netif_1 = create_netif(id_1, host_dev_name_1, guest_mac_1);
 
-        assert!(net_builder.build(netif_1).is_ok());
+        net_builder.build(netif_1).unwrap();
         assert_eq!(net_builder.net_devices.len(), 1);
 
         // Test update host_dev_name (the tap will be updated).
         host_dev_name_1 = "dev2";
         let netif_1 = create_netif(id_1, host_dev_name_1, guest_mac_1);
-        assert!(net_builder.build(netif_1).is_ok());
+        net_builder.build(netif_1).unwrap();
         assert_eq!(net_builder.net_devices.len(), 1);
     }
 
@@ -251,7 +251,7 @@ mod tests {
 
         // Adding the first valid network config.
         let netif_1 = create_netif(id_1, host_dev_name_1, guest_mac_1);
-        assert!(net_builder.build(netif_1).is_ok());
+        net_builder.build(netif_1).unwrap();
 
         // Error Cases for CREATE
         // Error Case: Add new network config with the same mac as netif_1.
@@ -283,7 +283,7 @@ mod tests {
 
         // Adding the second valid network config.
         let netif_2 = create_netif(id_2, host_dev_name_2, guest_mac_2);
-        assert!(net_builder.build(netif_2).is_ok());
+        net_builder.build(netif_2).unwrap();
 
         // Error Cases for UPDATE
         // Error Case: Update netif_2 mac using the same mac as netif_1.
@@ -321,7 +321,7 @@ mod tests {
         );
 
         let mut net_builder = NetBuilder::new();
-        assert!(net_builder.build(net_if_cfg.clone()).is_ok());
+        net_builder.build(net_if_cfg.clone()).unwrap();
         assert_eq!(net_builder.net_devices.len(), 1);
 
         let configs = net_builder.configs();

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -724,10 +724,10 @@ mod tests {
         let memfd = create_memfd(size).unwrap();
 
         assert_eq!(memfd.as_file().metadata().unwrap().len(), size_mb);
-        assert!(memfd.as_file().set_len(0x69).is_err());
+        memfd.as_file().set_len(0x69).unwrap_err();
 
         let mut seals = memfd::SealsHashSet::new();
         seals.insert(memfd::FileSeal::SealGrow);
-        assert!(memfd.add_seals(&seals).is_err());
+        memfd.add_seals(&seals).unwrap_err();
     }
 }

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -347,7 +347,6 @@ mod tests {
         unsafe { libc::close(vm.fd().as_raw_fd()) };
 
         let err = KvmVcpu::new(0, &vm);
-        assert!(err.is_err());
         assert_eq!(
             err.err().unwrap().to_string(),
             "Error creating vcpu: Bad file descriptor (os error 9)".to_string()
@@ -363,13 +362,12 @@ mod tests {
             smt: false,
             cpu_config: CpuConfiguration::default(),
         };
-        assert!(vcpu
-            .configure(
-                &vm_mem,
-                GuestAddress(crate::arch::get_kernel_start()),
-                &vcpu_config,
-            )
-            .is_ok());
+        vcpu.configure(
+            &vm_mem,
+            GuestAddress(crate::arch::get_kernel_start()),
+            &vcpu_config,
+        )
+        .unwrap();
 
         unsafe { libc::close(vcpu.fd.as_raw_fd()) };
 
@@ -378,7 +376,6 @@ mod tests {
             GuestAddress(crate::arch::get_kernel_start()),
             &vcpu_config,
         );
-        assert!(err.is_err());
         assert_eq!(
             err.unwrap_err(),
             KvmVcpuError::ConfigureRegisters(ArchError::SetOneReg(
@@ -416,7 +413,6 @@ mod tests {
         let (vm, mut vcpu, _) = setup_vcpu(0x10000);
         unsafe { libc::close(vm.fd().as_raw_fd()) };
         let err = vcpu.init(vm.fd(), &[]);
-        assert!(err.is_err());
         assert_eq!(
             err.err().unwrap().to_string(),
             "Error getting the vcpu preferred target: Bad file descriptor (os error 9)".to_string()
@@ -431,7 +427,6 @@ mod tests {
 
         // Calling KVM_GET_REGLIST before KVM_VCPU_INIT will result in error.
         let res = vcpu.save_state();
-        assert!(res.is_err());
         assert!(matches!(
             res.unwrap_err(),
             KvmVcpuError::SaveState(ArchError::GetRegList(_))
@@ -447,7 +442,6 @@ mod tests {
             ..Default::default()
         };
         let res = vcpu.restore_state(vm.fd(), &faulty_vcpu_state);
-        assert!(res.is_err());
         assert!(matches!(
             res.unwrap_err(),
             KvmVcpuError::RestoreState(ArchError::SetOneReg(0, _))
@@ -470,7 +464,7 @@ mod tests {
         let vcpu = KvmVcpu::new(0, &vm).unwrap();
         vm.setup_irqchip(1).unwrap();
 
-        assert!(vcpu.dump_cpu_config().is_err());
+        vcpu.dump_cpu_config().unwrap_err();
     }
 
     #[test]
@@ -481,16 +475,16 @@ mod tests {
         vm.setup_irqchip(1).unwrap();
         vcpu.init(vm.fd(), &[]).unwrap();
 
-        assert!(vcpu.dump_cpu_config().is_ok());
+        vcpu.dump_cpu_config().unwrap();
     }
 
     #[test]
     fn test_setup_non_boot_vcpu() {
         let (vm, _) = setup_vm(0x1000);
         let mut vcpu1 = KvmVcpu::new(0, &vm).unwrap();
-        assert!(vcpu1.init(vm.fd(), &[]).is_ok());
+        vcpu1.init(vm.fd(), &[]).unwrap();
         let mut vcpu2 = KvmVcpu::new(1, &vm).unwrap();
-        assert!(vcpu2.init(vm.fd(), &[]).is_ok());
+        vcpu2.init(vm.fd(), &[]).unwrap();
     }
 
     #[test]
@@ -500,7 +494,7 @@ mod tests {
         // - X1: 0x6030 0000 0010 0002
         let (_, vcpu, _) = setup_vcpu(0x10000);
         let reg_list = Vec::<u64>::from([0x6030000000100000, 0x6030000000100002]);
-        assert!(get_registers(&vcpu.fd, &reg_list, &mut Aarch64RegisterVec::default()).is_ok());
+        get_registers(&vcpu.fd, &reg_list, &mut Aarch64RegisterVec::default()).unwrap();
     }
 
     #[test]
@@ -508,6 +502,6 @@ mod tests {
         // Test `get_regs()` with invalid register IDs.
         let (_, vcpu, _) = setup_vcpu(0x10000);
         let reg_list = Vec::<u64>::from([0x6030000000100001, 0x6030000000100003]);
-        assert!(get_registers(&vcpu.fd, &reg_list, &mut Aarch64RegisterVec::default()).is_err());
+        get_registers(&vcpu.fd, &reg_list, &mut Aarch64RegisterVec::default()).unwrap_err();
     }
 }

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -877,7 +877,7 @@ mod tests {
         };
         vcpu.configure(&vm_mem, GuestAddress(0), &vcpu_config)
             .unwrap();
-        assert!(vcpu.dump_cpu_config().is_ok());
+        vcpu.dump_cpu_config().unwrap();
     }
 
     #[test]
@@ -923,14 +923,14 @@ mod tests {
         );
 
         if vm.fd().check_extension(Cap::TscControl) {
-            assert!(vcpu.set_tsc_khz(state.tsc_khz.unwrap()).is_ok());
+            vcpu.set_tsc_khz(state.tsc_khz.unwrap()).unwrap();
             if vm.fd().check_extension(Cap::GetTscKhz) {
                 assert_eq!(vcpu.get_tsc_khz().ok(), state.tsc_khz);
             } else {
-                assert!(vcpu.get_tsc_khz().is_err());
+                vcpu.get_tsc_khz().unwrap_err();
             }
         } else {
-            assert!(vcpu.set_tsc_khz(state.tsc_khz.unwrap()).is_err());
+            vcpu.set_tsc_khz(state.tsc_khz.unwrap()).unwrap_err();
         }
     }
 
@@ -939,9 +939,8 @@ mod tests {
         // Test `get_msrs()` with the MSR indices that should be serialized into snapshots.
         // The MSR indices should be valid and this test should succeed.
         let (_, vcpu, _) = setup_vcpu(0x1000);
-        assert!(vcpu
-            .get_msrs(&vcpu.msrs_to_save.iter().copied().collect::<Vec<_>>())
-            .is_ok());
+        vcpu.get_msrs(&vcpu.msrs_to_save.iter().copied().collect::<Vec<_>>())
+            .unwrap();
     }
 
     #[test]
@@ -952,7 +951,7 @@ mod tests {
 
         let kvm = kvm_ioctls::Kvm::new().unwrap();
         let msrs_to_dump = crate::arch::x86_64::msr::get_msrs_to_dump(&kvm).unwrap();
-        assert!(vcpu.get_msrs(msrs_to_dump.as_slice()).is_ok());
+        vcpu.get_msrs(msrs_to_dump.as_slice()).unwrap();
     }
 
     #[test]

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -486,7 +486,7 @@ pub(crate) mod tests {
         let gm = GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), mem_size)], false).unwrap();
 
         let vm = Vm::new(vec![]).expect("Cannot create new vm");
-        assert!(vm.memory_init(&gm, false).is_ok());
+        vm.memory_init(&gm, false).unwrap();
 
         (vm, gm)
     }
@@ -494,7 +494,7 @@ pub(crate) mod tests {
     #[test]
     fn test_new() {
         // Testing with a valid /dev/kvm descriptor.
-        assert!(Vm::new(vec![]).is_ok());
+        Vm::new(vec![]).unwrap();
     }
 
     #[test]
@@ -521,7 +521,7 @@ pub(crate) mod tests {
 
         // Create valid memory region and test that the initialization is successful.
         let gm = GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), 0x1000)], false).unwrap();
-        assert!(vm.memory_init(&gm, true).is_ok());
+        vm.memory_init(&gm, true).unwrap();
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -529,7 +529,7 @@ pub(crate) mod tests {
     fn test_vm_save_restore_state() {
         let vm = Vm::new(vec![]).expect("new vm failed");
         // Irqchips, clock and pitstate are not configured so trying to save state should fail.
-        assert!(vm.save_state().is_err());
+        vm.save_state().unwrap_err();
 
         let (vm, _mem) = setup_vm(0x1000);
         vm.setup_irqchip().unwrap();
@@ -547,7 +547,7 @@ pub(crate) mod tests {
         let (mut vm, _mem) = setup_vm(0x1000);
         vm.setup_irqchip().unwrap();
 
-        assert!(vm.restore_state(&vm_state).is_ok());
+        vm.restore_state(&vm_state).unwrap();
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -565,18 +565,18 @@ pub(crate) mod tests {
         // Try to restore an invalid PIC Master chip ID
         let orig_master_chip_id = vm_state.pic_master.chip_id;
         vm_state.pic_master.chip_id = KVM_NR_IRQCHIPS;
-        assert!(vm.restore_state(&vm_state).is_err());
+        vm.restore_state(&vm_state).unwrap_err();
         vm_state.pic_master.chip_id = orig_master_chip_id;
 
         // Try to restore an invalid PIC Slave chip ID
         let orig_slave_chip_id = vm_state.pic_slave.chip_id;
         vm_state.pic_slave.chip_id = KVM_NR_IRQCHIPS;
-        assert!(vm.restore_state(&vm_state).is_err());
+        vm.restore_state(&vm_state).unwrap_err();
         vm_state.pic_slave.chip_id = orig_slave_chip_id;
 
         // Try to restore an invalid IOPIC chip ID
         vm_state.ioapic.chip_id = KVM_NR_IRQCHIPS;
-        assert!(vm.restore_state(&vm_state).is_err());
+        vm.restore_state(&vm_state).unwrap_err();
     }
 
     #[test]
@@ -585,7 +585,7 @@ pub(crate) mod tests {
 
         let gm = GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), 0x1000)], false).unwrap();
         let res = vm.set_kvm_memory_regions(&gm, false);
-        assert!(res.is_ok());
+        res.unwrap();
 
         // Trying to set a memory region with a size that is not a multiple of PAGE_SIZE
         // will result in error.

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -80,11 +80,11 @@ fn test_pause_resume_microvm() {
 
     // There's a race between this thread and the vcpu thread, but this thread
     // should be able to pause vcpu thread before it finishes running its test-binary.
-    assert!(vmm.lock().unwrap().pause_vm().is_ok());
+    vmm.lock().unwrap().pause_vm().unwrap();
     // Pausing again the microVM should not fail (microVM remains in the
     // `Paused` state).
-    assert!(vmm.lock().unwrap().pause_vm().is_ok());
-    assert!(vmm.lock().unwrap().resume_vm().is_ok());
+    vmm.lock().unwrap().pause_vm().unwrap();
+    vmm.lock().unwrap().resume_vm().unwrap();
     vmm.lock().unwrap().stop(FcExitCode::Ok);
 }
 
@@ -304,7 +304,7 @@ fn test_snapshot_load_sanity_checks() {
 
     let mut microvm_state = get_microvm_state_from_snapshot();
 
-    assert!(snapshot_state_sanity_check(&microvm_state).is_ok());
+    snapshot_state_sanity_check(&microvm_state).unwrap();
 
     // Remove memory regions.
     microvm_state.memory_state.regions.clear();

--- a/src/vmm/tests/io_uring.rs
+++ b/src/vmm/tests/io_uring.rs
@@ -24,7 +24,7 @@ mod test_utils {
 
     fn drain_cqueue(ring: &mut IoUring) {
         while let Some(entry) = unsafe { ring.pop::<usize>().unwrap() } {
-            assert!(entry.result().is_ok());
+            entry.result().unwrap();
         }
     }
 
@@ -241,7 +241,7 @@ fn test_ring_push() {
         assert_eq!(ring.num_ops(), NUM_ENTRIES);
 
         // Full Ring.
-        assert!(ring.submit().is_ok());
+        ring.submit().unwrap();
         // Wait for the io_uring ops to reach the CQ
         thread::sleep(Duration::from_millis(150));
         for _ in 0..NUM_ENTRIES {
@@ -250,7 +250,7 @@ fn test_ring_push() {
             }
             .is_ok());
         }
-        assert!(ring.submit().is_ok());
+        ring.submit().unwrap();
         // Wait for the io_uring ops to reach the CQ
         thread::sleep(Duration::from_millis(150));
         assert_eq!(ring.num_ops(), NUM_ENTRIES * 2);


### PR DESCRIPTION
Asserting on .is_ok() leads to hard to debug failures (as if the test fails, it will only say "assertion failed: false"). We replace these with `.unwrap()`, which also prints the exact error variant that was unexpectedly encountered (we can to this these days thanks to efforts to implement Display and Debug for our error types). If the assert!((...).is_ok()) was followed by an .unwrap() anyway, we just drop the assert.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
