### PR TITLE
test(cmdline): add delay for serial output file to appear

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -993,6 +993,11 @@ class Serial:
             # serial already opened
             return
 
+        attempt = 0
+        while not Path(self._vm.screen_log).exists() and attempt < 5:
+            time.sleep(0.2)
+            attempt += 1
+
         screen_log_fd = os.open(self._vm.screen_log, os.O_RDONLY)
         self._poller = select.poll()
         self._poller.register(screen_log_fd, select.POLLIN | select.POLLHUP)


### PR DESCRIPTION
## Changes

Add a delay before opening the VM serial output file to avoid a race condition.

## Reason

It is possible that by the time we open the screen output file, guest Linux has not yet started booting, so we may fail to open the file.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this~~
  PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
