### PR TITLE
Made pre-commit work in sillicon macos and linux

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -23,7 +23,7 @@ for i in $(git diff --name-only --cached --diff-filter=d); do
     extension="${filename##*.}"
     if [ "$extension" = "rs" ]; then
         # Read rustfmt config, replace '\n' with ','
-        rustfmt_config="$(sed -z "s/\n/,/g;s/,$/\n/" ./tests/fmt.toml)"
+        rustfmt_config="$(paste -sd, ./tests/fmt.toml)"
         # We first do a check run, this will fail when it finds a non-matching license.
         rustfmt $i --check --config $rustfmt_config
         # Run `cargo fmt` for this file


### PR DESCRIPTION
## Changes

Replaced a `sed -z` command in the pre-commit hook that seemed to only work on linux with a `paste`
command that seems to work on macos and linux.

## Reason

While running the previous version of the precommit I got the following error:
```
Found configured hook: pre-commit
Running command: sh pre-commit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (184 crate dependencies)
src/jailer/src/env.rs
sed: illegal option -- z
usage: sed script [-Ealnru] [-i extension] [file ...]
	sed [-Ealnu] [-i extension] [-e script] ... [-f script_file] ... [file ...]
Configured hook command failed
pre-commit hook rejected
```

Tested a couple different things and the `paste` command seemed to work both on macos (M1) and on linux (tested it in an ubuntu:22.04 container).


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
