### PR TITLE
fix: Disable A/B tests alarming on m6.metal 6.1

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -52,7 +52,6 @@ IGNORED = [
     },
     # High volatility due to AMI.
     {
-        "performance_test": "test_restore_latency",
         "instance": "m6i.metal",
         "host_kernel": "linux-6.1",
     },


### PR DESCRIPTION
## Changes

Previously 5af8df1b8152845c44fb6c53b70ea3f74a40334c only disabled alarming for `test_restore_latency` where the intention was to disable alarming for all m6i 6.1 A/B tests, this fixes this.

## Reason

Fixes https://github.com/firecracker-microvm/firecracker/pull/4430

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
