### PR TITLE
Hugepages support for Firecracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to
   `VcpuExit::MmioRead`, `VcpuExit::MmioWrite`, `VcpuExit::IoIn` and
   `VcpuExit::IoOut`. The average for these VM exits is not emitted since it can
   be deduced from the available emitted metrics.
+- [#4360](https://github.com/firecracker-microvm/firecracker/pull/4360): Added
+  dev-preview support for backing a VM's guest memory by 2M hugetlbfs pages.
+  Please see the [documentation](docs/hugepages.md) for more information.
 
 ### Changed
 

--- a/docs/hugepages.md
+++ b/docs/hugepages.md
@@ -1,0 +1,55 @@
+# Backing Guest Memory by Huge Pages
+
+> \[!WARNING\]
+>
+> Support is currently in **developer preview**. See
+> [this section](RELEASE_POLICY.md#developer-preview-features) for more info.
+
+Firecracker supports backing the guest memory of a VM by 2MB hugetlbfs pages.
+This can be enabled by setting the `huge_pages` field of `PUT` or `PATCH`
+requests to the `/machine-config` endpoint to `2M`.
+
+Backing guest memory by huge pages can bring performance improvements for
+specific workloads, due to less TLB contention and less overhead during
+virtual->physical address resolution. It can also help reduce the number of
+KVM_EXITS required to rebuild extended page tables post snapshot restore, as
+well as improve boot times (by up to 50% as measured by Firecracker's
+[boot time performance tests](../tests/integration_tests/performance/test_boottime.py))
+
+Using hugetlbfs requires the host running Firecracker to have a pre-allocated
+pool of 2M pages. Should this pool be too small, Firecracker may behave
+erratically or receive the `SIGBUS` signal. This is because Firecracker uses the
+`MAP_NORESERVE` flag when mapping guest memory. This flag means the kernel will
+not try to reserve sufficient hugetlbfs pages at the time of the `mmap` call,
+trying to claim them from the pool on-demand. For details on how to manage this
+pool, please refer to the [Linux Documentation][hugetlbfs_docs].
+
+## Huge Pages and Snapshotting
+
+Restoring a Firecracker snapshot of a microVM backed by huge pages will also use
+huge pages to back the restored guest. There is no option to flip between
+regular, 4K, pages and huge pages at restore time. Furthermore, snapshots of
+microVMs backed with huge pages can only be restored via UFFD. Lastly, note that
+even for guests backed by huge pages, differential snapshots will always track
+write accesses to guest memory at 4K granularity.
+
+## Known Limitations
+
+Currently, hugetlbfs support is mutually exclusive with the following
+Firecracker features:
+
+- Memory Ballooning via the [Balloon Device](./ballooning.md)
+- Initrd
+
+## FAQ
+
+### Why does Firecracker not offer a transparent huge pages (THP) setting?
+
+Firecracker's guest memory is memfd based. Linux (as of 6.1) does not offer a
+way to dynamically enable THP for such memory regions. Additionally, UFFD does
+not integrate with THP (no transparent huge pages will be allocated during
+userfaulting). Please refer to the [Linux Documentation][thp_docs] for more
+information.
+
+[hugetlbfs_docs]: https://docs.kernel.org/admin-guide/mm/hugetlbpage.html
+[thp_docs]: https://www.kernel.org/doc/html/next/admin-guide/mm/transhuge.html#hugepages-in-tmpfs-shmem

--- a/docs/snapshotting/handling-page-faults-on-snapshot-resume.md
+++ b/docs/snapshotting/handling-page-faults-on-snapshot-resume.md
@@ -161,7 +161,7 @@ connect/send data.
 ### Example
 
 An example of a handler process can be found
-[here](../../src/firecracker/examples/uffd/valid_handler.rs). The process is
+[here](../../src/firecracker/examples/uffd/valid_4k_handler.rs). The process is
 designed to tackle faults on a certain address by loading into memory the entire
 region that the address belongs to, but users can choose any other behavior that
 suits their use case best.

--- a/resources/overlay/usr/local/bin/fast_page_fault_helper.c
+++ b/resources/overlay/usr/local/bin/fast_page_fault_helper.c
@@ -1,0 +1,44 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Helper program for triggering fast page faults after UFFD snapshot restore.
+// Allocates a 128M memory area using mmap, touches every page in it using memset and then
+// calls `sigwait` to wait for a SIGUSR1 signal. Upon receiving this signal,
+// set the entire memory area to 1, to trigger fast page fault.
+// The idea is that an integration test takes a snapshot while the process is
+// waiting for the SIGUSR1 signal, and then sends the signal after restoring.
+// This way, the `memset` will trigger a fast page fault for every page in
+// the memory region.
+
+#include <stdio.h>    // perror
+#include <signal.h>   // sigwait and friends
+#include <string.h>   // memset
+#include <sys/mman.h> // mmap
+
+#define MEM_SIZE_MIB (128 * 1024 * 1024)
+
+int main(int argc, char *const argv[]) {
+    sigset_t set;
+    int signal;
+
+    sigemptyset(&set);
+    if(sigaddset(&set, SIGUSR1) == -1) {
+        perror("sigaddset");
+        return -1;
+    }
+
+    void *ptr = mmap(NULL, MEM_SIZE_MIB, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+
+    memset(ptr, 1, MEM_SIZE_MIB);
+
+    if(MAP_FAILED == ptr) {
+        perror("mmap");
+        return -1;
+    }
+
+    sigwait(&set, &signal);
+
+    memset(ptr, 2, MEM_SIZE_MIB);
+
+    return 0;
+}

--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -205,6 +205,7 @@ install_dependencies
 BIN=overlay/usr/local/bin
 compile_and_install $BIN/init.c    $BIN/init
 compile_and_install $BIN/fillmem.c $BIN/fillmem
+compile_and_install $BIN/fast_page_fault_helper.c $BIN/fast_page_fault_helper
 compile_and_install $BIN/readmem.c $BIN/readmem
 if [ $ARCH == "aarch64" ]; then
     compile_and_install $BIN/devmemread.c $BIN/devmemread

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -50,12 +50,12 @@ serde_json = "1.0.113"
 tracing = ["log-instrument", "seccompiler/tracing", "utils/tracing", "vmm/tracing"]
 
 [[example]]
-name = "uffd_malicious_handler"
-path = "examples/uffd/malicious_handler.rs"
+name = "uffd_malicious_4k_handler"
+path = "examples/uffd/malicious_4k_handler.rs"
 
 [[example]]
-name = "uffd_valid_handler"
-path = "examples/uffd/valid_handler.rs"
+name = "uffd_valid_4k_handler"
+path = "examples/uffd/valid_4k_handler.rs"
 
 [[example]]
 name = "seccomp_harmless"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -58,6 +58,10 @@ name = "uffd_valid_4k_handler"
 path = "examples/uffd/valid_4k_handler.rs"
 
 [[example]]
+name = "uffd_valid_2m_handler"
+path = "examples/uffd/valid_2m_handler.rs"
+
+[[example]]
 name = "seccomp_harmless"
 path = "examples/seccomp/harmless.rs"
 

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -62,6 +62,10 @@ name = "uffd_valid_2m_handler"
 path = "examples/uffd/valid_2m_handler.rs"
 
 [[example]]
+name = "uffd_fault_all_handler"
+path = "examples/uffd/fault_all_handler.rs"
+
+[[example]]
 name = "seccomp_harmless"
 path = "examples/seccomp/harmless.rs"
 

--- a/src/firecracker/examples/uffd/fault_all_handler.rs
+++ b/src/firecracker/examples/uffd/fault_all_handler.rs
@@ -1,0 +1,50 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides functionality for a userspace page fault handler
+//! which loads the whole region from the backing memory file
+//! when a page fault occurs.
+
+mod uffd_utils;
+
+use std::fs::File;
+use std::os::unix::net::UnixListener;
+
+use uffd_utils::{Runtime, UffdHandler};
+use utils::get_page_size;
+
+fn main() {
+    let mut args = std::env::args();
+    let uffd_sock_path = args.nth(1).expect("No socket path given");
+    let mem_file_path = args.next().expect("No memory file given");
+
+    let file = File::open(mem_file_path).expect("Cannot open memfile");
+
+    // Get Uffd from UDS. We'll use the uffd to handle PFs for Firecracker.
+    let listener = UnixListener::bind(uffd_sock_path).expect("Cannot bind to socket path");
+    let (stream, _) = listener.accept().expect("Cannot listen on UDS socket");
+
+    // Populate a single page from backing memory file.
+    // This is just an example, probably, with the worst-case latency scenario,
+    // of how memory can be loaded in guest RAM.
+    let len = get_page_size().unwrap(); // page size does not matter, we fault in everything on the first fault
+
+    let mut runtime = Runtime::new(stream, file);
+    runtime.run(len, |uffd_handler: &mut UffdHandler| {
+        // Read an event from the userfaultfd.
+        let event = uffd_handler
+            .read_event()
+            .expect("Failed to read uffd_msg")
+            .expect("uffd_msg not ready");
+
+        match event {
+            userfaultfd::Event::Pagefault { .. } => {
+                for region in uffd_handler.mem_regions.clone() {
+                    uffd_handler
+                        .serve_pf(region.mapping.base_host_virt_addr as _, region.mapping.size)
+                }
+            }
+            _ => panic!("Unexpected event on userfaultfd"),
+        }
+    });
+}

--- a/src/firecracker/examples/uffd/malicious_4k_handler.rs
+++ b/src/firecracker/examples/uffd/malicious_4k_handler.rs
@@ -23,7 +23,7 @@ fn main() {
     let (stream, _) = listener.accept().expect("Cannot listen on UDS socket");
 
     let mut runtime = Runtime::new(stream, file);
-    runtime.run(|uffd_handler: &mut UffdHandler| {
+    runtime.run(4096, |uffd_handler: &mut UffdHandler| {
         // Read an event from the userfaultfd.
         let event = uffd_handler
             .read_event()

--- a/src/firecracker/examples/uffd/uffd_utils.rs
+++ b/src/firecracker/examples/uffd/uffd_utils.rs
@@ -12,7 +12,6 @@ use std::ptr;
 
 use serde::{Deserialize, Serialize};
 use userfaultfd::{Error, Event, Uffd};
-use utils::get_page_size;
 use utils::sock_ctrl_msg::ScmSocket;
 
 // This is the same with the one used in src/vmm.
@@ -33,7 +32,7 @@ pub struct GuestRegionUffdMapping {
     pub offset: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum MemPageState {
     Uninitialized,
     FromFile,
@@ -50,12 +49,18 @@ struct MemRegion {
 #[derive(Debug)]
 pub struct UffdHandler {
     mem_regions: Vec<MemRegion>,
+    page_size: usize,
     backing_buffer: *const u8,
     uffd: Uffd,
 }
 
 impl UffdHandler {
-    pub fn from_unix_stream(stream: &UnixStream, backing_buffer: *const u8, size: usize) -> Self {
+    pub fn from_unix_stream(
+        stream: &UnixStream,
+        page_size: usize,
+        backing_buffer: *const u8,
+        size: usize,
+    ) -> Self {
         let mut message_buf = vec![0u8; 1024];
         let (bytes_read, file) = stream
             .recv_with_fd(&mut message_buf[..])
@@ -71,13 +76,15 @@ impl UffdHandler {
 
         // Make sure memory size matches backing data size.
         assert_eq!(memsize, size);
+        assert!(page_size.is_power_of_two());
 
         let uffd = unsafe { Uffd::from_raw_fd(file.into_raw_fd()) };
 
-        let mem_regions = create_mem_regions(&mappings);
+        let mem_regions = create_mem_regions(&mappings, page_size);
 
         Self {
             mem_regions,
+            page_size,
             backing_buffer,
             uffd,
         }
@@ -87,21 +94,19 @@ impl UffdHandler {
         self.uffd.read_event()
     }
 
-    pub fn update_mem_state_mappings(&mut self, start: u64, end: u64, state: &MemPageState) {
+    pub fn update_mem_state_mappings(&mut self, start: u64, end: u64, state: MemPageState) {
         for region in self.mem_regions.iter_mut() {
             for (key, value) in region.page_states.iter_mut() {
                 if key >= &start && key < &end {
-                    *value = state.clone();
+                    *value = state;
                 }
             }
         }
     }
 
     pub fn serve_pf(&mut self, addr: *mut u8, len: usize) {
-        let page_size = get_page_size().unwrap();
-
         // Find the start of the page that the current faulting address belongs to.
-        let dst = (addr as usize & !(page_size as usize - 1)) as *mut libc::c_void;
+        let dst = (addr as usize & !(self.page_size - 1)) as *mut libc::c_void;
         let fault_page_addr = dst as u64;
 
         // Get the state of the current faulting page.
@@ -117,12 +122,12 @@ impl UffdHandler {
                 //    memory from the host (through balloon device)
                 Some(MemPageState::Uninitialized) | Some(MemPageState::FromFile) => {
                     let (start, end) = self.populate_from_file(region, fault_page_addr, len);
-                    self.update_mem_state_mappings(start, end, &MemPageState::FromFile);
+                    self.update_mem_state_mappings(start, end, MemPageState::FromFile);
                     return;
                 }
                 Some(MemPageState::Removed) | Some(MemPageState::Anonymous) => {
                     let (start, end) = self.zero_out(fault_page_addr);
-                    self.update_mem_state_mappings(start, end, &MemPageState::Anonymous);
+                    self.update_mem_state_mappings(start, end, MemPageState::Anonymous);
                     return;
                 }
                 None => {}
@@ -152,17 +157,15 @@ impl UffdHandler {
     }
 
     fn zero_out(&mut self, addr: u64) -> (u64, u64) {
-        let page_size = get_page_size().unwrap();
-
         let ret = unsafe {
             self.uffd
-                .zeropage(addr as *mut _, page_size, true)
+                .zeropage(addr as *mut _, self.page_size, true)
                 .expect("Uffd zeropage failed")
         };
         // Make sure the UFFD zeroed out some bytes.
         assert!(ret > 0);
 
-        (addr, addr + page_size as u64)
+        (addr, addr + self.page_size as u64)
     }
 }
 
@@ -211,7 +214,7 @@ impl Runtime {
     /// When uffd is polled, page fault is handled by
     /// calling `pf_event_dispatch` with corresponding
     /// uffd object passed in.
-    pub fn run(&mut self, pf_event_dispatch: impl Fn(&mut UffdHandler)) {
+    pub fn run(&mut self, page_size: usize, pf_event_dispatch: impl Fn(&mut UffdHandler)) {
         let mut pollfds = vec![];
 
         // Poll the stream for incoming uffds
@@ -246,6 +249,7 @@ impl Runtime {
                         // Handle new uffd from stream
                         let handler = UffdHandler::from_unix_stream(
                             &self.stream,
+                            page_size,
                             self.backing_memory,
                             self.backing_memory_size,
                         );
@@ -270,8 +274,7 @@ impl Runtime {
     }
 }
 
-fn create_mem_regions(mappings: &Vec<GuestRegionUffdMapping>) -> Vec<MemRegion> {
-    let page_size = get_page_size().unwrap();
+fn create_mem_regions(mappings: &Vec<GuestRegionUffdMapping>, page_size: usize) -> Vec<MemRegion> {
     let mut mem_regions: Vec<MemRegion> = Vec::with_capacity(mappings.len());
 
     for r in mappings.iter() {
@@ -327,7 +330,7 @@ mod tests {
             let (stream, _) = listener.accept().expect("Cannot listen on UDS socket");
             // Update runtime with actual runtime
             let runtime = uninit_runtime.write(Runtime::new(stream, file));
-            runtime.run(|_: &mut UffdHandler| {});
+            runtime.run(4096, |_: &mut UffdHandler| {});
         });
 
         // wait for runtime thread to initialize itself

--- a/src/firecracker/examples/uffd/uffd_utils.rs
+++ b/src/firecracker/examples/uffd/uffd_utils.rs
@@ -40,15 +40,15 @@ pub enum MemPageState {
     Anonymous,
 }
 
-#[derive(Debug)]
-struct MemRegion {
-    mapping: GuestRegionUffdMapping,
+#[derive(Debug, Clone)]
+pub struct MemRegion {
+    pub mapping: GuestRegionUffdMapping,
     page_states: HashMap<u64, MemPageState>,
 }
 
 #[derive(Debug)]
 pub struct UffdHandler {
-    mem_regions: Vec<MemRegion>,
+    pub mem_regions: Vec<MemRegion>,
     page_size: usize,
     backing_buffer: *const u8,
     uffd: Uffd,
@@ -317,7 +317,7 @@ mod tests {
         let mut uninit_runtime = Box::new(MaybeUninit::<Runtime>::uninit());
         // We will use this pointer to bypass a bunch of Rust Safety
         // for the sake of convenience.
-        let runtime_ptr = uninit_runtime.as_ptr() as *const Runtime;
+        let runtime_ptr = uninit_runtime.as_ptr().cast::<Runtime>();
 
         let runtime_thread = std::thread::spawn(move || {
             let tmp_file = TempFile::new().unwrap();

--- a/src/firecracker/examples/uffd/valid_2m_handler.rs
+++ b/src/firecracker/examples/uffd/valid_2m_handler.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides functionality for a userspace page fault handler
+//! which loads the whole region from the backing memory file
+//! when a page fault occurs.
+
+mod uffd_utils;
+
+use std::fs::File;
+use std::os::unix::net::UnixListener;
+
+use uffd_utils::{MemPageState, Runtime, UffdHandler};
+
+fn main() {
+    let mut args = std::env::args();
+    let uffd_sock_path = args.nth(1).expect("No socket path given");
+    let mem_file_path = args.next().expect("No memory file given");
+
+    let file = File::open(mem_file_path).expect("Cannot open memfile");
+
+    // Get Uffd from UDS. We'll use the uffd to handle PFs for Firecracker.
+    let listener = UnixListener::bind(uffd_sock_path).expect("Cannot bind to socket path");
+    let (stream, _) = listener.accept().expect("Cannot listen on UDS socket");
+
+    // Populate a single page from backing memory file.
+    // This is just an example, probably, with the worst-case latency scenario,
+    // of how memory can be loaded in guest RAM.
+    let len = 2 * 1024 * 1024;
+
+    let mut runtime = Runtime::new(stream, file);
+    runtime.run(len, |uffd_handler: &mut UffdHandler| {
+        // Read an event from the userfaultfd.
+        let event = uffd_handler
+            .read_event()
+            .expect("Failed to read uffd_msg")
+            .expect("uffd_msg not ready");
+
+        // We expect to receive either a Page Fault or Removed
+        // event (if the balloon device is enabled).
+        match event {
+            userfaultfd::Event::Pagefault { addr, .. } => uffd_handler.serve_pf(addr.cast(), len),
+            userfaultfd::Event::Remove { start, end } => uffd_handler.update_mem_state_mappings(
+                start as u64,
+                end as u64,
+                MemPageState::Removed,
+            ),
+            _ => panic!("Unexpected event on userfaultfd"),
+        }
+    });
+}

--- a/src/firecracker/examples/uffd/valid_4k_handler.rs
+++ b/src/firecracker/examples/uffd/valid_4k_handler.rs
@@ -30,7 +30,7 @@ fn main() {
     let len = get_page_size().unwrap();
 
     let mut runtime = Runtime::new(stream, file);
-    runtime.run(|uffd_handler: &mut UffdHandler| {
+    runtime.run(len, |uffd_handler: &mut UffdHandler| {
         // Read an event from the userfaultfd.
         let event = uffd_handler
             .read_event()
@@ -44,7 +44,7 @@ fn main() {
             userfaultfd::Event::Remove { start, end } => uffd_handler.update_mem_state_mappings(
                 start as u64,
                 end as u64,
-                &MemPageState::Removed,
+                MemPageState::Removed,
             ),
             _ => panic!("Unexpected event on userfaultfd"),
         }

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -331,9 +331,10 @@ paths:
         The vCPU count is restricted to the [1, 32] range.
         With SMT enabled, the vCPU count is required to be either 1 or an even number in the range.
         otherwise there are no restrictions regarding the vCPU count.
+        If 2M hugetlbfs pages are specified, then `mem_size_mib` must be a multiple of 2.
         If any of the parameters has an incorrect value, the whole update fails.
         All parameters that are optional and are not specified are set to their default values
-        (smt = false, track_dirty_pages = false, cpu_template = None).
+        (smt = false, track_dirty_pages = false, cpu_template = None, huge_pages = None).
       operationId: putMachineConfiguration
       parameters:
         - name: body
@@ -1015,7 +1016,7 @@ definitions:
   MachineConfiguration:
     type: object
     description:
-      Describes the number of vCPUs, memory size, SMT capabilities and
+      Describes the number of vCPUs, memory size, SMT capabilities, huge page configuration and
       the CPU template.
     required:
       - mem_size_mib
@@ -1043,6 +1044,12 @@ definitions:
         minimum: 1
         maximum: 32
         description: Number of vCPUs (either 1 or an even number)
+      huge_pages:
+        type: string
+        enum:
+          - None
+          - 2M
+        description: Which huge pages configuration (if any) should be used to back guest memory.
 
   MemoryBackend:
     type: object

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -237,9 +237,12 @@ pub fn build_microvm_for_boot(
         .ok_or(MissingKernelConfig)?;
 
     let track_dirty_pages = vm_resources.track_dirty_pages();
-    let guest_memory =
-        GuestMemoryMmap::memfd_backed(vm_resources.vm_config.mem_size_mib, track_dirty_pages)
-            .map_err(StartMicrovmError::GuestMemory)?;
+    let guest_memory = GuestMemoryMmap::memfd_backed(
+        vm_resources.vm_config.mem_size_mib,
+        track_dirty_pages,
+        vm_resources.vm_config.huge_pages,
+    )
+    .map_err(StartMicrovmError::GuestMemory)?;
     let entry_addr = load_kernel(boot_config, &guest_memory)?;
     let initrd = load_initrd_from_config(boot_config, &guest_memory)?;
     // Clone the command-line so that a failed boot doesn't pollute the original.

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -797,7 +797,8 @@ mod tests {
     "vcpu_count": 1,
     "mem_size_mib": 128,
     "smt": false,
-    "track_dirty_pages": false
+    "track_dirty_pages": false,
+    "huge_pages": "None"
   }},
   "metrics": null,
   "mmds-config": {{

--- a/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
@@ -206,6 +206,7 @@ pub mod tests {
     use super::*;
     use crate::devices::virtio::block::virtio::device::FileEngineType;
     use crate::devices::virtio::block::virtio::request::PendingRequest;
+    use crate::vmm_config::machine_config::HugePageConfig;
     use crate::vstate::memory::{Bitmap, Bytes, GuestMemory, GuestMemoryExtension};
 
     const FILE_LEN: u32 = 1024;
@@ -256,7 +257,8 @@ pub mod tests {
     }
 
     fn create_mem() -> GuestMemoryMmap {
-        GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), MEM_LEN)], true).unwrap()
+        GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), MEM_LEN)], true, HugePageConfig::None)
+            .unwrap()
     }
 
     fn check_dirty_mem(mem: &GuestMemoryMmap, addr: GuestAddress, len: u32) {

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -32,7 +32,7 @@ use crate::resources::VmResources;
 use crate::snapshot::Snapshot;
 use crate::vmm_config::boot_source::BootSourceConfig;
 use crate::vmm_config::instance_info::InstanceInfo;
-use crate::vmm_config::machine_config::{MachineConfigUpdate, VmConfigError};
+use crate::vmm_config::machine_config::{HugePageConfig, MachineConfigUpdate, VmConfigError};
 use crate::vmm_config::snapshot::{
     CreateSnapshotParams, LoadSnapshotParams, MemBackendType, SnapshotType,
 };
@@ -54,6 +54,8 @@ pub struct VmInfo {
     pub cpu_template: StaticCpuTemplate,
     /// Boot source information.
     pub boot_source: BootSourceConfig,
+    /// Huge page configuration
+    pub huge_pages: HugePageConfig,
 }
 
 impl From<&VmResources> for VmInfo {
@@ -63,6 +65,7 @@ impl From<&VmResources> for VmInfo {
             smt: value.vm_config.smt,
             cpu_template: StaticCpuTemplate::from(&value.vm_config.cpu_template),
             boot_source: value.boot_source_config().clone(),
+            huge_pages: value.vm_config.huge_pages,
         }
     }
 }
@@ -399,7 +402,7 @@ pub fn restore_from_snapshot(
             smt: Some(microvm_state.vm_info.smt),
             cpu_template: Some(microvm_state.vm_info.cpu_template),
             track_dirty_pages: Some(track_dirty_pages),
-            huge_pages: None, // TODO: snapshot integration
+            huge_pages: Some(microvm_state.vm_info.huge_pages),
         })
         .map_err(BuildMicrovmFromSnapshotError::VmUpdateConfig)?;
 
@@ -411,8 +414,13 @@ pub fn restore_from_snapshot(
 
     let (guest_memory, uffd) = match params.mem_backend.backend_type {
         MemBackendType::File => (
-            guest_memory_from_file(mem_backend_path, mem_state, track_dirty_pages)
-                .map_err(RestoreFromSnapshotGuestMemoryError::File)?,
+            guest_memory_from_file(
+                mem_backend_path,
+                mem_state,
+                track_dirty_pages,
+                vm_resources.vm_config.huge_pages,
+            )
+            .map_err(RestoreFromSnapshotGuestMemoryError::File)?,
             None,
         ),
         MemBackendType::Uffd => guest_memory_from_uffd(
@@ -422,6 +430,7 @@ pub fn restore_from_snapshot(
             // We enable the UFFD_FEATURE_EVENT_REMOVE feature only if a balloon device
             // is present in the microVM state.
             microvm_state.device_states.balloon_device.is_some(),
+            vm_resources.vm_config.huge_pages,
         )
         .map_err(RestoreFromSnapshotGuestMemoryError::Uffd)?,
     };
@@ -475,9 +484,11 @@ fn guest_memory_from_file(
     mem_file_path: &Path,
     mem_state: &GuestMemoryState,
     track_dirty_pages: bool,
+    huge_pages: HugePageConfig,
 ) -> Result<GuestMemoryMmap, GuestMemoryFromFileError> {
     let mem_file = File::open(mem_file_path)?;
-    let guest_mem = GuestMemoryMmap::from_state(Some(&mem_file), mem_state, track_dirty_pages)?;
+    let guest_mem =
+        GuestMemoryMmap::from_state(Some(&mem_file), mem_state, track_dirty_pages, huge_pages)?;
     Ok(guest_mem)
 }
 
@@ -501,8 +512,9 @@ fn guest_memory_from_uffd(
     mem_state: &GuestMemoryState,
     track_dirty_pages: bool,
     enable_balloon: bool,
+    huge_pages: HugePageConfig,
 ) -> Result<(GuestMemoryMmap, Option<Uffd>), GuestMemoryFromUffdError> {
-    let guest_memory = GuestMemoryMmap::from_state(None, mem_state, track_dirty_pages)?;
+    let guest_memory = GuestMemoryMmap::from_state(None, mem_state, track_dirty_pages, huge_pages)?;
 
     let mut uffd_builder = UffdBuilder::new();
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -399,6 +399,7 @@ pub fn restore_from_snapshot(
             smt: Some(microvm_state.vm_info.smt),
             cpu_template: Some(microvm_state.vm_info.cpu_template),
             track_dirty_pages: Some(track_dirty_pages),
+            huge_pages: None, // TODO: snapshot integration
         })
         .map_err(BuildMicrovmFromSnapshotError::VmUpdateConfig)?;
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -261,6 +261,12 @@ impl VmResources {
             return Err(VmConfigError::BalloonAndHugePages);
         }
 
+        if self.boot_source.config.initrd_path.is_some()
+            && updated.huge_pages != HugePageConfig::None
+        {
+            return Err(VmConfigError::InitrdAndHugePages);
+        }
+
         self.vm_config = updated;
 
         Ok(())
@@ -337,6 +343,12 @@ impl VmResources {
         &mut self,
         boot_source_cfg: BootSourceConfig,
     ) -> Result<(), BootSourceConfigError> {
+        if boot_source_cfg.initrd_path.is_some()
+            && self.vm_config.huge_pages != HugePageConfig::None
+        {
+            return Err(BootSourceConfigError::HugePagesAndInitRd);
+        }
+
         self.set_boot_source_config(boot_source_cfg);
         self.boot_source.builder = Some(BootConfig::new(self.boot_source_config())?);
         Ok(())

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -10,7 +10,7 @@ use utils::net::ipv4addr::is_link_local_valid;
 
 use crate::cpu_config::templates::CustomCpuTemplate;
 use crate::device_manager::persist::SharedDeviceType;
-use crate::logger::info;
+use crate::logger::{info, log_dev_preview_warning};
 use crate::mmds;
 use crate::mmds::data_store::{Mmds, MmdsVersion};
 use crate::mmds::ns::MmdsNetworkStack;
@@ -22,7 +22,7 @@ use crate::vmm_config::drive::*;
 use crate::vmm_config::entropy::*;
 use crate::vmm_config::instance_info::InstanceInfo;
 use crate::vmm_config::machine_config::{
-    MachineConfig, MachineConfigUpdate, VmConfig, VmConfigError,
+    HugePageConfig, MachineConfig, MachineConfigUpdate, VmConfig, VmConfigError,
 };
 use crate::vmm_config::metrics::{init_metrics, MetricsConfig, MetricsConfigError};
 use crate::vmm_config::mmds::{MmdsConfig, MmdsConfigError};
@@ -238,6 +238,10 @@ impl VmResources {
 
     /// Updates the configuration of the microVM.
     pub fn update_vm_config(&mut self, update: &MachineConfigUpdate) -> Result<(), VmConfigError> {
+        if update.huge_pages.is_some() && update.huge_pages != Some(HugePageConfig::None) {
+            log_dev_preview_warning("Huge pages support", None);
+        }
+
         let updated = self.vm_config.update(update)?;
 
         // The VM cannot have a memory size smaller than the target size

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -472,6 +472,7 @@ mod tests {
     use std::str::FromStr;
 
     use serde_json::{Map, Value};
+    use utils::kernel_version::KernelVersion;
     use utils::net::mac::MacAddr;
     use utils::tempfile::TempFile;
 
@@ -1378,9 +1379,11 @@ mod tests {
             VmConfigError::InvalidMemorySize
         );
 
-        // mem_size_mib compatible with huge page configuration
-        aux_vm_config.mem_size_mib = Some(2048);
-        vm_resources.update_vm_config(&aux_vm_config).unwrap();
+        if KernelVersion::get().unwrap() >= KernelVersion::new(5, 10, 0) {
+            // mem_size_mib compatible with huge page configuration
+            aux_vm_config.mem_size_mib = Some(2048);
+            vm_resources.update_vm_config(&aux_vm_config).unwrap();
+        }
     }
 
     #[test]

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1069,6 +1069,7 @@ mod tests {
                 smt: value.vm_config.smt,
                 cpu_template: StaticCpuTemplate::from(&value.vm_config.cpu_template),
                 boot_source: value.boot_source_config().clone(),
+                huge_pages: value.vm_config.huge_pages,
             }
         }
     }

--- a/src/vmm/src/utilities/test_utils/mod.rs
+++ b/src/vmm/src/utilities/test_utils/mod.rs
@@ -13,6 +13,7 @@ use crate::seccomp_filters::get_empty_filters;
 use crate::utilities::mock_resources::{MockBootSourceConfig, MockVmConfig, MockVmResources};
 use crate::vmm_config::boot_source::BootSourceConfig;
 use crate::vmm_config::instance_info::InstanceInfo;
+use crate::vmm_config::machine_config::HugePageConfig;
 use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryMmap};
 use crate::{EventManager, Vmm};
 
@@ -30,7 +31,8 @@ pub fn single_region_mem_at(at: u64, size: usize) -> GuestMemoryMmap {
 
 /// Creates a [`GuestMemoryMmap`] with multiple regions and without dirty page tracking.
 pub fn multi_region_mem(regions: &[(GuestAddress, usize)]) -> GuestMemoryMmap {
-    GuestMemoryMmap::from_raw_regions(regions, false).expect("Cannot initialize memory")
+    GuestMemoryMmap::from_raw_regions(regions, false, HugePageConfig::None)
+        .expect("Cannot initialize memory")
 }
 
 /// Creates a [`GuestMemoryMmap`] of the given size with the contained regions laid out in

--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -28,6 +28,8 @@ pub enum BalloonConfigError {
     CreateFailure(crate::devices::virtio::balloon::BalloonError),
     /// Error updating the balloon device configuration: {0:?}
     UpdateFailure(std::io::Error),
+    /// Firecracker's huge pages support is incompatible with memory ballooning.
+    HugePages,
 }
 
 /// This struct represents the strongly typed equivalent of the json body

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -42,6 +42,8 @@ pub enum BootSourceConfigError {
     InvalidInitrdPath(io::Error),
     /// The kernel command line is invalid: {0}
     InvalidKernelCommandLine(String),
+    /// Firecracker's huge pages support is incompatible with initrds.
+    HugePagesAndInitRd,
 }
 
 /// Holds the kernel specification (both configuration as well as runtime details).

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -52,6 +52,29 @@ impl HugePageConfig {
 
         mem_size_mib % divisor == 0
     }
+
+    /// Returns the flags required to pass to `mmap`, in addition to `MAP_ANONYMOUS`, to
+    /// create a mapping backed by huge pages as described by this [`HugePageConfig`].
+    pub fn mmap_flags(&self) -> libc::c_int {
+        match self {
+            HugePageConfig::None => 0,
+            HugePageConfig::Hugetlbfs2M => libc::MAP_HUGETLB | libc::MAP_HUGE_2MB,
+        }
+    }
+
+    /// Returns `true` iff this [`HugePageConfig`] describes a hugetlbfs-based configuration.
+    pub fn is_hugetlbfs(&self) -> bool {
+        matches!(self, HugePageConfig::Hugetlbfs2M)
+    }
+}
+
+impl From<HugePageConfig> for Option<memfd::HugetlbSize> {
+    fn from(value: HugePageConfig) -> Self {
+        match value {
+            HugePageConfig::None => None,
+            HugePageConfig::Hugetlbfs2M => Some(memfd::HugetlbSize::Huge2MB),
+        }
+    }
 }
 
 /// Struct used in PUT `/machine-config` API call.

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -35,6 +35,8 @@ pub enum VmConfigError {
     HugetlbfsNotSupported,
     /// Firecracker's huge pages support is incompatible with memory ballooning.
     BalloonAndHugePages,
+    /// Firecracker's huge pages support is incompatible with initrds.
+    InitrdAndHugePages,
 }
 
 // We cannot do a `KernelVersion(kernel_version::Error)` variant because `kernel_version::Error`

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -286,6 +286,7 @@ mod tests {
             let base_config = VmConfig::default();
             let update = MachineConfigUpdate {
                 huge_pages: Some(HugePageConfig::Hugetlbfs2M),
+                mem_size_mib: Some(1024),
                 ..Default::default()
             };
 

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -33,6 +33,8 @@ pub enum VmConfigError {
     KernelVersion,
     /// Firecracker's hugetlbfs support requires at least host kernel 5.10.
     HugetlbfsNotSupported,
+    /// Firecracker's huge pages support is incompatible with memory ballooning.
+    BalloonAndHugePages,
 }
 
 // We cannot do a `KernelVersion(kernel_version::Error)` variant because `kernel_version::Error`

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -16,6 +16,7 @@ use vmm::utilities::mock_resources::{MockVmResources, NOISY_KERNEL_IMAGE};
 use vmm::utilities::test_utils::dirty_tracking_vmm;
 use vmm::utilities::test_utils::{create_vmm, default_vmm, default_vmm_no_boot};
 use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
+use vmm::vmm_config::machine_config::HugePageConfig;
 use vmm::vmm_config::snapshot::{CreateSnapshotParams, SnapshotType};
 use vmm::{DumpCpuConfigError, EventManager, FcExitCode};
 
@@ -236,6 +237,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
         Some(memory_file.as_file()),
         &microvm_state.memory_state,
         false,
+        HugePageConfig::None,
     )
     .unwrap();
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ def uffd_handler_paths():
     """Build UFFD handler binaries."""
     handlers = {
         f"{handler}_handler": build_tools.get_example(f"uffd_{handler}_handler")
-        for handler in ["malicious_4k", "valid_4k", "valid_2m"]
+        for handler in ["malicious_4k", "valid_4k", "valid_2m", "fault_all"]
     }
     yield handlers
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ def uffd_handler_paths():
     """Build UFFD handler binaries."""
     handlers = {
         f"{handler}_handler": build_tools.get_example(f"uffd_{handler}_handler")
-        for handler in ["malicious", "valid"]
+        for handler in ["malicious_4k", "valid_4k"]
     }
     yield handlers
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ def uffd_handler_paths():
     """Build UFFD handler binaries."""
     handlers = {
         f"{handler}_handler": build_tools.get_example(f"uffd_{handler}_handler")
-        for handler in ["malicious_4k", "valid_4k"]
+        for handler in ["malicious_4k", "valid_4k", "valid_2m"]
     }
     yield handlers
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -138,6 +138,13 @@ class Snapshot:
         self.vmstate.unlink()
 
 
+class HugePagesConfig(str, Enum):
+    """Enum describing the huge pages configurations supported Firecracker"""
+
+    NONE = "None"
+    HUGETLBFS_2MB = "2M"
+
+
 # pylint: disable=R0904
 class Microvm:
     """Class to represent a Firecracker microvm.
@@ -631,6 +638,7 @@ class Microvm:
         boot_args: str = None,
         use_initrd: bool = False,
         track_dirty_pages: bool = False,
+        huge_pages: HugePagesConfig = None,
         rootfs_io_engine=None,
         cpu_template: Optional[str] = None,
         enable_entropy_device=False,
@@ -658,6 +666,7 @@ class Microvm:
             mem_size_mib=mem_size_mib,
             track_dirty_pages=track_dirty_pages,
             cpu_template=cpu_template,
+            huge_pages=huge_pages,
         )
         self.vcpus_count = vcpu_count
         self.mem_size_bytes = mem_size_mib * 2**20

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Generic utility functions that are used in the framework."""
-
 import functools
 import glob
 import json

--- a/tests/framework/utils_ftrace.py
+++ b/tests/framework/utils_ftrace.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Utilities for interacting with the kernel's ftrace subsystem"""
+import contextlib
+
+from framework.utils import run_cmd
+
+
+@contextlib.contextmanager
+def ftrace_events(events: str = "*:*"):
+    """Temporarily enables the kernel's tracing functionality for the specified events
+
+    Assumes that the caller is the only test executing on the host"""
+
+    # We have to do system-wide tracing because inside docker we live in a pidns, but trace-cmd does not know about
+    # this. We don't know how to translate the pidns PID to one ftrace would understand, so we use the fact that only
+    # one vm is running at the same time, and thus we can attribute all KVM events to this one VM
+    run_cmd("mount -t tracefs nodev /sys/kernel/tracing")
+    run_cmd("echo > /sys/kernel/tracing/trace")  # clear the trace buffers
+    run_cmd(f"echo {events} > /sys/kernel/tracing/set_event")
+    run_cmd("echo nop > /sys/kernel/tracing/current_tracer")
+    run_cmd("echo 1 > /sys/kernel/tracing/tracing_on")
+
+    try:
+        yield
+    finally:
+        run_cmd("echo 0 > /sys/kernel/tracing/tracing_on")
+        run_cmd("umount /sys/kernel/tracing")

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -21,7 +21,8 @@
     "vcpu_count": 2,
     "mem_size_mib": 1024,
     "smt": false,
-    "track_dirty_pages": false
+    "track_dirty_pages": false,
+    "huge_pages": "None"
   },
   "cpu-config": null,
   "balloon": null,

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -399,7 +399,10 @@ def test_api_machine_config(uvm_plain):
 
     # Test invalid mem_size_mib = 0.
     with pytest.raises(
-        RuntimeError, match=re.escape("The memory size (MiB) is invalid.")
+        RuntimeError,
+        match=re.escape(
+            "The memory size (MiB) is either 0, or not a multiple of the configured page size."
+        ),
     ):
         test_microvm.api.machine_config.patch(mem_size_mib=0)
 
@@ -1105,6 +1108,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
         "mem_size_mib": 256,
         "smt": True,
         "track_dirty_pages": False,
+        "huge_pages": "None",
     }
 
     if cpu_vendor == utils_cpuid.CpuVendor.ARM:
@@ -1221,6 +1225,7 @@ def test_get_full_config(uvm_plain):
         "mem_size_mib": 256,
         "smt": False,
         "track_dirty_pages": False,
+        "huge_pages": "None",
     }
     expected_cfg["cpu-config"] = None
     expected_cfg["boot-source"] = {

--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -110,7 +110,7 @@ def test_valid_handler(uvm_plain, snapshot, uffd_handler_paths):
 
     # Spawn page fault handler process.
     _pf_handler = spawn_pf_handler(
-        vm, uffd_handler_paths["valid_handler"], snapshot.mem
+        vm, uffd_handler_paths["valid_4k_handler"], snapshot.mem
     )
 
     vm.restore_from_snapshot(snapshot, resume=True, uffd_path=SOCKET_PATH)
@@ -144,7 +144,7 @@ def test_malicious_handler(uvm_plain, snapshot, uffd_handler_paths):
 
     # Spawn page fault handler process.
     _pf_handler = spawn_pf_handler(
-        vm, uffd_handler_paths["malicious_handler"], snapshot.mem
+        vm, uffd_handler_paths["malicious_4k_handler"], snapshot.mem
     )
 
     # We expect Firecracker to freeze while resuming from a snapshot

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for Firecracker's huge pages support"""
+import pytest
+
+from framework import utils
+from framework.microvm import HugePagesConfig
+from framework.properties import global_props
+
+
+def check_hugetlbfs_in_use(pid: int, allocation_name: str):
+    """Asserts that the process with the given `pid` is using hugetlbfs pages somewhere.
+
+    `allocation_name` should be the name of the smaps entry for which we want to verify that huge pages are used.
+    For memfd-backed guest memory, this would be "memfd:guest_mem" (the `guest_mem` part originating from the name
+    we give the memfd in memory.rs), for anonymous memory this would be "/anon_hugepage"
+    """
+
+    # Format of a sample smaps entry:
+    #   7fc2bc400000-7fc2cc400000 rw-s 00000000 00:10 25488401                   /memfd:guest_mem (deleted)
+    #   Size:             262144 kB
+    #   KernelPageSize:     2048 kB
+    #   MMUPageSize:        2048 kB
+    #   Rss:                   0 kB
+    #   Pss:                   0 kB
+    #   Pss_Dirty:             0 kB
+    #   Shared_Clean:          0 kB
+    #   Shared_Dirty:          0 kB
+    #   Private_Clean:         0 kB
+    #   Private_Dirty:         0 kB
+    #   Referenced:            0 kB
+    #   Anonymous:             0 kB
+    #   LazyFree:              0 kB
+    #   AnonHugePages:         0 kB
+    #   ShmemPmdMapped:        0 kB
+    #   FilePmdMapped:         0 kB
+    #   Shared_Hugetlb:        0 kB
+    #   Private_Hugetlb:   92160 kB
+    #   Swap:                  0 kB
+    #   SwapPss:               0 kB
+    #   Locked:                0 kB
+    #   THPeligible:           0
+    #   ProtectionKey:         0
+    cmd = f"cat /proc/{pid}/smaps | grep {allocation_name} -A 23 | grep KernelPageSize"
+    _, stdout, _ = utils.run_cmd(cmd)
+
+    kernel_page_size_kib = int(stdout.split()[1])
+    assert kernel_page_size_kib > 4
+
+
+@pytest.mark.skipif(
+    global_props.host_linux_version == "4.14",
+    reason="MFD_HUGETLB | MFD_ALLOW_SEALING only supported on kernels >= 4.16",
+)
+def test_hugetlbfs_boot(uvm_plain):
+    """Tests booting a microvm with guest memory backed by 2MB hugetlbfs pages"""
+
+    uvm_plain.spawn()
+    uvm_plain.basic_config(huge_pages=HugePagesConfig.HUGETLBFS_2MB, mem_size_mib=128)
+    uvm_plain.add_net_iface()
+    uvm_plain.start()
+
+    rc, _, _ = uvm_plain.ssh.run("true")
+    assert not rc
+
+    check_hugetlbfs_in_use(uvm_plain.firecracker_pid, "memfd:guest_mem")

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -139,3 +139,45 @@ def test_negative_huge_pages_plus_balloon(uvm_plain):
         match="Machine config error: Firecracker's huge pages support is incompatible with memory ballooning.",
     ):
         uvm_plain.basic_config(huge_pages=HugePagesConfig.HUGETLBFS_2MB)
+
+
+@pytest.mark.skipif(
+    global_props.host_linux_version == "4.14",
+    reason="MFD_HUGETLB | MFD_ALLOW_SEALING only supported on kernels >= 4.16",
+)
+def test_negative_huge_pages_plus_initrd(uvm_with_initrd):
+    """Tests that huge pages and initrd cannot be used together"""
+    uvm_with_initrd.jailer.daemonize = False
+    uvm_with_initrd.spawn()
+    uvm_with_initrd.memory_monitor = None
+
+    # Ensure setting huge pages and then telling FC to boot an initrd does not work
+    with pytest.raises(
+        RuntimeError,
+        match="Boot source error: Firecracker's huge pages support is incompatible with initrds.",
+    ):
+        # `basic_config` first does a PUT to /machine-config, which will apply the huge pages configuration,
+        # and then a PUT to /boot-source, which will register the initrd
+        uvm_with_initrd.basic_config(
+            boot_args="console=ttyS0 reboot=k panic=1 pci=off",
+            use_initrd=True,
+            huge_pages=HugePagesConfig.HUGETLBFS_2MB,
+            add_root_device=False,
+            vcpu_count=1,
+        )
+
+    # Ensure telling FC about the initrd first and then setting huge pages doesn't work
+    # This first does a PUT to /machine-config to reset the huge pages configuration, before doing a
+    # PUT to /boot-source to register the initrd
+    uvm_with_initrd.basic_config(
+        huge_pages=HugePagesConfig.NONE,
+        boot_args="console=ttyS0 reboot=k panic=1 pci=off",
+        use_initrd=True,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="Machine config error: Firecracker's huge pages support is incompatible with initrds.",
+    ):
+        uvm_with_initrd.api.machine_config.patch(
+            huge_pages=HugePagesConfig.HUGETLBFS_2MB
+        )

--- a/tools/devtool
+++ b/tools/devtool
@@ -687,10 +687,26 @@ cmd_test() {
     say "RPM microcode_ctl version: $(rpm -q microcode_ctl)"
 
     env |grep -P "^(AWS_EMF_|BUILDKITE|CODECOV_)" > env.list
-    if [[ $performance_tweaks -eq 1 ]] && [[ "$(uname --machine)" == "x86_64" ]]; then
-      say "Detected CI and performance tests, tuning CPU frequency scaling and idle states for reduced variability"
+    if [[ $performance_tweaks -eq 1 ]]; then
+      if [[ "$(uname --machine)" == "x86_64" ]]; then
+        say "Detected CI and performance tests, tuning CPU frequency scaling and idle states for reduced variability"
 
-      apply_performance_tweaks
+        apply_performance_tweaks
+      fi
+
+      # It seems that even if the tests using huge pages run sequentially on ag=1 agents, right-sizing the huge pages
+      # pool to the total number of huge pages used across all tests results in spurious failures with pool depletion
+      # anyway (something else on the host seems to be stealing our huge pages, and we cannot "ear mark" them for
+      # Firecracker processes). Thus, just allocate 4GB of them and call it a day.
+      say "Setting up huge pages pool"
+      num_hugetlbfs_pages=2048
+
+      huge_pages_old=$(cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages)
+      huge_pages_new=$(echo $num_hugetlbfs_pages |sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages)
+    fi
+
+    if [[ "$huge_pages_new" -ne "$num_hugetlbfs_pages" ]]; then
+      die "Failed to allocate $num_hugetlbfs_pages hugetlbfs pages, only got $huge_pages_new"
     fi
 
     say "Starting test run ..."
@@ -727,8 +743,12 @@ cmd_test() {
     cmd_fix_perms
 
     # undo performance tweaks (in case the instance gets recycled for a non-perf test)
-    if [[ $performance_tweaks -eq 1 ]] && [[ "$(uname --machine)" == "x86_64" ]]; then
-      unapply_performance_tweaks
+    if [[ $performance_tweaks -eq 1 ]]; then
+      if [[ "$(uname --machine)" == "x86_64" ]]; then
+        unapply_performance_tweaks
+      fi
+
+      echo $huge_pages_old |sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages >/dev/null
     fi
 
     # do not leave behind env.list file


### PR DESCRIPTION
## Changes

Adds initial support for backing guest memory with huge pages. They can be configured via the `/machine-config` API, with Firecracker supporting 2M hugetlbfs pages. Huge page configuration is stored in the snapshot state, and a snapshot will be restored into a VM whose huge pages configuration matches that of the VM from which the snapshot was taken (with the operation erroring out if this is not possible for some reason, e.g. if trying to restore a hugetlbfs backed snapshot by mmaping the memory file). For the initial devpreview release, features that would require explicit integration with huge pages (such as memory ballooning) are mutually exclusive with huge page support. 

This is linked to the #2139.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
