### PR TITLE
Bump userfaultfd to 0.8.1

### DIFF
--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.78"
 timerfd = "1.5.0"
 thiserror = "1.0.32"
 displaydoc = "0.2.4"
-userfaultfd = "0.7.0"
+userfaultfd = "0.8.1"
 vhost = { version = "0.10.0", features = ["vhost-user-frontend"] }
 vm-allocator = "0.1.0"
 vm-superio = "0.7.0"


### PR DESCRIPTION
## Changes

Depend on newer version of userfaultfd

## Reason

UFFD support is not compatible with newer kernels as there was a new ioctl option added that the older userfaultfd version does not recognize:
```
[PUT /snapshot/load][400] loadSnapshotBadRequest  &{FaultMessage:Load snapshot error: Failed to restore from snapshot: Failed to load guest memory: Error creating guest memory from uffd: Failed to register memory address range with the userfaultfd object: Unrecognized ioctl flags: 284}
```

This was reported in https://github.com/bytecodealliance/userfaultfd-rs/issues/61 and fixed in https://github.com/bytecodealliance/userfaultfd-rs/pull/62

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
