### PR TITLE
ci: add aarch64 to cross-kernel tests

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -618,46 +618,26 @@ The test restores the snapshot and ensures that all the devices set-up in the
 configuration file (network devices, disk, vsock, balloon and MMDS) are
 operational post-load.
 
-The tables below reflect the snapshot compatibility observed on Intel and AMD.
-On ARM, snapshot restore between kernel versions is not possible due to
-registers incompatibility.
+In those tests the instance is fixed, except some combinations where we also
+test across the same CPU family (Intel x86, Gravitons). In general cross-CPU
+snapshots [are not supported](./versioning.md#cpu-model)
 
-### Intel
+The tables below reflect the snapshot compatibility observed on the AWS
+instances we support.
 
-<table>
-  <tr>
-    <th></th>
-    <th>Snapshot taken on host 4.14</th>
-    <th>Snapshot taken on host 5.10</th>
-  </tr>
-  <tr>
-    <th>Load snapshot on host 4.14</th>
-    <td style="background-color:mediumseagreen">successful</td>
-    <td style="background-color:darkred">unsuccessful due to unresponsive net devices</td>
-  </tr>
-  <tr>
-    <th>Load snapshot on host 5.10</th>
-    <td style="background-color:mediumseagreen">successful</td>
-    <td style="background-color:mediumseagreen">successful</td>
-  </tr>
-</table>
+**all** means all currently supported Intel/AMD/ARM metal instances (m6g, m7g,
+m5n, c5n, m6i, m7i, m6a). It does not mean cross-instance, i.e. a snapshot taken
+on m6i won't work on an m6g instance.
 
-### AMD
+| *CPU family* | *taken on host kernel* | *restored on host kernel* | *working?* |
+| ------------ | ---------------------- | ------------------------- | ---------- |
+| **x86_64**   | 4.14                   | 5.10                      | Y          |
+| **all**      | 5.10                   | 4.14                      | N          |
+| **all**      | 5.10                   | 6.1                       | Y          |
+| **all**      | 6.1                    | 5.10                      | Y          |
 
-<table>
-  <tr>
-    <th></th>
-    <th>Snapshot taken on host 4.14</th>
-    <th>Snapshot taken on host 5.10</th>
-  </tr>
-  <tr>
-    <th>Load snapshot on host 4.14</th>
-    <td style="background-color:mediumseagreen">successful</td>
-    <td style="background-color:mediumseagreen">unsuccessful due to mismatch in MSRs</td>
-  </tr>
-  <tr>
-    <th>Load snapshot on host 5.10</th>
-    <td style="background-color:mediumseagreen">successful</td>
-    <td style="background-color:mediumseagreen">successful</td>
-  </tr>
-</table>
+What doesn't work:
+
+- Graviton 4.14 \<-> 5.10 does not restore due to register incompatibility.
+- Intel 5.10 -> 4.14 does not restore because unresponsive net devices
+- AMD m6a 5.10 -> 4.14 does not restore due to mismatch in MSRs


### PR DESCRIPTION
Also test 6.1 -> 5.10

## Changes

Add more tests since they work and we want to validate this functionality forwards and backwards.

## Reason

Gain more confidence on the cross-kernel snapshot-restore.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
