### PR TITLE
test(drive): avoid calling sync inside sfdisk

### DIFF
--- a/tests/framework/utils_drive.py
+++ b/tests/framework/utils_drive.py
@@ -30,7 +30,7 @@ def partuuid_and_disk_path(rootfs_ubuntu_22, disk_path):
     initial_size = rootfs_ubuntu_22.stat().st_size + 50 * MB
     disk_path.touch()
     os.truncate(disk_path, initial_size)
-    check_output(f"echo type=83 | sfdisk {str(disk_path)}", shell=True)
+    check_output(f"echo type=83 | sfdisk --no-tell-kernel {str(disk_path)}", shell=True)
     check_output(
         f"dd bs=1M seek=1 if={str(rootfs_ubuntu_22)} of={disk_path}", shell=True
     )


### PR DESCRIPTION
## Changes

Internally, `sfdisk` calls `sync()` by default that is the main suspect as it may take very long depending on the filesystem activity (see https://www.linuxquestions.org/questions/slackware-14/sync-hangs-in-kernel-but-i-o-is-working-4175468599/#post4996115).

This change adds sfdisk option `--no-tell-kernel` that makes `sfdisk` omit the `sync()` call.

Before:
```
    49269 write(1, "The partition table has been alt"..., 38) = 38
    49269 fstat(3, {st_mode=S_IFREG|0644, st_size=524288, ...}) = 0
    49269 fsync(3)                          = 0
    49269 close(3)                          = 0
    49269 write(1, "Syncing disks.\n", 15)  = 15
    49269 sync()                            = 0
    49269 close(1)                          = 0
    49269 close(2)                          = 0
    49269 exit_group(0)                     = ?
    49269 +++ exited with 0 +++
```
After:
```
    48858 write(1, "The partition table has been alt"..., 38) = 38
    48858 fsync(3)                          = 0
    48858 close(3)                          = 0
    48858 close(1)                          = 0
    48858 close(2)                          = 0
    48858 exit_group(0)                     = ?
    48858 +++ exited with 0 +++
```

## Reason

We are seeing intermittent test failures when `sfdisk` command times out.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
