### PR TITLE
Increase timeout of kani tests

### DIFF
--- a/tests/integration_tests/test_kani.py
+++ b/tests/integration_tests/test_kani.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
-Proofs ensuring memory safety properites, user-defined assertions,
+Proofs ensuring memory safety properties, user-defined assertions,
 absence of panics and some types of unexpected behavior (e.g., arithmetic overflows).
 """
 import os
@@ -14,7 +14,9 @@ from framework import utils
 PLATFORM = platform.machine()
 
 
-@pytest.mark.timeout(1800)
+# The `check_output` timeout will always fire before this one, but we need to
+# set a timeout here to override the default pytest timeout of 180s.
+@pytest.mark.timeout(2420)
 @pytest.mark.skipif(PLATFORM != "x86_64", reason="Kani proofs run only on x86_64.")
 @pytest.mark.skipif(
     os.environ.get("BUILDKITE") != "true",
@@ -31,7 +33,8 @@ def test_kani(results_dir):
     # --output-format terse is required by -j
     # --enable-unstable is needed to enable `-Z` flags
     _, stdout, _ = utils.check_output(
-        "cargo kani --enable-unstable -Z stubbing -Z function-contracts --restrict-vtable -j --output-format terse"
+        "cargo kani --enable-unstable -Z stubbing -Z function-contracts --restrict-vtable -j --output-format terse",
+        timeout=2400,
     )
 
     (results_dir / "kani_log").write_text(stdout, encoding="utf-8")


### PR DESCRIPTION

## Changes

Increase the timeout for kani test from 30 to 40 minutes.

## Reason

Some changes that we did in the VirtIO queue in this PR: https://github.com/firecracker-microvm/firecracker/pull/4726 pushed kani proofs close to the time limit we set in the CI.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
