### PR TITLE
Fix duplicated attach_pid and create_dir_all on cgroup v2

### DIFF
--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -15,7 +15,7 @@ use utils::arg_parser::Error::MissingValue;
 use utils::syscall::SyscallReturnCode;
 use utils::{arg_parser, validators};
 
-use crate::cgroup::{Cgroup, CgroupBuilder};
+use crate::cgroup::{CgroupConfiguration, CgroupConfigurationBuilder};
 use crate::chroot::chroot;
 use crate::resource_limits::{ResourceLimits, FSIZE_ARG, NO_FILE_ARG};
 use crate::JailerError;
@@ -128,7 +128,7 @@ pub struct Env {
     start_time_cpu_us: u64,
     jailer_cpu_time_us: u64,
     extra_args: Vec<String>,
-    cgroups: Vec<Box<dyn Cgroup>>,
+    cgroup_conf: CgroupConfiguration,
     resource_limits: ResourceLimits,
     uffd_dev_minor: Option<u32>,
 }
@@ -147,14 +147,7 @@ impl fmt::Debug for Env {
             .field("start_time_us", &self.start_time_us)
             .field("jailer_cpu_time_us", &self.jailer_cpu_time_us)
             .field("extra_args", &self.extra_args)
-            .field(
-                "cgroups",
-                &self
-                    .cgroups
-                    .iter()
-                    .map(|b| b as *const _)
-                    .collect::<Vec<_>>(),
-            )
+            .field("cgroups", &self.cgroup_conf)
             .field("resource_limits", &self.resource_limits)
             .finish()
     }
