### PR TITLE
[CI] Make the style checks step quicker to run

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -22,7 +22,7 @@ DEFAULT_PRIORITY = 1
 args = COMMON_PARSER.parse_args()
 
 step_style = {
-    "command": "./tools/devtool -y test -- ../tests/integration_tests/style/",
+    "command": "./tools/devtool -y test -- -n 8 --dist worksteal ../tests/integration_tests/style/",
     "label": "🪶 Style",
     "priority": DEFAULT_PRIORITY,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ import pytest
 
 import host_tools.cargo_build as build_tools
 from framework import defs, utils
-from framework.artifacts import firecracker_artifacts, kernel_params, rootfs_params
+from framework.artifacts import kernel_params, rootfs_params
 from framework.microvm import MicroVMFactory
 from framework.properties import global_props
 from framework.utils_cpu_templates import (
@@ -272,14 +272,6 @@ def microvm_factory(request, record_property, results_dir):
                 shutil.copy(uvm.metrics_file, dst)
 
     uvm_factory.kill()
-
-
-@pytest.fixture(params=firecracker_artifacts())
-def firecracker_release(request, record_property):
-    """Return all supported firecracker binaries."""
-    firecracker = request.param
-    record_property("firecracker_release", firecracker.name)
-    return firecracker
 
 
 @pytest.fixture(params=static_cpu_templates_params())

--- a/tests/integration_tests/functional/conftest.py
+++ b/tests/integration_tests/functional/conftest.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Imported by pytest when running tests in this directory"""
+
+import pytest
+
+from framework.artifacts import firecracker_artifacts
+
+
+# This fixture forces a Firecracker build, even if it doesn't get used.
+# By placing it here instead of the top-level conftest.py we skip the build.
+@pytest.fixture(params=firecracker_artifacts())
+def firecracker_release(request, record_property):
+    """Return all supported firecracker binaries."""
+    firecracker = request.param
+    record_property("firecracker_release", firecracker.name)
+    return firecracker


### PR DESCRIPTION
## Changes

Make the style step faster to complete.

Before: 1m48s
After: 1m22s

## Reason

Low priority. This test is not in the long pole of the build. 

While it is 25% faster test, it is only interesting if/when we we make the style step run before the full build.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
