### PR TITLE
doc(swagger): add cpu-config and entropy in vm config

### DIFF
--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -927,6 +927,8 @@ definitions:
           $ref: "#/definitions/Drive"
       boot-source:
         $ref: "#/definitions/BootSource"
+      cpu-config:
+        $ref: "#/definitions/CpuConfig"
       logger:
         $ref: "#/definitions/Logger"
       machine-config:
@@ -942,6 +944,8 @@ definitions:
           $ref: "#/definitions/NetworkInterface"
       vsock:
         $ref: "#/definitions/Vsock"
+      entropy:
+        $ref: "#/definitions/EntropyDevice"
 
   InstanceActionInfo:
     type: object


### PR DESCRIPTION
## Changes

This updates `firecracker.yaml` to reflect the implementation.

## Reason

cpu-config field was added by (https://github.com/firecracker-microvm/firecracker/pull/3678):
```
commit 9da9619ea480342e3c4063ed55193342cd7923ae
Author: Takahiro Itazuri <itazur@amazon.com>
Date:   Wed Apr 26 13:55:21 2023 +0000

    feat: Add "cpu-config" to config file
```
entropy field was added by (https://github.com/firecracker-microvm/firecracker/pull/3691):
```
commit 250036de87052e41e7ccea6d475cbace6d1ae8de
Author: Babis Chalios <bchalios@amazon.es>
Date:   Wed Nov 23 09:52:28 2022 +0000

    feat(entropy): plug in with API
```
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- ~~[ ] All added/changed functionality is tested.~~
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
