### PR TITLE
virtio: skip redundant memory check

### DIFF
--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -96,6 +96,9 @@ pub struct DescriptorChain<'a, M: GuestMemory = GuestMemoryMmap> {
 }
 
 impl<'a, M: GuestMemory> DescriptorChain<'a, M> {
+    /// Creates a new `DescriptorChain` from the given memory and descriptor table.
+    ///
+    /// Note that the desc_table and queue_size are assumed to be validated by the caller.
     fn checked_new(
         mem: &'a M,
         desc_table: GuestAddress,
@@ -106,8 +109,9 @@ impl<'a, M: GuestMemory> DescriptorChain<'a, M> {
             return None;
         }
 
-        let desc_head = mem.checked_offset(desc_table, (index as usize) * 16)?;
-        mem.checked_offset(desc_head, 16)?;
+        // There's no need for checking as we already validated the descriptor table and index
+        // bounds.
+        let desc_head = desc_table.unchecked_add(u64::from(index) * 16);
 
         // These reads can't fail unless Guest memory is hopelessly broken.
         let desc = match mem.read_obj::<Descriptor>(desc_head) {


### PR DESCRIPTION
## Changes

Remove redundant memory check for `DescriptorChain::new`.

## Reason

Since we already validated the queue layout and desc index, there's no need to check it again.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
