### PR TITLE
Update micro-http for empty MMDS path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ and this project adheres to
   mechanism to reliably fetch Firecracker PID. With this change, Firecracker
   process's PID will always be available in the Jailer's root directory
   regardless of whether new_pid_ns was set.
+- [#4468](https://github.com/firecracker-microvm/firecracker/pull/4468): Fixed a
+  bug where a client would hang or timeout when querying for an MMDS path whose
+  content is empty, because the 'Content-Length' header field was missing in a
+  response.
 
 ## \[1.6.0\]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http#e75dfa1eeea23b69caa7407bc2c3a76d7b7262fb"
+source = "git+https://github.com/firecracker-microvm/micro-http#7e2684d77930f8b06c3c085691e5c50202d06633"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -434,7 +434,8 @@ def assert_seccomp_level(pid, seccomp_level):
 
 def run_guest_cmd(ssh_connection, cmd, expected, use_json=False):
     """Runs a shell command at the remote accessible via SSH"""
-    _, stdout, stderr = ssh_connection.run(cmd)
+    rc, stdout, stderr = ssh_connection.run(cmd)
+    assert rc == 0
     assert stderr == ""
     stdout = stdout if not use_json else json.loads(stdout)
     assert stdout == expected

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -296,6 +296,7 @@ def test_mmds_response(uvm_plain, version):
                     "res_key": "res_value",
                 },
                 "dummy_array": ["arr_val1", "arr_val2"],
+                "dummy_empty": "",
             },
             "Limits": {"CPU": 512, "Memory": 512},
             "Usage": {"CPU": 12.12},
@@ -328,12 +329,12 @@ def test_mmds_response(uvm_plain, version):
     expected = (
         "ami-id\n"
         "dummy_array\n"
+        "dummy_empty\n"
         "dummy_obj/\n"
         "local-hostname\n"
         "public-hostname\n"
         "reservation-id"
     )
-
     run_guest_cmd(ssh_connection, cmd, expected)
 
     cmd = pre + "latest/meta-data/ami-id/"
@@ -341,6 +342,9 @@ def test_mmds_response(uvm_plain, version):
 
     cmd = pre + "latest/meta-data/dummy_array/0"
     run_guest_cmd(ssh_connection, cmd, "arr_val1")
+
+    cmd = pre + "latest/meta-data/dummy_empty"
+    run_guest_cmd(ssh_connection, cmd, "")
 
     cmd = pre + "latest/Usage/CPU"
     run_guest_cmd(


### PR DESCRIPTION
## Changes

- Check the return code of command run on guests.
- Update Cargo.lock to use the latest micro-http.
- Add an integration test for an empty MMDS path.

## Reason

When querying a MMDS path that has an empty content, the response didn't
contain 'Content-Length' field, resulting in the client waiting for the
connection closed by the server or timeout. To fix this issue,
micro-http made a change to have the field when the response status code
is not 1XX or 204.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
