### PR TITLE
Reset dirty log on full snapshot path

### DIFF
--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -249,7 +249,13 @@ fn snapshot_memory_to_file(
                 .dump_dirty(&mut file, &dirty_bitmap)
                 .map_err(Memory)
         }
-        SnapshotType::Full => vmm.guest_memory().dump(&mut file).map_err(Memory),
+        SnapshotType::Full => {
+            let dirty_bitmap = vmm.get_dirty_bitmap().map_err(DirtyBitmap)?;
+            vmm.guest_memory()
+                .dump_dirty(&mut file, &dirty_bitmap)
+                .map_err(Memory)
+        }
+
     }?;
     file.flush()
         .map_err(|err| MemoryBackingFile("flush", err))?;


### PR DESCRIPTION
## Changes

- Added the `get_dirty_bitmap` on the full snapshot path

## Reason

- The full snapshot path doesn’t call `Vmm:get_dirty_bitmap` thus doesn’t call `KVM_GET_DIRTY_LOG` which doesn’t reset dirty pages.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
