### PR TITLE
Remove unncessary encoding conversion

### DIFF
--- a/src/firecracker/src/api_server/parsed_request.rs
+++ b/src/firecracker/src/api_server/parsed_request.rs
@@ -276,7 +276,7 @@ pub(crate) enum RequestError {
     #[error("API Resource IDs can only contain alphanumeric characters and underscores.")]
     InvalidID,
     // The HTTP method & request path combination is not valid.
-    #[error("Invalid request method and/or path: {} {0}.", std::str::from_utf8(.1.raw()).expect("Cannot convert from UTF-8"))]
+    #[error("Invalid request method and/or path: {} {0}.", .1.to_str())]
     InvalidPathMethod(String, Method),
     // An error occurred when deserializing the json body of a request.
     #[error("An error occurred when deserializing the json body of a request: {0}.")]
@@ -508,7 +508,7 @@ pub mod tests {
         response.write_all(&mut buf).unwrap();
         let body = ApiServer::json_fault_message(format!(
             "Invalid request method and/or path: {} {}.",
-            std::str::from_utf8(Method::Get.raw()).unwrap(),
+            Method::Get.to_str(),
             "path"
         ));
         let expected_response = http_response(&body, 400);


### PR DESCRIPTION
Previously, the method argument was first being converted to raw bytes, and then into utf8. However, a to_str() method exists that converts directly to utf8.

## Changes

Remove instances in `parsed_request.rs` where HTTP method was being converted into raw bytes first and then UTF-8 and replace with `to_str()` method which converts directly into UTF-8

## Reason
Removes an unnecessary source of error that could occur when converting from raw to UTF-8.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
