### PR TITLE
Backport addition of `rust-toolchain.toml` to 1.6 release branch

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,17 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# We keep a rust-toolchain file checked into the repository such that in the
+# rare event that we need to do an A/B-test across toolchains, cargo will
+# download the toolchains of the A and B revisions on the fly (if they do not
+# match the toolchain installed in the environment in which the test is
+# executed). This is needed for example if a toolchain upgrade introduces a new
+# syscall into our seccomp filters. Then, since our PR CI contains A/B-tests,
+# we will compile a version of Firecracker that does not have this syscall
+# allowlisted using a toolchain that requires it, causing the A/B-test to
+# always fail.
+[toolchain]
+channel = "1.70.0"
+targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]
+profile = "minimal"
+

--- a/tools/devtool
+++ b/tools/devtool
@@ -487,7 +487,7 @@ cmd_build() {
 
 function cmd_make_release {
     run_devctr \
-        --user "$(id -u):$(id -g)" \
+        --privileged \
         --workdir "$CTR_FC_ROOT_DIR" \
         -- \
         ./tools/release.sh --libc musl --profile release --make-release


### PR DESCRIPTION
## Changes

Adds a rust-toolchain.toml file to the 1.6 release branch

## Reason

Without this, doing A/B-tests across releases is impossible due to older release branches not working when compiled with a newer docker container (and thus a newer rust toolchain). 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
