### PR TITLE
test: do not perf test with no-acpi kernels

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -376,6 +376,12 @@ def rootfs_fxt(request, record_property):
 
 # Fixtures for all guest kernels, and specific versions
 guest_kernel = pytest.fixture(guest_kernel_fxt, params=kernel_params("vmlinux-*"))
+guest_kernel_acpi = pytest.fixture(
+    guest_kernel_fxt,
+    params=filter(
+        lambda kernel: "no-acpi" not in kernel.id, kernel_params("vmlinux-*")
+    ),
+)
 guest_kernel_linux_4_14 = pytest.fixture(
     guest_kernel_fxt, params=kernel_params("vmlinux-4.14*")
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,7 +386,10 @@ guest_kernel_linux_4_14 = pytest.fixture(
     guest_kernel_fxt, params=kernel_params("vmlinux-4.14*")
 )
 guest_kernel_linux_5_10 = pytest.fixture(
-    guest_kernel_fxt, params=kernel_params("vmlinux-5.10*")
+    guest_kernel_fxt,
+    params=filter(
+        lambda kernel: "no-acpi" not in kernel.id, kernel_params("vmlinux-5.10*")
+    ),
 )
 guest_kernel_linux_6_1 = pytest.fixture(
     guest_kernel_fxt,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ import pytest
 
 import host_tools.cargo_build as build_tools
 from framework import defs, utils
-from framework.artifacts import kernel_params, kernels_unfiltered, rootfs_params
+from framework.artifacts import kernel_params, rootfs_params
 from framework.microvm import MicroVMFactory
 from framework.properties import global_props
 from framework.utils_cpu_templates import (

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -45,19 +45,6 @@ def kernels(glob) -> Iterator:
                 break
 
 
-def kernels_unfiltered(glob) -> Iterator:
-    """Return kernels from the CI artifacts. This one does not filter for
-    supported kernels. It will return any kernel in the CI artifacts folder
-    that matches the 'glob'
-    """
-    all_kernels = [r"vmlinux-\d.\d+.\d+", r"vmlinux-5.10-no-sve-bin"]
-    for kernel in sorted(ARTIFACT_DIR.rglob(glob)):
-        for kernel_regex in all_kernels:
-            if re.fullmatch(kernel_regex, kernel.name):
-                yield kernel
-                break
-
-
 def disks(glob) -> Iterator:
     """Return supported rootfs"""
     yield from sorted(ARTIFACT_DIR.glob(glob))

--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -142,7 +142,7 @@ def process_fio_logs(vm, fio_mode, logs_dir, metrics):
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_block_performance(
     microvm_factory,
-    guest_kernel,
+    guest_kernel_acpi,
     rootfs,
     vcpus,
     fio_mode,
@@ -153,7 +153,7 @@ def test_block_performance(
     """
     Execute block device emulation benchmarking scenarios.
     """
-    vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
+    vm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()
@@ -191,7 +191,7 @@ def test_block_performance(
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_block_vhost_user_performance(
     microvm_factory,
-    guest_kernel,
+    guest_kernel_acpi,
     rootfs,
     vcpus,
     fio_mode,
@@ -202,7 +202,7 @@ def test_block_vhost_user_performance(
     Execute block device emulation benchmarking scenarios.
     """
 
-    vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
+    vm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -173,7 +173,7 @@ def find_events(log_data):
     [(1, 128), (1, 1024), (2, 2048), (4, 4096)],
 )
 def test_boottime(
-    microvm_factory, guest_kernel, rootfs_rw, vcpu_count, mem_size_mib, metrics
+    microvm_factory, guest_kernel_acpi, rootfs_rw, vcpu_count, mem_size_mib, metrics
 ):
     """Test boot time with different guest configurations"""
 
@@ -181,14 +181,14 @@ def test_boottime(
         {
             **DIMENSIONS,
             "performance_test": "test_boottime",
-            "guest_kernel": guest_kernel.name,
+            "guest_kernel_acpi": guest_kernel_acpi.name,
             "vcpus": str(vcpu_count),
             "mem_size_mib": str(mem_size_mib),
         }
     )
 
     for _ in range(10):
-        vm = microvm_factory.build(guest_kernel, rootfs_rw)
+        vm = microvm_factory.build(guest_kernel_acpi, rootfs_rw)
         vm.jailer.extra_args.update({"boot-timer": None})
         vm.spawn()
         vm.basic_config(

--- a/tests/integration_tests/performance/test_memory_overhead.py
+++ b/tests/integration_tests/performance/test_memory_overhead.py
@@ -29,7 +29,7 @@ X86_MEMORY_GAP_START = 3328 * 2**20
     [(1, 128), (1, 1024), (2, 2048), (4, 4096)],
 )
 def test_memory_overhead(
-    microvm_factory, guest_kernel, rootfs, vcpu_count, mem_size_mib, metrics
+    microvm_factory, guest_kernel_acpi, rootfs, vcpu_count, mem_size_mib, metrics
 ):
     """Track Firecracker memory overhead.
 
@@ -37,7 +37,7 @@ def test_memory_overhead(
     """
 
     for _ in range(5):
-        microvm = microvm_factory.build(guest_kernel, rootfs)
+        microvm = microvm_factory.build(guest_kernel_acpi, rootfs)
         microvm.spawn(emit_metrics=True)
         microvm.basic_config(vcpu_count=vcpu_count, mem_size_mib=mem_size_mib)
         microvm.add_net_iface()

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -36,14 +36,14 @@ def consume_ping_output(ping_putput, request_per_round):
 
 
 @pytest.fixture
-def network_microvm(request, microvm_factory, guest_kernel, rootfs):
+def network_microvm(request, microvm_factory, guest_kernel_acpi, rootfs):
     """Creates a microvm with the networking setup used by the performance tests in this file.
     This fixture receives its vcpu count via indirect parameterization"""
 
     guest_mem_mib = 1024
     guest_vcpus = request.param
 
-    vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
+    vm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=guest_vcpus, mem_size_mib=guest_mem_mib)
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -43,12 +43,12 @@ class SnapshotRestoreTest:
     def configure_vm(
         self,
         microvm_factory,
-        guest_kernel,
+        guest_kernel_acpi,
         rootfs,
     ) -> Microvm:
         """Creates the initial snapshot that will be loaded repeatedly to sample latencies"""
         vm = microvm_factory.build(
-            guest_kernel,
+            guest_kernel_acpi,
             rootfs,
             monitor_memory=False,
         )

--- a/tests/integration_tests/performance/test_vhost_user_metrics.py
+++ b/tests/integration_tests/performance/test_vhost_user_metrics.py
@@ -11,7 +11,7 @@ import host_tools.drive as drive_tools
 
 @pytest.mark.parametrize("vcpu_count", [1, 2], ids=["1vcpu", "2vcpu"])
 def test_vhost_user_block_metrics(
-    microvm_factory, guest_kernel, rootfs_ubuntu_22, vcpu_count, metrics
+    microvm_factory, guest_kernel_acpi, rootfs_ubuntu_22, vcpu_count, metrics
 ):
     """
     This test tries to boot a VM with vhost-user-block
@@ -28,7 +28,9 @@ def test_vhost_user_block_metrics(
     # low->high->low->high and so the numbers are not in monotonic sequence.
     new_sizes = [20, 10, 30]  # MB
 
-    vm = microvm_factory.build(guest_kernel, rootfs_ubuntu_22, monitor_memory=False)
+    vm = microvm_factory.build(
+        guest_kernel_acpi, rootfs_ubuntu_22, monitor_memory=False
+    )
     vm.spawn(log_level="Info")
     vm.basic_config(vcpu_count=vcpu_count)
 

--- a/tests/integration_tests/performance/test_vsock_ab.py
+++ b/tests/integration_tests/performance/test_vsock_ab.py
@@ -73,7 +73,7 @@ class VsockIPerf3Test(IPerf3Test):
 @pytest.mark.parametrize("payload_length", ["64K", "1024K"], ids=["p64K", "p1024K"])
 @pytest.mark.parametrize("mode", ["g2h", "h2g", "bd"])
 def test_vsock_throughput(
-    microvm_factory, guest_kernel, rootfs, vcpus, payload_length, mode, metrics
+    microvm_factory, guest_kernel_acpi, rootfs, vcpus, payload_length, mode, metrics
 ):
     """
     Test vsock throughput for multiple vm configurations.
@@ -85,7 +85,7 @@ def test_vsock_throughput(
         pytest.skip("bidrectional test only done with at least 2 vcpus")
 
     mem_size_mib = 1024
-    vm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
+    vm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=mem_size_mib)
     vm.add_net_iface()


### PR DESCRIPTION
Using guests without ACPI support is deprecated, but we need to
functionally verify it until we can remove support in Firecracker 2.0.
However, we definitely do not need to performance test this
configuration. So don't, and speed up our perf tests by 25%.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
