### PR TITLE
Use new instances (c5n/m5n/m7g)

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -11,11 +11,12 @@ import subprocess
 from pathlib import Path
 
 DEFAULT_INSTANCES = [
-    "m5d.metal",
-    "m6i.metal",
-    "m6a.metal",
-    "m6g.metal",
-    "m7g.metal",
+    "c5n.metal",  # Intel Skylake
+    "m5n.metal",  # Intel Cascade Lake
+    "m6i.metal",  # Intel Icelake
+    "m6a.metal",  # AMD Milan
+    "m6g.metal",  # Graviton2
+    "m7g.metal",  # Graviton3
 ]
 
 DEFAULT_PLATFORMS = [

--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -15,7 +15,7 @@ DEFAULT_INSTANCES = [
     "m6i.metal",
     "m6a.metal",
     "m6g.metal",
-    "c7g.metal",
+    "m7g.metal",
 ]
 
 DEFAULT_PLATFORMS = [

--- a/.buildkite/pipeline_cpu_template.py
+++ b/.buildkite/pipeline_cpu_template.py
@@ -27,7 +27,7 @@ cpu_template_test = {
             "tools/devtool -y test -- -s -ra -m nonci -n4 --log-cli-level=INFO integration_tests/functional/test_cpu_features.py -k 'test_cpu_rdmsr' "
         ],
         BkStep.LABEL: "📖 rdmsr",
-        "instances": ["m5d.metal", "m6a.metal", "m6i.metal"],
+        "instances": ["c5n.metal", "m5n.metal", "m6a.metal", "m6i.metal"],
         "platforms": DEFAULT_PLATFORMS,
     },
     "cpuid_wrmsr": {
@@ -51,10 +51,11 @@ cpu_template_test = {
             BkStep.TIMEOUT: 30,
         },
         "cross_instances": {
-            "m5d.metal": ["m6i.metal"],
-            "m6i.metal": ["m5d.metal"],
+            "m5n.metal": ["c5n.metal", "m6i.metal"],
+            "c5n.metal": ["m5n.metal", "m6i.metal"],
+            "m6i.metal": ["m5n.metal", "c5n.metal"],
         },
-        "instances": ["m5d.metal", "m6i.metal", "m6a.metal"],
+        "instances": ["c5n.metal", "m5n.metal", "m6i.metal", "m6a.metal"],
     },
     "fingerprint": {
         BkStep.COMMAND: [

--- a/.buildkite/pipeline_cross.py
+++ b/.buildkite/pipeline_cross.py
@@ -17,7 +17,8 @@ from common import DEFAULT_PLATFORMS, group, pipeline_to_json
 def restore_step(label, src_instance, src_kv, dst_instance, dst_os, dst_kv):
     """Generate a restore step"""
     pytest_keyword_for_instance = {
-        "m5d.metal": "-k 'not None'",
+        "c5n.metal": "-k 'not None'",
+        "m5n.metal": "-k 'not None'",
         "m6i.metal": "-k 'not None'",
         "m6a.metal": "",
     }
@@ -36,7 +37,7 @@ def restore_step(label, src_instance, src_kv, dst_instance, dst_os, dst_kv):
 
 def cross_steps():
     """Generate group steps"""
-    snap_instances = ["m5d.metal", "m6i.metal", "m6a.metal"]
+    snap_instances = ["c5n.metal", "m5n.metal", "m6i.metal", "m6a.metal"]
     groups = []
     commands = [
         "./tools/devtool -y sh ./tools/create_snapshot_artifact/main.py",
@@ -59,11 +60,12 @@ def cross_steps():
     # allow-list of what instances can be restores on what other instances (in
     # addition to itself)
     supported = {
-        "m5d.metal": ["m6i.metal"],
-        "m6i.metal": ["m5d.metal"],
+        "c5n.metal": ["m5n.metal", "m6i.metal"],
+        "m5n.metal": ["c5n.metal", "m6i.metal"],
+        "m6i.metal": ["c5n.metal", "m5n.metal"],
     }
 
-    instances_x86_64 = ["m5d.metal", "m6i.metal", "m6a.metal"]
+    instances_x86_64 = ["c5n.metal", "m5n.metal", "m6i.metal", "m6a.metal"]
     # https://github.com/firecracker-microvm/firecracker/blob/main/docs/kernel-policy.md#experimental-snapshot-compatibility-across-kernel-versions
     # We currently have nothing for aarch64
     perms_aarch64 = []

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -38,7 +38,7 @@ defaults = {
 defaults = overlay_dict(defaults, args.step_param)
 
 defaults_once_per_architecture = defaults.copy()
-defaults_once_per_architecture["instances"] = ["m6i.metal", "c7g.metal"]
+defaults_once_per_architecture["instances"] = ["m6i.metal", "m7g.metal"]
 defaults_once_per_architecture["platforms"] = [("al2", "linux_5.10")]
 
 

--- a/.buildkite/pipeline_pr_no_block.py
+++ b/.buildkite/pipeline_pr_no_block.py
@@ -27,6 +27,7 @@ defaults = {
     # some non-blocking tests are performance, so make sure they get ag=1 instances
     "priority": DEFAULT_PRIORITY + 1,
     "agents": {"ag": 1},
+    "artifacts": ["./test_results/**/*"],
 }
 defaults = overlay_dict(defaults, args.step_param)
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ We test all combinations of:
 | m6i.metal | al2    linux_5.10 |              | linux_5.10   |
 | m6a.metal | al2023 linux_6.1  |              |              |
 | m6g.metal |                   |              |              |
-| c7g.metal |                   |              |              |
+| m7g.metal |                   |              |              |
 
 ## Known issues and Limitations
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ We test all combinations of:
 
 | Instance  | Host OS & Kernel  | Guest Rootfs | Guest Kernel |
 |:----------|:------------------|:-------------|:-------------|
-| m5d.metal | al2    linux_4.14 | ubuntu 22.04 | linux_4.14   |
-| m6i.metal | al2    linux_5.10 |              | linux_5.10   |
-| m6a.metal | al2023 linux_6.1  |              |              |
+| c5n.metal | al2    linux_4.14 | ubuntu 22.04 | linux_4.14   |
+| m5n.metal | al2    linux_5.10 |              | linux_5.10   |
+| m6i.metal | al2023 linux_6.1  |              |              |
+| m6a.metal |                   |              |              |
 | m6g.metal |                   |              |              |
 | m7g.metal |                   |              |              |
 

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -106,16 +106,8 @@ process will be terminated.
 ### Performance
 
 The Firecracker snapshot create/resume performance depends on the memory size,
-vCPU count and emulated devices count.
-The Firecracker CI runs snapshot tests on:
-
-- AWS **m5d.metal** and **m6i.metal** instances for Intel
-- AWS **m6g.metal** and **c7g.metal** for ARM
-- AWS **m6a.metal** for AMD
-
-We are running nightly performance tests for all the enumerated platforms on
-all supported kernel versions.
-The baselines can be found in their [respective config file](../../tests/integration_tests/performance/configs/).
+vCPU count and emulated devices count. The Firecracker CI runs snapshot tests on
+all [supported platforms](../../README.md#tested-platforms).
 
 ### Developer preview status
 

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_4.14host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.7.0-dev",
-  "kernel_version": "4.14.334-252.552.amzn2.x86_64",
+  "kernel_version": "4.14.336-253.554.amzn2.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",
   "bios_revision": "3.80",
@@ -183,7 +183,7 @@
           },
           {
             "register": "ecx",
-            "bitmap": "0b00000000000000001011111111111111"
+            "bitmap": "0b00000000000000001000111111111111"
           },
           {
             "register": "edx",
@@ -785,7 +785,7 @@
           },
           {
             "register": "edx",
-            "bitmap": "0b00110101001011100011001000100000"
+            "bitmap": "0b00110000001011100011001100100000"
           }
         ]
       },

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_5.10host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.7.0-dev",
-  "kernel_version": "5.10.205-195.804.amzn2.x86_64",
+  "kernel_version": "5.10.205-195.807.amzn2.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",
   "bios_revision": "3.80",
@@ -183,7 +183,7 @@
           },
           {
             "register": "ecx",
-            "bitmap": "0b00000000000000001011111111111111"
+            "bitmap": "0b00000000000000001000111111111111"
           },
           {
             "register": "edx",
@@ -969,7 +969,7 @@
           },
           {
             "register": "edx",
-            "bitmap": "0b00110101001011100011001000100000"
+            "bitmap": "0b00110000001011100011001100100000"
           }
         ]
       },

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.7.0-dev",
-  "kernel_version": "6.1.66-93.164.amzn2023.x86_64",
+  "kernel_version": "6.1.72-96.166.amzn2023.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",
   "bios_revision": "3.80",
