### PR TITLE
Improve error handling for malformed snapshot files

### DIFF
--- a/src/vmm/src/devices/virtio/block/vhost_user/mod.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/mod.rs
@@ -19,8 +19,8 @@ pub const QUEUE_SIZE: u16 = 256;
 pub enum VhostUserBlockError {
     /// Cannot create config
     Config,
-    /// Persistence error: {0}
-    Persist(crate::devices::virtio::persist::PersistError),
+    /// Snapshotting of vhost-user-blk devices is not supported
+    SnapshottingNotSupported,
     /// Vhost-user error: {0}
     VhostUser(VhostUserError),
     /// Vhost error: {0}

--- a/src/vmm/src/devices/virtio/block/vhost_user/persist.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/persist.rs
@@ -38,6 +38,6 @@ impl Persist<'_> for VhostUserBlock {
         _constructor_args: Self::ConstructorArgs,
         _state: &Self::State,
     ) -> Result<Self, Self::Error> {
-        unimplemented!("VhostUserBlock does not support snapshotting yet");
+        Err(VhostUserBlockError::SnapshottingNotSupported)
     }
 }

--- a/src/vmm/src/mmds/persist.rs
+++ b/src/vmm/src/mmds/persist.rs
@@ -4,6 +4,7 @@
 //! Defines the structures needed for saving/restoring MmdsNetworkStack.
 
 use std::net::Ipv4Addr;
+use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
@@ -19,8 +20,8 @@ pub struct MmdsNetworkStackState {
     mac_addr: [u8; MAC_ADDR_LEN as usize],
     ipv4_addr: u32,
     tcp_port: u16,
-    max_connections: usize,
-    max_pending_resets: usize,
+    max_connections: NonZeroUsize,
+    max_pending_resets: NonZeroUsize,
 }
 
 impl Persist<'_> for MmdsNetworkStack {
@@ -49,8 +50,8 @@ impl Persist<'_> for MmdsNetworkStack {
             MacAddr::from_bytes_unchecked(&state.mac_addr),
             Ipv4Addr::from(state.ipv4_addr),
             state.tcp_port,
-            std::num::NonZeroUsize::new(state.max_connections).unwrap(),
-            std::num::NonZeroUsize::new(state.max_pending_resets).unwrap(),
+            state.max_connections,
+            state.max_pending_resets,
             mmds,
         ))
     }


### PR DESCRIPTION
## Changes

Correctly handle various error conditions that can only occur if a malformed snapshot file is attempted to be loaded.

## Reason

Graceful exits are nicer than panics

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
