### PR TITLE
Fix Perf tests AB mode

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -202,7 +202,7 @@ def shared_build():
         ]
     revision_b = os.environ.get("REVISION_B")
     if revision_b is not None:
-        build_cmds.append(f"ln -svfT . build/{revision_b}")
+        build_cmds.append(f"ln -svfT .. build/{revision_b}")
     binary_dir = f"build_$(uname -m)_{random_str(k=8)}.tar.gz"
     build_cmds += [
         "du -sh build/*",

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -75,7 +75,10 @@ BKPipeline.parser.add_argument(
 retry = {}
 if REVISION_A:
     # Enable automatic retry and disable manual retries to suppress spurious issues.
-    retry["automatic"].append({"exit_status": 1, "limit": 1})
+    retry["automatic"] = [
+        {"exit_status": -1, "limit": 1},
+        {"exit_status": 1, "limit": 1},
+    ]
     retry["manual"] = False
 
 pipeline = BKPipeline(

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -158,7 +158,8 @@ def load_data_series(report_path: Path, revision: str = None, *, reemit: bool = 
 
 def collect_data(binary_dir: Path, tests: list[str]):
     """Executes the specified test using the provided firecracker binaries"""
-    revision = binary_dir.name
+    # Example binary_dir: ../build/main/build/cargo_target/x86_64-unknown-linux-musl/release
+    revision = binary_dir.parents[3].name
 
     print(f"Collecting samples with {binary_dir}")
     subprocess.run(
@@ -323,7 +324,7 @@ def ab_performance_test(
     print(commit_list.strip())
 
     def test_runner(workspace, _is_ab: bool):
-        bin_dir = ".." / get_binary("firecracker", workspace_dir=workspace).parent
+        bin_dir = get_binary("firecracker", workspace_dir=workspace).parent
         return collect_data(bin_dir, tests)
 
     return git_ab_test(

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -128,7 +128,8 @@ def load_data_series(report_path: Path, revision: str = None, *, reemit: bool = 
                 if reemit:
                     assert revision is not None
 
-                    emf["git_commit_id"] = revision
+                    # These will show up in Cloudwatch, so canonicalize to long commit SHAs
+                    emf["git_commit_id"] = canonicalize_revision(revision)
                     emit_raw_emf(emf)
 
                 dimensions, result = process_log_entry(emf)
@@ -399,9 +400,8 @@ if __name__ == "__main__":
 
     if args.command == "run":
         ab_performance_test(
-            # These will show up in Cloudwatch, so canonicalize to long commit SHAs
-            canonicalize_revision(args.a_revision),
-            canonicalize_revision(args.b_revision),
+            args.a_revision,
+            args.b_revision,
             args.test,
             args.significance,
             args.absolute_strength,


### PR DESCRIPTION
## Changes

Fix perf tests when running in AB mode 

## Reason

After the build sharing changes, this mode was working because we were still building Firecracker (unintentionally). After we removed that capability in 467c90d5ab69e191262781a46987c961a0b80cc1 this mode started failing.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
