### PR TITLE
chore: Upload FCMetrics with reduced dimensions

### DIFF
--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -16,6 +16,9 @@ from threading import Thread
 import jsonschema
 import pytest
 
+from framework.properties import global_props
+from host_tools.metrics import get_metrics_logger
+
 
 def validate_fc_metrics(metrics):
     """
@@ -434,7 +437,7 @@ class FCMetricsMonitor(Thread):
     of the metrics.
     """
 
-    def __init__(self, vm, metrics_logger, timer=60):
+    def __init__(self, vm, timer=60):
         Thread.__init__(self, daemon=True)
         self.vm = vm
         self.timer = timer
@@ -442,7 +445,14 @@ class FCMetricsMonitor(Thread):
         self.metrics_index = 0
         self.running = False
 
-        self.metrics_logger = metrics_logger
+        self.metrics_logger = get_metrics_logger()
+        self.metrics_logger.set_dimensions(
+            {
+                "instance": global_props.instance,
+                "host_kernel": "linux-" + global_props.host_linux_version,
+                "guest_kernel": vm.kernel_file.stem[2:],
+            }
+        )
 
     def _flush_metrics(self):
         """

--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -176,7 +176,7 @@ def test_block_performance(
             **vm.dimensions,
         }
     )
-    fcmetrics = FCMetricsMonitor(vm, metrics)
+    fcmetrics = FCMetricsMonitor(vm)
     fcmetrics.start()
 
     vm.pin_threads(0)
@@ -227,7 +227,7 @@ def test_block_vhost_user_performance(
             **vm.dimensions,
         }
     )
-    fcmetrics = FCMetricsMonitor(vm, metrics)
+    fcmetrics = FCMetricsMonitor(vm)
     fcmetrics.start()
 
     next_cpu = vm.pin_threads(0)

--- a/tests/integration_tests/performance/test_memory_overhead.py
+++ b/tests/integration_tests/performance/test_memory_overhead.py
@@ -47,7 +47,7 @@ def test_memory_overhead(
         metrics.set_dimensions(
             {"performance_test": "test_memory_overhead", **microvm.dimensions}
         )
-        fcmetrics = FCMetricsMonitor(microvm, metrics)
+        fcmetrics = FCMetricsMonitor(microvm)
         fcmetrics.start()
 
         # check that the vm is running

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -83,7 +83,7 @@ def test_network_latency(network_microvm, metrics, iteration):
             "iteration": str(iteration),
         }
     )
-    fcmetrics = FCMetricsMonitor(network_microvm, metrics)
+    fcmetrics = FCMetricsMonitor(network_microvm)
     fcmetrics.start()
 
     samples = []
@@ -160,7 +160,7 @@ def test_network_tcp_throughput(
             **network_microvm.dimensions,
         }
     )
-    fcmetrics = FCMetricsMonitor(network_microvm, metrics)
+    fcmetrics = FCMetricsMonitor(network_microvm)
     fcmetrics.start()
 
     test = TcpIPerf3Test(

--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -77,12 +77,15 @@ class SnapshotRestoreTest:
 
         return vm
 
-    def sample_latency(self, microvm_factory, snapshot) -> List[float]:
+    def sample_latency(
+        self, microvm_factory, snapshot, guest_kernel_linux_4_14
+    ) -> List[float]:
         """Collects latency samples for the microvm configuration specified by this instance"""
         values = []
 
         for _ in range(ITERATIONS):
             microvm = microvm_factory.build(
+                kernel=guest_kernel_linux_4_14,
                 monitor_memory=False,
             )
             microvm.spawn()
@@ -162,6 +165,7 @@ def test_restore_latency(
     samples = test_setup.sample_latency(
         microvm_factory,
         snapshot,
+        guest_kernel_linux_4_14,
     )
 
     for sample in samples:

--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -77,7 +77,7 @@ class SnapshotRestoreTest:
 
         return vm
 
-    def sample_latency(self, microvm_factory, snapshot, metrics_logger) -> List[float]:
+    def sample_latency(self, microvm_factory, snapshot) -> List[float]:
         """Collects latency samples for the microvm configuration specified by this instance"""
         values = []
 
@@ -88,7 +88,7 @@ class SnapshotRestoreTest:
             microvm.spawn()
             microvm.restore_from_snapshot(snapshot, resume=True)
 
-            fcmetrics = FCMetricsMonitor(microvm, metrics_logger)
+            fcmetrics = FCMetricsMonitor(microvm)
             fcmetrics.start()
 
             # Check if guest still runs commands.
@@ -152,7 +152,7 @@ def test_restore_latency(
             **vm.dimensions,
         }
     )
-    fcmetrics = FCMetricsMonitor(vm, metrics)
+    fcmetrics = FCMetricsMonitor(vm)
     fcmetrics.start()
 
     snapshot = vm.snapshot_full()
@@ -162,7 +162,6 @@ def test_restore_latency(
     samples = test_setup.sample_latency(
         microvm_factory,
         snapshot,
-        metrics,
     )
 
     for sample in samples:

--- a/tests/integration_tests/performance/test_vsock_ab.py
+++ b/tests/integration_tests/performance/test_vsock_ab.py
@@ -102,7 +102,7 @@ def test_vsock_throughput(
             **vm.dimensions,
         }
     )
-    fcmetrics = FCMetricsMonitor(vm, metrics)
+    fcmetrics = FCMetricsMonitor(vm)
     fcmetrics.start()
 
     vm.pin_threads(0)


### PR DESCRIPTION
FC metrics were uploaded to CW with the same dimensions as the test to make it easy to map the metrics with the test in CW. However, each test has a huge number of dimensions which when multiplied with the number of FC metrics we upload add upto too many datapoints stored in CW.
This makes CW slow hard to monitor the dashboard and also has a significant increase in billing.
So limit the dimensions to (cpu-host_version-guest_version) so that we can monitor the dashboard properly and reduce the billing. To map the datapoints with the test that emitted them we'll have to use the datapoint timestamp with some CW query.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
