### PR TITLE
Enable ftrace in guest kernels

### DIFF
--- a/resources/guest_configs/patches/0003-enable-ftrace.patch
+++ b/resources/guest_configs/patches/0003-enable-ftrace.patch
@@ -1,0 +1,161 @@
+diff --git a/resources/guest_configs/microvm-kernel-ci-aarch64-4.14.config b/resources/guest_configs/microvm-kernel-ci-aarch64-4.14.config
+index 694058ca9..bf06466ab 100644
+--- a/resources/guest_configs/microvm-kernel-ci-aarch64-4.14.config
++++ b/resources/guest_configs/microvm-kernel-ci-aarch64-4.14.config
+@@ -2482,7 +2482,17 @@ CONFIG_HAVE_FTRACE_MCOUNT_RECORD=y
+ CONFIG_HAVE_SYSCALL_TRACEPOINTS=y
+ CONFIG_HAVE_C_RECORDMCOUNT=y
+ CONFIG_TRACING_SUPPORT=y
+-# CONFIG_FTRACE is not set
++CONFIG_FTRACE=y
++CONFIG_FUNCTION_TRACER=y
++CONFIG_FUNCTION_GRAPH_TRACER=y
++CONFIG_IRQSOFF_TRACER=y
++CONFIG_PREEMPT_TRACER=y
++CONFIG_SCHED_TRACER=y
++CONFIG_STACK_TRACER=y
++CONFIG_BLK_DEV_IO_TRACE=y
++CONFIG_FUNCTION_PROFILER=y
++CONFIG_FTRACE_MCOUNT_RECORD=y
++CONFIG_FTRACE_SYSCALLS=y
+ # CONFIG_DMA_API_DEBUG is not set
+ # CONFIG_KUNIT is not set
+ 
+diff --git a/resources/guest_configs/microvm-kernel-ci-aarch64-5.10.config b/resources/guest_configs/microvm-kernel-ci-aarch64-5.10.config
+index ac44904c1..2a6f2310f 100644
+--- a/resources/guest_configs/microvm-kernel-ci-aarch64-5.10.config
++++ b/resources/guest_configs/microvm-kernel-ci-aarch64-5.10.config
+@@ -3089,7 +3089,17 @@ CONFIG_HAVE_FTRACE_MCOUNT_RECORD=y
+ CONFIG_HAVE_SYSCALL_TRACEPOINTS=y
+ CONFIG_HAVE_C_RECORDMCOUNT=y
+ CONFIG_TRACING_SUPPORT=y
+-# CONFIG_FTRACE is not set
++CONFIG_FTRACE=y
++CONFIG_FUNCTION_TRACER=y
++CONFIG_FUNCTION_GRAPH_TRACER=y
++CONFIG_IRQSOFF_TRACER=y
++CONFIG_PREEMPT_TRACER=y
++CONFIG_SCHED_TRACER=y
++CONFIG_STACK_TRACER=y
++CONFIG_BLK_DEV_IO_TRACE=y
++CONFIG_FUNCTION_PROFILER=y
++CONFIG_FTRACE_MCOUNT_RECORD=y
++CONFIG_FTRACE_SYSCALLS=y
+ # CONFIG_SAMPLES is not set
+ CONFIG_ARCH_HAS_DEVMEM_IS_ALLOWED=y
+ # CONFIG_STRICT_DEVMEM is not set
+diff --git a/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config b/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config
+index 26b87a658..f0f765298 100644
+--- a/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config
++++ b/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config
+@@ -3309,7 +3309,17 @@ CONFIG_HAVE_FTRACE_MCOUNT_RECORD=y
+ CONFIG_HAVE_SYSCALL_TRACEPOINTS=y
+ CONFIG_HAVE_C_RECORDMCOUNT=y
+ CONFIG_TRACING_SUPPORT=y
+-# CONFIG_FTRACE is not set
++CONFIG_FTRACE=y
++CONFIG_FUNCTION_TRACER=y
++CONFIG_FUNCTION_GRAPH_TRACER=y
++CONFIG_IRQSOFF_TRACER=y
++CONFIG_PREEMPT_TRACER=y
++CONFIG_SCHED_TRACER=y
++CONFIG_STACK_TRACER=y
++CONFIG_BLK_DEV_IO_TRACE=y
++CONFIG_FUNCTION_PROFILER=y
++CONFIG_FTRACE_MCOUNT_RECORD=y
++CONFIG_FTRACE_SYSCALLS=y
+ # CONFIG_SAMPLES is not set
+ # CONFIG_STRICT_DEVMEM is not set
+ 
+diff --git a/resources/guest_configs/microvm-kernel-ci-x86_64-4.14.config b/resources/guest_configs/microvm-kernel-ci-x86_64-4.14.config
+index ee6df5ffc..3ab74b395 100644
+--- a/resources/guest_configs/microvm-kernel-ci-x86_64-4.14.config
++++ b/resources/guest_configs/microvm-kernel-ci-x86_64-4.14.config
+@@ -2694,7 +2694,17 @@ CONFIG_HAVE_SYSCALL_TRACEPOINTS=y
+ CONFIG_HAVE_FENTRY=y
+ CONFIG_HAVE_C_RECORDMCOUNT=y
+ CONFIG_TRACING_SUPPORT=y
+-# CONFIG_FTRACE is not set
++CONFIG_FTRACE=y
++CONFIG_FUNCTION_TRACER=y
++CONFIG_FUNCTION_GRAPH_TRACER=y
++CONFIG_IRQSOFF_TRACER=y
++CONFIG_PREEMPT_TRACER=y
++CONFIG_SCHED_TRACER=y
++CONFIG_STACK_TRACER=y
++CONFIG_BLK_DEV_IO_TRACE=y
++CONFIG_FUNCTION_PROFILER=y
++CONFIG_FTRACE_MCOUNT_RECORD=y
++CONFIG_FTRACE_SYSCALLS=y
+ # CONFIG_PROVIDE_OHCI1394_DMA_INIT is not set
+ # CONFIG_DMA_API_DEBUG is not set
+ # CONFIG_KUNIT is not set
+diff --git a/resources/guest_configs/microvm-kernel-ci-x86_64-5.10-no-acpi.config b/resources/guest_configs/microvm-kernel-ci-x86_64-5.10-no-acpi.config
+index b87fb3e44..fc45dda19 100644
+--- a/resources/guest_configs/microvm-kernel-ci-x86_64-5.10-no-acpi.config
++++ b/resources/guest_configs/microvm-kernel-ci-x86_64-5.10-no-acpi.config
+@@ -2905,7 +2905,17 @@ CONFIG_HAVE_SYSCALL_TRACEPOINTS=y
+ CONFIG_HAVE_FENTRY=y
+ CONFIG_HAVE_C_RECORDMCOUNT=y
+ CONFIG_TRACING_SUPPORT=y
+-# CONFIG_FTRACE is not set
++CONFIG_FTRACE=y
++CONFIG_FUNCTION_TRACER=y
++CONFIG_FUNCTION_GRAPH_TRACER=y
++CONFIG_IRQSOFF_TRACER=y
++CONFIG_PREEMPT_TRACER=y
++CONFIG_SCHED_TRACER=y
++CONFIG_STACK_TRACER=y
++CONFIG_BLK_DEV_IO_TRACE=y
++CONFIG_FUNCTION_PROFILER=y
++CONFIG_FTRACE_MCOUNT_RECORD=y
++CONFIG_FTRACE_SYSCALLS=y
+ # CONFIG_SAMPLES is not set
+ CONFIG_ARCH_HAS_DEVMEM_IS_ALLOWED=y
+ CONFIG_STRICT_DEVMEM=y
+diff --git a/resources/guest_configs/microvm-kernel-ci-x86_64-5.10.config b/resources/guest_configs/microvm-kernel-ci-x86_64-5.10.config
+index 09461c178..6d85bce2c 100644
+--- a/resources/guest_configs/microvm-kernel-ci-x86_64-5.10.config
++++ b/resources/guest_configs/microvm-kernel-ci-x86_64-5.10.config
+@@ -2987,7 +2987,17 @@ CONFIG_HAVE_SYSCALL_TRACEPOINTS=y
+ CONFIG_HAVE_FENTRY=y
+ CONFIG_HAVE_C_RECORDMCOUNT=y
+ CONFIG_TRACING_SUPPORT=y
+-# CONFIG_FTRACE is not set
++CONFIG_FTRACE=y
++CONFIG_FUNCTION_TRACER=y
++CONFIG_FUNCTION_GRAPH_TRACER=y
++CONFIG_IRQSOFF_TRACER=y
++CONFIG_PREEMPT_TRACER=y
++CONFIG_SCHED_TRACER=y
++CONFIG_STACK_TRACER=y
++CONFIG_BLK_DEV_IO_TRACE=y
++CONFIG_FUNCTION_PROFILER=y
++CONFIG_FTRACE_MCOUNT_RECORD=y
++CONFIG_FTRACE_SYSCALLS=y
+ # CONFIG_SAMPLES is not set
+ CONFIG_ARCH_HAS_DEVMEM_IS_ALLOWED=y
+ CONFIG_STRICT_DEVMEM=y
+diff --git a/resources/guest_configs/microvm-kernel-ci-x86_64-6.1.config b/resources/guest_configs/microvm-kernel-ci-x86_64-6.1.config
+index 967e32031..d11ef968a 100644
+--- a/resources/guest_configs/microvm-kernel-ci-x86_64-6.1.config
++++ b/resources/guest_configs/microvm-kernel-ci-x86_64-6.1.config
+@@ -3185,7 +3185,17 @@ CONFIG_HAVE_OBJTOOL_MCOUNT=y
+ CONFIG_HAVE_C_RECORDMCOUNT=y
+ CONFIG_HAVE_BUILDTIME_MCOUNT_SORT=y
+ CONFIG_TRACING_SUPPORT=y
+-# CONFIG_FTRACE is not set
++CONFIG_FTRACE=y
++CONFIG_FUNCTION_TRACER=y
++CONFIG_FUNCTION_GRAPH_TRACER=y
++CONFIG_IRQSOFF_TRACER=y
++CONFIG_PREEMPT_TRACER=y
++CONFIG_SCHED_TRACER=y
++CONFIG_STACK_TRACER=y
++CONFIG_BLK_DEV_IO_TRACE=y
++CONFIG_FUNCTION_PROFILER=y
++CONFIG_FTRACE_MCOUNT_RECORD=y
++CONFIG_FTRACE_SYSCALLS=y
+ # CONFIG_SAMPLES is not set
+ CONFIG_HAVE_SAMPLE_FTRACE_DIRECT=y
+ CONFIG_HAVE_SAMPLE_FTRACE_DIRECT_MULTI=y

