### PR TITLE
Aggregate latency metrics for vm exits handling IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [#4346](https://github.com/firecracker-microvm/firecracker/pull/4346):
+  Added support to emit aggregate (minimum/maximum/sum) latency for
+  `VcpuExit::MmioRead`, `VcpuExit::MmioWrite`, `VcpuExit::IoIn` and
+  `VcpuExit::IoOut`. The average for these VM exits is not emitted since
+  it can be deduced from the available emitted metrics.
+
 ## [v1.6.0]
 
 ### Added

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -130,3 +130,20 @@ that component i.e. even if `vsock` device is not attached to the
 Microvm, Firecracker will still emit the Vsock metrics with key as
 `vsock` and value of all metrics defined in `VsockDeviceMetrics` as
 `0`.
+
+### Units for Firecracker metrics:
+
+Units for Firecracker metrics are embedded in their name.<br/>
+Below pseudo code should be to extract units from Firecracker metrics name:<br/>
+Note: An example of full_key for below logic is `"vcpu.exit_io_in_agg.min_us"`
+
+```
+    if substring "_bytes" or "_bytes_count" is present in any subkey of full_key
+        Unit is "Bytes"
+    else substring "_ms" is present in any subkey of full_key
+        Unit is "Milliseconds"
+    else substring "_us" is present in any subkey of full_key
+        Unit is "Microseconds"
+    else
+        Unit is "Count"
+```

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -450,6 +450,7 @@ impl Vcpu {
             Ok(run) => match run {
                 VcpuExit::MmioRead(addr, data) => {
                     if let Some(mmio_bus) = &self.kvm_vcpu.mmio_bus {
+                        let _metric = METRICS.vcpu.exit_mmio_read_agg.record_latency_metrics();
                         mmio_bus.read(addr, data);
                         METRICS.vcpu.exit_mmio_read.inc();
                     }
@@ -457,6 +458,7 @@ impl Vcpu {
                 }
                 VcpuExit::MmioWrite(addr, data) => {
                     if let Some(mmio_bus) = &self.kvm_vcpu.mmio_bus {
+                        let _metric = METRICS.vcpu.exit_mmio_write_agg.record_latency_metrics();
                         mmio_bus.write(addr, data);
                         METRICS.vcpu.exit_mmio_write.inc();
                     }

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -515,6 +515,7 @@ impl KvmVcpu {
         match exit {
             VcpuExit::IoIn(addr, data) => {
                 if let Some(pio_bus) = &self.pio_bus {
+                    let _metric = METRICS.vcpu.exit_io_in_agg.record_latency_metrics();
                     pio_bus.read(u64::from(addr), data);
                     METRICS.vcpu.exit_io_in.inc();
                 }
@@ -522,6 +523,7 @@ impl KvmVcpu {
             }
             VcpuExit::IoOut(addr, data) => {
                 if let Some(pio_bus) = &self.pio_bus {
+                    let _metric = METRICS.vcpu.exit_io_out_agg.record_latency_metrics();
                     pio_bus.write(u64::from(addr), data);
                     METRICS.vcpu.exit_io_out.inc();
                 }

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -96,10 +96,10 @@ def test_network_latency(network_microvm, metrics, iteration):
         assert rc == 0, stderr
 
         samples.extend(consume_ping_output(ping_output))
+    fcmetrics.stop()
 
     for sample in samples:
         metrics.put_metric("ping_latency", sample, "Milliseconds")
-    fcmetrics.stop()
 
 
 class TcpIPerf3Test(IPerf3Test):

--- a/tests/integration_tests/performance/test_vsock_ab.py
+++ b/tests/integration_tests/performance/test_vsock_ab.py
@@ -110,5 +110,5 @@ def test_vsock_throughput(
     test = VsockIPerf3Test(vm, mode, payload_length)
     data = test.run_test(vm.vcpus_count + 2)
 
-    emit_iperf3_metrics(metrics, data, VsockIPerf3Test.WARMUP_SEC)
     fcmetrics.stop()
+    emit_iperf3_metrics(metrics, data, VsockIPerf3Test.WARMUP_SEC)


### PR DESCRIPTION
## Changes

- Add a new struct to record aggregate (min/max/sum) of time
    difference as a metric.
    Use the Aggregate metrics structure to record aggregate of
    IO and MMIO vm exits.
- Firecracker till now had a "group_metrics:key_metrics:value" pair and
    with new metrics for kvm exits this relation changes to "group_metrics:
    key_metrics:sub_key_metrics:value".
    Update the flush_fc_metrics_to_cw() to be able to parse this and make
    it future proof to support further sub_key_metrics levels.

## Reason

- latency of kvm exits will improve observability.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~- [ ] If a specific issue led to this PR, this PR closes the issue.~

- [x] The description of changes is clear and encompassing.

~- [ ] Any required documentation changes (code and docs) are included in this PR.~

~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~
~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~

- [x] All added/changed functionality is tested.

~- [ ] New `TODO`s link to an issue.~

- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
