### PR TITLE
test: Increase timeout for microvm to boot up

### DIFF
--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -106,17 +106,20 @@ def test_initrd_boottime(uvm_with_initrd, record_property, metrics):
 
 def _get_microvm_boottime(vm):
     """Auxiliary function for asserting the expected boot time."""
-    boot_time_us = 0
+    boot_time_us = None
     timestamps = []
-    for _ in range(10):
+
+    iterations = 50
+    sleep_time_s = 0.1
+    for _ in range(iterations):
         timestamps = re.findall(TIMESTAMP_LOG_REGEX, vm.log_data)
         if timestamps:
             break
-        time.sleep(0.1)
+        time.sleep(sleep_time_s)
     if timestamps:
         boot_time_us = int(timestamps[0])
 
-    assert boot_time_us > 0
+    assert boot_time_us is not None, f"Timeout>{sleep_time_s * iterations}s"
     return boot_time_us
 
 


### PR DESCRIPTION
## Changes & Reason

It was observed that "Guest-boot-time" was not found in Firecracker log within 1 second in the nightly test. Set timeout to 5 seconds that is big enough for the guest to boot up even if it run concurrently on the same host. Otherwise, the boot time metric is always reported less than 1 second and lead to a false sense. By setting enough timeout, in the next occurrence of timeout error, it can be told that something went wrong inside guests. In happy cases, it will exit within 1 second, so it usually doesn't make the test running for long time.
    
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
