### PR TITLE
Add: flake.nix to root of the project

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
           '';
 
           buildInputs = [
+            cmake
             openssl
             pkg-config
             rust-bin.stable.latest.default

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Firecracker dependecies for developer environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [
+          (import rust-overlay)
+        ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+      in
+      with pkgs;
+      {
+        devShells.default = mkShell.override { stdenv = pkgs.clangStdenv; } {
+          # Point bindgen to where the clang library would be
+          LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+          # Make clang aware of a few headers (stdbool.h, wchar.h)
+          BINDGEN_EXTRA_CLANG_ARGS = with pkgs; ''
+            -isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion clang}/include
+            -isystem ${llvmPackages.libclang.out}/lib/clang/${lib.getVersion clang}/include
+            -isystem ${glibc.dev}/include
+          '';
+
+          buildInputs = [
+            openssl
+            pkg-config
+            rust-bin.stable.latest.default
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Changes
Added flake.nix to root of the project

## Reason
Some developers can benefit from the Nix and NixOs package management feature called flakes... This feature automatically enables all the declared packages and all the dependencies configuration in flake.nix file.
Contributing to https://github.com/firecracker-microvm/firecracker/issues/4488 I missed some nix-case development environment... That was my case btw.
## Details
[Nix](https://nixos.org/guides/how-nix-works) and [NixOs](https://nixos.org/) has a "experimental" feature called [flakes](https://nixos.wiki/wiki/Flakes) that improves modularity of Nix declarative package management.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [X] If a specific issue led to this PR, this PR closes the issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
