### PR TITLE
Fix A/B testing

### DIFF
--- a/tools/devctr/ctr_gitconfig
+++ b/tools/devctr/ctr_gitconfig
@@ -7,3 +7,4 @@
 
 [safe]
  directory = /firecracker
+ directory = /firecracker/.git

--- a/tools/devtool
+++ b/tools/devtool
@@ -68,7 +68,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v72}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v73}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
## Changes

Add `/firecracker/.git` as a safe directory in dev containers git configuration

## Reason

Otherwise "git clone /firecracker ..." fails in the container. This happens due to a patched version of git [1] addressing a CVE [2] that could lead to remote code execution when cloning specially crafted local repositories.

[1] https://ubuntu.com/security/notices/USN-6793-1
[2] https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-32004


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