--- a/resources/guest_configs/patches/0004-disable-CONFIG_ARM64_ERRATUM_3194386-for-aarch64.patch
+++ b/resources/guest_configs/patches/0004-disable-CONFIG_ARM64_ERRATUM_3194386-for-aarch64.patch
@@ -1,0 +1,24 @@
+diff --git a/resources/guest_configs/microvm-kernel-ci-aarch64-5.10.config b/resources/guest_configs/microvm-kernel-ci-aarch64-5.10.config
+index ac44904c1..9f912a70b 100644
+--- a/resources/guest_configs/microvm-kernel-ci-aarch64-5.10.config
++++ b/resources/guest_configs/microvm-kernel-ci-aarch64-5.10.config
+@@ -341,6 +341,7 @@ CONFIG_ARM64_ERRATUM_1463225=y
+ CONFIG_ARM64_ERRATUM_1542419=y
+ CONFIG_ARM64_ERRATUM_1508412=y
+ CONFIG_ARM64_ERRATUM_2457168=y
++# CONFIG_ARM64_ERRATUM_3194386 is not set
+ CONFIG_CAVIUM_ERRATUM_22375=y
+ CONFIG_CAVIUM_ERRATUM_23144=y
+ CONFIG_CAVIUM_ERRATUM_23154=y
+diff --git a/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config b/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config
+index 26b87a658..29fe130f2 100644
+--- a/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config
++++ b/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config
+@@ -362,6 +362,7 @@ CONFIG_ARM64_ERRATUM_2441009=y
+ CONFIG_ARM64_ERRATUM_2457168=y
+ CONFIG_ARM64_WORKAROUND_SPECULATIVE_UNPRIV_LOAD=y
+ CONFIG_ARM64_ERRATUM_2966298=y
++# CONFIG_ARM64_ERRATUM_3194386 is not set
+ CONFIG_CAVIUM_ERRATUM_22375=y
+ CONFIG_CAVIUM_ERRATUM_23144=y
+ CONFIG_CAVIUM_ERRATUM_23154=y

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -11,7 +11,9 @@ import pytest
 from framework.properties import global_props
 
 # The maximum acceptable boot time in us.
