### PR TITLE
fix(test): fix guest_kernel metric in boottime tests

### DIFF
--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -181,7 +181,7 @@ def test_boottime(
         {
             **DIMENSIONS,
             "performance_test": "test_boottime",
-            "guest_kernel_acpi": guest_kernel_acpi.name,
+            "guest_kernel": guest_kernel_acpi.name,
             "vcpus": str(vcpu_count),
             "mem_size_mib": str(mem_size_mib),
         }


### PR DESCRIPTION
The search-and-replace for excluding the no-acpi kernels from the performance tests was a bit overzealous and also renames the `guest_kernel` metric.

Fixes: 2360fcce44365d6bc01453acefc22dff3152b323

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
