### PR TITLE
Tiny refactors for vcpu-related code

### DIFF
--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -277,19 +277,6 @@ pub enum StartVcpusError {
     VcpuHandle(#[from] StartThreadedError),
 }
 
-/// Error type for [`Vmm::restore_vcpu_states`]
-#[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub enum RestoreVcpusError {
-    /// Failed to send event: {0}
-    SendEvent(#[from] VcpuSendEventError),
-    /// Unexpected vCPU response.
-    UnexpectedVcpuResponse,
-    /// Failed to restore vCPU state: {0}
-    RestoreVcpuState(#[from] vcpu::VcpuError),
-    /// Not allowed: {0}
-    NotAllowed(String),
-}
-
 /// Error type for [`Vmm::dump_cpu_config()`]
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum DumpCpuConfigError {

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -399,9 +399,9 @@ impl Vcpu {
     // Transition to the exited state and finish on command.
     fn exit(&mut self, exit_code: FcExitCode) -> StateMachine<Self> {
         // To avoid cycles, all teardown paths take the following route:
-        // +------------------------+----------------------------+------------------------+
-        // |        Vmm             |           Action           |           Vcpu         |
-        // +------------------------+----------------------------+------------------------+
+        //   +------------------------+----------------------------+------------------------+
+        //   |        Vmm             |           Action           |           Vcpu         |
+        //   +------------------------+----------------------------+------------------------+
         // 1 |                        |                            | vcpu.exit(exit_code)   |
         // 2 |                        |                            | vcpu.exit_evt.write(1) |
         // 3 |                        | <--- EventFd::exit_evt --- |                        |
@@ -410,7 +410,7 @@ impl Vcpu {
         // 6 |                        |                            | StateMachine::finish() |
         // 7 | VcpuHandle::join()     |                            |                        |
         // 8 | vmm.shutdown_exit_code becomes Some(exit_code) breaking the main event loop  |
-        // +------------------------+----------------------------+------------------------+
+        //   +------------------------+----------------------------+------------------------+
         // Vcpu initiated teardown starts from `fn Vcpu::exit()` (step 1).
         // Vmm initiated teardown starts from `pub fn Vmm::stop()` (step 4).
         // Once `vmm.shutdown_exit_code` becomes `Some(exit_code)`, it is the upper layer's

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -294,7 +294,7 @@ impl Vcpu {
                 // Nothing special to do.
                 self.response_sender
                     .send(VcpuResponse::Paused)
-                    .expect("failed to send pause status");
+                    .expect("vcpu channel unexpectedly closed");
 
                 // TODO: we should call `KVM_KVMCLOCK_CTRL` here to make sure
                 // TODO continued: the guest soft lockup watchdog does not panic on Resume.
@@ -305,7 +305,7 @@ impl Vcpu {
             Ok(VcpuEvent::Resume) => {
                 self.response_sender
                     .send(VcpuResponse::Resumed)
-                    .expect("failed to send resume status");
+                    .expect("vcpu channel unexpectedly closed");
             }
             // SaveState cannot be performed on a running Vcpu.
             Ok(VcpuEvent::SaveState) => {
@@ -313,7 +313,7 @@ impl Vcpu {
                     .send(VcpuResponse::NotAllowed(String::from(
                         "save/restore unavailable while running",
                     )))
-                    .expect("failed to send save not allowed status");
+                    .expect("vcpu channel unexpectedly closed");
             }
             // DumpCpuConfig cannot be performed on a running Vcpu.
             Ok(VcpuEvent::DumpCpuConfig) => {
@@ -321,7 +321,7 @@ impl Vcpu {
                     .send(VcpuResponse::NotAllowed(String::from(
                         "cpu config dump is unavailable while running",
                     )))
-                    .expect("failed to send save not allowed status");
+                    .expect("vcpu channel unexpectedly closed");
             }
             Ok(VcpuEvent::Finish) => return StateMachine::finish(),
             // Unhandled exit of the other end.
@@ -382,7 +382,7 @@ impl Vcpu {
                     .unwrap_or_else(|err| {
                         self.response_sender
                             .send(VcpuResponse::Error(VcpuError::VcpuResponse(err)))
-                            .expect("vcpu channel unnexpectedly closed");
+                            .expect("vcpu channel unexpectedly closed");
                     });
 
                 StateMachine::next(Self::paused)


### PR DESCRIPTION
## Changes / Reason

**Remove `RestoreVcpusError`**

Commit 8eb46c9a59e6 ("refactor(vmm): vcpu.init and vcpu.restore updates") removed `VcpuEvent::RestoreState`, `VcpuResponse::RestoreState` and `restore_vcpu_states()`. As `RestoreVcpusError` is an error type for `restore_vcpu_states()`, it is no longer needed. 


**Unify panic messages on failure to send a response from vcpu thread**

All the other `Vcpu`'s methods than `running()` uses "vcpu channel unexpectedly closed" message when it fails to send a response from the vcpu thread.

**Fix a broken table in comment**

The table in `exit()` comment explaining the interaction between vmm and vcpu threads was broken.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
