### PR TITLE
chore: Add 1.7 to release status table in RELEASE_POLICY.md

### DIFF
--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -90,6 +90,7 @@ v3.1 will be patched since were the last two Firecracker releases and less than
 
 | Release | Release Date | Latest Patch | Min. end of support | Official end of Support         |
 | ------: | -----------: | -----------: | ------------------: | :------------------------------ |
+|    v1.7 |   2024-03-18 |       v1.7.0 |          2024-09-18 | Supported                       |
 |    v1.6 |   2023-12-20 |       v1.6.0 |          2024-06-20 | Supported                       |
 |    v1.5 |   2023-10-09 |       v1.5.1 |          2024-04-09 | Supported                       |
 |    v1.4 |   2023-07-20 |       v1.4.1 |          2024-01-20 | 2024-01-20 (end of 6mo support) |


### PR DESCRIPTION
## Changes

 Add 1.7 to release status table in RELEASE_POLICY.md

## Reason

I forgot about it last week. Note that 1.5.0 is _not_ pushed out of support by 1.7 since it has not been 6 months since its initial release.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
