### PR TITLE
Generify docker container to not hardcode `/firecracker` paths

### DIFF
--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -110,7 +110,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOL
     && rustup target add x86_64-unknown-linux-musl \
     && rustup target add aarch64-unknown-linux-musl \
     && rustup component add llvm-tools-preview \
-    && cargo install --locked cargo-audit cargo-deny grcov cargo-sort \
+    && cargo install --locked cargo-audit cargo-deny grcov cargo-sort cargo-afl \
     && (if [ "$ARCH" = "x86_64" ]; then cargo install --locked kani-verifier && cargo kani setup; else true; fi) \
     \
     && apt-get update \

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends \
         # essential build tools
         gcc make libc-dev binutils-dev libssl-dev \
-        # Useful utilifies
+        # Useful utilities
         gdbserver \
         # Needed in order to be able to compile `userfaultfd-sys`.
         clang \

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -6,10 +6,6 @@ FROM public.ecr.aws/lts/ubuntu:22.04
 
 ARG RUST_TOOLCHAIN="1.79.0"
 ARG TMP_BUILD_DIR=/tmp/build
-ARG FIRECRACKER_SRC_DIR="/firecracker"
-ARG FIRECRACKER_BUILD_DIR="$FIRECRACKER_SRC_DIR/build"
-ARG CARGO_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_registry"
-ARG CARGO_GIT_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_git_registry"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ARCH
 
@@ -132,9 +128,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOL
     && cd && rm -r /tmp/crosvm \
     \
     && rm -rf "$CARGO_HOME/registry" \
-    && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
-    && rm -rf "$CARGO_HOME/git" \
-    && ln -s "$CARGO_GIT_REGISTRY_DIR" "$CARGO_HOME/git"
+    && rm -rf "$CARGO_HOME/git"
 
 # help musl-gcc find linux headers
 RUN cd /usr/include/$ARCH-linux-musl \
@@ -162,5 +156,4 @@ RUN cd /usr/local/bin \
 
 ADD tools/devctr/ctr_gitconfig /root/.gitconfig
 
-WORKDIR "$FIRECRACKER_SRC_DIR"
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/tools/devtool
+++ b/tools/devtool
@@ -228,6 +228,7 @@ cmd_fix_perms() {
     # Yes, running Docker to get elevated privileges, just to chown some files
     # is a dirty hack.
     run_devctr \
+        --workdir "$CTR_FC_ROOT_DIR" \
         -- \
         chown -R "$(id -u):$(id -g)" "$CTR_FC_BUILD_DIR"
 }
@@ -305,6 +306,8 @@ run_devctr() {
         --rm \
         --volume /dev:/dev \
         --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR:z" \
+        --volume "$FC_ROOT_DIR/build/cargo_registry:/usr/local/rust/registry:z" \
+        --volume "$FC_ROOT_DIR/build/cargo_git_registry:/usr/local/rust/git:z" \
         --tmpfs /srv:exec,dev,size=32G \
         -v /boot:/boot \
         --env PYTHONDONTWRITEBYTECODE=1 \

--- a/tools/devtool
+++ b/tools/devtool
@@ -68,7 +68,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v73}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v74}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
Update the docker container to not hardcode `/firecracker` as the root of all paths. Instead, use the `--workdir` option. Also use `--volume` instead of symlinks inside of the dockerfile to point the cargo registry toward `firecracker/build/cargo_{git_registry,registry}`. This is needed because we want to use this docker container to run fuzzers which we keep in a different (private) repository. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
