### PR TITLE
ci: move automatic retry to BKPipeline class

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -224,11 +224,18 @@ class BKPipeline:
     def __init__(self, initial_steps=None, **kwargs):
         self.steps = initial_steps or []
         self.args = args = self.parser.parse_args()
+        # Retry one time if agent was lost. This can happen if we terminate the
+        # instance or the agent gets disconnected for whatever reason
+        retry = {
+            "automatic": [{"exit_status": -1, "limit": 1}],
+        }
+        retry = overlay_dict(retry, kwargs.pop("retry", {}))
         # Calculate step defaults with parameters and kwargs
         per_instance = {
             "instances": args.instances,
             "platforms": args.platforms,
             "artifact_paths": ["./test_results/**/*"],
+            "retry": retry,
             **kwargs,
         }
         self.per_instance = overlay_dict(per_instance, args.step_param)

--- a/.buildkite/pipeline_cross.py
+++ b/.buildkite/pipeline_cross.py
@@ -15,6 +15,9 @@ from common import DEFAULT_PLATFORMS, BKPipeline
 
 if __name__ == "__main__":
     pipeline = BKPipeline()
+    per_instance = pipeline.per_instance.copy()
+    per_instance.pop("instances")
+    per_instance.pop("platforms")
     instances_x86_64 = ["c5n.metal", "m5n.metal", "m6i.metal", "m6a.metal"]
     instances_aarch64 = ["m7g.metal"]
     commands = [
@@ -86,6 +89,7 @@ if __name__ == "__main__":
             "label": f"🎬 {src_instance} {src_kv} ➡️ {dst_instance} {dst_kv}",
             "timeout": 30,
             "agents": {"instance": dst_instance, "kv": dst_kv, "os": dst_os},
+            **per_instance,
         }
         steps.append(step)
     pipeline.add_step(

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -72,21 +72,14 @@ BKPipeline.parser.add_argument(
     action="append",
 )
 
-retry = {
-    "automatic": [
-        # Agent was lost, retry one time
-        # this can happen if we terminate the instance or the agent gets
-        # disconnected for whatever reason
-        {"exit_status": -1, "limit": 1},
-    ]
-}
+retry = {}
 if REVISION_A:
     # Enable automatic retry and disable manual retries to suppress spurious issues.
     retry["automatic"].append({"exit_status": 1, "limit": 1})
     retry["manual"] = False
 
 pipeline = BKPipeline(
-    # Boost priority from 1 to 2 so these jobs are preferred by ag-1 agents
+    # Boost priority from 1 to 2 so these jobs are preferred by ag=1 agents
     priority=2,
     # use ag=1 instances to make sure no two performance tests are scheduled on the same instance
     agents={"ag": 1},


### PR DESCRIPTION
The automatic retry when a BK agent disconnects we want in all pipelines.

## Changes

Automatically retry when a BK agent is lost, in all pipelines.

## Reason

Before this was only done in the perf pipeline, but we want this behavior in all pipelines, so adding it as a default.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
