### PR TITLE
fix: do criterion benchmark comparision the correct way around

### DIFF
--- a/tests/integration_tests/performance/test_benchmarks.py
+++ b/tests/integration_tests/performance/test_benchmarks.py
@@ -79,7 +79,7 @@ def compare_results(location_a_baselines: Path, location_b_baselines: Path):
     _, stdout, _ = cargo(
         "bench",
         f"--all --target {platform.machine()}-unknown-linux-musl",
-        "--load-baseline a_baseline --baseline b_baseline",
+        "--baseline a_baseline --load-baseline b_baseline",
     )
 
     regressions_only = "\n\n".join(


### PR DESCRIPTION
The optional criterion benchmark A/B-test had swapped the "A" and "B" data, causing regressions to show up as improvements and improvements to show up as regressions.

See also [[1]] for a documentation of the criterion commandline arguments.

[1]: https://bheisler.github.io/criterion.rs/book/user_guide/command_line_options.html#baselines

Fixes: b6c0d43949843369be8913b2de0817d631721e52

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
