### PR TITLE
Wait for VM to boot in A/B snapshot test

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -145,6 +145,10 @@ def test_restore_latency(
     vm = test_setup.configure_vm(microvm_factory, guest_kernel_linux_4_14, rootfs)
     vm.start()
 
+    # Make sure the guest has booted before taking snapshot.
+    exit_code, _, _ = vm.ssh.run("true")
+    assert exit_code == 0
+
     metrics.set_dimensions(
         {
             "performance_test": "test_restore_latency",


### PR DESCRIPTION
## Changes

Add an SSH command after starting the microVM and before taking a snapshot in snapshot latency A/B test. This fixes the errors we saw in A/B tests after we merged VMGenID support.

## Reason

Since we added VMGenID support we need to wait that the guest kernel boots before taking a snapshot. That is because, if we send the VMGenID notification (upon snapshot resume) very early in the boot process, before the kernel had time to 
setup the interrupt handler for the device, the guest might crash.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
