### PR TITLE
chore: update linux-loader to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,11 +808,11 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-loader"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132a531b85b3a164012ab682c72f8f2cce7757f187be5f60782fd2b4cda9cb34"
+checksum = "eb68dd3452f25a8defaf0ae593509cff0c777683e4d8924f59ac7c5f89267a83"
 dependencies = [
- "vm-memory 0.13.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1457,7 +1457,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "vm-memory 0.13.1",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1484,7 +1484,7 @@ checksum = "2b64e816d0d49769fbfaa1494eb77cc2a3ddc526ead05c7f922cb7d64106286f"
 dependencies = [
  "bitflags 2.4.2",
  "libc",
- "vm-memory 0.14.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1503,17 +1503,6 @@ name = "vm-fdt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43fb5a6bd1a7d423ad72802801036719b7546cf847a103f8fe4575f5b0d45a6"
-
-[[package]]
-name = "vm-memory"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376c9ee5ebe2103a310d8241936cfb93c946734b0479a4fa5bdf7a64abbacd8"
-dependencies = [
- "libc",
- "thiserror",
- "winapi",
-]
 
 [[package]]
 name = "vm-memory"
@@ -1571,7 +1560,7 @@ dependencies = [
  "vhost",
  "vm-allocator",
  "vm-fdt",
- "vm-memory 0.13.1",
+ "vm-memory",
  "vm-superio",
 ]
 

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.165", features = ["derive"] }
 thiserror = "1.0.32"
 displaydoc = "0.2.4"
 vmm-sys-util = "0.12.1"
-vm-memory = { version = "0.13.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-bitmap"] }
 log-instrument = { path = "../log-instrument", optional = true }
 
 [dev-dependencies]

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -18,7 +18,7 @@ kvm-ioctls = "0.16.0"
 lazy_static = "1.4.0"
 libc = "0.2.117"
 memfd = "0.6.3"
-linux-loader = "0.10.0"
+linux-loader = "0.11.0"
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 semver = { version = "1.0.17", features = ["serde"] }
 serde_json = "1.0.78"
@@ -29,7 +29,7 @@ userfaultfd = "0.7.0"
 vhost = { version = "0.10.0", features = ["vhost-user-frontend"] }
 vm-allocator = "0.1.0"
 vm-superio = "0.7.0"
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-bitmap"] }
 log = { version = "0.4.17", features = ["std", "serde"] }
 aes-gcm =  { version = "0.10.1", default-features = false, features = ["aes"] }
 base64 = "0.21.0"


### PR DESCRIPTION
Update linux-loader to 0.11.0 to de-duplicate our vm-memory dependency.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
