### PR TITLE
test: add a test to check for nested virtualization

### DIFF
--- a/.buildkite/pipeline_cpu_template.py
+++ b/.buildkite/pipeline_cpu_template.py
@@ -56,14 +56,6 @@ cpu_template_test = {
         },
         "instances": ["m5d.metal", "m6i.metal", "m6a.metal"],
     },
-    "aarch64_cpu_templates": {
-        BkStep.COMMAND: [
-            "tools/devtool -y test -- -s -ra -m nonci --log-cli-level=INFO integration_tests/functional/test_cpu_features_aarch64.py"
-        ],
-        BkStep.LABEL: "📖 cpu templates",
-        "instances": ["m6g.metal", "c7g.metal"],
-        "platforms": [("al2023", "linux_6.1")],
-    },
     "fingerprint": {
         BkStep.COMMAND: [
             "tools/devtool -y test -- -m no_block_pr integration_tests/functional/test_cpu_template_helper.py -k test_guest_cpu_config_change",
@@ -171,8 +163,6 @@ def main():
         test_group = group_single(cpu_template_test[test_args.test])
     elif test_args.test == "cpuid_wrmsr":
         test_group = group_snapshot_restore(cpu_template_test[test_args.test])
-    elif test_args.test == "aarch64_cpu_templates":
-        test_group = group_single(cpu_template_test[test_args.test])
     elif test_args.test == "fingerprint":
         test_group = group_single(cpu_template_test[test_args.test])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,6 +293,18 @@ def custom_cpu_template(request, record_property):
     return request.param
 
 
+@pytest.fixture(
+    params=list(static_cpu_templates_params()) + list(custom_cpu_templates_params())
+)
+def cpu_template_any(request, record_property):
+    """This fixture combines static and custom CPU templates"""
+    if "name" in request.param:
+        record_property("custom_cpu_template", request.param["name"])
+    else:
+        record_property("static_cpu_template", request.param)
+    return request.param
+
+
 @pytest.fixture(params=["Sync", "Async"])
 def io_engine(request):
     """All supported io_engines"""

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -96,6 +96,11 @@ class GlobalProps:
             self.ami = "NA"
 
     @property
+    def host_linux_version_tpl(self):
+        """Host Linux version major.minor, as a tuple for easy comparison"""
+        return tuple(int(x) for x in self.host_linux_version.split("."))
+
+    @property
     def is_ec2(self):
         """Are we running on an EC2 instance?"""
         return self.environment == "ec2"

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -18,7 +18,6 @@ import host_tools.drive as drive_tools
 import host_tools.network as net_tools
 from framework import utils_cpuid
 from framework.utils import get_firecracker_version_from_toml, is_io_uring_supported
-from framework.utils_cpu_templates import nonci_on_arm
 
 MEM_LIMIT = 1000000000
 
@@ -462,7 +461,6 @@ def test_negative_machine_config_api(test_microvm_with_api):
     )
 
 
-@nonci_on_arm
 def test_api_cpu_config(test_microvm_with_api, custom_cpu_template):
     """
     Test /cpu-config PUT scenarios.

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -8,7 +8,6 @@ import re
 import pytest
 
 import framework.utils_cpuid as cpuid_utils
-from framework.utils_cpu_templates import nonci_on_arm
 from framework.utils_cpuid import CpuModel
 
 PLATFORM = platform.machine()
@@ -94,7 +93,6 @@ def test_default_cpu_features(microvm_factory, guest_kernel, rootfs_ubuntu_22):
     PLATFORM != "aarch64",
     reason="This is aarch64 specific test.",
 )
-@nonci_on_arm
 def test_cpu_features_with_static_template(
     microvm_factory, guest_kernel, rootfs_ubuntu_22, cpu_template
 ):
@@ -115,7 +113,6 @@ def test_cpu_features_with_static_template(
     PLATFORM != "aarch64",
     reason="This is aarch64 specific test.",
 )
-@nonci_on_arm
 def test_cpu_features_with_custom_template(
     microvm_factory, guest_kernel, rootfs_ubuntu_22, custom_cpu_template
 ):

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -412,6 +412,8 @@ def test_json_static_templates(
     """
     Verify that JSON static CPU templates are applied as intended.
     """
+    if custom_cpu_template["name"] == "aarch64_with_sve_and_pac":
+        pytest.skip("does not work yet")
     # Generate VM config with JSON static CPU template
     microvm = test_microvm_with_api
     microvm.spawn()

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -11,7 +11,6 @@ import pytest
 from framework import utils
 from framework.defs import SUPPORTED_HOST_KERNELS
 from framework.properties import global_props
-from framework.utils_cpu_templates import nonci_on_arm
 from framework.utils_cpuid import get_guest_cpuid
 from host_tools import cargo_build
 
@@ -405,7 +404,6 @@ def test_guest_cpu_config_change(
     )
 
 
-@nonci_on_arm
 def test_json_static_templates(
     test_microvm_with_api, cpu_template_helper, tmp_path, custom_cpu_template
 ):

--- a/tests/integration_tests/security/test_nv.py
+++ b/tests/integration_tests/security/test_nv.py
@@ -1,0 +1,48 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests ensuring nested virtualization is not present when using CPU templates.
+
+We have tests that ensure CPU templates provide a consistent set of features in
+the guest:
+
+- file:../functional/test_cpu_features.py
+- file:../functional/test_feat_parity.py
+- Commit: 681e781f999e3390b6d46422a3c7b1a7e36e1b24
+
+These already include the absence of VMX/SVM in the guest.
+
+This test is a safety-net to make the test explicit and catch cases where we
+start providing the feature by mistake.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def uvm_with_cpu_template(
+    microvm_factory, guest_kernel, rootfs_ubuntu_22, cpu_template_any
+):
+    """A microvm fixture parametrized with all possible templates"""
+    vm = microvm_factory.build(guest_kernel, rootfs_ubuntu_22)
+    vm.spawn()
+    cpu_template = None
+    if isinstance(cpu_template_any, str):
+        cpu_template = cpu_template_any
+    vm.basic_config(cpu_template=cpu_template)
+    if cpu_template is None:
+        vm.api.cpu_config.put(**cpu_template_any["template"])
+    vm.add_net_iface()
+    vm.start()
+    yield vm
+
+
+def test_no_nv_when_using_cpu_templates(uvm_with_cpu_template):
+    """
+    Double-check that guests using CPU templates don't have Nested Virtualization
+    enabled.
+    """
+
+    vm = uvm_with_cpu_template
+    rc, _, _ = vm.ssh.run("[ ! -e /dev/kvm ]")
+    assert rc == 0, "/dev/kvm exists"

--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -35,6 +35,6 @@ def test_cargo_audit():
         )
 
     git_ab_test_host_command_if_pr(
-        "cargo audit --deny warnings -q --json",
+        "cargo audit --deny warnings -q --json |grep -Po '{.*}'",
         comparator=set_did_not_grow_comparator(set_of_vulnerabilities),
     )

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -365,11 +365,16 @@ def test_spectre_meltdown_checker_on_restored_guest_with_template(
 )
 @nonci_on_arm
 def test_spectre_meltdown_checker_on_restored_guest_with_custom_template(
-    spectre_meltdown_checker, build_microvm_with_custom_template, microvm_factory
+    spectre_meltdown_checker,
+    build_microvm_with_custom_template,
+    microvm_factory,
+    custom_cpu_template,
 ):
     """
     Test with the spectre / meltdown checker on a restored guest with a custom CPU template.
     """
+    if custom_cpu_template["name"] == "aarch64_with_sve_and_pac":
+        pytest.skip("does not work yet")
     git_ab_test_guest_command_if_pr(
         with_checker(
             with_restore(build_microvm_with_custom_template, microvm_factory),
@@ -533,11 +538,13 @@ def test_vulnerabilities_files_on_restored_guest_with_template(
 
 @nonci_on_arm
 def test_vulnerabilities_files_on_restored_guest_with_custom_template(
-    build_microvm_with_custom_template, microvm_factory
+    build_microvm_with_custom_template, microvm_factory, custom_cpu_template
 ):
     """
     Test vulnerabilities files on a restored guest with a custom CPU template.
     """
+    if custom_cpu_template["name"] == "aarch64_with_sve_and_pac":
+        pytest.skip("does not work yet")
     check_vulnerabilities_files_ab(
         with_restore(build_microvm_with_custom_template, microvm_factory)
     )

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -20,7 +20,6 @@ from framework.ab_test import (
 )
 from framework.properties import global_props
 from framework.utils import CommandReturn
-from framework.utils_cpu_templates import nonci_on_arm
 
 CHECKER_URL = "https://meltdown.ovh"
 CHECKER_FILENAME = "spectre-meltdown-checker.sh"
@@ -299,7 +298,6 @@ def test_spectre_meltdown_checker_on_restored_guest(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@nonci_on_arm
 def test_spectre_meltdown_checker_on_guest_with_template(
     spectre_meltdown_checker, build_microvm_with_template
 ):
@@ -320,7 +318,6 @@ def test_spectre_meltdown_checker_on_guest_with_template(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@nonci_on_arm
 def test_spectre_meltdown_checker_on_guest_with_custom_template(
     spectre_meltdown_checker, build_microvm_with_custom_template
 ):
@@ -340,7 +337,6 @@ def test_spectre_meltdown_checker_on_guest_with_custom_template(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@nonci_on_arm
 def test_spectre_meltdown_checker_on_restored_guest_with_template(
     spectre_meltdown_checker, build_microvm_with_template, microvm_factory
 ):
@@ -363,7 +359,6 @@ def test_spectre_meltdown_checker_on_restored_guest_with_template(
     global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
     reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
 )
-@nonci_on_arm
 def test_spectre_meltdown_checker_on_restored_guest_with_custom_template(
     spectre_meltdown_checker,
     build_microvm_with_custom_template,
@@ -506,7 +501,6 @@ def test_vulnerabilities_files_on_restored_guest(build_microvm, microvm_factory)
     check_vulnerabilities_files_ab(with_restore(build_microvm, microvm_factory))
 
 
-@nonci_on_arm
 def test_vulnerabilities_files_on_guest_with_template(build_microvm_with_template):
     """
     Test vulnerabilities files on guest with CPU template.
@@ -514,7 +508,6 @@ def test_vulnerabilities_files_on_guest_with_template(build_microvm_with_templat
     check_vulnerabilities_files_ab(build_microvm_with_template)
 
 
-@nonci_on_arm
 def test_vulnerabilities_files_on_guest_with_custom_template(
     build_microvm_with_custom_template,
 ):
@@ -524,7 +517,6 @@ def test_vulnerabilities_files_on_guest_with_custom_template(
     check_vulnerabilities_files_ab(build_microvm_with_custom_template)
 
 
-@nonci_on_arm
 def test_vulnerabilities_files_on_restored_guest_with_template(
     build_microvm_with_template, microvm_factory
 ):
@@ -536,7 +528,6 @@ def test_vulnerabilities_files_on_restored_guest_with_template(
     )
 
 
-@nonci_on_arm
 def test_vulnerabilities_files_on_restored_guest_with_custom_template(
     build_microvm_with_custom_template, microvm_factory, custom_cpu_template
 ):


### PR DESCRIPTION
Check that nested virtualization is disabled in all our CPU templates.

Other tests already check for CPU features explicitly, but this test just checks that virtualization is not available to the guest, however the means.

## Changes

[rev3] 
- Added `fix: test_sec_audit`. The test has failed 3 times in this PR, so I am including it even though it is unrelated.
- Disabled some tests that don't pass. This is OK because the tests are completely disabled at the moment, so at least we enable the ones that pass. We will follow up on the 3 failing ones.

### How tested

https://buildkite.com/firecracker/firecracker-pr/builds/8665#018d3caa-7488-44ee-a123-ea76ca15f318/55-278

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
