### PR TITLE
test: Enable auto retries and disable manual retries on perf A/B test

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -114,6 +114,10 @@ for test_data in tests:
             {"exit_status": -1, "limit": 1},
         ]
     }
+    if REVISION_A:
+        # Enable automatic retry and disable manual retries to suppress spurious issues.
+        test_data["retry"]["automatic"].append({"exit_status": 1, "limit": 1})
+        test_data["retry"]["manual"] = False
     group_steps.append(build_group(test_data))
 
 pipeline = {


### PR DESCRIPTION
## Changes & Reason

We're observing spurious failures in the perf A/B pipeline. Some of them are gone in retries. To reduce unnecessary manual effort, enables automatic retries and disables manual retries on the pipeline.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
