### PR TITLE
fix(tests): lock while building in AB mode

### DIFF
--- a/tests/framework/ab_test.py
+++ b/tests/framework/ab_test.py
@@ -164,6 +164,7 @@ def git_ab_test_guest_command(
     """The same as git_ab_test_command, but via SSH. The closure argument should setup a microvm using the passed
     paths to firecracker and jailer binaries."""
 
+    @with_filelock
     def test_runner(workspace_dir, _is_a: bool):
         utils.run_cmd("./tools/release.sh --profile release", cwd=workspace_dir)
         bin_dir = get_binary(


### PR DESCRIPTION
During PR functional tests, we also run a build for the "B" branch. If the tests are running in parallel with xdist, there is a chance we try to build in parallel.

Add a lock to prevent that race condition.

Fixes: df112e39ccd558c51494b0d0e4ac8b288f6d140d

## Changes

...

## Reason

To fix https://buildkite.com/firecracker/firecracker-pr/builds/9578#018e8029-0278-4f09-9acc-c2283d8afd18/57-1236

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
