### PR TITLE
fix: do not limit pipeline_perf.py to nonci tests in metrics mode

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -73,7 +73,8 @@ def build_group(test):
         devtool_opts += " --ab"
         pytest_opts = f" {ab_opts} run {REVISION_A} {REVISION_B} --test {test_path}"
     else:
-        pytest_opts += f" -m nonci {test_path}"
+        # Passing `-m ''` below instructs pytest to collect tests regardless of their markers (e.g. it will collect both tests marked as nonci, and tests without any markers).
+        pytest_opts += f" -m '' {test_path}"
     binary_dir = test.pop("binary_dir")
     return group(
         label=test.pop("label"),


### PR DESCRIPTION
When running A/B-Tests, the pipeline generated by pipeline_perf.py does not care about pytest markers, it will run all tests specified and do the A/B-comparision. However, when running the pipeline in metrics collection mode, it passes `-m nonci` to pytest, which causes it to filter out tests that do not have the `nonci` marker. Some of our A/B-Tests (such as memory overhead) indeed do not have this marker, leading to confusing errors (where everything works in A/B-mode, but if just collecting metrics pytest fails with "no tests collected"). This commit makes the behavior consistent, but also triggering non-nonci tests in metrics collection mode.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
