### PR TITLE
fix(ci): ignore errors so we can capture the exit status

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -36,8 +36,14 @@ cp -ruvf build/img /srv
 
 cd tests
 export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} --pdbcls=IPython.terminal.debugger:TerminalPdb"
-pytest "$@"
-ret=$?
+
+{
+    # disable errexit momentarily so we can capture the exit status
+    set +e
+    pytest "$@"
+    ret=$?
+    set -e
+}
 
 # if the tests failed and we are running in CI, print some disk usage stats
 # to help troubleshooting


### PR DESCRIPTION
The rest of the script was not executed because we run the script under `-e`. Disable errors so we can capture the exit code and print the information.

Fixes: a46b60e9ba774e831484315f20b2e437cc6c150f

## Changes

Bugfix

## Reason

To make the change be effective.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
