### PR TITLE
Backport make_release fix for creating the build directory as non-root to v1.9

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -496,6 +496,7 @@ cmd_build() {
 }
 
 function cmd_make_release {
+    ensure_build_dir
     run_devctr \
         --user "$(id -u):$(id -g)" \
         --workdir "$CTR_FC_ROOT_DIR" \


### PR DESCRIPTION


## Changes

Fix `./tools/devtool make_release`  by making sure exists before building with proper permissions.

(cherry picked from commit 63749ec1af6a7d18cb3256be1579c5acfb174ff8)

## Reason

Unless we call `ensure_build_dir`, the build directory will be created inside the Docker container as root and subsequent builds will fail.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
