### PR TITLE
fix memory access benchmark panicking on ARM

### DIFF
--- a/src/vmm/benches/memory_access.rs
+++ b/src/vmm/benches/memory_access.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use vm_memory::{GuestAddress, GuestMemory};
+use vm_memory::GuestMemory;
 use vmm::resources::VmResources;
 use vmm::vmm_config::machine_config::{HugePageConfig, VmConfig};
 
@@ -11,11 +11,10 @@ fn bench_single_page_fault(c: &mut Criterion, configuration: VmResources) {
         b.iter_batched(
             || {
                 let memory = configuration.allocate_guest_memory().unwrap();
-                let ptr = memory
-                    .get_slice(GuestAddress(0), 1)
-                    .unwrap()
-                    .ptr_guard_mut()
-                    .as_ptr();
+                // Get a pointer to the first memory region (cannot do `.get_slice(GuestAddress(0),
+                // 1)`, because on ARM64 guest memory does not start at physical
+                // address 0).
+                let ptr = memory.iter().next().unwrap().as_ptr();
 
                 // fine to return both here, because ptr is not a reference into `memory` (e.g. no
                 // self-referential structs are happening here)


### PR DESCRIPTION
The benchmark tries to write to guest physical address 0, but on ARM guest memory doesn't start at 0, so when resolving the address we panicked.

Fix this by instead simply using whatever address guest memory starts with.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
