### PR TITLE
test: style: fix black ignoring `integration_test/build` directory

### DIFF
--- a/tests/integration_tests/style/test_python.py
+++ b/tests/integration_tests/style/test_python.py
@@ -8,7 +8,7 @@ from subprocess import run
 import pytest
 
 
-@pytest.mark.parametrize("formatter", ["black", "isort"])
+@pytest.mark.parametrize("formatter", ["black --config tests/pyproject.toml", "isort"])
 def test_python_style(formatter):
     """
     Test that python code passes `formatter`


### PR DESCRIPTION
When `black` is passed multiple directories, it will try to look for `pyproject.toml` in the common ancestor of those paths. In our cases, since we pass it `tests`, `.buildkite` and `tools`, that would be the repository root. However, our pyproject.toml sits in `tests`, and thus the `exclude` rule it defines is ignored (and it is this `exclude` rules that overwrites the default behavior of excluding directories called `build`).

Fix this by explicitly passing in a `--config` argument. Since `isort` does not support this argument, pass it in a quite ugly via by adding it to the pytest parameters.

Fixes: 4f55e491ee3bd08c21cf15db06162f4b4afccb04

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
