### PR TITLE
virtio-net: switch to `readv` + implement `MRG_RXBUF`

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -33,6 +33,10 @@
                 "comment": "Used by the VirtIO net device to write to tap"
             },
             {
+                "syscall": "readv",
+                "comment": "Used by the VirtIO net device to read from tap"
+            },
+            {
                 "syscall": "fsync"
             },
             {

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -33,6 +33,10 @@
                 "comment": "Used by the VirtIO net device to write to tap"
             },
             {
+                "syscall": "readv",
+                "comment": "Used by the VirtIO net device to read from tap"
+            },
+            {
                 "syscall": "fsync"
             },
             {

--- a/src/vmm/src/devices/virtio/iov_ring_buffer.rs
+++ b/src/vmm/src/devices/virtio/iov_ring_buffer.rs
@@ -70,7 +70,7 @@ pub enum IovRingBufferError {
 // Like that, the elements stored in the buffer are always laid out in contiguous virtual memory,
 // so making a slice out of them does not require any copies.
 #[derive(Debug)]
-pub(crate) struct IovRingBuffer {
+pub struct IovRingBuffer {
     iov_ptr: *mut iovec,
     start: usize,
     len: usize,

--- a/src/vmm/src/devices/virtio/iov_ring_buffer.rs
+++ b/src/vmm/src/devices/virtio/iov_ring_buffer.rs
@@ -1,0 +1,404 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::os::fd::AsRawFd;
+
+use libc::{c_int, c_void, iovec, off_t, size_t};
+use memfd::{self, FileSeal, Memfd, MemfdOptions};
+
+use super::queue::FIRECRACKER_MAX_QUEUE_SIZE;
+use crate::arch::PAGE_SIZE;
+
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum IovRingBufferError {
+    /// Error with memfd: {0}
+    Memfd(#[from] memfd::Error),
+    /// Error while resizing memfd: {0}
+    MemfdResize(std::io::Error),
+    /// Error calling mmap: {0}
+    Mmap(std::io::Error),
+}
+
+/// ['IovRingBuffer'] is a ring buffer tailored for `struct iovec` objects.
+///
+/// From the point of view of API, [`IovRingBuffer`] is a typical ring buffer that allows us to push
+/// `struct iovec` objects at the end of the buffer and pop them from its beginning.
+///
+/// It is tailored to store `struct iovec` objects that described memory that was passed to us from
+/// the guest via a VirtIO queue. This allows us to assume the maximum size of a ring buffer (the
+/// negotiated size of the queue).
+// An important feature of the data structure is that it can give us a slice of all `struct iovec`
+// objects in the queue, so that we can use this `&mut [iovec]` to perform operations such as
+// `readv`. A typical implementation of a ring buffer allows for entries to wrap around the end of
+// the underlying buffer. For example, a ring buffer with a capacity of 10 elements which
+// currently holds 4 elements can look like this:
+//
+//                      tail                        head
+//                       |                           |
+//                       v                           v
+//                 +---+---+---+---+---+---+---+---+---+---+
+// ring buffer:    | C | D |   |   |   |   |   |   | A | B |
+//                 +---+---+---+---+---+---+---+---+---+---+
+//
+// When getting a slice for this data we should get something like that: &[A, B, C, D], which
+// would require copies in order to make the elements continuous in memory.
+//
+// In order to avoid that and make the operation of getting a slice more efficient, we implement
+// the optimization described in the "Optimization" section of the "Circular buffer" wikipedia
+// entry: https://en.wikipedia.org/wiki/Circular_buffer. The optimization consists of allocating
+// double the size of the virtual memory required for the buffer and map both parts on the same
+// physical address. Looking at the same example as before, we should get, this picture:
+//
+//                                    head   |    tail
+//                                     |     |     |
+//                                     v     |     v
+//   +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+//   | C | D |   |   |   |   |   |   | A | B | C | D |   |   |   |   |   |   | A | B |
+//   +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+//            First virtual page             |       Second virtual page
+//                                           |
+//                                           |
+//
+//                                     Virtual memory
+// ---------------------------------------------------------------------------------------
+//                                    Physical memory
+//
+//                      +---+---+---+---+---+---+---+---+---+---+
+//                      | C | D |   |   |   |   |   |   | A | B |
+//                      +---+---+---+---+---+---+---+---+---+---+
+//
+// Like that, the elements stored in the buffer are always laid out in contiguous virtual memory,
+// so making a slice out of them does not require any copies.
+#[derive(Debug)]
+pub(crate) struct IovRingBuffer {
+    iov_ptr: *mut iovec,
+    start: usize,
+    len: usize,
+}
+
+// SAFETY: This is `Send`. We hold sole ownership of the underlying buffer.
+unsafe impl Send for IovRingBuffer {}
+
+impl IovRingBuffer {
+    /// Create a [`memfd`] object that represents a single physical page
+    fn create_memfd() -> Result<Memfd, IovRingBufferError> {
+        // Create a sealable memfd.
+        let opts = MemfdOptions::default().allow_sealing(true);
+        let mfd = opts.create("sized-1K")?;
+
+        // Resize to system page size.
+        mfd.as_file()
+            .set_len(PAGE_SIZE.try_into().unwrap())
+            .map_err(IovRingBufferError::MemfdResize)?;
+
+        // Add seals to prevent further resizing.
+        mfd.add_seals(&[FileSeal::SealShrink, FileSeal::SealGrow])?;
+
+        // Prevent further sealing changes.
+        mfd.add_seal(FileSeal::SealSeal)?;
+
+        Ok(mfd)
+    }
+
+    /// Wrapper for libc's `mmap` system call
+    unsafe fn mmap(
+        addr: *mut c_void,
+        len: size_t,
+        prot: c_int,
+        flags: c_int,
+        fd: c_int,
+        offset: off_t,
+    ) -> Result<*mut c_void, IovRingBufferError> {
+        // SAFETY: We are calling the system call with valid arguments and properly checking its
+        // return value
+        let ptr = unsafe { libc::mmap(addr, len, prot, flags, fd, offset) };
+        if ptr == libc::MAP_FAILED {
+            return Err(IovRingBufferError::Mmap(std::io::Error::last_os_error()));
+        }
+
+        Ok(ptr)
+    }
+
+    /// Allocate memory for our ring buffer
+    ///
+    /// This will allocate exactly two pages of virtual memory. In order to implement the
+    /// optimization that allows us to always have elements in contiguous memory we need
+    /// allocations at the granularity of `PAGE_SIZE`. Now, our queues are at maximum 256
+    /// descriptors long and `struct iovec` looks like this:
+    ///
+    /// ```Rust
+    /// pub struct iovec {
+    ///    pub iov_base: *mut ::c_void,
+    ///    pub iov_len: ::size_t,
+    /// }
+    /// ```
+    ///
+    /// so, it's 16 bytes long. As a result, we need a single page for holding the actual data of
+    /// our buffer.
+    fn allocate_ring_buffer_memory() -> Result<*mut c_void, IovRingBufferError> {
+        // The fact that we allocate two pages is due to the size of `struct iovec` times our queue
+        // size equals the page size. Add here a debug assertion to reflect that and ensure that we
+        // will adapt our logic if the assumption changes in the future.
+        debug_assert_eq!(
+            std::mem::size_of::<iovec>() * usize::from(FIRECRACKER_MAX_QUEUE_SIZE),
+            PAGE_SIZE
+        );
+
+        // SAFETY: We are calling this function with valid arguments
+        unsafe {
+            Self::mmap(
+                std::ptr::null_mut(),
+                PAGE_SIZE * 2,
+                libc::PROT_NONE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        }
+    }
+
+    /// Create a new [`IovRingBuffer`] that can hold memory described by a single VirtIO queue.
+    pub fn new() -> Result<Self, IovRingBufferError> {
+        let memfd = Self::create_memfd()?;
+        let raw_memfd = memfd.as_file().as_raw_fd();
+        let buffer = Self::allocate_ring_buffer_memory()?;
+
+        // Map the first page of virtual memory to the physical page described by the memfd object
+        // SAFETY: We are calling this function with valid arguments
+        unsafe {
+            let _ = Self::mmap(
+                buffer,
+                PAGE_SIZE,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED | libc::MAP_FIXED,
+                raw_memfd,
+                0,
+            )?;
+        }
+
+        // Map the second page of virtual memory to the physical page described by the memfd object
+        // SAFETY: safe because `Self::allocate_ring_buffer_memory` allocates exactly two pages for
+        // us
+        let next_page = unsafe { buffer.add(PAGE_SIZE) };
+        // SAFETY: We are calling this function with valid arguments
+        unsafe {
+            let _ = Self::mmap(
+                next_page,
+                PAGE_SIZE,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED | libc::MAP_FIXED,
+                raw_memfd,
+                0,
+            )?;
+        }
+
+        Ok(Self {
+            iov_ptr: buffer.cast(),
+            start: 0,
+            len: 0,
+            // head: 0,
+            // tail: 0,
+        })
+    }
+
+    /// Returns the number of `iovec` objects currently in the [`IovRingBuffer`]
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the [`IovRingBuffer`] is empty, `false` otherwise
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns `true` if the [`IovRingBuffer`] is full, `false` otherwise
+    #[inline(always)]
+    pub fn is_full(&self) -> bool {
+        self.len == usize::from(FIRECRACKER_MAX_QUEUE_SIZE)
+    }
+
+    /// Adds an `iovec` in the ring buffer.
+    /// Panics if the queue is already full.
+    pub fn push_back(&mut self, iov: iovec) {
+        // This should NEVER happen, since our ring buffer is as big as the maximum queue size.
+        // We also check for the sanity of the VirtIO queues, in queue.rs, which means that if we
+        // ever try to add something in a full ring buffer, there is an internal bug in the device
+        // emulation logic. Panic here because the device is hopelessly broken.
+        if self.is_full() {
+            panic!("The number of `iovec` objects is bigger than the available space");
+        }
+
+        // SAFETY: iov_ptr is valid and tail is within bounds
+        unsafe {
+            self.iov_ptr.add(self.start + self.len).write(iov);
+        }
+        self.len += 1;
+    }
+
+    /// Pop first `n` iovs from the back of the queue.
+    /// Panics if `n` is greater than length of the queue.
+    pub fn pop_back(&mut self, n: usize) {
+        if self.len() < n {
+            panic!("Attempt to pop more objects than are in the queue");
+        }
+        // We don't need to care about case where tail will underflow
+        // because this can only occur if the ring overflow.
+        self.len -= n;
+    }
+
+    /// Pop first `n` iovs from the front of the queue.
+    /// Panics if `n` is greater than length of the queue.
+    pub fn pop_front(&mut self, n: usize) {
+        if self.len() < n {
+            panic!("Attempt to pop more objects than are in the queue");
+        }
+        self.start += n;
+        self.len -= n;
+        if usize::from(FIRECRACKER_MAX_QUEUE_SIZE) <= self.start {
+            self.start -= usize::from(FIRECRACKER_MAX_QUEUE_SIZE);
+        }
+    }
+
+    /// Gets a slice of the `iovec` objects currently in the buffer.
+    pub fn as_slice(&self) -> &[iovec] {
+        // SAFETY: we create a slice which does not touch same memory twice.
+        // slice_start and slice_len are valid values.
+        unsafe {
+            let slice_start = self.iov_ptr.add(self.start);
+            let slice_len = self.len;
+            std::slice::from_raw_parts(slice_start, slice_len)
+        }
+    }
+
+    /// Gets a mutable slice of the `iovec` objects currently in the buffer.
+    pub fn as_mut_slice(&mut self) -> &mut [iovec] {
+        // SAFETY: we create a slice which does not touch same memory twice.
+        // slice_start and slice_len are valid values.
+        unsafe {
+            let slice_start = self.iov_ptr.add(self.start);
+            let slice_len = self.len;
+            std::slice::from_raw_parts_mut(slice_start, slice_len)
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::needless_range_loop)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let ring_buffer = IovRingBuffer::new().unwrap();
+        assert!(ring_buffer.is_empty());
+    }
+
+    fn make_iovec(id: usize, len: usize) -> iovec {
+        iovec {
+            iov_base: id as *mut libc::c_void,
+            iov_len: len,
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_push_back() {
+        let mut ring_buffer = IovRingBuffer::new().unwrap();
+        assert!(ring_buffer.is_empty());
+
+        for i in 0..256 {
+            ring_buffer.push_back(make_iovec(i, i));
+            assert_eq!(ring_buffer.len(), i + 1);
+        }
+
+        ring_buffer.push_back(make_iovec(0, 0));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_pop_back_empty() {
+        let mut deque = IovRingBuffer::new().unwrap();
+        assert!(deque.is_empty());
+        assert!(!deque.is_full());
+
+        deque.pop_back(1);
+    }
+
+    #[test]
+    fn test_pop_back() {
+        let mut ring_buffer = IovRingBuffer::new().unwrap();
+        assert!(ring_buffer.is_empty());
+        assert!(!ring_buffer.is_full());
+
+        for i in 0..256 {
+            ring_buffer.push_back(make_iovec(i, i));
+            assert_eq!(ring_buffer.len(), i + 1);
+        }
+
+        assert!(ring_buffer.is_full());
+        assert!(!ring_buffer.is_empty());
+
+        ring_buffer.pop_back(256);
+        assert!(ring_buffer.is_empty());
+        assert!(!ring_buffer.is_full());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_pop_front_empty() {
+        let mut ring_buffer = IovRingBuffer::new().unwrap();
+        assert!(ring_buffer.is_empty());
+        assert!(!ring_buffer.is_full());
+
+        ring_buffer.pop_front(1);
+    }
+
+    #[test]
+    fn test_pop_front() {
+        let mut ring_buffer = IovRingBuffer::new().unwrap();
+        assert!(ring_buffer.is_empty());
+        assert!(!ring_buffer.is_full());
+
+        for i in 0..256 {
+            ring_buffer.push_back(make_iovec(i, i));
+            assert_eq!(ring_buffer.len(), i + 1);
+        }
+
+        assert!(ring_buffer.is_full());
+        assert!(!ring_buffer.is_empty());
+
+        ring_buffer.pop_front(256);
+        assert!(ring_buffer.is_empty());
+        assert!(!ring_buffer.is_full());
+    }
+
+    #[test]
+    fn test_as_slice() {
+        let mut buffer = IovRingBuffer::new().unwrap();
+        assert_eq!(buffer.as_mut_slice(), &mut []);
+
+        for i in 0..256 {
+            buffer.push_back(make_iovec(i, 100));
+        }
+
+        let buffer_len = buffer.len();
+        let slice = buffer.as_slice();
+        assert_eq!(slice.len(), buffer_len);
+        for i in 0..256 {
+            assert_eq!(slice[i], make_iovec(i, 100));
+        }
+
+        let slice = buffer.as_mut_slice();
+        assert_eq!(slice.len(), buffer_len);
+        for i in 0..256 {
+            assert_eq!(slice[i], make_iovec(i, 100));
+        }
+
+        buffer.pop_front(256);
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.as_slice(), &mut []);
+        assert_eq!(buffer.as_mut_slice(), &mut []);
+    }
+}

--- a/src/vmm/src/devices/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/mod.rs
@@ -16,6 +16,7 @@ pub mod balloon;
 pub mod block;
 pub mod device;
 pub mod gen;
+pub mod iov_ring_buffer;
 pub mod iovec;
 pub mod mmio;
 pub mod net;

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -648,7 +648,10 @@ impl Net {
 
     fn read_tap(&mut self) -> std::io::Result<usize> {
         if self.has_feature(u64::from(VIRTIO_NET_F_MRG_RXBUF)) {
-            self.tap.read_iovec(self.rx_buffer.all_chains_mut_slice())
+            let Some(s) = self.rx_buffer.all_chains_mut_slice() else {
+                return Err(std::io::Error::from_raw_os_error(EAGAIN));
+            };
+            self.tap.read_iovec(s)
         } else {
             self.tap.read_iovec(self.rx_buffer.one_chain_mut_slice())
         }

--- a/src/vmm/src/devices/virtio/net/mod.rs
+++ b/src/vmm/src/devices/virtio/net/mod.rs
@@ -21,14 +21,17 @@ pub mod device;
 mod event_handler;
 pub mod metrics;
 pub mod persist;
+pub mod rx_buffer;
 mod tap;
 pub mod test_utils;
 
 mod gen;
 
 pub use tap::{Tap, TapError};
+use vm_memory::VolatileMemoryError;
 
 pub use self::device::Net;
+use self::rx_buffer::RxBufferError;
 
 /// Enum representing the Net device queue types
 #[derive(Debug)]
@@ -50,6 +53,10 @@ pub enum NetError {
     EventFd(io::Error),
     /// IO error: {0}
     IO(io::Error),
+    /// Error writing in guest memory: {0}
+    GuestMemoryError(#[from] VolatileMemoryError),
     /// The VNET header is missing from the frame
     VnetHeaderMissing,
+    /// RxBuffer error: {0}
+    RxBufferError(#[from] RxBufferError),
 }

--- a/src/vmm/src/devices/virtio/net/rx_buffer.rs
+++ b/src/vmm/src/devices/virtio/net/rx_buffer.rs
@@ -1,0 +1,382 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::mem::offset_of;
+use std::num::Wrapping;
+
+use libc::{c_void, iovec, size_t};
+use serde::{Deserialize, Serialize};
+use vm_memory::bitmap::Bitmap;
+use vm_memory::{GuestMemory, GuestMemoryError};
+
+use crate::devices::virtio::gen::virtio_net::virtio_net_hdr_v1;
+use crate::devices::virtio::iov_ring_buffer::{IovRingBuffer, IovRingBufferError};
+use crate::devices::virtio::net::device::vnet_hdr_len;
+use crate::devices::virtio::queue::{DescriptorChain, Queue, FIRECRACKER_MAX_QUEUE_SIZE};
+use crate::logger::error;
+use crate::utils::ring_buffer::RingBuffer;
+use crate::vstate::memory::GuestMemoryMmap;
+
+/// Writes number of buffers to the [`num_buffers`] field of a virtio_net_hdr_v1 struct
+/// pointed by the [`ptr`].
+///
+/// # Safety
+/// Memory area needs to be big enoug for virtio_net_hdr_v1 to fit.
+pub unsafe fn header_set_num_buffers(ptr: *mut virtio_net_hdr_v1, num_buffers: u16) {
+    debug_assert!(
+        ptr.is_aligned(),
+        "Pointer should have at least 0x2 aligment"
+    );
+
+    let ptr: *mut u8 = ptr.cast();
+    let ptr = ptr.add(offset_of!(virtio_net_hdr_v1, num_buffers));
+    let bytes = num_buffers.to_le_bytes();
+    let ptr: *mut [u8; 2] = ptr.cast();
+    ptr.write_volatile(bytes);
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RxBufferState {
+    pub chains_count: u16,
+    pub used_descriptors: u16,
+}
+
+impl RxBufferState {
+    pub fn from_rx_buffer(buffer: &RxBuffer) -> Self {
+        // The maximum number of chains is the maximum size of the queue
+        // which is FIRECRACKER_MAX_QUEUE_SIZE (256).
+        Self {
+            chains_count: buffer.chain_infos.len().try_into().unwrap(),
+            used_descriptors: buffer.used_descriptors,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ChainInfo {
+    pub head_index: u16,
+    pub chain_len: u16,
+}
+
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum RxBufferError {
+    /// Cannot create `RxBuffer` due to error for `IovRingBuffer`: {0}
+    New(#[from] IovRingBufferError),
+    /// Guest memory error: {0}
+    GuestMemory(#[from] GuestMemoryError),
+    /// Tried to add a read-only descriptor chain to the `RxBuffer`
+    ReadOnlyDescriptor,
+    /// Tried to write more bytes than `RxBuffer` can hold.
+    WriteOverflow,
+}
+
+/// A map of all the memory the guest has provided us with for performing RX
+#[derive(Debug)]
+pub struct RxBuffer {
+    // An ring covering all the memory we have available for receiving network
+    // frames.
+    pub iovecs: IovRingBuffer,
+    // Ring buffer of meta data about descriptor chains stored in the `iov_ring`.
+    pub chain_infos: RingBuffer<ChainInfo>,
+    // Number of descriptor chains we have used to process packets.
+    pub used_descriptors: u16,
+}
+
+impl RxBuffer {
+    /// Create a new [`RxBuffers`] object for storing guest memory for performing RX
+    pub fn new() -> Result<Self, RxBufferError> {
+        Ok(Self {
+            iovecs: IovRingBuffer::new()?,
+            chain_infos: RingBuffer::new_with_size(u32::from(FIRECRACKER_MAX_QUEUE_SIZE)),
+            used_descriptors: 0,
+        })
+    }
+
+    /// Is number of iovecs is zero.
+    pub fn is_empty(&self) -> bool {
+        self.iovecs.is_empty()
+    }
+
+    /// Returns a slice of underlying iovec for the first chain
+    /// in the buffer.
+    pub fn one_chain_mut_slice(&mut self) -> &mut [iovec] {
+        if let Some(chain_info) = self.chain_infos.first() {
+            let chain_len = usize::from(chain_info.chain_len);
+            &mut self.iovecs.as_mut_slice()[0..chain_len]
+        } else {
+            &mut []
+        }
+    }
+
+    /// Add a new `DescriptorChain` that we received from the RX queue in the buffer.
+    ///
+    /// # Safety
+    /// The `DescriptorChain` cannot be referencing the same memory location as any other
+    /// `DescriptorChain`.
+    pub unsafe fn add_chain(
+        &mut self,
+        mem: &GuestMemoryMmap,
+        head: DescriptorChain,
+    ) -> Result<(), RxBufferError> {
+        let head_index = head.index;
+
+        let mut next_descriptor = Some(head);
+        let mut chain_len: u16 = 0;
+        while let Some(desc) = next_descriptor {
+            if !desc.is_write_only() {
+                self.iovecs.pop_back(usize::from(chain_len));
+                return Err(RxBufferError::ReadOnlyDescriptor);
+            }
+
+            // We use get_slice instead of `get_host_address` here in order to have the whole
+            // range of the descriptor chain checked, i.e. [addr, addr + len) is a valid memory
+            // region in the GuestMemoryMmap.
+            let slice = match mem.get_slice(desc.addr, desc.len as usize) {
+                Ok(slice) => slice,
+                Err(e) => {
+                    self.iovecs.pop_back(usize::from(chain_len));
+                    return Err(RxBufferError::GuestMemory(e));
+                }
+            };
+
+            // We need to mark the area of guest memory that will be mutated through this
+            // IoVecBufferMut as dirty ahead of time, as we loose access to all
+            // vm-memory related information after converting down to iovecs.
+            slice.bitmap().mark_dirty(0, desc.len as usize);
+
+            let iov_base = slice.ptr_guard_mut().as_ptr().cast::<c_void>();
+            self.iovecs.push_back(iovec {
+                iov_base,
+                iov_len: desc.len as size_t,
+            });
+            chain_len += 1;
+
+            next_descriptor = desc.next_descriptor();
+        }
+        self.chain_infos.push_back(ChainInfo {
+            head_index,
+            chain_len,
+        });
+
+        Ok(())
+    }
+
+    /// Writes bytes from a slice into buffer.
+    pub fn write(&mut self, mut bytes: &[u8]) -> Result<(), RxBufferError> {
+        for iov in self.iovecs.as_mut_slice() {
+            if bytes.is_empty() {
+                break;
+            }
+            let iov_slice_len = bytes.len().min(iov.iov_len);
+            // SAFETY: The user space pointer and the length were verified during
+            // the iovec creation.
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), iov.iov_base.cast(), iov_slice_len)
+            };
+            bytes = &bytes[iov_slice_len..];
+        }
+        if !bytes.is_empty() {
+            Err(RxBufferError::WriteOverflow)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Finish packet processing by removing used iovecs from the buffer and
+    /// writing information about used descriptor chains into the queue.
+    ///
+    /// # Safety
+    /// `RxBuffer` should not be empty when this method is called because it
+    /// assumes there is at least one chain holding data.
+    pub unsafe fn finish_packet(&mut self, bytes_written: u32, rx_queue: &mut Queue) {
+        // This function is called only after some bytes were written to the
+        // buffer. This means the iov_ring cannot be empty.
+        debug_assert!(!self.iovecs.is_empty());
+        let header_ptr: *mut virtio_net_hdr_v1 = self.iovecs.as_slice()[0].iov_base.cast();
+        let header_buff_len = self.iovecs.as_slice()[0].iov_len;
+        assert!(
+            vnet_hdr_len() <= header_buff_len,
+            "Network buffer should be big enough for virtio_net_hdr_v1 object"
+        );
+
+        let iov_info = self
+            .chain_infos
+            .pop_front()
+            .expect("This should never happen if write to the buffer succeded.");
+        self.iovecs.pop_front(usize::from(iov_info.chain_len));
+
+        if let Err(err) = rx_queue.write_used_element(
+            (rx_queue.next_used + Wrapping(self.used_descriptors)).0,
+            iov_info.head_index,
+            bytes_written,
+        ) {
+            error!(
+                "net: Failed to add used descriptor {} of length {} to RX queue: {err}",
+                iov_info.head_index, bytes_written
+            );
+        }
+        self.used_descriptors += 1;
+
+        // SAFETY: The user space pointer was verified at the point of creation and
+        // we verified the alignment and header buffer size.
+        unsafe {
+            header_set_num_buffers(header_ptr, 1);
+        }
+    }
+
+    /// Notify queue about all descriptor chains we used to process packets so far.
+    pub fn notify_queue(&mut self, rx_queue: &mut Queue) {
+        rx_queue.advance_used_ring(self.used_descriptors);
+        self.used_descriptors = 0;
+    }
+}
+
+#[cfg(test)]
+// TODO why are we going through this? why clippy hates everything?
+#[allow(clippy::cast_possible_wrap)]
+#[allow(clippy::needless_range_loop)]
+#[allow(clippy::cast_possible_truncation)]
+mod tests {
+    use vm_memory::GuestAddress;
+
+    use super::*;
+    use crate::devices::virtio::test_utils::{set_dtable_one_chain, VirtQueue};
+    use crate::test_utils::single_region_mem;
+
+    #[test]
+    fn test_rx_buffer_new() {
+        let mut buff = RxBuffer::new().unwrap();
+        assert!(buff.is_empty());
+        assert_eq!(buff.one_chain_mut_slice(), &mut []);
+    }
+
+    #[test]
+    fn test_rx_buffer_add_chain() {
+        let mem = single_region_mem(65562);
+        let rxq = VirtQueue::new(GuestAddress(0), &mem, 256);
+        let mut queue = rxq.create_queue();
+
+        // Single chain with len of 16
+        {
+            let chain_len = 16;
+            set_dtable_one_chain(&rxq, chain_len);
+            let desc = queue.pop().unwrap();
+
+            let mut buff = RxBuffer::new().unwrap();
+            // SAFETY: safe it is a test memory
+            unsafe {
+                buff.add_chain(&mem, desc).unwrap();
+            }
+            let slice = buff.one_chain_mut_slice();
+            for i in 0..chain_len {
+                assert_eq!(
+                    slice[i].iov_base as u64,
+                    mem.get_host_address(GuestAddress((2048 + 1024 * i) as u64))
+                        .unwrap() as u64
+                );
+                assert_eq!(slice[i].iov_len, 1024);
+            }
+            assert_eq!(buff.chain_infos.len(), 1);
+            assert_eq!(
+                buff.chain_infos.items[0],
+                ChainInfo {
+                    head_index: 0,
+                    chain_len: 16
+                }
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_rx_buffer_write_panic() {
+        let mem = single_region_mem(65562);
+        let rxq = VirtQueue::new(GuestAddress(0), &mem, 256);
+        let mut queue = rxq.create_queue();
+
+        set_dtable_one_chain(&rxq, 1);
+        let desc = queue.pop().unwrap();
+
+        let mut buff = RxBuffer::new().unwrap();
+        // SAFETY: safe it is a test memory
+        unsafe {
+            buff.add_chain(&mem, desc).unwrap();
+        }
+
+        // Write should panic, because we unwrap on error
+        // because we try to write more than buffer can hold.
+        buff.write(&[69; 2 * 1024]).unwrap();
+    }
+
+    #[test]
+    fn test_rx_buffer_write() {
+        let mem = single_region_mem(65562);
+        let rxq = VirtQueue::new(GuestAddress(0), &mem, 256);
+        let mut queue = rxq.create_queue();
+
+        set_dtable_one_chain(&rxq, 1);
+        let desc = queue.pop().unwrap();
+
+        let mut buff = RxBuffer::new().unwrap();
+        // SAFETY: safe it is a test memory
+        unsafe {
+            buff.add_chain(&mem, desc).unwrap();
+        }
+
+        // Initially data should be all zeros
+        let slice = buff.one_chain_mut_slice();
+        let data_slice_before: &[u8] =
+            // SAFETY: safe as iovecs are verified on creation
+            unsafe { std::slice::from_raw_parts(slice[0].iov_base.cast(), slice[0].iov_len) };
+        assert_eq!(data_slice_before, &[0; 1024]);
+
+        // Write should happen to first iovec (as there is only 1)
+        buff.write(&[69; 1024]).unwrap();
+
+        let slice = buff.one_chain_mut_slice();
+        let data_slice_after: &[u8] =
+            // SAFETY: safe as iovecs are verified on creation
+            unsafe { std::slice::from_raw_parts(slice[0].iov_base.cast(), slice[0].iov_len) };
+        assert_eq!(data_slice_after, &[69; 1024]);
+    }
+
+    #[test]
+    fn test_rx_buffer_finish_packet_and_notify() {
+        let mem = single_region_mem(65562);
+        let rxq = VirtQueue::new(GuestAddress(0), &mem, 256);
+        let mut queue = rxq.create_queue();
+
+        let chain_len = 16;
+        set_dtable_one_chain(&rxq, chain_len);
+        let desc = queue.pop().unwrap();
+
+        let mut buff = RxBuffer::new().unwrap();
+        // SAFETY: safe it is a test memory
+        unsafe {
+            buff.add_chain(&mem, desc).unwrap();
+        }
+
+        let slice = buff.one_chain_mut_slice();
+        // SAFETY: The user space pointer was verified at the  point of creation.
+        #[allow(clippy::transmute_ptr_to_ref)]
+        let header: &virtio_net_hdr_v1 = unsafe { std::mem::transmute(slice[0].iov_base) };
+        assert_eq!(header.num_buffers, 0);
+
+        // There is one chain in the buffer. The length of the data "written" does
+        // not really matter. We just need to check that single chain present was popped
+        // and number of buffers is correctly set in the header.
+        // SAFETY: the buff is not empty
+        unsafe {
+            buff.finish_packet(1024, &mut queue);
+        }
+        assert_eq!(buff.iovecs.len(), 0);
+        assert!(buff.is_empty());
+        assert_eq!(header.num_buffers, 1);
+
+        assert_eq!(buff.used_descriptors, 1);
+        assert_eq!(rxq.used.idx.get(), 0);
+        buff.notify_queue(&mut queue);
+        assert_eq!(buff.used_descriptors, 0);
+        assert_eq!(rxq.used.idx.get(), 1);
+    }
+}

--- a/src/vmm/src/utils/mod.rs
+++ b/src/vmm/src/utils/mod.rs
@@ -5,6 +5,8 @@
 pub mod byte_order;
 /// Module with network related helpers
 pub mod net;
+/// Module with `RingBuffer` struct
+pub mod ring_buffer;
 /// Module with external libc functions
 pub mod signal;
 /// Module with state machine
@@ -20,6 +22,15 @@ pub fn get_page_size() -> Result<usize, vmm_sys_util::errno::Error> {
         -1 => Err(vmm_sys_util::errno::Error::last()),
         ps => Ok(usize::try_from(ps).unwrap()),
     }
+}
+
+/// Safely converts a u32 value to a usize value.
+/// This bypasses the Clippy lint check because we only support 64-bit platforms.
+#[cfg(target_pointer_width = "64")]
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+pub const fn u32_to_usize(num: u32) -> usize {
+    num as usize
 }
 
 /// Safely converts a u64 value to a usize value.

--- a/src/vmm/src/utils/ring_buffer.rs
+++ b/src/vmm/src/utils/ring_buffer.rs
@@ -1,0 +1,163 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::u32_to_usize;
+
+/// Simple ring buffer of fixed size. Because we probably will never
+/// need to have buffers with size bigger that u32::MAX,
+/// indexes in this struct are u32, so the maximum size is u32::MAX.
+/// This saves 8 bytes compared to `VecDequeue` in the standard library.
+/// (24 bytes vs 32 bytes)
+/// Making indexes smaller than u32 does not make sense, as the alignment
+/// of `Box` is 8 bytes.
+#[derive(Debug, Default, Clone)]
+pub struct RingBuffer<T: std::fmt::Debug + Default + Clone> {
+    /// Fixed array of items.
+    pub items: Box<[T]>,
+    /// Start index.
+    pub start: u32,
+    /// Current length of the ring.
+    pub len: u32,
+}
+
+impl<T: std::fmt::Debug + Default + Clone> RingBuffer<T> {
+    /// New with specified size.
+    pub fn new_with_size(size: u32) -> Self {
+        Self {
+            items: vec![T::default(); u32_to_usize(size)].into_boxed_slice(),
+            start: 0,
+            len: 0,
+        }
+    }
+
+    /// Get number of items in the buffer
+    pub fn len(&self) -> u32 {
+        self.len
+    }
+
+    /// Check if ring is empty
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Check if ring is full
+    pub fn is_full(&self) -> bool {
+        u32_to_usize(self.len) == self.items.len()
+    }
+
+    /// Returns a reference to the first element if ring is not empty.
+    pub fn first(&self) -> Option<&T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(&self.items[u32_to_usize(self.start)])
+        }
+    }
+
+    /// Push new item to the end of the ring and increases
+    /// the length.
+    /// If there is no space for it, nothing will happen.
+    pub fn push_back(&mut self, item: T) {
+        if !self.is_full() {
+            let index = u32_to_usize(self.start + self.len) % self.items.len();
+            self.items[index] = item;
+            self.len += 1;
+        }
+    }
+
+    /// Pop item from the from of the ring and return
+    /// a reference to it.
+    /// If ring is empty returns None.
+    pub fn pop_front(&mut self) -> Option<&T> {
+        if self.is_empty() {
+            None
+        } else {
+            let index = u32_to_usize(self.start);
+            self.start += 1;
+
+            // Need to allow this, because we cast `items.len()` to u32,
+            // but this is safe as the max size of the buffer is u32::MAX.
+            #[allow(clippy::cast_possible_truncation)]
+            let items_len = self.items.len() as u32;
+
+            self.start %= items_len;
+            self.len -= 1;
+            Some(&self.items[index])
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let a = RingBuffer::<u8>::new_with_size(69);
+        assert_eq!(a.items.len(), 69);
+        assert_eq!(a.start, 0);
+        assert_eq!(a.len, 0);
+        assert!(a.is_empty());
+        assert!(!a.is_full());
+    }
+
+    #[test]
+    fn test_push() {
+        let mut a = RingBuffer::<u8>::new_with_size(4);
+
+        a.push_back(0);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        a.push_back(1);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        a.push_back(2);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        a.push_back(3);
+        assert!(!a.is_empty());
+        assert!(a.is_full());
+
+        assert_eq!(a.items.as_ref(), &[0, 1, 2, 3]);
+
+        a.push_back(4);
+        assert!(!a.is_empty());
+        assert!(a.is_full());
+
+        assert_eq!(a.items.as_ref(), &[0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_pop_front() {
+        let mut a = RingBuffer::<u8>::new_with_size(4);
+        a.push_back(0);
+        a.push_back(1);
+        a.push_back(2);
+        a.push_back(3);
+        assert!(!a.is_empty());
+        assert!(a.is_full());
+
+        assert_eq!(*a.pop_front().unwrap(), 0);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        assert_eq!(*a.pop_front().unwrap(), 1);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        assert_eq!(*a.pop_front().unwrap(), 2);
+        assert!(!a.is_empty());
+        assert!(!a.is_full());
+
+        assert_eq!(*a.pop_front().unwrap(), 3);
+        assert!(a.is_empty());
+        assert!(!a.is_full());
+
+        assert!(a.pop_front().is_none());
+        assert!(a.is_empty());
+        assert!(!a.is_full());
+    }
+}


### PR DESCRIPTION
## Changes
Switch virtio-net device to use `readv` to read from a tap device and implement `MRG_RXBUF` flag.

## Reason
Improve performance of the network device.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
