### PR TITLE
fix: Flush metrics to cloudwatch

### DIFF
--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -425,6 +425,7 @@ def flush_fc_metrics_to_cw(fc_metrics, metrics):
             walk_key(group, keys)
             if group in metrics_to_export_once:
                 skip.add(group)
+    metrics.flush()
 
 
 class FCMetricsMonitor(Thread):


### PR DESCRIPTION
To reduce the dimensions used to upload FC metrics, we used a new metrics logger as part of this commit 6f16d705e9a849add15ed8125bc913ffc715da46 however,
what was missed was actually flushing the metrics to CW.

Earlier to the said commit, since fc_metrics.py used the same metrics_logger as the performance tests, there was no need to flush because all metrics were flushed together as part of the performance test.
However, since we have a separate metrics_logger now, we need to add this missing step to actually have the metrics uploaded to CloudWatch

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
- ~[ ] New `TODO`s link to an issue.~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
