### PR TITLE
snapshot-editor: fix rebase command description

### DIFF
--- a/src/snapshot-editor/src/edit_memory.rs
+++ b/src/snapshot-editor/src/edit_memory.rs
@@ -30,7 +30,7 @@ pub enum EditMemoryError {
 
 #[derive(Debug, Subcommand)]
 pub enum EditMemorySubCommand {
-    /// Remove registers from vcpu states.
+    /// Apply a diff snapshot on top of a base one
     Rebase {
         /// Path to the memory file.
         #[arg(short, long)]


### PR DESCRIPTION
The `rebase` command had a copy pasted description from `remove-regs`.

## Changes

Fix command description

## Reason

Command description may be confusing otherwise

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
