### PR TITLE
Delete intermediary snapshots created by tests, to avoid out-of-disk-space errors during artifact generation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,7 +272,7 @@ def microvm_factory(request, record_property, results_dir):
             uvm_data = results_dir / uvm.id
             uvm_data.mkdir()
 
-            uvm_root = uvm.path / "root"
+            uvm_root = Path(uvm.chroot())
             for item in os.listdir(uvm_root):
                 src = uvm_root / item
                 if not os.path.isfile(src):

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -165,6 +165,7 @@ def test_5_snapshots(
     start_guest_echo_server(vm)
     snapshot = vm.make_snapshot(snapshot_type)
     base_snapshot = snapshot
+    vm.kill()
 
     for i in range(seq_len):
         logger.info("Load snapshot #%s, mem %s", i, snapshot.mem)
@@ -199,6 +200,7 @@ def test_5_snapshots(
                 base_snapshot, use_snapshot_editor=use_snapshot_editor
             )
 
+        microvm.kill()
         # Update the base for next iteration.
         base_snapshot = snapshot
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -171,7 +171,7 @@ def test_5_snapshots(
         logger.info("Load snapshot #%s, mem %s", i, snapshot.mem)
         microvm = microvm_factory.build()
         microvm.spawn()
-        microvm.restore_from_snapshot(snapshot, resume=True)
+        copied_snapshot = microvm.restore_from_snapshot(snapshot, resume=True)
 
         # FIXME: This and the sleep below reduce the rate of vsock/ssh connection
         # related spurious test failures, although we do not know why this is the case.
@@ -201,6 +201,7 @@ def test_5_snapshots(
             )
 
         microvm.kill()
+        copied_snapshot.delete()
         # Update the base for next iteration.
         base_snapshot = snapshot
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -561,7 +561,7 @@ def test_vmgenid(guest_kernel_linux_6_1, rootfs, microvm_factory, snapshot_type)
     for i in range(5):
         vm = microvm_factory.build()
         vm.spawn()
-        vm.restore_from_snapshot(snapshot, resume=True)
+        copied_snapshot = vm.restore_from_snapshot(snapshot, resume=True)
         vm.wait_for_up()
 
         # We should have as DMESG_VMGENID_RESUME messages as
@@ -570,6 +570,7 @@ def test_vmgenid(guest_kernel_linux_6_1, rootfs, microvm_factory, snapshot_type)
 
         snapshot = vm.make_snapshot(snapshot_type)
         vm.kill()
+        copied_snapshot.delete()
 
         # If we are testing incremental snapshots we ust merge the base with
         # current layer.

--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -89,7 +89,7 @@ class SnapshotRestoreTest:
                 monitor_memory=False,
             )
             microvm.spawn()
-            microvm.restore_from_snapshot(snapshot, resume=True)
+            snapshot_copy = microvm.restore_from_snapshot(snapshot, resume=True)
 
             fcmetrics = FCMetricsMonitor(microvm)
             fcmetrics.start()
@@ -108,6 +108,7 @@ class SnapshotRestoreTest:
             values.append(value)
             fcmetrics.stop()
             microvm.kill()
+            snapshot_copy.delete()
 
         snapshot.delete()
         return values


### PR DESCRIPTION
## Changes

Delete intermediary snapshot while when tests create snapshots in loops.

## Reason

Tests such as `test_snapshot_ab.py` or `test_5_snapshots` create snapshot files in a loop. This interacts badly with some debugging infrastructure added in #4590: If a test fails, then all files from all microVM chroots from that test are copied to `test_results`, and then uploaded as run artifacts. This means that if one of the 30 microVM restorations in `test_snapshot_ab.py` fails, we copy all, potentially 30, snapshot files to `test_results`. If these are large (which they can be: the test goes up to 12GB microVMs), this can cause the buildkite agent to run out of disk space.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
