### PR TITLE
ci: drop guest 4.14 kernel

### DIFF
--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -220,7 +220,6 @@ clone_amazon_linux_repo
 # Apply kernel patches on top of AL configuration
 apply_kernel_patches_for_ci
 
-build_al_kernel $PWD/guest_configs/microvm-kernel-ci-$ARCH-4.14.config
 build_al_kernel $PWD/guest_configs/microvm-kernel-ci-$ARCH-5.10.config
 if [ $ARCH == "x86_64" ]; then
     build_al_kernel $PWD/guest_configs/microvm-kernel-ci-$ARCH-5.10-no-acpi.config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -382,9 +382,6 @@ guest_kernel_acpi = pytest.fixture(
         lambda kernel: "no-acpi" not in kernel.id, kernel_params("vmlinux-*")
     ),
 )
-guest_kernel_linux_4_14 = pytest.fixture(
-    guest_kernel_fxt, params=kernel_params("vmlinux-4.14*")
-)
 guest_kernel_linux_5_10 = pytest.fixture(
     guest_kernel_fxt,
     params=filter(

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -21,7 +21,7 @@ def select_supported_kernels():
     """Select guest kernels supported by the current combination of kernel and
     instance type.
     """
-    supported_kernels = [r"vmlinux-4.14.\d+", r"vmlinux-5.10.\d+", r"vmlinux-6.1.\d+"]
+    supported_kernels = [r"vmlinux-5.10.\d+", r"vmlinux-6.1.\d+"]
 
     # Booting with MPTable is deprecated but we still want to test
     # for it. Until we drop support for it we will be building a 5.10 guest

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -19,15 +19,12 @@ DEFAULT_G2_FEATURES = set(
     ).split(" ")
 )
 
-DEFAULT_G3_FEATURES_4_14 = DEFAULT_G2_FEATURES | set(
-    "sha512 asimdfhm dit uscat ilrcpc flagm jscvt fcma sha3 sm3 sm4 rng".split(" ")
+DEFAULT_G3_FEATURES_5_10 = set(
+    "sha512 asimdfhm dit uscat ilrcpc flagm jscvt fcma sha3 sm3 sm4 rng dcpodp i8mm bf16 dgh".split(
+        " "
+    )
 )
 
-DEFAULT_G3_FEATURES_5_10 = DEFAULT_G3_FEATURES_4_14 | set(
-    "dcpodp i8mm bf16 dgh".split(" ")
-)
-
-DEFAULT_G3_FEATURES_WITH_SVE_AND_PAC_4_14 = DEFAULT_G3_FEATURES_4_14
 DEFAULT_G3_FEATURES_WITH_SVE_AND_PAC_5_10 = DEFAULT_G3_FEATURES_5_10 | set(
     "paca pacg sve svebf16 svei8mm".split(" ")
 )
@@ -42,10 +39,6 @@ def _check_cpu_features_arm(test_microvm, guest_kv, template_name=None):
             expected_cpu_features = DEFAULT_G2_FEATURES
         case CpuModel.ARM_NEOVERSE_N1, _, None:
             expected_cpu_features = DEFAULT_G2_FEATURES
-        case CpuModel.ARM_NEOVERSE_V1, "4.14", "aarch64_with_sve_and_pac":
-            expected_cpu_features = DEFAULT_G3_FEATURES_WITH_SVE_AND_PAC_4_14
-        case CpuModel.ARM_NEOVERSE_V1, "4.14", None:
-            expected_cpu_features = DEFAULT_G3_FEATURES_4_14
 
         # [cm]7g with guest kernel 5.10 and later
         case CpuModel.ARM_NEOVERSE_V1, _, "v1n1":

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -31,7 +31,7 @@ DIMENSIONS = {
 
 
 @pytest.fixture
-def fast_microvm(microvm_factory, guest_kernel_linux_4_14, rootfs_rw):
+def fast_microvm(microvm_factory, guest_kernel_linux_5_10, rootfs_rw):
     """The microvm defined for the boottime SLA
 
     Guest kernel 4.14
@@ -40,7 +40,7 @@ def fast_microvm(microvm_factory, guest_kernel_linux_4_14, rootfs_rw):
     Using ext4 seems to result in a faster boot than with squashfs. Probably
     because we have to spend CPU time decompressing and extracting into memory.
     """
-    return microvm_factory.build(kernel=guest_kernel_linux_4_14, rootfs=rootfs_rw)
+    return microvm_factory.build(kernel=guest_kernel_linux_5_10, rootfs=rootfs_rw)
 
 
 def test_no_boottime(uvm_plain):

--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -77,14 +77,14 @@ class SnapshotRestoreTest:
         return vm
 
     def sample_latency(
-        self, microvm_factory, snapshot, guest_kernel_linux_4_14
+        self, microvm_factory, snapshot, guest_kernel_linux_5_10
     ) -> List[float]:
         """Collects latency samples for the microvm configuration specified by this instance"""
         values = []
 
         for _ in range(ITERATIONS):
             microvm = microvm_factory.build(
-                kernel=guest_kernel_linux_4_14,
+                kernel=guest_kernel_linux_5_10,
                 monitor_memory=False,
             )
             microvm.spawn(emit_metrics=True)
@@ -127,7 +127,7 @@ class SnapshotRestoreTest:
     ids=lambda x: x.id,
 )
 def test_restore_latency(
-    microvm_factory, rootfs, guest_kernel_linux_4_14, test_setup, metrics
+    microvm_factory, rootfs, guest_kernel_linux_5_10, test_setup, metrics
 ):
     """
     Restores snapshots with vcpu/memory configuration, roughly scaling according to mem = (vcpus - 1) * 2048MB,
@@ -136,7 +136,7 @@ def test_restore_latency(
 
     We only test a single guest kernel, as the guest kernel does not "participate" in snapshot restore.
     """
-    vm = test_setup.configure_vm(microvm_factory, guest_kernel_linux_4_14, rootfs)
+    vm = test_setup.configure_vm(microvm_factory, guest_kernel_linux_5_10, rootfs)
     vm.start()
     vm.wait_for_up()
 
@@ -157,7 +157,7 @@ def test_restore_latency(
     samples = test_setup.sample_latency(
         microvm_factory,
         snapshot,
-        guest_kernel_linux_4_14,
+        guest_kernel_linux_5_10,
     )
 
     for sample in samples:

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -21,13 +21,13 @@ def snapshot_create_producer(vm):
 
 def test_snapshot_create_latency(
     microvm_factory,
-    guest_kernel_linux_4_14,
+    guest_kernel_linux_5_10,
     rootfs,
     metrics,
 ):
     """Measure the latency of creating a Full snapshot"""
 
-    vm = microvm_factory.build(guest_kernel_linux_4_14, rootfs, monitor_memory=False)
+    vm = microvm_factory.build(guest_kernel_linux_5_10, rootfs, monitor_memory=False)
     vm.spawn()
     vm.basic_config(vcpu_count=2, mem_size_mib=512)
     vm.start()


### PR DESCRIPTION
## Changes

Change resources/rebuild.sh to not re-build 4.14 kernels. Also, drop various fixtures for 4.14 kernels in the CI and switch to 5.10 wherever the default was 4.14.

## Reason

4.14 guest is now deprecated.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
