### PR TITLE
Save Firecracker PID in Jailer's root directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@ and this project adheres to
   This fixes a bug where a microVM with incompatible balloon and guest memory
   size could be booted, due to the check for this condition happening after
   Firecracker's configuration was updated.
+- [#4259](https://github.com/firecracker-microvm/firecracker/pull/4259): Added a
+  double fork mechanism in the Jailer to avoid setsid() failures occurred while
+  running Jailer as the process group leader. However, this changed the
+  behaviour of Jailer and now the Firecracker process will always have a
+  different PID than the Jailer process.
+  [#4436](https://github.com/firecracker-microvm/firecracker/pull/4436): Added a
+  "Known Limitations" section in the Jailer docs to highlight the above change
+  in behaviour introduced in PR#4259.
+  [#4442](https://github.com/firecracker-microvm/firecracker/pull/4442): As a
+  solution to the change in behaviour introduced in PR#4259, provided a
+  mechanism to reliably fetch Firecracker PID. With this change, Firecracker
+  process's PID will always be available in the Jailer's root directory
+  regardless of whether new_pid_ns was set.
 
 ## \[1.6.0\]
 

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -280,10 +280,13 @@ Note: default value for `<api-sock>` is `/run/firecracker.socket`.
 ### Known limitations
 
 - When passing the --daemonize option to Firecracker without the --new-ns-pid
-  option, the Firecracker process will have a different pid than the Jailer
-  process. The suggested workaround to get Firecracker process's pid in this
-  case is using `--new-pid-ns` flag and read Firecracker's pid from the
-  `firecracker.pid` file present in the jailer's root directory.
+  option, the Firecracker process will have a different PID than the Jailer
+  process and killing the Jailer will not kill the Firecracker process. As a
+  workaround to get Firecracker PID, the Jailer stores the PID of the child
+  process in the jail root directory inside `<exec_file_name>.pid` for all cases
+  regardless of whether `--new-pid-ns` was provided. The suggested way to fetch
+  Firecracker's PID when using the Jailer is to read the `firecracker.pid` file
+  present in the Jailer's root directory.
 
 ## Caveats
 

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -8,7 +8,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
-use std::process::{exit, Command, Stdio};
+use std::process::{exit, id, Command, Stdio};
 use std::{fmt, io};
 
 use utils::arg_parser::Error::MissingValue;
@@ -739,6 +739,7 @@ impl Env {
         if self.new_pid_ns {
             self.exec_into_new_pid_ns(chroot_exec_file)
         } else {
+            self.save_exec_file_pid(id().try_into().unwrap(), chroot_exec_file.clone())?;
             Err(JailerError::Exec(self.exec_command(chroot_exec_file)))
         }
     }

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -543,9 +543,6 @@ class Microvm:
             # Checking the timings requires DEBUG level log messages
             self.time_api_requests = False
 
-        if not self.jailer.daemonize:
-            self.jailer.new_pid_ns = False
-
         cmd = [str(self.jailer_binary_path)] + self.jailer.construct_param_list()
         if self._numa_node is not None:
             node = str(self._numa_node)

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -372,22 +372,15 @@ class Microvm:
         return self.api.describe.get().json()["state"]
 
     @property
-    def pid_in_new_ns(self):
-        """Get the pid of the Firecracker process in the new namespace.
-
-        Reads the pid from a file created by jailer with `--new-pid-ns` flag.
-        """
-        # Read the PID stored inside the file.
-        return int(self.jailer.pid_file.read_text(encoding="ascii"))
-
-    @property
     def firecracker_pid(self):
-        """Return Firecracker's PID"""
+        """Return Firecracker's PID
+
+        Reads the pid from a file created by jailer.
+        """
         if not self._spawned:
             return None
-        if self.jailer.new_pid_ns:
-            return self.pid_in_new_ns
-        return self._screen_firecracker_pid
+        # Read the PID stored inside the file.
+        return int(self.jailer.pid_file.read_text(encoding="ascii"))
 
     @property
     def dimensions(self):

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -191,7 +191,6 @@ class Microvm:
         self.jailer.jailed_path("/etc/localtime", subdir="etc")
 
         self._screen_pid = None
-        self._screen_firecracker_pid = None
 
         self.time_api_requests = global_props.host_linux_version != "6.1"
         # disable the HTTP API timings as they cause a lot of false positives
@@ -269,7 +268,8 @@ class Microvm:
                 assert (
                     rc == 0 and stderr == "" and stdout.find("firecracker") == -1
                 ), f"Firecracker pid {self.firecracker_pid} was not killed as expected"
-        else:
+
+        if self.screen_pid:
             # Killing screen will send SIGHUP to underlying Firecracker.
             # Needed to avoid false positives in case kill() is called again.
             self.expect_kill_by_signal = True
@@ -569,14 +569,13 @@ class Microvm:
             # Run Firecracker under screen. This is used when we want to access
             # the serial console. The file will collect the output from
             # 'screen'ed Firecracker.
-            screen_pid, binary_pid = utils.start_screen_process(
+            screen_pid = utils.start_screen_process(
                 self.screen_log,
                 self.screen_session,
                 cmd[0],
                 cmd[1:],
             )
             self._screen_pid = screen_pid
-            self._screen_firecracker_pid = binary_pid
 
         self._spawned = True
 

--- a/tests/framework/microvm_helpers.py
+++ b/tests/framework/microvm_helpers.py
@@ -122,6 +122,7 @@ class MicrovmHelpers:
             self.vm.boot_args = ""
         self.vm.boot_args += "console=ttyS0 reboot=k panic=1"
         self.vm.jailer.daemonize = False
+        self.vm.jailer.new_pid_ns = False
 
     def how_to_console(self):
         """Print how to connect to the VM console"""

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -715,14 +715,7 @@ def start_screen_process(screen_log, session_name, binary_path, binary_params):
     # Configure screen to flush stdout to file.
     run_cmd(FLUSH_CMD.format(session=session_name))
 
-    children_count = len(screen_ps.children())
-    if children_count != 1:
-        raise RuntimeError(
-            f"Failed to retrieve child process id for binary '{binary_path}' "
-            f"screen session process had [{children_count}]"
-        )
-
-    return screen_pid, screen_ps.children()[0].pid
+    return screen_pid
 
 
 def guest_run_fio_iteration(ssh_connection, iteration):

--- a/tests/integration_tests/functional/test_initrd.py
+++ b/tests/integration_tests/functional/test_initrd.py
@@ -12,7 +12,7 @@ def test_microvm_initrd_with_serial(uvm_with_initrd):
     Test that a boot using initrd successfully loads the root filesystem.
     """
     vm = uvm_with_initrd
-    vm.jailer.daemonize = False
+    vm.help.enable_console()
     vm.spawn()
     vm.memory_monitor = None
 

--- a/tests/integration_tests/functional/test_kernel_cmdline.py
+++ b/tests/integration_tests/functional/test_kernel_cmdline.py
@@ -13,7 +13,7 @@ def test_init_params(uvm_plain):
     altered or misplaced.
     """
     vm = uvm_plain
-    vm.jailer.daemonize = False
+    vm.help.enable_console()
     vm.spawn()
     vm.memory_monitor = None
 

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -50,7 +50,7 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
     Serial I/O after restoring from a snapshot.
     """
     microvm = uvm_plain
-    microvm.jailer.daemonize = False
+    microvm.help.enable_console()
     microvm.spawn()
     microvm.basic_config(
         vcpu_count=2,
@@ -71,7 +71,7 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
 
     # Load microVM clone from snapshot.
     vm = microvm_factory.build()
-    vm.jailer.daemonize = False
+    vm.help.enable_console()
     vm.spawn()
     vm.restore_from_snapshot(snapshot, resume=True)
     serial = Serial(vm)
@@ -91,7 +91,7 @@ def test_serial_console_login(uvm_plain_any):
     Test serial console login.
     """
     microvm = uvm_plain_any
-    microvm.jailer.daemonize = False
+    microvm.help.enable_console()
     microvm.spawn()
 
     # We don't need to monitor the memory for this test because we are
@@ -139,7 +139,7 @@ def test_serial_dos(uvm_plain_any):
     Test serial console behavior under DoS.
     """
     microvm = uvm_plain_any
-    microvm.jailer.daemonize = False
+    microvm.help.enable_console()
     microvm.spawn()
 
     # Set up the microVM with 1 vCPU and a serial console.
@@ -169,7 +169,7 @@ def test_serial_block(uvm_plain_any):
     Test that writing to stdout never blocks the vCPU thread.
     """
     test_microvm = uvm_plain_any
-    test_microvm.jailer.daemonize = False
+    test_microvm.help.enable_console()
     test_microvm.spawn()
     # Set up the microVM with 1 vCPU so we make sure the vCPU thread
     # responsible for the SSH connection will also run the serial.


### PR DESCRIPTION
## Changes

- Always save Firecracker PID in Jailer root directory regardless of whether `new_pid-ns` flag was set.
- Modify the CI to kill Firecracker using the PID saved in the file in Jailer's root directory.
- Add new tests to try all verify the Microvm.kill behaviour is same for all combinations of daemonize/new_pid_ns flags.

## Reason

- There was a change in behaviour introduced in Jailer because of which Firecracker pid will always be different from the Jailer PID. So we need to suggested a reliable workaround to fetch Firecracker PID.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
