### PR TITLE
Declare support for 6.1 guest kernels and deprecation for 4.14.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,18 @@ and this project adheres to
   Support for VMGenID via DeviceTree bindings exists only on mainline 6.10 Linux
   onwards. Users of Firecracker will need to backport the relevant patches on
   top of their 6.1 kernels to make use of the feature.
+- [#4732](https://github.com/firecracker-microvm/firecracker/pull/4732),
+  [#4733](https://github.com/firecracker-microvm/firecracker/pull/4733),
+  [#4741](https://github.com/firecracker-microvm/firecracker/pull/4741),
+  [#4746](https://github.com/firecracker-microvm/firecracker/pull/4746): Added
+  official support for 6.1 microVM guest kernels.
 
 ### Changed
 
 ### Deprecated
+
+- Support for guest kernel 4.14 is now deprecated. We will completely remove
+  4.14 support with Firecracker version v1.10
 
 ### Removed
 

--- a/docs/kernel-policy.md
+++ b/docs/kernel-policy.md
@@ -10,7 +10,9 @@ per [Firecracker’s release policy](../docs/RELEASE_POLICY.md)) using a
 combination of:
 
 - host linux kernel versions 5.10, and 6.1;
-- guest linux kernel versions 4.14, and 5.10.
+- guest linux kernel versions 5.10 and 6.1. Guest linux kernels 4.14 are
+  deprecated with Firecracker v1.9 and we will drop support for them with
+  Firecracker v1.10.
 
 While other versions and other kernel configs might work, they are not
 periodically validated in our test suite, and using them might result in
@@ -21,10 +23,10 @@ Once a kernel version is officially enabled, it is supported for a **minimum of
 2 years**. Adding support for a new kernel version will result in a Firecracker
 release only if compatibility changes are required.
 
-| Host kernel | Guest kernel v4.14 | Guest kernel v5.10 | Min. end of support |
-| ----------: | :----------------: | :----------------: | ------------------: |
-|       v5.10 |         Y          |         Y          |          2024-01-31 |
-|        v6.1 |         Y          |         Y          |          2025-10-12 |
+| Host kernel | Guest kernel v4.14 (deprecated) | Guest kernel v5.10 | Guest kernel v6.1 | Min. end of support |
+| ----------: | :-----------------------------: | :----------------: | :---------------: | ------------------: |
+|       v5.10 |         Y (deprecated)          |         Y          |         Y         |          2024-01-31 |
+|        v6.1 |         Y (deprecated)          |         Y          |         Y         |          2025-10-12 |
 
 The guest kernel configs used in our validation pipelines can be found
 [here](../resources/guest_configs/) while a breakdown of the relevant guest


### PR DESCRIPTION
Add an entry in the CHANGELOG about deprecation of 4.14 guest kernel and officially supporting 6.1. Also, update the kernel policy documentation to mention the changes.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