@@ -183,7 +183,7 @@
           },
           {
             "register": "ecx",
-            "bitmap": "0b00000000000000001011111111111111"
+            "bitmap": "0b00000000000000001000111111111111"
           },
           {
             "register": "edx",
@@ -969,7 +969,7 @@
           },
           {
             "register": "edx",
-            "bitmap": "0b00110101001011100011001000100000"
+            "bitmap": "0b00110000001011100011001100100000"
           }
         ]
       },

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -7,8 +7,12 @@ import pytest
 from framework.properties import global_props
 from framework.utils import check_entropy
 
-if global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14":
-    pytestmark = pytest.mark.skip(reason="c7g requires no SVE 5.10 kernel")
+if (
+    global_props.cpu_model == "ARM_NEOVERSE_V1"
+    and global_props.host_linux_version == "4.14"
+):
+    # Graviton3 instances in 4.14 require a non-SVE kernel to boot
+    pytestmark = pytest.mark.skip(reason="[cm]7g requires non-SVE 5.10 kernel")
 
 
 @pytest.fixture(params=[None])

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -29,6 +29,14 @@ REMOTE_CHECKER_COMMAND = f"sh {REMOTE_CHECKER_PATH} --no-intel-db --batch json"
 VULN_DIR = "/sys/devices/system/cpu/vulnerabilities"
 
 
