### PR TITLE
bench: add benchmark for page fault latencies

### DIFF
--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -70,5 +70,9 @@ harness = false
 name = "block_request"
 harness = false
 
+[[bench]]
+name = "memory_access"
+harness = false
+
 [lints]
 workspace = true

--- a/src/vmm/benches/memory_access.rs
+++ b/src/vmm/benches/memory_access.rs
@@ -1,0 +1,70 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use vm_memory::{GuestAddress, GuestMemory};
+use vmm::resources::VmResources;
+use vmm::vmm_config::machine_config::{HugePageConfig, VmConfig};
+
+fn bench_single_page_fault(c: &mut Criterion, configuration: VmResources) {
+    c.bench_function("page_fault", |b| {
+        b.iter_batched(
+            || {
+                let memory = configuration.allocate_guest_memory().unwrap();
+                let ptr = memory
+                    .get_slice(GuestAddress(0), 1)
+                    .unwrap()
+                    .ptr_guard_mut()
+                    .as_ptr();
+
+                // fine to return both here, because ptr is not a reference into `memory` (e.g. no
+                // self-referential structs are happening here)
+                (memory, ptr)
+            },
+            |(_, ptr)| unsafe {
+                // Cause a single page fault
+                ptr.write_volatile(1);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+pub fn bench_4k_page_fault(c: &mut Criterion) {
+    bench_single_page_fault(
+        c,
+        VmResources {
+            vm_config: VmConfig {
+                vcpu_count: 1,
+                mem_size_mib: 2,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+}
+
+pub fn bench_2m_page_fault(c: &mut Criterion) {
+    bench_single_page_fault(
+        c,
+        VmResources {
+            vm_config: VmConfig {
+                vcpu_count: 1,
+                mem_size_mib: 2,
+                huge_pages: HugePageConfig::Hugetlbfs2M,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+}
+
+criterion_group! {
+    name = memory_access_benches;
+    config = Criterion::default().noise_threshold(0.05);
+    targets = bench_4k_page_fault, bench_2m_page_fault
+}
+
+criterion_main! {
+    memory_access_benches
+}

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -252,8 +252,6 @@ pub fn build_microvm_for_boot(
         .boot_source_builder()
         .ok_or(MissingKernelConfig)?;
 
-    let track_dirty_pages = vm_resources.track_dirty_pages();
-
     let vhost_user_device_used = vm_resources
         .block
         .devices
@@ -272,7 +270,7 @@ pub fn build_microvm_for_boot(
     let guest_memory = if vhost_user_device_used {
         GuestMemoryMmap::memfd_backed(
             vm_resources.vm_config.mem_size_mib,
-            track_dirty_pages,
+            vm_resources.vm_config.track_dirty_pages,
             vm_resources.vm_config.huge_pages,
         )
         .map_err(StartMicrovmError::GuestMemory)?
@@ -280,7 +278,7 @@ pub fn build_microvm_for_boot(
         let regions = crate::arch::arch_memory_regions(vm_resources.vm_config.mem_size_mib << 20);
         GuestMemoryMmap::from_raw_regions(
             &regions,
-            track_dirty_pages,
+            vm_resources.vm_config.track_dirty_pages,
             vm_resources.vm_config.huge_pages,
         )
         .map_err(StartMicrovmError::GuestMemory)?
@@ -299,7 +297,7 @@ pub fn build_microvm_for_boot(
         event_manager,
         guest_memory,
         None,
-        track_dirty_pages,
+        vm_resources.vm_config.track_dirty_pages,
         vm_resources.vm_config.vcpu_count,
         cpu_template.kvm_capabilities.clone(),
     )?;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -234,11 +234,6 @@ impl VmResources {
         Ok(())
     }
 
-    /// Returns whether dirty page tracking is enabled or not.
-    pub fn track_dirty_pages(&self) -> bool {
-        self.vm_config.track_dirty_pages
-    }
-
     /// Add a custom CPU template to the VM resources
     /// to configure vCPUs.
     pub fn set_custom_cpu_template(&mut self, cpu_template: CustomCpuTemplate) {

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -755,7 +755,7 @@ impl RuntimeApiController {
         log_dev_preview_warning("Virtual machine snapshots", None);
 
         if create_params.snapshot_type == SnapshotType::Diff
-            && !self.vm_resources.track_dirty_pages()
+            && !self.vm_resources.vm_config.track_dirty_pages
         {
             return Err(VmmActionError::NotSupported(
                 "Diff snapshots are not allowed on uVMs with dirty page tracking disabled."


### PR DESCRIPTION
Add a benchmark that attempts to capture the latency of a single page
fault in a guest memory configuration that we also use in production.
This should catch regressions such as the 1.6 memfd/vhost post
snapshot-restore latency regression, and does indeed do so:

MAP_ANONYMOUS:
```
     Running benches/memory_access.rs
page_fault    time:   [2.8611 µs 2.9327 µs 3.0170 µs]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
```

memfd_create:
```
     Running benches/memory_access.rs
page_fault    time:   [5.7449 µs 5.8779 µs 6.0450 µs]
              change: [+85.649% +92.231% +98.074%] (p = 0.00 < 0.05)
              Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
```

Add the same benchmark for huge pages, just in case. Funnily enough,
there is no vhost-tax to be paid for huge pages.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
