### PR TITLE
chore(ci): double pytest timeout duration temporarily

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -15,7 +15,9 @@ markers =
 norecursedirs = .*
 
 ; Default timeout for tests. can be overwritten at finer grained levels.
-timeout = 300
+; TODO: reduce the number of times to build Firecracker in A/B test and set it
+; back to 300 seconds.
+timeout = 600
 
 ; Set the cache dir location to our build dir, so we don't litter the source
 ; tree.


### PR DESCRIPTION
## Reason

Currently our A/B testing builds Firecracker for each test and each environment while running tests. As the Firecracker build time increases, some tests timeout the current duration (300s). 

## Changes

To mitigate this issue temporarily, sets it to 600s. It should be set it back to the original value after fixing the issue in PR #4624.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- ~~[ ] All added/changed functionality is tested.~~
- [ ] New `TODO`s link to an issue. => the new TODO to be removed in PR #4624.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
