### PR TITLE
chore: deduplicate emails in CREDITS.md

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,12 +18,18 @@ Alexandru Cihodaru <cihodar@amazon.com>
 Liviu Berciu <lberciu@amazon.com>
 Jonathan Woollett-Light <jcawl@amazon.co.uk> <jonathanwoollettlight@gmail.com>
 Jonathan Woollett-Light <jcawl@amazon.co.uk> <jonthanwoollettlight@gmail.com>
-Sudan Landge <sudanl@amazon.com> <sudan@amazon.co.uk>
+Sudan Landge <sudanl@amazon.co.uk> <119602619+sudanl0@users.noreply.github.com>
+Sudan Landge <sudanl@amazon.co.uk> <sudanl@amazon.com>
 karthik nedunchezhiyan <karthik.n@zohocorp.com>
 Babis Chalios <bchalios@amazon.es> <babis.chalios@gmail.com>
 Pablo Barbáchano <pablob@amazon.com>
 Nikita Kalyazin <kalyazin@amazon.co.uk> <kalyazin@amazon.com>
 Trăistaru Andrei Cristian <atc@amazon.com>
 Trăistaru Andrei Cristian <atc@amazon.com> <56828222+andreitraistaru@users.noreply.github.com>
-Sudan Landge <sudanl@amazon.com> <sudanl@amazon.co.uk>
 Takahiro Itazuri <itazur@amazon.com> <zulinx86@gmail.com>
+Jack Thomson <jackabt@amazon.co.uk> <jackabt@amazon.com>
+Ashwin Ginoria <aginoria@amazon.com> <ec2-user@ip-10-0-10-88.us-west-2.compute.internal>
+Muskaan Singla <msinglaa@amazon.com> <ec2-user@ip-172-31-1-28.us-west-2.compute.internal>
+Egor Lazarchuk <yegorlz@amazon.co.uk>
+Nikita Zakirov <zakironi@amazon.com> <ec2-user@ip-10-0-15-219.us-west-2.compute.internal>
+Tomoya Iwata <iwata.tomoya@classmethod.jp>

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -181,7 +181,7 @@ Contributors to the Firecracker repository:
 - milahu <milahu@gmail.com>
 - moricho <ikeda.morito@gmail.com>
 - Muki Kiboigo <muki@kiboigo.com>
-- Muskaan Singla <ec2-user@ip-172-31-1-28.us-west-2.compute.internal>
+- Muskaan Singla <msinglaa@amazon.com>
 - Narek Galstyan <narekg@berkeley.edu>
 - Nathan Hoang <nathanhoang5@gmail.com>
 - Nathan Sizemore <nathanrsizemore@gmail.com>
@@ -226,7 +226,6 @@ Contributors to the Firecracker repository:
 - Sean Lavine <freewil@users.noreply.github.com>
 - Sebastien Boeuf <sebastien.boeuf@intel.com>
 - Serban Iorga <seriorga@amazon.com>
-- ShadowCurse <yegorlz@amazon.co.uk>
 - shakram02 <ahmedhamdyau@gmail.com>
 - Shen Jiale <shenjiale@baidu.com>
 - Shion Yamashita <shioyama1118@gmail.com>
@@ -235,7 +234,7 @@ Contributors to the Firecracker repository:
 - Sripracha <ramsri@amazon.com>
 - Stefan Nita <32079871+stefannita01@users.noreply.github.com>
 - StemCll <lydjotj6f@mozmail.com>
-- Sudan Landge <sudanl@amazon.com>
+- Sudan Landge <sudanl@amazon.co.uk>
 - sundar.preston.789@gmail.com <sundar.preston.789@gmail.com>
 - Takahiro Itazuri <itazur@amazon.com>
 - Tal Hoffman <talhof8@gmail.com>


### PR DESCRIPTION
Add entries to `.mailmap` to make re-generating CREDITS.md easier.

- Deduplicate some entries.
- Correct some existing addresses of maintainers.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
