### PR TITLE
Fail early in case of too big a frame in the TX path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ and this project adheres to
 
 ### Fixed
 
+- [4526](https://github.com/firecracker-microvm/firecracker/pull/4526): Added a
+  check in the network TX path that the size of the network frames the guest
+  passes to us is not bigger than the maximum frame the device expects to
+  handle. On the TX path, we copy frames destined to MMDS from guest memory to
+  Firecracker memory. Without the check, a mis-behaving virtio-net driver could
+  cause an increase in the memory footprint of the Firecracker process. Now, if
+  we receive such a frame, we ignore it and increase `Net::tx_malformed_frames`
+  metric.
+
 ## \[1.7.0\]
 
 ### Added

--- a/src/vmm/src/devices/virtio/net/test_utils.rs
+++ b/src/vmm/src/devices/virtio/net/test_utils.rs
@@ -395,7 +395,7 @@ pub mod test {
         pub fn get_default() -> TestHelper<'a> {
             let mut event_manager = EventManager::new().unwrap();
             let mut net = default_net();
-            let mem = single_region_mem(MAX_BUFFER_SIZE);
+            let mem = single_region_mem(2 * MAX_BUFFER_SIZE);
 
             // transmute mem_ref lifetime to 'a
             let mem_ref = unsafe { mem::transmute::<&GuestMemoryMmap, &'a GuestMemoryMmap>(&mem) };


### PR DESCRIPTION
## Changes

Introduce a check that the size of a frame in the TX queue is not bigger than the one the device can handle.

## Reason

We do not handle malformed packets that the driver might send to us. Also, we avoid big allocations when copying from guest memory to Firecracker memory when handling MMDS frames.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
