### PR TITLE
chore: Update TODO in artifacts.py

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -120,11 +120,11 @@ class FirecrackerArtifact:
     def snapshot_version_tuple(self):
         """Return the artifact's snapshot version as a tuple: `X.Y.0`."""
 
-        # Starting from Firecracker v1.6.0, snapshots have their own version that is
+        # Starting from Firecracker v1.7.0, snapshots have their own version that is
         # independent of Firecracker versions. For these Firecracker versions, use
         # the --snapshot-version Firecracker flag, to figure out which snapshot version
         # it supports.
-        # TODO: remove this check once all version prior to 1.6.0 go out of support.
+        # TODO: remove this check once all version up to (and including) 1.6.0 go out of support.
         if packaging.version.parse(self.version) < packaging.version.parse("1.7.0"):
             return self.version_tuple[:2] + (0,)
 


### PR DESCRIPTION


## Reason

Snapshot versioning changes only made it into 1.7.0, so the TODO should say "remove check once all versions _including_ 1.6.0" go out of support
## Changes

Update the comment to reflect this.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
