### PR TITLE
Decrease logging in test_rng tests

### DIFF
--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -16,15 +16,18 @@ if (
 
 
 @pytest.fixture(params=[None])
-def uvm_with_rng(uvm_nano, request):
+def uvm_with_rng(uvm_plain, request):
     """Fixture of a microvm with virtio-rng configured"""
     rate_limiter = request.param
-    uvm_nano.add_net_iface()
-    uvm_nano.api.entropy.put(rate_limiter=rate_limiter)
-    uvm_nano.start()
+    uvm = uvm_plain
+    uvm.spawn(log_level="INFO")
+    uvm.basic_config(vcpu_count=2, mem_size_mib=256)
+    uvm.add_net_iface()
+    uvm.api.entropy.put(rate_limiter=rate_limiter)
+    uvm.start()
     # Just stuff it in the microvm so we can look at it later
-    uvm_nano.rng_rate_limiter = rate_limiter
-    return uvm_nano
+    uvm.rng_rate_limiter = rate_limiter
+    return uvm
 
 
 def test_rng_not_present(uvm_nano):


### PR DESCRIPTION
## Changes

For the RNG tests, set the log level to INFO instead of DEBUG. The virtio-rng device does output a lot of DEBUG information, and that can add overhead and make some of our perf tests fail.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
