### PR TITLE
[1.7] fix(vmm): only use memfd if no vhost-user-blk devices configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to
   information about page size to the payload Firecracker sends to the UFFD
   handler. Each memory region object now contains a `page_size_kib` field. See
   also the [hugepages documentation](docs/hugepages.md).
+- [#4501](https://github.com/firecracker-microvm/firecracker/pull/4501): Only
+  use memfd to back guest memory if a vhost-user-blk device is configured,
+  otherwise use anonymous private memory. This is because serving page faults of
+  shared memory used by memfd is slower and may impact workloads.
 
 ### Fixed
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -392,7 +392,7 @@ def test_api_machine_config(uvm_plain):
     test_microvm.api.machine_config.patch(mem_size_mib=bad_size)
 
     fail_msg = re.escape(
-        "Invalid Memory Configuration: Cannot resize memfd file: Custom { kind: InvalidInput, error: TryFromIntError(()) }"
+        "Invalid Memory Configuration: Cannot create mmap region: Out of memory (os error 12)"
     )
     with pytest.raises(RuntimeError, match=fail_msg):
         test_microvm.start()

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -18,11 +18,13 @@ def check_hugetlbfs_in_use(pid: int, allocation_name: str):
 
     `allocation_name` should be the name of the smaps entry for which we want to verify that huge pages are used.
     For memfd-backed guest memory, this would be "memfd:guest_mem" (the `guest_mem` part originating from the name
-    we give the memfd in memory.rs), for anonymous memory this would be "/anon_hugepage"
+    we give the memfd in memory.rs), for anonymous memory this would be "/anon_hugepage".
+    Note: in our testing, we do not currently configure vhost-user-blk devices, so we only exercise
+    the "/anon_hugepage" case.
     """
 
     # Format of a sample smaps entry:
-    #   7fc2bc400000-7fc2cc400000 rw-s 00000000 00:10 25488401                   /memfd:guest_mem (deleted)
+    #   7fc2bc400000-7fc2cc400000 rw-s 00000000 00:10 25488401                   /anon_hugepage
     #   Size:             262144 kB
     #   KernelPageSize:     2048 kB
     #   MMUPageSize:        2048 kB
@@ -70,7 +72,7 @@ def test_hugetlbfs_boot(uvm_plain):
 
     check_hugetlbfs_in_use(
         uvm_plain.firecracker_pid,
-        "memfd:guest_mem",
+        "/anon_hugepage",
     )
 
 
@@ -97,7 +99,7 @@ def test_hugetlbfs_snapshot(
     rc, _, _ = vm.ssh.run("true")
     assert not rc
 
-    check_hugetlbfs_in_use(vm.firecracker_pid, "memfd:guest_mem")
+    check_hugetlbfs_in_use(vm.firecracker_pid, "/anon_hugepage")
 
     snapshot = vm.snapshot_full()
 


### PR DESCRIPTION
## Changes

Backport https://github.com/firecracker-microvm/firecracker/pull/4498/

## Reason

To avoid page fault latency regression.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] The description of changes is clear and encompassing.~~
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- ~~[ ] All added/changed functionality is tested.~~
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
