### PR TITLE
fix: broken license check for dependencies

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,12 @@ allow = [
     "Unicode-DFS-2016"
 ]
 
+# Lint level for licenses considered copyleft
+copyleft = "deny"
+
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+
 [[bans.deny]]
 name = "serde_derive"
 version = ">1.0.171, < 1.0.184"

--- a/tests/integration_tests/build/test_dependencies.py
+++ b/tests/integration_tests/build/test_dependencies.py
@@ -24,4 +24,17 @@ def test_licenses():
         os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../../Cargo.toml")
     )
 
-    cargo("deny", f"--manifest-path {toml_file} check licenses bans")
+    _, stdout, stderr = cargo("deny", f"--manifest-path {toml_file} check licenses bans")
+    assert "licenses ok" in stdout
+
+    # "cargo deny" should deny licenses by default but for some reason copyleft is allowed
+    # by it and if we add a dependency which has copyleft licenses "cargo deny" won't report
+    # it unless it is explicitly told to do so from the deny.toml.
+    # Our current deny.toml seems to cover all the cases we need but,
+    # if there is an exception like copyleft (where we don't want and don't deny
+    # in deny.toml and is allowed by cardo deny), we don't want to be left in the dark.
+    # For such cases check "cargo deny" output, make sure that there are no warnings reported
+    # related to the license and take appropriate actions i.e. either add them to allow list
+    # or remove them if they are incompatible with our licenses.
+    license_res = [line for line in stderr.split("\n") if "license" in line]
+    assert not license_res


### PR DESCRIPTION
`test_licenses` does not warn or fail if we
accidentally add a dependency having GPL2.0 license. `cargo deny` with current deny.toml prints a warning if we a dependency has GPL2.0 license but the test doesn't consider the cargo output.

We update the deny.toml to deny copyleft (includes GPL) and unlicensed crates but there could be other licenses which we don't want to add accidentally so, along with it assert that `cargo deny` output does not have any warning at all.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
