### PR TITLE
Enable uvm kernel 6.1 tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,11 +377,9 @@ guest_kernel_linux_4_14 = pytest.fixture(
 guest_kernel_linux_5_10 = pytest.fixture(
     guest_kernel_fxt, params=kernel_params("vmlinux-5.10*")
 )
-# Use the unfiltered selector, since we don't officially support 6.1 yet.
-# TODO: switch to default selector once we add full 6.1 support.
 guest_kernel_linux_6_1 = pytest.fixture(
     guest_kernel_fxt,
-    params=kernel_params("vmlinux-6.1*", select=kernels_unfiltered),
+    params=kernel_params("vmlinux-6.1*"),
 )
 
 # Fixtures for all Ubuntu rootfs, and specific versions

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -12,7 +12,6 @@ import packaging.version
 import pytest
 
 from framework.defs import ARTIFACT_DIR
-from framework.properties import global_props
 from framework.utils import check_output, get_firecracker_version_from_toml
 from framework.with_filelock import with_filelock
 from host_tools.cargo_build import get_binary
@@ -22,8 +21,7 @@ def select_supported_kernels():
     """Select guest kernels supported by the current combination of kernel and
     instance type.
     """
-    hlv = packaging.version.parse(global_props.host_linux_version)
-    supported_kernels = [r"vmlinux-4.14.\d+", r"vmlinux-5.10.\d+"]
+    supported_kernels = [r"vmlinux-4.14.\d+", r"vmlinux-5.10.\d+", r"vmlinux-6.1.\d+"]
 
     # Booting with MPTable is deprecated but we still want to test
     # for it. Until we drop support for it we will be building a 5.10 guest
@@ -31,10 +29,6 @@ def select_supported_kernels():
     # as well.
     # TODO: remove this once we drop support for MPTable
     supported_kernels.append(r"vmlinux-5.10.\d+-no-acpi")
-
-    # Support Linux 6.1 guest in a limited fashion
-    if global_props.cpu_model == "ARM_NEOVERSE_V1" and (hlv.major, hlv.minor) >= (6, 1):
-        supported_kernels.append(r"vmlinux-6.1.\d+")
 
     return supported_kernels
 


### PR DESCRIPTION
## Changes

Enable microvm kernel 6.1 tests.

This only applies to tests that use the fixture `uvm_plain_any` or derivatives. Tests using `uvm_plain` will continue using only 5.10. I did some tests with 6.1 kernel as default and uncovered some testing issues (not functional nor performance). I will push separate PRs to fix those.
Also, I didn't check the performance results yet, just that they passed.

## Reason

We are phasing out support for 4.14, so we're adding the next supported LTS.

## Questions
- Do we need to update any docs?

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
