### PR TITLE
CI: build Firecracker once and share it with all the jobs

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -8,6 +8,8 @@ Common helpers to create Buildkite pipelines
 import argparse
 import json
 import os
+import random
+import string
 import subprocess
 from pathlib import Path
 
@@ -179,6 +181,11 @@ def revision_a():
     return os.environ.get("REVISION_A")
 
 
+def random_str(k: int):
+    """Generate a random string of hex characters."""
+    return "".join(random.choices(string.hexdigits, k=k))
+
+
 def shared_build():
     """Helper function to make it simple to share a compilation artifacts for a
     whole Buildkite build
@@ -196,7 +203,7 @@ def shared_build():
     revision_b = os.environ.get("REVISION_B")
     if revision_b is not None:
         build_cmds.append(f"ln -svfT . build/{revision_b}")
-    binary_dir = "build_$(uname -m).tar.gz"
+    binary_dir = f"build_$(uname -m)_{random_str(k=8)}.tar.gz"
     build_cmds += [
         "du -sh build/*",
         f"tar czf {binary_dir} build",

--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -70,12 +70,12 @@ def group(label, command, instances, platforms, **kwargs):
     if isinstance(command, str):
         commands = [command]
     for instance in instances:
-        for os, kv in platforms:
+        for os_, kv in platforms:
             # fill any templated variables
-            args = {"instance": instance, "os": os, "kv": kv}
+            args = {"instance": instance, "os": os_, "kv": kv}
             step = {
                 "command": [cmd.format(**args) for cmd in commands],
-                "label": f"{label1} {instance} {os} {kv}",
+                "label": f"{label1} {instance} {os_} {kv}",
                 "agents": args,
             }
             step_kwargs = dict_fmt(kwargs, args)

--- a/.buildkite/pipeline_cpu_template.py
+++ b/.buildkite/pipeline_cpu_template.py
@@ -4,10 +4,9 @@
 
 """Generate Buildkite CPU Template pipelines dynamically"""
 
-import argparse
 from enum import Enum
 
-from common import DEFAULT_INSTANCES, DEFAULT_PLATFORMS, group, pipeline_to_json
+from common import DEFAULT_INSTANCES, DEFAULT_PLATFORMS, BKPipeline, group
 
 
 class BkStep(str, Enum):
@@ -17,7 +16,7 @@ class BkStep(str, Enum):
 
     LABEL = "label"
     TIMEOUT = "timeout"
-    COMMAND = "commands"
+    COMMAND = "command"
     ARTIFACTS = "artifact_paths"
 
 
@@ -28,6 +27,14 @@ cpu_template_test = {
         ],
         BkStep.LABEL: "📖 rdmsr",
         "instances": ["c5n.metal", "m5n.metal", "m6a.metal", "m6i.metal"],
+        "platforms": DEFAULT_PLATFORMS,
+    },
+    "fingerprint": {
+        BkStep.COMMAND: [
+            "tools/devtool -y test -- -m no_block_pr integration_tests/functional/test_cpu_template_helper.py -k test_guest_cpu_config_change",
+        ],
+        BkStep.LABEL: "🖐️ fingerprint",
+        "instances": DEFAULT_INSTANCES,
         "platforms": DEFAULT_PLATFORMS,
     },
     "cpuid_wrmsr": {
@@ -57,31 +64,7 @@ cpu_template_test = {
         },
         "instances": ["c5n.metal", "m5n.metal", "m6i.metal", "m6a.metal"],
     },
-    "fingerprint": {
-        BkStep.COMMAND: [
-            "tools/devtool -y test -- -m no_block_pr integration_tests/functional/test_cpu_template_helper.py -k test_guest_cpu_config_change",
-        ],
-        BkStep.LABEL: "🖐️ fingerprint",
-        "instances": DEFAULT_INSTANCES,
-        "platforms": DEFAULT_PLATFORMS,
-    },
 }
-
-
-def group_single(tests):
-    """
-    Generate a group step with specified parameters for each instance
-    and kernel combination
-    https://buildkite.com/docs/pipelines/group-step
-    """
-    group_step = group(
-        label=tests[BkStep.LABEL],
-        command=tests[BkStep.COMMAND],
-        instances=tests["instances"],
-        platforms=tests["platforms"],
-        artifacts=["./test_results/**/*"],
-    )
-    return [group_step]
 
 
 def group_snapshot_restore(test_step):
@@ -146,30 +129,20 @@ def group_snapshot_restore(test_step):
     return groups
 
 
-def main():
-    """
-    Generate group template required to trigger pipelines for
-    the requested CPU template test.
-    """
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
+if __name__ == "__main__":
+    BKPipeline.parser.add_argument(
         "--test",
-        required=True,
         choices=list(cpu_template_test),
         help="CPU template test",
+        action="append",
     )
-    test_args = parser.parse_args()
-
-    if test_args.test == "rdmsr":
-        test_group = group_single(cpu_template_test[test_args.test])
-    elif test_args.test == "cpuid_wrmsr":
-        test_group = group_snapshot_restore(cpu_template_test[test_args.test])
-    elif test_args.test == "fingerprint":
-        test_group = group_single(cpu_template_test[test_args.test])
-
-    pipeline = {"steps": test_group}
-    print(pipeline_to_json(pipeline))
-
-
-if __name__ == "__main__":
-    main()
+    pipeline = BKPipeline()
+    for test in pipeline.args.test or list(cpu_template_test):
+        if test == "cpuid_wrmsr":
+            groups = group_snapshot_restore(cpu_template_test[test])
+            for grp in groups:
+                pipeline.add_step(grp)
+        else:
+            test_data = cpu_template_test[test]
+            pipeline.build_group(**test_data, artifacts=["./test_results/**/*"])
+    print(pipeline.to_json())

--- a/.buildkite/pipeline_cpu_template.py
+++ b/.buildkite/pipeline_cpu_template.py
@@ -23,7 +23,7 @@ class BkStep(str, Enum):
 cpu_template_test = {
     "rdmsr": {
         BkStep.COMMAND: [
-            "tools/devtool -y test -- -s -ra -m nonci -n4 --log-cli-level=INFO integration_tests/functional/test_cpu_features.py -k 'test_cpu_rdmsr' "
+            "tools/devtool -y test --no-build -- -s -ra -m nonci -n4 --log-cli-level=INFO integration_tests/functional/test_cpu_features.py -k 'test_cpu_rdmsr' "
         ],
         BkStep.LABEL: "📖 rdmsr",
         "instances": ["c5n.metal", "m5n.metal", "m6a.metal", "m6i.metal"],
@@ -31,7 +31,7 @@ cpu_template_test = {
     },
     "fingerprint": {
         BkStep.COMMAND: [
-            "tools/devtool -y test -- -m no_block_pr integration_tests/functional/test_cpu_template_helper.py -k test_guest_cpu_config_change",
+            "tools/devtool -y test --no-build -- -m no_block_pr integration_tests/functional/test_cpu_template_helper.py -k test_guest_cpu_config_change",
         ],
         BkStep.LABEL: "🖐️ fingerprint",
         "instances": DEFAULT_INSTANCES,
@@ -40,7 +40,7 @@ cpu_template_test = {
     "cpuid_wrmsr": {
         "snapshot": {
             BkStep.COMMAND: [
-                "tools/devtool -y test -- -s -ra -m nonci -n4 --log-cli-level=INFO integration_tests/functional/test_cpu_features.py -k 'test_cpu_wrmsr_snapshot or test_cpu_cpuid_snapshot'",
+                "tools/devtool -y test --no-build -- -s -ra -m nonci -n4 --log-cli-level=INFO integration_tests/functional/test_cpu_features.py -k 'test_cpu_wrmsr_snapshot or test_cpu_cpuid_snapshot'",
                 "mkdir -pv tests/snapshot_artifacts_upload/{instance}_{os}_{kv}",
                 "sudo mv tests/snapshot_artifacts/* tests/snapshot_artifacts_upload/{instance}_{os}_{kv}",
             ],
@@ -52,7 +52,7 @@ cpu_template_test = {
             BkStep.COMMAND: [
                 "buildkite-agent artifact download tests/snapshot_artifacts_upload/{instance}_{os}_{kv}/**/* .",
                 "mv tests/snapshot_artifacts_upload/{instance}_{os}_{kv} tests/snapshot_artifacts",
-                "tools/devtool -y test -- -s -ra -m nonci -n4 --log-cli-level=INFO integration_tests/functional/test_cpu_features.py -k 'test_cpu_wrmsr_restore or test_cpu_cpuid_restore'",
+                "tools/devtool -y test --no-build -- -s -ra -m nonci -n4 --log-cli-level=INFO integration_tests/functional/test_cpu_features.py -k 'test_cpu_wrmsr_restore or test_cpu_cpuid_restore'",
             ],
             BkStep.LABEL: "📸 load snapshot artifacts created on {instance} {snapshot_os} {snapshot_kv} to {restore_instance} {restore_os} {restore_kv}",
             BkStep.TIMEOUT: 30,

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Generate Buildkite performance pipelines dynamically"""
+
+# pylint: disable=invalid-name
+
 import os
 
