### PR TITLE
Eliminate a handful of unwraps from the codebase

### DIFF
--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -112,16 +112,14 @@ fn build_arg_parser() -> ArgParser<'static> {
 }
 
 fn get_argument_values(arguments: &ArgumentsBag) -> Result<Arguments, SeccompError> {
-    let arch_string = arguments.single_value("target-arch");
-    if arch_string.is_none() {
+    let Some(arch_string) = arguments.single_value("target-arch") else {
         return Err(SeccompError::MissingTargetArch);
-    }
-    let target_arch: TargetArch = arch_string.unwrap().as_str().try_into()?;
+    };
+    let target_arch: TargetArch = arch_string.as_str().try_into()?;
 
-    let input_file = arguments.single_value("input-file");
-    if input_file.is_none() {
+    let Some(input_file) = arguments.single_value("input-file") else {
         return Err(SeccompError::MissingInputFile);
-    }
+    };
 
     let is_basic = arguments.flag_present("basic");
     if is_basic {
@@ -133,7 +131,7 @@ fn get_argument_values(arguments: &ArgumentsBag) -> Result<Arguments, SeccompErr
 
     Ok(Arguments {
         target_arch,
-        input_file: input_file.unwrap().to_owned(),
+        input_file: input_file.to_owned(),
         // Safe to unwrap because it has a default value
         output_file: arguments.single_value("output-file").unwrap().to_owned(),
         is_basic,

--- a/src/vmm/src/devices/virtio/block/virtio/metrics.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/metrics.rs
@@ -100,20 +100,14 @@ impl BlockMetricsPerDevice {
     /// lock is always initialized so it is safe the unwrap
     /// the lock without a check.
     pub fn alloc(drive_id: String) -> Arc<BlockDeviceMetrics> {
-        if METRICS.read().unwrap().metrics.get(&drive_id).is_none() {
+        Arc::clone(
             METRICS
                 .write()
                 .unwrap()
                 .metrics
-                .insert(drive_id.clone(), Arc::new(BlockDeviceMetrics::new()));
-        }
-        METRICS
-            .read()
-            .unwrap()
-            .metrics
-            .get(&drive_id)
-            .unwrap()
-            .clone()
+                .entry(drive_id)
+                .or_insert_with(|| Arc::new(BlockDeviceMetrics::default())),
+        )
     }
 }
 

--- a/src/vmm/src/devices/virtio/net/metrics.rs
+++ b/src/vmm/src/devices/virtio/net/metrics.rs
@@ -102,20 +102,14 @@ impl NetMetricsPerDevice {
     /// lock is always initialized so it is safe the unwrap
     /// the lock without a check.
     pub fn alloc(iface_id: String) -> Arc<NetDeviceMetrics> {
-        if METRICS.read().unwrap().metrics.get(&iface_id).is_none() {
+        Arc::clone(
             METRICS
                 .write()
                 .unwrap()
                 .metrics
-                .insert(iface_id.clone(), Arc::new(NetDeviceMetrics::new()));
-        }
-        METRICS
-            .read()
-            .unwrap()
-            .metrics
-            .get(&iface_id)
-            .unwrap()
-            .clone()
+                .entry(iface_id)
+                .or_insert_with(|| Arc::new(NetDeviceMetrics::default())),
+        )
     }
 }
 

--- a/src/vmm/src/devices/virtio/vhost_user_metrics.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_metrics.rs
@@ -95,19 +95,14 @@ impl VhostUserMetricsPerDevice {
     /// lock is always initialized so it is safe the unwrap
     /// the lock without a check.
     pub fn alloc(drive_id: String) -> Arc<VhostUserDeviceMetrics> {
-        if METRICS.read().unwrap().metrics.get(&drive_id).is_none() {
-            METRICS.write().unwrap().metrics.insert(
-                drive_id.clone(),
-                Arc::new(VhostUserDeviceMetrics::default()),
-            );
-        }
-        METRICS
-            .read()
-            .unwrap()
-            .metrics
-            .get(&drive_id)
-            .unwrap()
-            .clone()
+        Arc::clone(
+            METRICS
+                .write()
+                .unwrap()
+                .metrics
+                .entry(drive_id)
+                .or_insert_with(|| Arc::new(VhostUserDeviceMetrics::default())),
+        )
     }
 }
 

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer_killq.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer_killq.rs
@@ -106,7 +106,7 @@ impl MuxerKillQ {
     pub fn pop(&mut self) -> Option<ConnMapKey> {
         if let Some(item) = self.q.front() {
             if Instant::now() > item.kill_time {
-                return Some(self.q.pop_front().unwrap().key);
+                return self.q.pop_front().map(|entry| entry.key);
             }
         }
         None

--- a/src/vmm/src/dumbo/tcp/connection.rs
+++ b/src/vmm/src/dumbo/tcp/connection.rs
@@ -714,13 +714,9 @@ impl Connection {
 
             // We check this here because if a valid payload has been received, then we must have
             // set enqueue_ack = true earlier.
-            if payload_len > 0 {
+            if let Some(payload_len) = NonZeroUsize::new(payload_len.into()) {
                 buf[..payload_len.into()].copy_from_slice(s.payload());
-                // The unwrap is safe because payload_len > 0.
-                return Ok((
-                    Some(NonZeroUsize::new(payload_len.into()).unwrap()),
-                    recv_status_flags,
-                ));
+                return Ok((Some(payload_len), recv_status_flags));
             }
         }
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -235,10 +235,10 @@ impl Vm {
         }
         guest_mem
             .iter()
-            .enumerate()
-            .try_for_each(|(index, region)| {
+            .zip(0u32..)
+            .try_for_each(|(region, slot)| {
                 let memory_region = kvm_userspace_memory_region {
-                    slot: u32::try_from(index).unwrap(),
+                    slot,
                     guest_phys_addr: region.start_addr().raw_value(),
                     memory_size: region.len(),
                     // It's safe to unwrap because the guest address is valid.


### PR DESCRIPTION
## Changes

Eliminate some unneeded use of unwrap from Firecracker.

## Reason

While looking into the feasibility of #593, I stumbled across a few unwraps that were very simple to fix. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
