### PR TITLE
test: add a global dimension to test failure metric

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,17 +117,24 @@ def record_props(request, record_property):
 def pytest_runtest_logreport(report):
     """Send general test metrics to CloudWatch"""
     if report.when == "call":
-        dimensions = {
-            "test": report.nodeid,
-            "instance": global_props.instance,
-            "cpu_model": global_props.cpu_model,
-            "host_kernel": "linux-" + global_props.host_linux_version,
-        }
+        METRICS.set_dimensions(
+            {
+                "test": report.nodeid,
+                "instance": global_props.instance,
+                "cpu_model": global_props.cpu_model,
+                "host_kernel": "linux-" + global_props.host_linux_version,
+            },
+            # per host kernel
+            {"host_kernel": "linux-" + global_props.host_linux_version},
+            # per CPU
+            {"cpu_model": global_props.cpu_model},
+            # and global
+            {},
+        )
         METRICS.set_property("result", report.outcome)
         METRICS.set_property("location", report.location)
         for prop_name, prop_val in report.user_properties:
             METRICS.set_property(prop_name, prop_val)
-        METRICS.set_dimensions(dimensions)
         METRICS.put_metric(
             "duration",
             report.duration,


### PR DESCRIPTION
The current test failure metrics have high cardinality because they include the test name. This makes it hard to visualize them in CloudWatch since we run into aggregation limits.

It would be nice to have one global failure rate, and some views per-kernel and per-CPU type.

This adds 10 new metrics = 6 per-CPU + 3 per-host kernel + 1 global metric so it is not too costly.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
