### PR TITLE
Fix test `test_shut_down::test_reboot` failure in Ubuntu tests with 6.2 kernel

### DIFF
--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -6,6 +6,8 @@ import os
 import platform
 import time
 
+from packaging import version
+
 from framework import utils
 
 
@@ -58,7 +60,7 @@ def test_reboot(test_microvm_with_api):
     if platform.machine() != "x86_64":
         message = (
             "Received KVM_SYSTEM_EVENT: type: 2, event: [0]"
-            if "6.1" in platform.release()
+            if version.parse(utils.get_kernel_version()) >= version.parse("5.18")
             else "Received KVM_SYSTEM_EVENT: type: 2, event: []"
         )
         vm.check_log_message(message)


### PR DESCRIPTION
## Reason

PR #4353 upgraded versions of various rust-vmm crates that got patched for a security vulnerability found in vmm-sys-util (not affecting Firecracker). This included a new version of kvm-bindings which includes bindings from a newer kernel. In this, `struct system_event`, which is the type that KVM passes over to us during a KVM_EXIT_SYSTEM_EVENT exit, changed from being a `u64` to being a `&[u64]`. The change itself, landed in kernel 5.18.

This changed, altered Firecracker logging during shutdown (in some cases), so #4353 PR made the necessary changes to fix the tests that relied on the log entry. The fix boils down to "if we are on 6.1 check for the new type of message". That caused our testing on latest Ubuntu to fail, because now it uses a 6.2 kernel.

## Changes

Fix the test by correctly checking if we are running on a kernel >= 5.18 (the kernel version that introduced the change in the KVM type).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
