### PR TITLE
Update seccomp filters for rust toolchain upgrade

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -616,6 +616,19 @@
                 ]
             },
             {
+                "syscall": "madvise",
+                "comment": "Triggered on some deallocation paths in musl free()",
+                "args": [
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 8,
+                        "comment": "libc::MADV_FREE"
+                    }
+                ]
+            },
+            {
                 "syscall": "mmap",
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
@@ -838,6 +851,19 @@
                         "op": "eq",
                         "val": 4,
                         "comment": "libc::MADV_DONTNEED"
+                    }
+                ]
+            },
+            {
+                "syscall": "madvise",
+                "comment": "Triggered on some deallocation paths in musl free()",
+                "args": [
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 8,
+                        "comment": "libc::MADV_FREE"
                     }
                 ]
             },

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -855,6 +855,26 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used for allocating memory for FamStructWrapper called by KvmCpu::get_cpuid",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 34,
+                        "comment": "libc::MAP_ANONYMOUS|libc::MAP_PRIVATE"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "libc::PROT_READ|libc::PROT_WRITE"
+                    }
+                ]
+            },
+            {
                 "syscall": "rt_sigaction",
                 "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
                 "args": [

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -867,6 +867,26 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used for allocating memory for FamStructWrapper called by KvmCpu::get_cpuid",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 34,
+                        "comment": "libc::MAP_ANONYMOUS|libc::MAP_PRIVATE"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "libc::PROT_READ|libc::PROT_WRITE"
+                    }
+                ]
+            },
+            {
                 "syscall": "rt_sigaction",
                 "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
                 "args": [

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -628,6 +628,19 @@
                 ]
             },
             {
+                "syscall": "madvise",
+                "comment": "Triggered on some deallocation paths in musl free()",
+                "args": [
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 8,
+                        "comment": "libc::MADV_FREE"
+                    }
+                ]
+            },
+            {
                 "syscall": "mmap",
                 "comment": "Used for large buffers sent to api_server",
                 "args": [
@@ -850,6 +863,19 @@
                         "op": "eq",
                         "val": 4,
                         "comment": "libc::MADV_DONTNEED"
+                    }
+                ]
+            },
+            {
+                "syscall": "madvise",
+                "comment": "Triggered on some deallocation paths in musl free()",
+                "args": [
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 8,
+                        "comment": "libc::MADV_FREE"
                     }
                 ]
             },


### PR DESCRIPTION
## Changes

Add new entries for `mmap` and `madvise` in seccomp filters. The actual upgrade of the toolchain will
come in a follow up PR here: #4258. The reason for the separate PRs, is that if we bundle them together
A/B tests will run some tests on `main` with the new toolchain but using the old seccomp filters and cause
tests to fail due to seccomp violations. 

## Reason

Rust toolchain upgrade to 1.73.0 introduces new `mmap` and `madvise` calls.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
