### PR TITLE
test: Print debug information on test failure

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -369,7 +369,7 @@ def run_cmd_sync(cmd, ignore_return_code=False, no_shell=False, cwd=None, timeou
 
     :param cmd: command to execute
     :param ignore_return_code: whether a non-zero return code should be ignored
-    :param noshell: don't run the command in a sub-shell
+    :param no_shell: don't run the command in a sub-shell
     :param cwd: sets the current directory before the child is executed
     :return: return code, stdout, stderr
     """

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -38,7 +38,8 @@ class SSHConnection:
         self.user = user
 
         self.options = [
-            "-q",
+            "-o",
+            "LogLevel=ERROR",
             "-o",
             "ConnectTimeout=1",
             "-o",

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -81,11 +81,7 @@ def test_drive_io_engine(uvm_plain):
         test_microvm.api.drive.put(**kwargs)
 
     test_microvm.start()
-
-    # Execute a simple command to check that the guest booted successfully.
-    rc, _, stderr = test_microvm.ssh.run("true")
-    assert rc == 0
-    assert stderr == ""
+    test_microvm.wait_for_up()
 
     assert test_microvm.api.vm_config.get().json()["drives"][0]["io_engine"] == "Sync"
 

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -242,13 +242,12 @@ def test_reinflate_balloon(uvm_plain_any):
 
     # Start the microvm.
     test_microvm.start()
+    test_microvm.wait_for_up()
     firecracker_pid = test_microvm.firecracker_pid
 
     # First inflate the balloon to free up the uncertain amount of memory
     # used by the kernel at boot and establish a baseline, then give back
     # the memory.
-    # wait until boot completes:
-    test_microvm.ssh.run("true")
     test_microvm.api.balloon.patch(amount_mib=200)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -483,8 +482,7 @@ def test_balloon_snapshot(microvm_factory, guest_kernel, rootfs):
     microvm.restore_from_snapshot(snapshot)
     microvm.resume()
 
-    # Attempt to connect to resumed microvm.
-    microvm.ssh.run("true")
+    microvm.wait_for_up()
 
     # Get the firecracker from snapshot pid, and open an ssh connection.
     firecracker_pid = microvm.firecracker_pid

--- a/tests/integration_tests/functional/test_concurrency.py
+++ b/tests/integration_tests/functional/test_concurrency.py
@@ -42,10 +42,8 @@ def test_run_concurrency_with_mmds(microvm_factory, guest_kernel, rootfs):
         populate_data_store(microvm, data_store)
         microvm.basic_config(vcpu_count=1, mem_size_mib=128)
         microvm.start()
+        microvm.wait_for_up()
 
-        # We check that the vm is running by testing that the ssh does
-        # not time out.
-        microvm.ssh.run("true")
         microvms.append(microvm)
 
     # With all guests launched and running send a batch of
@@ -85,10 +83,7 @@ def test_run_concurrency(microvm_factory, guest_kernel, rootfs):
         microvm.basic_config(vcpu_count=1, mem_size_mib=128)
         microvm.add_net_iface()
         microvm.start()
-
-        # We check that the vm is running by testing that the ssh does
-        # not time out.
-        microvm.ssh.run("true")
+        microvm.wait_for_up()
 
     with ThreadPoolExecutor(max_workers=NO_OF_MICROVMS) as tpe:
         for _ in range(NO_OF_MICROVMS):

--- a/tests/integration_tests/functional/test_dirty_pages_in_full_snapshot.py
+++ b/tests/integration_tests/functional/test_dirty_pages_in_full_snapshot.py
@@ -14,7 +14,7 @@ def test_dirty_pages_after_full_snapshot(uvm_plain):
     uvm.basic_config(mem_size_mib=vm_mem_size, track_dirty_pages=True)
     uvm.add_net_iface()
     uvm.start()
-    uvm.ssh.run("true")
+    uvm.wait_for_up()
 
     snap_full = uvm.snapshot_full(vmstate_path="vmstate_full", mem_path="mem_full")
     snap_diff = uvm.snapshot_diff(vmstate_path="vmstate_diff", mem_path="mem_diff")

--- a/tests/integration_tests/functional/test_drive_vhost_user.py
+++ b/tests/integration_tests/functional/test_drive_vhost_user.py
@@ -56,12 +56,7 @@ def test_vhost_user_block(microvm_factory, guest_kernel, rootfs_ubuntu_22):
         "vhost_user_block", 1, aggr_supported=False
     )
     vm.start()
-
-    # Attempt to connect to the VM.
-    # Verify if guest can run commands.
-    exit_code, _, _ = vm.ssh.run("ls")
-
-    assert exit_code == 0
+    vm.wait_for_up()
 
     # Now check that vhost-user-block with rw is last.
     # 1-0 means line 1, column 0.
@@ -96,11 +91,7 @@ def test_vhost_user_block_read_write(microvm_factory, guest_kernel, rootfs_ubunt
     vm.add_vhost_user_drive("rootfs", rootfs_rw, is_root_device=True)
     vm.add_net_iface()
     vm.start()
-
-    # Attempt to connect to the VM.
-    # Verify if guest can run commands.
-    exit_code, _, _ = vm.ssh.run("ls")
-    assert exit_code == 0
+    vm.wait_for_up()
 
     # Now check that vhost-user-block with rw is last.
     # 1-0 means line 1, column 0.
@@ -129,11 +120,7 @@ def test_vhost_user_block_disconnect(microvm_factory, guest_kernel, rootfs_ubunt
     )
     vm.add_net_iface()
     vm.start()
-
-    # Attempt to connect to the VM.
-    # Verify if guest can run commands.
-    exit_code, _, _ = vm.ssh.run("ls")
-    assert exit_code == 0
+    vm.wait_for_up()
 
     # Killing the backend
     vm.disks_vhost_user["rootfs"].kill()
@@ -244,11 +231,7 @@ def test_partuuid_boot(
     )
     vm.add_net_iface()
     vm.start()
-
-    # Attempt to connect to the VM.
-    # Verify if guest can run commands.
-    exit_code, _, _ = vm.ssh.run("ls")
-    assert exit_code == 0
+    vm.wait_for_up()
 
     # Now check that vhost-user-block with rw is last.
     # 1-0 means line 1, column 0.
@@ -292,11 +275,7 @@ def test_partuuid_update(microvm_factory, guest_kernel, rootfs_ubuntu_22):
         "vhost_user_block", 1, aggr_supported=False
     )
     vm.start()
-
-    # Attempt to connect to the VM.
-    # Verify if guest can run commands.
-    exit_code, _, _ = vm.ssh.run("ls")
-    assert exit_code == 0
+    vm.wait_for_up()
 
     # Now check that vhost-user-block with rw is last.
     # 1-0 means line 1, column 0.

--- a/tests/integration_tests/functional/test_drive_virtio.py
+++ b/tests/integration_tests/functional/test_drive_virtio.py
@@ -285,10 +285,10 @@ def test_patch_drive(uvm_plain_any, io_engine):
 
     # The `lsblk` command should output 2 lines to STDOUT: "SIZE" and the size
     # of the device, in bytes.
-    blksize_cmd = "lsblk -b /dev/vdb --output SIZE"
+    blksize_cmd = "LSBLK_DEBUG=all lsblk -b /dev/vdb --output SIZE"
     size_bytes_str = "536870912"  # = 512 MiB
-    _, stdout, stderr = test_microvm.ssh.run(blksize_cmd)
-    assert stderr == ""
+    rc, stdout, stderr = test_microvm.ssh.run(blksize_cmd)
+    assert rc == 0, stderr
     lines = stdout.split("\n")
     # skip "SIZE"
     assert lines[1].strip() == size_bytes_str

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -41,10 +41,7 @@ def test_pause_resume(uvm_nano):
         microvm.api.vm.patch(state="Resumed")
 
     microvm.start()
-
-    # Verify guest is active.
-    exit_code, _, _ = microvm.ssh.run("ls")
-    assert exit_code == 0
+    microvm.wait_for_up()
 
     # Pausing the microVM after it's been started is successful.
     microvm.api.vm.patch(state="Paused")
@@ -53,16 +50,16 @@ def test_pause_resume(uvm_nano):
     microvm.flush_metrics()
 
     # Verify guest is no longer active.
-    exit_code, _, _ = microvm.ssh.run("ls")
-    assert exit_code != 0
+    with pytest.raises(AssertionError):
+        microvm.wait_for_up()
 
     # Verify emulation was indeed paused and no events from either
     # guest or host side were handled.
     verify_net_emulation_paused(microvm.flush_metrics())
 
     # Verify guest is no longer active.
-    exit_code, _, _ = microvm.ssh.run("ls")
-    assert exit_code != 0
+    with pytest.raises(AssertionError):
+        microvm.wait_for_up()
 
     # Pausing the microVM when it is already `Paused` is allowed
     # (microVM remains in `Paused` state).
@@ -72,16 +69,14 @@ def test_pause_resume(uvm_nano):
     microvm.api.vm.patch(state="Resumed")
 
     # Verify guest is active again.
-    exit_code, _, _ = microvm.ssh.run("ls")
-    assert exit_code == 0
+    microvm.wait_for_up()
 
     # Resuming the microVM when it is already `Resumed` is allowed
     # (microVM remains in the running state).
     microvm.api.vm.patch(state="Resumed")
 
     # Verify guest is still active.
-    exit_code, _, _ = microvm.ssh.run("ls")
-    assert exit_code == 0
+    microvm.wait_for_up()
 
     microvm.kill()
 

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -230,7 +230,6 @@ def test_no_serial_fd_error_when_daemonized(uvm_plain):
         mem_size_mib=512,
     )
     test_microvm.start()
-
-    test_microvm.ssh.run("true")
+    test_microvm.wait_for_up()
 
     assert REGISTER_FAILED_WARNING not in test_microvm.log_data

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -112,9 +112,7 @@ def test_5_snapshots(
     vm.add_net_iface()
     vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path=VSOCK_UDS_PATH)
     vm.start()
-    # Verify if guest can run commands.
-    exit_code, _, _ = vm.ssh.run("sync")
-    assert exit_code == 0
+    vm.wait_for_up()
 
     vm_blob_path = "/tmp/vsock/test.blob"
     # Generate a random data file for vsock.
@@ -183,9 +181,7 @@ def test_patch_drive_snapshot(uvm_nano, microvm_factory):
     scratch_disk1 = drive_tools.FilesystemFile(scratch_path1, size=128)
     basevm.add_drive("scratch", scratch_disk1.path)
     basevm.start()
-    # Verify if guest can run commands.
-    exit_code, _, _ = basevm.ssh.run("sync")
-    assert exit_code == 0
+    basevm.wait_for_up()
 
     # Update drive to have another backing file, double in size.
     new_file_size_mb = 2 * int(scratch_disk1.size() / (1024 * 1024))
@@ -264,10 +260,7 @@ def test_cmp_full_and_first_diff_mem(microvm_factory, guest_kernel, rootfs):
     )
     vm.add_net_iface()
     vm.start()
-
-    # Verify if guest can run commands.
-    exit_code, _, _ = vm.ssh.run("sync")
-    assert exit_code == 0
+    vm.wait_for_up()
 
     logger.info("Create diff snapshot.")
     # Create diff snapshot.
@@ -290,9 +283,7 @@ def test_negative_postload_api(uvm_plain, microvm_factory):
     basevm.basic_config(track_dirty_pages=True)
     basevm.add_net_iface()
     basevm.start()
-    # Verify if guest can run commands.
-    exit_code, _, _ = basevm.ssh.run("sync")
-    assert exit_code == 0
+    basevm.wait_for_up()
 
     # Create base snapshot.
     snapshot = basevm.snapshot_diff()
@@ -438,10 +429,7 @@ def test_diff_snapshot_overlay(guest_kernel, rootfs, microvm_factory):
     basevm.basic_config(track_dirty_pages=True)
     basevm.add_net_iface()
     basevm.start()
-
-    # Wait for microvm to be booted
-    rc, _, stderr = basevm.ssh.run("true")
-    assert rc == 0, stderr
+    basevm.wait_for_up()
 
     # The first snapshot taken will always contain all memory (even if its specified as "diff").
     # We use a diff snapshot here, as taking a full snapshot does not clear the dirty page tracking,
@@ -469,9 +457,8 @@ def test_diff_snapshot_overlay(guest_kernel, rootfs, microvm_factory):
     new_vm.spawn()
     new_vm.restore_from_snapshot(merged_snapshot, resume=True)
 
-    # Run some command to check that the restored VM works
-    rc, _, stderr = new_vm.ssh.run("true")
-    assert rc == 0, stderr
+    # Check that the restored VM works
+    new_vm.wait_for_up()
 
 
 def test_snapshot_overwrite_self(guest_kernel, rootfs, microvm_factory):
@@ -487,10 +474,7 @@ def test_snapshot_overwrite_self(guest_kernel, rootfs, microvm_factory):
     base_vm.basic_config()
     base_vm.add_net_iface()
     base_vm.start()
-
-    # Wait for microvm to be booted
-    rc, _, stderr = base_vm.ssh.run("true")
-    assert rc == 0, stderr
+    base_vm.wait_for_up()
 
     snapshot = base_vm.snapshot_full()
     base_vm.kill()
@@ -510,8 +494,7 @@ def test_snapshot_overwrite_self(guest_kernel, rootfs, microvm_factory):
 
     # Check the overwriting the snapshot file from which this microvm was originally
     # restored, with a new snapshot of this vm, does not break the VM
-    rc, _, stderr = vm.ssh.run("true")
-    assert rc == 0, stderr
+    vm.wait_for_up()
 
 
 @pytest.mark.parametrize("snapshot_type", [SnapshotType.DIFF, SnapshotType.FULL])
@@ -527,10 +510,7 @@ def test_vmgenid(guest_kernel_linux_6_1, rootfs, microvm_factory, snapshot_type)
     base_vm.basic_config(track_dirty_pages=True)
     base_vm.add_net_iface()
     base_vm.start()
-
-    # Wait for microVM to be booted
-    rc, _, stderr = base_vm.ssh.run("true")
-    assert rc == 0, stderr
+    base_vm.wait_for_up()
 
     snapshot = base_vm.make_snapshot(snapshot_type)
     base_snapshot = snapshot
@@ -540,10 +520,7 @@ def test_vmgenid(guest_kernel_linux_6_1, rootfs, microvm_factory, snapshot_type)
         vm = microvm_factory.build()
         vm.spawn()
         vm.restore_from_snapshot(snapshot, resume=True)
-
-        # Make sure the microVM is up
-        rc, _, stderr = vm.ssh.run("true")
-        assert rc == 0, stderr
+        vm.wait_for_up()
 
         # We should have as DMESG_VMGENID_RESUME messages as
         # snapshots we have resumed

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -44,9 +44,9 @@ def check_vmgenid_update_count(vm, resume_count):
 def _get_guest_drive_size(ssh_connection, guest_dev_name="/dev/vdb"):
     # `lsblk` command outputs 2 lines to STDOUT:
     # "SIZE" and the size of the device, in bytes.
-    blksize_cmd = "lsblk -b {} --output SIZE".format(guest_dev_name)
-    _, stdout, stderr = ssh_connection.run(blksize_cmd)
-    assert stderr == ""
+    blksize_cmd = "LSBLK_DEBUG=all lsblk -b {} --output SIZE".format(guest_dev_name)
+    rc, stdout, stderr = ssh_connection.run(blksize_cmd)
+    assert rc == 0, stderr
     lines = stdout.split("\n")
     return lines[1].strip()
 

--- a/tests/integration_tests/functional/test_snapshot_editor.py
+++ b/tests/integration_tests/functional/test_snapshot_editor.py
@@ -71,8 +71,4 @@ def test_remove_regs(uvm_nano, microvm_factory):
     new_vm = microvm_factory.build()
     new_vm.spawn()
     new_vm.restore_from_snapshot(snapshot, resume=True)
-
-    # Attempt to connect to resumed microvm.
-    # Verify if guest can run commands.
-    exit_code, _, _ = new_vm.ssh.run("ls")
-    assert exit_code == 0
+    new_vm.wait_for_up()

--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -28,10 +28,7 @@ def snapshot_fxt(microvm_factory, guest_kernel_linux_5_10, rootfs_ubuntu_22):
     )
 
     basevm.start()
-
-    # Verify if guest can run commands.
-    exit_code, _, _ = basevm.ssh.run("sync")
-    assert exit_code == 0
+    basevm.wait_for_up()
 
     # Create base snapshot.
     snapshot = basevm.snapshot_full()
@@ -121,10 +118,8 @@ def test_valid_handler(uvm_plain, snapshot, uffd_handler_paths):
     # Deflate balloon.
     vm.api.balloon.patch(amount_mib=0)
 
-    # Verify if guest can run commands.
-    exit_code, _, _ = vm.ssh.run("sync")
-
-    assert exit_code == 0
+    # Verify if the restored guest works.
+    vm.wait_for_up()
 
 
 def test_malicious_handler(uvm_plain, snapshot, uffd_handler_paths):

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -74,10 +74,9 @@ def negative_test_host_connections(vm, blob_path, blob_hash):
         wrk.close_uds()
         wrk.join()
 
-    # Validate that Firecracker is still up and running.
-    ecode, _, _ = vm.ssh.run("sync")
+    # Validate that guest is still up and running.
     # Should fail if Firecracker exited from SIGPIPE handler.
-    assert ecode == 0
+    vm.wait_for_up()
 
     metrics = vm.flush_metrics()
     validate_fc_metrics(metrics)

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -106,17 +106,24 @@ def test_initrd_boottime(uvm_with_initrd, record_property, metrics):
 
 def _get_microvm_boottime(vm):
     """Auxiliary function for asserting the expected boot time."""
-    boot_time_us = 0
+    boot_time_us = None
     timestamps = []
-    for _ in range(10):
+
+    iterations = 50
+    sleep_time_s = 0.1
+    for _ in range(iterations):
         timestamps = re.findall(TIMESTAMP_LOG_REGEX, vm.log_data)
         if timestamps:
             break
-        time.sleep(0.1)
+        time.sleep(sleep_time_s)
     if timestamps:
         boot_time_us = int(timestamps[0])
 
-    assert boot_time_us > 0
+    assert boot_time_us, (
+        f"MicroVM did not boot within {sleep_time_s * iterations}s\n"
+        f"Firecracker logs:\n{vm.log_data}\n"
+        f"Thread backtraces:\n{vm.thread_backtraces}"
+    )
     return boot_time_us
 
 

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -66,9 +66,7 @@ def test_hugetlbfs_boot(uvm_plain):
     uvm_plain.basic_config(huge_pages=HugePagesConfig.HUGETLBFS_2MB, mem_size_mib=128)
     uvm_plain.add_net_iface()
     uvm_plain.start()
-
-    rc, _, _ = uvm_plain.ssh.run("true")
-    assert not rc
+    uvm_plain.wait_for_up()
 
     check_hugetlbfs_in_use(
         uvm_plain.firecracker_pid,
@@ -94,10 +92,7 @@ def test_hugetlbfs_snapshot(
     vm.basic_config(huge_pages=HugePagesConfig.HUGETLBFS_2MB, mem_size_mib=128)
     vm.add_net_iface()
     vm.start()
-
-    # Wait for microvm to boot
-    rc, _, _ = vm.ssh.run("true")
-    assert not rc
+    vm.wait_for_up()
 
     check_hugetlbfs_in_use(vm.firecracker_pid, "/anon_hugepage")
 
@@ -115,10 +110,7 @@ def test_hugetlbfs_snapshot(
     )
 
     vm.restore_from_snapshot(snapshot, resume=True, uffd_path=SOCKET_PATH)
-
-    # Verify if guest can run commands.
-    rc, _, _ = vm.ssh.run("true")
-    assert not rc
+    vm.wait_for_up()
 
     check_hugetlbfs_in_use(vm.firecracker_pid, "/anon_hugepage")
 
@@ -146,8 +138,7 @@ def test_hugetlbfs_diff_snapshot(microvm_factory, uvm_plain, uffd_handler_paths)
     uvm_plain.start()
 
     # Wait for microvm to boot
-    rc, _, _ = uvm_plain.ssh.run("true")
-    assert not rc
+    uvm_plain.wait_for_up()
 
     base_snapshot = uvm_plain.snapshot_diff()
     uvm_plain.resume()
@@ -171,9 +162,8 @@ def test_hugetlbfs_diff_snapshot(microvm_factory, uvm_plain, uffd_handler_paths)
 
     vm.restore_from_snapshot(snapshot_merged, resume=True, uffd_path=SOCKET_PATH)
 
-    # Verify if guest can run commands.
-    rc, _, _ = vm.ssh.run("true")
-    assert not rc
+    # Verify if the restored microvm works.
+    vm.wait_for_up()
 
 
 @pytest.mark.skipif(

--- a/tests/integration_tests/performance/test_memory_overhead.py
+++ b/tests/integration_tests/performance/test_memory_overhead.py
@@ -49,9 +49,7 @@ def test_memory_overhead(
         )
         fcmetrics = FCMetricsMonitor(microvm)
         fcmetrics.start()
-
-        # check that the vm is running
-        microvm.ssh.run("true")
+        microvm.wait_for_up()
 
         guest_mem_bytes = mem_size_mib * 2**20
         guest_mem_splits = {

--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -93,10 +93,7 @@ class SnapshotRestoreTest:
 
             fcmetrics = FCMetricsMonitor(microvm)
             fcmetrics.start()
-
-            # Check if guest still runs commands.
-            exit_code, _, _ = microvm.ssh.run("true")
-            assert exit_code == 0
+            microvm.wait_for_up()
 
             value = 0
             # Parse all metric data points in search of load_snapshot time.
@@ -144,10 +141,7 @@ def test_restore_latency(
     """
     vm = test_setup.configure_vm(microvm_factory, guest_kernel_linux_4_14, rootfs)
     vm.start()
-
-    # Make sure the guest has booted before taking snapshot.
-    exit_code, _, _ = vm.ssh.run("true")
-    assert exit_code == 0
+    vm.wait_for_up()
 
     metrics.set_dimensions(
         {

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -604,10 +604,7 @@ def test_firecracker_kill_by_pid(uvm_plain, daemonize, new_pid_ns):
     microvm.basic_config()
     microvm.add_net_iface()
     microvm.start()
-
-    # verify the guest is active
-    exit_code, _, _ = microvm.ssh.run("ls")
-    assert exit_code == 0
+    microvm.wait_for_up()
 
     # before killing microvm make sure the Jailer config is what we set it to be.
     assert (

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -122,9 +122,8 @@ def with_restore(factory, microvm_factory):
 
     def restore(firecracker=None, jailer=None):
         microvm = factory(firecracker, jailer)
-        # Ensure that we have booted before getting the snapshot.
-        rc, _, stderr = microvm.ssh.run("true")
-        assert rc == 0, stderr
+        microvm.wait_for_up()
+
         snapshot = microvm.snapshot_full()
 
         if firecracker:

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -439,7 +439,7 @@ def check_vulnerabilities_files_on_guest(microvm):
     """
     # Retrieve a list of vulnerabilities files available inside guests.
     vuln_dir = "/sys/devices/system/cpu/vulnerabilities"
-    ecode, stdout, stderr = microvm.ssh.run(f"find {vuln_dir} -type f")
+    ecode, stdout, stderr = microvm.ssh.run(f"find -D all {vuln_dir} -type f")
     assert ecode == 0, f"stdout:\n{stdout}\nstderr:\n{stderr}\n"
     vuln_files = stdout.split("\n")
 


### PR DESCRIPTION
## Changes

- Enable debug print of `find` and `lsblk` command.
- Change the log level of `ssh` command from quiet to error.
- Print debug information when guest is not up.
- Increase the waiting time for microVM to boot up.

## Reason

We run into multiple intermittent issues where commands exit with status code 255 without any useful info in stderr on microVMs restored from snapshots. As per man page, the failing commands don't list 255 in the possible status codes while `ssh` does, so `ssh` is mostly likely to be the culprit. However, currently we're not sure whether the commands themselves failed or something happened before entering the commands. To make it debuggable in the next occurrence, enable debug print for some commands and change the log level of `ssh` command from quiet and error. 

`find` command failure
```
_ test_vulnerabilities_files_on_restored_guest_with_template[vmlinux-5.10.210-ubuntu-22.04.squashfs-static_T2] _
[gw6] linux -- Python 3.10.12 /usr/bin/python3
integration_tests/security/test_vulnerabilities.py:515: in test_vulnerabilities_files_on_restored_guest_with_template
    check_vulnerabilities_files_ab(
        build_microvm_with_template = <function build_microvm_with_template.<locals>.<lambda> at 0x7d32ad044af0>
        microvm_factory = <framework.microvm.MicroVMFactory object at 0x7d32ad071900>
integration_tests/security/test_vulnerabilities.py:476: in check_vulnerabilities_files_ab
    check_vulnerabilities_files_on_guest(builder())
        builder    = <function with_restore.<locals>.restore at 0x7d32ad109750>
integration_tests/security/test_vulnerabilities.py:443: in check_vulnerabilities_files_on_guest
    assert ecode == 0, f"stdout:\n{stdout}\nstderr:\n{stderr}\n"
E   AssertionError: stdout:
E     
E     stderr:
E     
E     
E   assert 255 == 0
        ecode      = 255
        microvm    = <Microvm id=6f2b405f-5ff7-4496-86e0-4bc5686a4f50>
        stderr     = ''
        stdout     = ''
        vuln_dir   = '/sys/devices/system/cpu/vulnerabilities'
```

`grep` command failure
```
_ test_vulnerabilities_files_on_restored_guest_with_template[vmlinux-5.10.210-no-acpi-ubuntu-22.04.squashfs-static_T2] _
[gw3] linux -- Python 3.10.12 /usr/bin/python3
integration_tests/security/test_vulnerabilities.py:515: in test_vulnerabilities_files_on_restored_guest_with_template
    check_vulnerabilities_files_ab(
        build_microvm_with_template = <function build_microvm_with_template.<locals>.<lambda> at 0x7f40c89c43a0>
        microvm_factory = <framework.microvm.MicroVMFactory object at 0x7f40c8a63160>
integration_tests/security/test_vulnerabilities.py:476: in check_vulnerabilities_files_ab
    check_vulnerabilities_files_on_guest(builder())
        builder    = <function with_restore.<locals>.restore at 0x7f40c89ff640>
integration_tests/security/test_vulnerabilities.py:460: in check_vulnerabilities_files_on_guest
    assert ecode == 1, f"{vuln_file}: stdout:\n{stdout}\nstderr:\n{stderr}\n"
E   AssertionError: /sys/devices/system/cpu/vulnerabilities/spectre_v2: stdout:
E     
E     stderr:
E     
E     
E   assert 255 == 1
        cmd        = 'grep Vulnerable /sys/devices/system/cpu/vulnerabilities/spectre_v2'
        ecode      = 255
        exceptions = {}
        filename   = 'spectre_v2'
        microvm    = <Microvm id=84b419c3-97ad-4222-88f6-e685708c3f00>
        stderr     = ''
        stdout     = ''
        template   = 'T2'
        vuln_dir   = '/sys/devices/system/cpu/vulnerabilities'
        vuln_file  = '/sys/devices/system/cpu/vulnerabilities/spectre_v2'
        vuln_files = ['/sys/devices/system/cpu/vulnerabilities/spectre_v2', 
```

`lsblk` command failure:
```
__ test_patch_drive_snapshot[vmlinux-5.10.210-no-acpi-ubuntu-22.04.squashfs] ___
[gw2] linux -- Python 3.10.12 /usr/bin/python3
integration_tests/functional/test_snapshot_basic.py:192: in test_patch_drive_snapshot
    guest_drive_size = _get_guest_drive_size(vm.ssh)
        _          = ''
        basevm     = <Microvm id=ffa2a4af-d11d-45b3-9a8d-4d3c662c32cb>
        exit_code  = 0
        logger     = <Logger snapshot_sequence (WARNING)>
        microvm_factory = <framework.microvm.MicroVMFactory object at 0x7f1134a076a0>
        new_file_size_mb = 256
        root       = PosixPath('/srv/jailer/firecracker/ffa2a4af-d11d-45b3-9a8d-4d3c662c32cb')
        scratch_disk1 = <FilesystemFile path=/srv/jailer/firecracker/ffa2a4af-d11d-45b3-9a8d-4d3c662c32cb/scratch1.ext4 size=134217728>
        scratch_disk2 = <FilesystemFile path=/srv/jailer/firecracker/ffa2a4af-d11d-45b3-9a8d-4d3c662c32cb/scratch2.ext4 size=268435456>
        scratch_path1 = '/srv/jailer/firecracker/ffa2a4af-d11d-45b3-9a8d-4d3c662c32cb/scratch1'
        scratch_path2 = '/srv/jailer/firecracker/ffa2a4af-d11d-45b3-9a8d-4d3c662c32cb/scratch2'
        snapshot   = Snapshot(vmstate=PosixPath('/srv/jailer/firecracker/ffa2a4af-d11d-45b3-9a8d-4d3c662c32cb/root/vmstate'), mem=PosixPath...3c662c32cb/scratch2.ext4')}, ssh_key=PosixPath('/srv/img/x86_64/ubuntu-22.04.id_rsa'), snapshot_type=SnapshotType.FULL)
        uvm_nano   = <Microvm id=ffa2a4af-d11d-45b3-9a8d-4d3c662c32cb>
        vm         = <Microvm id=4820cad4-2b74-426e-9788-6d18d4a3169c>
integration_tests/functional/test_snapshot_basic.py:36: in _get_guest_drive_size
    return lines[1].strip()
E   IndexError: list index out of range
        _          = 255
        blksize_cmd = 'lsblk -b /dev/vdb --output SIZE'
        guest_dev_name = '/dev/vdb'
        lines      = ['']
        ssh_connection = <host_tools.network.SSHConnection object at 0x7f11349fa3b0>
        stderr     = ''
        stdout     = ''
```

We are running into another intermittent issue that the guest doesn't boot within 1 second in `tests/integration_tests/performance/test_boottime.py::test_boottime`. The fact that it doesn't emit metrics on failure may lead to a false sense of boot time performance. To avoid this, the waiting time should be big enough. It would be helpful to print Firecracker logs and thread backtraces for debug if the guest doesn't boot within such a big waiting time.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
