### PR TITLE
fix clippy warning casting u64 to usize

### DIFF
--- a/src/firecracker/examples/uffd/uffd_utils.rs
+++ b/src/firecracker/examples/uffd/uffd_utils.rs
@@ -182,7 +182,7 @@ impl Runtime {
         let file_meta = backing_file
             .metadata()
             .expect("can not get backing file metadata");
-        let backing_memory_size = file_meta.len() as usize;
+        let backing_memory_size = usize::try_from(file_meta.len());
         // # Safety:
         // File size and fd are valid
         let ret = unsafe {


### PR DESCRIPTION
fix clippy warning casting u64 to usize may truncate the value on targets with 32-bit wide pointer

clippy tips:
```
warning: casting `u64` to `usize` may truncate the value on targets with 32-bit wide pointers
   --> src/firecracker/examples/uffd/uffd_utils.rs:185:35
    |
185 |         let backing_memory_size = file_meta.len() as usize;
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
    = note: requested on the command line with `-W clippy::cast-possible-truncation`
help: ... or use `try_from` and handle the error accordingly
    |
185 |         let backing_memory_size = usize::try_from(file_meta.len());
    |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


```