### PR TITLE
Add git-secrets to pre-commit

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -40,3 +40,13 @@ for i in $(git diff --name-only --cached --diff-filter=d); do
     # Add changes to this file (as a result of formatting) to the commit.
     git add $i
 done
+
+# Check if git-secrets is present.
+if command -v git-secrets >/dev/null 2>&1; then
+    # Ensure the AWS patterns are registered.
+    git-secrets --register-aws
+    # Scan for and report secrets.
+    git-secrets --scan
+else
+    echo "WARNING: git-secrets is not on PATH. Automated secrets scanning could not be performed."
+fi


### PR DESCRIPTION
Use git-secrets to ensure that no secrets are commited to the repository. Fails if it detects a secret and logs a warning if git-secrets is not present. Closes #386 

## Changes
Adds a couple lines to the `pre-commit` file that checks if git-secrets exists. If it exists,  use it to scan and if it doesn't, just logs that scanning could not be performed.
...

## Reason
To provide an extra layer of protection from committing secrets to the repository.
...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
