### PR TITLE
Add vCPUs to VMM via new endpoint 

### DIFF
--- a/src/firecracker/src/api_server/request/hotplug.rs
+++ b/src/firecracker/src/api_server/request/hotplug.rs
@@ -1,0 +1,47 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use vmm::logger::{IncMetric, METRICS};
+use vmm::rpc_interface::VmmAction;
+use vmm::vmm_config::hotplug::HotplugRequestConfig;
+
+use super::super::parsed_request::{ParsedRequest, RequestError};
+use super::Body;
+
+pub(crate) fn parse_put_hotplug(body: &Body) -> Result<ParsedRequest, RequestError> {
+    METRICS.put_api_requests.hotplug.inc();
+    METRICS.hotplug.hotplug_request_count.inc();
+    let config = serde_json::from_slice::<HotplugRequestConfig>(body.raw()).map_err(|err| {
+        METRICS.hotplug.hotplug_request_fails.inc();
+        err
+    })?;
+    Ok(ParsedRequest::new_sync(VmmAction::HotplugRequest(config)))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use hotplug::parse_put_hotplug;
+    use vmm::rpc_interface::VmmAction;
+    use vmm::vmm_config::hotplug::{HotplugRequestConfig, HotplugVcpuConfig};
+
+    use super::super::*;
+    use crate::api_server::parsed_request::tests::vmm_action_from_request;
+
+    #[test]
+    fn test_parse_put_hotplug() {
+        // Case 1. Invalid body
+        parse_put_hotplug(&Body::new("invalid body")).unwrap_err();
+
+        // Case 2. vCPU Resource
+        let body = r#"{
+            "Vcpu" : { "add": 4 }
+        }"#;
+
+        let expected_config = HotplugVcpuConfig { add: 4 };
+
+        assert_eq!(
+            vmm_action_from_request(parse_put_hotplug(&Body::new(body)).unwrap()),
+            VmmAction::HotplugRequest(HotplugRequestConfig::Vcpu(expected_config))
+        );
+    }
+}

--- a/src/firecracker/src/api_server/request/mod.rs
+++ b/src/firecracker/src/api_server/request/mod.rs
@@ -7,6 +7,8 @@ pub mod boot_source;
 pub mod cpu_configuration;
 pub mod drive;
 pub mod entropy;
+#[cfg(target_arch = "x86_64")]
+pub mod hotplug;
 pub mod instance_info;
 pub mod logger;
 pub mod machine_configuration;

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -282,6 +282,30 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /hotplug:
+    put:
+      summary: Hotplugs resources to the microVM. Only available for x86_64 hosts. Post-boot only.
+      description:
+        Adds new resources to the VM.
+      parameters:
+        - name: body
+          in: body
+          description: The resource type and amount to be hotplugged.
+          required: true
+          schema: 
+            $ref: "#/definitions/Hotplug"
+      responses:
+        204:
+          description: Resources hotplugged successfully.
+        400: 
+          description: Resources cannot be hotplugged due to bad input or a VMM-related error.
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal server error.
+          schema:
+            $ref: "#/definitions/Error"
+
   /logger:
     put:
       summary: Initializes the logger by specifying a named pipe or a file for the logs output.
@@ -942,6 +966,21 @@ definitions:
           $ref: "#/definitions/NetworkInterface"
       vsock:
         $ref: "#/definitions/Vsock"
+
+  Hotplug:
+    type: object
+    description:
+      Defines the configuration for hot plugging.
+    properties:
+      Vcpu:
+        type: object
+        description: Hotplug requests relating to vCPU cores.
+        properties:
+          add:
+            description: Number of vCPUs cores to be added to the VM
+            type: integer
+            minimum: 1
+
 
   InstanceActionInfo:
     type: object

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -145,6 +145,7 @@ impl std::convert::From<linux_loader::cmdline::Error> for StartMicrovmError {
 }
 
 #[cfg_attr(target_arch = "aarch64", allow(unused))]
