### PR TITLE
doc: network for clones iptables dnat command error

### DIFF
--- a/docs/snapshotting/network-for-clones.md
+++ b/docs/snapshotting/network-for-clones.md
@@ -126,7 +126,7 @@ sudo ip netns exec fc0 iptables -t nat -A POSTROUTING -o veth0 \
 # do the reverse operation; rewrites the destination address of packets
 # heading towards the clone address to 192.168.241.2
 sudo ip netns exec fc0 iptables -t nat -A PREROUTING -i veth0 \
--d 192.168.0.3 -j DNAT —to 192.168.241.2
+-d 192.168.0.3 -j DNAT --to 192.168.241.2
 
 # (adds a route on the host for the clone address)
 sudo ip route add 192.168.0.3 via 10.0.0.2


### PR DESCRIPTION
## Changes
docs network for clones iptables DNAT command

## Reason
There is a problem with the command

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
