### PR TITLE
chore: Update fingerprints

### DIFF
--- a/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_4.14host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "4.14.336-257.562.amzn2.x86_64",
+  "kernel_version": "4.14.336-257.568.amzn2.x86_64",
   "microcode_version": "0xa0011d1",
   "bios_version": "1.0",
   "bios_revision": "0.69",

--- a/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_5.10host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.210-201.852.amzn2.x86_64",
+  "kernel_version": "5.10.214-202.855.amzn2.x86_64",
   "microcode_version": "0xa0011d1",
   "bios_version": "1.0",
   "bios_revision": "0.69",

--- a/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_6.1host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.79-99.164.amzn2023.x86_64",
+  "kernel_version": "6.1.84-99.169.amzn2023.x86_64",
   "microcode_version": "0xa0011d1",
   "bios_version": "1.0",
   "bios_revision": "0.69",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_4.14host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "4.14.336-256.559.amzn2.aarch64",
+  "kernel_version": "4.14.336-257.568.amzn2.aarch64",
   "microcode_version": "0x00000000000000ff",
   "bios_version": "1.0",
   "bios_revision": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_5.10host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.209-198.858.amzn2.aarch64",
+  "kernel_version": "5.10.214-202.855.amzn2.aarch64",
   "microcode_version": "0x00000000000000ff",
   "bios_version": "1.0",
   "bios_revision": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_N1_6.1host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.79-99.164.amzn2023.aarch64",
+  "kernel_version": "6.1.84-99.169.amzn2023.aarch64",
   "microcode_version": "0x00000000000000ff",
   "bios_version": "1.0",
   "bios_revision": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_4.14host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "4.14.336-256.559.amzn2.aarch64",
+  "kernel_version": "4.14.336-257.568.amzn2.aarch64",
   "microcode_version": "0x0000000000000001",
   "bios_version": "1.0",
   "bios_revision": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_5.10host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.209-198.858.amzn2.aarch64",
+  "kernel_version": "5.10.214-202.855.amzn2.aarch64",
   "microcode_version": "0x0000000000000001",
   "bios_version": "1.0",
   "bios_revision": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_ARM_NEOVERSE_V1_6.1host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.79-99.164.amzn2023.aarch64",
+  "kernel_version": "6.1.84-99.169.amzn2023.aarch64",
   "microcode_version": "0x0000000000000001",
   "bios_version": "1.0",
   "bios_revision": "1.0",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_4.14host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "4.14.336-257.562.amzn2.x86_64",
+  "kernel_version": "4.14.336-257.568.amzn2.x86_64",
   "microcode_version": "0x5003604",
   "bios_version": "1.0",
   "bios_revision": "3.80",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_5.10host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.210-201.852.amzn2.x86_64",
+  "kernel_version": "5.10.214-202.855.amzn2.x86_64",
   "microcode_version": "0x5003604",
   "bios_version": "1.0",
   "bios_revision": "3.80",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_6.1host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.79-99.164.amzn2023.x86_64",
+  "kernel_version": "6.1.84-99.169.amzn2023.x86_64",
   "microcode_version": "0x5003604",
   "bios_version": "1.0",
   "bios_revision": "3.80",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_4.14host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "4.14.336-257.562.amzn2.x86_64",
+  "kernel_version": "4.14.336-257.568.amzn2.x86_64",
   "microcode_version": "0xd0003b9",
   "bios_version": "1.0",
   "bios_revision": "1.36",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_5.10host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.210-201.852.amzn2.x86_64",
+  "kernel_version": "5.10.214-202.855.amzn2.x86_64",
   "microcode_version": "0xd0003b9",
   "bios_version": "1.0",
   "bios_revision": "1.36",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_6.1host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.79-99.164.amzn2023.x86_64",
+  "kernel_version": "6.1.84-99.169.amzn2023.x86_64",
   "microcode_version": "0xd0003b9",
   "bios_version": "1.0",
   "bios_revision": "1.36",
@@ -267,7 +267,7 @@
         "modifiers": [
           {
             "register": "eax",
-            "bitmap": "0b00000000000000000000000000000001"
+            "bitmap": "0b00000000000000000000000000000010"
           },
           {
             "register": "ebx",
@@ -303,6 +303,29 @@
           {
             "register": "edx",
             "bitmap": "0b00000000000000000000000000000000"
+          }
+        ]
+      },
+      {
+        "leaf": "0x7",
+        "subleaf": "0x2",
+        "flags": 1,
+        "modifiers": [
+          {
+            "register": "eax",
+            "bitmap": "0b00000000000000000000000000000000"
+          },
+          {
+            "register": "ebx",
+            "bitmap": "0b00000000000000000000000000000000"
+          },
+          {
+            "register": "ecx",
+            "bitmap": "0b00000000000000000000000000000000"
+          },
+          {
+            "register": "edx",
+            "bitmap": "0b00000000000000000000000000000001"
           }
         ]
       },

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_4.14host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_4.14host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "4.14.336-257.562.amzn2.x86_64",
+  "kernel_version": "4.14.336-257.568.amzn2.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",
   "bios_revision": "3.80",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_5.10host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.210-201.852.amzn2.x86_64",
+  "kernel_version": "5.10.214-202.855.amzn2.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",
   "bios_revision": "3.80",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json
@@ -1,6 +1,6 @@
 {
   "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.79-99.164.amzn2023.x86_64",
+  "kernel_version": "6.1.84-99.169.amzn2023.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",
   "bios_revision": "3.80",


### PR DESCRIPTION
## Changes

- Update fingerprints

## Reason

On m6i.metal + kernel 6.1, the following changes were detected:
- CPUID.(EAX=7,ECX=0):EDX[bit 0]: the number of subleaves
- CPUID.(EAX=7,ECX=2):EDX[bit 0]: support of IA32_SPEC_CTRL[bit 0 (PSFD)]

No changes are detected on IA32_SPEC_CTRL MSR. It is up to guests to set the bit or not inside.
Kernel commit to advertize it to userspace: https://github.com/torvalds/linux/commit/eefe5e6682099445f77f2d97d4c525f9ac9d9b07

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
