### PR TITLE
Fixes related to moving the build out of the testrun

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -14,6 +14,7 @@ import pytest
 from framework.defs import ARTIFACT_DIR
 from framework.properties import global_props
 from framework.utils import get_firecracker_version_from_toml, run_cmd
+from framework.with_filelock import with_filelock
 from host_tools.cargo_build import get_binary
 
 
@@ -131,6 +132,7 @@ class FirecrackerArtifact:
         return ".".join(str(x) for x in self.snapshot_version_tuple)
 
 
+@with_filelock
 def current_release(version):
     """Massage this working copy Firecracker binary to look like a normal
     release, so it can run the same tests.
@@ -139,8 +141,9 @@ def current_release(version):
     for binary in ["firecracker", "jailer"]:
         bin_path1 = get_binary(binary)
         bin_path2 = bin_path1.with_name(f"{binary}-v{version}")
-        bin_path2.unlink(missing_ok=True)
-        bin_path2.hardlink_to(bin_path1)
+        if not bin_path2.exists():
+            bin_path2.unlink(missing_ok=True)
+            bin_path2.hardlink_to(bin_path1)
         binaries.append(bin_path2)
     return binaries
 


### PR DESCRIPTION
Two issues:

1. There are some new errors:

    FileExistsError: [Errno 17] File exists:
    (from /firecracker/tests/integration_tests/functional/conftest.py)

https://buildkite.com/firecracker/firecracker-pr/builds/9536#018e65dd-d001-4c41-afc0-6a4ef97d2790/58-586

We removed some locks when simplifying the build. This function was depending on get_binary to serialize accesses, but it was always vulnerable to race conditions to begin with.

2. The binaries used for the testrun are not stripped.

Fixes: df112e39ccd558c51494b0d0e4ac8b288f6d140d

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
