### PR TITLE
test(balloon): add delay in stats update test

### DIFF
--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -426,6 +426,7 @@ def test_stats_update(uvm_plain_any):
 
     # Inflate the balloon more to trigger a change in the stats.
     test_microvm.api.balloon.patch(amount_mib=30)
+    time.sleep(1)
 
     # Change the polling interval.
     test_microvm.api.balloon_stats.patch(stats_polling_interval_s=60)


### PR DESCRIPTION
## Changes

Insert a 1 second delay after the inflation request to increase the chance of memory allocation completion by the time of the stats check.

## Reason

It looks like there is a race condition leading to intermittent failures. The test does the following:
 - request pages from the driver
 - change the polling interval to trigger stats update
 - read stats and check that available memory has updated
 
Processing of the inflation request may take time due to memory allocation happening in the guest.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
