### PR TITLE
tests: capture host dmesg on test failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,9 +284,11 @@ def microvm_factory(request, record_property, results_dir):
     # if the test failed, save important files from the root of the uVM into `test_results` for troubleshooting
     report = request.node.stash[PHASE_REPORT_KEY]
     if "call" in report and report["call"].failed:
+        dmesg = utils.run_cmd(["dmesg", "-dPx"])
         for uvm in uvm_factory.vms:
             uvm_data = results_dir / uvm.id
             uvm_data.mkdir()
+            uvm_data.joinpath("host-dmesg.log").write_text(dmesg.stdout)
 
             uvm_root = Path(uvm.chroot())
             for item in os.listdir(uvm_root):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,6 +297,9 @@ def microvm_factory(request, record_property, results_dir):
                     continue
                 dst = uvm_data / item
                 shutil.copy(src, dst)
+                console_data = uvm.console_data
+                if console_data:
+                    uvm_data.joinpath("guest-console.log").write_text(console_data)
 
     uvm_factory.kill()
 


### PR DESCRIPTION
In some situations it would be useful to have the dmesg output to troubleshoot.

## Changes

- Add host dmesg output
- Add guest dmesg screen output if available

## Reason

To help troubleshooting

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
