### PR TITLE
Virtio tweaks

### DIFF
--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -41,6 +41,15 @@ pub const fn u64_to_usize(num: u64) -> usize {
     num as usize
 }
 
+/// Safely converts a usize value to a u64 value.
+/// This bypasses the Clippy lint check because we only support 64-bit platforms.
+#[cfg(target_pointer_width = "64")]
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+pub const fn usize_to_u64(num: usize) -> u64 {
+    num as u64
+}
+
 /// Converts a usize into a wrapping u32.
 #[inline]
 pub const fn wrap_usize_to_u32(num: usize) -> Wrapping<u32> {

--- a/src/vmm/src/devices/virtio/net/test_utils.rs
+++ b/src/vmm/src/devices/virtio/net/test_utils.rs
@@ -312,7 +312,7 @@ pub(crate) fn inject_tap_tx_frame(net: &Net, len: usize) -> Vec<u8> {
 pub fn write_element_in_queue(net: &Net, idx: u16, val: u64) -> Result<(), DeviceError> {
     if idx as usize > net.queue_evts.len() {
         return Err(DeviceError::QueueError(QueueError::DescIndexOutOfBounds(
-            idx,
+            u32::from(idx),
         )));
     }
     net.queue_evts[idx as usize].write(val).unwrap();
@@ -322,7 +322,7 @@ pub fn write_element_in_queue(net: &Net, idx: u16, val: u64) -> Result<(), Devic
 pub fn get_element_from_queue(net: &Net, idx: u16) -> Result<u64, DeviceError> {
     if idx as usize > net.queue_evts.len() {
         return Err(DeviceError::QueueError(QueueError::DescIndexOutOfBounds(
-            idx,
+            u32::from(idx),
         )));
     }
     Ok(u64::try_from(net.queue_evts[idx as usize].as_raw_fd()).unwrap())

--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -333,7 +333,10 @@ impl Queue {
             // We are choosing to interrupt execution since this could be a potential malicious
             // driver scenario. This way we also eliminate the risk of repeatedly
             // logging and potentially clogging the microVM through the log system.
-            panic!("The number of available virtio descriptors is greater than queue size!");
+            panic!(
+                "The number of available virtio descriptors {len} is greater than queue size: {}!",
+                self.actual_size()
+            );
         }
 
         if len == 0 {
@@ -514,7 +517,11 @@ impl Queue {
                 // driver scenario. This way we also eliminate the risk of
                 // repeatedly logging and potentially clogging the microVM through
                 // the log system.
-                panic!("The number of available virtio descriptors is greater than queue size!");
+                panic!(
+                    "The number of available virtio descriptors {len} is greater than queue size: \
+                     {}!",
+                    self.actual_size()
+                );
             }
             return false;
         }
@@ -1292,7 +1299,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "The number of available virtio descriptors is greater than queue size!"
+        expected = "The number of available virtio descriptors 5 is greater than queue size: 4!"
     )]
     fn test_invalid_avail_idx_no_notification() {
         // This test ensures constructing a descriptor chain succeeds
@@ -1337,7 +1344,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "The number of available virtio descriptors is greater than queue size!"
+        expected = "The number of available virtio descriptors 6 is greater than queue size: 4!"
     )]
     fn test_invalid_avail_idx_with_notification() {
         // This test ensures constructing a descriptor chain succeeds


### PR DESCRIPTION
## Changes
Minor tweaks to the virtio queue methods:
- more explicit offset calculations
- more descriptive names and methods

## Reason
These changes were part of #4658, but are quite independent of it, so moved to separate PR.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