+#[allow(clippy::too_many_arguments)]
 fn create_vmm_and_vcpus(
     instance_info: &InstanceInfo,
     event_manager: &mut EventManager,
@@ -152,6 +153,7 @@ fn create_vmm_and_vcpus(
     uffd: Option<Uffd>,
     track_dirty_pages: bool,
     vcpu_count: u8,
+    #[cfg(target_arch = "x86_64")] seccomp_filters: BpfThreadMap,
     kvm_capabilities: Vec<KvmCapability>,
 ) -> Result<(Vmm, Vec<Vcpu>), StartMicrovmError> {
     use self::StartMicrovmError::*;
@@ -229,6 +231,8 @@ fn create_vmm_and_vcpus(
         uffd,
         vcpus_handles: Vec::new(),
         vcpus_exit_evt,
+        #[cfg(target_arch = "x86_64")]
+        seccomp_filters,
         resource_allocator,
         mmio_device_manager,
         #[cfg(target_arch = "x86_64")]
@@ -309,6 +313,8 @@ pub fn build_microvm_for_boot(
         None,
         track_dirty_pages,
         vm_resources.vm_config.vcpu_count,
+        #[cfg(target_arch = "x86_64")]
+        seccomp_filters.clone(),
         cpu_template.kvm_capabilities.clone(),
     )?;
 
@@ -478,6 +484,8 @@ pub fn build_microvm_from_snapshot(
         uffd,
         vm_resources.vm_config.track_dirty_pages,
         vm_resources.vm_config.vcpu_count,
+        #[cfg(target_arch = "x86_64")]
+        seccomp_filters.clone(),
         microvm_state.vm_state.kvm_cap_modifiers.clone(),
     )?;
 
@@ -1155,6 +1163,8 @@ pub mod tests {
             uffd: None,
             vcpus_handles: Vec::new(),
             vcpus_exit_evt,
+            #[cfg(target_arch = "x86_64")]
+            seccomp_filters: crate::seccomp_filters::get_empty_filters(),
             resource_allocator: ResourceAllocator::new().unwrap(),
             mmio_device_manager,
             #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -616,12 +616,12 @@ impl Vmm {
         config: HotplugVcpuConfig,
     ) -> Result<MachineConfigUpdate, HotplugVcpuError> {
         use crate::logger::IncMetric;
-        if config.vcpu_count < 1 {
+        if config.add < 1 {
             return Err(HotplugVcpuError::VcpuCountTooLow);
         } else if self
             .vcpus_handles
             .len()
-            .checked_add(config.vcpu_count.into())
+            .checked_add(config.add.into())
             .ok_or(HotplugVcpuError::VcpuCountTooHigh)?
             > MAX_SUPPORTED_VCPUS.into()
         {
@@ -629,11 +629,11 @@ impl Vmm {
         }
 
         // Create and start new vcpus
-        let mut vcpus = Vec::with_capacity(config.vcpu_count.into());
+        let mut vcpus = Vec::with_capacity(config.add.into());
 
         #[allow(clippy::cast_possible_truncation)]
         let start_idx = self.vcpus_handles.len().try_into().unwrap();
-        for cpu_idx in start_idx..(start_idx + config.vcpu_count) {
+        for cpu_idx in start_idx..(start_idx + config.add) {
             let exit_evt = self
                 .vcpus_exit_evt
                 .try_clone()
@@ -653,7 +653,7 @@ impl Vmm {
         .map_err(HotplugVcpuError::VcpuStart)?;
 
         #[allow(clippy::cast_lossless)]
-        METRICS.hotplug.vcpus_added.add(config.vcpu_count.into());
+        METRICS.hotplug.vcpus_added.add(config.add.into());
 
         // Update VM config to reflect new CPUs added
         #[allow(clippy::cast_possible_truncation)]

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -410,6 +410,10 @@ pub struct PutRequestsMetrics {
     pub drive_count: SharedIncMetric,
     /// Number of failures in attaching a block device.
     pub drive_fails: SharedIncMetric,
+    /// Number of PUTs for hotplugging
+    pub hotplug: SharedIncMetric,
+    /// Number of failures for hotplugging.
+    pub hotplug_fails: SharedIncMetric,
     /// Number of PUTs for initializing the logging system.
     pub logger_count: SharedIncMetric,
     /// Number of failures in initializing the logging system.
@@ -449,6 +453,8 @@ impl PutRequestsMetrics {
             boot_source_fails: SharedIncMetric::new(),
             drive_count: SharedIncMetric::new(),
             drive_fails: SharedIncMetric::new(),
+            hotplug: SharedIncMetric::new(),
+            hotplug_fails: SharedIncMetric::new(),
             logger_count: SharedIncMetric::new(),
             logger_fails: SharedIncMetric::new(),
             machine_cfg_count: SharedIncMetric::new(),
@@ -824,6 +830,28 @@ impl VmmMetrics {
     }
 }
 
+/// Metrics specific to hotplugging
+#[derive(Debug, Default, Serialize)]
+pub struct HotplugMetrics {
+    pub hotplug_request_count: SharedIncMetric,
+    pub hotplug_request_fails: SharedIncMetric,
+    pub vcpu_hotplug_request_fails: SharedIncMetric,
+    pub vcpus_added: SharedIncMetric,
+}
+
+impl HotplugMetrics {
+    /// Const default construction.
+
+    pub const fn new() -> Self {
+        Self {
+            hotplug_request_count: SharedIncMetric::new(),
+            hotplug_request_fails: SharedIncMetric::new(),
+            vcpu_hotplug_request_fails: SharedIncMetric::new(),
+            vcpus_added: SharedIncMetric::new(),
+        }
+    }
+}
+
 // The sole purpose of this struct is to produce an UTC timestamp when an instance is serialized.
 #[derive(Debug, Default)]
 struct SerializeToUtcTimestampMs;
@@ -887,6 +915,8 @@ pub struct FirecrackerMetrics {
     pub deprecated_api: DeprecatedApiMetrics,
     /// Metrics related to API GET requests.
     pub get_api_requests: GetRequestsMetrics,
+    /// Metrics related to hot-plugging.
+    pub hotplug: HotplugMetrics,
     #[serde(flatten)]
     /// Metrics related to the legacy device.
     pub legacy_dev_ser: LegacyDevMetricsSerializeProxy,
@@ -931,6 +961,7 @@ impl FirecrackerMetrics {
             block_ser: BlockMetricsSerializeProxy {},
             deprecated_api: DeprecatedApiMetrics::new(),
             get_api_requests: GetRequestsMetrics::new(),
+            hotplug: HotplugMetrics::new(),
             legacy_dev_ser: LegacyDevMetricsSerializeProxy {},
             latencies_us: PerformanceMetrics::new(),
             logger: LoggerSystemMetrics::new(),

--- a/src/vmm/src/vmm_config/hotplug.rs
+++ b/src/vmm/src/vmm_config/hotplug.rs
@@ -1,0 +1,47 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+
+use serde::{Deserialize, Serialize};
+
+use crate::vstate::vcpu::VcpuError;
+use crate::StartVcpusError;
+/// Unifying enum for all types of hotplug request configs.
+/// Currently only Vcpus may be hotplugged.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HotplugRequestConfig {
+    /// Vcpu hotplug request
+    Vcpu(HotplugVcpuConfig),
+}
+
+/// Errors related to different types of hotplugging.
+/// Currently only Vcpus can be hotplugged.
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum HotplugRequestError {
+    /// Vcpu hotplugging error: {0}
+    Vcpu(#[from] HotplugVcpuError),
+}
+
+/// Errors associated with hot-plugging vCPUs
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum HotplugVcpuError {
+    /// The number of vCPUs added must be greater than 0.
+    VcpuCountTooLow,
+    /// The number of vCPUs added must be less than 32.
+    VcpuCountTooHigh,
+    /// Event fd error: {0}
+    EventFd(io::Error),
+    /// Error creating the vcpu: {0}
+    VcpuCreate(VcpuError),
+    /// Failed to start vCPUs
+    VcpuStart(StartVcpusError),
+}
+
+/// Config for hotplugging vCPUS
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct HotplugVcpuConfig {
+    /// Number of vcpus to start.
+    pub add: u8,
+}

--- a/src/vmm/src/vmm_config/hotplug.rs
+++ b/src/vmm/src/vmm_config/hotplug.rs
@@ -36,6 +36,8 @@ pub enum HotplugVcpuError {
     VcpuCreate(VcpuError),
     /// Failed to start vCPUs
     VcpuStart(StartVcpusError),
+    /// No seccomp filter for thread category: {0}
+    MissingSeccompFilters(String),
 }
 
 /// Config for hotplugging vCPUS

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -20,6 +20,9 @@ pub mod boot_source;
 pub mod drive;
 /// Wrapper for configuring the entropy device attached to the microVM.
 pub mod entropy;
+/// Wrapper over hotplug configuration.
+#[cfg(target_arch = "x86_64")]
+pub mod hotplug;
 /// Wrapper over the microVM general information attached to the microVM.
 pub mod instance_info;
 /// Wrapper for configuring the memory and CPU of the microVM.

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -152,6 +152,12 @@ def validate_fc_metrics(metrics):
             "mmds_count",
             "vmm_version_count",
         ],
+        "hotplug": [
+            "hotplug_request_count",
+            "hotplug_request_fails",
+            "vcpu_hotplug_request_fails",
+            "vcpus_added",
+        ],
         "i8042": [
             "error_count",
             "missed_read_count",
@@ -209,6 +215,8 @@ def validate_fc_metrics(metrics):
             "boot_source_fails",
             "drive_count",
             "drive_fails",
+            "hotplug",
+            "hotplug_fails",
             "logger_count",
             "logger_fails",
             "machine_cfg_count",


### PR DESCRIPTION
## Changes
* Created new API endpoint `hotplug` used to request resources on demand (currently only vCPU implemented)
* Currently, when a valid request is made to `hotplug`, the specified number of vCPU threads are added directly to the guest VMM
* For now, in order to allow hotplugging Firecracker must be launched with `--no-seccomp` option
* Unit tests added to test functionality of both endpoint and adding of vCPUs

## Reason
This is the first step in implementing resource hotplugging via ACPI.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
