### PR TITLE
doc: update README.md with up-to-date links to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ functionality to reduce the memory footprint and attack surface area of each
 microVM. This improves security, decreases the startup time, and increases
 hardware utilization. Firecracker has also been integrated in container
 runtimes, for example
-[Kata Containers](https://github.com/kata-containers/documentation/wiki/Initial-release-of-Kata-Containers-with-Firecracker-support)
-and [Weaveworks Ignite](https://github.com/weaveworks/ignite).
+[Kata Containers](https://github.com/kata-containers/kata-containers) and
+[Flintlock](https://github.com/liquidmetal-dev/flintlock).
 
 Firecracker was developed at Amazon Web Services to accelerate the speed and
 efficiency of services like [AWS Lambda](https://aws.amazon.com/lambda/) and


### PR DESCRIPTION
Update links to Kata Containers and Flintlock projects.

## Changes

(Resubmitting Again to fix the Commit message cause amend wouldn't let me go far enough back again)
Swap the link from pointing at outdated v1 kata container docs that are achieved
Swap the name and the linker for weaver because it was archived and deprecated and the deprecated statement points to Flintlock

## Reason

Updating the examples to active projects to make it easier for people looking for them. (reason im making this pr is i went and clicked on them and found both archived) so people don't have to dig into the readmes and the links to get to the active projects

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ x ] If a specific issue led to this PR, this PR closes the issue.
- [ x ] The description of changes is clear and encompassing.
- [ x ] Any required documentation changes (code and docs) are included in this
  PR.
- [ x ] API changes follow the [Runbook for Firecracker API changes][2].
- [ x ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ x ] All added/changed functionality is tested.
- [ x  ] New `TODO`s link to an issue.
- [ x ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
