### PR TITLE
docs: Highlight getting-started.md resources are not production ready

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,8 @@
 # Getting Started with Firecracker
 
+**All resources are used for demonstration purposes and are not intended for
+production.**
+
 ## Prerequisites
 
 You can check if your system meets the requirements by running


### PR DESCRIPTION
## Changes

Adds a disclaimer to highlight resources used in getting-started.md are not production ready.

## Reason

Discussion highlighted this should be clarified.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
