### PR TITLE
tests: fix console_data if not under screen

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -411,7 +411,10 @@ class Microvm:
         """Return the output of microVM's console"""
         if self.screen_log is None:
             return None
-        return Path(self.screen_log).read_text(encoding="utf-8")
+        file = Path(self.screen_log)
+        if not file.exists():
+            return None
+        return file.read_text(encoding="utf-8")
 
     @property
     def state(self):


### PR DESCRIPTION
In commit 059aa62216f8f1e22b2b7d7cbc1f15931c2dfe23 we started gathering console_data if a test failed. However console_data errors if we were not using screen in the first place.

Fixes: 059aa62216f8f1e22b2b7d7cbc1f15931c2dfe23

## Changes

...

## Reason

To avoid an error during teardown if a test failed.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
