### PR TITLE
fix(ci): build Firecracker when we need to

### DIFF
--- a/.buildkite/pipeline_cross.py
+++ b/.buildkite/pipeline_cross.py
@@ -41,6 +41,7 @@ def cross_steps():
     instances_aarch64 = ["m6g.metal", "m7g.metal"]
     groups = []
     commands = [
+        "./tools/devtool -y build --release",
         "./tools/devtool -y sh ./tools/create_snapshot_artifact/main.py",
         "mkdir -pv snapshots/{instance}_{kv}",
         "sudo chown -Rc $USER: snapshot_artifacts",

--- a/tools/devtool
+++ b/tools/devtool
@@ -851,6 +851,7 @@ cmd_sh() {
 }
 
 cmd_sandbox() {
+    cmd_build --release
     cmd_sh "tmux new env PYTEST_ADDOPTS=--pdbcls=IPython.terminal.debugger:TerminalPdb PYTHONPATH=tests IPYTHONDIR=\$PWD/.ipython ipython -i ./tools/sandbox.py $@"
 }
 


### PR DESCRIPTION
## Changes
The commit df112e3 missed a few places where we depend on firecracker build.

## Reason
Fixes: df112e39ccd558c51494b0d0e4ac8b288f6d140d

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
