### PR TITLE
Fix AB tests

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -368,7 +368,7 @@ if __name__ == "__main__":
             canonicalize_revision(args.b_revision),
             args.test,
             args.significance,
-            args.relative_strength,
+            args.absolute_strength,
             args.noise_threshold,
         )
     else:


### PR DESCRIPTION
## Changes

Use the right argument `absolute-strength` to run AB tests.

## Reason

The argument was added in d073c2bb89585df6d9aba1a58e9d20674a7eda77 replacing `relative-strength`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
