### PR TITLE
chore: Unpin 6.1 kernel

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -24,8 +24,7 @@ DEFAULT_INSTANCES = {
 
 DEFAULT_PLATFORMS = [
     ("al2", "linux_5.10"),
-    # TODO: unpin 6.1 AMI once the bug is fixed
-    ("al2023", "linux_6.1-pinned"),
+    ("al2023", "linux_6.1"),
 ]
 
 


### PR DESCRIPTION
## Changes

Unpin 6.1 kernel

## Reason

Fixes #4795.

Now the latest AL2023 kernel is 6.1.109-118.189.amzn2023 and the issue has gone.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
