### PR TITLE
tests: Install tools with `--locked` option

### DIFF
--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -110,8 +110,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOL
     && rustup target add x86_64-unknown-linux-musl \
     && rustup target add aarch64-unknown-linux-musl \
     && rustup component add llvm-tools-preview \
-    && cargo install cargo-audit cargo-deny grcov cargo-sort \
-    && (if [ "$ARCH" = "x86_64" ]; then cargo install kani-verifier && cargo kani setup; else true; fi) \
+    && cargo install --locked cargo-audit cargo-deny grcov cargo-sort \
+    && (if [ "$ARCH" = "x86_64" ]; then cargo install --locked kani-verifier && cargo kani setup; else true; fi) \
     \
     && apt-get update \
     && apt-get -y install --no-install-recommends \


### PR DESCRIPTION
## Changes

Install cargo tools with `--locked` option.

## Reason

Without `--locked` option, installation cargo tools may fail for some reasons. `--locked` option is useful for reproducible installation since it ensures to use the exact same set of dependencies.
https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile

For example, on v1.5 and v1.6, the installation failed due to an older rustc version.
```
error: failed to compile `cargo-audit v0.20.0`, intermediate artifacts can be found at `/tmp/cargo-installORO8R6`
--
  |  
  | Caused by:
  | package `clap_derive v4.5.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0
  | Try re-running cargo install with `--locked`
  | error: failed to compile `cargo-deny v0.14.11`, intermediate artifacts can be found at `/tmp/cargo-installioMzbq`
  |  
  | Caused by:
  | package `clap_builder v4.5.1` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0
  | Try re-running cargo install with `--locked`
  | error: failed to compile `grcov v0.8.19`, intermediate artifacts can be found at `/tmp/cargo-installOqwGlC`
  |  
  | Caused by:
  | package `clap_derive v4.5.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0
  | Try re-running cargo install with `--locked`
  | error: failed to compile `cargo-sort v1.0.9`, intermediate artifacts can be found at `/tmp/cargo-install8DeK7Q`
  |  
  | Caused by:
  | package `clap_lex v0.7.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0
  | Try re-running cargo install with `--locked`
  | Summary Failed to install cargo-audit, cargo-deny, grcov, cargo-sort (see error(s) above).
  | error: some crates failed to install


```

This is to be backported to v1.5 and v1.6.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
