### PR TITLE
test: stop all monitors before killing microvm

### DIFF
--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -500,6 +500,7 @@ class FCMetricsMonitor(Thread):
     def __init__(self, vm, timer=60):
         Thread.__init__(self, daemon=True)
         self.vm = vm
+        vm.monitors.append(self)
         self.timer = timer
 
         self.metrics_index = 0
@@ -538,13 +539,14 @@ class FCMetricsMonitor(Thread):
         in sleep when stop is called and once it wakes out of sleep
         the "vm" might not be avaiable to provide the metrics.
         """
-        self.running = False
-        # wait for the running thread to finish
-        # this should also avoid any race condition leading to
-        # uploading the same metrics twice
-        self.join()
-        self.vm.api.actions.put(action_type="FlushMetrics")
-        self._flush_metrics()
+        if self.is_alive():
+            self.running = False
+            # wait for the running thread to finish
+            # this should also avoid any race condition leading to
+            # uploading the same metrics twice
+            self.join()
+            self.vm.api.actions.put(action_type="FlushMetrics")
+            self._flush_metrics()
 
     def run(self):
         self.running = True

--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -46,6 +46,12 @@ class MemoryMonitor(Thread):
         """Signal that the thread should stop."""
         self._should_stop = True
 
+    def stop(self):
+        """Stop the thread"""
+        if self.is_alive():
+            self.signal_stop()
+            self.join(timeout=1)
+
     def run(self):
         """Thread for monitoring the RSS memory usage of a Firecracker process.
 


### PR DESCRIPTION
If a test fails, the FCmetricsMonitor keeps running in some tests. After we kill the microvm and remove the resources, the monitor complains it cannot find the metrics file.

This is tricky to fix simply since we don't have a handle to the monitor either at fixture teardown or in the Microvm class.

Add a hook in the Microvm class to register monitors, so we can stop all of them before killing the microvm.

Also adapt existing monitors to fix this pattern.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
