### PR TITLE
chore: Pin 5.10 kernel AMIs

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -22,7 +22,8 @@ DEFAULT_INSTANCES = [
 
 DEFAULT_PLATFORMS = [
     ("al2", "linux_4.14"),
-    ("al2", "linux_5.10"),
+    # TODO: Unpin 5.10 kernel AMI once io_uring issues is solved.
+    ("al2", "linux_5.10-pinned"),
     ("al2023", "linux_6.1"),
 ]
 


### PR DESCRIPTION

## Reason & Changes

We are running into io_uring test failures after 5.10 kernel update on 2024-04-19. The issue is under investigation, but it prevents us from merging PRs and it makes multiple pipelines fail. Until solving the issue, pin 5.10 kernel AMIs to older ones and set them default.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