-MAX_BOOT_TIME_US = 150000
+# It is a bit bigger than the default 150_000 because
+# we have ftrace enabled in the guest kernels.
+MAX_BOOT_TIME_US = 170000
 
 # Regex for obtaining boot time from some string.
 TIMESTAMP_LOG_REGEX = r"Guest-boot-time\s+\=\s+(\d+)\s+us"

--- a/tests/integration_tests/performance/test_vhost_user_metrics.py
+++ b/tests/integration_tests/performance/test_vhost_user_metrics.py
@@ -33,6 +33,7 @@ def test_vhost_user_block_metrics(
     )
     vm.spawn(log_level="Info")
     vm.basic_config(vcpu_count=vcpu_count)
+    vm.add_net_iface()
 
     # Add a block device to test resizing.
     fs = drive_tools.FilesystemFile(size=orig_size)


### PR DESCRIPTION
## Changes
Enabled `ftrace` feature in guest kernels. This will help us to debug problems in the future.
Additionally we need to disable `CONFIG_ARM64_ERRATUM_3194386` in aarch64 guest configs as this option hides `ssbs` feature from the guest user space and this breaks our integration test that verifies these features. The option itself was added in recent  kernel versions and is intended for `Cortex-X4` and `Neoverse-V3` cpus, and we are not using those. Link: https://lore.kernel.org/stable/20240809095745.3476191-6-mark.rutland@arm.com/

