### PR TITLE
Update `members` field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
-members = ["src/acpi-tables", "src/clippy-tracing", "src/cpu-template-helper", "src/firecracker", "src/jailer", "src/log-instrument", "src/log-instrument-macros", "src/rebase-snap", "src/seccompiler", "src/snapshot-editor"]
+members = ["src/*"]
+# We exclude the jailer below so that it does not get build by default. This is because "cargo build" compiles
+# for the gnu target, and the jailer needs a statically compiled binary to work correctly.
+# See https://github.com/firecracker-microvm/firecracker/commit/3bf285c8f8a815149923c562dd7edaffcaf10c4e
+# and https://github.com/firecracker-microvm/firecracker/issues/2102
 default-members = ["src/clippy-tracing", "src/cpu-template-helper", "src/firecracker", "src/rebase-snap", "src/seccompiler", "src/snapshot-editor", "src/acpi-tables"]
 resolver = "2"
 

--- a/src/cpu-template-helper/Cargo.toml
+++ b/src/cpu-template-helper/Cargo.toml
@@ -17,9 +17,9 @@ log-instrument = { path = "../log-instrument", optional = true }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.115"
 thiserror = "1.0.58"
-vmm-sys-util = "0.12.1"
 
 vmm = { path = "../vmm" }
+vmm-sys-util = "0.12.1"
 
 [features]
 tracing = ["log-instrument", "vmm/tracing"]

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -21,13 +21,13 @@ event-manager = "0.4.0"
 libc = "0.2.153"
 log-instrument = { path = "../log-instrument", optional = true }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http" }
+
+seccompiler = { path = "../seccompiler" }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_derive = "1.0.136"
 serde_json = "1.0.115"
 thiserror = "1.0.58"
 timerfd = "1.6.0"
-
-seccompiler = { path = "../seccompiler" }
 utils = { path = "../utils" }
 vmm = { path = "../vmm" }
 

--- a/src/snapshot-editor/Cargo.toml
+++ b/src/snapshot-editor/Cargo.toml
@@ -12,13 +12,13 @@ bench = false
 [dependencies]
 clap = { version = "4.5.4", features = ["derive", "string"] }
 displaydoc = "0.2.4"
+
+fc_utils = { package = "utils", path = "../utils" }
 libc = "0.2.153"
 log-instrument = { path = "../log-instrument", optional = true }
 semver = "1.0.22"
 thiserror = "1.0.58"
 vmm = { path = "../vmm" }
-
-fc_utils = { package = "utils", path = "../utils" }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 clap-num = "1.0.2"

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -10,13 +10,13 @@ bench = false
 
 [dependencies]
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
+displaydoc = "0.2.4"
 libc = "0.2.147"
+log-instrument = { path = "../log-instrument", optional = true }
 serde = { version = "1.0.165", features = ["derive"] }
 thiserror = "1.0.32"
-displaydoc = "0.2.4"
-vmm-sys-util = "0.12.1"
 vm-memory = { version = "0.14.1", features = ["backend-mmap", "backend-bitmap"] }
-log-instrument = { path = "../log-instrument", optional = true }
+vmm-sys-util = "0.12.1"
 
 [dev-dependencies]
 serde_json = "1.0.99"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -9,41 +9,41 @@ license = "Apache-2.0"
 bench = false
 
 [dependencies]
+acpi_tables = { path = "../acpi-tables" } 
+aes-gcm =  { version = "0.10.1", default-features = false, features = ["aes"] }
 aws-lc-rs = { version = "1.6.1", features = ["bindgen"] }
+base64 = "0.21.0"
+bincode = "1.2.1"
 bitflags = "2.0.2"
+crc64 = "2.0.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
+displaydoc = "0.2.4"
 event-manager = "0.4.0"
 kvm-bindings = { version = "0.7.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.16.0"
 lazy_static = "1.4.0"
 libc = "0.2.117"
-memfd = "0.6.3"
 linux-loader = "0.11.0"
-serde = { version = "1.0.136", features = ["derive", "rc"] }
-semver = { version = "1.0.17", features = ["serde"] }
-serde_json = "1.0.78"
-timerfd = "1.5.0"
-thiserror = "1.0.32"
-displaydoc = "0.2.4"
-userfaultfd = "0.7.0"
-vhost = { version = "0.10.0", features = ["vhost-user-frontend"] }
-vm-allocator = "0.1.0"
-vm-superio = "0.7.0"
-vm-memory = { version = "0.14.1", features = ["backend-mmap", "backend-bitmap"] }
 log = { version = "0.4.17", features = ["std", "serde"] }
-aes-gcm =  { version = "0.10.1", default-features = false, features = ["aes"] }
-base64 = "0.21.0"
-bincode = "1.2.1"
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http" }
 log-instrument = { path = "../log-instrument", optional = true }
-crc64 = "2.0.0"
-slab = "0.4.7"
-zerocopy = { version = "0.7.32" }
+memfd = "0.6.3"
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http" }
 
 seccompiler = { path = "../seccompiler" }
-utils = { path = "../utils" }
+semver = { version = "1.0.17", features = ["serde"] }
+serde = { version = "1.0.136", features = ["derive", "rc"] }
+serde_json = "1.0.78"
+slab = "0.4.7"
 smallvec = "1.11.2"
-acpi_tables = { path = "../acpi-tables" } 
+thiserror = "1.0.32"
+timerfd = "1.5.0"
+userfaultfd = "0.7.0"
+utils = { path = "../utils" }
+vhost = { version = "0.10.0", features = ["vhost-user-frontend"] }
+vm-allocator = "0.1.0"
+vm-memory = { version = "0.14.1", features = ["backend-mmap", "backend-bitmap"] }
+vm-superio = "0.7.0"
+zerocopy = { version = "0.7.32" }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 vm-fdt = "0.2.0"
@@ -51,8 +51,8 @@ vm-fdt = "0.2.0"
 [dev-dependencies]
 criterion = { version = "0.5.0", default-features = false }
 device_tree = "1.1.0"
-proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 itertools = "0.12.0"
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 
 [features]
 tracing = ["log-instrument"]


### PR DESCRIPTION
Formally include all crates, both binary and library, in the cargo workspace, so that dependabot can discover the Cargo.toml files of the library crates as well.

Also document the reason why we have a default-members entry, and why it excludes the jailer.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
