### PR TITLE
chore(docs): deprecate --start-time-cpu-us parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project adheres to
   handler. Each memory region object now contains a `page_size_kib` field. See
   also the [hugepages documentation](docs/hugepages.md).
 
+### Deprecated
+
+- Firecracker's `--start-time-cpu-us` parameter is deprecated and will be
+  removed in v2.0 or later. It is used by the jailer to pass the value that
+  should be subtracted from the CPU time, but in practice it is always 0. The
+  parameter was never meant to be used by end customers, and we recommend doing
+  any such time adjustments outside Firecracker.
+
 ### Fixed
 
 - [#4409](https://github.com/firecracker-microvm/firecracker/pull/4409): Fixed a

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -144,10 +144,9 @@ After starting, the Jailer goes through the following operations:
   inside `<exec_file_name>.pid`, while the child drops privileges and `exec()`s
   into the `<exec_file_name>`, as described below.
 - Drop privileges via setting the provided `uid` and `gid`.
-- Exec into
-  `<exec_file_name> --id=<id> --start-time-us=<opaque> --start-time-cpu-us=<opaque>`
-  (and also forward any extra arguments provided to the jailer after `--`, as
-  mentioned in the **Jailer Usage** section), where:
+- Exec into `<exec_file_name> --id=<id> --start-time-us=<opaque>` (and also
+  forward any extra arguments provided to the jailer after `--`, as mentioned in
+  the **Jailer Usage** section), where:
   - `id`: (`string`) - The `id` argument provided to jailer.
   - `opaque`: (`number`) time calculated by the jailer that it spent doing its
     work.
@@ -243,8 +242,7 @@ Finally, the jailer switches the `uid` to `123`, and `gid` to `100`, and execs
 ```console
 ./firecracker \
   --id="551e7604-e35c-42b3-b825-416853441234" \
-  --start-time-us=<opaque> \
-  --start-time-cpu-us=<opaque>
+  --start-time-us=<opaque>
 ```
 
 Now firecracker creates the socket at

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -22,7 +22,7 @@ use utils::terminal::Terminal;
 use utils::validators::validate_instance_id;
 use vmm::builder::StartMicrovmError;
 use vmm::logger::{
-    debug, error, info, LoggerConfig, ProcessTimeReporter, StoreMetric, LOGGER, METRICS,
+    debug, error, info, warn, LoggerConfig, ProcessTimeReporter, StoreMetric, LOGGER, METRICS,
 };
 use vmm::persist::SNAPSHOT_VERSION;
 use vmm::resources::VmResources;
@@ -397,6 +397,7 @@ fn main_exec() -> Result<(), MainError> {
         });
 
         let start_time_cpu_us = arguments.single_value("start-time-cpu-us").map(|s| {
+            warn!("The --start-time-cpu-us argument is deprecated");
             s.parse::<u64>()
                 .expect("'start-time-cpu-us' parameter expected to be of 'u64' type.")
         });

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -369,7 +369,6 @@ fn main_exec() -> Result<(), JailerError> {
     Env::new(
         arguments,
         utils::time::get_time_us(utils::time::ClockType::Monotonic),
-        utils::time::get_time_us(utils::time::ClockType::ProcessCpu),
     )
     .and_then(|env| {
         fs::create_dir_all(env.chroot_dir())

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -333,15 +333,13 @@ impl ProcessTimeReporter {
 
     /// Obtain process CPU start time in microseconds.
     pub fn report_cpu_start_time(&self) {
-        if let Some(cpu_start_time) = self.start_time_cpu_us {
-            let delta_us = utils::time::get_time_us(utils::time::ClockType::ProcessCpu)
-                - cpu_start_time
-                + self.parent_cpu_time_us.unwrap_or_default();
-            METRICS
-                .api_server
-                .process_startup_time_cpu_us
-                .store(delta_us);
-        }
+        let delta_us = utils::time::get_time_us(utils::time::ClockType::ProcessCpu)
+            - self.start_time_cpu_us.unwrap_or_default()
+            + self.parent_cpu_time_us.unwrap_or_default();
+        METRICS
+            .api_server
+            .process_startup_time_cpu_us
+            .store(delta_us);
     }
 }
 


### PR DESCRIPTION
## Changes

Deprecate the `--start-time-cpu-us` parameter.

## Reason

It is always 0 so it does not provide any useful information.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
