### PR TITLE
Add VIRTIO_NET_F_MRG_RXBUF to virtio-net 

### DIFF
--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -14,6 +14,7 @@ pub use vmm_sys_util::{
 pub mod arg_parser;
 pub mod byte_order;
 pub mod net;
+pub mod ring_buffer;
 pub mod signal;
 pub mod sm;
 pub mod time;

--- a/src/utils/src/ring_buffer.rs
+++ b/src/utils/src/ring_buffer.rs
@@ -1,0 +1,193 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+#[derive(Debug, Default, Clone)]
+pub struct RingBuffer<T: std::fmt::Debug + Default + Clone> {
+    pub items: Box<[T]>,
+    pub start: usize,
+    pub len: usize,
+}
+
+impl<T: std::fmt::Debug + Default + Clone> RingBuffer<T> {
+    /// New with zero size
+    pub fn new() -> Self {
+        Self {
+            items: Box::new([]),
+            start: 0,
+            len: 0,
+        }
+    }
+
+    /// New with specified size
+    pub fn new_with_size(size: usize) -> Self {
+        Self {
+            items: vec![T::default(); size].into_boxed_slice(),
+            start: 0,
+            len: 0,
+        }
+    }
+
+    /// Get number of items in the buffer
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Check if ring is empty
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Check if ring is full
+    pub fn is_full(&self) -> bool {
+        self.len == self.items.len()
+    }
+
+    /// Push new item to the end of the ring and increases
+    /// the length.
+    /// If there is no space for it, nothing will happen.
+    pub fn push(&mut self, item: T) {
+        if !self.is_full() {
+            let index = (self.start + self.len) % self.items.len();
+            self.items[index] = item;
+            self.len += 1;
+        }
+    }
+
+    /// Return next item that will be written to and increases
+    /// the length.
+    /// If ring is full returns None.
+    pub fn next_available(&mut self) -> Option<&mut T> {
+        if self.is_full() {
+            None
+        } else {
+            let index = (self.start + self.len) % self.items.len();
+            self.len += 1;
+            Some(&mut self.items[index])
+        }
+    }
+
+    /// Pop item from the from of the ring.
+    /// If ring is empty returns None.
+    pub fn pop_front(&mut self) -> Option<&mut T> {
+        if self.is_empty() {
+            None
+        } else {
+            let index = self.start;
+            self.start += 1;
+            self.start %= self.items.len();
+            self.len -= 1;
+            Some(&mut self.items[index])
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let a = RingBuffer::<u8>::new();
+        assert_eq!(a.items.len(), 0);
+        assert_eq!(a.start, 0);
+        assert_eq!(a.len, 0);
+        assert!(a.is_empty());
+        assert!(a.is_full());
+
+        let a = RingBuffer::<u8>::new_with_size(69);
+        assert_eq!(a.items.len(), 69);
+        assert_eq!(a.start, 0);
+        assert_eq!(a.len, 0);
+        assert!(a.is_empty());
+        assert!(!a.is_full());
+    }
+
+    #[test]
+    fn test_push() {
+        let mut a = RingBuffer::<u8>::new_with_size(4);
+
+        a.push(0);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        a.push(1);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        a.push(2);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        a.push(3);
+        assert!(!a.is_empty());
+        assert!(a.is_full());
+
+        assert_eq!(a.items.as_ref(), &[0, 1, 2, 3]);
+
+        a.push(4);
+        assert!(!a.is_empty());
+        assert!(a.is_full());
+
+        assert_eq!(a.items.as_ref(), &[0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_next_available() {
+        let mut a = RingBuffer::<u8>::new_with_size(4);
+        assert!(a.is_empty());
+        assert!(!a.is_full());
+
+        *a.next_available().unwrap() = 0;
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        *a.next_available().unwrap() = 1;
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        *a.next_available().unwrap() = 2;
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        *a.next_available().unwrap() = 3;
+        assert!(!a.is_empty());
+        assert!(a.is_full());
+
+        assert_eq!(a.items.as_ref(), &[0, 1, 2, 3]);
+
+        assert!(a.next_available().is_none());
+
+        assert_eq!(a.items.as_ref(), &[0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_pop_front() {
+        let mut a = RingBuffer::<u8>::new_with_size(4);
+        a.push(0);
+        a.push(1);
+        a.push(2);
+        a.push(3);
+        assert!(!a.is_empty());
+        assert!(a.is_full());
+
+        assert_eq!(*a.pop_front().unwrap(), 0);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        assert_eq!(*a.pop_front().unwrap(), 1);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        assert_eq!(*a.pop_front().unwrap(), 2);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        assert_eq!(*a.pop_front().unwrap(), 3);
+        assert!(a.is_empty());
+        assert!(!a.is_full());
+
+        assert!(a.pop_front().is_none());
+        assert!(a.is_empty());
+        assert!(!a.is_full());
+    }
+}

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1225,7 +1225,16 @@ pub mod tests {
             MmdsNetworkStack::default_ipv4_addr(),
             Arc::new(Mutex::new(mmds)),
         );
-
+        // Minimal setup for queues to be considered `valid`
+        for q in net.lock().unwrap().queues.iter_mut() {
+            q.ready = true;
+            q.size = 1;
+            // Need to explicitly set these addresses otherwise the aarch64
+            // will error out as it's memory does not start at 0.
+            q.desc_table = GuestAddress(crate::arch::SYSTEM_MEM_START);
+            q.avail_ring = GuestAddress(crate::arch::SYSTEM_MEM_START);
+            q.used_ring = GuestAddress(crate::arch::SYSTEM_MEM_START);
+        }
         attach_net_devices(vmm, cmdline, net_builder.iter(), event_manager).unwrap();
     }
 

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -218,11 +218,11 @@ impl IoVecBuffer {
 #[derive(Debug, Default, Clone)]
 pub struct IoVecBufferMut {
     // Index of the head desciptor
-    head_index: u16,
+    pub head_index: u16,
     // container of the memory regions included in this IO vector
-    vecs: IoVecVec,
+    pub vecs: IoVecVec,
     // Total length of the IoVecBufferMut
-    len: u32,
+    pub len: u32,
 }
 
 impl IoVecBufferMut {

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -97,10 +97,8 @@ impl IoVecBuffer {
     ///
     /// The descriptor chain cannot be referencing the same memory location as another chain
     pub unsafe fn from_descriptor_chain(head: DescriptorChain) -> Result<Self, IoVecError> {
-        let mut new_buffer: Self = Default::default();
-
+        let mut new_buffer = Self::default();
         new_buffer.load_descriptor_chain(head)?;
-
         Ok(new_buffer)
     }
 
@@ -275,10 +273,8 @@ impl IoVecBufferMut {
     ///
     /// The descriptor chain cannot be referencing the same memory location as another chain
     pub unsafe fn from_descriptor_chain(head: DescriptorChain) -> Result<Self, IoVecError> {
-        let mut new_buffer: Self = Default::default();
-
+        let mut new_buffer = Self::default();
         new_buffer.load_descriptor_chain(head)?;
-
         Ok(new_buffer)
     }
 

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -281,6 +281,23 @@ impl IoVecBufferMut {
         Ok(new_buffer)
     }
 
+    /// Get the index of the haed descriptor from which this IoVecBuffer
+    /// was built.
+    pub fn head_index(&self) -> u16 {
+        self.head_index
+    }
+
+    /// Get the host pointer to the first buffer in the guest,
+    /// this buffer points to.
+    ///
+    /// # Safety
+    ///
+    /// It is assumed that IoVecBuffer will never have 0 elements
+    /// as it is build from at DescriptorChain with length of at least 1.
+    pub fn start_address(&self) -> *mut libc::c_void {
+        self.vecs[0].iov_base
+    }
+
     /// Get the total length of the memory regions covered by this `IoVecBuffer`
     pub(crate) fn len(&self) -> u32 {
         self.len

--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -59,10 +59,10 @@ unsafe impl ByteValued for Descriptor {}
 /// https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-430008
 /// 2.6.8 The Virtqueue Used Ring
 #[repr(C)]
-#[derive(Default, Clone, Copy)]
-struct UsedElement {
-    id: u32,
-    len: u32,
+#[derive(Default, Debug, Clone, Copy)]
+pub struct UsedElement {
+    pub id: u32,
+    pub len: u32,
 }
 
 // SAFETY: `UsedElement` is a POD and contains no padding.
@@ -391,7 +391,7 @@ impl Queue {
     /// # Important
     /// This is an internal method that ASSUMES THAT THERE ARE AVAILABLE DESCRIPTORS. Otherwise it
     /// will retrieve a descriptor that contains garbage data (obsolete/empty).
-    fn do_pop_unchecked<'b, M: GuestMemory>(
+    pub fn do_pop_unchecked<'b, M: GuestMemory>(
         &mut self,
         mem: &'b M,
     ) -> Option<DescriptorChain<'b, M>> {
@@ -485,7 +485,7 @@ impl Queue {
 
     /// Read used element to the used ring at specified index.
     #[inline(always)]
-    fn write_used_ring<M: GuestMemory>(
+    pub fn write_used_ring<M: GuestMemory>(
         &self,
         mem: &M,
         index: u16,
@@ -575,7 +575,7 @@ impl Queue {
 
     /// Helper method that writes to the `avail_event` field of the used ring.
     #[inline(always)]
-    fn set_used_ring_avail_event<M: GuestMemory>(&mut self, avail_event: u16, mem: &M) {
+    pub fn set_used_ring_avail_event<M: GuestMemory>(&mut self, avail_event: u16, mem: &M) {
         debug_assert!(self.is_layout_valid(mem));
 
         // Used ring has layout:
@@ -598,7 +598,7 @@ impl Queue {
 
     /// Helper method that writes to the `idx` field of the used ring.
     #[inline(always)]
-    fn set_used_ring_idx<M: GuestMemory>(&mut self, next_used: u16, mem: &M) {
+    pub fn set_used_ring_idx<M: GuestMemory>(&mut self, next_used: u16, mem: &M) {
         debug_assert!(self.is_layout_valid(mem));
 
         // Used ring has layout:

--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -454,15 +454,19 @@ impl Queue {
             len,
         };
         self.write_used_ring(mem, next_used, used_element)?;
+        self.advance_used_ring(mem, 1);
+        Ok(())
+    }
 
-        self.num_added += Wrapping(1);
-        self.next_used += Wrapping(1);
+    /// Advance number of used descriptor heads by `n`.
+    pub fn advance_used_ring<M: GuestMemory>(&mut self, mem: &M, n: u16) {
+        self.num_added += Wrapping(n);
+        self.next_used += Wrapping(n);
 
         // This fence ensures all descriptor writes are visible before the index update is.
         fence(Ordering::Release);
 
         self.set_used_ring_idx(self.next_used.0, mem);
-        Ok(())
     }
 
     fn write_used_ring<M: GuestMemory>(

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -132,7 +132,10 @@ impl Entropy {
             let index = desc.index;
             METRICS.entropy_event_count.inc();
 
-            let bytes = match IoVecBufferMut::from_descriptor_chain(desc) {
+            // SAFETY: This descriptor chain is only loaded once
+            // virtio requests are handled sequentially so no two IoVecBuffers
+            // are live at the same time, meaning this has exclusive ownership over the memory
+            let bytes = match unsafe { IoVecBufferMut::from_descriptor_chain(desc) } {
                 Ok(mut iovec) => {
                     debug!(
                         "entropy: guest request for {} bytes of entropy",
@@ -428,13 +431,15 @@ mod tests {
         // This should succeed, we just added two descriptors
         let desc = entropy_dev.queues_mut()[RNG_QUEUE].pop(&mem).unwrap();
         assert!(matches!(
-            IoVecBufferMut::from_descriptor_chain(desc),
+            // SAFETY: This descriptor chain is only loaded into one buffer
+            unsafe { IoVecBufferMut::from_descriptor_chain(desc) },
             Err(crate::devices::virtio::iovec::IoVecError::ReadOnlyDescriptor)
         ));
 
         // This should succeed, we should have one more descriptor
         let desc = entropy_dev.queues_mut()[RNG_QUEUE].pop(&mem).unwrap();
-        let mut iovec = IoVecBufferMut::from_descriptor_chain(desc).unwrap();
+        // SAFETY: This descriptor chain is only loaded into one buffer
+        let mut iovec = unsafe { IoVecBufferMut::from_descriptor_chain(desc).unwrap() };
         entropy_dev.handle_one(&mut iovec).unwrap();
     }
 


### PR DESCRIPTION
## Changes
Add `VIRTIO_NET_F_MRG_RXBUF` to virtio-net.

Now virtio-net device can split incoming packets across multiple descriptor chains if `VIRTIO_NET_F_MRG_RXBUF` is enabled by the guest. The amount of descriptor chains (also known as heads) is written into the `virtio_net_hdr_v1` structure which is located at the very begging of the packet. Virtio spec states that the number of heads used should always be correct:
- 1 - if `VIRTIO_NET_F_MRG_RXBUF` is not negotiated
- N - if `VIRTIO_NET_F_MRG_RXBUF` is negotiated
Prior to this commit Firecracker never set the number of used heads to 1, but Linux was fine with it. Now we always set correct number of heads. Because of this some changes were introduced into the unit test code that was generating testing frames.

Fixes: #1314

## Reason
Better performance and guest memory utilization.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
