### PR TITLE
test-popular-containers: add ubuntu 23.10 and 24.04

### DIFF
--- a/tools/test-popular-containers/build_rootfs.sh
+++ b/tools/test-popular-containers/build_rootfs.sh
@@ -43,7 +43,9 @@ function make_rootfs {
     umount -l mnt
     rmdir mnt
 
-    systemd-nspawn --pipe -i $IMG /bin/sh <<EOF
+    # --timezone=off parameter is needed to prevent systemd-nspawn from
+    # bind-mounting /etc/timezone, which causes a file conflict in Ubuntu 24.04
+    systemd-nspawn --timezone=off --pipe -i $IMG /bin/sh <<EOF
 set -x
 . /etc/os-release
 passwd -d root
@@ -65,5 +67,6 @@ EOF
 
 make_rootfs alpine:latest
 make_rootfs ubuntu:22.04
-make_rootfs ubuntu:23.04
+make_rootfs ubuntu:23.10
+make_rootfs ubuntu:24.04
 # make_rootfs ubuntu:latest


### PR DESCRIPTION
Add support for testing Ubuntu 23.10 and 24.04

## Changes

Add Ubuntu 23.10 and 24.04 to the popular Docker integration tests

## Reason

To make sure Firecracker runs on the latest Ubuntu LTS release.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
