### PR TITLE
fix(cpu-template-helper): Fix error message display

### DIFF
--- a/src/cpu-template-helper/src/fingerprint/compare.rs
+++ b/src/cpu-template-helper/src/fingerprint/compare.rs
@@ -7,7 +7,7 @@ use crate::fingerprint::{Fingerprint, FingerprintField};
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum FingerprintCompareError {
-    /// Difference detected between source and target:\n{0}
+    /// Difference detected between source and target: {0}
     DiffDetected(String),
     /// Failed to serialize/deserialize JSON: {0}
     Serde(#[from] serde_json::Error),
@@ -85,7 +85,10 @@ pub fn compare(
     if results.is_empty() {
         Ok(())
     } else {
-        Err(FingerprintCompareError::DiffDetected(results.join("\n")))
+        Err(FingerprintCompareError::DiffDetected(format!(
+            "\n{}",
+            results.join("\n")
+        )))
     }
 }
 
@@ -132,7 +135,7 @@ mod tests {
             Err(FingerprintCompareError::DiffDetected(err)) => {
                 assert_eq!(
                     err,
-                    "{\
+                    "\n{\
                     \n  \"name\": \"kernel_version\",\
                     \n  \"prev\": \"sample_kernel_version\",\
                     \n  \"curr\": \"different_kernel_version\"\

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -190,14 +190,14 @@ fn run(cli: Cli) -> Result<(), HelperError> {
     Ok(())
 }
 
-fn main() {
+fn main() -> std::process::ExitCode {
     let cli = Cli::parse();
     let result = run(cli);
     if let Err(e) = result {
         eprintln!("{}", e);
-        std::process::exit(1);
+        std::process::ExitCode::FAILURE
     } else {
-        std::process::exit(0);
+        std::process::ExitCode::SUCCESS
     }
 }
 

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -190,14 +190,14 @@ fn run(cli: Cli) -> Result<(), HelperError> {
     Ok(())
 }
 
-fn main() -> Result<(), HelperError> {
+fn main() {
     let cli = Cli::parse();
     let result = run(cli);
     if let Err(e) = result {
         eprintln!("{}", e);
-        Err(e)
+        std::process::exit(1);
     } else {
-        Ok(())
+        std::process::exit(0);
     }
 }
 


### PR DESCRIPTION
## Changes

- Don't show diff twice.
- Handle a new line correctly in error message.

## Reason

Before
```
$ build/cargo_target/x86_64-unknown-linux-musl/debug/cpu-template-helper fingerprint compare --prev tests/data/cpu_template_helpe
r/fingerprint_INTEL_SKYLAKE_5.10host.json --curr tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json 
Difference detected between source and target: \n{
  "name": "kernel_version",
  "prev": "5.10.215-203.850.amzn2.x86_64",
  "curr": "6.1.84-99.169.amzn2023.x86_64"
}
Error: FingerprintCompare(DiffDetected("{\n  \"name\": \"kernel_version\",\n  \"prev\": \"5.10.215-203.850.amzn2.x86_64\",\n  \"curr\": \"6.1.84-99.169.amzn2023.x86_64\"\n}"))
```

After
```
$ build/cargo_target/x86_64-unknown-linux-musl/debug/cpu-template-helper fingerprint compare --prev tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_5.10host.json --curr tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json 
Difference detected between source and target:
{
  "name": "kernel_version",
  "prev": "5.10.215-203.850.amzn2.x86_64",
  "curr": "6.1.84-99.169.amzn2023.x86_64"
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
