### PR TITLE
refactor: simplify get_msr_chunks

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -770,10 +770,9 @@ pub fn configure_system_for_boot(
         use crate::cpu_config::x86_64::cpuid;
         let cpuid = cpuid::Cpuid::try_from(vmm.vm.supported_cpuid().clone())
             .map_err(GuestConfigError::CpuidFromKvmCpuid)?;
-        let msr_index_list = cpu_template.get_msr_index_list();
         let msrs = vcpus[0]
             .kvm_vcpu
-            .get_msrs(&msr_index_list)
+            .get_msrs(cpu_template.msr_index_iter())
             .map_err(GuestConfigError::VcpuIoctl)?;
         CpuConfiguration { cpuid, msrs }
     };

--- a/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
+++ b/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs
@@ -144,12 +144,9 @@ pub struct CustomCpuTemplate {
 }
 
 impl CustomCpuTemplate {
-    /// Get a list of MSR indices that are modified by the CPU template.
-    pub fn get_msr_index_list(&self) -> Vec<u32> {
-        self.msr_modifiers
-            .iter()
-            .map(|modifier| modifier.addr)
-            .collect()
+    /// Get an iterator of MSR indices that are modified by the CPU template.
+    pub fn msr_index_iter(&self) -> impl ExactSizeIterator<Item = u32> + '_ {
+        self.msr_modifiers.iter().map(|modifier| modifier.addr)
     }
 
     /// Validate the correctness of the template.


### PR DESCRIPTION
## Changes
Move logic to create single msr chunk into separate function. Also use iterators for msr indexes to remove some unneeded allocations.

## Reason
Minor simplification and removal of unneeded allocations.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
