### PR TITLE
docs: Add back guidance to disable SMT

### DIFF
--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -274,17 +274,37 @@ echo "swap partitions present (Recommendation: no swap)" \
 
 #### Side channel attacks
 
-It is strongly recommended that users follow the
-[Linux kernel documentation on hardware vulnerabilities](https://docs.kernel.org/admin-guide/hw-vuln/index.html)
-when configuring mitigations against side channel attacks including "Spectre"
-and "Meltdown" attacks (see
-[Page Table Isolation](https://docs.kernel.org/arch/x86/pti.html) and
-[Speculation Control](https://docs.kernel.org/userspace-api/spec_ctrl.html)).
+For the purposes of this document we assume a workload that involves arbitrary
+code execution in a multi-tenant context where each Firecracker process
+corresponds to a single tenant.
 
-Additionally users should consider disabling
+Specific mitigations for side channel issues are constantly evolving as
+researchers find additional issues on a regular basis. Firecracker itself has no
+control over many lower-level software and hardware behaviors and capabilities
+and is not able to mitigate all these issues. Thus, it is strongly recommended
+that users follow the very latest
+[Linux kernel documentation on hardware vulnerabilities](https://docs.kernel.org/admin-guide/hw-vuln/index.html)
+as well as hardware/processor-specific recommendations and firmware updates (see
+[vendor-specific recommendations](#vendor-specific-recommendations) below) when
+configuring mitigations against side channel attacks including "Spectre" and
+"Meltdown" attacks.
+
+However, some generic recommendations are also provided in what follows.
+
+##### Disable SMT
+
+Simultaneous Multi-Threading (SMT) is frequently a precondition for speculation
+issues utilized in side channel attacks such as Spectre variants, MDS, and
+others, where one tenant could leak information to another tenant or the host.
+As such, our recommendation is to disable SMT in production scenarios that
+require tenant separation.
+
+##### Disable Kernel Samepage Merging
+
+Users should disable
 [Kernel Samepage Merging](https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html)
-to mitigate [side channel issues](https://eprint.iacr.org/2013/448.pdf) relying
-on the page deduplication for revealing what memory pages are accessed by
+to mitigate [side channel issues](https://eprint.iacr.org/2013/448.pdf) that
+rely on page deduplication for revealing what memory pages are accessed by
 another process.
 
 ##### Use memory with Rowhammer mitigation support


### PR DESCRIPTION
This recommends disabling SMT and breaks out KSM into its own subsection.

## Reason

We had previously removed this as part of focusing on Linux & vendor documentation that would be more holistic and up to date. However it is clear that disabling SMT is a good practice in general we should continue to emphasize that.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- ~~[ ] All added/changed functionality is tested.~~
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

~~- [ ] This functionality cannot be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
