### PR TITLE
doc: Correct description for pytest capturing

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -59,9 +59,10 @@ python3 -m pytest [<pytest argument>...]
 
 ### Output
 
-Output, including testrun results, goes to `stdout`. Errors go to `stderr`.
-Pytest by default only captures the stdout of tests if they fail. To also
-capture the output of passing tests, pass the `-s` flag, e.g.
+Output, including testrun results, goes to `stdout`. Errors go to `stderr`. By
+default, stdout and stderr are captured while tests are running and are printed
+in the final failure report only if they fail. To print them while running
+regardless of success or failure, pass the `-s` flag, e.g.
 `tools/devtool -y test -- -s`.
 
 ### Dependencies


### PR DESCRIPTION
## Changes

Correct description for pytest capturing.

## Reason

Description for pytest capturing added in commit ea4a7cca5ac8 ("doc: Include information on how to capture stdout") was not quite accurate.

```
$ tools/devtool -y test -- test_sample.py
...
test_sample.py::test_success PASSED                                                       [ 50%]
test_sample.py::test_fail FAILED                                                          [100%]

=========================================== FAILURES ============================================
___________________________________________ test_fail ___________________________________________
test_sample.py:17: in test_fail
    assert False
E   assert False
------------------------------------- Captured stdout call --------------------------------------
hello stdout
------------------------------------- Captured stderr call --------------------------------------
hello stderr
```
```
$ tools/devtool -y test -- test_sample.py -s
...
test_sample.py::test_success hello stdout
hello stderr
PASSED
test_sample.py::test_fail hello stdout
hello stderr
FAILED

=========================================== FAILURES ============================================
___________________________________________ test_fail ___________________________________________
test_sample.py:17: in test_fail
    assert False
E   assert False
```

https://docs.pytest.org/en/7.1.x/how-to/capture-stdout-stderr.html
> pytest -s                  # disable all capturing


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
