### PR TITLE
feat(vmm): Make SerialOut into Write+Send+Debug

### DIFF
--- a/src/cpu-template-helper/src/utils/mod.rs
+++ b/src/cpu-template-helper/src/utils/mod.rs
@@ -87,6 +87,7 @@ pub fn build_microvm_from_config(
         &vm_resources,
         &mut event_manager,
         &seccomp_filters,
+        Box::new(std::io::stdout()),
     )?;
 
     Ok((vmm, vm_resources))

--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -15,7 +15,6 @@ use utils::eventfd::EventFd;
 use vm_superio::Serial;
 
 use crate::devices::bus::BusDevice;
-use crate::devices::legacy::serial::SerialOut;
 use crate::devices::legacy::{EventFdTrigger, SerialDevice, SerialEventsWrapper};
 
 /// Errors corresponding to the `PortIODeviceManager`.
@@ -109,7 +108,7 @@ impl PortIODeviceManager {
                 SerialEventsWrapper {
                     buffer_ready_event_fd: None,
                 },
-                SerialOut::Sink(std::io::sink()),
+                Box::new(std::io::sink()),
             ),
             input: None,
         })));
@@ -119,7 +118,7 @@ impl PortIODeviceManager {
                 SerialEventsWrapper {
                     buffer_ready_event_fd: None,
                 },
-                SerialOut::Sink(std::io::sink()),
+                Box::new(std::io::sink()),
             ),
             input: None,
         })));
@@ -188,7 +187,7 @@ mod tests {
                     SerialEventsWrapper {
                         buffer_ready_event_fd: None,
                     },
-                    SerialOut::Sink(std::io::sink()),
+                    Box::new(std::io::sink()),
                 ),
                 input: None,
             }))),

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -372,7 +372,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                     let serial = crate::builder::setup_serial_device(
                         constructor_args.event_manager,
                         std::io::stdin(),
-                        std::io::stdout(),
+                        Box::new(std::io::stdout()),
                     )?;
 
                     dev_manager

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -541,6 +541,7 @@ impl<'a> PrebootApiController<'a> {
             self.vm_resources,
             self.event_manager,
             self.seccomp_filters,
+            Box::new(std::io::stdout()),
         )
         .map(|vmm| {
             self.built_vmm = Some(vmm);
@@ -861,6 +862,7 @@ mod tests {
     use super::*;
     use crate::cpu_config::templates::test_utils::build_test_template;
     use crate::cpu_config::templates::{CpuTemplateType, StaticCpuTemplate};
+    use crate::devices::legacy::serial::SerialOut;
     use crate::devices::virtio::balloon::{BalloonConfig, BalloonError};
     use crate::devices::virtio::block::CacheType;
     use crate::devices::virtio::rng::EntropyError;
@@ -1214,6 +1216,7 @@ mod tests {
         _: &VmResources,
         _: &mut EventManager,
         _: &BpfThreadMap,
+        _: Box<dyn SerialOut>,
     ) -> Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
         Ok(Arc::new(Mutex::new(MockVmm::default())))
     }

--- a/src/vmm/src/utilities/test_utils/mod.rs
+++ b/src/vmm/src/utilities/test_utils/mod.rs
@@ -71,6 +71,7 @@ pub fn create_vmm(
         &resources,
         &mut event_manager,
         &empty_seccomp_filters,
+        Box::new(std::io::stdout()),
     )
     .unwrap();
 

--- a/src/vmm/tests/devices.rs
+++ b/src/vmm/tests/devices.rs
@@ -10,7 +10,6 @@ use event_manager::{EventManager, SubscriberOps};
 use libc::EFD_NONBLOCK;
 use utils::eventfd::EventFd;
 use vm_superio::Serial;
-use vmm::devices::legacy::serial::SerialOut;
 use vmm::devices::legacy::{EventFdTrigger, SerialEventsWrapper, SerialWrapper};
 
 fn create_serial(
@@ -26,7 +25,7 @@ fn create_serial(
             SerialEventsWrapper {
                 buffer_ready_event_fd: Some(kick_stdin_evt.try_clone().unwrap()),
             },
-            SerialOut::Stdout(std::io::stdout()),
+            Box::new(std::io::stdout()),
         ),
         input: Some(Box::new(serial_in)),
     }))

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -33,6 +33,7 @@ fn test_build_and_boot_microvm() {
             &resources,
             &mut event_manager,
             &empty_seccomp_filters,
+            Box::new(std::io::stdout()),
         );
         assert_eq!(format!("{:?}", vmm_ret.err()), "Some(MissingKernelConfig)");
     }


### PR DESCRIPTION

## Changes

Remove the SerialOut specialized enum and replace it with a generic Trait.

## Reason

Now other `Write` types can be used, such as `std::fs::File`, sockets, etc.
I'm using `vmm` as a crate to launch multiple VMs on the same process, and they all have un-synchronized access to stdout.
## Other

I've decided to not make changes to `stdin` without first having these reviewed first

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [X] If a specific issue led to this PR, this PR closes the issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this
  PR.
- [X] API changes follow the [Runbook for Firecracker API changes][2].
- [X] User-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.
- [X] New `TODO`s link to an issue.
- [X] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [X] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
