### PR TITLE
chore: Use pinned AMIs for cross snapshot restore target

### DIFF
--- a/.buildkite/pipeline_cross.py
+++ b/.buildkite/pipeline_cross.py
@@ -71,7 +71,8 @@ def cross_steps():
 
     # https://github.com/firecracker-microvm/firecracker/blob/main/docs/kernel-policy.md#experimental-snapshot-compatibility-across-kernel-versions
     aarch64_platforms = [
-        ("al2", "linux_5.10"),
+        # TODO: unpin kernel 5.10 AMI once we fix io_uring test failures.
+        ("al2", "linux_5.10-pinned"),
         ("al2023", "linux_6.1"),
     ]
     perms_aarch64 = itertools.product(


### PR DESCRIPTION
## Changes

- Use pinned AMIs for cross snapshot restore target.

## Reason

We pinned 5.10 kernel AMIs to an old one to mitigate io_uring test failures temporarily. We just changed `DEFAULT_PLATFORMS` but ARM cross snapshot restore test uses a custom set of platforms. 

Fixes: 238f55c18adb ("chore: Pin 5.10 kernel AMIs")

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [ ] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
