### PR TITLE
fix: subtract pre-`run()` execution time from startup time again

### DIFF
--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -596,6 +596,7 @@ impl Env {
     }
 
     pub fn run(mut self) -> Result<(), JailerError> {
+        let jailer_start_time_cpu = utils::time::get_time_us(utils::time::ClockType::ProcessCpu);
         let exec_file_name = self.copy_exec_to_chroot()?;
         let chroot_exec_file = PathBuf::from("/").join(exec_file_name);
 
@@ -723,7 +724,8 @@ impl Env {
         }
 
         // Compute jailer's total CPU time up to the current time.
-        self.jailer_cpu_time_us += utils::time::get_time_us(utils::time::ClockType::ProcessCpu);
+        self.jailer_cpu_time_us +=
+            utils::time::get_time_us(utils::time::ClockType::ProcessCpu) - jailer_start_time_cpu;
 
         // If specified, exec the provided binary into a new PID namespace.
         if self.new_pid_ns {


### PR DESCRIPTION
Deprecating --startup-time-cpu-us accidentally involved us to double count some time spent in the jailer. This commit reverts that behavior.

A/B-Test to compare to commit before --startup-time-cpu-us deprecation:

```bash
 ./tools/devtool test --ab -- run b546bc566244695d0c709a318c30d483fb86ed2c HEAD --test integration_tests/performance/test_process_startup_time.py

...

Doing A/B-test for dimensions frozenset({('rootfs', 'ubuntu-22.04.squashfs'), ('performance_test', 'test_startup_time_new_pid_ns'), ('host_kernel', 'linux-6.5'), ('cpu_model', '11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz'), ('guest_kernel', 'linux-5.10'), ('vcpus', '2'), ('instance', 'NA'), ('guest_memory', '1024.0MB')}) and property startup_time
Doing A/B-test for dimensions frozenset({('rootfs', 'ubuntu-22.04.squashfs'), ('performance_test', 'test_startup_time_daemonize'), ('host_kernel', 'linux-6.5'), ('cpu_model', '11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz'), ('guest_kernel', 'linux-5.10'), ('vcpus', '2'), ('instance', 'NA'), ('guest_memory', '1024.0MB')}) and property startup_time
Doing A/B-test for dimensions frozenset({('rootfs', 'ubuntu-22.04.squashfs'), ('performance_test', 'test_startup_time_custom_seccomp'), ('host_kernel', 'linux-6.5'), ('cpu_model', '11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz'), ('guest_kernel', 'linux-5.10'), ('vcpus', '2'), ('instance', 'NA'), ('guest_memory', '1024.0MB')}) and property startup_time
No regressions detected!
[Firecracker devtool 2024-02-27T11:03:47+00:00] Finished test run ...


```

Fixes: 21f0dea22aa1bb38daf32520b1196a9ff72b5815

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
