### PR TITLE
Backport #4507

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -108,7 +108,7 @@ for step in kani_grp["steps"]:
     step["label"] = "🔍 Kani"
 
 steps = [step_style]
-changed_files = get_changed_files("main")
+changed_files = get_changed_files()
 
 # run sanity build of devtool if Dockerfile is changed
 if any(x.name == "Dockerfile" for x in changed_files):

--- a/.buildkite/pipeline_pr_no_block.py
+++ b/.buildkite/pipeline_pr_no_block.py
@@ -38,6 +38,6 @@ optional_grp = group(
     **defaults,
 )
 
-changed_files = get_changed_files("main")
+changed_files = get_changed_files()
 pipeline = {"steps": [optional_grp]} if run_all_tests(changed_files) else {"steps": []}
 print(pipeline_to_json(pipeline))


### PR DESCRIPTION
## Changes:
- In non PR context, return empty list for changed files.
- In PR context, use $BUILDKITE_PULL_REQUEST_BASE_BRANCH if available or else "main" as the base branch to check for list of files changed.

## Reason:
- For custom buildkite jobs or nightly tests the concept of changed files is not valid.
- When PR's are raised on release branches, comparing changed files against main leads to running unnecessary tests like buid_devctr even when there is no Dockerfile change in the release branch.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
