### PR TITLE
Rustdoc fixes

### DIFF
--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -321,7 +321,7 @@ fn clean_env_vars() {
     }
 }
 
-/// Turns an AsRef<Path> into a CString (c style string).
+/// Turns an [`AsRef<Path>`] into a [`CString`] (c style string).
 /// The expect should not fail, since Linux paths only contain valid Unicode chars (do they?),
 /// and do not contain null bytes (do they?).
 pub fn to_cstring<T: AsRef<Path> + Debug>(path: T) -> Result<CString, JailerError> {

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -42,7 +42,7 @@ pub enum GetCpuTemplateError {
     InvalidCpuModel,
 }
 
-/// Trait to unwrap the inner `CustomCpuTemplate` from Option<CpuTemplateType>.
+/// Trait to unwrap the inner [`CustomCpuTemplate`] from [`Option<CpuTemplateType>`].
 ///
 /// This trait is needed because static CPU template and custom CPU template have different nested
 /// structures: `CpuTemplateType::Static(StaticCpuTemplate::StaticTemplateType(CustomCpuTemplate))`

--- a/src/vmm/src/cpu_config/x86_64/cpuid/amd/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/amd/normalize.rs
@@ -10,7 +10,7 @@ use crate::cpu_config::x86_64::cpuid::{
     MissingBrandStringLeaves, BRAND_STRING_LENGTH, VENDOR_ID_AMD,
 };
 
-/// Error type for [`AmdCpuid::normalize`].
+/// Error type for [`super::AmdCpuid::normalize`].
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
 pub enum NormalizeCpuidError {
@@ -34,7 +34,7 @@ pub enum NormalizeCpuidError {
     BrandString(MissingBrandStringLeaves),
 }
 
-/// Error type for setting cache topology section of [`AmdCpuid::normalize`].
+/// Error type for setting cache topology section of [`super::AmdCpuid::normalize`].
 #[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
 pub enum PassthroughCacheTopologyError {
     /// Failed to get the host vendor id: {0}
@@ -43,7 +43,7 @@ pub enum PassthroughCacheTopologyError {
     BadVendorId,
 }
 
-/// Error type for setting leaf 0x80000008 section of [`AmdCpuid::normalize`].
+/// Error type for setting leaf 0x80000008 section of [`super::AmdCpuid::normalize`].
 #[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
 pub enum FeatureEntryError {
     /// Missing leaf 0x80000008.
@@ -54,7 +54,7 @@ pub enum FeatureEntryError {
     NumberOfPhysicalThreads(CheckedAssignError),
 }
 
-/// Error type for setting leaf 0x8000001d section of [`AmdCpuid::normalize`].
+/// Error type for setting leaf 0x8000001d section of [`super::AmdCpuid::normalize`].
 #[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
 pub enum ExtendedCacheTopologyError {
     /// Missing leaf 0x8000001d.
@@ -65,7 +65,7 @@ pub enum ExtendedCacheTopologyError {
     NumSharingCache(CheckedAssignError),
 }
 
-/// Error type for setting leaf 0x8000001e section of [`AmdCpuid::normalize`].
+/// Error type for setting leaf 0x8000001e section of [`super::AmdCpuid::normalize`].
 #[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
 pub enum ExtendedApicIdError {
     /// Missing leaf 0x8000001e.

--- a/src/vmm/src/cpu_config/x86_64/cpuid/intel/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/intel/normalize.rs
@@ -9,7 +9,7 @@ use crate::cpu_config::x86_64::cpuid::{
     BRAND_STRING_LENGTH,
 };
 
-/// Error type for [`IntelCpuid::normalize`].
+/// Error type for [`super::IntelCpuid::normalize`].
 #[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
 pub enum NormalizeCpuidError {
     /// Failed to set deterministic cache leaf: {0}
@@ -26,7 +26,7 @@ pub enum NormalizeCpuidError {
     ApplyBrandString(MissingBrandStringLeaves),
 }
 
-/// Error type for setting leaf 4 section of `IntelCpuid::normalize`.
+/// Error type for setting leaf 4 section of [`super::IntelCpuid::normalize`].
 // `displaydoc::Display` does not support multi-line comments, `rustfmt` will format these comments
 // across multiple lines, so we skip formatting here. This can be removed when
 // https://github.com/yaahc/displaydoc/issues/44 is resolved.
@@ -227,7 +227,7 @@ impl super::IntelCpuid {
     }
 }
 
-/// Error type for [`IntelCpuid::default_brand_string`].
+/// Error type for [`default_brand_string`].
 #[derive(Debug, Eq, PartialEq, thiserror::Error, displaydoc::Display)]
 pub enum DefaultBrandStringError {
     /// Missing frequency: {0:?}.

--- a/src/vmm/src/cpu_config/x86_64/cpuid/mod.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/mod.rs
@@ -286,17 +286,10 @@ impl CpuidTrait for kvm_bindings::CpuId {
     }
 }
 
-/// Error type for [`apply_brand_string`].
+/// Error type for [`CpuidTrait::apply_brand_string`].
 #[derive(Debug, thiserror::Error, Eq, PartialEq)]
 #[error("Missing brand string leaves 0x80000002, 0x80000003 and 0x80000004.")]
 pub struct MissingBrandStringLeaves;
-
-/// Error type for [`Cpuid::kvm_get_supported_cpuid`].
-#[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
-pub enum KvmGetSupportedCpuidError {
-    /// Could not access KVM: {0}
-    KvmAccess(#[from] utils::errno::Error),
-}
 
 /// Error type for conversion from `kvm_bindings::CpuId` to `Cpuid`.
 #[rustfmt::skip]
@@ -560,8 +553,8 @@ pub struct CpuidEntry {
 }
 
 /// To transmute this into leaves such that we can return mutable reference to it with leaf specific
-/// accessors, requires this to have a consistent member ordering. [`core::arch::x86::CpuidResult`]
-/// is not `repr(C)`.
+/// accessors, requires this to have a consistent member ordering.
+/// [`core::arch::x86_64::CpuidResult`] is not `repr(C)`.
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[repr(C)]
 pub struct CpuidRegisters {

--- a/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
@@ -5,7 +5,7 @@ use crate::cpu_config::x86_64::cpuid::{
     cpuid, CpuidEntry, CpuidKey, CpuidRegisters, CpuidTrait, KvmCpuidFlags,
 };
 
-/// Error type for [`Cpuid::normalize`].
+/// Error type for [`super::Cpuid::normalize`].
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
 pub enum NormalizeCpuidError {
@@ -165,8 +165,8 @@ impl super::Cpuid {
     /// # Errors
     ///
     /// When:
-    /// - [`IntelCpuid::normalize`] errors.
-    /// - [`AmdCpuid::normalize`] errors.
+    /// - [`super::IntelCpuid::normalize`] errors.
+    /// - [`super::AmdCpuid::normalize`] errors.
     // As we pass through host frequency, we require CPUID and thus `cfg(cpuid)`.
     #[inline]
     pub fn normalize(

--- a/src/vmm/src/cpu_config/x86_64/static_cpu_templates/c3.rs
+++ b/src/vmm/src/cpu_config/x86_64/static_cpu_templates/c3.rs
@@ -57,7 +57,7 @@ use crate::cpu_config::x86_64::custom_cpu_template::{
 /// =====
 ///
 /// References:
-/// - Intel SDM: https://cdrdv2.intel.com/v1/dl/getContent/671200
+/// - Intel SDM: <https://cdrdv2.intel.com/v1/dl/getContent/671200>
 #[allow(clippy::unusual_byte_groupings)]
 pub fn c3() -> CustomCpuTemplate {
     CustomCpuTemplate {

--- a/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2.rs
+++ b/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2.rs
@@ -57,7 +57,7 @@ use crate::cpu_config::x86_64::custom_cpu_template::{
 /// =====
 ///
 /// References:
-/// - Intel SDM: https://cdrdv2.intel.com/v1/dl/getContent/671200
+/// - Intel SDM: <https://cdrdv2.intel.com/v1/dl/getContent/671200>
 #[allow(clippy::unusual_byte_groupings)]
 pub fn t2() -> CustomCpuTemplate {
     CustomCpuTemplate {

--- a/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2a.rs
+++ b/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2a.rs
@@ -12,9 +12,9 @@ use crate::cpu_config::x86_64::custom_cpu_template::{
 /// Provide instruction set feature partity with Intel Cascade Lake or later using T2CL template.
 ///
 /// References:
-/// - Intel SDM: https://cdrdv2.intel.com/v1/dl/getContent/671200
-/// - AMD APM: https://www.amd.com/system/files/TechDocs/40332.pdf
-/// - CPUID Enumeration and Architectural MSRs: https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/technical-documentation/cpuid-enumeration-and-architectural-msrs.html
+/// - Intel SDM: <https://cdrdv2.intel.com/v1/dl/getContent/671200>
+/// - AMD APM: <https://www.amd.com/system/files/TechDocs/40332.pdf>
+/// - CPUID Enumeration and Architectural MSRs: <https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/technical-documentation/cpuid-enumeration-and-architectural-msrs.html>
 #[allow(clippy::unusual_byte_groupings)]
 pub fn t2a() -> CustomCpuTemplate {
     CustomCpuTemplate {

--- a/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2cl.rs
+++ b/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2cl.rs
@@ -13,9 +13,9 @@ use crate::cpu_config::x86_64::custom_cpu_template::{
 /// instruction set feature partity with AMD Milan using T2A template.
 ///
 /// References:
-/// - Intel SDM: https://cdrdv2.intel.com/v1/dl/getContent/671200
-/// - AMD APM: https://www.amd.com/system/files/TechDocs/40332.pdf
-/// - CPUID Enumeration and Architectural MSRs: https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/technical-documentation/cpuid-enumeration-and-architectural-msrs.html
+/// - Intel SDM: <https://cdrdv2.intel.com/v1/dl/getContent/671200>
+/// - AMD APM: <https://www.amd.com/system/files/TechDocs/40332.pdf>
+/// - CPUID Enumeration and Architectural MSRs: <https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/technical-documentation/cpuid-enumeration-and-architectural-msrs.html>
 #[allow(clippy::unusual_byte_groupings)]
 pub fn t2cl() -> CustomCpuTemplate {
     CustomCpuTemplate {

--- a/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2s.rs
+++ b/src/vmm/src/cpu_config/x86_64/static_cpu_templates/t2s.rs
@@ -13,8 +13,8 @@ use crate::cpu_config::x86_64::custom_cpu_template::{
 /// migrating snapshots between hosts with Intel Skylake and Cascade Lake securely.
 ///
 /// Reference:
-/// - Intel SDM: https://cdrdv2.intel.com/v1/dl/getContent/671200
-/// - CPUID Enumeration and Architectural MSRs: https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/technical-documentation/cpuid-enumeration-and-architectural-msrs.html
+/// - Intel SDM: <https://cdrdv2.intel.com/v1/dl/getContent/671200>
+/// - CPUID Enumeration and Architectural MSRs: <https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/technical-documentation/cpuid-enumeration-and-architectural-msrs.html>
 #[allow(clippy::unusual_byte_groupings)]
 pub fn t2s() -> CustomCpuTemplate {
     CustomCpuTemplate {

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -225,8 +225,8 @@ pub struct DeviceStates {
     pub entropy_device: Option<ConnectedEntropyState>,
 }
 
-/// A type used to extract the concrete Arc<Mutex<T>> for each of the device types when restoring
-/// from a snapshot.
+/// A type used to extract the concrete `Arc<Mutex<T>>` for each of the device
+/// types when restoring from a snapshot.
 #[derive(Debug)]
 pub enum SharedDeviceType {
     VirtioBlock(Arc<Mutex<VirtioBlock>>),

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -98,8 +98,9 @@ use crate::logger::IncMetric;
 
 /// Trait that vsock connection backends need to implement.
 ///
-/// Used as an alias for `Read + ReadVolatile + Write + WriteVolatile + AsRawFd` (sadly, trait
-/// aliases are not supported, https://github.com/rust-lang/rfcs/pull/1733#issuecomment-243840014).
+/// Used as an alias for `ReadVolatile + Write + WriteVolatile + AsRawFd`
+/// (sadly, trait aliases are not supported,
+/// <https://github.com/rust-lang/rfcs/pull/1733#issuecomment-243840014>).
 pub trait VsockConnectionBackend: ReadVolatile + Write + WriteVolatile + AsRawFd {}
 
 /// A self-managing connection object, that handles communication between a guest-side AF_VSOCK

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -74,7 +74,7 @@ enum EpollListener {
     Connection { key: ConnMapKey, evset: EventSet },
     /// A listener interested in new host-initiated connections.
     HostSock,
-    /// A listener interested in reading host "connect <port>" commands from a freshly
+    /// A listener interested in reading host `connect <port>` commands from a freshly
     /// connected host socket.
     LocalStream(UnixStream),
 }
@@ -98,7 +98,7 @@ pub struct VsockMuxer {
     /// The Unix socket, through which host-initiated connections are accepted.
     host_sock: UnixListener,
     /// The file system path of the host-side Unix socket. This is used to figure out the path
-    /// to Unix sockets listening on specific ports. I.e. "<this path>_<port number>".
+    /// to Unix sockets listening on specific ports. I.e. `"<this path>_<port number>"`.
     pub(crate) host_sock_path: String,
     /// The nested epoll event set, used to register epoll listeners.
     epoll: Epoll,

--- a/src/vmm/src/dumbo/pdu/bytes.rs
+++ b/src/vmm/src/dumbo/pdu/bytes.rs
@@ -113,8 +113,8 @@ pub trait NetworkBytesMut: NetworkBytes + DerefMut<Target = [u8]> {
     ///
     /// # Panics
     ///
-    /// If `value` cannot be written into `self` at the given `offset` (e.g. if `offset > self.len()
-    /// - size_of::<u16>()`).
+    /// If `value` cannot be written into `self` at the given `offset`
+    /// (e.g. if `offset > self.len() - size_of::<u16>()`).
     #[inline]
     fn htons_unchecked(&mut self, offset: usize, value: u16) {
         assert!(offset <= self.len() - std::mem::size_of::<u16>());
@@ -125,8 +125,8 @@ pub trait NetworkBytesMut: NetworkBytes + DerefMut<Target = [u8]> {
     ///
     /// # Panics
     ///
-    /// If `value` cannot be written into `self` at the given `offset` (e.g. if `offset > self.len()
-    /// - size_of::<u32>()`).
+    /// If `value` cannot be written into `self` at the given `offset`
+    /// (e.g. if `offset > self.len() - size_of::<u32>()`).
     #[inline]
     fn htonl_unchecked(&mut self, offset: usize, value: u32) {
         assert!(offset <= self.len() - std::mem::size_of::<u32>());

--- a/src/vmm/src/dumbo/tcp/connection.rs
+++ b/src/vmm/src/dumbo/tcp/connection.rs
@@ -155,7 +155,7 @@ pub enum WriteNextError {
 /// user to supply an opaque `u64` timestamp value when invoking send or receive functionality. The
 /// timestamps must be non-decreasing, and are mainly used for retransmission timeouts.
 ///
-/// See https://github.com/firecracker-microvm/firecracker/blob/main/docs/mmds/mmds-design.md#dumbo
+/// See [mmds-design](https://github.com/firecracker-microvm/firecracker/blob/main/docs/mmds/mmds-design.md#dumbo)
 /// for why we are able to make these simplifications. Specifically, we want to stress that no
 /// traffic handled by dumbo ever leaves a microVM.
 ///

--- a/src/vmm/src/io_uring/operation/cqe.rs
+++ b/src/vmm/src/io_uring/operation/cqe.rs
@@ -17,12 +17,13 @@ pub struct Cqe<T> {
 }
 
 impl<T: Debug> Cqe<T> {
-    /// Construct a Cqe object from a raw `io_uring_cqe`.
+    /// Construct a [`Cqe`] object from a raw `io_uring_cqe`.
     ///
     /// # Safety
     /// Unsafe because we assume full ownership of the inner.user_data address.
-    /// We assume that it points to a valid address created with a Box<T>, with the correct type T,
-    /// and that ownership of that address is passed to this function.
+    /// We assume that it points to a valid address created with a `Box<T>`,
+    /// with the correct type `T`, and that ownership of that address is passed
+    /// to this function.
     pub(crate) unsafe fn new(inner: io_uring_cqe) -> Self {
         Self {
             res: inner.res,

--- a/src/vmm/src/io_uring/operation/sqe.rs
+++ b/src/vmm/src/io_uring/operation/sqe.rs
@@ -27,8 +27,8 @@ impl Sqe {
     /// Consume the sqe and return the `user_data`.
     ///
     /// # Safety
-    /// Safe only if you guarantee that this is a valid pointer to some memory where there is a
-    /// value of type T created from a Box<T>.
+    /// Safe only if you guarantee that this is a valid pointer to some memory
+    /// where there is a value of type `T` created from a [`Box<T>`].
     pub(crate) unsafe fn user_data<T: Debug>(self) -> T {
         *Box::from_raw(self.0.user_data as *mut T)
     }

--- a/src/vmm/src/logger/logging.rs
+++ b/src/vmm/src/logger/logging.rs
@@ -202,17 +202,17 @@ pub struct LoggerConfig {
 /// its default deserialization).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum LevelFilter {
-    /// [`log::LevelFilter:Off`]
+    /// [`log::LevelFilter::Off`]
     Off,
-    /// [`log::LevelFilter:Trace`]
+    /// [`log::LevelFilter::Trace`]
     Trace,
-    /// [`log::LevelFilter:Debug`]
+    /// [`log::LevelFilter::Debug`]
     Debug,
-    /// [`log::LevelFilter:Info`]
+    /// [`log::LevelFilter::Info`]
     Info,
-    /// [`log::LevelFilter:Warn`]
+    /// [`log::LevelFilter::Warn`]
     Warn,
-    /// [`log::LevelFilter:Error`]
+    /// [`log::LevelFilter::Error`]
     Error,
 }
 impl From<LevelFilter> for log::LevelFilter {

--- a/src/vmm/src/mmds/data_store.rs
+++ b/src/vmm/src/mmds/data_store.rs
@@ -186,7 +186,7 @@ impl Mmds {
     /// Currently, only JSON objects and strings can be IMDS formatted.
     ///
     /// See the docs for detailed description of the IMDS format:
-    /// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+    /// <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html>
     ///
     /// # Examples
     ///

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -153,7 +153,8 @@ impl From<&RateLimiter> for RateLimiterConfig {
 }
 
 impl RateLimiterConfig {
-    /// Option<T> already implements From<T> so we have to use a custom one.
+    /// [`Option<T>`] already implements [`From<T>`] so we have to use a custom
+    /// one.
     pub fn into_option(self) -> Option<RateLimiterConfig> {
         if self.bandwidth.is_some() || self.ops.is_some() {
             Some(self)

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -293,7 +293,7 @@ impl KvmVcpu {
     ///
     /// KVM only supports getting `KVM_MAX_MSR_ENTRIES` at a time, so we divide
     /// the list of MSR indices into chunks, call `KVM_GET_MSRS` for each
-    /// chunk, and collect into a Vec<Msrs>.
+    /// chunk, and collect into a [`Vec<Msrs>`].
     ///
     /// # Arguments
     ///

--- a/tools/devtool
+++ b/tools/devtool
@@ -833,26 +833,7 @@ cmd_test_debug() {
 # Example: `devtool fmt`
 #
 cmd_fmt() {
-
-    # Parse any command line args.
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            "-h"|"--help")      { cmd_help; exit 1; } ;;
-            *)
-                die "Unknown argument: $1. Please use --help for help."
-            ;;
-        esac
-        shift
-    done
-
-    ensure_devctr
-
-    say "Applying rustfmt ..."
-    run_devctr \
-        --user "$(id -u):$(id -g)" \
-        --workdir "$CTR_FC_ROOT_DIR" \
-        -- \
-        cargo fmt --all
+    cmd_sh "cargo fmt --all -- --config $(tr '\n' ',' <tests/fmt.toml)"
 }
 
 cmd_mkdocs() {

--- a/tools/devtool
+++ b/tools/devtool
@@ -417,6 +417,9 @@ cmd_help() {
 
     test_sandbox
         Run Firecracker in an IPython REPL
+
+    mkdocs
+        Use 'cargo doc' to generate rustdoc documentation
 EOF
 }
 
@@ -852,6 +855,9 @@ cmd_fmt() {
         cargo fmt --all
 }
 
+cmd_mkdocs() {
+    cmd_sh "cargo doc --workspace --no-deps --document-private-items"
+}
 
 # Check if able to run firecracker.
 # ../docs/getting-started.md#prerequisites


### PR DESCRIPTION
## Changes

Change some Rustdoc comments so that they render correctly 

## Reason

Just to make them more usable when looking at the documentation locally.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
