### PR TITLE
metrics: dump the error metrics during failure

### DIFF
--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -8,6 +8,7 @@
 """
 
 import datetime
+import json
 import math
 import platform
 import time
@@ -463,14 +464,15 @@ def flush_fc_metrics_to_cw(fc_metrics, metrics):
             continue
         metrics.put_metric(key, value, get_emf_unit_for_fc_metrics(key))
 
-    assert not {
+    metrics.flush()
+
+    failure_metrics = {
         key: value
         for key, value in flattened_metrics.items()
         if "err" in key or "fail" in key or "panic" in key or "num_faults" in key
         if value
     }
-
-    metrics.flush()
+    assert not failure_metrics, json.dumps(failure_metrics, indent=1)
 
 
 class FCMetricsMonitor(Thread):


### PR DESCRIPTION
## Changes

Fix the assertion to print a more useful message when an error metric is non-zero. Also, make sure that we upload metrics to CloudWatch even when there is a non-zero error metric.

## Reason

Right now the assertion message is not very legible which makes it difficult to debug. Also, if an error happens we don't upload the metrics to cloudwatch.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
