### PR TITLE
Clean up create_fdt

### DIFF
--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -65,7 +65,7 @@ pub enum FdtError {
 }
 
 /// Creates the flattened device tree for this aarch64 microVM.
-pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug, S: std::hash::BuildHasher>(
+pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug>(
     guest_mem: &GuestMemoryMmap,
     vcpu_mpidr: Vec<u64>,
     cmdline: CString,

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -106,10 +106,6 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug>(
 
     // Allocate another buffer so we can format and then write fdt to guest.
     let fdt_final = fdt_writer.finish()?;
-
-    // Write FDT to memory.
-    let fdt_address = GuestAddress(get_fdt_addr(guest_mem));
-    guest_mem.write_slice(fdt_final.as_slice(), fdt_address)?;
     Ok(fdt_final)
 }
 

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -513,7 +513,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let gic = create_gic(&vm, 1, None).unwrap();
-        create_fdt(
+        let fdt_with_devices = create_fdt(
             &mem,
             vec![0],
             CString::new("console=tty0").unwrap(),
@@ -533,7 +533,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let gic = create_gic(&vm, 1, None).unwrap();
-        create_fdt(
+        let fdt_with_vmgenid = create_fdt(
             &mem,
             vec![0],
             CString::new("console=tty0").unwrap(),

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -64,7 +64,7 @@ pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug, S: std::hash::Build
     vmgenid: &Option<VmGenId>,
     initrd: &Option<super::InitrdConfig>,
 ) -> Result<(), ConfigurationError> {
-    fdt::create_fdt(
+    let fdt = fdt::create_fdt(
         guest_mem,
         vcpu_mpidr,
         cmdline_cstring,


### PR DESCRIPTION
## Changes
removed std::Hash::HashBuilder
removed guest writing to guest memory in create_fdt
updated calls to create_fdt
...

## Reason
#4700 
I'm unsure how to run the fdt.rs tests. I also am not sure if this is exactly what you mean by letting callers write to guest memory. If you could please steer me in the right direction and help me test my code that would be amazing.

Thank you. 
...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x ] If a specific issue led to this PR, this PR closes the issue.
- [ x] The description of changes is clear and encompassing.
- [x ] Any required documentation changes (code and docs) are included in this
  PR.
- [ x] API changes follow the [Runbook for Firecracker API changes][2].
- [x ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ x] All added/changed functionality is tested.
- [x ] New `TODO`s link to an issue.
- [ x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
