### PR TITLE
Update contribution guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,19 @@
 # All markdown files
-*.md @xmarcalx @kalyazin @pb8o @sudanl0
+*.md @xmarcalx @kalyazin @pb8o
 
 # But not the ones in docs/
 docs/*.md
 
 # Except these specific ones
-docs/getting-started.md @xmarcalx @kalyazin @pb8o @sudanl0
-docs/prod-host-setup.md @xmarcalx @kalyazin @pb8o @sudanl0
+docs/getting-started.md @xmarcalx @kalyazin @pb8o
+docs/prod-host-setup.md @xmarcalx @kalyazin @pb8o
 
 # Also cover all "*policy*.md" documents
-**/*policy*.md @xmarcalx @kalyazin @pb8o @sudanl0
-**/*POLICY*.md @xmarcalx @kalyazin @pb8o @sudanl0
+**/*policy*.md @xmarcalx @kalyazin @pb8o
+**/*POLICY*.md @xmarcalx @kalyazin @pb8o
 
 # Also these non-md files in the repository root
-THIRD_PARTY @xmarcalx @kalyazin @pb8o @sudanl0
-LICENSE @xmarcalx @kalyazin @pb8o @sudanl0
-NOTICE @xmarcalx @kalyazin @pb8o @sudanl0
-PGP-KEY.asc @xmarcalx @kalyazin @pb8o @sudanl0
+THIRD_PARTY @xmarcalx @kalyazin @pb8o
+LICENSE @xmarcalx @kalyazin @pb8o
+NOTICE @xmarcalx @kalyazin @pb8o
+PGP-KEY.asc @xmarcalx @kalyazin @pb8o

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,33 @@ Your contribution needs to meet the following standards:
   }
   ```
 
+- Avoid using `Option::unwrap`/`Result::unwrap`. Prefer propagating errors
+  instead of aborting execution, or using `Option::expect`/`Result::except` if
+  no alternative exists. Leave a comment explaining why the code will not panic
+  in practice. Often, `unwrap`s are used because a previous check ensures they
+  are safe, e.g.
+
+  ```rs
+  let my_value: u32 = ...;
+  if my_value <= u16::MAX {
+      Ok(my_value.try_into::<u16>().unwrap())
+  } else {
+      Err(Error::Overflow)
+  }
+  ```
+
+  These can often be rewritten using `.map`/`.map_err` or `match`/`if let`
+  constructs such as
+
+  ```rs
+  my_value.try_into::<u16>()
+      .map_err(|_| Error::Overflow)
+  ```
+
+  See also
+  [this PR](https://github.com/firecracker-microvm/firecracker/pull/3557) for a
+  lot of examples.
+
 - Document your pull requests. Include the reasoning behind each change, and the
   testing done.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,10 @@ you want to merge your changes to Firecracker:
    against the main branch of the Firecracker repository.
 1. Add two reviewers to your pull request (a maintainer will do that for you if
    you're new). Work with your reviewers to address any comments and obtain a
-   minimum of 2 approvals, at least one of which must be provided by
-   [a maintainer](MAINTAINERS.md). To update your pull request amend existing
-   commits whenever applicable and then push the new changes to your pull
-   request branch.
+   minimum of 2 approvals from [maintainers](MAINTAINERS.md). To update your
+   pull request, amend existing commits whenever applicable. Then force-push the
+   new changes to your pull request branch. Address all review comments you
+   receive.
 1. Once the pull request is approved, one of the maintainers will merge it.
 
 ## Request for Comments

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,5 +11,4 @@ Firecracker is maintained by a dedicated team within Amazon:
 - Nikita Kalyazin <kalyazin@amazon.com>
 - Pablo Barbachano <pablob@amazon.com>
 - Patrick Roy <roypat@amazon.com>
-- Sudan Landge <sudanl@amazon.com>
 - Takahiro Itazuri <itazur@amazon.com>


### PR DESCRIPTION
## Changes

- Clarify guidance on using `.unwrap()`
- Correct statement about how many approvals are needed
- Remove former team members from CODEOWNERS/MAINTAINERS.md

## Reason

#808 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
