### PR TITLE
fix: logic to detect changed files

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -93,6 +93,10 @@ def get_changed_files():
     """
     Get all files changed since `branch`
     """
+    # Files are changed only in context of a PR
+    if os.environ.get("BUILDKITE_PULL_REQUEST", "false") == "false":
+        return []
+
     branch = os.environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")
     stdout = subprocess.check_output(f"git diff --name-only origin/{branch}".split(" "))
 


### PR DESCRIPTION
## Changes:
- In non PR context, return empty list for changed files.

## Reason:
- For custom buildkite jobs or nightly tests the concept of changed
  files is not valid.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
