### PR TITLE
test: Add unit test for installing resource limits

### DIFF
--- a/src/jailer/src/resource_limits.rs
+++ b/src/jailer/src/resource_limits.rs
@@ -187,4 +187,42 @@ mod tests {
         assert_eq!(rlim.rlim_cur, new_limit);
         assert_eq!(rlim.rlim_max, new_limit);
     }
+
+    #[test]
+    fn test_install() {
+        // Setup the resource limits
+        let mut rlimits = ResourceLimits::default();
+        let new_limit = 100;
+        rlimits.set_file_size(new_limit);
+        rlimits.set_no_file(new_limit);
+        
+        // Install the new limits to file size and 
+        // the number of file descriptors
+        let result = rlimits.install();
+        assert_eq!(result.unwrap(), ());
+    
+        // Verify the new limit for file size
+        let file_size_resource = Resource::RlimitFsize;
+        let mut file_size_limit: libc::rlimit = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        unsafe { 
+            libc::getrlimit(file_size_resource.into(), &mut file_size_limit) 
+        };
+        assert_eq!(file_size_limit.rlim_cur, new_limit);
+        assert_eq!(file_size_limit.rlim_max, new_limit);
+
+        // Verify the new limit for the number of file descriptors
+        let file_descriptor_resource = Resource::RlimitNoFile;
+        let mut file_descriptor_limit: libc::rlimit = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        unsafe { 
+            libc::getrlimit(file_descriptor_resource.into(), &mut file_descriptor_limit) 
+        };
+        assert_eq!(file_descriptor_limit.rlim_cur, new_limit);
+        assert_eq!(file_descriptor_limit.rlim_max, new_limit);
+    }
 }

--- a/src/jailer/src/resource_limits.rs
+++ b/src/jailer/src/resource_limits.rs
@@ -192,9 +192,10 @@ mod tests {
     fn test_install() {
         // Setup the resource limits
         let mut rlimits = ResourceLimits::default();
-        let new_limit = 100;
-        rlimits.set_file_size(new_limit);
-        rlimits.set_no_file(new_limit);
+        let new_file_size_limit = 2097151;
+        let new_no_file_limit = 100;
+        rlimits.set_file_size(new_file_size_limit);
+        rlimits.set_no_file(new_no_file_limit);
 
         // Install the new limits to file size and
         // the number of file descriptors
@@ -207,8 +208,8 @@ mod tests {
             rlim_max: 0,
         };
         unsafe { libc::getrlimit(file_size_resource.into(), &mut file_size_limit) };
-        assert_eq!(file_size_limit.rlim_cur, new_limit);
-        assert_eq!(file_size_limit.rlim_max, new_limit);
+        assert_eq!(file_size_limit.rlim_cur, new_file_size_limit);
+        assert_eq!(file_size_limit.rlim_max, new_file_size_limit);
 
         // Verify the new limit for the number of file descriptors
         let file_descriptor_resource = Resource::RlimitNoFile;
@@ -217,7 +218,7 @@ mod tests {
             rlim_max: 0,
         };
         unsafe { libc::getrlimit(file_descriptor_resource.into(), &mut file_descriptor_limit) };
-        assert_eq!(file_descriptor_limit.rlim_cur, new_limit);
-        assert_eq!(file_descriptor_limit.rlim_max, new_limit);
+        assert_eq!(file_descriptor_limit.rlim_cur, new_no_file_limit);
+        assert_eq!(file_descriptor_limit.rlim_max, new_no_file_limit);
     }
 }

--- a/src/jailer/src/resource_limits.rs
+++ b/src/jailer/src/resource_limits.rs
@@ -195,21 +195,18 @@ mod tests {
         let new_limit = 100;
         rlimits.set_file_size(new_limit);
         rlimits.set_no_file(new_limit);
-        
-        // Install the new limits to file size and 
+
+        // Install the new limits to file size and
         // the number of file descriptors
-        let result = rlimits.install();
-        assert_eq!(result.unwrap(), ());
-    
+        rlimits.install().unwrap();
+
         // Verify the new limit for file size
         let file_size_resource = Resource::RlimitFsize;
         let mut file_size_limit: libc::rlimit = libc::rlimit {
             rlim_cur: 0,
             rlim_max: 0,
         };
-        unsafe { 
-            libc::getrlimit(file_size_resource.into(), &mut file_size_limit) 
-        };
+        unsafe { libc::getrlimit(file_size_resource.into(), &mut file_size_limit) };
         assert_eq!(file_size_limit.rlim_cur, new_limit);
         assert_eq!(file_size_limit.rlim_max, new_limit);
 
@@ -219,9 +216,7 @@ mod tests {
             rlim_cur: 0,
             rlim_max: 0,
         };
-        unsafe { 
-            libc::getrlimit(file_descriptor_resource.into(), &mut file_descriptor_limit) 
-        };
+        unsafe { libc::getrlimit(file_descriptor_resource.into(), &mut file_descriptor_limit) };
         assert_eq!(file_descriptor_limit.rlim_cur, new_limit);
         assert_eq!(file_descriptor_limit.rlim_max, new_limit);
     }


### PR DESCRIPTION
This change adds unit test for verifying that the resource limits for file size and the number of file descriptors has been set properly.

## Changes

Minor change to add a unit test for installing the ResourceLimits for file size and the number of file descriptors.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [N/A] If a specific issue led to this PR, this PR closes the issue.
- [X] The description of changes is clear and encompassing.
- [N/A] Any required documentation changes (code and docs) are included in this PR.
- [N/A] API changes follow the [Runbook for Firecracker API changes][2].
- [N/A] User-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.
- [N/A] New `TODO`s link to an issue.
- [X] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
