### PR TITLE
chore: test to check if killing microvm works as expected

### DIFF
--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -277,6 +277,14 @@ Note: default value for `<api-sock>` is `/run/firecracker.socket`.
   associated with `--daemonize` runs towards the end, instead of the very
   beginning. We are working on adding better logging capabilities.
 
+### Known limitations
+
+- When passing the --daemonize option to Firecracker without the --new-ns-pid
+  option, the Firecracker process will have a different pid than the Jailer
+  process. The suggested workaround to get Firecracker process's pid in this
+  case is using `--new-pid-ns` flag and read Firecracker's pid from the
+  `firecracker.pid` file present in the jailer's root directory.
+
 ## Caveats
 
 - If all the cgroup controllers are bunched up on a single mount point using the


### PR DESCRIPTION
## Changes:
Add a test to make sure there is no change in behaviour in killing firecracker_pid.

## Reason:
In our CI we pass `--new-pid-ns` along with `--daemonize` and so firecracker pid can be read from the file `firecracker.pid` present in the jailers root directory.
However, if there is a change in behaviour that leads to this file not having the actual firecracker pid then it could cause a regression.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
