### PR TITLE
build: Lints in `.toml` files

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,16 +2,6 @@
 target-dir = "build/cargo_target"
 rustflags = [
   "-Ccodegen-units=1",
-  "-Wclippy::ptr_as_ptr",
-  "-Wclippy::undocumented_unsafe_blocks",
-  "-Wclippy::cast_lossless",
-  "-Wclippy::cast_possible_truncation",
-  "-Wclippy::cast_possible_wrap",
-  "-Wclippy::cast_sign_loss",
-  "-Wmissing_debug_implementations",
-  "-Wclippy::exit",
-  "-Wclippy::tests_outside_test_module",
-  "-Wclippy::assertions_on_result_states"
 ]
 
 [net]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,20 @@ members = ["src/clippy-tracing", "src/cpu-template-helper", "src/firecracker", "
 default-members = ["src/clippy-tracing", "src/cpu-template-helper", "src/firecracker", "src/rebase-snap", "src/seccompiler", "src/snapshot-editor"]
 resolver = "2"
 
+[workspace.lints.rust]
+missing_debug_implementations = "warn"
+
+[workspace.lints.clippy]
+ptr_as_ptr = "warn"
+undocumented_unsafe_blocks = "warn"
+cast_lossless = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_sign_loss = "warn"
+exit = "warn"
+tests_outside_test_module = "warn"
+assertions_on_result_states = "warn"
+
 [profile.dev]
 panic = "abort"
 

--- a/src/clippy-tracing/Cargo.toml
+++ b/src/clippy-tracing/Cargo.toml
@@ -19,3 +19,6 @@ walkdir = "2.3.3"
 
 [dev-dependencies]
 uuid = { version = "1.6.1", features = ["v4"] }
+
+[lints]
+workspace = true

--- a/src/cpu-template-helper/Cargo.toml
+++ b/src/cpu-template-helper/Cargo.toml
@@ -26,3 +26,6 @@ utils = { path = "../utils" }
 
 [features]
 tracing = ["log-instrument", "vmm/tracing"]
+
+[lints]
+workspace = true

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -49,6 +49,9 @@ serde_json = "1.0.113"
 [features]
 tracing = ["log-instrument", "seccompiler/tracing", "utils/tracing", "vmm/tracing"]
 
+[lints]
+workspace = true
+
 [[example]]
 name = "uffd_malicious_handler"
 path = "examples/uffd/malicious_handler.rs"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -22,3 +22,6 @@ utils = { path = "../utils" }
 
 [features]
 tracing = ["log-instrument", "utils/tracing"]
+
+[lints]
+workspace = true

--- a/src/log-instrument-macros/Cargo.toml
+++ b/src/log-instrument-macros/Cargo.toml
@@ -14,3 +14,6 @@ bench = false
 proc-macro2 = "1.0.73"
 quote = "1.0.34"
 syn = { version = "2.0.49", features = ["full", "extra-traits"] }
+
+[lints]
+workspace = true

--- a/src/log-instrument/Cargo.toml
+++ b/src/log-instrument/Cargo.toml
@@ -33,3 +33,6 @@ log-instrument-macros = { path = "../log-instrument-macros" }
 
 [dev-dependencies]
 env_logger = "0.11.2"
+
+[lints]
+workspace = true

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -19,3 +19,6 @@ utils = { path = "../utils" }
 
 [features]
 tracing = ["log-instrument", "utils/tracing"]
+
+[lints]
+workspace = true

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -28,3 +28,6 @@ utils = { path = "../utils" }
 
 [features]
 tracing = ["log-instrument", "utils/tracing"]
+
+[lints]
+workspace = true

--- a/src/snapshot-editor/Cargo.toml
+++ b/src/snapshot-editor/Cargo.toml
@@ -25,3 +25,6 @@ clap-num = "1.0.2"
 
 [features]
 tracing = ["log-instrument", "fc_utils/tracing", "vmm/tracing"]
+
+[lints]
+workspace = true

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "1.0.99"
 
 [features]
 tracing = ["log-instrument"]
+
+[lints]
+workspace = true

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -58,3 +58,6 @@ tracing = ["log-instrument"]
 [[bench]]
 name = "cpu_templates"
 harness = false
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Changes

Moves lint configuration from `.cargo/config` to `Cargo.toml`.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
