### PR TITLE
fix(test): avoid parsing broken metrics lines

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -420,15 +420,24 @@ class Microvm:
             return None
         return tuple(int(x) for x in splits[1].split("."))
 
+    def get_metrics(self):
+        """Return iterator to metric data points written by FC"""
+        with self.metrics_file.open() as fd:
+            for line in fd:
+                if not line.endswith("}\n"):
+                    LOG.warning("Line is not a proper JSON object. Partial write?")
+                    continue
+                yield json.loads(line)
+
+    def get_all_metrics(self):
+        """Return all metric data points written by FC."""
+        return list(self.get_metrics())
+
     def flush_metrics(self):
         """Flush the microvm metrics and get the latest datapoint"""
         self.api.actions.put(action_type="FlushMetrics")
         # get the latest metrics
         return self.get_all_metrics()[-1]
-
-    def get_all_metrics(self):
-        """Return all metric data points written by FC."""
-        return [json.loads(line) for line in self.metrics_file.read_text().splitlines()]
 
     def create_jailed_resource(self, path):
         """Create a hard link to some resource inside this microvm."""

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -197,13 +197,15 @@ def test_failing_filter(uvm_plain):
     )
 
     # Check the metrics
-    datapoints = test_microvm.get_all_metrics()
-
+    datapoints = test_microvm.get_metrics()
     num_faults = 0
     for datapoint in datapoints:
         num_faults += datapoint["seccomp"]["num_faults"]
+        # exit early to avoid potentially broken JSON entries in the logs
+        if num_faults > 0:
+            break
 
-    assert num_faults >= 1
+    assert num_faults == 1
 
     # assert that the process was killed
     assert not psutil.pid_exists(test_microvm.firecracker_pid)


### PR DESCRIPTION
## Changes

Ignore metric lines that cannot be parsed.

## Reason

Improve the stability of tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
