### PR TITLE
Don't spam console with "failed to write to tap" messages

### DIFF
--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -498,8 +498,7 @@ impl Net {
                 net_metrics.tx_packets_count.inc();
                 net_metrics.tx_count.inc();
             }
-            Err(err) => {
-                error!("Failed to write to tap: {:?}", err);
+            Err(_) => {
                 net_metrics.tap_write_fails.inc();
             }
         };


### PR DESCRIPTION
A common first experience with firecracker (see e.g. #746) is to start a
new virtual machine and immediately start getting spammed with messages
like:

    2024-06-21T22:10:18.189726925 [anonymous-instance:main] Failed to write
    to tap: Os { code: 5, kind: Uncategorized, message: "Input/output
    error" }

This happens because firecracker will create the tap device if it doesn't
already exist, and unlike most vmms it will not configure the device `up`
in this case.

All that means that this is both a common and an expected situation and
does not require this level of notification.

Signed-off-by: Lars Kellogg-Stedman <lars@oddbit.com>