-from common import COMMON_PARSER, devtool_test, group, overlay_dict, pipeline_to_json
+from common import BKPipeline
 
 # In `devtool_opts`, we restrict both the set of CPUs on which the docker container's threads can run,
 # and its memory node. For the cpuset, we pick a continuous set of CPUs from a single NUMA node
@@ -61,34 +64,7 @@ REVISION_B = os.environ.get("REVISION_B")
 # into buildkite's "commit" field.
 assert (REVISION_A and REVISION_B) or (not REVISION_A and not REVISION_B)
 
-
-def build_group(test):
-    """Build a Buildkite pipeline `group` step"""
-    devtool_opts = test.pop("devtool_opts")
-    test_path = test.pop("test_path")
-    ab_opts = test.pop("ab_opts", "")
-    devtool_opts += " --performance"
-    pytest_opts = ""
-    if REVISION_A:
-        devtool_opts += " --ab"
-        pytest_opts = f" {ab_opts} run {REVISION_A} {REVISION_B} --test {test_path}"
-    else:
-        # Passing `-m ''` below instructs pytest to collect tests regardless of their markers (e.g. it will collect both tests marked as nonci, and tests without any markers).
-        pytest_opts += f" -m '' {test_path}"
-    binary_dir = test.pop("binary_dir")
-    return group(
-        label=test.pop("label"),
-        command=devtool_test(devtool_opts, pytest_opts, binary_dir),
-        artifacts=["./test_results/*"],
-        instances=test.pop("instances"),
-        platforms=test.pop("platforms"),
-        # and the rest can be command arguments
-        **test,
-    )
-
-
-parser = COMMON_PARSER
-parser.add_argument(
+BKPipeline.parser.add_argument(
     "--test",
     choices=list(perf_test.keys()),
     required=False,
@@ -96,36 +72,53 @@ parser.add_argument(
     action="append",
 )
 
-group_steps = []
+retry = {
+    "automatic": [
+        # Agent was lost, retry one time
+        # this can happen if we terminate the instance or the agent gets
+        # disconnected for whatever reason
+        {"exit_status": -1, "limit": 1},
+    ]
+}
+if REVISION_A:
+    # Enable automatic retry and disable manual retries to suppress spurious issues.
+    retry["automatic"].append({"exit_status": 1, "limit": 1})
+    retry["manual"] = False
 
-args = parser.parse_args()
-tests = [perf_test[test] for test in args.test or perf_test.keys()]
-for test_data in tests:
-    test_data.setdefault("platforms", args.platforms)
-    test_data.setdefault("instances", args.instances)
+pipeline = BKPipeline(
+    priority=1,
     # use ag=1 instances to make sure no two performance tests are scheduled on the same instance
-    test_data.setdefault("agents", {"ag": 1})
-    test_data["binary_dir"] = args.binary_dir
-    test_data = overlay_dict(test_data, args.step_param)
-    test_data["retry"] = {
-        "automatic": [
-            # Agent was lost, retry one time
-            # this can happen if we terminate the instance or the agent gets
-            # disconnected for whatever reason
-            {"exit_status": -1, "limit": 1},
-        ]
-    }
+    agents={"ag": 1},
+    retry=retry,
+)
+
+tests = [perf_test[test] for test in pipeline.args.test or perf_test.keys()]
+for test in tests:
+    devtool_opts = test.pop("devtool_opts")
+    test_path = test.pop("test_path")
+    ab_opts = test.pop("ab_opts", "")
+    devtool_opts += " --performance"
+    pytest_opts = ""
     if REVISION_A:
-        # Enable automatic retry and disable manual retries to suppress spurious issues.
-        test_data["retry"]["automatic"].append({"exit_status": 1, "limit": 1})
-        test_data["retry"]["manual"] = False
-    group_steps.append(build_group(test_data))
+        devtool_opts += " --ab"
+        pytest_opts = f"{ab_opts} run {REVISION_A} {REVISION_B} --test {test_path}"
+    else:
+        # Passing `-m ''` below instructs pytest to collect tests regardless of
+        # their markers (e.g. it will collect both tests marked as nonci, and
+        # tests without any markers).
+        pytest_opts += f" -m '' {test_path}"
+
+    pipeline.build_group(
+        command=pipeline.devtool_test(devtool_opts, pytest_opts),
+        # and the rest can be command arguments
+        **test,
+    )
 
 
 # Stores the info about pinning tests to agents with particular kernel versions.
 # For example, the following:
 # pins = {
-#    "linux_6.1-pinned": {"instance": "m6i.metal", "kv": "linux_6.1"},
+#   "linux_6.1-pinned": {"instance": "m6i.metal", "kv": "linux_6.1"},
 # }
 # will pin steps running on instances "m6i.metal" with kernel version tagged "linux_6.1"
 # to a new kernel version tagged "linux_6.1-pinned"
@@ -136,7 +129,9 @@ def apply_pins(steps):
     """Apply pins"""
     new_steps = []
     for step in steps:
-        if "group" in step:
+        if isinstance(step, str):
+            pass
+        elif "group" in step:
             step["steps"] = apply_pins(step["steps"])
         else:
             agents = step["agents"]
@@ -149,6 +144,5 @@ def apply_pins(steps):
     return new_steps
 
 
-group_steps = apply_pins(group_steps)
-
-print(pipeline_to_json({"steps": group_steps}))
+pipeline.steps = apply_pins(pipeline.steps)
+print(pipeline.to_json())

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -86,7 +86,8 @@ if REVISION_A:
     retry["manual"] = False
 
 pipeline = BKPipeline(
-    priority=1,
+    # Boost priority from 1 to 2 so these jobs are preferred by ag-1 agents
+    priority=2,
     # use ag=1 instances to make sure no two performance tests are scheduled on the same instance
     agents={"ag": 1},
     retry=retry,

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -4,133 +4,82 @@
 
 """Generate Buildkite pipelines dynamically"""
 
-from common import (
-    COMMON_PARSER,
-    devtool_test,
-    get_changed_files,
-    group,
-    overlay_dict,
-    pipeline_to_json,
-    run_all_tests,
-)
+from common import BKPipeline, get_changed_files, run_all_tests
 
 # Buildkite default job priority is 0. Setting this to 1 prioritizes PRs over
 # scheduled jobs and other batch jobs.
 DEFAULT_PRIORITY = 1
-
-
-args = COMMON_PARSER.parse_args()
-
-step_style = {
-    "command": "./tools/devtool -y checkstyle",
-    "label": "🪶 Style",
-    "priority": DEFAULT_PRIORITY,
+DEFAULTS_PERF = {
+    "priority": DEFAULT_PRIORITY + 1,
+    "agents": {"ag": 1},
 }
 
-defaults = {
-    "instances": args.instances,
-    "platforms": args.platforms,
-    # buildkite step parameters
-    "priority": DEFAULT_PRIORITY,
-    "timeout_in_minutes": 45,
-    "artifacts": ["./test_results/**/*"],
-}
-defaults = overlay_dict(defaults, args.step_param)
-
-defaults_once_per_architecture = defaults.copy()
-defaults_once_per_architecture["instances"] = ["m6i.metal", "m7g.metal"]
-defaults_once_per_architecture["platforms"] = [("al2", "linux_5.10")]
-
-
-devctr_grp = group(
-    "🐋 Dev Container Sanity Build",
-    "./tools/devtool -y build_devctr",
-    **defaults_once_per_architecture,
+pipeline = BKPipeline(
+    priority=DEFAULT_PRIORITY,
+    timeout_in_minutes=45,
+    initial_steps=[
+        {
+            "command": "./tools/devtool -y checkstyle",
+            "label": "🪶 Style",
+        },
+    ],
 )
 
-release_grp = group(
-    "📦 Release Sanity Build",
-    "./tools/devtool -y make_release",
-    **defaults_once_per_architecture,
-)
-
-build_grp = group(
-    "📦 Build",
-    "./tools/devtool -y test -- ../tests/integration_tests/build/",
-    **defaults,
-)
-
-functional_grp = group(
-    "⚙ Functional and security 🔒",
-    devtool_test(
-        pytest_opts="-n 8 --dist worksteal integration_tests/{{functional,security}}",
-        binary_dir=args.binary_dir,
-    ),
-    **defaults,
-)
-
-defaults_for_performance = overlay_dict(
-    defaults,
-    {
-        # We specify higher priority so the ag=1 jobs get picked up before the ag=n
-        # jobs in ag=1 agents
-        "priority": DEFAULT_PRIORITY + 1,
-        "agents": {"ag": 1},
-    },
-)
-
-performance_grp = group(
-    "⏱ Performance",
-    devtool_test(
-        devtool_opts="--performance -c 1-10 -m 0",
-        pytest_opts="../tests/integration_tests/performance/",
-        binary_dir=args.binary_dir,
-    ),
-    **defaults_for_performance,
-)
-
-defaults_for_kani = overlay_dict(
-    defaults_for_performance,
-    {
-        # Kani runs fastest on m6i.metal
-        "instances": ["m6a.metal"],
-        "platforms": [("al2", "linux_5.10")],
-        "timeout_in_minutes": 300,
-    },
-)
-
-kani_grp = group(
-    "🔍 Kani",
-    "./tools/devtool -y test -- ../tests/integration_tests/test_kani.py -n auto",
-    **defaults_for_kani,
-)
-for step in kani_grp["steps"]:
-    step["label"] = "🔍 Kani"
-
-steps = [step_style]
 changed_files = get_changed_files()
 
 # run sanity build of devtool if Dockerfile is changed
 if any(x.name == "Dockerfile" for x in changed_files):
-    steps.append(devctr_grp)
+    pipeline.build_group_per_arch(
+        "🐋 Dev Container Sanity Build",
+        "./tools/devtool -y build_devctr",
+    )
 
 if any(
     x.parent.name == "tools" and ("release" in x.name or x.name == "devtool")
     for x in changed_files
 ):
-    steps.append(release_grp)
+    pipeline.build_group_per_arch(
+        "📦 Release Sanity Build",
+        "./tools/devtool -y make_release",
+    )
 
 if not changed_files or any(
     x.suffix in [".rs", ".toml", ".lock"] for x in changed_files
 ):
-    steps.append(kani_grp)
+    kani_grp = pipeline.build_group(
+        "🔍 Kani",
+        "./tools/devtool -y test -- ../tests/integration_tests/test_kani.py -n auto",
+        # Kani step default
+        # Kani runs fastest on m6i.metal
+        instances=["m6a.metal"],
+        platforms=[("al2", "linux_5.10")],
+        timeout_in_minutes=300,
+        **DEFAULTS_PERF,
+    )
+    # modify Kani steps' label
+    for step in kani_grp["steps"]:
+        step["label"] = "🔍 Kani"
 
 if run_all_tests(changed_files):
-    steps += [
-        build_grp,
-        functional_grp,
-        performance_grp,
-    ]
+    pipeline.build_group(
+        "📦 Build",
+        pipeline.devtool_test(pytest_opts="integration_tests/build/"),
+    )
 
-pipeline = {"steps": steps}
-print(pipeline_to_json(pipeline))
+    pipeline.build_group(
+        "⚙ Functional and security 🔒",
+        pipeline.devtool_test(
+            pytest_opts="-n 8 --dist worksteal integration_tests/{{functional,security}}",
+        ),
+    )
+
+    pipeline.build_group(
+        "⏱ Performance",
+        pipeline.devtool_test(
+            devtool_opts="--performance -c 1-10 -m 0",
+            pytest_opts="../tests/integration_tests/performance/",
+        ),
+        **DEFAULTS_PERF,
+    )
+
+print(pipeline.to_json())

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -50,7 +50,7 @@ if not changed_files or any(
         "🔍 Kani",
         "./tools/devtool -y test -- ../tests/integration_tests/test_kani.py -n auto",
         # Kani step default
-        # Kani runs fastest on m6i.metal
+        # Kani runs fastest on m6a.metal
         instances=["m6a.metal"],
         platforms=[("al2", "linux_5.10")],
         timeout_in_minutes=300,

--- a/.buildkite/pipeline_pr_no_block.py
+++ b/.buildkite/pipeline_pr_no_block.py
@@ -4,40 +4,26 @@
 
 """Generate Buildkite pipelines dynamically"""
 
-from common import (
-    COMMON_PARSER,
-    get_changed_files,
-    group,
-    overlay_dict,
-    pipeline_to_json,
-    run_all_tests,
-)
+from common import BKPipeline, get_changed_files, run_all_tests
 
 # Buildkite default job priority is 0. Setting this to 1 prioritizes PRs over
 # scheduled jobs and other batch jobs.
 DEFAULT_PRIORITY = 1
 
-args = COMMON_PARSER.parse_args()
-
-defaults = {
-    "instances": args.instances,
-    "platforms": args.platforms,
-    # buildkite step parameters
-    "timeout_in_minutes": 45,
+pipeline = BKPipeline(
+    timeout_in_minutes=45,
     # some non-blocking tests are performance, so make sure they get ag=1 instances
-    "priority": DEFAULT_PRIORITY + 1,
-    "agents": {"ag": 1},
-    "artifacts": ["./test_results/**/*"],
-}
-defaults = overlay_dict(defaults, args.step_param)
-
-
-optional_grp = group(
-    "❓ Optional",
-    "./tools/devtool -y test --performance -c 1-10 -m 0 -- ../tests/integration_tests/ -m 'no_block_pr and not nonci' --log-cli-level=INFO",
-    **defaults,
+    priority=DEFAULT_PRIORITY + 1,
+    agents={"ag": 1},
 )
 
-changed_files = get_changed_files()
-pipeline = {"steps": [optional_grp]} if run_all_tests(changed_files) else {"steps": []}
-print(pipeline_to_json(pipeline))
+pipeline.build_group(
+    "❓ Optional",
+    pipeline.devtool_test(
+        devtool_opts="--performance -c 1-10 -m 0",
+        pytest_opts="integration_tests/ -m 'no_block_pr and not nonci' --log-cli-level=INFO",
+    ),
+)
+if not run_all_tests(get_changed_files()):
+    pipeline.steps = []
+print(pipeline.to_json())

--- a/tests/framework/ab_test.py
+++ b/tests/framework/ab_test.py
@@ -165,11 +165,14 @@ def git_ab_test_guest_command(
     paths to firecracker and jailer binaries."""
 
     @with_filelock
-    def test_runner(workspace_dir, _is_a: bool):
+    def build_firecracker(workspace_dir):
         utils.check_output("./tools/release.sh --profile release", cwd=workspace_dir)
-        bin_dir = get_binary(
-            "firecracker", workspace_dir=workspace_dir
-        ).parent.resolve()
+
+    def test_runner(workspace_dir, _is_a: bool):
+        firecracker = get_binary("firecracker", workspace_dir=workspace_dir)
+        if not firecracker.exists():
+            build_firecracker(workspace_dir)
+        bin_dir = firecracker.parent.resolve()
         firecracker, jailer = bin_dir / "firecracker", bin_dir / "jailer"
         microvm = microvm_factory(firecracker, jailer)
         return microvm.ssh.run(command)

--- a/tests/framework/ab_test.py
+++ b/tests/framework/ab_test.py
@@ -37,7 +37,7 @@ from host_tools.cargo_build import get_binary, get_firecracker_binaries
 
 # Locally, this will always compare against main, even if we try to merge into, say, a feature branch.
 # We might want to do a more sophisticated way to determine a "parent" branch here.
-DEFAULT_A_REVISION = os.environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")
+DEFAULT_A_REVISION = os.environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH") or "main"
 
 
 T = TypeVar("T")

--- a/tests/framework/ab_test.py
+++ b/tests/framework/ab_test.py
@@ -82,11 +82,11 @@ def git_ab_test(
              (alternatively, your comparator can perform any required assertions and not return anything).
     """
 
-    dir_a = git_clone(Path("build") / a_revision, a_revision)
+    dir_a = git_clone(Path("../build") / a_revision, a_revision)
     result_a = test_runner(dir_a, True)
 
     if b_revision:
-        dir_b = git_clone(Path("build") / b_revision, b_revision)
+        dir_b = git_clone(Path("../build") / b_revision, b_revision)
     else:
         # By default, pytest execution happens inside the `tests` subdirectory. Pass the repository root, as
         # documented.
@@ -237,10 +237,13 @@ def git_clone(clone_path, commitish):
             # git didn't recognize this object; qualify it if it is a branch
             commitish = f"origin/{commitish}"
         # make a temp branch for that commit so we can directly check it out
-        utils.check_output(f"git branch {clone_path} {commitish}")
-        _, git_root, _ = utils.check_output("git rev-parse --show-toplevel")
+        branch_name = f"tmp-{commitish}"
+        utils.check_output(f"git branch {branch_name} {commitish}")
+        _, git_root, _ = utils.run_cmd("git rev-parse --show-toplevel")
         # split off the '\n' at the end of the stdout
-        utils.check_output(f"git clone -b {clone_path} {git_root.strip()} {clone_path}")
+        utils.check_output(
+            f"git clone -b {branch_name} {git_root.strip()} {clone_path}"
+        )
     return clone_path
 
 

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -53,7 +53,6 @@ def get_binary(name, *, workspace_dir=FC_WORKSPACE_DIR, example=None):
     bin_path = target_dir / name
     if example:
         bin_path = target_dir / "examples" / example
-    assert bin_path.exists()
     return bin_path
 
 

--- a/tests/integration_tests/functional/test_concurrency.py
+++ b/tests/integration_tests/functional/test_concurrency.py
@@ -4,71 +4,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 
-from framework.utils import configure_mmds, populate_data_store
-
 NO_OF_MICROVMS = 20
-
-
-def test_run_concurrency_with_mmds(microvm_factory, guest_kernel, rootfs):
-    """
-    Spawn multiple firecracker processes to run concurrently with MMDS
-    """
-
-    data_store = {
-        "latest": {
-            "meta-data": {
-                "ami-id": "ami-12345678",
-                "reservation-id": "r-fea54097",
-                "local-hostname": "ip-10-251-50-12.ec2.internal",
-                "public-hostname": "ec2-203-0-113-25.compute-1.amazonaws.com",
-                "dummy_res": ["res1", "res2"],
-            },
-            "Limits": {"CPU": 512, "Memory": 512},
-            "Usage": {"CPU": 12.12},
-        }
-    }
-
-    microvms = []
-    # Launch guests with initially populated data stores
-    for index in range(NO_OF_MICROVMS):
-        microvm = microvm_factory.build(guest_kernel, rootfs)
-        microvm.spawn()
-        microvm.add_net_iface()
-
-        # Configure MMDS before population
-        configure_mmds(microvm, iface_ids=["eth0"], version="V2")
-
-        # Populate data store with some data prior to starting the guest
-        populate_data_store(microvm, data_store)
-        microvm.basic_config(vcpu_count=1, mem_size_mib=128)
-        microvm.start()
-        microvm.wait_for_up()
-
-        microvms.append(microvm)
-
-    # With all guests launched and running send a batch of
-    # MMDS patch requests to all running microvms.
-    for index in range(NO_OF_MICROVMS):
-        test_microvm = microvms[index]
-        dummy_json = {
-            "latest": {
-                "meta-data": {
-                    "ami-id": "another_dummy",
-                    "secret_key10": "eaasda48141411aeaeae10",
-                    "secret_key11": "eaasda48141411aeaeae11",
-                    "secret_key12": "eaasda48141411aeaeae12",
-                    "secret_key13": "eaasda48141411aeaeae13",
-                    "secret_key14": "eaasda48141411aeaeae14",
-                    "secret_key15": "eaasda48141411aeaeae15",
-                    "secret_key16": "eaasda48141411aeaeae16",
-                    "secret_key17": "eaasda48141411aeaeae17",
-                    "secret_key18": "eaasda48141411aeaeae18",
-                    "secret_key19": "eaasda48141411aeaeae19",
-                    "secret_key20": "eaasda48141411aeaeae20",
-                }
-            }
-        }
-        test_microvm.api.mmds.patch(json=dummy_json)
 
 
 def test_run_concurrency(microvm_factory, guest_kernel, rootfs):

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -322,7 +322,6 @@ def ab_performance_test(
     print(commit_list.strip())
 
     def test_runner(workspace, _is_ab: bool):
-        utils.check_output("./tools/release.sh --profile release", cwd=workspace)
         bin_dir = ".." / get_binary("firecracker", workspace_dir=workspace).parent
         return collect_data(bin_dir, tests)
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -884,7 +884,9 @@ cmd_test_debug() {
 #
 cmd_fmt() {
     cmd_sh "cargo fmt --all -- --config $(tr '\n' ',' <tests/fmt.toml)"
+    cmd_sh "cargo sort"
     cmd_sh "cd tests; black . ../tools ../.buildkite"
+    cmd_sh "cd tests; isort . ../tools ../.buildkite"
     cmd_sh "mdformat $(git ls-files '*.md' | tr '\n' ' ')"
 }
 


### PR DESCRIPTION
## Changes

The main change is to share the build. To do that without complicating each pipeline script, we first encapsulate all the complexity of parsing options and all the logic that each script duplicates into a BKPipeline class, and then we can make the build sharing change in a single place without having to touch each script.

The rest of the changes are small issues found while working on this PR.

## Reason

- We use less resources by doing it this way. For example for an A/B performance run we built Firecracker 252 times. After this change, we only build it 4 times. This may ease the contention at the beginning of a build, as agents are not trying to access the network at the same time.
- Test runs may use less instance time overall. For PR for example it would be 4min * 108 = 432 minutes. Wall time will remain the same, however.
- Retries of a step should be a bit faster as they don't have to rebuild Firecracker.
- The A/B tests currently build Firecracker within a test. This runs against the 300s per-test timeout and occasionally causes false positive test failures. By moving it out of the test run, we avoid this failures scenario. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
