### PR TITLE
Add microvm helper for enabling console data

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -371,6 +371,13 @@ class Microvm:
         return self.log_file.read_text()
 
     @property
+    def console_data(self):
+        """Return the output of microVM's console"""
+        if self.screen_log is None:
+            return None
+        return Path(self.screen_log).read_text(encoding="utf-8")
+
+    @property
     def state(self):
         """Get the InstanceInfo property and return the state field."""
         return self.api.describe.get().json()["state"]


### PR DESCRIPTION
## Changes

Add a property in microvm class for printing console data. If console is disabled this will print an empty string.

## Reason

I found it useful, when debugging some guest kernel changes. Essentially, if we call that method before launching a microVM we can later print it's console output in the same way we can print Firecracker logs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
