### PR TITLE
chore: bump version to 1.7.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.40",
+ "syn 2.0.41",
  "which",
 ]
 
@@ -327,7 +327,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -344,7 +344,7 @@ dependencies = [
  "itertools 0.12.0",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
  "uuid",
  "walkdir",
 ]
@@ -366,7 +366,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "cpu-template-helper"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 dependencies = [
  "clap",
  "displaydoc",
@@ -472,7 +472,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 dependencies = [
  "api_server",
  "bincode",
@@ -668,7 +668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.20",
+ "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
 
@@ -698,7 +698,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jailer"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 dependencies = [
  "libc",
  "log-instrument",
@@ -780,9 +780,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "log"
@@ -808,7 +808,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -823,7 +823,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.20",
+ "rustix 0.38.28",
 ]
 
 [[package]]
@@ -933,7 +933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "rebase-snap"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 dependencies = [
  "displaydoc",
  "libc",
@@ -1071,15 +1071,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.10",
- "windows-sys 0.48.0",
+ "linux-raw-sys 0.4.12",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "seccompiler"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bincode",
  "displaydoc",
@@ -1137,7 +1137,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "snapshot-editor"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 dependencies = [
  "clap",
  "clap-num",
@@ -1225,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.40"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1260,7 +1260,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1565,7 +1565,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.20",
+ "rustix 0.38.28",
 ]
 
 [[package]]
@@ -1733,9 +1733,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.26"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
+checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
 dependencies = [
  "memchr",
 ]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,13 +76,13 @@ with a Ubuntu 22.04 rootfs from our CI:
 ARCH="$(uname -m)"
 
 # Download a linux kernel binary
-wget https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.6/${ARCH}/vmlinux-5.10.198
+wget https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.7/${ARCH}/vmlinux-5.10.198
 
 # Download a rootfs
-wget https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.6/${ARCH}/ubuntu-22.04.ext4
+wget https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.7/${ARCH}/ubuntu-22.04.ext4
 
 # Download the ssh key for the rootfs
-wget https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.6/${ARCH}/ubuntu-22.04.id_rsa
+wget https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.7/${ARCH}/ubuntu-22.04.id_rsa
 
 # Set user read permission on the ssh key
 chmod 400 ./ubuntu-22.04.id_rsa

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 1.6.0-dev
+  version: 1.7.0-dev
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/cpu-template-helper/Cargo.toml
+++ b/src/cpu-template-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpu-template-helper"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "build.rs"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 description = "Process for starting Firecracker in production scenarios; applies a cgroup/namespace isolation barrier and then drops privileges."

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rebase-snap"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seccompiler"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 description = "Program that compiles multi-threaded seccomp-bpf filters expressed as JSON into raw BPF programs, serializing them and outputting them to a file."

--- a/src/snapshot-editor/Cargo.toml
+++ b/src/snapshot-editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapshot-editor"
-version = "1.6.0-dev"
+version = "1.7.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -38,6 +38,8 @@ pub const FC_V1_4_SNAP_VERSION: u16 = 8;
 pub const FC_V1_5_SNAP_VERSION: u16 = 9;
 /// Snap version for Firecracker v1.6
 pub const FC_V1_6_SNAP_VERSION: u16 = 10;
+/// Snap version for Firecracker v1.7
+pub const FC_V1_7_SNAP_VERSION: u16 = 11;
 
 lazy_static! {
     // Note: until we have a better design, this needs to be updated when the version changes.
@@ -88,6 +90,9 @@ lazy_static! {
         version_map.set_type_version(VirtioDeviceState::type_id(), 2);
         version_map.set_type_version(DeviceStates::type_id(), 5);
 
+        // v1.7 state change mappings
+        version_map.new_version();
+
         version_map
     };
 
@@ -116,6 +121,7 @@ lazy_static! {
         mapping.insert(Version::new(1, 4, 0), FC_V1_4_SNAP_VERSION);
         mapping.insert(Version::new(1, 5, 0), FC_V1_5_SNAP_VERSION);
         mapping.insert(Version::new(1, 6, 0), FC_V1_6_SNAP_VERSION);
+        mapping.insert(Version::new(1, 7, 0), FC_V1_7_SNAP_VERSION);
 
         mapping
     };

--- a/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_4.14host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "4.14.327-246.539.amzn2.x86_64",
   "microcode_version": "0xa0011d1",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_5.10host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "5.10.198-187.748.amzn2.x86_64",
   "microcode_version": "0xa0011d1",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_6.1host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "6.1.59-84.139.amzn2023.x86_64",
   "microcode_version": "0xa0011d1",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_4.14host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "4.14.327-246.539.amzn2.aarch64",
   "microcode_version": "0x00000000000000ff",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_5.10host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "5.10.198-187.748.amzn2.aarch64",
   "microcode_version": "0x00000000000000ff",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_6.1host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "6.1.59-84.139.amzn2023.aarch64",
   "microcode_version": "0x00000000000000ff",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_4.14host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "4.14.327-246.539.amzn2.aarch64",
   "microcode_version": "0x0000000000000001",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_5.10host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "5.10.198-187.748.amzn2.aarch64",
   "microcode_version": "0x0000000000000001",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_6.1host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "6.1.59-84.139.amzn2023.aarch64",
   "microcode_version": "0x0000000000000001",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_4.14host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "4.14.327-246.539.amzn2.x86_64",
   "microcode_version": "0x5003604",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_5.10host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "5.10.198-187.748.amzn2.x86_64",
   "microcode_version": "0x5003604",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_4.14host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "4.14.327-246.539.amzn2.x86_64",
   "microcode_version": "0xd0003b9",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_5.10host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "5.10.198-187.748.amzn2.x86_64",
   "microcode_version": "0xd0003b9",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_6.1host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "6.1.59-84.139.amzn2023.x86_64",
   "microcode_version": "0xd0003b9",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_5.10host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "5.10.198-187.748.amzn2.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json
@@ -1,5 +1,5 @@
 {
-  "firecracker_version": "1.6.0-dev",
+  "firecracker_version": "1.7.0-dev",
   "kernel_version": "6.1.59-84.139.amzn2023.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",

--- a/tools/devtool
+++ b/tools/devtool
@@ -518,7 +518,7 @@ ensure_ci_artifacts() {
 
     # Fetch all the artifacts so they are local
     say "Fetching CI artifacts from S3"
-    S3_URL=s3://spec.ccfc.min/firecracker-ci/v1.6/$(uname -m)
+    S3_URL=s3://spec.ccfc.min/firecracker-ci/v1.7/$(uname -m)
     ARTIFACTS=$MICROVM_IMAGES_DIR/$(uname -m)
     if [ ! -d "$ARTIFACTS" ]; then
         mkdir -pv $ARTIFACTS


### PR DESCRIPTION
## Changes

Bumps version.

## Reason

Following release of 1.6.0.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
