### PR TITLE
jailer: check if exec file exists in the jail dir before copy

### DIFF
--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -472,15 +472,19 @@ impl Env {
         // a new PathBuf, with something like chroot_dir.join(exec_file_name) ?!
         self.chroot_dir.push(exec_file_name);
 
-        // We do a copy instead of a hard-link for 2 reasons
-        // 1. hard-linking is not possible if the file is in another device
-        // 2. while hardlinking would save up disk space and also memory by sharing parts of the
-        //    Firecracker binary (like the executable .text section), this latter part is not
-        //    desirable in Firecracker's threat model. Copying prevents 2 Firecracker processes from
-        //    sharing memory.
-        fs::copy(&self.exec_file_path, &self.chroot_dir).map_err(|err| {
-            JailerError::Copy(self.exec_file_path.clone(), self.chroot_dir.clone(), err)
-        })?;
+        // Copying the exec file is a costly operation. Check if it exists before actually copying
+        // it, to avoid wasting unnecessary time on repeated runs in the same jail.
+        if !self.chroot_dir.is_file() {
+            // We do a copy instead of a hard-link for 2 reasons
+            // 1. hard-linking is not possible if the file is in another device
+            // 2. while hardlinking would save up disk space and also memory by sharing parts of the
+            //    Firecracker binary (like the executable .text section), this latter part is not
+            //    desirable in Firecracker's threat model. Copying prevents 2 Firecracker processes from
+            //    sharing memory.
+            fs::copy(&self.exec_file_path, &self.chroot_dir).map_err(|err| {
+                JailerError::Copy(self.exec_file_path.clone(), self.chroot_dir.clone(), err)
+            })?;
+        }
 
         // Pop exec_file_name.
         self.chroot_dir.pop();


### PR DESCRIPTION
## Changes

Check whether the exec file already exists in the jail dir before copying it.

## Reason

While trying to spawn multiple instances in parallel (more than 500), we're seeing contention while the jailer tries to copy the exec file to each of the instances jail dirs (some VMs end up starting in more than 20 seconds). Hard-linking the exec file in the jail dirs before starting the VMs avoids the issue, but the copy operation in the jailer needs to be skipped.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
