### PR TITLE
fix(changelog): add entry about virtio-net feature negotiation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to
 
 ### Fixed
 
+- [4680](https://github.com/firecracker-microvm/firecracker/pull/4680): Fixed an
+  issue
+  ([#4659](https://github.com/firecracker-microvm/firecracker/issues/4659))
+  where the virtio-net device implementation would always assume the guest
+  accepts all VirtIO features the device offers. This is always true with the
+  Linux guest kernels we are testing but other kernels, like FreeBSD make
+  different assumptions. This PR fixes the emulation code to set the TAP
+  features based on the features accepted by the guest.
+
 ## \[1.8.0\]
 
 ### Added


### PR DESCRIPTION
## Changes

Adds an entry in CHANGELOG.md about the fix
https://github.com/firecracker-microvm/firecracker/pull/4680. The fix ensures that we set to the TAP device only features that were successfully negotiated with the guest driver.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
