### PR TITLE
Indirect desc

### DIFF
--- a/src/vmm/src/devices/virtio/gen/virtio_ring.rs
+++ b/src/vmm/src/devices/virtio/gen/virtio_ring.rs
@@ -14,4 +14,5 @@
     clippy::tests_outside_test_module
 )]
 
+pub const VIRTIO_RING_F_INDIRECT_DESC: u32 = 28;
 pub const VIRTIO_RING_F_EVENT_IDX: u32 = 29;

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -21,7 +21,9 @@ use crate::devices::virtio::gen::virtio_net::{
     VIRTIO_NET_F_GUEST_TSO6, VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_F_HOST_TSO4,
     VIRTIO_NET_F_HOST_TSO6, VIRTIO_NET_F_HOST_UFO, VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF,
 };
-use crate::devices::virtio::gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
+use crate::devices::virtio::gen::virtio_ring::{
+    VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
+};
 use crate::devices::virtio::iovec::{
     IoVecBuffer, IoVecBufferMut, IoVecError, ParsedDescriptorChain,
 };
@@ -281,9 +283,10 @@ impl Net {
             | 1 << VIRTIO_NET_F_HOST_TSO4
             | 1 << VIRTIO_NET_F_HOST_TSO6
             | 1 << VIRTIO_NET_F_HOST_UFO
-            | 1 << VIRTIO_F_VERSION_1
             | 1 << VIRTIO_NET_F_MRG_RXBUF
-            | 1 << VIRTIO_RING_F_EVENT_IDX;
+            | 1 << VIRTIO_RING_F_INDIRECT_DESC
+            | 1 << VIRTIO_RING_F_EVENT_IDX
+            | 1 << VIRTIO_F_VERSION_1;
 
         let mut config_space = ConfigSpace::default();
         if let Some(mac) = guest_mac {

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -125,6 +125,8 @@ pub enum VsockError {
     DescChainTooShortForHeader(usize),
     /// The descriptor chain length was greater than the max ([u32::MAX])
     DescChainOverflow,
+    /// Nested indirect descriptor
+    NestedIndirectDescriptor,
     /// The vsock header `len` field holds an invalid value: {0}
     InvalidPktLen(u32),
     /// A data fetch was attempted when no data was available.
@@ -154,6 +156,7 @@ impl From<IoVecError> for VsockError {
             IoVecError::OverflowedDescriptor => VsockError::DescChainOverflow,
             IoVecError::IovDeque(err) => VsockError::IovDeque(err),
             IoVecError::IovDequeOverflow => VsockError::IovDequeOverflow,
+            IoVecError::NestedIndirectDescriptor => VsockError::NestedIndirectDescriptor,
         }
     }
 }

--- a/tools/bindgen.sh
+++ b/tools/bindgen.sh
@@ -67,7 +67,7 @@ fc-bindgen \
 
 info "BINDGEN virtio_ring.h"
 fc-bindgen \
-    --allowlist-var "VIRTIO_RING_F_EVENT_IDX" \
+    --allowlist-var "VIRTIO_RING_.*" \
     "$KERNEL_HEADERS_HOME/include/linux/virtio_ring.h" >src/vmm/src/devices/virtio/gen/virtio_ring.rs
 
 info "BINDGEN virtio_blk.h"


### PR DESCRIPTION
## Changes
Add support for `INDIRECT_DESC` for `IoVecBuff/Mut` and enabled `VIRTIO_RING_F_INDIRECT_DESC` flag for `virtio-net` device. This feature allows guest to create more buffers for packets which in turn should help with throughput when all available descriptors are used.

Note that indirect descriptors can only be enabled for TX queue. This is a linux virtio-net driver behavior.

## Reason
Should help with network performance.

## Note
This PR is built on top of #4658, so needs to be merged after it.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
