### PR TITLE
fix(test_rng): do not test for virtio-rng performance

### DIFF
--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -84,7 +84,7 @@ def _get_percentage_difference(measured, base):
     if measured == base:
         return 0
     try:
-        return (abs(measured - base) / base) * 100.0
+        return ((measured - base) / base) * 100.0
     except ZeroDivisionError:
         # It means base and only base is 0.
         return 100.0
@@ -148,7 +148,8 @@ def _get_throughput(ssh, random_bytes):
 def _check_entropy_rate_limited(ssh, random_bytes, expected_kbps):
     """
     Ask for `random_bytes` from `/dev/hwrng` in the guest and check
-    that achieved throughput is within a 10% of the expected throughput.
+    that achieved throughput does not exceed the expected throughput by
+    more than 10%.
 
     NOTE: 10% is an arbitrarily selected limit which should be safe enough,
     so that we don't run into many intermittent CI failures.


### PR DESCRIPTION
## Changes

Modify `test_rng.py::test_rng_bw_rate_limiter` to not check if the device achieves the performance defined by the devices rate limiter limit.

## Reason

Currently, our test for virtio-rng rate limiter tests if the performance obtained by the device is within 10% of the rate limiter limit. This does not only test whether the rate limiter works (achieved bandwidth > 10% of limit), but also if the device performs at that same limit.

This test is supposed to be a functional test, not a performance one. In fact, it does not run in isolation. Moreover, we have not thoroughly profiled the performance we can achieve from the device, so we cannot be sure that the limits in the functional test correspond to the capabilities of the device. If we want, we should do that as part of a performance test.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
