### PR TITLE
fix(cpu-template-helper): ignore wide registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Firecracker snapshots (up to Firecracker version v1.6.0) incompatible with
   the current Firecracker version.
 
+### Fixed
+
+- [#4409](https://github.com/firecracker-microvm/firecracker/pull/4409):
+  Fixed a bug in the cpu-template-helper that made it panic during conversion
+  of cpu configuration with SVE registers to the cpu template on aarch64 platform.
+  Now cpu-template-helper will print warnings if it encounters SVE registers
+  during the conversion process. This is because cpu templates are limited
+  to only modify registers less than 128 bits.
+
 ## [v1.6.0]
 
 ### Added

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -410,8 +410,6 @@ def test_json_static_templates(
     """
     Verify that JSON static CPU templates are applied as intended.
     """
-    if custom_cpu_template["name"] == "aarch64_with_sve_and_pac":
-        pytest.skip("does not work yet")
     # Generate VM config with JSON static CPU template
     microvm = test_microvm_with_api
     microvm.spawn()


### PR DESCRIPTION
## Changes

When SVE extension is enabled on aarch64 cpus, KVM will return wide registers when queried. Because cpu templates do not support registers wider than 128 bits we need to ignore wide registers when converting cpu configuration into a cpu template.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
