### PR TITLE
refactor(vmm): Use unwrap_or_default() for startup time calculation

### DIFF
--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -325,10 +325,9 @@ impl ProcessTimeReporter {
 
     /// Obtain process start time in microseconds.
     pub fn report_start_time(&self) {
-        if let Some(start_time) = self.start_time_us {
-            let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time;
-            METRICS.api_server.process_startup_time_us.store(delta_us);
-        }
+        let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic)
+            - self.start_time_us.unwrap_or_default();
+        METRICS.api_server.process_startup_time_us.store(delta_us);
     }
 
     /// Obtain process CPU start time in microseconds.


### PR DESCRIPTION
## Changes / Reason

As done to the process startup **CPU** time calculation in commit 21f0dea22aa1 ("chore(docs): deprecate --start-time-cpu-us parameter"), use `unwrap_or_default()` to calculate the process startup time. With this change, it comes to report the process startup time regardless of whether `--start-time-us` is given or not.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
