### PR TITLE
test: remove aarch64 'no-ssbs' CPU template

### DIFF
--- a/tests/data/static_cpu_templates/aarch64_remove_ssbs.json
+++ b/tests/data/static_cpu_templates/aarch64_remove_ssbs.json
@@ -1,8 +1,0 @@
-{
-  "reg_modifiers": [
-      {
-          "addr": "0x603000000013c021",
-          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx0000xxxx"
-      }
-  ]
-}

--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -44,9 +44,8 @@ def get_supported_cpu_templates():
 SUPPORTED_CPU_TEMPLATES = get_supported_cpu_templates()
 
 # Custom CPU templates for Aarch64 for testing
-AARCH64_CUSTOM_CPU_TEMPLATES_G2 = ["aarch64_remove_ssbs", "v1n1"]
+AARCH64_CUSTOM_CPU_TEMPLATES_G2 = ["v1n1"]
 AARCH64_CUSTOM_CPU_TEMPLATES_G3 = [
-    "aarch64_remove_ssbs",
     "aarch64_with_sve_and_pac",
     "v1n1",
 ]

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -20,8 +20,6 @@ DEFAULT_G2_FEATURES = set(
     ).split(" ")
 )
 
-DEFAULT_G2_FEATURES_NO_SSBS = DEFAULT_G2_FEATURES - {"ssbs"}
-
 DEFAULT_G3_FEATURES_4_14 = DEFAULT_G2_FEATURES | set(
     "sha512 asimdfhm dit uscat ilrcpc flagm jscvt fcma sha3 sm3 sm4".split(" ")
 )
@@ -29,9 +27,6 @@ DEFAULT_G3_FEATURES_4_14 = DEFAULT_G2_FEATURES | set(
 DEFAULT_G3_FEATURES_5_10 = DEFAULT_G3_FEATURES_4_14 | set(
     "dcpodp i8mm bf16 dgh rng".split(" ")
 )
-
-DEFAULT_G3_FEATURES_NO_SSBS_4_14 = DEFAULT_G3_FEATURES_4_14 - {"ssbs"}
-DEFAULT_G3_FEATURES_NO_SSBS_5_10 = DEFAULT_G3_FEATURES_5_10 - {"ssbs"}
 
 DEFAULT_G3_FEATURES_WITH_SVE_AND_PAC_4_14 = DEFAULT_G3_FEATURES_4_14
 DEFAULT_G3_FEATURES_WITH_SVE_AND_PAC_5_10 = DEFAULT_G3_FEATURES_5_10 | set(
@@ -44,22 +39,16 @@ DEFAULT_G3_FEATURES_V1N1 = DEFAULT_G2_FEATURES
 def _check_cpu_features_arm(test_microvm, guest_kv, template_name=None):
     expected_cpu_features = {"Flags": []}
     match cpuid_utils.get_cpu_model_name(), guest_kv, template_name:
-        case CpuModel.ARM_NEOVERSE_N1, _, "aarch64_remove_ssbs":
-            expected_cpu_features = DEFAULT_G2_FEATURES_NO_SSBS
         case CpuModel.ARM_NEOVERSE_N1, _, "v1n1":
             expected_cpu_features = DEFAULT_G2_FEATURES
         case CpuModel.ARM_NEOVERSE_N1, _, None:
             expected_cpu_features = DEFAULT_G2_FEATURES
-        case CpuModel.ARM_NEOVERSE_V1, "4.14", "aarch64_remove_ssbs":
-            expected_cpu_features = DEFAULT_G3_FEATURES_NO_SSBS_4_14
         case CpuModel.ARM_NEOVERSE_V1, "4.14", "aarch64_with_sve_and_pac":
             expected_cpu_features = DEFAULT_G3_FEATURES_WITH_SVE_AND_PAC_4_14
         case CpuModel.ARM_NEOVERSE_V1, "4.14", None:
             expected_cpu_features = DEFAULT_G3_FEATURES_4_14
 
         # [cm]7g with guest kernel 5.10 and later
-        case CpuModel.ARM_NEOVERSE_V1, _, "aarch64_remove_ssbs":
-            expected_cpu_features = DEFAULT_G3_FEATURES_NO_SSBS_5_10
         case CpuModel.ARM_NEOVERSE_V1, _, "v1n1":
             expected_cpu_features = DEFAULT_G3_FEATURES_V1N1
         case CpuModel.ARM_NEOVERSE_V1, _, "aarch64_with_sve_and_pac":


### PR DESCRIPTION
This was testing something that worked accidentally using an old version of the CPU masking patches. This functionality didn't make it into the version that was merged in AL2023 6.1.

## Changes

Drop `ssbs` tests and template

## Reason

This is not supposed to work.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
