### PR TITLE
fix(vmm): call KVMCLOCK_CTRL when pausing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to
   `VIRTIO_NET_F_RX_MRGBUF` support to the `virtio-net` device. When this feature
   is negotiated, guest `virtio-net` driver can perform more efficient memory
   management which in turn improves RX and TX performance.
+- [#4460](https://github.com/firecracker-microvm/firecracker/pull/4460): Add a
+  call to
+  [`KVM_KVMCLOCK_CTRL`](https://docs.kernel.org/virt/kvm/api.html#kvm-kvmclock-ctrl)
+  after pausing vCPUs on x86_64 architectures. This ioctl sets a flag in the KVM
+  state of the vCPU indicating that it has been paused by the host userspace. In
+  guests that use kvmclock, the soft lockup watchdog checks this flag. If it is
+  set, it won't trigger the lockup condition. Calling the ioctl for guests that
+  don't use kvmclock will fail. These failures are not fatal. We log the failure
+  and increase the `vcpu.kvmclock_ctrl_fails` metric.
 
 ### Changed
 

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -1255,6 +1255,18 @@
                 ]
             },
             {
+                "syscall": "ioctl",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 44717,
+                        "comment": "KVM_KVMCLOCK_CTRL. We call this after pausing vCPUs to avoid soft lockups in the guest."
+                    }
+                ]
+            },
+            {
                 "syscall": "sched_yield",
                 "comment": "Used by the rust standard library in std::sync::mpmc. Firecracker uses mpsc channels from this module for inter-thread communication"
             },

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -779,6 +779,8 @@ pub struct VcpuMetrics {
     pub exit_mmio_write: SharedIncMetric,
     /// Number of errors during this VCPU's run.
     pub failures: SharedIncMetric,
+    /// Number of times that the `KVM_KVMCLOCK_CTRL` ioctl failed.
+    pub kvmclock_ctrl_fails: SharedIncMetric,
     /// Provides Min/max/sum for KVM exits handling input IO.
     pub exit_io_in_agg: LatencyAggregateMetrics,
     /// Provides Min/max/sum for KVM exits handling output IO.
@@ -797,6 +799,7 @@ impl VcpuMetrics {
             exit_mmio_read: SharedIncMetric::new(),
             exit_mmio_write: SharedIncMetric::new(),
             failures: SharedIncMetric::new(),
+            kvmclock_ctrl_fails: SharedIncMetric::new(),
             exit_io_in_agg: LatencyAggregateMetrics::new(),
             exit_io_out_agg: LatencyAggregateMetrics::new(),
             exit_mmio_read_agg: LatencyAggregateMetrics::new(),

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -336,8 +336,15 @@ impl Vcpu {
                     .send(VcpuResponse::Paused)
                     .expect("vcpu channel unexpectedly closed");
 
-                // TODO: we should call `KVM_KVMCLOCK_CTRL` here to make sure
-                // TODO continued: the guest soft lockup watchdog does not panic on Resume.
+                // Calling `KVM_KVMCLOCK_CTRL` to make sure the guest softlockup watchdog
+                // does not panic on resume, see https://docs.kernel.org/virt/kvm/api.html .
+                // We do not want to fail if the call is not successful, because depending
+                // that may be acceptable depending on the workload.
+                // TODO: add a metric
+                #[cfg(target_arch = "x86_64")]
+                if let Err(err) = self.kvm_vcpu.fd.kvmclock_ctrl() {
+                    warn!("KVM_KVMCLOCK_CTRL call failed {}", err);
+                }
 
                 // Move to 'paused' state.
                 state = StateMachine::next(Self::paused);

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -340,9 +340,9 @@ impl Vcpu {
                 // does not panic on resume, see https://docs.kernel.org/virt/kvm/api.html .
                 // We do not want to fail if the call is not successful, because depending
                 // that may be acceptable depending on the workload.
-                // TODO: add a metric
                 #[cfg(target_arch = "x86_64")]
                 if let Err(err) = self.kvm_vcpu.fd.kvmclock_ctrl() {
+                    METRICS.vcpu.kvmclock_ctrl_fails.inc();
                     warn!("KVM_KVMCLOCK_CTRL call failed {}", err);
                 }
 

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -234,6 +234,7 @@ def validate_fc_metrics(metrics):
             "exit_mmio_read",
             "exit_mmio_write",
             "failures",
+            "kvmclock_ctrl_fails",
             {"exit_io_in_agg": latency_agg_metrics_fields},
             {"exit_io_out_agg": latency_agg_metrics_fields},
             {"exit_mmio_read_agg": latency_agg_metrics_fields},


### PR DESCRIPTION
## Changes

Call `KVM_KVMCLOCK_CTRL` when pausing vCPUs. This allows guest kernel's soft lockup watchdog to know that it was the hypervisor that paused the vCPUs and don't trigger an exception.

Fixes: https://github.com/firecracker-microvm/firecracker/issues/1859

## Reason

This is to avoid guest kernel panic on resume path due to soft lockup detection.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
