### PR TITLE
fix(test): Stop guest from panicking in boottime tests on AMD

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -222,7 +222,7 @@ class BKPipeline:
     parser = COMMON_PARSER
 
     def __init__(self, initial_steps=None, **kwargs):
-        self.steps = initial_steps or []
+        self.steps = []
         self.args = args = self.parser.parse_args()
         # Retry one time if agent was lost. This can happen if we terminate the
         # instance or the agent gets disconnected for whatever reason
@@ -247,6 +247,12 @@ class BKPipeline:
         build_cmds, self.shared_build = shared_build()
         step_build = group("🏗️ Build", build_cmds, **self.per_arch)
         self.steps += [step_build, "wait"]
+
+        if initial_steps:
+            for step in initial_steps:
+                step["depends_on"] = None
+
+            self.steps += initial_steps
 
     def add_step(self, step, decorate=True):
         """

--- a/resources/overlay/usr/local/bin/init.c
+++ b/resources/overlay/usr/local/bin/init.c
@@ -38,7 +38,7 @@ int main () {
    const char *init = "/sbin/init";
 
    char *const argv[] = { "/sbin/init", NULL };
-   char *const envp[] = { };
+   char *const envp[] = { NULL };
 
    execve(init, argv, envp);
 }


### PR DESCRIPTION
In our boottime tests, we use a custom `init` script to signal to
Firecracker (via MMIO) that booting has finished. This script then
`execve`s into `/sbin/init` (e.g. systemd) to continue the normal boot
process. However, when execve-ing, we forgot to NULL-terminate the
`envp` array, resulting a buffer over-run that caused systemd to crash
on m6a.metal instances.

Thus, NULL-terminate the array to fix the buffer-overrun. For this
change to take effect, we need to rebuild CI artifacts.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
