### PR TITLE
Use u32 for Vsock related buffer sizes

### DIFF
--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -69,7 +69,7 @@ impl VsockChannel for TestBackend {
                 let buf_size = pkt.buf_size();
                 if buf_size > 0 {
                     let buf: Vec<u8> = (0..buf_size)
-                        .map(|i| cool_buf[i % cool_buf.len()])
+                        .map(|i| cool_buf[i as usize % cool_buf.len()])
                         .collect();
                     pkt.read_at_offset_from(&mut buf.as_slice(), 0, buf_size)
                         .unwrap();
@@ -206,8 +206,8 @@ impl<'a> EventHandlerContext<'a> {
 }
 
 #[cfg(test)]
-pub fn read_packet_data(pkt: &VsockPacket, how_much: usize) -> Vec<u8> {
-    let mut buf = vec![0; how_much];
+pub fn read_packet_data(pkt: &VsockPacket, how_much: u32) -> Vec<u8> {
+    let mut buf = vec![0; how_much as usize];
     pkt.write_from_offset_to(&mut buf.as_mut_slice(), 0, how_much)
         .unwrap();
     buf

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -869,11 +869,11 @@ mod tests {
             peer_port: u32,
             mut data: &[u8],
         ) -> &mut VsockPacket {
-            assert!(data.len() <= self.tx_pkt.buf_size());
+            assert!(data.len() <= self.tx_pkt.buf_size() as usize);
             self.init_tx_pkt(local_port, peer_port, uapi::VSOCK_OP_RW)
                 .set_len(u32::try_from(data.len()).unwrap());
 
-            let data_len = data.len(); // store in tmp var to make borrow checker happy.
+            let data_len = data.len().try_into().unwrap(); // store in tmp var to make borrow checker happy.
             self.rx_pkt
                 .read_at_offset_from(&mut data, 0, data_len)
                 .unwrap();


### PR DESCRIPTION
## Changes

Use u32 for all Vsock reletated buffers  instead of usize, since the Virtio specification states that lengths of virtio-buffers fit into u32

## Reason

Close #4627 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
