### PR TITLE
Restore public documentation with key information for Firecracker users

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,8 +8,11 @@ You can check if your system meets the requirements by running
 An opinionated way to run Firecracker is to launch an
 [EC2](https://aws.amazon.com/ec2/) `c5.metal` instance with Ubuntu 22.04.
 
-EC2 only supports nested virtualization on metal instances, which is why we use
-`.metal` instances exclusively.
+Firecracker requires [the KVM Linux kernel module](https://www.linux-kvm.org/)
+to perform its virtualization and emulation tasks.
+
+We exclusively use `.metal` instance types, because EC2 only supports KVM on
+`.metal` instance types.
 
 ### Architecture & OS
 
@@ -18,7 +21,7 @@ Firecracker supports **x86_64** and **aarch64** Linux, see
 
 ### KVM
 
-Firecracker requires [the KVM Linux kernel module](https://www.linux-kvm.org/).
+Firecracker requires read/write access to `/dev/kvm` exposed by the KVM module.
 
 The presence of the KVM module can be checked with:
 
@@ -61,14 +64,15 @@ You can check if you have access to `/dev/kvm` with:
 
 ## Running Firecracker
 
-In production, Firecracker is designed to be run inside an execution jail, set
-up by the [`jailer`](../src/jailer/) binary. This is how our
-[integration test suite](#running-the-integration-test-suite) does it. This
-guide will not use the [`jailer`](../src/jailer/).
+In production, Firecracker is designed to be run securely inside an execution
+jail, set up by the [`jailer`](../src/jailer/) binary. This is how our
+[integration test suite](#running-the-integration-test-suite) does it.
+
+For simplicity, this guide will not use the [`jailer`](../src/jailer/).
 
 ### Getting a rootfs and Guest Kernel Image
 
-To successfully start a microVM with you will need an uncompressed Linux kernel
+To successfully start a microVM, you will need an uncompressed Linux kernel
 binary, and an ext4 file system image (to use as rootfs). This guide uses a 5.10
 kernel image with a Ubuntu 22.04 rootfs from our CI:
 
@@ -97,7 +101,7 @@ There are two options for getting a firecracker binary:
   or
 - Building firecracker from source.
 
-To download the latest firecracker release, run
+To download the latest firecracker release, run:
 
 ```bash
 ARCH="$(uname -m)"

--- a/docs/kernel-policy.md
+++ b/docs/kernel-policy.md
@@ -1,13 +1,31 @@
 # Firecracker's Kernel Support Policy
 
-Once officially supported kernel versions are supported for a **minimum of 2
-years**.
+Firecracker is tightly coupled with the guest and host kernels on which it is
+run. This document presents our kernel support policy which aims to help our
+customers choose host and guest OS configuration, and predict future kernel
+related changes.
 
-We are validating the currently supported Firecracker releases as per
-[Firecracker’s release policy](../docs/RELEASE_POLICY.md). Starting with release
-`v1.0` each major and minor release will specify the supported kernel versions.
-Adding support for a new kernel version will result in a Firecracker release
-only if compatibility changes are required.
+We are continuously validating the currently supported Firecracker releases (as
+per [Firecracker’s release policy](../docs/RELEASE_POLICY.md)) using a
+combination of:
+
+- host linux kernel versions 4.14, 5.10, and 6.1;
+- guest linux kernel versions 4.14, and 5.10.
+
+While other versions and other kernel configs might work, they are not
+periodically validated in our test suite, and using them might result in
+unexpected behaviour. Starting with release `v1.0` each major and minor release
+will specify the supported kernel versions.
+
+Once a kernel version is officially enabled, it is supported for a **minimum of
+2 years**. Adding support for a new kernel version will result in a Firecracker
+release only if compatibility changes are required.
+
+| Host kernel | Guest kernel v4.14 | Guest kernel v5.10 | Min. end of support |
+| ----------: | :----------------: | :----------------: | ------------------: |
+|       v4.14 |          Y         |          Y         |          2021-01-22 |
+|       v5.10 |          Y         |          Y         |          2024-01-31 |
+|        v6.1 |          Y         |          Y         |          2025-10-12 |
 
 The guest kernel configs used in our validation pipelines can be found
 [here](../resources/guest_configs/) while a breakdown of the relevant guest
@@ -15,7 +33,7 @@ kernel modules can be found in the next section.
 
 ## Guest kernel configuration items
 
-Some configuration items that may be of interest are:
+The configuration items that may be relevant for Firecracker are:
 
 - serial console - `CONFIG_SERIAL_8250_CONSOLE`, `CONFIG_PRINTK`
 - initrd support - `CONFIG_BLK_DEV_INITRD`

--- a/docs/kernel-policy.md
+++ b/docs/kernel-policy.md
@@ -23,9 +23,9 @@ release only if compatibility changes are required.
 
 | Host kernel | Guest kernel v4.14 | Guest kernel v5.10 | Min. end of support |
 | ----------: | :----------------: | :----------------: | ------------------: |
-|       v4.14 |          Y         |          Y         |          2021-01-22 |
-|       v5.10 |          Y         |          Y         |          2024-01-31 |
-|        v6.1 |          Y         |          Y         |          2025-10-12 |
+|       v4.14 |         Y          |         Y          |          2021-01-22 |
+|       v5.10 |         Y          |         Y          |          2024-01-31 |
+|        v6.1 |         Y          |         Y          |          2025-10-12 |
 
 The guest kernel configs used in our validation pipelines can be found
 [here](../resources/guest_configs/) while a breakdown of the relevant guest

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -2,10 +2,12 @@
 
 ## Introduction
 
-Firecracker implements a framework for instrumentation based tracing.
+Firecracker implements a framework for instrumentation based tracing with the
+aim to improve its debugability.
 
-Instrumentation based tracing as defined by
-[Sheng Liang on usenix.org](https://www.usenix.org/legacy/publications/library/proceedings/coots99/full_papers/liang/liang_html/node9.html):
+Instrumentation based tracing was defined by
+[Sheng Liang on usenix.org](https://www.usenix.org/legacy/publications/library/proceedings/coots99/full_papers/liang/liang_html/node9.html)
+as:
 
 > There are two ways to obtain profiling information: either statistical
 > sampling or code instrumentation. Statistical sampling is less disruptive to
@@ -16,8 +18,6 @@ Instrumentation based tracing as defined by
 > percentage of time spent in frequently-called methods, whereas code
 > instrumentation can report the exact number of time each method is invoked.
 
-The focus with tracing in Firecracker is to improve debug-ability.
-
 Enabling tracing adds logs output on each functions entry and exit. This assists
 debugging problems that relate to deadlocks or high latencies by quickly
 identifying elongated function calls.
@@ -26,11 +26,12 @@ identifying elongated function calls.
 
 Firecracker implements instrumentation based tracing via
 [`log`](https://github.com/rust-lang/log) and
-[`log_instrument`](https://github.com/JonathanWoollett-Light/log-instrument),
-outputting a `Trace` level log when entering and exiting every function.
+[`log_instrument`](../src/log-instrument), outputting a `Trace` level log when
+entering and exiting every function.
 
-It is disabled by default at compile-time. Tracing functionality has no impact
-on the release binary.
+Adding traces impacts Firecracker binary size and its performance, so
+instrumentation is not present by default. Instrumentation is also not present
+on the release binaries.
 
 You can use `cargo run --bin clippy-tracing --` to build and run the latest
 version in the repo or you can run `cargo install --path src/clippy-tracing` to


### PR DESCRIPTION
## Changes

As part of this pull request i updated three files (getting-started.md, kernel-policy.md, and tracing.md) to restore important information about our kernel policy, and fix information or links in the remaining files. 

## Reason
#3903 regressed the content of getting-started.md and kernel-policy.md, removing information which were useful to explain to Firecracker's customers our kernel policy, and introducing grammar mistakes. This PR aim to restore that content to enable Firecracker customers to be able to clearly identify host and guest kernel supported as well as fix grammar or other minor mistakes
 
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
~~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
