### PR TITLE
fix(net): Apply only supported TAP offloading features

### DIFF
--- a/src/vmm/src/devices/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/mod.rs
@@ -10,6 +10,8 @@
 use std::any::Any;
 use std::io::Error as IOError;
 
+use crate::devices::virtio::net::TapError;
+
 pub mod balloon;
 pub mod block_common;
 pub mod device;
@@ -68,6 +70,8 @@ pub enum ActivateError {
     BadActivate,
     /// Vhost user: {0}
     VhostUser(vhost_user::VhostUserError),
+    /// Setting tap interface offload flags failed: {0}
+    TapSetOffload(TapError),
 }
 
 /// Trait that helps in upcasting an object to Any

--- a/src/vmm/src/devices/virtio/net/mod.rs
+++ b/src/vmm/src/devices/virtio/net/mod.rs
@@ -45,8 +45,6 @@ pub enum NetQueue {
 pub enum NetError {
     /// Open tap device failed: {0}
     TapOpen(TapError),
-    /// Setting tap interface offload flags failed: {0}
-    TapSetOffload(TapError),
     /// Setting vnet header size failed: {0}
     TapSetVnetHdrSize(TapError),
     /// EventFd error: {0}


### PR DESCRIPTION
## Changes
Checking what offload features are supported by virtio driver and apply only them to TAP device
...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x ] If a specific issue led to this PR, this PR closes the issue.
- [x ] The description of changes is clear and encompassing.
- [ x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
