### PR TITLE
doc: Troubleshooting for `ab_test.py analyze`

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -260,6 +260,25 @@ tools/ab_test.py analyze <first test-report.json> <second test-report.json>
 
 This will then print the same analysis described in the previous sections.
 
+#### Troubleshooting
+
+If during `tools/ab_test.py analyze` you get an error like
+
+```bash
+$ tools/ab_test.py analyze <first test-report.json> <second test-report.json>
+Traceback (most recent call last):
+  File "/firecracker/tools/ab_test.py", line 412, in <module>
+    data_a = load_data_series(args.report_a)
+  File "/firecracker/tools/ab_test.py", line 122, in load_data_series
+    for line in test["teardown"]["stdout"].splitlines():
+KeyError: 'stdout'
+```
+
+double check that the `AWS_EMF_ENVIRONMENT` and `AWS_EMF_NAMESPACE` environment
+variables are set to `local`. Particularly, when collecting data from buildkite
+pipelines generated from `.buildkite/pipeline_perf.py`, ensure you pass
+`--step-param env/AWS_EMF_NAMESPACE=local --step-param env/AWS_EMF_SERVICE_NAME=local`!
+
 ## Adding Python Tests
 
 Tests can be added in any (existing or new) sub-directory of `tests/`, in files


### PR DESCRIPTION
## Changes

Include which error one would see if one forgets to set the `AWS_EMF_NAMESPACE` and `AWS_EMF_ENVIRONMENT` variables to `local`. Note a common pitfall of trying to set environment variables through buildkite.

## Reason

Happened a few times, and I'm not always here

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
