### PR TITLE
Improve observability into failing tests

### DIFF
--- a/resources/chroot.sh
+++ b/resources/chroot.sh
@@ -11,7 +11,7 @@ PS4='+\t '
 
 cp -ruv $rootfs/* /
 
-packages="udev systemd-sysv openssh-server iproute2 curl socat python3-minimal iperf3 iputils-ping fio kmod tmux hwloc-nox vim-tiny trace-cmd linuxptp"
+packages="udev systemd-sysv openssh-server iproute2 curl socat python3-minimal iperf3 iputils-ping fio kmod tmux hwloc-nox vim-tiny trace-cmd linuxptp strace"
 
 # msr-tools is only supported on x86-64.
 arch=$(uname -m)

--- a/tests/framework/ab_test.py
+++ b/tests/framework/ab_test.py
@@ -106,7 +106,7 @@ def git_ab_test_host_command_if_pr(
     command: str,
     *,
     comparator: Callable[[CommandReturn, CommandReturn], bool] = default_comparator,
-    ignore_return_code_in_nonpr=False,
+    check_in_nonpr=True,
 ):
     """Runs the given bash command as an A/B-Test if we're in a pull request context (asserting that its stdout and
     stderr did not change across the PR). Otherwise runs the command, asserting it returns a zero exit code
@@ -115,9 +115,9 @@ def git_ab_test_host_command_if_pr(
         git_ab_test_host_command(command, comparator=comparator)
         return None
 
-    return utils.check_output(
+    return utils.run_cmd(
         command,
-        ignore_return_code=ignore_return_code_in_nonpr,
+        check=check_in_nonpr,
         cwd=Path.cwd().parent,
     )
 
@@ -131,9 +131,7 @@ def git_ab_test_host_command(
 ):
     """Performs an A/B-Test of the specified command, asserting that both the A and B invokations return the same stdout/stderr"""
     (_, old_out, old_err), (_, new_out, new_err), the_same = git_ab_test(
-        lambda path, _is_a: utils.check_output(
-            command, ignore_return_code=True, cwd=path
-        ),
+        lambda path, _is_a: utils.run_cmd(command, cwd=path),
         comparator,
         a_revision=a_revision,
         b_revision=b_revision,
@@ -190,7 +188,7 @@ def git_ab_test_guest_command_if_pr(
     command: str,
     *,
     comparator=default_comparator,
-    ignore_return_code_in_nonpr=False,
+    check_in_nonpr=True,
 ):
     """The same as git_ab_test_command_if_pr, but via SSH"""
     if is_pr():
@@ -198,10 +196,7 @@ def git_ab_test_guest_command_if_pr(
         return None
 
     microvm = microvm_factory(*get_firecracker_binaries())
-    ecode, stdout, stderr = microvm.ssh.run(command)
-    if not ignore_return_code_in_nonpr:
-        assert ecode == 0, f"stdout:\n{stdout}\nstderr:\n{stderr}\n"
-    return CommandReturn(ecode, stdout, stderr)
+    return microvm.ssh.run(command, check=check_in_nonpr)
 
 
 def check_regression(
@@ -237,9 +232,7 @@ def git_clone(clone_path, commitish):
     :return: the working copy directory.
     """
     if not clone_path.exists():
-        ret, _, _ = utils.check_output(
-            f"git cat-file -t {commitish}", ignore_return_code=True
-        )
+        ret, _, _ = utils.run_cmd(f"git cat-file -t {commitish}")
         if ret != 0:
             # git didn't recognize this object; qualify it if it is a branch
             commitish = f"origin/{commitish}"

--- a/tests/framework/ab_test.py
+++ b/tests/framework/ab_test.py
@@ -115,7 +115,7 @@ def git_ab_test_host_command_if_pr(
         git_ab_test_host_command(command, comparator=comparator)
         return None
 
-    return utils.run_cmd(
+    return utils.check_output(
         command,
         ignore_return_code=ignore_return_code_in_nonpr,
         cwd=Path.cwd().parent,
@@ -131,7 +131,9 @@ def git_ab_test_host_command(
 ):
     """Performs an A/B-Test of the specified command, asserting that both the A and B invokations return the same stdout/stderr"""
     (_, old_out, old_err), (_, new_out, new_err), the_same = git_ab_test(
-        lambda path, _is_a: utils.run_cmd(command, ignore_return_code=True, cwd=path),
+        lambda path, _is_a: utils.check_output(
+            command, ignore_return_code=True, cwd=path
+        ),
         comparator,
         a_revision=a_revision,
         b_revision=b_revision,
@@ -166,7 +168,7 @@ def git_ab_test_guest_command(
 
     @with_filelock
     def test_runner(workspace_dir, _is_a: bool):
-        utils.run_cmd("./tools/release.sh --profile release", cwd=workspace_dir)
+        utils.check_output("./tools/release.sh --profile release", cwd=workspace_dir)
         bin_dir = get_binary(
             "firecracker", workspace_dir=workspace_dir
         ).parent.resolve()
@@ -235,17 +237,17 @@ def git_clone(clone_path, commitish):
     :return: the working copy directory.
     """
     if not clone_path.exists():
-        ret, _, _ = utils.run_cmd(
+        ret, _, _ = utils.check_output(
             f"git cat-file -t {commitish}", ignore_return_code=True
         )
         if ret != 0:
             # git didn't recognize this object; qualify it if it is a branch
             commitish = f"origin/{commitish}"
         # make a temp branch for that commit so we can directly check it out
-        utils.run_cmd(f"git branch {clone_path} {commitish}")
-        _, git_root, _ = utils.run_cmd("git rev-parse --show-toplevel")
+        utils.check_output(f"git branch {clone_path} {commitish}")
+        _, git_root, _ = utils.check_output("git rev-parse --show-toplevel")
         # split off the '\n' at the end of the stdout
-        utils.run_cmd(f"git clone -b {clone_path} {git_root.strip()} {clone_path}")
+        utils.check_output(f"git clone -b {clone_path} {git_root.strip()} {clone_path}")
     return clone_path
 
 

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -13,7 +13,7 @@ import pytest
 
 from framework.defs import ARTIFACT_DIR
 from framework.properties import global_props
-from framework.utils import get_firecracker_version_from_toml, run_cmd
+from framework.utils import check_output, get_firecracker_version_from_toml
 from framework.with_filelock import with_filelock
 from host_tools.cargo_build import get_binary
 
@@ -129,7 +129,7 @@ class FirecrackerArtifact:
             return self.version_tuple[:2] + (0,)
 
         return (
-            run_cmd([self.path, "--snapshot-version"])
+            check_output([self.path, "--snapshot-version"])
             .stdout.strip()
             .split("\n")[0]
             .split(".")

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -214,7 +214,7 @@ class JailerContext:
                 # We do not need to know if it succeeded or not; afterall,
                 # we are trying to clean up resources created by the jailer
                 # itself not the testing system.
-                utils.check_output(cmd, ignore_return_code=True)
+                utils.run_cmd(cmd)
 
     def _kill_cgroup_tasks(self, controller):
         """Simulate wait on pid.

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -214,7 +214,7 @@ class JailerContext:
                 # We do not need to know if it succeeded or not; afterall,
                 # we are trying to clean up resources created by the jailer
                 # itself not the testing system.
-                utils.run_cmd(cmd, ignore_return_code=True)
+                utils.check_output(cmd, ignore_return_code=True)
 
     def _kill_cgroup_tasks(self, controller):
         """Simulate wait on pid.
@@ -234,7 +234,7 @@ class JailerContext:
             return True
 
         cmd = "cat {}".format(tasks_file)
-        result = utils.run_cmd(cmd)
+        result = utils.check_output(cmd)
 
         tasks_split = result.stdout.splitlines()
         for task in tasks_split:

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -294,7 +294,7 @@ class Microvm:
             # Killing screen will send SIGHUP to underlying Firecracker.
             # Needed to avoid false positives in case kill() is called again.
             self.expect_kill_by_signal = True
-            utils.run_cmd("kill -9 {} || true".format(self.screen_pid))
+            utils.check_output("kill -9 {} || true".format(self.screen_pid))
 
         # if microvm was spawned then check if it gets killed
         if self._spawned:
@@ -302,7 +302,9 @@ class Microvm:
             #  checking if the process is killed.
             time.sleep(1)
             # filter ps results for the jailer's unique id
-            rc, stdout, stderr = utils.run_cmd(f"ps aux | grep {self.jailer.jailer_id}")
+            rc, stdout, stderr = utils.check_output(
+                f"ps aux | grep {self.jailer.jailer_id}"
+            )
             # make sure firecracker was killed
             assert (
                 rc == 0 and stderr == "" and stdout.find("firecracker") == -1
@@ -374,7 +376,7 @@ class Microvm:
     @property
     def firecracker_version(self):
         """Return the version of the Firecracker executable."""
-        _, stdout, _ = utils.run_cmd(f"{self.fc_binary_path} --version")
+        _, stdout, _ = utils.check_output(f"{self.fc_binary_path} --version")
         return re.match(r"^Firecracker v(.+)", stdout.partition("\n")[0]).group(1)
 
     @property
@@ -666,7 +668,7 @@ class Microvm:
     def serial_input(self, input_string):
         """Send a string to the Firecracker serial console via screen."""
         input_cmd = f'screen -S {self.screen_session} -p 0 -X stuff "{input_string}"'
-        return utils.run_cmd(input_cmd)
+        return utils.check_output(input_cmd)
 
     def basic_config(
         self,
@@ -964,7 +966,7 @@ class Microvm:
             for pid in thread_pids:
                 backtraces.append(
                     f"{thread_name} ({pid=}):\n"
-                    f"{utils.run_cmd(f'cat /proc/{pid}/stack').stdout}"
+                    f"{utils.check_output(f'cat /proc/{pid}/stack').stdout}"
                 )
         return "\n".join(backtraces)
 

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -374,7 +374,7 @@ def _format_output_message(proc, stdout, stderr):
     return output_message
 
 
-def run_cmd(cmd, check=False, no_shell=False, cwd=None, timeout=None) -> CommandReturn:
+def run_cmd(cmd, check=False, shell=True, cwd=None, timeout=None) -> CommandReturn:
     """
     Execute a given command.
 
@@ -385,7 +385,7 @@ def run_cmd(cmd, check=False, no_shell=False, cwd=None, timeout=None) -> Command
     :param timeout: Time before command execution should be aborted with a `TimeoutExpired` exception
     :return: return code, stdout, stderr
     """
-    if isinstance(cmd, list) or no_shell:
+    if isinstance(cmd, list) or not shell:
         # Create the async process
         proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd
@@ -423,9 +423,9 @@ def run_cmd(cmd, check=False, no_shell=False, cwd=None, timeout=None) -> Command
     return CommandReturn(proc.returncode, stdout.decode(), stderr.decode())
 
 
-def check_output(cmd, no_shell=False, cwd=None, timeout=None) -> CommandReturn:
+def check_output(cmd, shell=True, cwd=None, timeout=None) -> CommandReturn:
     """Identical to `run_cmd`, but always sets `check_output` to `True`."""
-    return run_cmd(cmd, True, no_shell, cwd, timeout)
+    return run_cmd(cmd, True, shell, cwd, timeout)
 
 
 def assert_seccomp_level(pid, seccomp_level):

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -444,8 +444,7 @@ def assert_seccomp_level(pid, seccomp_level):
 
 def run_guest_cmd(ssh_connection, cmd, expected, use_json=False):
     """Runs a shell command at the remote accessible via SSH"""
-    rc, stdout, stderr = ssh_connection.run(cmd)
-    assert rc == 0
+    _, stdout, stderr = ssh_connection.check_output(cmd)
     assert stderr == ""
     stdout = stdout if not use_json else json.loads(stdout)
     assert stdout == expected
@@ -611,16 +610,12 @@ def check_filesystem(ssh_connection, disk_fmt, disk):
     """Check for filesystem corruption inside a microVM."""
     if disk_fmt == "squashfs":
         return
-    cmd = "fsck.{} -n {}".format(disk_fmt, disk)
-    exit_code, _, stderr = ssh_connection.run(cmd)
-    assert exit_code == 0, stderr
+    ssh_connection.check_output(f"fsck.{disk_fmt} -n {disk}")
 
 
 def check_entropy(ssh_connection):
     """Check that we can get random numbers from /dev/hwrng"""
-    cmd = "dd if=/dev/hwrng of=/dev/null bs=4096 count=1"
-    exit_code, _, stderr = ssh_connection.run(cmd)
-    assert exit_code == 0, stderr
+    ssh_connection.check_output("dd if=/dev/hwrng of=/dev/null bs=4096 count=1")
 
 
 @retry(wait=wait_fixed(0.5), stop=stop_after_attempt(5), reraise=True)

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -374,14 +374,12 @@ def _format_output_message(proc, stdout, stderr):
     return output_message
 
 
-def check_output(
-    cmd, ignore_return_code=False, no_shell=False, cwd=None, timeout=None
-) -> CommandReturn:
+def run_cmd(cmd, check=False, no_shell=False, cwd=None, timeout=None) -> CommandReturn:
     """
     Execute a given command.
 
     :param cmd: command to execute
-    :param ignore_return_code: whether a non-zero return code should result in a `ChildProcessError` or not.
+    :param check: whether a non-zero return code should result in a `ChildProcessError` or not.
     :param no_shell: don't run the command in a sub-shell
     :param cwd: sets the current directory before the child is executed
     :param timeout: Time before command execution should be aborted with a `TimeoutExpired` exception
@@ -415,7 +413,7 @@ def check_output(
     output_message = _format_output_message(proc, stdout, stderr)
 
     # If a non-zero return code was thrown, raise an exception
-    if not ignore_return_code and proc.returncode != 0:
+    if check and proc.returncode != 0:
         CMDLOG.warning("Command failed: %s\n", output_message)
 
         raise ChildProcessError(output_message)
@@ -423,6 +421,11 @@ def check_output(
     CMDLOG.debug(output_message)
 
     return CommandReturn(proc.returncode, stdout.decode(), stderr.decode())
+
+
+def check_output(cmd, no_shell=False, cwd=None, timeout=None) -> CommandReturn:
+    """Identical to `run_cmd`, but always sets `check_output` to `True`."""
+    return run_cmd(cmd, True, no_shell, cwd, timeout)
 
 
 def assert_seccomp_level(pid, seccomp_level):

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -397,8 +397,6 @@ def run_cmd_sync(cmd, ignore_return_code=False, no_shell=False, cwd=None, timeou
     if not ignore_return_code and proc.returncode != 0:
         output_message += f"\nReturned error code: {proc.returncode}"
 
-        if stderr != "":
-            output_message += f"\nstderr:\n{stderr.decode()}"
         raise ChildProcessError(output_message)
 
     # Log the message with one call so that multiple statuses

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -473,8 +473,7 @@ def get_firecracker_version_from_toml():
     the code has not been released.
     """
     cmd = "cd ../src/firecracker && cargo pkgid | cut -d# -f2 | cut -d: -f2"
-    rc, stdout, stderr = run_cmd(cmd)
-    assert rc == 0, stderr
+    _, stdout, _ = run_cmd(cmd)
     return packaging.version.parse(stdout)
 
 

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -374,14 +374,17 @@ def _format_output_message(proc, stdout, stderr):
     return output_message
 
 
-def run_cmd_sync(cmd, ignore_return_code=False, no_shell=False, cwd=None, timeout=None):
+def run_cmd(
+    cmd, ignore_return_code=False, no_shell=False, cwd=None, timeout=None
+) -> CommandReturn:
     """
     Execute a given command.
 
     :param cmd: command to execute
-    :param ignore_return_code: whether a non-zero return code should be ignored
+    :param ignore_return_code: whether a non-zero return code should result in a `ChildProcessError` or not.
     :param no_shell: don't run the command in a sub-shell
     :param cwd: sets the current directory before the child is executed
+    :param timeout: Time before command execution should be aborted with a `TimeoutExpired` exception
     :return: return code, stdout, stderr
     """
     if isinstance(cmd, list) or no_shell:
@@ -420,16 +423,6 @@ def run_cmd_sync(cmd, ignore_return_code=False, no_shell=False, cwd=None, timeou
     CMDLOG.debug(output_message)
 
     return CommandReturn(proc.returncode, stdout.decode(), stderr.decode())
-
-
-def run_cmd(cmd, **kwargs):
-    """
-    Run a command using the sync function that logs the output.
-
-    :param cmd: command to run
-    :returns: tuple of (return code, stdout, stderr)
-    """
-    return run_cmd_sync(cmd, **kwargs)
 
 
 def assert_seccomp_level(pid, seccomp_level):

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -409,11 +409,15 @@ def run_cmd_sync(cmd, ignore_return_code=False, no_shell=False, cwd=None, timeou
 
         raise
 
+    output_message = _format_output_message(proc, stdout, stderr)
+
     # If a non-zero return code was thrown, raise an exception
     if not ignore_return_code and proc.returncode != 0:
-        raise ChildProcessError(_format_output_message(proc, stdout, stderr))
+        CMDLOG.warning("Command failed: %s\n", output_message)
 
-    CMDLOG.debug(_format_output_message(proc, stdout, stderr))
+        raise ChildProcessError(output_message)
+
+    CMDLOG.debug(output_message)
 
     return CommandReturn(proc.returncode, stdout.decode(), stderr.decode())
 

--- a/tests/framework/utils_cpuid.py
+++ b/tests/framework/utils_cpuid.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 from enum import Enum, auto
 
-from framework.utils import run_cmd
+from framework.utils import check_output
 from framework.utils_imdsv2 import imdsv2_get
 
 
@@ -58,9 +58,9 @@ def get_cpu_vendor():
 def get_cpu_model_name():
     """Return the CPU model name."""
     if platform.machine() == "aarch64":
-        _, stdout, _ = run_cmd("cat /proc/cpuinfo | grep 'CPU part' | uniq")
+        _, stdout, _ = check_output("cat /proc/cpuinfo | grep 'CPU part' | uniq")
     else:
-        _, stdout, _ = run_cmd("cat /proc/cpuinfo | grep 'model name' | uniq")
+        _, stdout, _ = check_output("cat /proc/cpuinfo | grep 'model name' | uniq")
     info = stdout.strip().split(sep=":")
     assert len(info) == 2
     raw_cpu_model = info[1].strip()

--- a/tests/framework/utils_drive.py
+++ b/tests/framework/utils_drive.py
@@ -173,7 +173,7 @@ class CrosvmVhostUserBlkBackend(VhostUserBlkBackend):
         assert self.proc, "backend is not spawned"
         assert self.ctr_socket_path.exists()
 
-        utils.run_cmd(
+        utils.check_output(
             f"crosvm disk resize 0 {new_size * 1024 * 1024} {self.ctr_socket_path}"
         )
 

--- a/tests/framework/utils_ftrace.py
+++ b/tests/framework/utils_ftrace.py
@@ -3,7 +3,7 @@
 """Utilities for interacting with the kernel's ftrace subsystem"""
 import contextlib
 
-from framework.utils import run_cmd
+from framework.utils import check_output
 
 
 @contextlib.contextmanager
@@ -15,14 +15,14 @@ def ftrace_events(events: str = "*:*"):
     # We have to do system-wide tracing because inside docker we live in a pidns, but trace-cmd does not know about
     # this. We don't know how to translate the pidns PID to one ftrace would understand, so we use the fact that only
     # one vm is running at the same time, and thus we can attribute all KVM events to this one VM
-    run_cmd("mount -t tracefs nodev /sys/kernel/tracing")
-    run_cmd("echo > /sys/kernel/tracing/trace")  # clear the trace buffers
-    run_cmd(f"echo {events} > /sys/kernel/tracing/set_event")
-    run_cmd("echo nop > /sys/kernel/tracing/current_tracer")
-    run_cmd("echo 1 > /sys/kernel/tracing/tracing_on")
+    check_output("mount -t tracefs nodev /sys/kernel/tracing")
+    check_output("echo > /sys/kernel/tracing/trace")  # clear the trace buffers
+    check_output(f"echo {events} > /sys/kernel/tracing/set_event")
+    check_output("echo nop > /sys/kernel/tracing/current_tracer")
+    check_output("echo 1 > /sys/kernel/tracing/tracing_on")
 
     try:
         yield
     finally:
-        run_cmd("echo 0 > /sys/kernel/tracing/tracing_on")
-        run_cmd("umount /sys/kernel/tracing")
+        check_output("echo 0 > /sys/kernel/tracing/tracing_on")
+        check_output("umount /sys/kernel/tracing")

--- a/tests/framework/utils_iperf.py
+++ b/tests/framework/utils_iperf.py
@@ -48,7 +48,7 @@ class IPerf3Test:
                 .with_arg("--affinity", assigned_cpu)
                 .build()
             )
-            utils.run_cmd(f"{self._microvm.netns.cmd_prefix()} {cmd}")
+            utils.check_output(f"{self._microvm.netns.cmd_prefix()} {cmd}")
             first_free_cpu += 1
 
         # Wait for the iperf3 server to start

--- a/tests/framework/utils_iperf.py
+++ b/tests/framework/utils_iperf.py
@@ -119,11 +119,7 @@ class IPerf3Test:
             .build()
         )
 
-        rc, stdout, stderr = self._microvm.ssh.run(cmd)
-
-        assert rc == 0, stderr
-
-        return stdout
+        return self._microvm.ssh.check_output(cmd).stdout
 
     def host_command(self, port_offset):
         """Builds the command used for spawning an iperf3 server on the host"""

--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -100,8 +100,7 @@ def start_guest_echo_server(vm):
     Returns a UDS path to connect to the server.
     """
     cmd = f"nohup socat VSOCK-LISTEN:{ECHO_SERVER_PORT},backlog=128,reuseaddr,fork EXEC:'/bin/cat' > /dev/null 2>&1 &"
-    ecode, _, stderr = vm.ssh.run(cmd)
-    assert ecode == 0, stderr
+    vm.ssh.check_output(cmd)
 
     # Give the server time to initialise
     time.sleep(1)

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -26,7 +26,7 @@ def cargo(
     env = env or {}
     env_string = " ".join(f'{key}="{str(value)}"' for key, value in env.items())
     cmd = f"{env_string} cargo {subcommand} {cargo_args} -- {subcommand_args}"
-    return utils.run_cmd(cmd, cwd=cwd)
+    return utils.check_output(cmd, cwd=cwd)
 
 
 def get_rustflags():
@@ -90,7 +90,7 @@ def run_seccompiler_bin(bpf_path, json_path=defs.SECCOMP_JSON_DIR, basic=False):
         seccompiler_args += " --basic"
 
     seccompiler = get_binary("seccompiler-bin")
-    utils.run_cmd(f"{seccompiler} {seccompiler_args}")
+    utils.check_output(f"{seccompiler} {seccompiler_args}")
 
 
 def run_snap_editor_rebase(base_snap, diff_snap):
@@ -102,7 +102,7 @@ def run_snap_editor_rebase(base_snap, diff_snap):
     """
 
     snap_ed = get_binary("snapshot-editor")
-    utils.run_cmd(
+    utils.check_output(
         f"{snap_ed} edit-memory rebase --memory-path {base_snap} --diff-path {diff_snap}"
     )
 
@@ -115,7 +115,7 @@ def run_rebase_snap_bin(base_snap, diff_snap):
     :param diff_snap: path to diff snapshot mem file
     """
     rebase_snap = get_binary("rebase-snap")
-    utils.run_cmd(f"{rebase_snap} --base-file {base_snap} --diff-file {diff_snap}")
+    utils.check_output(f"{rebase_snap} --base-file {base_snap} --diff-file {diff_snap}")
 
 
 @with_filelock
@@ -124,4 +124,4 @@ def gcc_compile(src_file, output_file, extra_flags="-static -O3"):
     output_file = Path(output_file)
     if not output_file.exists():
         compile_cmd = f"gcc {src_file} -o {output_file} {extra_flags}"
-        utils.run_cmd(compile_cmd)
+        utils.check_output(compile_cmd)

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -90,8 +90,7 @@ def run_seccompiler_bin(bpf_path, json_path=defs.SECCOMP_JSON_DIR, basic=False):
         seccompiler_args += " --basic"
 
     seccompiler = get_binary("seccompiler-bin")
-    rc, _, _ = utils.run_cmd(f"{seccompiler} {seccompiler_args}")
-    assert rc == 0
+    utils.run_cmd(f"{seccompiler} {seccompiler_args}")
 
 
 def run_snap_editor_rebase(base_snap, diff_snap):
@@ -103,10 +102,9 @@ def run_snap_editor_rebase(base_snap, diff_snap):
     """
 
     snap_ed = get_binary("snapshot-editor")
-    rc, _, _ = utils.run_cmd(
+    utils.run_cmd(
         f"{snap_ed} edit-memory rebase --memory-path {base_snap} --diff-path {diff_snap}"
     )
-    assert rc == 0
 
 
 def run_rebase_snap_bin(base_snap, diff_snap):
@@ -117,10 +115,7 @@ def run_rebase_snap_bin(base_snap, diff_snap):
     :param diff_snap: path to diff snapshot mem file
     """
     rebase_snap = get_binary("rebase-snap")
-    rc, _, _ = utils.run_cmd(
-        f"{rebase_snap} --base-file {base_snap} --diff-file {diff_snap}"
-    )
-    assert rc == 0
+    utils.run_cmd(f"{rebase_snap} --base-file {base_snap} --diff-file {diff_snap}")
 
 
 @with_filelock

--- a/tests/host_tools/drive.py
+++ b/tests/host_tools/drive.py
@@ -36,11 +36,11 @@ class FilesystemFile:
         if os.path.isfile(path):
             raise FileExistsError("File already exists: " + path)
 
-        utils.run_cmd(
+        utils.check_output(
             "dd status=none if=/dev/zero"
             "    of=" + path + "    bs=1M count=" + str(size)
         )
-        utils.run_cmd("mkfs.ext4 -qF " + path)
+        utils.check_output("mkfs.ext4 -qF " + path)
         self.path = path
 
     def __repr__(self):
@@ -48,8 +48,8 @@ class FilesystemFile:
 
     def resize(self, new_size):
         """Resize the filesystem."""
-        utils.run_cmd("truncate --size " + str(new_size) + "M " + self.path)
-        utils.run_cmd("resize2fs " + self.path)
+        utils.check_output("truncate --size " + str(new_size) + "M " + self.path)
+        utils.check_output("resize2fs " + self.path)
 
     def size(self):
         """Return the size of the filesystem."""

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -77,7 +77,7 @@ class SSHConnection:
         self._scp(self.remote_path(remote_path), local_path, opts)
 
     @retry(
-        retry=retry_if_exception_type(ConnectionError),
+        retry=retry_if_exception_type(ChildProcessError),
         wait=wait_fixed(0.15),
         stop=stop_after_attempt(20),
         reraise=True,
@@ -90,9 +90,7 @@ class SSHConnection:
         We'll keep trying to execute a remote command that can't fail
         (`/bin/true`), until we get a successful (0) exit code.
         """
-        ecode, _, _ = self.run("true")
-        if ecode != 0:
-            raise ConnectionError
+        self.check_output("true")
 
     def run(self, cmd_string, timeout=None, *, check=False):
         """Execute the command passed as a string in the ssh context."""

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -113,9 +113,8 @@ class SSHConnection:
         """Private function that handles the ssh client invocation."""
         if self.netns is not None:
             cmd = ["ip", "netns", "exec", self.netns] + cmd
-        return utils.check_output(
-            cmd, ignore_return_code=not check, timeout=timeout
-        )
+
+        return utils.run_cmd(cmd, check=check, timeout=timeout)
 
 
 def mac_from_ip(ip_address):

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -113,7 +113,9 @@ class SSHConnection:
         """Private function that handles the ssh client invocation."""
         if self.netns is not None:
             cmd = ["ip", "netns", "exec", self.netns] + cmd
-        return utils.run_cmd(cmd, ignore_return_code=not check, timeout=timeout)
+        return utils.check_output(
+            cmd, ignore_return_code=not check, timeout=timeout
+        )
 
 
 def mac_from_ip(ip_address):
@@ -160,10 +162,10 @@ class Tap:
         # Avoid a conflict if two tests want to create the same tap device tap0
         # in the host before moving it into its own netns
         temp_name = "tap" + random_str(k=8)
-        utils.run_cmd(f"ip tuntap add mode tap name {temp_name}")
-        utils.run_cmd(f"ip link set {temp_name} name {name} netns {netns}")
+        utils.check_output(f"ip tuntap add mode tap name {temp_name}")
+        utils.check_output(f"ip link set {temp_name} name {name} netns {netns}")
         if ip:
-            utils.run_cmd(f"ip netns exec {netns} ifconfig {name} {ip} up")
+            utils.check_output(f"ip netns exec {netns} ifconfig {name} {ip} up")
         self._name = name
         self._netns = netns
 
@@ -179,7 +181,7 @@ class Tap:
 
     def set_tx_queue_len(self, tx_queue_len):
         """Set the length of the tap's TX queue."""
-        utils.run_cmd(
+        utils.check_output(
             "ip netns exec {} ip link set {} txqueuelen {}".format(
                 self.netns, self.name, tx_queue_len
             )
@@ -243,12 +245,12 @@ class NetNs:
     def setup(self):
         """Set up this network namespace."""
         if not self.path.exists():
-            utils.run_cmd(f"ip netns add {self.id}")
+            utils.check_output(f"ip netns add {self.id}")
 
     def cleanup(self):
         """Clean up this network namespace."""
         if self.path.exists():
-            utils.run_cmd(f"ip netns del {self.id}")
+            utils.check_output(f"ip netns del {self.id}")
 
     def add_tap(self, name, ip):
         """Add a TAP device to the namespace

--- a/tests/host_tools/proc.py
+++ b/tests/host_tools/proc.py
@@ -9,14 +9,14 @@ from framework import utils
 def proc_type():
     """Obtain the model processor on a Linux system."""
     cmd = "cat /proc/cpuinfo"
-    result = utils.run_cmd(cmd)
+    result = utils.check_output(cmd)
     lines = result.stdout.strip().splitlines()
     for line in lines:
         if "model name" in line:
             return re.sub(".*model name.*:", "", line, 1)
 
     cmd = "uname -m"
-    result = utils.run_cmd(cmd).stdout.strip()
+    result = utils.check_output(cmd).stdout.strip()
     if "aarch64" in result:
         return "ARM"
     return ""

--- a/tests/integration_tests/build/test_binary_static_linking.py
+++ b/tests/integration_tests/build/test_binary_static_linking.py
@@ -5,6 +5,7 @@
 """
 
 import pytest
+
 from framework import utils
 
 
@@ -14,7 +15,7 @@ def test_firecracker_binary_static_linking(microvm_factory):
     Test to make sure the firecracker binary is statically linked.
     """
     fc_binary_path = microvm_factory.fc_binary_path
-    _, stdout, stderr = utils.run_cmd(f"file {fc_binary_path}")
+    _, stdout, stderr = utils.check_output(f"file {fc_binary_path}")
     assert "" in stderr
     # expected "statically linked" for aarch64 and
     # "static-pie linked" for x86_64

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -84,7 +84,7 @@ def test_coverage(monkeypatch):
             --ignore *t2a* \
             "
 
-    utils.run_cmd(cmd)
+    utils.check_output(cmd)
 
     # Only upload if token is present and we're in EC2
     if "CODECOV_TOKEN" in os.environ and global_props.is_ec2:
@@ -92,7 +92,7 @@ def test_coverage(monkeypatch):
         branch = os.environ.get("BUILDKITE_BRANCH")
 
         if not branch:
-            branch = utils.run_cmd("git rev-parse --abbrev-ref HEAD").stdout
+            branch = utils.check_output("git rev-parse --abbrev-ref HEAD").stdout
 
         codecov_cmd = f"codecov -f {lcov_file} -F {global_props.host_linux_version}-{global_props.instance}"
 
@@ -101,7 +101,7 @@ def test_coverage(monkeypatch):
         else:
             codecov_cmd += f" -B {branch}"
 
-        utils.run_cmd(codecov_cmd)
+        utils.check_output(codecov_cmd)
     else:
         warnings.warn(
             "Not uploading coverage report due to missing CODECOV_TOKEN environment variable"

--- a/tests/integration_tests/functional/test_api_server.py
+++ b/tests/integration_tests/functional/test_api_server.py
@@ -4,7 +4,7 @@
 
 import socket
 
-from framework.utils import run_cmd
+from framework.utils import check_output
 
 
 def test_api_socket_in_use(uvm_plain):
@@ -19,7 +19,7 @@ def test_api_socket_in_use(uvm_plain):
     microvm = uvm_plain
 
     cmd = "mkdir {}/run".format(microvm.chroot())
-    run_cmd(cmd)
+    check_output(cmd)
 
     sock = socket.socket(socket.AF_UNIX)
     sock.bind(microvm.jailer.api_socket_path())

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -571,5 +571,4 @@ def test_memory_scrub(microvm_factory, guest_kernel, rootfs):
     # Wait for the deflate to complete.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
-    exit_code, _, _ = microvm.ssh.run("/usr/local/bin/readmem {} {}".format(60, 1))
-    assert exit_code == 0
+    microvm.ssh.check_output("/usr/local/bin/readmem {} {}".format(60, 1))

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -9,7 +9,7 @@ from subprocess import TimeoutExpired
 import pytest
 from tenacity import retry, stop_after_attempt, wait_fixed
 
-from framework.utils import get_free_mem_ssh, run_cmd
+from framework.utils import check_output, get_free_mem_ssh
 
 STATS_POLLING_INTERVAL_S = 1
 
@@ -26,7 +26,7 @@ def get_stable_rss_mem_by_pid(pid, percentage_delta=1):
     # All values are reported as KiB
 
     def get_rss_from_pmap():
-        _, output, _ = run_cmd("pmap -X {}".format(pid))
+        _, output, _ = check_output("pmap -X {}".format(pid))
         return int(output.split("\n")[-2].split()[1], 10)
 
     first_rss = get_rss_from_pmap()

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import packaging.version
 import pytest
 
-from framework.utils import run_cmd
+from framework.utils import check_output
 from host_tools.fcmetrics import validate_fc_metrics
 
 
@@ -49,7 +49,7 @@ def test_describe_snapshot_all_versions(
     fc_binary = microvm_factory.fc_binary_path
     # Verify the output of `--describe-snapshot` command line parameter
     cmd = [fc_binary] + ["--describe-snapshot", snapshot.vmstate]
-    _, stdout, stderr = run_cmd(cmd)
+    _, stdout, stderr = check_output(cmd)
     assert stderr == ""
     assert target_version in stdout
 

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -49,8 +49,7 @@ def test_describe_snapshot_all_versions(
     fc_binary = microvm_factory.fc_binary_path
     # Verify the output of `--describe-snapshot` command line parameter
     cmd = [fc_binary] + ["--describe-snapshot", snapshot.vmstate]
-    code, stdout, stderr = run_cmd(cmd)
-    assert code == 0, stderr
+    _, stdout, stderr = run_cmd(cmd)
     assert stderr == ""
     assert target_version in stdout
 

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -261,7 +261,7 @@ def test_config_start_with_limit(uvm_plain, vm_config_file):
     response += '{ "error": "Request payload with size 260 is larger than '
     response += "the limit of 250 allowed by server.\n"
     response += 'All previous unanswered requests will be dropped." }'
-    _, stdout, _stderr = utils.run_cmd(cmd)
+    _, stdout, _stderr = utils.check_output(cmd)
     assert stdout.encode("utf-8") == response.encode("utf-8")
 
 
@@ -295,7 +295,7 @@ def test_config_with_default_limit(uvm_plain, vm_config_file):
     response_err += '{ "error": "Request payload with size 51201 is larger '
     response_err += "than the limit of 51200 allowed by server.\n"
     response_err += 'All previous unanswered requests will be dropped." }'
-    _, stdout, _stderr = utils.run_cmd(cmd_err)
+    _, stdout, _stderr = utils.check_output(cmd_err)
     assert stdout.encode("utf-8") == response_err.encode("utf-8")
 
 

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -55,8 +55,7 @@ def _check_cpu_features_arm(test_microvm, guest_kv, template_name=None):
         case CpuModel.ARM_NEOVERSE_V1, _, None:
             expected_cpu_features = DEFAULT_G3_FEATURES_5_10
 
-    ret, stdout, stderr = test_microvm.ssh.run(r"lscpu |grep -oP '^Flags:\s+\K.+'")
-    assert ret == 0, stderr
+    _, stdout, _ = test_microvm.ssh.check_output(r"lscpu |grep -oP '^Flags:\s+\K.+'")
     flags = set(stdout.strip().split(" "))
     assert flags == expected_cpu_features
 

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -33,23 +33,23 @@ class CpuTemplateHelper:
     def template_dump(self, output_path):
         """Dump guest CPU config in the JSON custom CPU template format"""
         cmd = f"{self.binary} template dump --output {output_path}"
-        utils.run_cmd(cmd)
+        utils.check_output(cmd)
 
     def template_strip(self, paths, suffix=""):
         """Strip entries shared between multiple CPU template files"""
         paths = " ".join([str(path) for path in paths])
         cmd = f"{self.binary} template strip --paths {paths} --suffix '{suffix}'"
-        utils.run_cmd(cmd)
+        utils.check_output(cmd)
 
     def template_verify(self, template_path):
         """Verify the specified CPU template"""
         cmd = f"{self.binary} template verify --template {template_path}"
-        utils.run_cmd(cmd)
+        utils.check_output(cmd)
 
     def fingerprint_dump(self, output_path):
         """Dump a fingerprint"""
         cmd = f"{self.binary} fingerprint dump --output {output_path}"
-        utils.run_cmd(cmd)
+        utils.check_output(cmd)
 
     def fingerprint_compare(
         self,
@@ -64,7 +64,7 @@ class CpuTemplateHelper:
         )
         if filters:
             cmd += f" --filters {' '.join(filters)}"
-        utils.run_cmd(cmd)
+        utils.check_output(cmd)
 
 
 @pytest.fixture(scope="session", name="cpu_template_helper")

--- a/tests/integration_tests/functional/test_drive_vhost_user.py
+++ b/tests/integration_tests/functional/test_drive_vhost_user.py
@@ -312,8 +312,7 @@ def test_config_change(microvm_factory, guest_kernel, rootfs):
     _check_block_size(vm.ssh, "/dev/vdb", orig_size * 1024 * 1024)
 
     # Check that we can create a filesystem and mount it
-    ret, out, err = vm.ssh.run(mkfs_mount_cmd)
-    assert ret == 0, f"{ret}, {out}, {err}"
+    vm.ssh.check_output(mkfs_mount_cmd)
 
     for new_size in new_sizes:
         # Instruct the backend to resize the device.
@@ -328,5 +327,4 @@ def test_config_change(microvm_factory, guest_kernel, rootfs):
         _check_block_size(vm.ssh, "/dev/vdb", new_size * 1024 * 1024)
 
         # Check that we can create a filesystem and mount it
-        ret, out, err = vm.ssh.run(mkfs_mount_cmd)
-        assert ret == 0, f"{new_size=}, {ret=}, {out=}, {err=}"
+        vm.ssh.check_output(mkfs_mount_cmd)

--- a/tests/integration_tests/functional/test_drive_virtio.py
+++ b/tests/integration_tests/functional/test_drive_virtio.py
@@ -48,7 +48,7 @@ def test_rescan_file(uvm_plain_any, io_engine):
     # Check if reading from the entire disk results in a file of the same size
     # or errors out, after a truncate on the host.
     truncated_size = block_size // 2
-    utils.run_cmd(f"truncate --size {truncated_size}M {fs.path}")
+    utils.check_output(f"truncate --size {truncated_size}M {fs.path}")
     block_copy_name = "/tmp/dev_vdb_copy"
     _, _, stderr = test_microvm.ssh.run(
         f"dd if=/dev/vdb of={block_copy_name} bs=1M count={block_size}"
@@ -94,7 +94,7 @@ def test_device_ordering(uvm_plain_any, io_engine):
     test_microvm.start()
 
     # Determine the size of the microVM rootfs in bytes.
-    _, stdout, _ = utils.run_cmd(
+    _, stdout, _ = utils.check_output(
         "du --apparent-size --block-size=1 {}".format(test_microvm.rootfs_file),
     )
 
@@ -135,7 +135,7 @@ def test_rescan_dev(uvm_plain_any, io_engine):
     )
 
     losetup = ["losetup", "--find", "--show", fs2.path]
-    rc, stdout, _ = utils.run_cmd(losetup)
+    rc, stdout, _ = utils.check_output(losetup)
     assert rc == 0
     loopback_device = stdout.rstrip()
 
@@ -148,7 +148,7 @@ def test_rescan_dev(uvm_plain_any, io_engine):
         _check_block_size(test_microvm.ssh, "/dev/vdb", fs2.size())
     finally:
         if loopback_device:
-            utils.run_cmd(["losetup", "--detach", loopback_device])
+            utils.check_output(["losetup", "--detach", loopback_device])
 
 
 def test_non_partuuid_boot(uvm_plain_any, io_engine):

--- a/tests/integration_tests/functional/test_drive_virtio.py
+++ b/tests/integration_tests/functional/test_drive_virtio.py
@@ -94,10 +94,9 @@ def test_device_ordering(uvm_plain_any, io_engine):
     test_microvm.start()
 
     # Determine the size of the microVM rootfs in bytes.
-    rc, stdout, stderr = utils.run_cmd(
+    _, stdout, _ = utils.run_cmd(
         "du --apparent-size --block-size=1 {}".format(test_microvm.rootfs_file),
     )
-    assert rc == 0, f"Failed to get microVM rootfs size: {stderr}"
 
     assert len(stdout.split()) == 2
     rootfs_size = stdout.split("\t")[0]

--- a/tests/integration_tests/functional/test_drive_virtio.py
+++ b/tests/integration_tests/functional/test_drive_virtio.py
@@ -287,8 +287,7 @@ def test_patch_drive(uvm_plain_any, io_engine):
     # of the device, in bytes.
     blksize_cmd = "LSBLK_DEBUG=all lsblk -b /dev/vdb --output SIZE"
     size_bytes_str = "536870912"  # = 512 MiB
-    rc, stdout, stderr = test_microvm.ssh.run(blksize_cmd)
-    assert rc == 0, stderr
+    _, stdout, _ = test_microvm.ssh.check_output(blksize_cmd)
     lines = stdout.split("\n")
     # skip "SIZE"
     assert lines[1].strip() == size_bytes_str

--- a/tests/integration_tests/functional/test_kvm_ptp.py
+++ b/tests/integration_tests/functional/test_kvm_ptp.py
@@ -18,9 +18,7 @@ def test_kvm_ptp(uvm_plain_any):
     vm.add_net_iface()
     vm.start()
 
-    ret, _, stderr = vm.ssh.run("[ -c /dev/ptp0 ]")
-    assert ret == 0, stderr
+    vm.ssh.check_output("[ -c /dev/ptp0 ]")
 
     # phc_ctl[14515.127]: clock time is 1697545854.728335694 or Tue Oct 17 12:30:54 2023
-    ret, _, stderr = vm.ssh.run("phc_ctl /dev/ptp0 -- get")
-    assert ret == 0, stderr
+    vm.ssh.check_output("phc_ctl /dev/ptp0 -- get")

--- a/tests/integration_tests/functional/test_log_instrument.py
+++ b/tests/integration_tests/functional/test_log_instrument.py
@@ -78,7 +78,7 @@ def test_instrumentation_example_output(example, expected_output):
     example_binary = get_binary("log-instrument", example=example)
 
     # Logging output goes to stderr
-    _, stdout, stderr = utils.run_cmd(str(example_binary))
+    _, stdout, stderr = utils.check_output(str(example_binary))
 
     assert not stdout
 

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -33,8 +33,7 @@ def test_attach_maximum_devices(uvm_plain_any):
     # Test that network devices attached are operational.
     for i in range(MAX_DEVICES_ATTACHED - 1):
         # Verify if guest can run commands.
-        exit_code, _, _ = test_microvm.ssh_iface(i).run("sync")
-        assert exit_code == 0
+        test_microvm.ssh_iface(i).check_output("sync")
 
 
 @pytest.mark.skipif(

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -38,13 +38,12 @@ def test_high_ingress_traffic(uvm_plain_any):
 
     # Start iperf3 client on the host. Send 1Gbps UDP traffic.
     # If the net device breaks, iperf will freeze. We have to use a timeout.
-    utils.check_output(
+    utils.run_cmd(
         "timeout 30 {} {} -c {} -u -V -b 1000000000 -t 30".format(
             test_microvm.netns.cmd_prefix(),
             IPERF_BINARY,
             guest_ip,
         ),
-        ignore_return_code=True,
     )
 
     # Check if the high ingress traffic broke the net interface.

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -38,7 +38,7 @@ def test_high_ingress_traffic(uvm_plain_any):
 
     # Start iperf3 client on the host. Send 1Gbps UDP traffic.
     # If the net device breaks, iperf will freeze. We have to use a timeout.
-    utils.run_cmd(
+    utils.check_output(
         "timeout 30 {} {} -c {} -u -V -b 1000000000 -t 30".format(
             test_microvm.netns.cmd_prefix(),
             IPERF_BINARY,
@@ -63,8 +63,8 @@ def test_multi_queue_unsupported(uvm_plain):
 
     tapname = microvm.id[:8] + "tap1"
 
-    utils.run_cmd(f"ip tuntap add name {tapname} mode tap multi_queue")
-    utils.run_cmd(f"ip link set {tapname} netns {microvm.netns.id}")
+    utils.check_output(f"ip tuntap add name {tapname} mode tap multi_queue")
+    utils.check_output(f"ip link set {tapname} netns {microvm.netns.id}")
 
     expected_msg = re.escape(
         "Could not create the network device: Open tap device failed:"

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -50,8 +50,7 @@ def test_high_ingress_traffic(uvm_plain_any):
     # Check if the high ingress traffic broke the net interface.
     # If the net interface still works we should be able to execute
     # ssh commands.
-    exit_code, _, _ = test_microvm.ssh.run("echo success\n")
-    assert exit_code == 0
+    test_microvm.ssh.check_output("echo success\n")
 
 
 def test_multi_queue_unsupported(uvm_plain):

--- a/tests/integration_tests/functional/test_net_config_space.py
+++ b/tests/integration_tests/functional/test_net_config_space.py
@@ -75,8 +75,7 @@ def test_net_change_mac_address(uvm_plain_any, change_net_config_space_bin):
     cmd = f"chmod u+x {rmt_path} && {rmt_path} {net_addr_base} {mac_hex}"
 
     # This should be executed successfully.
-    exit_code, stdout, stderr = ssh_conn.run(cmd)
-    assert exit_code == 0, stderr
+    _, stdout, _ = ssh_conn.check_output(cmd)
     assert stdout == mac
 
     # Discard any parasite data exchange which might've been
@@ -155,9 +154,8 @@ def _send_data_g2h(ssh_connection, host_ip, host_port, iterations, data, retries
     )
 
     # Wait server to initialize.
-    exit_code, _, stderr = ssh_connection.run(cmd)
+    _, _, stderr = ssh_connection.check_output(cmd)
     # If this assert fails, a connection refused happened.
-    assert exit_code == 0, stderr
     assert stderr == ""
 
 
@@ -239,8 +237,7 @@ def _get_net_mem_addr_base_x86_acpi(ssh_connection, if_name):
     # are identified as "LNRO0005" and appear under /sys/devices/platform
     sys_virtio_mmio_cmdline = "/sys/devices/platform/"
     cmd = "ls {}"
-    exit_code, stdout, stderr = ssh_connection.run(cmd.format(sys_virtio_mmio_cmdline))
-    assert exit_code == 0, stderr
+    _, stdout, _ = ssh_connection.check_output(cmd.format(sys_virtio_mmio_cmdline))
     virtio_devs = list(filter(lambda x: "LNRO0005" in x, stdout.strip().split()))
 
     # For virtio-net LNRO0005 devices, we should have a path like:
@@ -267,8 +264,7 @@ def _get_net_mem_addr_base_x86_cmdline(ssh_connection, if_name):
     virtio_devs_idx = stdout.strip().split()
 
     cmd = "cat /proc/cmdline"
-    exit_code, cmd_line, stderr = ssh_connection.run(cmd)
-    assert exit_code == 0, stderr
+    _, cmd_line, _ = ssh_connection.check_output(cmd)
     pattern_dev = re.compile("(virtio_mmio.device=4K@0x[0-9a-f]+:[0-9]+)+")
     pattern_addr = re.compile("virtio_mmio.device=4K@(0x[0-9a-f]+):[0-9]+")
     devs_addr = []

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -44,8 +44,7 @@ def test_rng_not_present(uvm_nano):
     # the device should exist in the guest filesystem but we should
     # not be able to get random numbers out of it.
     cmd = "test -e /dev/hwrng"
-    ecode, _, _ = vm.ssh.run(cmd)
-    assert ecode == 0
+    vm.ssh.check_output(cmd)
 
     cmd = "dd if=/dev/hwrng of=/dev/null bs=10 count=1"
     ecode, _, _ = vm.ssh.run(cmd)
@@ -138,8 +137,7 @@ def _get_throughput(ssh, random_bytes):
     # Issue a `dd` command to request 100 times `random_bytes` from the device.
     # 100 here is used to get enough confidence on the achieved throughput.
     cmd = "dd if=/dev/hwrng of=/dev/null bs={} count=100".format(random_bytes)
-    exit_code, _, stderr = ssh.run(cmd)
-    assert exit_code == 0, stderr
+    _, _, stderr = ssh.check_output(cmd)
 
     # dd gives its output on stderr
     return _process_dd_output(stderr)

--- a/tests/integration_tests/functional/test_rtc.py
+++ b/tests/integration_tests/functional/test_rtc.py
@@ -32,6 +32,6 @@ def test_rtc(uvm_plain_any):
     _, stdout, _ = vm.ssh.run("stat /dev/rtc0")
     assert "character special file" in stdout
 
-    _, host_stdout, _ = utils.run_cmd("date +%s")
+    _, host_stdout, _ = utils.check_output("date +%s")
     _, guest_stdout, _ = vm.ssh.run("date +%s")
     assert abs(int(guest_stdout) - int(host_stdout)) < 5

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -117,7 +117,7 @@ def test_serial_console_login(uvm_plain_any):
 def get_total_mem_size(pid):
     """Get total memory usage for a process."""
     cmd = f"pmap {pid} | tail -n 1 | sed 's/^ //' | tr -s ' ' | cut -d' ' -f2"
-    _, stdout, stderr = utils.run_cmd(cmd)
+    _, stdout, stderr = utils.check_output(cmd)
     assert stderr == ""
 
     return stdout

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -190,17 +190,15 @@ def test_serial_block(uvm_plain_any):
     subprocess.check_call("kill -s STOP {}".format(screen_pid), shell=True)
 
     # Generate a random text file.
-    exit_code, _, _ = test_microvm.ssh.run(
+    test_microvm.ssh.check_output(
         "base64 /dev/urandom | head -c 100000 > /tmp/file.txt"
     )
 
     # Dump output to terminal
-    exit_code, _, _ = test_microvm.ssh.run("cat /tmp/file.txt > /dev/ttyS0")
-    assert exit_code == 0
+    test_microvm.ssh.check_output("cat /tmp/file.txt > /dev/ttyS0")
 
     # Check that the vCPU isn't blocked.
-    exit_code, _, _ = test_microvm.ssh.run("cd /")
-    assert exit_code == 0
+    test_microvm.ssh.check_output("cd /")
 
     # Check the metrics to see if the serial missed bytes.
     fc_metrics = test_microvm.flush_metrics()

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -117,8 +117,7 @@ def test_serial_console_login(uvm_plain_any):
 def get_total_mem_size(pid):
     """Get total memory usage for a process."""
     cmd = f"pmap {pid} | tail -n 1 | sed 's/^ //' | tr -s ' ' | cut -d' ' -f2"
-    rc, stdout, stderr = utils.run_cmd(cmd)
-    assert rc == 0
+    _, stdout, stderr = utils.run_cmd(cmd)
     assert stderr == ""
 
     return stdout

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -34,7 +34,7 @@ def test_reboot(uvm_plain_any):
 
     # Get number of threads in Firecracker
     cmd = "ps -o nlwp {} | tail -1 | awk '{{print $1}}'".format(firecracker_pid)
-    _, stdout, _ = utils.run_cmd(cmd)
+    _, stdout, _ = utils.check_output(cmd)
     nr_of_threads = stdout.rstrip()
     assert int(nr_of_threads) == 6
 

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -97,7 +97,7 @@ def test_sigxfsz_handler(uvm_plain_rw):
 
     while True:
         try:
-            utils.run_cmd("ps -p {}".format(firecracker_pid))
+            utils.check_output("ps -p {}".format(firecracker_pid))
             sleep(1)
         except ChildProcessError:
             break

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -37,8 +37,7 @@ def check_vmgenid_update_count(vm, resume_count):
     Kernel will emit the DMESG_VMGENID_RESUME every time we resume
     from a snapshot
     """
-    rc, stdout, stderr = vm.ssh.run("dmesg")
-    assert rc == 0, stderr
+    _, stdout, _ = vm.ssh.check_output("dmesg")
     assert resume_count == stdout.count(DMESG_VMGENID_RESUME)
 
 
@@ -481,8 +480,7 @@ def test_diff_snapshot_overlay(guest_kernel, rootfs, microvm_factory):
     basevm.resume()
 
     # Run some command to dirty some pages
-    rc, _, stderr = basevm.ssh.run("true")
-    assert rc == 0, stderr
+    basevm.ssh.check_output("true")
 
     # First copy the base snapshot somewhere else, so we can make sure
     # it will actually get updated

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -15,7 +15,7 @@ import pytest
 import host_tools.drive as drive_tools
 from framework.microvm import SnapshotType
 from framework.properties import global_props
-from framework.utils import check_filesystem, run_cmd, wait_process_termination
+from framework.utils import check_filesystem, check_output, wait_process_termination
 from framework.utils_vsock import (
     ECHO_SERVER_PORT,
     VSOCK_UDS_PATH,
@@ -108,13 +108,13 @@ def test_snapshot_current_version(uvm_nano):
     fc_binary = uvm_nano.fc_binary_path
     # Get supported snapshot version from Firecracker binary
     snapshot_version = (
-        run_cmd(f"{fc_binary} --snapshot-version").stdout.strip().splitlines()[0]
+        check_output(f"{fc_binary} --snapshot-version").stdout.strip().splitlines()[0]
     )
 
     # Verify the output of `--describe-snapshot` command line parameter
     cmd = [str(fc_binary)] + ["--describe-snapshot", str(snapshot.vmstate)]
 
-    _, stdout, _ = run_cmd(cmd)
+    _, stdout, _ = check_output(cmd)
     assert snapshot_version in stdout
 
 

--- a/tests/integration_tests/functional/test_snapshot_editor.py
+++ b/tests/integration_tests/functional/test_snapshot_editor.py
@@ -40,7 +40,7 @@ def test_remove_regs(uvm_nano, microvm_factory):
         "--vmstate-path",
         str(snapshot.vmstate),
     ]
-    _, stdout, _ = utils.run_cmd(cmd)
+    _, stdout, _ = utils.check_output(cmd)
     assert MIDR_EL1 in stdout
 
     # Remove MIDR_EL1 register from the snapshot
@@ -54,7 +54,7 @@ def test_remove_regs(uvm_nano, microvm_factory):
         str(snapshot.vmstate),
         str(MIDR_EL1),
     ]
-    utils.run_cmd(cmd)
+    utils.check_output(cmd)
 
     # Test that MIDR_EL1 is not in the snapshot
     cmd = [
@@ -64,7 +64,7 @@ def test_remove_regs(uvm_nano, microvm_factory):
         "--vmstate-path",
         str(snapshot.vmstate),
     ]
-    _, stdout, _ = utils.run_cmd(cmd)
+    _, stdout, _ = utils.check_output(cmd)
     assert MIDR_EL1 not in stdout
 
     # test that we can restore from a snapshot

--- a/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
+++ b/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
@@ -59,8 +59,7 @@ def _test_mmds(vm, mmds_net_iface):
     cmd = "ip route add {} dev {}".format(
         mmds_net_iface.guest_ip, mmds_net_iface.dev_name
     )
-    code, _, _ = vm.ssh.run(cmd)
-    assert code == 0
+    vm.ssh.check_output(cmd)
 
     # The base microVM had MMDS version 2 configured, which was persisted
     # across the snapshot-restore.
@@ -117,8 +116,7 @@ def test_snap_restore_from_artifacts(
     # Test that net devices have connectivity after restore.
     for idx, iface in enumerate(vm.iface.values()):
         logger.info("Testing net device %s...", iface["iface"].dev_name)
-        exit_code, _, _ = vm.ssh_iface(idx).run("true")
-        assert exit_code == 0
+        vm.ssh_iface(idx).check_output("true")
 
     logger.info("Testing data store behavior...")
     _test_mmds(vm, vm.iface["eth3"]["iface"])

--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -8,7 +8,7 @@ import re
 import pytest
 import requests
 
-from framework.utils import Timeout, UffdHandler, run_cmd
+from framework.utils import Timeout, UffdHandler, check_output
 
 SOCKET_PATH = "/firecracker-uffd.sock"
 
@@ -82,7 +82,7 @@ def test_unbinded_socket(uvm_plain, snapshot):
 
     jailed_vmstate = vm.create_jailed_resource(snapshot.vmstate)
     socket_path = os.path.join(vm.path, "firecracker-uffd.sock")
-    run_cmd("touch {}".format(socket_path))
+    check_output("touch {}".format(socket_path))
     jailed_sock_path = vm.create_jailed_resource(socket_path)
 
     expected_msg = re.escape(

--- a/tests/integration_tests/performance/test_benchmarks.py
+++ b/tests/integration_tests/performance/test_benchmarks.py
@@ -50,7 +50,7 @@ def run_criterion(firecracker_checkout: Path, is_a: bool) -> Path:
                     executables.append(executable)
 
         for executable in executables:
-            utils.run_cmd(
+            utils.check_output(
                 f"CARGO_TARGET_DIR=build/cargo_target taskset -c 1 {executable} --bench --save-baseline {baseline_name}"
             )
 

--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 import host_tools.drive as drive_tools
-from framework.utils import CmdBuilder, run_cmd, track_cpu_utilization
+from framework.utils import CmdBuilder, check_output, track_cpu_utilization
 from host_tools.fcmetrics import FCMetricsMonitor
 
 # size of the block device used in the test, in MB
@@ -41,8 +41,8 @@ def prepare_microvm_for_test(microvm):
     assert stderr == ""
 
     # Then, flush all host cached data to hardware, also drop host FS caches.
-    run_cmd("sync")
-    run_cmd("echo 3 > /proc/sys/vm/drop_caches")
+    check_output("sync")
+    check_output("echo 3 > /proc/sys/vm/drop_caches")
 
 
 def run_fio(microvm, mode, block_size):

--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -29,16 +29,15 @@ GUEST_MEM_MIB = 1024
 def prepare_microvm_for_test(microvm):
     """Prepares the microvm for running a fio-based performance test by tweaking
     various performance related parameters."""
-    rc, _, stderr = microvm.ssh.run("echo 'none' > /sys/block/vdb/queue/scheduler")
-    assert rc == 0, stderr
+    _, _, stderr = microvm.ssh.check_output(
+        "echo 'none' > /sys/block/vdb/queue/scheduler"
+    )
     assert stderr == ""
 
     # First, flush all guest cached data to host, then drop guest FS caches.
-    rc, _, stderr = microvm.ssh.run("sync")
-    assert rc == 0, stderr
+    _, _, stderr = microvm.ssh.check_output("sync")
     assert stderr == ""
-    rc, _, stderr = microvm.ssh.run("echo 3 > /proc/sys/vm/drop_caches")
-    assert rc == 0, stderr
+    _, _, stderr = microvm.ssh.check_output("echo 3 > /proc/sys/vm/drop_caches")
     assert stderr == ""
 
     # Then, flush all host cached data to hardware, also drop host FS caches.
@@ -99,8 +98,7 @@ def run_fio(microvm, mode, block_size):
         assert stderr == ""
 
         microvm.ssh.scp_get("/tmp/*.log", logs_path)
-        rc, _, stderr = microvm.ssh.run("rm /tmp/*.log")
-        assert rc == 0, stderr
+        microvm.ssh.check_output("rm /tmp/*.log")
 
         return logs_path, cpu_load_future.result()
 

--- a/tests/integration_tests/performance/test_drive_rate_limiter.py
+++ b/tests/integration_tests/performance/test_drive_rate_limiter.py
@@ -19,8 +19,7 @@ def check_iops_limit(ssh_connection, block_size, count, min_time, max_time):
     )
     print("Running cmd {}".format(dd))
     # Check write iops (writing with oflag=direct is more reliable).
-    exit_code, _, stderr = ssh_connection.run(dd)
-    assert exit_code == 0
+    _, _, stderr = ssh_connection.check_output(dd)
 
     # "dd" writes to stderr by design. We drop first lines
     lines = stderr.split("\n")

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -49,7 +49,7 @@ def check_hugetlbfs_in_use(pid: int, allocation_name: str):
     #   THPeligible:           0
     #   ProtectionKey:         0
     cmd = f"cat /proc/{pid}/smaps | grep {allocation_name} -A 23 | grep KernelPageSize"
-    _, stdout, _ = utils.run_cmd(cmd)
+    _, stdout, _ = utils.check_output(cmd)
 
     kernel_page_size_kib = int(stdout.split()[1])
     assert kernel_page_size_kib > 4
@@ -249,7 +249,7 @@ def test_ept_violation_count(
             trace_entry = "kvm_guest_fault"
             metric = "guest_page_faults"
 
-        _, metric_value, _ = utils.run_cmd(
+        _, metric_value, _ = utils.check_output(
             f"cat /sys/kernel/tracing/trace | grep '{trace_entry}' | wc -l"
         )
 

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -78,10 +78,9 @@ def test_network_latency(network_microvm, metrics):
     host_ip = network_microvm.iface["eth0"]["iface"].host_ip
 
     for _ in range(rounds):
-        rc, ping_output, stderr = network_microvm.ssh.run(
+        _, ping_output, _ = network_microvm.ssh.check_output(
             f"ping -c {request_per_round} -i {delay} {host_ip}"
         )
-        assert rc == 0, stderr
 
         samples.extend(consume_ping_output(ping_output, request_per_round))
     fcmetrics.stop()

--- a/tests/integration_tests/performance/test_rate_limiter.py
+++ b/tests/integration_tests/performance/test_rate_limiter.py
@@ -404,7 +404,7 @@ def _start_iperf_server_on_host(netns_cmd_prefix):
 
     # Don't check the result of this command because it can fail if no iperf
     # is running.
-    utils.check_output(iperf_cmd, ignore_return_code=True)
+    utils.run_cmd(iperf_cmd)
 
     iperf_cmd = "{} {} -sD -f KBytes\n".format(netns_cmd_prefix, IPERF_BINARY)
 

--- a/tests/integration_tests/performance/test_rate_limiter.py
+++ b/tests/integration_tests/performance/test_rate_limiter.py
@@ -404,11 +404,11 @@ def _start_iperf_server_on_host(netns_cmd_prefix):
 
     # Don't check the result of this command because it can fail if no iperf
     # is running.
-    utils.run_cmd(iperf_cmd, ignore_return_code=True)
+    utils.check_output(iperf_cmd, ignore_return_code=True)
 
     iperf_cmd = "{} {} -sD -f KBytes\n".format(netns_cmd_prefix, IPERF_BINARY)
 
-    utils.run_cmd(iperf_cmd)
+    utils.check_output(iperf_cmd)
 
     # Wait for the iperf daemon to start.
     time.sleep(1)
@@ -416,7 +416,7 @@ def _start_iperf_server_on_host(netns_cmd_prefix):
 
 def _run_iperf_on_host(iperf_cmd):
     """Execute a client related iperf command locally."""
-    code, stdout, stderr = utils.run_cmd(iperf_cmd)
+    code, stdout, stderr = utils.check_output(iperf_cmd)
     assert code == 0, f"stdout: {stdout}\nstderr: {stderr}"
 
     return stdout

--- a/tests/integration_tests/performance/test_rate_limiter.py
+++ b/tests/integration_tests/performance/test_rate_limiter.py
@@ -395,9 +395,7 @@ def _start_iperf_server_on_guest(test_microvm, hostname):
 def _run_iperf_on_guest(test_microvm, iperf_cmd, hostname):
     """Run a client related iperf command through an SSH connection."""
     test_microvm.guest_ip = hostname
-    code, stdout, stderr = test_microvm.ssh.run(iperf_cmd)
-    assert code == 0, f"stdout: {stdout}\nstderr: {stderr}"
-    return stdout
+    return test_microvm.ssh.check_output(iperf_cmd).stdout
 
 
 def _start_iperf_server_on_host(netns_cmd_prefix):

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -115,7 +115,7 @@ def test_seccomp_ls(bin_seccomp_paths):
     bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer.
-    outcome = utils.run_cmd(
+    outcome = utils.check_output(
         [demo_jailer, ls_command_path, bpf_path], no_shell=True, ignore_return_code=True
     )
 
@@ -180,7 +180,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
     bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer for harmless binary.
-    outcome = utils.run_cmd(
+    outcome = utils.check_output(
         [demo_jailer, demo_harmless, bpf_path], no_shell=True, ignore_return_code=True
     )
 
@@ -188,7 +188,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
     assert outcome.returncode == 0
 
     # Run the mini jailer for malicious binary.
-    outcome = utils.run_cmd(
+    outcome = utils.check_output(
         [demo_jailer, demo_malicious, bpf_path], no_shell=True, ignore_return_code=True
     )
 
@@ -201,7 +201,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
     bpf_path = _run_seccompiler_bin(json_filter, basic=True)
 
     # Run the mini jailer for malicious binary.
-    outcome = utils.run_cmd(
+    outcome = utils.check_output(
         [demo_jailer, demo_malicious, bpf_path], no_shell=True, ignore_return_code=True
     )
 
@@ -224,7 +224,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
     # Run seccompiler-bin.
     bpf_path = _run_seccompiler_bin(json_filter)
 
-    outcome = utils.run_cmd(
+    outcome = utils.check_output(
         [demo_jailer, demo_harmless, bpf_path], no_shell=True, ignore_return_code=True
     )
 
@@ -288,7 +288,7 @@ def test_seccomp_rust_panic(bin_seccomp_paths):
 
     # Run the panic binary with all filters.
     for thread in filter_threads:
-        code, _, _ = utils.run_cmd(
+        code, _, _ = utils.check_output(
             [demo_panic, bpf_path, thread], no_shell=True, ignore_return_code=True
         )
         # The demo panic binary should have terminated with SIGABRT

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -115,7 +115,7 @@ def test_seccomp_ls(bin_seccomp_paths):
     bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer.
-    outcome = utils.run_cmd([demo_jailer, ls_command_path, bpf_path], no_shell=True)
+    outcome = utils.run_cmd([demo_jailer, ls_command_path, bpf_path], shell=False)
 
     os.unlink(bpf_path)
 
@@ -178,13 +178,13 @@ def test_advanced_seccomp(bin_seccomp_paths):
     bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer for harmless binary.
-    outcome = utils.run_cmd([demo_jailer, demo_harmless, bpf_path], no_shell=True)
+    outcome = utils.run_cmd([demo_jailer, demo_harmless, bpf_path], shell=False)
 
     # The demo harmless binary should have terminated gracefully.
     assert outcome.returncode == 0
 
     # Run the mini jailer for malicious binary.
-    outcome = utils.run_cmd([demo_jailer, demo_malicious, bpf_path], no_shell=True)
+    outcome = utils.run_cmd([demo_jailer, demo_malicious, bpf_path], shell=False)
 
     # The demo malicious binary should have received `SIGSYS`.
     assert outcome.returncode == -31
@@ -195,7 +195,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
     bpf_path = _run_seccompiler_bin(json_filter, basic=True)
 
     # Run the mini jailer for malicious binary.
-    outcome = utils.run_cmd([demo_jailer, demo_malicious, bpf_path], no_shell=True)
+    outcome = utils.run_cmd([demo_jailer, demo_malicious, bpf_path], shell=False)
 
     # The malicious binary also terminates gracefully, since the --basic option
     # disables all argument checks.
@@ -216,7 +216,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
     # Run seccompiler-bin.
     bpf_path = _run_seccompiler_bin(json_filter)
 
-    outcome = utils.run_cmd([demo_jailer, demo_harmless, bpf_path], no_shell=True)
+    outcome = utils.run_cmd([demo_jailer, demo_harmless, bpf_path], shell=False)
 
     # The demo binary should have received `SIGSYS`.
     assert outcome.returncode == -31
@@ -278,7 +278,7 @@ def test_seccomp_rust_panic(bin_seccomp_paths):
 
     # Run the panic binary with all filters.
     for thread in filter_threads:
-        code, _, _ = utils.run_cmd([demo_panic, bpf_path, thread], no_shell=True)
+        code, _, _ = utils.run_cmd([demo_panic, bpf_path, thread], shell=False)
         # The demo panic binary should have terminated with SIGABRT
         # and not with a seccomp violation.
         # On a seccomp violation, the program exits with code -31 for

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -115,9 +115,7 @@ def test_seccomp_ls(bin_seccomp_paths):
     bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer.
-    outcome = utils.check_output(
-        [demo_jailer, ls_command_path, bpf_path], no_shell=True, ignore_return_code=True
-    )
+    outcome = utils.run_cmd([demo_jailer, ls_command_path, bpf_path], no_shell=True)
 
     os.unlink(bpf_path)
 
@@ -180,17 +178,13 @@ def test_advanced_seccomp(bin_seccomp_paths):
     bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer for harmless binary.
-    outcome = utils.check_output(
-        [demo_jailer, demo_harmless, bpf_path], no_shell=True, ignore_return_code=True
-    )
+    outcome = utils.run_cmd([demo_jailer, demo_harmless, bpf_path], no_shell=True)
 
     # The demo harmless binary should have terminated gracefully.
     assert outcome.returncode == 0
 
     # Run the mini jailer for malicious binary.
-    outcome = utils.check_output(
-        [demo_jailer, demo_malicious, bpf_path], no_shell=True, ignore_return_code=True
-    )
+    outcome = utils.run_cmd([demo_jailer, demo_malicious, bpf_path], no_shell=True)
 
     # The demo malicious binary should have received `SIGSYS`.
     assert outcome.returncode == -31
@@ -201,9 +195,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
     bpf_path = _run_seccompiler_bin(json_filter, basic=True)
 
     # Run the mini jailer for malicious binary.
-    outcome = utils.check_output(
-        [demo_jailer, demo_malicious, bpf_path], no_shell=True, ignore_return_code=True
-    )
+    outcome = utils.run_cmd([demo_jailer, demo_malicious, bpf_path], no_shell=True)
 
     # The malicious binary also terminates gracefully, since the --basic option
     # disables all argument checks.
@@ -224,9 +216,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
     # Run seccompiler-bin.
     bpf_path = _run_seccompiler_bin(json_filter)
 
-    outcome = utils.check_output(
-        [demo_jailer, demo_harmless, bpf_path], no_shell=True, ignore_return_code=True
-    )
+    outcome = utils.run_cmd([demo_jailer, demo_harmless, bpf_path], no_shell=True)
 
     # The demo binary should have received `SIGSYS`.
     assert outcome.returncode == -31
@@ -288,9 +278,7 @@ def test_seccomp_rust_panic(bin_seccomp_paths):
 
     # Run the panic binary with all filters.
     for thread in filter_threads:
-        code, _, _ = utils.check_output(
-            [demo_panic, bpf_path, thread], no_shell=True, ignore_return_code=True
-        )
+        code, _, _ = utils.run_cmd([demo_panic, bpf_path, thread], no_shell=True)
         # The demo panic binary should have terminated with SIGABRT
         # and not with a seccomp violation.
         # On a seccomp violation, the program exits with code -31 for

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -436,8 +436,7 @@ def check_vulnerabilities_files_on_guest(microvm):
     """
     # Retrieve a list of vulnerabilities files available inside guests.
     vuln_dir = "/sys/devices/system/cpu/vulnerabilities"
-    ecode, stdout, stderr = microvm.ssh.run(f"find -D all {vuln_dir} -type f")
-    assert ecode == 0, f"stdout:\n{stdout}\nstderr:\n{stderr}\n"
+    _, stdout, _ = microvm.ssh.check_output(f"find -D all {vuln_dir} -type f")
     vuln_files = stdout.split("\n")
 
     # Fixtures in this file (test_vulnerabilities.py) add this special field.

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -232,7 +232,7 @@ def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
         comparator=set_did_not_grow_comparator(
             spectre_meltdown_reported_vulnerablities
         ),
-        ignore_return_code_in_nonpr=True,
+        check_in_nonpr=False,
     )
 
     # Outside the PR context, checks the return code with some exceptions.
@@ -269,7 +269,7 @@ def test_spectre_meltdown_checker_on_guest(spectre_meltdown_checker, build_micro
         comparator=set_did_not_grow_comparator(
             spectre_meltdown_reported_vulnerablities
         ),
-        ignore_return_code_in_nonpr=True,
+        check_in_nonpr=False,
     )
     if status and status.returncode != 0:
         check_vulnerabilities_on_guest(status)
@@ -290,7 +290,7 @@ def test_spectre_meltdown_checker_on_restored_guest(
         comparator=set_did_not_grow_comparator(
             spectre_meltdown_reported_vulnerablities
         ),
-        ignore_return_code_in_nonpr=True,
+        check_in_nonpr=False,
     )
     if status and status.returncode != 0:
         check_vulnerabilities_on_guest(status)

--- a/tests/integration_tests/style/test_gitlint.py
+++ b/tests/integration_tests/style/test_gitlint.py
@@ -14,7 +14,7 @@ def test_gitlint():
     os.environ["LC_ALL"] = "C.UTF-8"
     os.environ["LANG"] = "C.UTF-8"
 
-    rc, _, stderr = utils.run_cmd(
+    rc, _, stderr = utils.check_output(
         "gitlint --commits origin/main..HEAD -C ../.gitlint --extra-path framework/gitlint_rules.py",
         ignore_return_code=True,
     )

--- a/tests/integration_tests/style/test_gitlint.py
+++ b/tests/integration_tests/style/test_gitlint.py
@@ -14,8 +14,7 @@ def test_gitlint():
     os.environ["LC_ALL"] = "C.UTF-8"
     os.environ["LANG"] = "C.UTF-8"
 
-    rc, _, stderr = utils.check_output(
+    rc, _, stderr = utils.run_cmd(
         "gitlint --commits origin/main..HEAD -C ../.gitlint --extra-path framework/gitlint_rules.py",
-        ignore_return_code=True,
     )
     assert rc == 0, "Commit message violates gitlint rules: {}".format(stderr)

--- a/tests/integration_tests/style/test_gitlint.py
+++ b/tests/integration_tests/style/test_gitlint.py
@@ -14,11 +14,8 @@ def test_gitlint():
     os.environ["LC_ALL"] = "C.UTF-8"
     os.environ["LANG"] = "C.UTF-8"
 
-    try:
-        utils.run_cmd(
-            "gitlint --commits origin/main..HEAD"
-            " -C ../.gitlint"
-            " --extra-path framework/gitlint_rules.py"
-        )
-    except ChildProcessError as error:
-        assert False, "Commit message violates gitlint rules: {}".format(error)
+    rc, _, stderr = utils.run_cmd(
+        "gitlint --commits origin/main..HEAD -C ../.gitlint --extra-path framework/gitlint_rules.py",
+        ignore_return_code=True,
+    )
+    assert rc == 0, "Commit message violates gitlint rules: {}".format(stderr)

--- a/tests/integration_tests/style/test_markdown.py
+++ b/tests/integration_tests/style/test_markdown.py
@@ -21,7 +21,7 @@ def test_markdown_style():
 
     # Run commands
     for md_file in md_files:
-        rc, output, _ = utils.run_cmd(
+        rc, output, _ = utils.check_output(
             f"bash -c 'diff -u --color {md_file} <(mdformat - < {md_file})'",
             ignore_return_code=True,
         )

--- a/tests/integration_tests/style/test_markdown.py
+++ b/tests/integration_tests/style/test_markdown.py
@@ -21,9 +21,8 @@ def test_markdown_style():
 
     # Run commands
     for md_file in md_files:
-        rc, output, _ = utils.check_output(
+        rc, output, _ = utils.run_cmd(
             f"bash -c 'diff -u --color {md_file} <(mdformat - < {md_file})'",
-            ignore_return_code=True,
         )
         if rc != 0:
             print(output)

--- a/tests/integration_tests/style/test_rust.py
+++ b/tests/integration_tests/style/test_rust.py
@@ -13,7 +13,9 @@ def test_rust_order():
     """
 
     # Runs `cargo-sort` with the current working directory (`cwd`) as the repository root.
-    _, _, _ = utils.run_cmd(cmd="cargo-sort --workspace --check --grouped", cwd="..")
+    _, _, _ = utils.check_output(
+        cmd="cargo-sort --workspace --check --grouped", cwd=".."
+    )
 
 
 def test_rust_style():
@@ -24,7 +26,7 @@ def test_rust_style():
     #  ../src/io_uring/src/bindings.rs
     config = open("fmt.toml", encoding="utf-8").read().replace("\n", ",")
     # Check that the output is empty.
-    _, stdout, _ = utils.run_cmd(f"cargo fmt --all -- --check --config {config}")
+    _, stdout, _ = utils.check_output(f"cargo fmt --all -- --check --config {config}")
 
     # rustfmt prepends `"Diff in"` to the reported output.
     assert "Diff in" not in stdout

--- a/tests/integration_tests/test_kani.py
+++ b/tests/integration_tests/test_kani.py
@@ -29,7 +29,7 @@ def test_kani(results_dir):
     # -j enables kani harnesses to be verified in parallel (required to keep CI time low)
     # --output-format terse is required by -j
     # --enable-unstable is needed for each of the above
-    _, stdout, _ = utils.run_cmd(
+    _, stdout, _ = utils.check_output(
         "cargo kani --enable-unstable -Z stubbing -Z function-contracts --restrict-vtable -j --output-format terse"
     )
 

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -313,7 +313,7 @@ def ab_performance_test(
     a_revision, b_revision, tests, p_thresh, strength_abs_thresh, noise_threshold
 ):
     """Does an A/B-test of the specified test across the given revisions"""
-    _, commit_list, _ = utils.run_cmd(
+    _, commit_list, _ = utils.check_output(
         f"git --no-pager log --oneline {a_revision}..{b_revision}"
     )
     print(
@@ -322,7 +322,7 @@ def ab_performance_test(
     print(commit_list.strip())
 
     def test_runner(workspace, _is_ab: bool):
-        utils.run_cmd("./tools/release.sh --profile release", cwd=workspace)
+        utils.check_output("./tools/release.sh --profile release", cwd=workspace)
         bin_dir = ".." / get_binary("firecracker", workspace_dir=workspace).parent
         return collect_data(bin_dir, tests)
 
@@ -343,7 +343,7 @@ def ab_performance_test(
 
 def canonicalize_revision(revision):
     """Canonicalizes the given revision to a 40 digit hex SHA"""
-    return utils.run_cmd(f"git rev-parse {revision}").stdout.strip()
+    return utils.check_output(f"git rev-parse {revision}").stdout.strip()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

The spiritual successor to "Misc Changes 4". The meat of this PR are two small changes in `utils.run_cmd_sync` that aim to improve output if a command fails (e.g. `ChildProcessError` is raised), or times out (e.g. `TimeoutExpired` is raised). 

Before this patch series, if a test failed due to `TimeoutExpired`, we would only be provided this fact, along with a backtrace. We change this to include the stdout and stderr of the command before it timed out in the pytest log.

Second, previously if a command returned a non-zero return code, and the `ChildProcessError` raised resulted in termination of the test run, pytest would truncate the exception message, which often lead to stdout/stderr of the failing command to become truncated or even omitted. Similarly to the above case, we now always log stdout and stderr in full. 

After making `run_cmd_sync` nicely provide a lot of debugging data, we could change a lot of ad-hoc assertions on error code (especially when it comes to ssh commands) to just rely on `run_cmd_sync` to handle exception raising and logging. This is where the PR gets its large-ish diff from.

Lastly, we update the whole `run_cmd` API in `utils` by inverting the default behavior of raising exceptions to align it with the APIs offered by `SSHConnection` and the `subprocess` module.

## Reason

I got a bit annoyed when I couldn't read some critical stderr output from a rarely reproducing intermittent CI failure because pytest truncated it.

... and then it kinda just spiraled from there into fixing up other things that have been bothering me for the better part of a year

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
