### PR TITLE
Reset dirty log on full snapshot path

### DIFF
--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -249,7 +249,10 @@ fn snapshot_memory_to_file(
                 .dump_dirty(&mut file, &dirty_bitmap)
                 .map_err(Memory)
         }
-        SnapshotType::Full => vmm.guest_memory().dump(&mut file).map_err(Memory),
+        SnapshotType::Full => {
+            let _ = vmm.get_dirty_bitmap().map_err(DirtyBitmap)?;
+            vmm.guest_memory().dump(&mut file).map_err(Memory)
+        }
     }?;
     file.flush()
         .map_err(|err| MemoryBackingFile("flush", err))?;

--- a/tests/integration_tests/functional/test_dirty_pages_in_full_snapshot.py
+++ b/tests/integration_tests/functional/test_dirty_pages_in_full_snapshot.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test scenario for reseting dirty pages after making a full snapshot."""
+
+
+def test_dirty_pages_after_full_snapshot(uvm_plain):
+    """
+    Test if dirty pages are erased after making a full snapshot of a VM
+    """
+
+    vm_mem_size = 128
+    uvm = uvm_plain
+    uvm.spawn()
+    uvm.basic_config(mem_size_mib=vm_mem_size, track_dirty_pages=True)
+    uvm.add_net_iface()
+    uvm.start()
+    uvm.ssh.run("true")
+
+    snap_full = uvm.snapshot_full(vmstate_path="vmstate_full", mem_path="mem_full")
+    snap_diff = uvm.snapshot_diff(vmstate_path="vmstate_diff", mem_path="mem_diff")
+    snap_diff2 = uvm.snapshot_diff(vmstate_path="vmstate_diff2", mem_path="mem_diff2")
+
+    # file size is the same, but the `diff` snapshot is actually a sparse file
+    assert snap_full.mem.stat().st_size == snap_diff.mem.stat().st_size
+
+    # diff -> diff there should be no differences
+    assert snap_diff2.mem.stat().st_blocks == 0
+
+    # full -> diff there should be no differences
+    assert snap_diff.mem.stat().st_blocks == 0


### PR DESCRIPTION
## Changes

* Added the `get_dirty_bitmap` on the full snapshot path


## Reason

* The full snapshot path doesn’t call `Vmm:get_dirty_bitmap` thus doesn’t call
`KVM_GET_DIRTY_LOG` which doesn’t reset dirty pages.

Closes #4543.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the
Apache 2.0 license. For more information on following Developer Certificate of Origin and signing
off your commits, please check
[`CONTRIBUTING.md`](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md).
## PR Checklist

* [ ]  If a specific issue led to this PR, this PR closes the issue.                                                                                                                                                                                                                      

* [ ]  The description of changes is clear and encompassing.

* [ ]  Any required documentation changes (code and docs) are included in this PR. 

* [ ]  API changes follow the [Runbook for Firecracker API 
changes](https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md).

* [ ]  User-facing changes are mentioned in `CHANGELOG.md`.

* [ ]  All added/changed functionality is tested.

* [ ]  New `TODO`s link to an issue.

* [ ]  Commits meet [contribution quality
standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).


* [ ]  This functionality cannot be added in [`rust-vmm`](https://github.com/rust-vmm).
