### PR TITLE
tests: Exclude  X2APIC MSRs from `test_cpu_wrmsr_restore`

### DIFF
--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -197,6 +197,14 @@ def test_brand_string(test_microvm_with_api):
         assert False
 
 
+# From the `Intel® 64 Architecture x2APIC Specification`
+# (https://courses.cs.washington.edu/courses/cse451/24wi/documentation/x2apic.pdf):
+# > The X2APIC MSRs cannot to be loaded and stored on VMX transitions. A VMX transition fails
+# > if the VMM has specified that the transition should access any MSRs in the address range
+# > from 0000_0800H to 0000_08FFH
+X2APIC_MSRS = [hex(i) for i in range(0x0000_0800, 0x0000_08FF + 1)]
+
+
 # Some MSR values should not be checked since they can change at guest runtime
 # and between different boots.
 # Current exceptions:
@@ -239,7 +247,7 @@ MSR_EXCEPTION_LIST = [
                    # Trigger Mode equal to Edge,
                    # and a Delivery Mode equal to Fixed.
                    # bit 0-7 represent interrupt vector that varies.
-]
+] + X2APIC_MSRS
 # fmt: on
 
 


### PR DESCRIPTION
## Changes

Excludes X2APIC MSRs from checking in `test_cpu_wrmsr_restore` 

## Reason

They cannot be reliabilty controlled and thus cause intermittent test failures.

> The X2APIC MSRs cannot to be loaded and stored on VMX transitions.
> A VMX transition fails if the VMM has specified that the transition
> should access any MSRs in the address range from 0000_0800H to
> 0000_08FFH

From the `Intel® 64 Architecture x2APIC Specification` at https://courses.cs.washington.edu/courses/cse451/24wi/documentation/x2apic.pdf.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
