### PR TITLE
Uffd protocol update

### DIFF
--- a/src/firecracker/examples/uffd/malicious_handler.rs
+++ b/src/firecracker/examples/uffd/malicious_handler.rs
@@ -9,7 +9,7 @@ mod uffd_utils;
 use std::fs::File;
 use std::os::unix::net::UnixListener;
 
-use uffd_utils::{Runtime, UffdPfHandler};
+use uffd_utils::{Runtime, UffdHandler};
 
 fn main() {
     let mut args = std::env::args();
@@ -23,10 +23,9 @@ fn main() {
     let (stream, _) = listener.accept().expect("Cannot listen on UDS socket");
 
     let mut runtime = Runtime::new(stream, file);
-    runtime.run(|uffd_handler: &mut UffdPfHandler| {
+    runtime.run(|uffd_handler: &mut UffdHandler| {
         // Read an event from the userfaultfd.
         let event = uffd_handler
-            .uffd
             .read_event()
             .expect("Failed to read uffd_msg")
             .expect("uffd_msg not ready");

--- a/src/firecracker/examples/uffd/uffd_utils.rs
+++ b/src/firecracker/examples/uffd/uffd_utils.rs
@@ -55,7 +55,7 @@ pub enum MemPageState {
 }
 
 impl UffdPfHandler {
-    pub fn from_unix_stream(stream: UnixStream, backing_buffer: *const u8, size: usize) -> Self {
+    pub fn from_unix_stream(stream: &UnixStream, backing_buffer: *const u8, size: usize) -> Self {
         let mut message_buf = vec![0u8; 1024];
         let (bytes_read, file) = stream
             .recv_with_fd(&mut message_buf[..])
@@ -213,5 +213,5 @@ pub fn create_pf_handler() -> UffdPfHandler {
 
     let (stream, _) = listener.accept().expect("Cannot listen on UDS socket");
 
-    UffdPfHandler::from_unix_stream(stream, memfile_buffer, size)
+    UffdPfHandler::from_unix_stream(&stream, memfile_buffer, size)
 }

--- a/src/firecracker/examples/uffd/valid_handler.rs
+++ b/src/firecracker/examples/uffd/valid_handler.rs
@@ -10,7 +10,7 @@ mod uffd_utils;
 use std::fs::File;
 use std::os::unix::net::UnixListener;
 
-use uffd_utils::{MemPageState, Runtime, UffdPfHandler};
+use uffd_utils::{MemPageState, Runtime, UffdHandler};
 use utils::get_page_size;
 
 fn main() {
@@ -30,10 +30,9 @@ fn main() {
     let len = get_page_size().unwrap();
 
     let mut runtime = Runtime::new(stream, file);
-    runtime.run(|uffd_handler: &mut UffdPfHandler| {
+    runtime.run(|uffd_handler: &mut UffdHandler| {
         // Read an event from the userfaultfd.
         let event = uffd_handler
-            .uffd
             .read_event()
             .expect("Failed to read uffd_msg")
             .expect("uffd_msg not ready");

--- a/src/firecracker/examples/uffd/valid_handler.rs
+++ b/src/firecracker/examples/uffd/valid_handler.rs
@@ -7,42 +7,30 @@
 
 mod uffd_utils;
 
-use std::os::unix::io::AsRawFd;
+use std::fs::File;
+use std::os::unix::net::UnixListener;
 
-use uffd_utils::{create_pf_handler, MemPageState};
+use uffd_utils::{MemPageState, Runtime, UffdPfHandler};
 use utils::get_page_size;
 
 fn main() {
-    let mut uffd_handler = create_pf_handler();
+    let mut args = std::env::args();
+    let uffd_sock_path = args.nth(1).expect("No socket path given");
+    let mem_file_path = args.next().expect("No memory file given");
+
+    let file = File::open(mem_file_path).expect("Cannot open memfile");
+
+    // Get Uffd from UDS. We'll use the uffd to handle PFs for Firecracker.
+    let listener = UnixListener::bind(uffd_sock_path).expect("Cannot bind to socket path");
+    let (stream, _) = listener.accept().expect("Cannot listen on UDS socket");
 
     // Populate a single page from backing memory file.
     // This is just an example, probably, with the worst-case latency scenario,
     // of how memory can be loaded in guest RAM.
     let len = get_page_size().unwrap();
 
-    let mut pollfd = libc::pollfd {
-        fd: uffd_handler.uffd.as_raw_fd(),
-        events: libc::POLLIN,
-        revents: 0,
-    };
-    // Loop, handling incoming events on the userfaultfd file descriptor.
-    loop {
-        // See what poll() tells us about the userfaultfd.
-        let nready = unsafe { libc::poll(&mut pollfd, 1, -1) };
-
-        if nready == -1 {
-            panic!("Could not poll for events!")
-        }
-
-        let revents = pollfd.revents;
-
-        println!(
-            "poll() returns: nready = {}; POLLIN = {}; POLLERR = {}",
-            nready,
-            revents & libc::POLLIN,
-            revents & libc::POLLERR,
-        );
-
+    let mut runtime = Runtime::new(stream, file);
+    runtime.run(|uffd_handler: &mut UffdPfHandler| {
         // Read an event from the userfaultfd.
         let event = uffd_handler
             .uffd
@@ -53,15 +41,13 @@ fn main() {
         // We expect to receive either a Page Fault or Removed
         // event (if the balloon device is enabled).
         match event {
-            userfaultfd::Event::Pagefault { addr, .. } => {
-                uffd_handler.serve_pf(addr as *mut u8, len)
-            }
+            userfaultfd::Event::Pagefault { addr, .. } => uffd_handler.serve_pf(addr.cast(), len),
             userfaultfd::Event::Remove { start, end } => uffd_handler.update_mem_state_mappings(
-                start as *mut u8 as u64,
-                end as *mut u8 as u64,
+                start as u64,
+                end as u64,
                 &MemPageState::Removed,
             ),
             _ => panic!("Unexpected event on userfaultfd"),
         }
-    }
+    });
 }

--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -23,6 +23,7 @@ def test_unittests(test_fc_session_root_path):
 
     extra_args = f"--target {TARGET}"
     host.cargo_test(test_fc_session_root_path, extra_args=extra_args)
+    host.cargo_test(test_fc_session_root_path, extra_args=extra_args + " --examples")
 
 
 def test_benchmarks_compile():


### PR DESCRIPTION
## Changes
Update to uffd handler used in tests to handle multiple uffd objects send through the UDS. This upgrade is needed for supporting snapshot restore with vhost-used devices. During restoration process FC will ask vhost-user devices to give it their uffds and then send them to global uffd handler.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
