### PR TITLE
ci: output disk usage if tests fail

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -37,4 +37,14 @@ cp -ruvf build/img /srv
 cd tests
 export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} --pdbcls=IPython.terminal.debugger:TerminalPdb"
 pytest "$@"
-exit $?
+ret=$?
+
+# if the tests failed and we are running in CI, print some disk usage stats
+# to help troubleshooting
+if [ $ret != 0 ] && [ "$BUILDKITE" == "true" ]; then
+    df -ih
+    df -h
+    du -h / 2>/dev/null |sort -h |tail -32
+fi
+
+exit $ret


### PR DESCRIPTION
Sometimes test fail because of running out of space. In that case it would be helpful to dump some information on disk usage.

## Changes

Add debug information when a test run fails

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
