### PR TITLE
Rollup of stale PRs

### DIFF
--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -94,8 +94,10 @@ impl<'a, M: GuestMemory> DescriptorChain<'a, M> {
         let desc = match mem.read_obj::<Descriptor>(desc_head) {
             Ok(ret) => ret,
             Err(err) => {
-                // TODO log address
-                error!("Failed to read virtio descriptor from memory: {}", err);
+                error!(
+                    "Failed to read virtio descriptor from memory at address {:#x}: {}",
+                    desc_head.0, err
+                );
                 return None;
             }
         };

--- a/src/vmm/src/dumbo/tcp/endpoint.rs
+++ b/src/vmm/src/dumbo/tcp/endpoint.rs
@@ -81,13 +81,23 @@ pub struct Endpoint {
 // is the only option).
 
 impl Endpoint {
+    /// Creates a new Endpoint from a [`crate::tcp::connection::Connection`]
+    /// ## Arguments:
+    /// - `segment`: The incoming `SYN`.
+    /// - `eviction_threshold`: CPU cycles that must elapse before this Endpoint is evictable
+    /// - `connection_rto_period`: How long the connection waits before a retransmission timeout
+    ///   fires for the first segment which has not been acknowledged yet. This uses an opaque time
+    ///   unit.
+    /// - `connection_rto_count_max`: How many consecutive timeout-based retransmission may occur
+    ///   before the connection resets itself.
+    /// ## Panics:
+    /// - `assert!(RCV_BUF_MAX_SIZE <= MAX_WINDOW_SIZE as usize);`
     pub fn new<T: NetworkBytes + Debug>(
         segment: &TcpSegment<T>,
         eviction_threshold: NonZeroU64,
         connection_rto_period: NonZeroU64,
         connection_rto_count_max: NonZeroU16,
     ) -> Result<Self, PassiveOpenError> {
-        // TODO: mention this in doc comment for function
         // This simplifies things, and is a very reasonable assumption.
         #[allow(clippy::assertions_on_constants)]
         {

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -94,8 +94,6 @@ pub struct Metrics<T: Serialize, M: Write + Send> {
 
 impl<T: Serialize + Debug, M: Write + Send + Debug> Metrics<T, M> {
     /// Creates a new instance of the current metrics.
-    // TODO: We need a better name than app_metrics (something that says that these are the actual
-    // values that we are writing to the metrics_buf).
     pub const fn new(app_metrics: T) -> Metrics<T, M> {
         Metrics {
             metrics_buf: OnceLock::new(),


### PR DESCRIPTION
## Changes

Resolve 3 TODOs in the codebase

## Reason

Rollup seemingly abandoned PRs that we still think have value to be merged.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
