### PR TITLE
fix: Use the right url to view the release

### DIFF
--- a/.github/workflows/send_release_notification.yml
+++ b/.github/workflows/send_release_notification.yml
@@ -12,5 +12,5 @@ jobs:
         run: |
           curl -X POST ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK }} \
                -H 'Content-Type: application/json' \
-               -d '{ "GITHUB_RELEASE_URL": "${{ github.event.release.url }}",
+               -d '{ "GITHUB_RELEASE_URL": "${{ github.event.release.html_url }}",
                      "GITHUB_RELEASE_TAG": "${{ github.event.release.tag_name }}"}'


### PR DESCRIPTION


## Changes

Use `html_url` instead of `url` so that the release slack notification contains the url that can be used to navigate to the release page.

## Reason

The release Slack notification points to an url like https://api.github.com/repos/firecracker-microvm/firecracker/releases/134631702 instead of the release page.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~- [ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.

~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~
~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~

- [x] All added/changed functionality is tested.

~- [ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
