### PR TITLE
test: disable time_api_requests for cross-kernel snapshot tests

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
+++ b/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
@@ -105,6 +105,7 @@ def test_snap_restore_from_artifacts(
     logger.info("Working with snapshot artifacts in %s.", snapshot_dir)
 
     vm = microvm_factory.build()
+    vm.time_api_requests = False
     vm.spawn()
     logger.info("Loading microVM from snapshot...")
     vm.restore_from_path(snapshot_dir)


### PR DESCRIPTION
These tests run on ag=n buildkite workers (e.g. in parallel with other test runs), which can cause contention on kernel locks. See also ba7b6db53834e031ec9949cf840daa5661545487.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
