### PR TITLE
Display for errors

### DIFF
--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -136,17 +136,17 @@ pub enum MicrovmStateError {
     InvalidInput,
     /// Operation not allowed: {0}
     NotAllowed(String),
-    /// Cannot restore devices: {0:?}
+    /// Cannot restore devices: {0}
     RestoreDevices(DevicePersistError),
-    /// Cannot restore Vcpu state: {0:?}
+    /// Cannot restore Vcpu state: {0}
     RestoreVcpuState(vstate::vcpu::VcpuError),
-    /// Cannot restore Vm state: {0:?}
+    /// Cannot restore Vm state: {0}
     RestoreVmState(vstate::vm::VmError),
-    /// Cannot save Vcpu state: {0:?}
+    /// Cannot save Vcpu state: {0}
     SaveVcpuState(vstate::vcpu::VcpuError),
-    /// Cannot save Vm state: {0:?}
+    /// Cannot save Vm state: {0}
     SaveVmState(vstate::vm::VmError),
-    /// Cannot signal Vcpu: {0:?}
+    /// Cannot signal Vcpu: {0}
     SignalVcpu(VcpuSendEventError),
     /// Vcpu is in unexpected state.
     UnexpectedVcpuResponse,

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -38,17 +38,17 @@ const TSC_KHZ_TOL_DENOMINATOR: u32 = 1_000_000;
 pub enum KvmVcpuError {
     /// Failed to convert `kvm_bindings::CpuId` to `Cpuid`: {0}
     ConvertCpuidType(#[from] cpuid::CpuidTryFromKvmCpuid),
-    /// Failed FamStructWrapper operation: {0:?}
+    /// Failed FamStructWrapper operation: {0}
     Fam(#[from] utils::fam::Error),
-    /// Error configuring the floating point related registers: {0:?}
+    /// Error configuring the floating point related registers: {0}
     FpuConfiguration(crate::arch::x86_64::regs::RegsError),
     /// Failed to get dumpable MSR index list: {0}
     GetMsrsToDump(#[from] crate::arch::x86_64::msr::MsrError),
-    /// Cannot set the local interruption due to bad configuration: {0:?}
+    /// Cannot set the local interruption due to bad configuration: {0}
     LocalIntConfiguration(crate::arch::x86_64::interrupts::InterruptError),
-    /// Error configuring the general purpose registers: {0:?}
+    /// Error configuring the general purpose registers: {0}
     RegsConfiguration(crate::arch::x86_64::regs::RegsError),
-    /// Error configuring the special registers: {0:?}
+    /// Error configuring the special registers: {0}
     SregsConfiguration(crate::arch::x86_64::regs::RegsError),
     /// Cannot open the VCPU file descriptor: {0}
     VcpuFd(kvm_ioctls::Error),

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -357,7 +357,7 @@ def test_negative_snapshot_permissions(uvm_plain_rw, microvm_factory):
     microvm = microvm_factory.build()
     microvm.spawn()
 
-    expected_err = "Block(BackingFile(Os { code: 13, kind: PermissionDenied"
+    expected_err = "VirtioBlock: Error manipulating the backing file: Permission denied (os error 13)"
     with pytest.raises(RuntimeError, match=re.escape(expected_err)):
         microvm.restore_from_snapshot(snapshot, resume=True)
 


### PR DESCRIPTION
## Changes
Used `Display` for internal data in errors.

## Reason
The errors are more descriptive.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
