### PR TITLE
refactor(virtio-net): avoid copy on rx

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -26,6 +26,10 @@
                 "syscall": "read"
             },
             {
+                "syscall": "readv",
+                "comment": "Used by the VirtIO net device to read from tap"
+            },
+            {
                 "syscall": "write"
             },
             {

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -26,6 +26,10 @@
                 "syscall": "read"
             },
             {
+                "syscall": "readv",
+                "comment": "Used by the VirtIO net device to read from tap"
+            },
+            {
                 "syscall": "write"
             },
             {

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -45,6 +45,16 @@ pub struct IoVecBuffer {
     len: u32,
 }
 
+impl IoVecBuffer {
+    /// Create an empty `IoVecBuffer` with a given capacity.
+    pub fn with_capacity(cap: usize) -> IoVecBuffer {
+        IoVecBuffer {
+            vecs: IoVecVec::with_capacity(cap),
+            len: 0,
+        }
+    }
+}
+
 // SAFETY: `IoVecBuffer` doesn't allow for interior mutability and no shared ownership is possible
 // as it doesn't implement clone
 unsafe impl Send for IoVecBuffer {}
@@ -218,7 +228,7 @@ impl IoVecBuffer {
 /// It describes a write-only buffer passed to us by the guest that is scattered across multiple
 /// memory regions. Additionally, this wrapper provides methods that allow reading arbitrary ranges
 /// of data from that buffer.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct IoVecBufferMut {
     // container of the memory regions included in this IO vector
     vecs: IoVecVec,
@@ -227,12 +237,30 @@ pub struct IoVecBufferMut {
 }
 
 impl IoVecBufferMut {
-    /// Create an `IoVecBufferMut` from a `DescriptorChain`
-    pub fn from_descriptor_chain(head: DescriptorChain) -> Result<Self, IoVecError> {
-        let mut vecs = IoVecVec::new();
-        let mut len = 0u32;
+    /// Create an empty `IoVecBufferMut` with a given capacity.
+    pub fn with_capacity(cap: usize) -> IoVecBufferMut {
+        IoVecBufferMut {
+            vecs: IoVecVec::with_capacity(cap),
+            len: 0,
+        }
+    }
+}
 
-        for desc in head {
+// SAFETY: iovec pointers are safe to send across threads.
+unsafe impl Send for IoVecBufferMut {}
+
+impl IoVecBufferMut {
+    /// Create an `IoVecBufferMut` from a `DescriptorChain`
+    /// # Safety
+    /// The descriptor chain cannot be referencing the same memory location as another chain.
+    pub unsafe fn load_descriptor_chain(
+        &mut self,
+        mut desc: DescriptorChain,
+        max_size: Option<u32>,
+    ) -> Result<(), IoVecError> {
+        self.clear();
+
+        loop {
             if !desc.is_write_only() {
                 return Err(IoVecError::ReadOnlyDescriptor);
             }
@@ -248,21 +276,55 @@ impl IoVecBufferMut {
             slice.bitmap().mark_dirty(0, desc.len as usize);
 
             let iov_base = slice.ptr_guard_mut().as_ptr().cast::<c_void>();
-            vecs.push(iovec {
+            self.vecs.push(iovec {
                 iov_base,
                 iov_len: desc.len as size_t,
             });
-            len = len
+            self.len = self
+                .len
                 .checked_add(desc.len)
                 .ok_or(IoVecError::OverflowedDescriptor)?;
+            if matches!(max_size, Some(max) if self.len >= max) {
+                break;
+            }
+            if desc.load_next_descriptor().is_none() {
+                break;
+            }
         }
 
-        Ok(Self { vecs, len })
+        Ok(())
+    }
+
+    /// Create an `IoVecBufferMut` from a `DescriptorChain`
+    /// # Safety
+    /// The descriptor chain cannot be referencing the same memory location as another chain.
+    pub unsafe fn from_descriptor_chain(head: DescriptorChain) -> Result<Self, IoVecError> {
+        let mut new_buffer = Self::default();
+
+        Self::load_descriptor_chain(&mut new_buffer, head, None)?;
+
+        Ok(new_buffer)
     }
 
     /// Get the total length of the memory regions covered by this `IoVecBuffer`
     pub(crate) fn len(&self) -> u32 {
         self.len
+    }
+
+    /// Returns a pointer to the memory keeping the `iovec` structs
+    pub fn as_iovec_ptr(&self) -> *const iovec {
+        self.vecs.as_ptr()
+    }
+
+    /// Returns the length of the `iovec` array.
+    pub fn iovec_count(&self) -> usize {
+        self.vecs.len()
+    }
+
+    /// Clears the `iovec` array
+    pub fn clear(&mut self) {
+        self.vecs.clear();
+        self.len = 0u32;
     }
 
     /// Writes a number of bytes into the `IoVecBufferMut` starting at a given offset.
@@ -469,11 +531,13 @@ mod tests {
 
         let (mut q, _) = read_only_chain(&mem);
         let head = q.pop(&mem).unwrap();
-        IoVecBufferMut::from_descriptor_chain(head).unwrap_err();
+        // SAFETY: This descriptor chain is only loaded into one buffer.
+        unsafe { IoVecBufferMut::from_descriptor_chain(head).unwrap_err() };
 
         let (mut q, _) = write_only_chain(&mem);
         let head = q.pop(&mem).unwrap();
-        IoVecBufferMut::from_descriptor_chain(head).unwrap();
+        // SAFETY: This descriptor chain is only loaded into one buffer.
+        unsafe { IoVecBufferMut::from_descriptor_chain(head).unwrap() };
     }
 
     #[test]
@@ -494,7 +558,7 @@ mod tests {
         let head = q.pop(&mem).unwrap();
 
         // SAFETY: This descriptor chain is only loaded once in this test
-        let iovec = IoVecBufferMut::from_descriptor_chain(head).unwrap();
+        let iovec = unsafe { IoVecBufferMut::from_descriptor_chain(head).unwrap() };
         assert_eq!(iovec.len(), 4 * 64);
     }
 
@@ -559,7 +623,8 @@ mod tests {
         // This is a descriptor chain with 4 elements 64 bytes long each.
         let head = q.pop(&mem).unwrap();
 
-        let mut iovec = IoVecBufferMut::from_descriptor_chain(head).unwrap();
+        // SAFETY: This descriptor chain is only loaded into one buffer.
+        let mut iovec = unsafe { IoVecBufferMut::from_descriptor_chain(head).unwrap() };
         let buf = vec![0u8, 1, 2, 3, 4];
 
         // One test vector for each part of the chain

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -470,6 +470,24 @@ mod tests {
         }
     }
 
+    impl<'a> From<Vec<&'a mut [u8]>> for IoVecBufferMut {
+        fn from(buffer: Vec<&'a mut [u8]>) -> Self {
+            let mut len = 0_u32;
+            let vecs = buffer
+                .into_iter()
+                .map(|slice| {
+                    len += TryInto::<u32>::try_into(slice.len()).unwrap();
+                    iovec {
+                        iov_base: slice.as_ptr() as *mut c_void,
+                        iov_len: slice.len(),
+                    }
+                })
+                .collect();
+
+            Self { vecs, len }
+        }
+    }
+
     fn default_mem() -> GuestMemoryMmap {
         multi_region_mem(&[
             (GuestAddress(0), 0x10000),

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -57,12 +57,11 @@ impl IoVecBuffer {
     /// The descriptor chain cannot be referencing the same memory location as another chain
     pub unsafe fn load_descriptor_chain(
         &mut self,
-        head: DescriptorChain,
+        mut desc: DescriptorChain,
     ) -> Result<(), IoVecError> {
         self.clear();
 
-        let mut next_descriptor = Some(head);
-        while let Some(desc) = next_descriptor {
+        loop {
             if desc.is_write_only() {
                 return Err(IoVecError::WriteOnlyDescriptor);
             }
@@ -85,7 +84,9 @@ impl IoVecBuffer {
                 .checked_add(desc.len)
                 .ok_or(IoVecError::OverflowedDescriptor)?;
 
-            next_descriptor = desc.next_descriptor();
+            if desc.load_next_descriptor().is_none() {
+                break;
+            }
         }
 
         Ok(())

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -327,6 +327,23 @@ impl IoVecBufferMut {
         self.len = 0u32;
     }
 
+    /// Push an iovec into the `IoVecBufferMut`.
+    /// # Safety
+    /// The iovec must refer to a valid memory slice.
+    pub unsafe fn push(&mut self, iovec: iovec) -> Result<(), IoVecError> {
+        let iov_len = iovec
+            .iov_len
+            .try_into()
+            .map_err(|_| IoVecError::OverflowedDescriptor)?;
+
+        self.vecs.push(iovec);
+        self.len = self
+            .len
+            .checked_add(iov_len)
+            .ok_or(IoVecError::OverflowedDescriptor)?;
+        Ok(())
+    }
+
     /// Writes a number of bytes into the `IoVecBufferMut` starting at a given offset.
     ///
     /// This will try to fill `IoVecBufferMut` writing bytes from the `buf` starting from

--- a/src/vmm/src/devices/virtio/net/test_utils.rs
+++ b/src/vmm/src/devices/virtio/net/test_utils.rs
@@ -270,6 +270,13 @@ pub fn if_index(tap: &Tap) -> i32 {
     unsafe { ifreq.ifr_ifru.ifru_ivalue }
 }
 
+
+pub fn drain_tap(tap: &Tap) {
+    let mut buf = [0u8; 1024];
+    // SAFETY: The call is safe since the parameters are valid.
+    while unsafe { libc::read(tap.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len()) != -1 } {}
+}
+
 /// Enable the tap interface.
 pub fn enable(tap: &Tap) {
     // Disable IPv6 router advertisment requests
@@ -294,6 +301,8 @@ pub fn enable(tap: &Tap) {
         )
         .execute(&sock, c_ulong::from(super::gen::sockios::SIOCSIFFLAGS))
         .unwrap();
+    // Drain the initial packets that might be in the tap interface.
+    drain_tap(tap);
 }
 
 #[cfg(test)]

--- a/src/vmm/src/devices/virtio/net/test_utils.rs
+++ b/src/vmm/src/devices/virtio/net/test_utils.rs
@@ -494,8 +494,8 @@ pub mod test {
             event_fd.write(1).unwrap();
         }
 
-        /// Generate a tap frame of `frame_len` and check that it is deferred
-        pub fn check_rx_deferred_frame(&mut self, frame_len: usize) -> Vec<u8> {
+        /// Generate a tap frame of `frame_len` and check that it is handled or discarded.
+        pub fn check_rx_frame(&mut self, frame_len: usize, rx_packets_count: u64) -> Vec<u8> {
             self.net().tap.mocks.set_read_tap(ReadTapMock::TapFrame);
             let used_idx = self.rxq.used.idx.get();
 
@@ -503,12 +503,10 @@ pub mod test {
             let frame = inject_tap_tx_frame(&self.net(), frame_len);
             check_metric_after_block!(
                 self.net().metrics.rx_packets_count,
-                0,
+                rx_packets_count,
                 self.event_manager.run_with_timeout(100).unwrap()
             );
-            // Check that the frame has been deferred.
-            assert!(self.net().rx_deferred_frame);
-            // Check that the descriptor chain has been discarded.
+            // Check that the descriptor chain has been used or discarded.
             assert_eq!(self.rxq.used.idx.get(), used_idx + 1);
             assert!(&self.net().irq_trigger.has_pending_irq(IrqType::Vring));
 

--- a/src/vmm/src/devices/virtio/vsock/packet.rs
+++ b/src/vmm/src/devices/virtio/vsock/packet.rs
@@ -161,7 +161,8 @@ impl VsockPacket {
     /// Returns [`VsockError::DescChainTooShortForHeader`] if the descriptor chain's total buffer
     /// length is insufficient to hold the 44 byte vsock header
     pub fn from_rx_virtq_head(chain: DescriptorChain) -> Result<Self, VsockError> {
-        let buffer = IoVecBufferMut::from_descriptor_chain(chain)?;
+        // SAFETY: This descriptor chain is only loaded into one buffer.
+        let buffer = unsafe { IoVecBufferMut::from_descriptor_chain(chain)? };
 
         if buffer.len() < VSOCK_PKT_HDR_SIZE {
             return Err(VsockError::DescChainTooShortForHeader(buffer.len() as usize));


### PR DESCRIPTION
Improve virtio-net performance by directly read into desc chain; introduce Readiness management to avoid redundant readv and make code more readable.

## Changes

1. Change virtio-net from copy-read to direct-read: Previously, the net device implementation would read data from the TAP into a buffer in VMM, and then copy it into the descriptor chain. The new implementation converts the descriptor chain into iovec first and then reads the data directly into it.
2. Optimize the reading performance of the descriptor chain: Reduce stack copying and the overhead of guest memory reads.
3. Refactor the code related to reading data in the net device: Add management of readiness and centralize the main logic in the process_rx function, making the code simpler and clearer.

## Reason

1. Performance
In the current VMM simulated net device read implementation, data is copied to a VMM-owned buffer before being copied to the descriptor chain. The new method converts the descriptor chain directly into an iovec and then uses tap readv for direct input.

Each implementation has its advantages and disadvantages. The current method avoids traversing the entire descriptor chain for iovec conversion when handling small packets but incurs copy overhead for larger packets.

Previously, https://github.com/firecracker-microvm/firecracker/pull/2958 switched from copy+write to writev, resulting in performance improvement for the write side. The author of that PR mentioned that modifying it to readv was tried but faced iovec conversion overhead.

However, I believe this issue is hard to avoid completely but isn't unsolvable. We can try to minimize the read overhead of the descriptor chain to reduce conversion costs:
   1. In https://github.com/firecracker-microvm/firecracker/pull/4723, I removed an unnecessary check which reduced certain memory read costs in my benchmarks.
   2. I introduced a `load_next_descriptor` method that reduces the stack copying overhead of the DescriptorChain structure.
   3. I added a `MemBytesExt`, which after passing certain safety checks (inevitably passed by a non-malicious guest, if not pass, it fallbacks to read_obj), uses `ptr::read_volatile` to replace the more complex `read_obj`, achieving significant performance improvements in benchmarks.
   4. For future optimization, focusing on GuestMemory look-up could be effective. Since memory mappings are static, if the entire virtio queue is within a single contiguous mapping region, we could save this specific GuestMemoryRegion instead of the entire GuestMemory upon device activation. This would substantially reduce the lookup overhead for each memory access. Although there might typically be only two regions, the performance data show significant overhead that should not be overlooked. I have attempted to make changes to facilitate this optimization in the vm-memory repository: https://github.com/rust-vmm/vm-memory/pull/293.

Performance comparison data under these optimizations(the unit is Gbps):
```markdown
| Bench  | Old   | New   | Change   |
|--------|-------|-------|----------|
| F      | 37.74 | 42.4  | +12.35%  |
| R      | 40.8  | 40.4  | -0.98%   |
| F-96   | 37.6  | 42.8  | +13.83%  |
| F-128  | 37.81 | 42.5  | +12.40%  |
| F-256  | 37.43 | 42.8  | +14.35%  |
| F-1460 | 37.89 | 42.4  | +11.90%  |
| R-96   | 38.42 | 39.82 | +3.64%   |
| R-128  | 38.22 | 38.29 | +0.18%   |
| R-256  | 38.55 | 38.3  | -0.65%   |
| R-1460 | 40.8  | 40.3  | -1.23%   |
```

Attention, because this is a home-use CPU and Turbo Boost has not been disabled, the data may be somewhat inaccurate. If needed, I can upload some perf data.

Testing environment:
- CPU: AMD Ryzen 7 7840HS w/ Radeon Graphics
- VM: 4C2G, Host: 16C32G
- Affinity: 4 vCPUs and 1 main thread bound to 5 different cores; 4 host iperf processes bound to 4 different cores.
- iperf3: 4 host clients, 4 guest servers.
    - F: `iperf3 -A 1 --client 172.16.0.2 -T 5201 -p 5201 --omit 5 --time 30 -l 512K`
    - R: `iperf3 -A 1 --client 172.16.0.2 -T 5201 -p 5201 --omit 5 --time 30 -l 512K -R`
    - F-num: `iperf3 -A 1 --client 172.16.0.2 -T 5201 -p 5201 --omit 5 --time 30 -l 512K -M "$1"`
    - R-num: `iperf3 -A 1 --client 172.16.0.2 -T 5201 -p 5201 --omit 5 --time 30 -l 512K -R -M "$1"`

The new implementation shows significant performance improvements when reading large packets, with over a 10% maximum throughput increase in my benchmarks; however, it has a minor performance degradation with small packets.

2. Code Refactoring
The current implementation on the read link is quite complex as below:
<img width="1571" alt="image" src="https://github.com/user-attachments/assets/89ef3ed5-58ee-45b3-8f63-e3c76ae69849">
In the new implementation, the main logic is consolidated in `process_rx` and `process_tx`, with states managed using readiness tracking. Recording states with readiness also avoids potential overhead from queue and tap reads, making the code easier to understand.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
