### PR TITLE
CI: move Firecracker build out of test

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -48,7 +48,7 @@ perf_test = {
     },
     "memory-overhead": {
         "label": "💾 Memory Overhead and 👢 Boottime",
-        "test_path": "'integration_tests/performance/test_memory_overhead.py integration_tests/performance/test_boottime.py::test_boottime'",
+        "test_path": "integration_tests/performance/test_memory_overhead.py integration_tests/performance/test_boottime.py::test_boottime",
         "devtool_opts": "-c 1-10 -m 0",
     },
 }
@@ -71,7 +71,7 @@ def build_group(test):
     pytest_opts = ""
     if REVISION_A:
         devtool_opts += " --ab"
-        pytest_opts = f" {ab_opts} run {REVISION_A} {REVISION_B} --test {test_path}"
+        pytest_opts = f" {ab_opts} run {REVISION_A} {REVISION_B} --test '{test_path}'"
     else:
         # Passing `-m ''` below instructs pytest to collect tests regardless of their markers (e.g. it will collect both tests marked as nonci, and tests without any markers).
         pytest_opts += f" -m '' {test_path}"

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -71,7 +71,7 @@ def build_group(test):
     pytest_opts = ""
     if REVISION_A:
         devtool_opts += " --ab"
-        pytest_opts = f" {ab_opts} run {REVISION_A} {REVISION_B} --test '{test_path}'"
+        pytest_opts = f" {ab_opts} run {REVISION_A} {REVISION_B} --test {test_path}"
     else:
         # Passing `-m ''` below instructs pytest to collect tests regardless of their markers (e.g. it will collect both tests marked as nonci, and tests without any markers).
         pytest_opts += f" -m '' {test_path}"

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -22,7 +22,7 @@ DEFAULT_PRIORITY = 1
 args = COMMON_PARSER.parse_args()
 
 step_style = {
-    "command": "./tools/devtool -y test -- -n 8 --dist worksteal ../tests/integration_tests/style/",
+    "command": "./tools/devtool -y checkstyle",
     "label": "🪶 Style",
     "priority": DEFAULT_PRIORITY,
 }

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -1132,10 +1132,15 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_num_pages() {
+    fn test_cannot_update_inactive_device() {
         let mut balloon = Balloon::new(0, true, 0, false).unwrap();
         // Assert that we can't update an inactive device.
         balloon.update_size(1).unwrap_err();
+    }
+
+    #[test]
+    fn test_num_pages() {
+        let mut balloon = Balloon::new(0, true, 0, false).unwrap();
         // Switch the state to active.
         balloon.device_state = DeviceState::Activated(single_region_mem(0x1));
 

--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -11,9 +11,6 @@ FC_BINARY_NAME = "firecracker"
 # The Firecracker sources workspace dir
 FC_WORKSPACE_DIR = Path(__file__).parent.parent.parent.resolve()
 
-# Cargo build directory for seccompiler
-SECCOMPILER_TARGET_DIR = FC_WORKSPACE_DIR / "build/seccompiler"
-
 # Folder containing JSON seccomp filters
 SECCOMP_JSON_DIR = FC_WORKSPACE_DIR / "resources/seccomp"
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1056,16 +1056,6 @@ def test_api_balloon(uvm_nano):
     # Start the microvm.
     test_microvm.start()
 
-    # Updating should fail as driver didn't have time to initialize.
-    with pytest.raises(RuntimeError):
-        test_microvm.api.balloon.patch(amount_mib=4)
-
-    # Overwriting the existing device should give an error now.
-    with pytest.raises(RuntimeError):
-        test_microvm.api.balloon.put(
-            amount_mib=3, deflate_on_oom=False, stats_polling_interval_s=3
-        )
-
     # Give the balloon driver time to initialize.
     # 500 ms is the maximum acceptable boot time.
     time.sleep(0.5)

--- a/tools/devtool
+++ b/tools/devtool
@@ -349,7 +349,7 @@ cmd_help() {
     echo ""
     echo "Available commands:"
     echo ""
-    echo "    build [--debug|--release] [-l|--libc musl|gnu] [-- [<cargo args>]]"
+    echo "    build [--debug|--release] [-l|--libc musl|gnu]"
     echo "        Build the Firecracker binaries."
     echo "        Firecracker is built using the Rust build system (cargo). All arguments after --"
     echo "        will be passed through to cargo."
@@ -650,6 +650,7 @@ unapply_performance_tweaks() {
 #
 cmd_test() {
     do_ab_test=0
+    do_build=1
     # Parse any command line args.
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -668,6 +669,9 @@ cmd_test() {
             "--ab")
                 do_ab_test=1
                 ;;
+            "--no-build")
+                do_build=0
+                ;;
             "--")               { shift; break;     } ;;
             *)
                 die "Unknown argument: $1. Please use --help for help."
@@ -681,6 +685,7 @@ cmd_test() {
     ensure_devctr
     ensure_build_dir
     ensure_ci_artifacts
+    [ $do_build != 0 ] && cmd_build --release
 
     apply_linux_61_tweaks
 
@@ -866,7 +871,7 @@ cmd_mkdocs() {
 }
 
 cmd_checkstyle() {
-    cmd_test -- integration_tests/style -n 4 --dist worksteal
+    cmd_test --no-build -- integration_tests/style -n 4 --dist worksteal
 }
 
 # Check if able to run firecracker.

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -127,7 +127,7 @@ fi
 
 say "Building version=$VERSION, profile=$PROFILE, target=$CARGO_TARGET, Rust toolchain=${RUST_TOOLCHAIN}..."
 # shellcheck disable=SC2086
-cargo build --target "$CARGO_TARGET" $CARGO_OPTS --workspace
+cargo build --target "$CARGO_TARGET" $CARGO_OPTS --workspace --bins --examples
 
 say "Binaries placed under $CARGO_TARGET_DIR"
 


### PR DESCRIPTION
## Changes

Move the build step out of the test

## Reason

The Firecracker build is done as part of test setup in one of the fixtures.

- The build log is hidden. It may be interesting to have it inlined in the build logs to see how long it takes and in case it fails.
- The Firecracker build is growing over time, and seems it is starting to fail in some CI builds.
- the first tests that compile Firecracker are penalized, as the Firecracker compilation is taken agains their 300s timeout quota

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
