### PR TITLE
#4547: Refactor vmm builder code to simplify logic that creates the microVM to boot

### DIFF
--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -728,7 +728,7 @@ mod tests {
             #[cfg(target_arch = "x86_64")]
             vm_state: vmm.vm.save_state().unwrap(),
             #[cfg(target_arch = "x86_64")]
-            acpi_dev_state: vmm.acpi_device_manager.save(),
+            acpi_dev_state: vmm.devices_for_x86_64.unwrap().acpi_device_manager.save(),
         };
 
         let mut buf = vec![0; 10000];

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -728,7 +728,7 @@ mod tests {
             #[cfg(target_arch = "x86_64")]
             vm_state: vmm.vm.save_state().unwrap(),
             #[cfg(target_arch = "x86_64")]
-            acpi_dev_state: vmm.devices_for_x86_64.unwrap().acpi_device_manager.save(),
+            acpi_dev_state: vmm.acpi_device_manager.save(),
         };
 
         let mut buf = vec![0; 10000];


### PR DESCRIPTION
## Changes
-Refactor code building VMM to be more modular and reduce compile time conditionals.
...

## Reason
-Currently, the logic to create a Vmm object is scattered across vmm/lib.rs and vmm.builder.rs files and it is quite convoluted and some times difficult to follow. Moreover, there is a lot of architecture specific code inserted in arbitrary places which further increases the un-readability. Apart from the aesthetics and readability aspect, the state of the code makes it quite difficult to unit test.

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
