### PR TITLE
Update schema to validate breaking change in metrics

### DIFF
--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -33,6 +33,12 @@ def create_metrics_schema_objects(metrics):
     }
 
     if isinstance(metrics, dict):
+        special_metrics = "utc_timestamp_ms"
+        if special_metrics in metrics.keys():
+            metrics.pop(special_metrics)
+            metrics_schema["properties"][special_metrics] = {"type": "number"}
+            metrics_schema["required"].append(special_metrics)
+
         for sub_metrics_name, sub_metrics_fields in metrics.items():
             obj = create_metrics_schema_objects(sub_metrics_fields)
             metrics_schema["properties"][sub_metrics_name] = obj
@@ -66,7 +72,61 @@ def validate_fc_metrics(metrics):
         "max_us",
         "sum_us",
     ]
+    block_metrics = [
+        "activate_fails",
+        "cfg_fails",
+        "no_avail_buffer",
+        "event_fails",
+        "execute_fails",
+        "invalid_reqs_count",
+        "flush_count",
+        "queue_event_count",
+        "rate_limiter_event_count",
+        "update_count",
+        "update_fails",
+        "read_bytes",
+        "write_bytes",
+        "read_count",
+        "write_count",
+        "rate_limiter_throttled_events",
+        "io_engine_throttled_events",
+        "remaining_reqs_count",
+        {"read_agg": latency_agg_metrics_fields},
+        {"write_agg": latency_agg_metrics_fields},
+    ]
+    net_metrics = [
+        "activate_fails",
+        "cfg_fails",
+        "mac_address_updates",
+        "no_rx_avail_buffer",
+        "no_tx_avail_buffer",
+        "event_fails",
+        "rx_queue_event_count",
+        "rx_event_rate_limiter_count",
+        "rx_partial_writes",
+        "rx_rate_limiter_throttled",
+        "rx_tap_event_count",
+        "rx_bytes_count",
+        "rx_packets_count",
+        "rx_fails",
+        "rx_count",
+        "tap_read_fails",
+        "tap_write_fails",
+        "tx_bytes_count",
+        "tx_malformed_frames",
+        "tx_fails",
+        "tx_count",
+        "tx_packets_count",
+        "tx_partial_reads",
+        "tx_queue_event_count",
+        "tx_rate_limiter_event_count",
+        "tx_rate_limiter_throttled",
+        "tx_spoofed_mac_count",
+        "tx_remaining_reqs_count",
+        {"tap_write_agg": latency_agg_metrics_fields},
+    ]
     firecracker_metrics = {
+        "utc_timestamp_ms": "",
         "api_server": [
             "process_startup_time_us",
             "process_startup_time_cpu_us",
@@ -81,28 +141,7 @@ def validate_fc_metrics(metrics):
             "deflate_count",
             "event_fails",
         ],
-        "block": [
-            "activate_fails",
-            "cfg_fails",
-            "no_avail_buffer",
-            "event_fails",
-            "execute_fails",
-            "invalid_reqs_count",
-            "flush_count",
-            "queue_event_count",
-            "rate_limiter_event_count",
-            "update_count",
-            "update_fails",
-            "read_bytes",
-            "write_bytes",
-            "read_count",
-            "write_count",
-            "rate_limiter_throttled_events",
-            "io_engine_throttled_events",
-            "remaining_reqs_count",
-            {"read_agg": latency_agg_metrics_fields},
-            {"write_agg": latency_agg_metrics_fields},
-        ],
+        "block": block_metrics,
         "deprecated_api": [
             "deprecated_http_api_calls",
             "deprecated_cmd_line_api_calls",
@@ -152,37 +191,7 @@ def validate_fc_metrics(metrics):
             "connections_created",
             "connections_destroyed",
         ],
-        "net": [
-            "activate_fails",
-            "cfg_fails",
-            "mac_address_updates",
-            "no_rx_avail_buffer",
-            "no_tx_avail_buffer",
-            "event_fails",
-            "rx_queue_event_count",
-            "rx_event_rate_limiter_count",
-            "rx_partial_writes",
-            "rx_rate_limiter_throttled",
-            "rx_tap_event_count",
-            "rx_bytes_count",
-            "rx_packets_count",
-            "rx_fails",
-            "rx_count",
-            "tap_read_fails",
-            "tap_write_fails",
-            "tx_bytes_count",
-            "tx_malformed_frames",
-            "tx_fails",
-            "tx_count",
-            "tx_packets_count",
-            "tx_partial_reads",
-            "tx_queue_event_count",
-            "tx_rate_limiter_event_count",
-            "tx_rate_limiter_throttled",
-            "tx_spoofed_mac_count",
-            "tx_remaining_reqs_count",
-            {"tap_write_agg": latency_agg_metrics_fields},
-        ],
+        "net": net_metrics,
         "patch_api_requests": [
             "drive_count",
             "drive_fails",
@@ -224,6 +233,10 @@ def validate_fc_metrics(metrics):
             "exit_mmio_read",
             "exit_mmio_write",
             "failures",
+            {"exit_io_in_agg": latency_agg_metrics_fields},
+            {"exit_io_out_agg": latency_agg_metrics_fields},
+            {"exit_mmio_read_agg": latency_agg_metrics_fields},
+            {"exit_mmio_write_agg": latency_agg_metrics_fields},
         ],
         "vmm": [
             "device_events",
@@ -308,6 +321,10 @@ def validate_fc_metrics(metrics):
                 "config_change_time_us",
             ]
             vhost_user_devices.append(metrics_name)
+        if metrics_name.startswith("block_"):
+            firecracker_metrics[metrics_name] = block_metrics
+        if metrics_name.startswith("net_"):
+            firecracker_metrics[metrics_name] = net_metrics
 
     firecracker_metrics_schema = create_metrics_schema_objects(firecracker_metrics)
 


### PR DESCRIPTION
## Change:
Update the Firecracker metrics schema to cover breaking change in
LatencyAggregateMetrics.
Use the 'additionalProperties' flag to catch new metrics which are not
covered by jsonschema validate and add required missing metrics to the schema.

## Reason:
LatencyAggregateMetrics added nested dictionaries in Firecracker's
json-formatted-metrics-object and validate_fc_metrics() failed to cover
breaking change in these metrics.
validate_fc_metrics() reported block_rootfs and vcpu metrics missing
from jsonschema validation after the additionalProperties flag was added.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
