### PR TITLE
Jailer: added the `-h` flag as a shorthand for `--help`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to
   [#4741](https://github.com/firecracker-microvm/firecracker/pull/4741),
   [#4746](https://github.com/firecracker-microvm/firecracker/pull/4746): Added
   official support for 6.1 microVM guest kernels.
+- [#4743](https://github.com/firecracker-microvm/firecracker/pull/4743): Added
+  support for `-h` help flag to the Jailer. The Jailer will now print the help
+  message with either `--help` or `-h`.
 
 ### Changed
 

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -9,6 +9,7 @@ pub type Result<T> = result::Result<T, UtilsArgParserError>;
 const ARG_PREFIX: &str = "--";
 const ARG_SEPARATOR: &str = "--";
 const HELP_ARG: &str = "--help";
+const SHORT_HELP_ARG: &str = "-h";
 const VERSION_ARG: &str = "--version";
 
 /// Errors associated with parsing and validating arguments.
@@ -330,10 +331,10 @@ impl<'a> Arguments<'a> {
         let (args, extra_args) = Arguments::split_args(&args[1..]);
         self.extra_args = extra_args.to_vec();
 
-        // If `--help` is provided as a parameter, we artificially skip the parsing of other
+        // If `--help` or `-h`is provided as a parameter, we artificially skip the parsing of other
         // command line arguments by adding just the help argument to the parsed list and
         // returning.
-        if args.contains(&HELP_ARG.to_string()) {
+        if args.contains(&HELP_ARG.to_string()) || args.contains(&SHORT_HELP_ARG.to_string()) {
             let mut help_arg = Argument::new("help").help("Show the help message.");
             help_arg.user_value = Some(Value::Flag);
             self.insert_arg(help_arg);
@@ -643,6 +644,16 @@ mod tests {
         let mut arguments = arg_parser.arguments().clone();
 
         let args = vec!["binary-name", "--exec-file", "foo", "--help"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+
+        arguments.parse(&args).unwrap();
+        assert!(arguments.args.contains_key("help"));
+
+        arguments = arg_parser.arguments().clone();
+
+        let args = vec!["binary-name", "--exec-file", "foo", "-h"]
             .into_iter()
             .map(String::from)
             .collect::<Vec<String>>();


### PR DESCRIPTION
## Changes

Jailer: added the `-h` flag as a shorthand for `--help`.

## Reason

This is a common convention - thought it would be useful.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md




---

# Additional Details

Tried to replicate the workings of the ArgParser by starting from
https://github.com/firecracker-microvm/firecracker/blob/e67b2bedbe01a958cc3140f0e951bd5ffa98ff0a/src/jailer/src/main.rs#L318-L320

Which leads to 
https://github.com/firecracker-microvm/firecracker/blob/e67b2bedbe01a958cc3140f0e951bd5ffa98ff0a/src/utils/src/arg_parser.rs#L320-L323

From there I tried to replicate the logic with this small script to see if this patch would work:

```rust
use std::env;                                                           
                                                                        
const ARG_SEPARATOR: &str = "--";                                       
const HELP_ARG: &str = "--help";                                        
const SHORT_HELP_ARG: &str = "-h";                                      
                                                                        
fn split_args(args: &[String]) -> (&[String], &[String]) {              
    if let Some(index) = args.iter().position(|arg| arg == ARG_SEPARATOR) {
        return (&args[..index], &args[index + 1..]);                    
    }                                                                   
                                                                        
    (args, &[])                                                         
}                                                                       
                                                                        
fn parse(args: &[String]) {                                             
    // Skipping the first element of `args` as it is the name of the binary.
    let (args, _) = split_args(&args[1..]);                             
                                                                        
    if args.contains(&HELP_ARG.to_string()) || args.contains(&SHORT_HELP_ARG.to_string()) {
        println!("found help args: {args:?}");                          
    }                                                                   
}                                                                       
                                                                        
fn main() {                                                             
    let args: Vec<String> = env::args().collect();                      
                                                                        
    parse(&args)                                                        
}
```

I tried it out and saw the following:

```
➜  ~/src/temp/args_help git:(master) ✗ ./target/debug/args_help --help 
found help args: ["--help"]
➜  ~/src/temp/args_help git:(master) ✗ ./target/debug/args_help -h    
found help args: ["-h"]
➜  ~/src/temp/args_help git:(master) ✗ ./target/debug/args_help --helpo
➜  ~/src/temp/args_help git:(master) ✗ ./target/debug/args_help --h    
➜  ~/src/temp/args_help git:(master) ✗ ./target/debug/args_help -hello
```
So it seems like this "should" work.