### PR TITLE
Revert "feat: use host network for docker"

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -305,7 +305,6 @@ run_devctr() {
         --rm \
         --volume /dev:/dev \
         --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR:z" \
-        --network="host" \
         --tmpfs /srv:exec,dev,size=32G \
         -v /boot:/boot \
         --env PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
Reverts firecracker-microvm/firecracker#4614 because this configuration change appeared to be unnecessary.
Additionally it introduce unwanted changes to the way CI was working.