### PR TITLE
Unpin m6i AMI for 6.1 kernels

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -122,9 +122,14 @@ for test_data in tests:
     group_steps.append(build_group(test_data))
 
 
-pins = {
-    "linux_6.1-pinned": {"instance": "m6i.metal", "kv": "linux_6.1"},
-}
+# Stores the info about pinning tests to agents with particular kernel versions.
+# For example, the following:
+# pins = {
+#    "linux_6.1-pinned": {"instance": "m6i.metal", "kv": "linux_6.1"},
+# }
+# will pin steps running on instances "m6i.metal" with kernel version tagged "linux_6.1"
+# to a new kernel version tagged "linux_6.1-pinned"
+pins = {}
 
 
 def apply_pins(steps):


### PR DESCRIPTION

## Changes

Unpin 6.1 kernel in `m6i` test agents

## Reason

Performance variations has gone away. We can start consuming the latest AMI again for A/B tests.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
