### PR TITLE
Unpin kernel 5.10 AMI

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -22,8 +22,7 @@ DEFAULT_INSTANCES = [
 
 DEFAULT_PLATFORMS = [
     ("al2", "linux_4.14"),
-    # TODO: Unpin 5.10 kernel AMI once io_uring issues is solved.
-    ("al2", "linux_5.10-pinned"),
+    ("al2", "linux_5.10"),
     ("al2023", "linux_6.1"),
 ]
 

--- a/.buildkite/pipeline_cross.py
+++ b/.buildkite/pipeline_cross.py
@@ -71,8 +71,7 @@ def cross_steps():
 
     # https://github.com/firecracker-microvm/firecracker/blob/main/docs/kernel-policy.md#experimental-snapshot-compatibility-across-kernel-versions
     aarch64_platforms = [
-        # TODO: unpin kernel 5.10 AMI once we fix io_uring test failures.
-        ("al2", "linux_5.10-pinned"),
+        ("al2", "linux_5.10"),
         ("al2023", "linux_6.1"),
     ]
     perms_aarch64 = itertools.product(


### PR DESCRIPTION
## Changes

Unpin kernel 5.10 AMI.

Fix #4586.

## Reason

Now that a new Amazon Linux 2 kernel 5.10 AMI arrived and I confirmed it solves the io_uring test failures (issue #4586)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [Y] If a specific issue led to this PR, this PR closes the issue.
- [Y] The description of changes is clear and encompassing.
- [N/A] Any required documentation changes (code and docs) are included in this
  PR.
- [N/A] API changes follow the [Runbook for Firecracker API changes][2].
- [N/A] User-facing changes are mentioned in `CHANGELOG.md`.
- [Y] All added/changed functionality is tested.
- [N/A] New `TODO`s link to an issue.
- [Y] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
