### PR TITLE
chore: move aarch64 CPU template tests to al2023

### DIFF
--- a/.buildkite/pipeline_cpu_template.py
+++ b/.buildkite/pipeline_cpu_template.py
@@ -62,7 +62,7 @@ cpu_template_test = {
         ],
         BkStep.LABEL: "📖 cpu templates",
         "instances": ["m6g.metal", "c7g.metal"],
-        "platforms": [("al2_armpatch", "linux_5.10")],
+        "platforms": [("al2023", "linux_6.1")],
     },
     "fingerprint": {
         BkStep.COMMAND: [


### PR DESCRIPTION
The AL2023 Linux 6.1 kernel now has the CPU masking patches we need for snapshot / restore to work.

## Changes

Move the tests to a platform where they are supported.

## Reason

So we can run the tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
