### PR TITLE
ci: start kani test without waiting for build

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -314,8 +314,9 @@ class BKPipeline:
 
         https://buildkite.com/docs/pipelines/group-step
         """
+        decorate = kwargs.pop("decorate", True)
         combined = overlay_dict(self.per_instance, kwargs)
-        return self.add_step(group(*args, **combined))
+        return self.add_step(group(*args, **combined), decorate=decorate)
 
     def build_group_per_arch(self, *args, **kwargs):
         """

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -58,10 +58,12 @@ if not changed_files or any(
         platforms=[("al2", "linux_5.10")],
         timeout_in_minutes=300,
         **DEFAULTS_PERF,
+        decorate=False,
     )
     # modify Kani steps' label
     for step in kani_grp["steps"]:
         step["label"] = "🔍 Kani"
+    kani_grp["depends_on"] = None
 
 if run_all_tests(changed_files):
     pipeline.build_group(


### PR DESCRIPTION
The kani test does not use the pre-built firecracker binaries, as kani does static analysis, and does not execute binaries. Thus, do not have the kani test block on compilation finishing.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
