### PR TITLE
Fix optional PR tests

### DIFF
--- a/.buildkite/pipeline_pr_no_block.py
+++ b/.buildkite/pipeline_pr_no_block.py
@@ -11,6 +11,7 @@ from common import BKPipeline, get_changed_files, run_all_tests
 DEFAULT_PRIORITY = 1
 
 pipeline = BKPipeline(
+    with_build_step=False,
     timeout_in_minutes=45,
     # some non-blocking tests are performance, so make sure they get ag=1 instances
     priority=DEFAULT_PRIORITY + 1,


### PR DESCRIPTION
## Changes

Change no block pipelines to not use the build step

## Reason

No block pipeline runs rust benchmarks (among other things) which need to run `cargo bench` to build those benchmarks. Problem is that when we use pre-build artifacts some build paths don't match leading to errors like this: https://buildkite.com/firecracker/firecracker-pr-optional/builds/8136#0190dfc2-bdd9-42fc-9471-91b816f43d3f

Since we anyway rebuild these artifacts just do it in the test step and drop the build step.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
