### PR TITLE
doc: fix network setup in getting started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -165,14 +165,16 @@ sudo ip link set dev "$TAP_DEV" up
 # Enable ip forwarding
 sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
 
+HOST_IFACE="eth0"
+
 # Set up microVM internet access
-sudo iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE || true
+sudo iptables -t nat -D POSTROUTING -o "$HOST_IFACE" -j MASQUERADE || true
 sudo iptables -D FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT \
     || true
-sudo iptables -D FORWARD -i tap0 -o eth0 -j ACCEPT || true
-sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+sudo iptables -D FORWARD -i tap0 -o "$HOST_IFACE" -j ACCEPT || true
+sudo iptables -t nat -A POSTROUTING -o "$HOST_IFACE" -j MASQUERADE
 sudo iptables -I FORWARD 1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-sudo iptables -I FORWARD 1 -i tap0 -o eth0 -j ACCEPT
+sudo iptables -I FORWARD 1 -i tap0 -o "$HOST_IFACE" -j ACCEPT
 
 API_SOCKET="/tmp/firecracker.socket"
 LOGFILE="./firecracker.log"
@@ -279,6 +281,9 @@ names of their fields are the same that are used in the API requests.
 
 An example of configuration file is provided:
 [`tests/framework/vm_config.json`](../tests/framework/vm_config.json).
+
+Once the guest is booted, refer [network-setup](./network-setup.md#in-the-guest)
+to bring up the network in the guest machine.
 
 After the microVM is started you can still use the socket to send API requests
 for post-boot operations.


### PR DESCRIPTION
## Changes
- fix network setup for guest in getting started guide
- make host interface configurable in doc

## Reason
- While following the getting started guide, new users might get confused with the host interface to use and might default to `eth0` as mentioned. Giving this as an env, makes users aware that we have to use the host interface that is connected to internet for getting internet access inside the VM.
- Refer to the network-setup guide from getting started, so that the next step to configure network in the guests are available.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
