### PR TITLE
Fix: Add library target to src/firecracker crate

### DIFF
--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -12,6 +12,9 @@ license = "Apache-2.0"
 name = "firecracker"
 bench = false
 
+[lib]
+bench = false
+
 [dependencies]
 displaydoc = "0.2.4"
 event-manager = "0.4.0"

--- a/src/firecracker/src/api_server/mod.rs
+++ b/src/firecracker/src/api_server/mod.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(missing_docs)]
-
 //! Implements the interface for intercepting API requests, forwarding them to the VMM
 //! and responding to the user.
 //! It is constructed on top of an HTTP Server that uses Unix Domain Sockets and `EPOLL` to

--- a/src/firecracker/src/lib.rs
+++ b/src/firecracker/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod api_server;


### PR DESCRIPTION
Since #4377, the firecracker crate contains library code that specific tests expect to be able to `use`, however it was only a binary target so far. Add a library target that exposes the library components of the crate that now exists.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
