### PR TITLE
ci(perf/net_latency): increase absolute delta threshold to 10us

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -28,6 +28,8 @@ perf_test = {
         "label": "📠 Network Latency",
         "test_path": "integration_tests/performance/test_network_ab.py::test_network_latency",
         "devtool_opts": "-c 1-10 -m 0",
+        # Triggers if delta is > 0.01ms (10µs) or default relative threshold (5%)
+        "ab_opts": "--absolute-strength 0.010",
     },
     "network-throughput": {
         "label": "📠 Network TCP Throughput",

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -211,7 +211,7 @@ def analyze_data(processed_emf_a, processed_emf_b, *, n_resamples: int = 9999):
 
 
 def ab_performance_test(
-    a_revision, b_revision, test, p_thresh, strength_thresh, noise_threshold
+    a_revision, b_revision, test, p_thresh, strength_abs_thresh, noise_threshold
 ):
     """Does an A/B-test of the specified test across the given revisions"""
     _, commit_list, _ = utils.run_cmd(
@@ -279,10 +279,7 @@ def ab_performance_test(
             relative_changes_by_metric[metric] = []
         relative_changes_by_metric[metric].append(result.statistic / baseline_mean)
 
-        if (
-            result.pvalue < p_thresh
-            and abs(result.statistic) > baseline_mean * strength_thresh
-        ):
+        if result.pvalue < p_thresh and abs(result.statistic) > strength_abs_thresh:
             failures.append((dimension_set, metric, result, unit))
 
     messages = []
@@ -351,8 +348,8 @@ if __name__ == "__main__":
         default=0.01,
     )
     parser.add_argument(
-        "--relative-strength",
-        help="The minimal delta required before a regression will be considered valid",
+        "--absolute-strength",
+        help="The minimum absolute delta required before a regression will be considered valid",
         type=float,
         default=0.0,
     )


### PR DESCRIPTION
In some instances we see AB tests failing with very small deltas:

    A/B-testing shows a change of 1.75μs, or 5.46%, (from 32.08μs to 33.83μs) for metric ping_latency

In Graviton instances the 5% default threshold is too narrow since, and we get false positives like the one above, that are mostly due to noise.

Set the absolute delta threshold for network latency test to 10us, which is chosen arbitrarily but should reduce the number of false positives.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
