### PR TITLE
Uvm 6.1/tests

### DIFF
--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1166,6 +1166,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
         }
     ]
 
+    uvm_nano.wait_for_up()
     snapshot = uvm_nano.snapshot_full()
     uvm2 = microvm_factory.build()
     uvm2.spawn()

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -5,6 +5,7 @@
 import pytest
 
 from framework.utils import check_entropy
+from host_tools.network import SSHConnection
 
 
 @pytest.fixture(params=[None])
@@ -22,6 +23,15 @@ def uvm_with_rng(uvm_plain, request):
     return uvm
 
 
+def list_rng_available(ssh_connection: SSHConnection) -> list[str]:
+    """Returns a list of rng devices available in the VM"""
+    return (
+        ssh_connection.check_output("cat /sys/class/misc/hw_random/rng_available")
+        .stdout.strip()
+        .split()
+    )
+
+
 def test_rng_not_present(uvm_nano):
     """
     Test a guest microVM *without* an entropy device and ensure that
@@ -32,15 +42,9 @@ def test_rng_not_present(uvm_nano):
     vm.add_net_iface()
     vm.start()
 
-    # If the guest kernel has been built with the virtio-rng module
-    # the device should exist in the guest filesystem but we should
-    # not be able to get random numbers out of it.
-    cmd = "test -e /dev/hwrng"
-    vm.ssh.check_output(cmd)
-
-    cmd = "dd if=/dev/hwrng of=/dev/null bs=10 count=1"
-    ecode, _, _ = vm.ssh.run(cmd)
-    assert ecode == 1
+    assert not any(
+        rng.startswith("virtio_rng") for rng in list_rng_available(vm.ssh)
+    ), "virtio_rng device should not be available in the uvm"
 
 
 def test_rng_present(uvm_with_rng):

--- a/tests/integration_tests/functional/test_snapshot_editor.py
+++ b/tests/integration_tests/functional/test_snapshot_editor.py
@@ -27,6 +27,7 @@ def test_remove_regs(uvm_nano, microvm_factory):
     vm = uvm_nano
     vm.add_net_iface()
     vm.start()
+    vm.wait_for_up()
 
     snapshot = vm.snapshot_full()
 


### PR DESCRIPTION
## Changes

This patchset fixes some tests that would fail if run on a guest kernel 6.1. None of these seems to be an issue with the firecracker/guest kernel integration, but only a testing framework issue.

### 1. wait for VM to be up before taking snapshots

```
test_get_full_config_after_restoring_snapshot
test_remove_regs
```

These two tests are failing on uvm 6.1. The reason is unknown, but we're taking the snapshot without waiting for the guest to be alive which might introduce race conditions with the kernel setup.
This patch 

### 2. remove assumption on no hwrng device except virtio_rng
`test_rng.py` tests assume that `virtio_rng` device is the only hw rng available in the microvm. Since 5.15, ARM uvms have a SMCCC TRNG which is paravirtualized by KVM (https://patchwork.kernel.org/project/linux-arm-kernel/list/?series=400659&state=%2A&archive=both).
This patch removes that assumption by checking which rng are available and which is currently in use in the tests to ensure the right device is tested.

## Reason

We are adding support for uvm 6.1, these tests, despite being only run on 5.10 in the CI, would fail if run on 6.1

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
