### PR TITLE
test(net): add test for tap offload features

### DIFF
--- a/tests/host_tools/udp_offload.py
+++ b/tests/host_tools/udp_offload.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+A utility for sending a UDP message with UDP oflload enabled.
+
+Inspired by the "TUN_F_CSUM is a must" chapter
+in https://blog.cloudflare.com/fr-fr/virtual-networking-101-understanding-tap/
+by Cloudflare.
+"""
+
+import socket
+import sys
+
+
+def eprint(*args, **kwargs):
+    """Print to stderr"""
+    print(*args, file=sys.stderr, **kwargs)
+
+
+# Define SOL_UDP and UDP_SEGMENT if not defined in the system headers
+try:
+    from socket import SOL_UDP, UDP_SEGMENT
+except ImportError:
+    SOL_UDP = 17  # Protocol number for UDP
+    UDP_SEGMENT = 103  # Option code for UDP segmentation (non-standard)
+
+# Get the IP and port from command-line arguments
+if len(sys.argv) != 3:
+    eprint("Usage: python3 udp_offload.py <ip_address> <port>")
+    sys.exit(1)
+
+ip_address = sys.argv[1]
+port = int(sys.argv[2])
+
+# Create a UDP socket
+sockfd = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+# Set the UDP segmentation option (UDP_SEGMENT) to 1400 bytes
+OPTVAL = 1400
+try:
+    sockfd.setsockopt(SOL_UDP, UDP_SEGMENT, OPTVAL)
+except (AttributeError, PermissionError):
+    eprint("Unable to set UDP_SEGMENT option")
+    sys.exit(1)
+
+# Set the destination address and port
+servaddr = (ip_address, port)
+
+# Send the message to the destination address
+MESSAGE = b"x"
+try:
+    sockfd.sendto(MESSAGE, servaddr)
+    print("Message sent successfully")
+except socket.error as e:
+    eprint(f"Error sending message: {e}")
+    sys.exit(1)
+
+sockfd.close()


### PR DESCRIPTION
## Changes

This is a regression test for the following fix (https://github.com/firecracker-microvm/firecracker/pull/4826):
```
commit a9e5f1381bb30f9ad9fca11f2eade83a642711b5
Author: Nikita Kalyazin <kalyazin@amazon.co.uk>
Date:   Mon Sep 30 13:05:28 2024 +0000

    fix(net): set tap offload features on restore
```
The test verifies that tap offload features are configured for both booted and restored VMs.

## Reason

Regression testing.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