+skip_if_g3_on_linux_4_14 = pytest.mark.skipif(
+    global_props.cpu_model == "ARM_NEOVERSE_V1"
+    and global_props.host_linux_version == "4.14",
+    # Graviton3 instances in 4.14 require a non-SVE kernel to boot
+    reason="[cm]7g 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
+)
+
+
 def configure_microvm(
     factory,
     kernel,
@@ -211,10 +219,7 @@ def check_vulnerabilities_on_guest(status):
     assert report_guest_vulnerabilities == known_guest_vulnerabilities
 
 
-@pytest.mark.skipif(
-    global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
-    reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
-)
+@skip_if_g3_on_linux_4_14
 def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
     """
     Test with the spectre / meltdown checker on host.
@@ -249,10 +254,7 @@ def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
         assert report == expected, f"Unexpected vulnerabilities: {report} vs {expected}"
 
 
-@pytest.mark.skipif(
-    global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
-    reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
-)
+@skip_if_g3_on_linux_4_14
 def test_spectre_meltdown_checker_on_guest(spectre_meltdown_checker, build_microvm):
     """
     Test with the spectre / meltdown checker on guest.
@@ -270,10 +272,7 @@ def test_spectre_meltdown_checker_on_guest(spectre_meltdown_checker, build_micro
         check_vulnerabilities_on_guest(status)
 
 
-@pytest.mark.skipif(
-    global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
-    reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
-)
+@skip_if_g3_on_linux_4_14
 def test_spectre_meltdown_checker_on_restored_guest(
     spectre_meltdown_checker, build_microvm, microvm_factory
 ):
@@ -294,10 +293,7 @@ def test_spectre_meltdown_checker_on_restored_guest(
         check_vulnerabilities_on_guest(status)
 
 
-@pytest.mark.skipif(
-    global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
-    reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
-)
+@skip_if_g3_on_linux_4_14
 def test_spectre_meltdown_checker_on_guest_with_template(
     spectre_meltdown_checker, build_microvm_with_template
 ):
@@ -314,10 +310,7 @@ def test_spectre_meltdown_checker_on_guest_with_template(
     )
 
 
-@pytest.mark.skipif(
-    global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
-    reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
-)
+@skip_if_g3_on_linux_4_14
 def test_spectre_meltdown_checker_on_guest_with_custom_template(
     spectre_meltdown_checker, build_microvm_with_custom_template
 ):
@@ -333,10 +326,7 @@ def test_spectre_meltdown_checker_on_guest_with_custom_template(
     )
 
 
-@pytest.mark.skipif(
-    global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
-    reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
-)
+@skip_if_g3_on_linux_4_14
 def test_spectre_meltdown_checker_on_restored_guest_with_template(
     spectre_meltdown_checker, build_microvm_with_template, microvm_factory
 ):
@@ -355,10 +345,7 @@ def test_spectre_meltdown_checker_on_restored_guest_with_template(
     )
 
 
-@pytest.mark.skipif(
-    global_props.instance == "c7g.metal" and global_props.host_linux_version == "4.14",
-    reason="c7g host 4.14 requires modifications to the 5.10 guest kernel to boot successfully.",
-)
+@skip_if_g3_on_linux_4_14
 def test_spectre_meltdown_checker_on_restored_guest_with_custom_template(
     spectre_meltdown_checker,
     build_microvm_with_custom_template,


### PR DESCRIPTION
## Changes

- use c5n/m5n to consistently get a Skylake/Cascade Lake
- Use m7g instead of c7g since we use m in other instance types

## Reason

To consistently test a homogeneous set of instance types

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
