### PR TITLE
Update Rust Toolchain to 1.76.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -11,7 +11,7 @@
 # allowlisted using a toolchain that requires it, causing the A/B-test to
 # always fail.
 [toolchain]
-channel = "1.73.0"
+channel = "1.76.0"
 targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]
 profile = "minimal"
 

--- a/src/firecracker/src/api_server/mod.rs
+++ b/src/firecracker/src/api_server/mod.rs
@@ -12,10 +12,7 @@ pub mod request;
 use std::fmt::Debug;
 use std::sync::mpsc;
 
-pub use micro_http::{
-    Body, HttpServer, Method, Request, RequestError, Response, ServerError, ServerRequest,
-    ServerResponse, StatusCode, Version,
-};
+pub use micro_http::{Body, HttpServer, Request, Response, ServerError, StatusCode, Version};
 use parsed_request::{ParsedRequest, RequestAction};
 use seccompiler::BpfProgramRef;
 use serde_json::json;

--- a/src/firecracker/src/api_server/request/mod.rs
+++ b/src/firecracker/src/api_server/request/mod.rs
@@ -16,6 +16,4 @@ pub mod net;
 pub mod snapshot;
 pub mod version;
 pub mod vsock;
-pub use micro_http::{
-    Body, HttpServer, Method, Request, RequestError, Response, StatusCode, Version,
-};
+pub use micro_http::{Body, Method, StatusCode};

--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -377,7 +377,7 @@ impl CgroupV2 {
             Err(_) => return false,
         };
 
-        for l in BufReader::new(f).lines().flatten() {
+        for l in BufReader::new(f).lines().map_while(Result::ok) {
             if l.split(' ').any(|x| x == controller) {
                 return true;
             }

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -14,7 +14,6 @@ pub mod test_utils;
 use vm_memory::GuestMemoryError;
 
 pub use self::device::VirtioBlock;
-pub use self::event_handler::*;
 pub use self::request::*;
 pub use crate::devices::virtio::block::CacheType;
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;

--- a/src/vmm/src/devices/virtio/net/gen/mod.rs
+++ b/src/vmm/src/devices/virtio/net/gen/mod.rs
@@ -23,4 +23,3 @@ pub mod if_tun;
 pub mod sockios;
 pub use if_tun::*;
 pub use iff::*;
-pub use sockios::*;

--- a/src/vmm/src/devices/virtio/net/mod.rs
+++ b/src/vmm/src/devices/virtio/net/mod.rs
@@ -29,7 +29,6 @@ mod gen;
 pub use tap::{Tap, TapError};
 
 pub use self::device::Net;
-pub use self::event_handler::*;
 
 /// Enum representing the Net device queue types
 #[derive(Debug)]

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -101,7 +101,7 @@ impl BlockBuilder {
     /// Specifies whether there is a root block device already present in the list.
     fn has_root_device(&self) -> bool {
         // If there is a root device, it would be at the top of the list.
-        if let Some(block) = self.devices.get(0) {
+        if let Some(block) = self.devices.front() {
             block.lock().expect("Poisoned lock").root_device()
         } else {
             false

--- a/src/vmm/tests/io_uring.rs
+++ b/src/vmm/tests/io_uring.rs
@@ -167,14 +167,14 @@ fn test_restrictions() {
         ring.push(Operation::read(0, buf.as_ptr() as usize, 4, 0, 71))
             .unwrap();
         assert_eq!(ring.submit_and_wait_all().unwrap(), 1);
-        assert!(ring.pop().unwrap().unwrap().result().is_ok());
+        ring.pop().unwrap().unwrap().result().unwrap();
 
         // Other operations are not allowed.
 
         ring.push(Operation::write(0, buf.as_ptr() as usize, 4, 0, 71))
             .unwrap();
         assert_eq!(ring.submit_and_wait_all().unwrap(), 1);
-        assert!(ring.pop().unwrap().unwrap().result().is_err());
+        ring.pop().unwrap().unwrap().result().unwrap_err();
     }
 }
 

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 # The Rust toolchain layer will get updated most frequently, but we could keep the system
 # dependencies layer intact for much longer.
 
-ARG RUST_TOOLCHAIN="1.73.0"
+ARG RUST_TOOLCHAIN="1.76.0"
 ARG TMP_BUILD_DIR=/tmp/build
 ARG FIRECRACKER_SRC_DIR="/firecracker"
 ARG FIRECRACKER_BUILD_DIR="$FIRECRACKER_SRC_DIR/build"

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -111,7 +111,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOL
     && rustup target add aarch64-unknown-linux-musl \
     && rustup component add llvm-tools-preview \
     && cargo install --locked cargo-audit cargo-deny grcov cargo-sort \
-    && (if [ "$ARCH" = "x86_64" ]; then cargo install --locked kani-verifier && cargo kani setup; else true; fi) \
+    && (if [ "$ARCH" = "x86_64" ]; then cargo install --locked kani-verifier --version 0.45.0 && cargo kani setup; else true; fi) \
     \
     && apt-get update \
     && apt-get -y install --no-install-recommends \

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v70}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v71}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
Some dependencies have recently adopted a MSRV of 1.74.0, which is higher than our current toolchain version (1.73.0). Update to the newest toolchain currently available, to unblock https://github.com/firecracker-microvm/firecracker/pull/4445

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