@@ -214,7 +207,7 @@ impl Env {
         let new_pid_ns = arguments.flag_present("new-pid-ns");
 
         // Optional arguments.
-        let mut cgroups: Vec<Box<dyn Cgroup>> = Vec::new();
+        let mut cgroup_conf = CgroupConfiguration::None;
         let parent_cgroup = match arguments.single_value("parent-cgroup") {
             Some(parent_cg) => Path::new(parent_cg),
             None => Path::new(&exec_file_name),
@@ -239,7 +232,7 @@ impl Env {
         // then the intent is to move the process to that cgroup.
         // Only applies to cgroupsv2 since it's a unified hierarchy
         if cgroups_args.is_empty() && cgroup_ver == 2 {
-            let mut builder = CgroupBuilder::new(cgroup_ver)?;
+            let mut builder = CgroupConfigurationBuilder::new(cgroup_ver)?;
             let cg_parent = builder.get_v2_hierarchy_path()?.join(parent_cgroup);
             let cg_parent_procs = cg_parent.join("cgroup.procs");
             if cg_parent.exists() {
@@ -250,7 +243,7 @@ impl Env {
 
         // cgroup format: <cgroup_controller>.<cgroup_property>=<value>,...
         if let Some(cgroups_args) = arguments.multiple_values("cgroup") {
-            let mut builder = CgroupBuilder::new(cgroup_ver)?;
+            let mut builder = CgroupConfigurationBuilder::new(cgroup_ver)?;
             for cg in cgroups_args {
                 let aux: Vec<&str> = cg.split('=').collect();
                 if aux.len() != 2 || aux[1].is_empty() {
@@ -263,14 +256,14 @@ impl Env {
                     return Err(JailerError::CgroupInvalidFile(cg.to_string()));
                 }
 
-                let cgroup = builder.new_cgroup(
+                builder.add_cgroup_property(
                     aux[0].to_string(), // cgroup file
                     aux[1].to_string(), // cgroup value
                     id,
                     parent_cgroup,
                 )?;
-                cgroups.push(cgroup);
             }
+            cgroup_conf = builder.build();
         }
 
         let mut resource_limits = ResourceLimits::default();
@@ -293,7 +286,7 @@ impl Env {
             start_time_cpu_us,
             jailer_cpu_time_us: 0,
             extra_args: arguments.extra_args(),
-            cgroups,
+            cgroup_conf,
             resource_limits,
             uffd_dev_minor,
         })
@@ -615,17 +608,11 @@ impl Env {
         self.resource_limits.install()?;
 
         // We have to setup cgroups at this point, because we can't do it anymore after chrooting.
-        // cgroups are iterated two times as some cgroups may require others (e.g cpuset requires
-        // cpuset.mems and cpuset.cpus) to be set before attaching any pid.
-        for cgroup in &self.cgroups {
-            // it will panic if any cgroup fails to write
-            cgroup.write_value().unwrap();
-        }
-
-        for cgroup in &self.cgroups {
-            // it will panic if any cgroup fails to attach
-            cgroup.attach_pid().unwrap();
-        }
+        match self.cgroup_conf {
+            CgroupConfiguration::V1(ref c) => c.setup()?,
+            CgroupConfiguration::V2(ref c) => c.setup()?,
+            CgroupConfiguration::None => (),
+        };
 
         // If daemonization was requested, open /dev/null before chrooting.
         let dev_null = if self.daemonize {

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -547,6 +547,8 @@ class Microvm:
             node = str(self._numa_node)
             cmd = ["numactl", "-N", node, "-m", node] + cmd
 
+        cmd = ["strace", "-tt", "--syscall-times=ns", "-y", "-e", "write,mkdir", "-o", "strace.out"] + cmd
+
         # When the daemonize flag is on, we want to clone-exec into the
         # jailer rather than executing it via spawning a shell.
         if self.jailer.daemonize:

--- a/tests/integration_tests/test_FC-DEV-1362.py
+++ b/tests/integration_tests/test_FC-DEV-1362.py
@@ -1,0 +1,84 @@
+import subprocess
+from pathlib import Path
+
+from integration_tests.security.test_jail import cgroups_info
+from framework.microvm_helpers import docker_apt_install
+
+
+def get_numa_cpus(node):
+    """Retrieve CPUs from NUMA node."""
+    node_dir = Path(f"/sys/devices/system/node/node{node}")
+    assert node_dir.is_dir()
+    node_cpus = node_dir / "cpulist"
+    return node_cpus.read_text().strip()
+
+
+def test_FC_DEV_1362(uvm_plain, cgroups_info):
+    """
+    https://sim.amazon.com/issues/FC-DEV-1903
+
+    ./tools/devtool test_debug integration_tests/test_FC-DEV-1362.py
+
+    Test that we only write to cgroup.procs once instead of once per --cgroup parameter.
+
+22:27:30.417558 write(3</sys/fs/cgroup/custom_cgroup/group2/9d1e4709-5789-4092-bc4b-f5b0a9169a86/cpuset.cpus>, "0-7\n", 4) = 4 <0.000012578>
+22:27:30.417649 write(3</sys/fs/cgroup/custom_cgroup/group2/9d1e4709-5789-4092-bc4b-f5b0a9169a86/cgroup.procs>, "76\n", 3) = 3 <0.023667513>
+22:27:30.441467 write(3</sys/fs/cgroup/custom_cgroup/group2/9d1e4709-5789-4092-bc4b-f5b0a9169a86/cgroup.procs>, "76\n", 3) = 3 <0.000011930>
+22:27:30.441615 write(3</sys/fs/cgroup/custom_cgroup/group2/9d1e4709-5789-4092-bc4b-f5b0a9169a86/cgroup.procs>, "76\n", 3) = 3 <0.000008260>
+    """
+
+    docker_apt_install("inotify-tools")
+
+    uvm = uvm_plain
+    uvm.jailer.cgroup_ver = cgroups_info.version
+    parent_cgroup = "custom_cgroup/group2"
+    uvm.jailer.parent_cgroup = parent_cgroup
+    cgroups_info.new_cgroup(parent_cgroup)
+    cgroups_info.new_cgroup(f"{parent_cgroup}/{uvm.id}")
+    Path("inot.log").unlink(missing_ok=True)
+    inot = subprocess.Popen("inotifywait -m -r -o inot.log /sys/fs/cgroup", shell=True)
+
+    cgroups = {
+        "cpuset.cpus": get_numa_cpus(0),
+        "cpu.weight": 2,
+        "memory.max": 256*2**20,
+        "memory.min": 1*2**20,
+    }
+    uvm.jailer.cgroups = [f"{k}={v}" for k, v in cgroups.items()]
+    uvm.spawn()
+    uvm.basic_config()
+    uvm.add_net_iface()
+    uvm.start()
+    strace_out = Path("strace.out").read_text().splitlines()
+    write_lines = [
+        line for line in strace_out
+        if "write" in line
+        and f"{uvm.id}/cgroup.procs" in line
+    ]
+    mkdir_lines = [
+        line for line in strace_out
+        if "mkdir" in line
+        and f"{parent_cgroup}/{uvm.id}" in line
+    ]
+    assert len(write_lines) != len(cgroups), "writes equal to number of cgroups"
+    assert len(write_lines) == 1
+    assert len(mkdir_lines) != len(cgroups), "mkdir equal to number of cgroups"
+    assert len(mkdir_lines) == 1
+
+
+
+"""
+    docker_apt_install("inotify-tools")
+inot = subprocess.Popen(
+    "inotifywait -m -r -o inot.log /sys/fs/cgroup",
+    shell=True,
+)
+    Path("inot.log").unlink()
+
+
+    dev_full = Path(uvm.chroot()) / "full"
+    os.mknod(dev_full, mode=0o666|stat.S_IFCHR, device=os.makedev(1, 7))
+    dev_full.chmod(0o666)
+    os.chown(dev_full, 1234, 1234)
+
+"""


### PR DESCRIPTION
## Changes
Ref
Duplicated attach_pid and create_dir_all on cgroup v2

## Reason
https://github.com/firecracker-microvm/firecracker/issues/2856

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
