### PR TITLE
refactor: error_impl_error in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ cast_sign_loss = "warn"
 exit = "warn"
 tests_outside_test_module = "warn"
 assertions_on_result_states = "warn"
+error_impl_error = "warn"
 
 [profile.dev]
 panic = "abort"

--- a/src/firecracker/src/api_server/request/actions.rs
+++ b/src/firecracker/src/api_server/request/actions.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 #[cfg(target_arch = "aarch64")]
 use super::StatusCode;
@@ -28,7 +28,7 @@ struct ActionBody {
     action_type: ActionType,
 }
 
-pub(crate) fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_actions(body: &Body) -> Result<ParsedRequest, RequestError> {
     METRICS.put_api_requests.actions_count.inc();
     let action_body = serde_json::from_slice::<ActionBody>(body.raw()).map_err(|err| {
         METRICS.put_api_requests.actions_fails.inc();
@@ -41,7 +41,7 @@ pub(crate) fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
         ActionType::SendCtrlAltDel => {
             // SendCtrlAltDel not supported on aarch64.
             #[cfg(target_arch = "aarch64")]
-            return Err(Error::Generic(
+            return Err(RequestError::Generic(
                 StatusCode::BadRequest,
                 "SendCtrlAltDel does not supported on aarch64.".to_string(),
             ));

--- a/src/firecracker/src/api_server/request/balloon.rs
+++ b/src/firecracker/src/api_server/request/balloon.rs
@@ -7,14 +7,16 @@ use vmm::vmm_config::balloon::{
     BalloonDeviceConfig, BalloonUpdateConfig, BalloonUpdateStatsConfig,
 };
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 
-pub(crate) fn parse_get_balloon(path_second_token: Option<&str>) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_get_balloon(
+    path_second_token: Option<&str>,
+) -> Result<ParsedRequest, RequestError> {
     match path_second_token {
         Some(stats_path) => match stats_path {
             "statistics" => Ok(ParsedRequest::new_sync(VmmAction::GetBalloonStats)),
-            _ => Err(Error::Generic(
+            _ => Err(RequestError::Generic(
                 StatusCode::BadRequest,
                 format!("Unrecognized GET request path `{}`.", stats_path),
             )),
@@ -23,7 +25,7 @@ pub(crate) fn parse_get_balloon(path_second_token: Option<&str>) -> Result<Parse
     }
 }
 
-pub(crate) fn parse_put_balloon(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_balloon(body: &Body) -> Result<ParsedRequest, RequestError> {
     Ok(ParsedRequest::new_sync(VmmAction::SetBalloonDevice(
         serde_json::from_slice::<BalloonDeviceConfig>(body.raw())?,
     )))
@@ -32,13 +34,13 @@ pub(crate) fn parse_put_balloon(body: &Body) -> Result<ParsedRequest, Error> {
 pub(crate) fn parse_patch_balloon(
     body: &Body,
     path_second_token: Option<&str>,
-) -> Result<ParsedRequest, Error> {
+) -> Result<ParsedRequest, RequestError> {
     match path_second_token {
         Some(config_path) => match config_path {
             "statistics" => Ok(ParsedRequest::new_sync(VmmAction::UpdateBalloonStatistics(
                 serde_json::from_slice::<BalloonUpdateStatsConfig>(body.raw())?,
             ))),
-            _ => Err(Error::Generic(
+            _ => Err(RequestError::Generic(
                 StatusCode::BadRequest,
                 format!("Unrecognized PATCH request path `{}`.", config_path),
             )),

--- a/src/firecracker/src/api_server/request/boot_source.rs
+++ b/src/firecracker/src/api_server/request/boot_source.rs
@@ -5,10 +5,10 @@ use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 use vmm::vmm_config::boot_source::BootSourceConfig;
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 
-pub(crate) fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, RequestError> {
     METRICS.put_api_requests.boot_source_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureBootSource(
         serde_json::from_slice::<BootSourceConfig>(body.raw()).map_err(|err| {

--- a/src/firecracker/src/api_server/request/cpu_configuration.rs
+++ b/src/firecracker/src/api_server/request/cpu_configuration.rs
@@ -5,17 +5,17 @@ use vmm::cpu_config::templates::CustomCpuTemplate;
 use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 
-pub(crate) fn parse_put_cpu_config(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_cpu_config(body: &Body) -> Result<ParsedRequest, RequestError> {
     METRICS.put_api_requests.cpu_cfg_count.inc();
 
     // Convert the API request into a a deserialized/binary format
     Ok(ParsedRequest::new_sync(VmmAction::PutCpuConfiguration(
         CustomCpuTemplate::try_from(body.raw()).map_err(|err| {
             METRICS.put_api_requests.cpu_cfg_fails.inc();
-            Error::SerdeJson(err)
+            RequestError::SerdeJson(err)
         })?,
     )))
 }
@@ -83,7 +83,7 @@ mod tests {
             expected_err_count
         );
         assert!(
-            matches!(invalid_put_result, Err(Error::SerdeJson(_))),
+            matches!(invalid_put_result, Err(RequestError::SerdeJson(_))),
             "{:?}",
             invalid_put_result
         );

--- a/src/firecracker/src/api_server/request/entropy.rs
+++ b/src/firecracker/src/api_server/request/entropy.rs
@@ -4,10 +4,10 @@
 use vmm::rpc_interface::VmmAction;
 use vmm::vmm_config::entropy::EntropyDeviceConfig;
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 
-pub(crate) fn parse_put_entropy(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_entropy(body: &Body) -> Result<ParsedRequest, RequestError> {
     let cfg = serde_json::from_slice::<EntropyDeviceConfig>(body.raw())?;
     Ok(ParsedRequest::new_sync(VmmAction::SetEntropyDevice(cfg)))
 }

--- a/src/firecracker/src/api_server/request/instance_info.rs
+++ b/src/firecracker/src/api_server/request/instance_info.rs
@@ -4,9 +4,9 @@
 use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 
-pub(crate) fn parse_get_instance_info() -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_get_instance_info() -> Result<ParsedRequest, RequestError> {
     METRICS.get_api_requests.instance_info_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::GetVmInstanceInfo))
 }

--- a/src/firecracker/src/api_server/request/logger.rs
+++ b/src/firecracker/src/api_server/request/logger.rs
@@ -4,10 +4,10 @@
 use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 
-pub(crate) fn parse_put_logger(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_logger(body: &Body) -> Result<ParsedRequest, RequestError> {
     METRICS.put_api_requests.logger_count.inc();
     let res = serde_json::from_slice::<vmm::logger::LoggerConfig>(body.raw());
     let config = res.map_err(|err| {

--- a/src/firecracker/src/api_server/request/machine_configuration.rs
+++ b/src/firecracker/src/api_server/request/machine_configuration.rs
@@ -5,15 +5,15 @@ use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 use vmm::vmm_config::machine_config::{MachineConfig, MachineConfigUpdate};
 
-use super::super::parsed_request::{method_to_error, Error, ParsedRequest};
+use super::super::parsed_request::{method_to_error, ParsedRequest, RequestError};
 use super::{Body, Method};
 
-pub(crate) fn parse_get_machine_config() -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_get_machine_config() -> Result<ParsedRequest, RequestError> {
     METRICS.get_api_requests.machine_cfg_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::GetVmMachineConfig))
 }
 
-pub(crate) fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, RequestError> {
     METRICS.put_api_requests.machine_cfg_count.inc();
     let config = serde_json::from_slice::<MachineConfig>(body.raw()).map_err(|err| {
         METRICS.put_api_requests.machine_cfg_fails.inc();
@@ -41,7 +41,7 @@ pub(crate) fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Err
     Ok(parsed_req)
 }
 
-pub(crate) fn parse_patch_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_patch_machine_config(body: &Body) -> Result<ParsedRequest, RequestError> {
     METRICS.patch_api_requests.machine_cfg_count.inc();
     let config_update =
         serde_json::from_slice::<MachineConfigUpdate>(body.raw()).map_err(|err| {

--- a/src/firecracker/src/api_server/request/metrics.rs
+++ b/src/firecracker/src/api_server/request/metrics.rs
@@ -5,10 +5,10 @@ use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 use vmm::vmm_config::metrics::MetricsConfig;
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 
-pub(crate) fn parse_put_metrics(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_metrics(body: &Body) -> Result<ParsedRequest, RequestError> {
     METRICS.put_api_requests.metrics_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureMetrics(
         serde_json::from_slice::<MetricsConfig>(body.raw()).map_err(|err| {

--- a/src/firecracker/src/api_server/request/version.rs
+++ b/src/firecracker/src/api_server/request/version.rs
@@ -4,9 +4,9 @@
 use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 
-pub(crate) fn parse_get_version() -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_get_version() -> Result<ParsedRequest, RequestError> {
     METRICS.get_api_requests.vmm_version_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::GetVmmVersion))
 }

--- a/src/firecracker/src/api_server/request/vsock.rs
+++ b/src/firecracker/src/api_server/request/vsock.rs
@@ -5,10 +5,10 @@ use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 
-use super::super::parsed_request::{Error, ParsedRequest};
+use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 
-pub(crate) fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, RequestError> {
     METRICS.put_api_requests.vsock_count.inc();
     let vsock_cfg = serde_json::from_slice::<VsockDeviceConfig>(body.raw()).map_err(|err| {
         METRICS.put_api_requests.vsock_fails.inc();

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -27,7 +27,7 @@ use vmm::logger::{
 use vmm::persist::SNAPSHOT_VERSION;
 use vmm::resources::VmResources;
 use vmm::signal_handler::register_signal_handlers;
-use vmm::snapshot::{Error as SnapshotError, Snapshot};
+use vmm::snapshot::{Snapshot, SnapshotError};
 use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
 use vmm::vmm_config::metrics::{init_metrics, MetricsConfig, MetricsConfigError};
 use vmm::{EventManager, FcExitCode, HTTP_MAX_PAYLOAD_SIZE};
@@ -48,7 +48,7 @@ enum MainError {
     /// Failed to register signal handlers: {0}
     RegisterSignalHandlers(#[source] utils::errno::Error),
     /// Arguments parsing error: {0} \n\nFor more information try --help.
-    ParseArguments(#[from] utils::arg_parser::Error),
+    ParseArguments(#[from] utils::arg_parser::UtilsArgParserError),
     /// When printing Snapshot Data format: {0}
     PrintSnapshotDataFormat(#[from] SnapshotVersionError),
     /// Invalid value for logger level: {0}.Possible values: [Error, Warning, Info, Debug]

--- a/src/firecracker/tests/verify_dependencies.rs
+++ b/src/firecracker/tests/verify_dependencies.rs
@@ -62,10 +62,16 @@ fn violating_dependencies_of_cargo_toml<T: AsRef<Path> + Debug>(
 ///
 /// The iterator produces tuples of the form (violating dependency, specified version)
 fn violating_dependencies_of_depsset(depsset: DepsSet) -> impl Iterator<Item = (String, String)> {
-    depsset.into_iter().filter_map(|(name, dependency)| {
-        match dependency {
-            Dependency::Simple(version) => Some((name, version)), // dependencies specified as `libc = "0.2.117"`
-            Dependency::Detailed(dependency_detail) => dependency_detail.version.map(|version| (name, version)), // dependencies specified without version, such as `libc = {path = "../libc"}
-            _ => None
-        }}).filter(|(_, version)| !Regex::new(r"^=?\d*\.\d*\.\d*$").unwrap().is_match(version))
+    depsset
+        .into_iter()
+        .filter_map(|(name, dependency)| {
+            match dependency {
+                Dependency::Simple(version) => Some((name, version)), // dependencies specified as `libc = "0.2.117"`
+                Dependency::Detailed(dependency_detail) => {
+                    dependency_detail.version.map(|version| (name, version))
+                } // dependencies specified without version, such as `libc = {path = "../libc"}
+                _ => None,
+            }
+        })
+        .filter(|(_, version)| !Regex::new(r"^=?\d*\.\d*\.\d*$").unwrap().is_match(version))
 }

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -11,7 +11,7 @@ use std::path::{Component, Path, PathBuf};
 use std::process::{exit, id, Command, Stdio};
 use std::{fmt, io};
 
-use utils::arg_parser::Error::MissingValue;
+use utils::arg_parser::UtilsArgParserError::MissingValue;
 use utils::syscall::SyscallReturnCode;
 use utils::{arg_parser, validators};
 

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -7,7 +7,7 @@ use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::{env as p_env, fs, io};
 
-use utils::arg_parser::{ArgParser, Argument, Error as ParsingError};
+use utils::arg_parser::{ArgParser, Argument, UtilsArgParserError as ParsingError};
 use utils::syscall::SyscallReturnCode;
 use utils::validators;
 
@@ -87,7 +87,7 @@ pub enum JailerError {
     #[error("Invalid gid: {0}")]
     Gid(String),
     #[error("Invalid instance ID: {0}")]
-    InvalidInstanceId(validators::Error),
+    InvalidInstanceId(validators::ValidatorError),
     #[error("{}", format!("File {:?} doesn't have a parent", .0).replace('\"', ""))]
     MissingParent(PathBuf),
     #[error("Failed to create the jail root directory before pivoting root: {0}")]

--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -6,7 +6,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom};
 use std::os::unix::io::AsRawFd;
 
-use utils::arg_parser::{ArgParser, Argument, Arguments, Error as ArgError};
+use utils::arg_parser::{ArgParser, Argument, Arguments, UtilsArgParserError as ArgError};
 use utils::seek_hole::SeekHole;
 use utils::u64_to_usize;
 

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -48,7 +48,9 @@ use bincode::Error as BincodeError;
 use common::BpfProgram;
 use compiler::{CompilationError, Compiler, JsonFile};
 use serde_json::error::Error as JSONError;
-use utils::arg_parser::{ArgParser, Argument, Arguments as ArgumentsBag, Error as ArgParserError};
+use utils::arg_parser::{
+    ArgParser, Argument, Arguments as ArgumentsBag, UtilsArgParserError as ArgParserError,
+};
 
 const SECCOMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_OUTPUT_FILENAME: &str = "seccomp_binary_filter.out";

--- a/src/snapshot-editor/src/utils.rs
+++ b/src/snapshot-editor/src/utils.rs
@@ -18,11 +18,11 @@ pub enum UtilsError {
     /// Can not retrieve metadata for snapshot file: {0}
     VmStateFileMeta(std::io::Error),
     /// Can not load snapshot: {0}
-    VmStateLoad(vmm::snapshot::Error),
+    VmStateLoad(vmm::snapshot::SnapshotError),
     /// Can not open output file: {0}
     OutputFileOpen(std::io::Error),
     /// Can not save snapshot: {0}
-    VmStateSave(vmm::snapshot::Error),
+    VmStateSave(vmm::snapshot::SnapshotError),
 }
 
 #[allow(unused)]

--- a/src/utils/src/validators.rs
+++ b/src/utils/src/validators.rs
@@ -7,7 +7,7 @@ const MAX_INSTANCE_ID_LEN: usize = 64;
 const MIN_INSTANCE_ID_LEN: usize = 1;
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
-pub enum Error {
+pub enum ValidatorError {
     /// Invalid char ({0}) at position {1}
     InvalidChar(char, usize), // (char, position)
     /// Invalid len ({0});  the length must be between {1} and {2}
@@ -16,9 +16,9 @@ pub enum Error {
 
 /// Checks that the instance id only contains alphanumeric chars and hyphens
 /// and that the size is between 1 and 64 characters.
-pub fn validate_instance_id(input: &str) -> Result<(), Error> {
+pub fn validate_instance_id(input: &str) -> Result<(), ValidatorError> {
     if input.len() > MAX_INSTANCE_ID_LEN || input.len() < MIN_INSTANCE_ID_LEN {
-        return Err(Error::InvalidLen(
+        return Err(ValidatorError::InvalidLen(
             input.len(),
             MIN_INSTANCE_ID_LEN,
             MAX_INSTANCE_ID_LEN,
@@ -26,7 +26,7 @@ pub fn validate_instance_id(input: &str) -> Result<(), Error> {
     }
     for (i, c) in input.chars().enumerate() {
         if !(c == '-' || c.is_alphanumeric()) {
-            return Err(Error::InvalidChar(c, i));
+            return Err(ValidatorError::InvalidChar(c, i));
         }
     }
     Ok(())
@@ -49,11 +49,11 @@ mod tests {
         );
         assert_eq!(
             validate_instance_id("12:3aa").unwrap_err(),
-            Error::InvalidChar(':', 2)
+            ValidatorError::InvalidChar(':', 2)
         );
         assert_eq!(
             validate_instance_id(str::repeat("a", MAX_INSTANCE_ID_LEN + 1).as_str()).unwrap_err(),
-            Error::InvalidLen(
+            ValidatorError::InvalidLen(
                 MAX_INSTANCE_ID_LEN + 1,
                 MIN_INSTANCE_ID_LEN,
                 MAX_INSTANCE_ID_LEN

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -53,7 +53,7 @@ pub enum FileEngineType {
 
 impl FileEngineType {
     /// Whether the Async engine is supported on the current host kernel.
-    pub fn is_supported(&self) -> Result<bool, utils::kernel_version::Error> {
+    pub fn is_supported(&self) -> Result<bool, utils::kernel_version::KernelVersionError> {
         match self {
             Self::Async if KernelVersion::get()? < min_kernel_version_for_io_uring() => Ok(false),
             _ => Ok(true),

--- a/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
@@ -33,7 +33,7 @@ pub enum BlockIoError {
     /// Unsupported engine type: {0:?}
     UnsupportedEngine(FileEngineType),
     /// Could not get kernel version: {0}
-    GetKernelVersion(utils::kernel_version::Error),
+    GetKernelVersion(utils::kernel_version::KernelVersionError),
 }
 
 impl BlockIoError {

--- a/src/vmm/src/dumbo/pdu/ethernet.rs
+++ b/src/vmm/src/dumbo/pdu/ethernet.rs
@@ -28,7 +28,7 @@ pub const ETHERTYPE_IPV4: u16 = 0x0800;
 
 /// Describes the errors which may occur when handling Ethernet frames.
 #[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
-pub enum Error {
+pub enum EthernetError {
     /// The specified byte sequence is shorter than the Ethernet header length.
     SliceTooShort,
 }
@@ -56,9 +56,9 @@ impl<'a, T: NetworkBytes + Debug> EthernetFrame<'a, T> {
 
     /// Checks whether the specified byte sequence can be interpreted as an Ethernet frame.
     #[inline]
-    pub fn from_bytes(bytes: T) -> Result<Self, Error> {
+    pub fn from_bytes(bytes: T) -> Result<Self, EthernetError> {
         if bytes.len() < PAYLOAD_OFFSET {
-            return Err(Error::SliceTooShort);
+            return Err(EthernetError::SliceTooShort);
         }
 
         Ok(EthernetFrame::from_bytes_unchecked(bytes))
@@ -108,9 +108,9 @@ impl<'a, T: NetworkBytesMut + Debug> EthernetFrame<'a, T> {
         dst_mac: MacAddr,
         src_mac: MacAddr,
         ethertype: u16,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, EthernetError> {
         if buf.len() < PAYLOAD_OFFSET {
-            return Err(Error::SliceTooShort);
+            return Err(EthernetError::SliceTooShort);
         }
 
         let mut frame = EthernetFrame::from_bytes_unchecked(buf);
@@ -131,7 +131,7 @@ impl<'a, T: NetworkBytesMut + Debug> EthernetFrame<'a, T> {
         dst_mac: MacAddr,
         src_mac: MacAddr,
         ethertype: u16,
-    ) -> Result<Incomplete<Self>, Error> {
+    ) -> Result<Incomplete<Self>, EthernetError> {
         Ok(Incomplete::new(Self::new_with_header(
             buf, dst_mac, src_mac, ethertype,
         )?))
@@ -200,12 +200,12 @@ mod tests {
 
         assert_eq!(
             EthernetFrame::from_bytes(bad_array.as_ref()).unwrap_err(),
-            Error::SliceTooShort
+            EthernetError::SliceTooShort
         );
         assert_eq!(
             EthernetFrame::new_with_header(bad_array.as_mut(), dst_mac, src_mac, ethertype)
                 .unwrap_err(),
-            Error::SliceTooShort
+            EthernetError::SliceTooShort
         );
 
         {

--- a/src/vmm/src/dumbo/tcp/connection.rs
+++ b/src/vmm/src/dumbo/tcp/connection.rs
@@ -13,7 +13,7 @@ use bitflags::bitflags;
 use utils::rand::xor_pseudo_rng_u32;
 
 use crate::dumbo::pdu::bytes::NetworkBytes;
-use crate::dumbo::pdu::tcp::{Error as TcpSegmentError, Flags as TcpFlags, TcpSegment};
+use crate::dumbo::pdu::tcp::{Flags as TcpFlags, TcpError as TcpSegmentError, TcpSegment};
 use crate::dumbo::pdu::Incomplete;
 use crate::dumbo::tcp::{
     seq_after, seq_at_or_after, NextSegmentStatus, RstConfig, MAX_WINDOW_SIZE, MSS_DEFAULT,

--- a/src/vmm/src/dumbo/tcp/handler.rs
+++ b/src/vmm/src/dumbo/tcp/handler.rs
@@ -13,8 +13,8 @@ use std::num::NonZeroUsize;
 use micro_http::{Request, Response};
 
 use crate::dumbo::pdu::bytes::NetworkBytes;
-use crate::dumbo::pdu::ipv4::{Error as IPv4PacketError, IPv4Packet, PROTOCOL_TCP};
-use crate::dumbo::pdu::tcp::{Error as TcpSegmentError, Flags as TcpFlags, TcpSegment};
+use crate::dumbo::pdu::ipv4::{IPv4Packet, Ipv4Error as IPv4PacketError, PROTOCOL_TCP};
+use crate::dumbo::pdu::tcp::{Flags as TcpFlags, TcpError as TcpSegmentError, TcpSegment};
 use crate::dumbo::tcp::endpoint::Endpoint;
 use crate::dumbo::tcp::{NextSegmentStatus, RstConfig};
 

--- a/src/vmm/src/mmds/ns.rs
+++ b/src/vmm/src/mmds/ns.rs
@@ -15,15 +15,15 @@ use utils::net::mac::MacAddr;
 use utils::time::timestamp_cycles;
 
 use crate::dumbo::pdu::arp::{
-    test_speculative_tpa, Error as ArpFrameError, EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN,
+    test_speculative_tpa, ArpError as ArpFrameError, EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN,
 };
 use crate::dumbo::pdu::ethernet::{
-    Error as EthernetFrameError, EthernetFrame, ETHERTYPE_ARP, ETHERTYPE_IPV4,
+    EthernetError as EthernetFrameError, EthernetFrame, ETHERTYPE_ARP, ETHERTYPE_IPV4,
 };
 use crate::dumbo::pdu::ipv4::{
-    test_speculative_dst_addr, Error as IPv4PacketError, IPv4Packet, PROTOCOL_TCP,
+    test_speculative_dst_addr, IPv4Packet, Ipv4Error as IPv4PacketError, PROTOCOL_TCP,
 };
-use crate::dumbo::pdu::tcp::Error as TcpSegmentError;
+use crate::dumbo::pdu::tcp::TcpError as TcpSegmentError;
 use crate::dumbo::pdu::Incomplete;
 use crate::dumbo::tcp::handler::{RecvEvent, TcpIPv4Handler, WriteEvent, WriteNextError};
 use crate::dumbo::tcp::NextSegmentStatus;

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -147,7 +147,7 @@ pub enum CreateSnapshotError {
     /// Cannot save the microVM state: {0}
     MicrovmState(MicrovmStateError),
     /// Cannot serialize the microVM state: {0}
-    SerializeMicrovmState(crate::snapshot::Error),
+    SerializeMicrovmState(crate::snapshot::SnapshotError),
     /// Cannot perform {0} on the snapshot backing file: {1}
     SnapshotBackingFile(&'static str, io::Error),
     /// Size mismatch when writing diff snapshot on top of base layer: base layer size is {0} but diff layer is size {1}.
@@ -456,7 +456,7 @@ pub enum SnapshotStateFromFileError {
     /// Failed to read snapshot file metadata: {0}
     Meta(std::io::Error),
     /// Failed to load snapshot state from file: {0}
-    Load(#[from] crate::snapshot::Error),
+    Load(#[from] crate::snapshot::SnapshotError),
 }
 
 fn snapshot_state_from_file(

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -13,7 +13,7 @@ pub mod persist;
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 /// Describes the errors that may occur while handling rate limiter events.
-pub enum Error {
+pub enum RateLimiterError {
     /// The event handler was called spuriously: {0}
     SpuriousRateLimiterEvent(&'static str),
 }
@@ -470,9 +470,9 @@ impl RateLimiter {
     /// # Errors
     ///
     /// If the rate limiter is disabled or is not blocked, an error is returned.
-    pub fn event_handler(&mut self) -> Result<(), Error> {
+    pub fn event_handler(&mut self) -> Result<(), RateLimiterError> {
         match self.timer_fd.read() {
-            0 => Err(Error::SpuriousRateLimiterEvent(
+            0 => Err(RateLimiterError::SpuriousRateLimiterEvent(
                 "Rate limiter event handler called without a present timer",
             )),
             _ => {

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -47,7 +47,7 @@ pub enum ResourcesError {
     /// Metrics error: {0}
     Metrics(#[from] MetricsConfigError),
     /// MMDS error: {0}
-    Mmds(#[from] mmds::data_store::Error),
+    Mmds(#[from] mmds::data_store::MmdsDatastoreError),
     /// MMDS config error: {0}
     MmdsConfig(#[from] MmdsConfigError),
     /// Network device error: {0}

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -41,8 +41,8 @@ pub enum VmConfigError {
 
 // We cannot do a `KernelVersion(kernel_version::Error)` variant because `kernel_version::Error`
 // does not implement `PartialEq, Eq` (due to containing an io error).
-impl From<kernel_version::Error> for VmConfigError {
-    fn from(_: kernel_version::Error) -> Self {
+impl From<kernel_version::KernelVersionError> for VmConfigError {
+    fn from(_: kernel_version::KernelVersionError) -> Self {
         VmConfigError::KernelVersion
     }
 }

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -49,5 +49,5 @@ pub enum MmdsConfigError {
     /// The list of network interface IDs provided contains at least one ID that does not correspond to any existing network interface.
     InvalidNetworkInterfaceId,
     /// The MMDS could not be configured to version {0}: {1}
-    MmdsVersion(MmdsVersion, data_store::Error),
+    MmdsVersion(MmdsVersion, data_store::MmdsDatastoreError),
 }


### PR DESCRIPTION
Add: error_impl_error in Cargo.toml so clippy does warn when a error is implemented as error

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the
    best of my knowledge, is covered under an appropriate open
    source license and I have the right under that license to
    submit that work with modifications, whether created in whole
    or in part by me, under the same open source license (unless
    I am permitted to submit under a different license), as
    Indicated in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including
    all personal information I submit with it, including my
    sign-off) is maintained indefinitely and may be redistributed
    consistent with this project or the open source license(s)
    involved.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