## Reason
Improve future debug-ability. 

## Examples:
```bash
root@ubuntu-fc-uvm:~# trace-cmd record -p function_graph -l 'hrtimer_*' -l 'lapic_*' -l 'wrmsr*'
...
root@ubuntu-fc-uvm:~# trace-cmd report
cpus=2
          <idle>-0     [001]   185.577231: funcgraph_entry:        1.040 us   |  hrtimer_get_next_event();
          <idle>-0     [001]   185.577234: funcgraph_entry:                   |  hrtimer_start_range_ns() {
          <idle>-0     [001]   185.577234: funcgraph_entry:                   |    hrtimer_force_reprogram() {
          <idle>-0     [001]   185.577235: funcgraph_entry:        3.120 us   |      lapic_next_deadline();
          <idle>-0     [001]   185.577238: funcgraph_exit:         3.910 us   |    }
          <idle>-0     [001]   185.577238: funcgraph_exit:         4.880 us   |  }
       trace-cmd-934   [000]   185.577401: funcgraph_entry:                   |  hrtimer_nanosleep() {
       trace-cmd-934   [000]   185.577401: funcgraph_entry:        0.300 us   |    hrtimer_init_sleeper();
       trace-cmd-934   [000]   185.577402: funcgraph_entry:        0.900 us   |    hrtimer_start_range_ns();
          <idle>-0     [000]   185.577850: funcgraph_entry:                   |  hrtimer_interrupt() {
          <idle>-0     [000]   185.577851: funcgraph_entry:        0.230 us   |    hrtimer_run_queues();
          <idle>-0     [000]   185.577852: funcgraph_entry:        0.210 us   |    hrtimer_forward();
          <idle>-0     [000]   185.577853: funcgraph_entry:        1.960 us   |    lapic_next_deadline();
          <idle>-0     [000]   185.577855: funcgraph_exit:         5.550 us   |  }
          <idle>-0     [001]   185.577870: funcgraph_entry:                   |  hrtimer_cancel() {
          <idle>-0     [001]   185.577870: funcgraph_entry:        0.250 us   |    hrtimer_active();
          <idle>-0     [001]   185.577871: funcgraph_entry:        0.370 us   |    hrtimer_try_to_cancel.part.0();
          <idle>-0     [001]   185.577871: funcgraph_exit:         1.880 us   |  }
          <idle>-0     [001]   185.577871: funcgraph_entry:        0.200 us   |  hrtimer_forward();
          <idle>-0     [001]   185.577872: funcgraph_entry:                   |  hrtimer_start_range_ns() {
          <idle>-0     [001]   185.577872: funcgraph_entry:                   |    hrtimer_reprogram() {
          <idle>-0     [001]   185.577872: funcgraph_entry:        2.030 us   |      lapic_next_deadline();
          <idle>-0     [001]   185.577875: funcgraph_exit:         2.560 us   |    }
          <idle>-0     [001]   185.577875: funcgraph_exit:         3.100 us   |  }

```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
