### PR TITLE
wait_for_up() in tests running guest commands

### DIFF
--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1167,8 +1167,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
     snapshot = uvm_nano.snapshot_full()
     uvm2 = microvm_factory.build()
     uvm2.spawn()
-    uvm2.restore_from_snapshot(snapshot)
-    uvm2.resume()
+    uvm2.restore_from_snapshot(snapshot, resume=True)
 
     expected_cfg = setup_cfg.copy()
 

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -479,8 +479,7 @@ def test_balloon_snapshot(microvm_factory, guest_kernel, rootfs):
     snapshot = vm.snapshot_full()
     microvm = microvm_factory.build()
     microvm.spawn()
-    microvm.restore_from_snapshot(snapshot)
-    microvm.resume()
+    microvm.restore_from_snapshot(snapshot, resume=True)
 
     microvm.wait_for_up()
 

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -671,6 +671,7 @@ def test_cpu_template(uvm_plain_any, cpu_template, microvm_factory):
     restored_vm = microvm_factory.build()
     restored_vm.spawn()
     restored_vm.restore_from_snapshot(snapshot, resume=True)
+    restored_vm.wait_for_up()
     check_masked_features(restored_vm, cpu_template)
     check_enabled_features(restored_vm, cpu_template)
 

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -114,6 +114,7 @@ def test_cpu_features_with_static_template(
     restored_vm = microvm_factory.build()
     restored_vm.spawn()
     restored_vm.restore_from_snapshot(snapshot, resume=True)
+    restored_vm.wait_for_up()
     _check_cpu_features_arm(restored_vm, guest_kv, "v1n1")
 
 
@@ -143,4 +144,5 @@ def test_cpu_features_with_custom_template(
     restored_vm = microvm_factory.build()
     restored_vm.spawn()
     restored_vm.restore_from_snapshot(snapshot, resume=True)
+    restored_vm.wait_for_up()
     _check_cpu_features_arm(restored_vm, guest_kv, custom_cpu_template["name"])

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -94,6 +94,7 @@ def _validate_mmds_snapshot(
     microvm = microvm_factory.build(**kwargs)
     microvm.spawn()
     microvm.restore_from_snapshot(snapshot, resume=True)
+    microvm.wait_for_up()
 
     ssh_connection = microvm.ssh
 

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -93,8 +93,7 @@ def _validate_mmds_snapshot(
         kwargs["jailer_binary_path"] = jailer_binary_path
     microvm = microvm_factory.build(**kwargs)
     microvm.spawn()
-    microvm.restore_from_snapshot(snapshot)
-    microvm.resume()
+    microvm.restore_from_snapshot(snapshot, resume=True)
 
     ssh_connection = microvm.ssh
 

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -72,6 +72,7 @@ def test_rng_snapshot(uvm_with_rng, microvm_factory):
     new_vm = microvm_factory.build()
     new_vm.spawn()
     new_vm.restore_from_snapshot(snapshot, resume=True)
+    new_vm.wait_for_up()
     check_entropy(new_vm.ssh)
 
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -51,6 +51,45 @@ def _get_guest_drive_size(ssh_connection, guest_dev_name="/dev/vdb"):
     return lines[1].strip()
 
 
+def test_resume_after_restoration(uvm_nano, microvm_factory):
+    """Tests snapshot is resumable after restoration.
+
+    Check that a restored microVM is resumable by calling PATCH /vm with Resumed
+    after PUT /snapshot/load with `resume_vm=False`.
+    """
+    vm = uvm_nano
+    vm.add_net_iface()
+    vm.start()
+    vm.wait_for_up()
+
+    snapshot = vm.snapshot_full()
+
+    restored_vm = microvm_factory.build()
+    restored_vm.spawn()
+    restored_vm.restore_from_snapshot(snapshot)
+    restored_vm.resume()
+    restored_vm.wait_for_up()
+
+
+def test_resume_at_restoration(uvm_nano, microvm_factory):
+    """Tests snapshot is resumable at restoration.
+
+    Check that a restored microVM is resumable by calling PUT /snapshot/load
+    with `resume_vm=True`.
+    """
+    vm = uvm_nano
+    vm.add_net_iface()
+    vm.start()
+    vm.wait_for_up()
+
+    snapshot = vm.snapshot_full()
+
+    restored_vm = microvm_factory.build()
+    restored_vm.spawn()
+    restored_vm.restore_from_snapshot(snapshot, resume=True)
+    restored_vm.wait_for_up()
+
+
 def test_snapshot_current_version(uvm_nano):
     """Tests taking a snapshot at the version specified in Cargo.toml
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -238,6 +238,7 @@ def test_patch_drive_snapshot(uvm_nano, microvm_factory):
     vm = microvm_factory.build()
     vm.spawn()
     vm.restore_from_snapshot(snapshot, resume=True)
+    vm.wait_for_up()
 
     # Attempt to connect to resumed microvm and verify the new microVM has the
     # right scratch drive.

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -203,6 +203,7 @@ def test_vsock_transport_reset(
     vm2 = microvm_factory.build()
     vm2.spawn()
     vm2.restore_from_snapshot(snapshot, resume=True)
+    vm2.wait_for_up()
 
     # Check that vsock device still works.
     # Test guest-initiated connections.

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -230,6 +230,7 @@ def test_ept_violation_count(
 
     with ftrace_events("kvm:*"):
         vm.restore_from_snapshot(snapshot, resume=True, uffd_path=SOCKET_PATH)
+        vm.wait_for_up()
 
         # Verify if guest can run commands, and also wake up the fast page fault helper to trigger page faults.
         rc, _, _ = vm.ssh.run(f"kill -s {signal.SIGUSR1} {pid}")

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -135,6 +135,7 @@ def with_restore(factory, microvm_factory):
         dst_vm.spawn()
         # Restore the destination VM from the snapshot
         dst_vm.restore_from_snapshot(snapshot, resume=True)
+        dst_vm.wait_for_up()
         dst_vm.cpu_template = microvm.cpu_template
 
         return dst_vm


### PR DESCRIPTION
## Changes

- Insert `wait_for_up()` before running guest commands.

## Reason

`wait_for_up()` shows debugging information if the guest is not up and running.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
