### PR TITLE
fix(test): remove `wait_for_up` from `test_vmgenid`

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -560,7 +560,6 @@ def test_vmgenid(guest_kernel_linux_6_1, rootfs, microvm_factory, snapshot_type)
         vm = microvm_factory.build()
         vm.spawn()
         copied_snapshot = vm.restore_from_snapshot(snapshot, resume=True)
-        vm.wait_for_up()
 
         # We should have as DMESG_VMGENID_RESUME messages as
         # snapshots we have resumed


### PR DESCRIPTION
The `wait_for_up()` sends a dummy SSH command with a timeout of 10s, with the intention of blocking the integration test until a VM is responsive after booting. However, post-snapshot restore it runs into issue https://github.com/firecracker-microvm/firecracker/issues/4099, where on AMD inside the guest, sshd gets stuck inside a nanosleep syscall for longer than intended (and thus longer than the 10s timeout).

Alternatively, we could pass `lapic=notscdeadline` in the kernel commandline arguments, but we do not have an easy way to _append_ to the default kernel command line from integration tests, and I'd like to avoid duplicating our default across a bunch of places.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
