### PR TITLE
vsock: reuse IoVecBuffer(Mut) buffers for packets within a connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,12 +1266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
 name = "snapshot-editor"
 version = "1.10.0-dev"
 dependencies = [
@@ -1575,7 +1569,6 @@ dependencies = [
  "serde",
  "serde_json",
  "slab",
- "smallvec",
  "thiserror",
  "timerfd",
  "userfaultfd",

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -34,7 +34,6 @@ semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.210", features = ["derive", "rc"] }
 serde_json = "1.0.128"
 slab = "0.4.7"
-smallvec = "1.11.2"
 thiserror = "1.0.64"
 timerfd = "1.5.0"
 userfaultfd = "0.8.1"

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -219,13 +219,17 @@ impl IoVecBuffer {
 /// It describes a write-only buffer passed to us by the guest that is scattered across multiple
 /// memory regions. Additionally, this wrapper provides methods that allow reading arbitrary ranges
 /// of data from that buffer.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct IoVecBufferMut {
     // container of the memory regions included in this IO vector
     vecs: IoVecVec,
     // Total length of the IoVecBufferMut
     len: u32,
 }
+
+// SAFETY: `IoVecBufferMut` doesn't allow for interior mutability and no shared ownership is possible
+// as it doesn't implement clone
+unsafe impl Send for IoVecBufferMut {}
 
 impl IoVecBufferMut {
     /// Create an `IoVecBuffer` from a `DescriptorChain`

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -4,7 +4,6 @@
 use std::io::ErrorKind;
 
 use libc::{c_void, iovec, size_t};
-use smallvec::SmallVec;
 use vm_memory::bitmap::Bitmap;
 use vm_memory::{
     GuestMemory, GuestMemoryError, ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile,
@@ -25,14 +24,6 @@ pub enum IoVecError {
     GuestMemory(#[from] GuestMemoryError),
 }
 
-// Using SmallVec in the kani proofs causes kani to use unbounded amounts of memory
-// during post-processing, and then crash.
-// TODO: remove new-type once kani performance regression are resolved
-#[cfg(kani)]
-type IoVecVec = Vec<iovec>;
-#[cfg(not(kani))]
-type IoVecVec = SmallVec<[iovec; 4]>;
-
 /// This is essentially a wrapper of a `Vec<libc::iovec>` which can be passed to `libc::writev`.
 ///
 /// It describes a buffer passed to us by the guest that is scattered across multiple
@@ -41,7 +32,7 @@ type IoVecVec = SmallVec<[iovec; 4]>;
 #[derive(Debug, Default)]
 pub struct IoVecBuffer {
     // container of the memory regions included in this IO vector
-    vecs: IoVecVec,
+    vecs: Vec<iovec>,
     // Total length of the IoVecBuffer
     len: u32,
 }
@@ -222,13 +213,13 @@ impl IoVecBuffer {
 #[derive(Debug, Default)]
 pub struct IoVecBufferMut {
     // container of the memory regions included in this IO vector
-    vecs: IoVecVec,
+    vecs: Vec<iovec>,
     // Total length of the IoVecBufferMut
     len: u32,
 }
 
-// SAFETY: `IoVecBufferMut` doesn't allow for interior mutability and no shared ownership is possible
-// as it doesn't implement clone
+// SAFETY: `IoVecBufferMut` doesn't allow for interior mutability and no shared ownership is
+// possible as it doesn't implement clone
 unsafe impl Send for IoVecBufferMut {}
 
 impl IoVecBufferMut {
@@ -406,8 +397,7 @@ mod tests {
                 vecs: vec![iovec {
                     iov_base: buf.as_ptr() as *mut c_void,
                     iov_len: buf.len(),
-                }]
-                .into(),
+                }],
                 len: buf.len().try_into().unwrap(),
             }
         }
@@ -437,8 +427,7 @@ mod tests {
                 vecs: vec![iovec {
                     iov_base: buf.as_mut_ptr().cast::<c_void>(),
                     iov_len: buf.len(),
-                }]
-                .into(),
+                }],
                 len: buf.len().try_into().unwrap(),
             }
         }
@@ -690,7 +679,7 @@ mod verification {
     use vm_memory::bitmap::BitmapSlice;
     use vm_memory::VolatileSlice;
 
-    use super::{IoVecBuffer, IoVecBufferMut, IoVecVec};
+    use super::{IoVecBuffer, IoVecBufferMut};
 
     // Maximum memory size to use for our buffers. For the time being 1KB.
     const GUEST_MEMORY_SIZE: usize = 1 << 10;
@@ -702,7 +691,7 @@ mod verification {
     // >= 1.
     const MAX_DESC_LENGTH: usize = 4;
 
-    fn create_iovecs(mem: *mut u8, size: usize, nr_descs: usize) -> (IoVecVec, u32) {
+    fn create_iovecs(mem: *mut u8, size: usize, nr_descs: usize) -> (Vec<iovec>, u32) {
         let mut vecs: Vec<iovec> = Vec::with_capacity(nr_descs);
         let mut len = 0u32;
         for _ in 0..nr_descs {

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -439,7 +439,9 @@ mod tests {
             // If the descriptor chain is already declared invalid, there's no reason to assemble
             // a packet.
             if let Some(rx_desc) = ctx.device.queues[RXQ_INDEX].pop() {
-                VsockPacket::from_rx_virtq_head(&test_ctx.mem, rx_desc).unwrap_err();
+                VsockPacketRx::default()
+                    .parse(&test_ctx.mem, rx_desc)
+                    .unwrap_err();
             }
         }
 
@@ -461,7 +463,9 @@ mod tests {
             ctx.guest_txvq.dtable[desc_idx].len.set(len);
 
             if let Some(tx_desc) = ctx.device.queues[TXQ_INDEX].pop() {
-                VsockPacket::from_tx_virtq_head(&test_ctx.mem, tx_desc).unwrap_err();
+                VsockPacketTx::default()
+                    .parse(&test_ctx.mem, tx_desc)
+                    .unwrap_err();
             }
         }
     }
@@ -486,13 +490,17 @@ mod tests {
         {
             let mut ctx = test_ctx.create_event_handler_context();
             let rx_desc = ctx.device.queues[RXQ_INDEX].pop().unwrap();
-            VsockPacket::from_rx_virtq_head(&test_ctx.mem, rx_desc).unwrap();
+            VsockPacketRx::default()
+                .parse(&test_ctx.mem, rx_desc)
+                .unwrap();
         }
 
         {
             let mut ctx = test_ctx.create_event_handler_context();
             let tx_desc = ctx.device.queues[TXQ_INDEX].pop().unwrap();
-            VsockPacket::from_tx_virtq_head(&test_ctx.mem, tx_desc).unwrap();
+            VsockPacketTx::default()
+                .parse(&test_ctx.mem, tx_desc)
+                .unwrap();
         }
 
         // Let's check what happens when the header descriptor is right before the gap.

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -22,13 +22,13 @@ mod unix;
 
 use std::os::unix::io::AsRawFd;
 
-use packet::VsockPacket;
 use vm_memory::GuestMemoryError;
 use vmm_sys_util::epoll::EventSet;
 
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
 pub use self::defs::VSOCK_DEV_ID;
 pub use self::device::Vsock;
+use self::packet::{VsockPacketRx, VsockPacketTx};
 pub use self::unix::{VsockUnixBackend, VsockUnixBackendError};
 use crate::devices::virtio::iovec::IoVecError;
 use crate::devices::virtio::persist::PersistError as VirtioStateError;
@@ -174,10 +174,10 @@ pub trait VsockEpollListener: AsRawFd {
 ///       - `send_pkt(&pkt)` will fetch data from `pkt`, and place it into the channel.
 pub trait VsockChannel {
     /// Read/receive an incoming packet from the channel.
-    fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> Result<(), VsockError>;
+    fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<(), VsockError>;
 
     /// Write/send a packet through the channel.
-    fn send_pkt(&mut self, pkt: &VsockPacket) -> Result<(), VsockError>;
+    fn send_pkt(&mut self, pkt: &VsockPacketTx) -> Result<(), VsockError>;
 
     /// Checks whether there is pending incoming data inside the channel, meaning that a subsequent
     /// call to `recv_pkt()` won't fail.

--- a/src/vmm/src/devices/virtio/vsock/packet.rs
+++ b/src/vmm/src/devices/virtio/vsock/packet.rs
@@ -77,40 +77,125 @@ pub struct VsockPacketHeader {
     fwd_cnt: u32,
 }
 
+impl VsockPacketHeader {
+    pub fn src_cid(&self) -> u64 {
+        u64::from_le(self.src_cid)
+    }
+
+    pub fn set_src_cid(&mut self, cid: u64) -> &mut Self {
+        self.src_cid = cid.to_le();
+        self
+    }
+
+    pub fn dst_cid(&self) -> u64 {
+        u64::from_le(self.dst_cid)
+    }
+
+    pub fn set_dst_cid(&mut self, cid: u64) -> &mut Self {
+        self.dst_cid = cid.to_le();
+        self
+    }
+
+    pub fn src_port(&self) -> u32 {
+        u32::from_le(self.src_port)
+    }
+
+    pub fn set_src_port(&mut self, port: u32) -> &mut Self {
+        self.src_port = port.to_le();
+        self
+    }
+
+    pub fn dst_port(&self) -> u32 {
+        u32::from_le(self.dst_port)
+    }
+
+    pub fn set_dst_port(&mut self, port: u32) -> &mut Self {
+        self.dst_port = port.to_le();
+        self
+    }
+
+    pub fn len(&self) -> u32 {
+        u32::from_le(self.len)
+    }
+
+    pub fn set_len(&mut self, len: u32) -> &mut Self {
+        self.len = len.to_le();
+        self
+    }
+
+    pub fn type_(&self) -> u16 {
+        u16::from_le(self.type_)
+    }
+
+    pub fn set_type(&mut self, type_: u16) -> &mut Self {
+        self.type_ = type_.to_le();
+        self
+    }
+
+    pub fn op(&self) -> u16 {
+        u16::from_le(self.op)
+    }
+
+    pub fn set_op(&mut self, op: u16) -> &mut Self {
+        self.op = op.to_le();
+        self
+    }
+
+    pub fn flags(&self) -> u32 {
+        u32::from_le(self.flags)
+    }
+
+    pub fn set_flags(&mut self, flags: u32) -> &mut Self {
+        self.flags = flags.to_le();
+        self
+    }
+
+    pub fn set_flag(&mut self, flag: u32) -> &mut Self {
+        self.set_flags(self.flags() | flag);
+        self
+    }
+
+    pub fn buf_alloc(&self) -> u32 {
+        u32::from_le(self.buf_alloc)
+    }
+
+    pub fn set_buf_alloc(&mut self, buf_alloc: u32) -> &mut Self {
+        self.buf_alloc = buf_alloc.to_le();
+        self
+    }
+
+    pub fn fwd_cnt(&self) -> u32 {
+        u32::from_le(self.fwd_cnt)
+    }
+
+    pub fn set_fwd_cnt(&mut self, fwd_cnt: u32) -> &mut Self {
+        self.fwd_cnt = fwd_cnt.to_le();
+        self
+    }
+}
+
 /// The vsock packet header struct size (the struct is packed).
 pub const VSOCK_PKT_HDR_SIZE: u32 = 44;
 
 // SAFETY: `VsockPacketHeader` is a POD and contains no padding.
 unsafe impl ByteValued for VsockPacketHeader {}
 
-/// Enum representing either a TX (e.g. read-only) or RX (e.g. write-only) buffer
-///
-/// Read and write permissions are statically enforced by using the correct `IoVecBuffer[Mut]`
-/// abstraction
-#[derive(Debug)]
-pub enum VsockPacketBuffer {
-    /// Buffer holds a read-only guest-to-host (TX) packet
-    Tx(IoVecBuffer),
-    /// Buffer holds a write-only host-to-guest (RX) packet
-    Rx(IoVecBufferMut),
-}
-
-/// Struct describing a single vsock packet.
-///
-/// Encapsulates the virtio descriptor chain containing the packet through the `IoVecBuffer[Mut]`
-/// abstractions.
-#[derive(Debug)]
-pub struct VsockPacket {
+// /// Struct describing a single vsock packet.
+// ///
+// /// Encapsulates the virtio descriptor chain containing the packet through the `IoVecBuffer[Mut]`
+// /// abstractions.
+#[derive(Debug, Default)]
+pub struct VsockPacketTx {
     /// A copy of the vsock packet's 44-byte header, held in hypervisor memory
     /// to minimize the number of accesses to guest memory. Can be written back
     /// to geust memory using [`VsockPacket::commit_hdr`] (only for RX buffers).
-    hdr: VsockPacketHeader,
+    pub hdr: VsockPacketHeader,
     /// The raw buffer, as it is contained in guest memory (containing both
     /// header and payload)
-    buffer: VsockPacketBuffer,
+    buffer: IoVecBuffer,
 }
 
-impl VsockPacket {
+impl VsockPacketTx {
     /// Create the packet wrapper from a TX virtq chain head.
     ///
     /// ## Errors
@@ -123,17 +208,18 @@ impl VsockPacket {
     ///   length would exceed [`defs::MAX_PKT_BUR_SIZE`].
     /// - [`VsockError::DescChainTooShortForPacket`] if the contained vsock header describes a vsock
     ///   packet whose length exceeds the descriptor chain's actual total buffer length.
-    pub fn from_tx_virtq_head(
+    pub fn parse(
+        &mut self,
         mem: &GuestMemoryMmap,
         chain: DescriptorChain,
-    ) -> Result<Self, VsockError> {
+    ) -> Result<(), VsockError> {
         // SAFETY: This descriptor chain is only loaded once
         // virtio requests are handled sequentially so no two IoVecBuffers
         // are live at the same time, meaning this has exclusive ownership over the memory
-        let buffer = unsafe { IoVecBuffer::from_descriptor_chain(mem, chain)? };
+        unsafe { self.buffer.load_descriptor_chain(mem, chain)? };
 
         let mut hdr = VsockPacketHeader::default();
-        match buffer.read_exact_volatile_at(hdr.as_mut_slice(), 0) {
+        match self.buffer.read_exact_volatile_at(hdr.as_mut_slice(), 0) {
             Ok(()) => (),
             Err(Error::PartialBuffer { completed, .. }) => {
                 return Err(VsockError::DescChainTooShortForHeader(completed))
@@ -145,50 +231,85 @@ impl VsockPacket {
             return Err(VsockError::InvalidPktLen(hdr.len));
         }
 
-        if hdr.len > buffer.len() - VSOCK_PKT_HDR_SIZE {
+        if hdr.len > self.buffer.len() - VSOCK_PKT_HDR_SIZE {
             return Err(VsockError::DescChainTooShortForPacket(
-                buffer.len(),
+                self.buffer.len(),
                 hdr.len,
             ));
         }
-
-        Ok(VsockPacket {
-            hdr,
-            buffer: VsockPacketBuffer::Tx(buffer),
-        })
+        self.hdr = hdr;
+        Ok(())
     }
 
+    pub fn write_from_offset_to<T: WriteVolatile + Debug>(
+        &self,
+        dst: &mut T,
+        offset: u32,
+        count: u32,
+    ) -> Result<u32, VsockError> {
+        if count
+            > self
+                .buffer
+                .len()
+                .saturating_sub(VSOCK_PKT_HDR_SIZE)
+                .saturating_sub(offset)
+        {
+            return Err(VsockError::GuestMemoryBounds);
+        }
+
+        self.buffer
+            .read_volatile_at(dst, (offset + VSOCK_PKT_HDR_SIZE) as usize, count as usize)
+            .map_err(|err| VsockError::GuestMemoryMmap(GuestMemoryError::from(err)))
+            .and_then(|read| read.try_into().map_err(|_| VsockError::DescChainOverflow))
+    }
+
+    /// Returns the total length of this [`VsockPacket`]'s buffer (e.g. the amount of data bytes
+    /// contained in this packet).
+    ///
+    /// Return value will equal the total length of the underlying descriptor chain's buffers,
+    /// minus the length of the vsock header.
+    pub fn buf_size(&self) -> u32 {
+        self.buffer.len() - VSOCK_PKT_HDR_SIZE
+    }
+}
+
+/// Struct describing a single vsock packet.
+///
+/// Encapsulates the virtio descriptor chain containing the packet through the `IoVecBuffer[Mut]`
+/// abstractions.
+#[derive(Debug, Default)]
+pub struct VsockPacketRx {
+    /// A copy of the vsock packet's 44-byte header, held in hypervisor memory
+    /// to minimize the number of accesses to guest memory. Can be written back
+    /// to geust memory using [`VsockPacket::commit_hdr`] (only for RX buffers).
+    pub hdr: VsockPacketHeader,
+    /// The raw buffer, as it is contained in guest memory (containing both
+    /// header and payload)
+    buffer: IoVecBufferMut,
+}
+
+impl VsockPacketRx {
     /// Create the packet wrapper from an RX virtq chain head.
     ///
     /// ## Errors
     /// Returns [`VsockError::DescChainTooShortForHeader`] if the descriptor chain's total buffer
     /// length is insufficient to hold the 44 byte vsock header
-    pub fn from_rx_virtq_head(
+    pub fn parse(
+        &mut self,
         mem: &GuestMemoryMmap,
         chain: DescriptorChain,
-    ) -> Result<Self, VsockError> {
+    ) -> Result<(), VsockError> {
         // SAFETY: This descriptor chain is only loaded once
         // virtio requests are handled sequentially so no two IoVecBuffers
         // are live at the same time, meaning this has exclusive ownership over the memory
-        let buffer = unsafe { IoVecBufferMut::from_descriptor_chain(mem, chain)? };
-
-        if buffer.len() < VSOCK_PKT_HDR_SIZE {
-            return Err(VsockError::DescChainTooShortForHeader(buffer.len() as usize));
+        unsafe { self.buffer.load_descriptor_chain(mem, chain)? };
+        if self.buffer.len() < VSOCK_PKT_HDR_SIZE {
+            return Err(VsockError::DescChainTooShortForHeader(
+                self.buffer.len() as usize
+            ));
         }
-
-        Ok(Self {
-            // On the Rx path the header has to be filled by Firecracker. The guest only provides
-            // a write-only memory area that Firecracker can write the header into. So we initialize
-            // the local copy with zeros, we write to it whenever we need to, and we only commit it
-            // to the guest memory once, before marking the RX descriptor chain as used.
-            hdr: VsockPacketHeader::default(),
-            buffer: VsockPacketBuffer::Rx(buffer),
-        })
-    }
-
-    /// Provides in-place access to the local copy of the vsock packet header.
-    pub fn hdr(&self) -> &VsockPacketHeader {
-        &self.hdr
+        self.hdr = VsockPacketHeader::default();
+        Ok(())
     }
 
     /// Writes the local copy of the packet header to the guest memory.
@@ -199,19 +320,13 @@ impl VsockPacket {
     /// packet's payload as described by this [`VsockPacket`] would exceed
     /// [`defs::MAX_PKT_BUF_SIZE`].
     pub fn commit_hdr(&mut self) -> Result<(), VsockError> {
-        match self.buffer {
-            VsockPacketBuffer::Tx(_) => Err(VsockError::UnwritableDescriptor),
-            VsockPacketBuffer::Rx(ref mut buffer) => {
-                if self.hdr.len > defs::MAX_PKT_BUF_SIZE {
-                    return Err(VsockError::InvalidPktLen(self.hdr.len));
-                }
-
-                buffer
-                    .write_all_volatile_at(self.hdr.as_slice(), 0)
-                    .map_err(GuestMemoryError::from)
-                    .map_err(VsockError::GuestMemoryMmap)
-            }
+        if self.hdr.len > defs::MAX_PKT_BUF_SIZE {
+            return Err(VsockError::InvalidPktLen(self.hdr.len));
         }
+        self.buffer
+            .write_all_volatile_at(self.hdr.as_slice(), 0)
+            .map_err(GuestMemoryError::from)
+            .map_err(VsockError::GuestMemoryMmap)
     }
 
     /// Returns the total length of this [`VsockPacket`]'s buffer (e.g. the amount of data bytes
@@ -220,11 +335,7 @@ impl VsockPacket {
     /// Return value will equal the total length of the underlying descriptor chain's buffers,
     /// minus the length of the vsock header.
     pub fn buf_size(&self) -> u32 {
-        let chain_length = match self.buffer {
-            VsockPacketBuffer::Tx(ref iovec_buf) => iovec_buf.len(),
-            VsockPacketBuffer::Rx(ref iovec_buf) => iovec_buf.len(),
-        };
-        chain_length - VSOCK_PKT_HDR_SIZE
+        self.buffer.len() - VSOCK_PKT_HDR_SIZE
     }
 
     pub fn read_at_offset_from<T: ReadVolatile + Debug>(
@@ -233,145 +344,20 @@ impl VsockPacket {
         offset: u32,
         count: u32,
     ) -> Result<u32, VsockError> {
-        match self.buffer {
-            VsockPacketBuffer::Tx(_) => Err(VsockError::UnwritableDescriptor),
-            VsockPacketBuffer::Rx(ref mut buffer) => {
-                if count
-                    > buffer
-                        .len()
-                        .saturating_sub(VSOCK_PKT_HDR_SIZE)
-                        .saturating_sub(offset)
-                {
-                    return Err(VsockError::GuestMemoryBounds);
-                }
-
-                buffer
-                    .write_volatile_at(src, (offset + VSOCK_PKT_HDR_SIZE) as usize, count as usize)
-                    .map_err(|err| VsockError::GuestMemoryMmap(GuestMemoryError::from(err)))
-                    .and_then(|read| read.try_into().map_err(|_| VsockError::DescChainOverflow))
-            }
+        if count
+            > self
+                .buffer
+                .len()
+                .saturating_sub(VSOCK_PKT_HDR_SIZE)
+                .saturating_sub(offset)
+        {
+            return Err(VsockError::GuestMemoryBounds);
         }
-    }
 
-    pub fn write_from_offset_to<T: WriteVolatile + Debug>(
-        &self,
-        dst: &mut T,
-        offset: u32,
-        count: u32,
-    ) -> Result<u32, VsockError> {
-        match self.buffer {
-            VsockPacketBuffer::Tx(ref buffer) => {
-                if count
-                    > buffer
-                        .len()
-                        .saturating_sub(VSOCK_PKT_HDR_SIZE)
-                        .saturating_sub(offset)
-                {
-                    return Err(VsockError::GuestMemoryBounds);
-                }
-
-                buffer
-                    .read_volatile_at(dst, (offset + VSOCK_PKT_HDR_SIZE) as usize, count as usize)
-                    .map_err(|err| VsockError::GuestMemoryMmap(GuestMemoryError::from(err)))
-                    .and_then(|read| read.try_into().map_err(|_| VsockError::DescChainOverflow))
-            }
-            VsockPacketBuffer::Rx(_) => Err(VsockError::UnreadableDescriptor),
-        }
-    }
-
-    pub fn src_cid(&self) -> u64 {
-        u64::from_le(self.hdr.src_cid)
-    }
-
-    pub fn set_src_cid(&mut self, cid: u64) -> &mut Self {
-        self.hdr.src_cid = cid.to_le();
-        self
-    }
-
-    pub fn dst_cid(&self) -> u64 {
-        u64::from_le(self.hdr.dst_cid)
-    }
-
-    pub fn set_dst_cid(&mut self, cid: u64) -> &mut Self {
-        self.hdr.dst_cid = cid.to_le();
-        self
-    }
-
-    pub fn src_port(&self) -> u32 {
-        u32::from_le(self.hdr.src_port)
-    }
-
-    pub fn set_src_port(&mut self, port: u32) -> &mut Self {
-        self.hdr.src_port = port.to_le();
-        self
-    }
-
-    pub fn dst_port(&self) -> u32 {
-        u32::from_le(self.hdr.dst_port)
-    }
-
-    pub fn set_dst_port(&mut self, port: u32) -> &mut Self {
-        self.hdr.dst_port = port.to_le();
-        self
-    }
-
-    pub fn len(&self) -> u32 {
-        u32::from_le(self.hdr.len)
-    }
-
-    pub fn set_len(&mut self, len: u32) -> &mut Self {
-        self.hdr.len = len.to_le();
-        self
-    }
-
-    pub fn type_(&self) -> u16 {
-        u16::from_le(self.hdr.type_)
-    }
-
-    pub fn set_type(&mut self, type_: u16) -> &mut Self {
-        self.hdr.type_ = type_.to_le();
-        self
-    }
-
-    pub fn op(&self) -> u16 {
-        u16::from_le(self.hdr.op)
-    }
-
-    pub fn set_op(&mut self, op: u16) -> &mut Self {
-        self.hdr.op = op.to_le();
-        self
-    }
-
-    pub fn flags(&self) -> u32 {
-        u32::from_le(self.hdr.flags)
-    }
-
-    pub fn set_flags(&mut self, flags: u32) -> &mut Self {
-        self.hdr.flags = flags.to_le();
-        self
-    }
-
-    pub fn set_flag(&mut self, flag: u32) -> &mut Self {
-        self.set_flags(self.flags() | flag);
-        self
-    }
-
-    pub fn buf_alloc(&self) -> u32 {
-        u32::from_le(self.hdr.buf_alloc)
-    }
-
-    pub fn set_buf_alloc(&mut self, buf_alloc: u32) -> &mut Self {
-        self.hdr.buf_alloc = buf_alloc.to_le();
-        self
-    }
-
-    pub fn fwd_cnt(&self) -> u32 {
-        u32::from_le(self.hdr.fwd_cnt)
-    }
-
-    pub fn set_fwd_cnt(&mut self, fwd_cnt: u32) -> &mut Self {
-        self.hdr.fwd_cnt = fwd_cnt.to_le();
-        self
+        self.buffer
+            .write_volatile_at(src, (offset + VSOCK_PKT_HDR_SIZE) as usize, count as usize)
+            .map_err(|err| VsockError::GuestMemoryMmap(GuestMemoryError::from(err)))
+            .and_then(|read| read.try_into().map_err(|_| VsockError::DescChainOverflow))
     }
 }
 
@@ -393,22 +379,6 @@ mod tests {
             let mut $handler_ctx = $test_ctx.create_event_handler_context();
             // For TX packets, hdr.len should be set to a valid value.
             set_pkt_len(4096, &$handler_ctx.guest_txvq.dtable[0], &$test_ctx.mem);
-        };
-    }
-
-    macro_rules! expect_asm_error {
-        (tx, $test_ctx:expr, $handler_ctx:expr, $err:pat) => {
-            expect_asm_error!($test_ctx, $handler_ctx, $err, from_tx_virtq_head, TXQ_INDEX);
-        };
-        (rx, $test_ctx:expr, $handler_ctx:expr, $err:pat) => {
-            expect_asm_error!($test_ctx, $handler_ctx, $err, from_rx_virtq_head, RXQ_INDEX);
-        };
-        ($test_ctx:expr, $handler_ctx:expr, $err:pat, $ctor:ident, $vq_index:ident) => {
-            let result = VsockPacket::$ctor(
-                &$test_ctx.mem,
-                $handler_ctx.device.queues[$vq_index].pop().unwrap(),
-            );
-            assert!(matches!(result, Err($err)), "{:?}", result)
         };
     }
 
@@ -434,7 +404,8 @@ mod tests {
         {
             create_context!(test_ctx, handler_ctx);
 
-            let pkt = VsockPacket::from_tx_virtq_head(
+            let mut pkt = VsockPacketTx::default();
+            pkt.parse(
                 &test_ctx.mem,
                 handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
             )
@@ -452,7 +423,13 @@ mod tests {
             handler_ctx.guest_txvq.dtable[0]
                 .flags
                 .set(VIRTQ_DESC_F_WRITE);
-            expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::UnreadableDescriptor);
+            assert!(matches!(
+                VsockPacketTx::default().parse(
+                    &test_ctx.mem,
+                    handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
+                ),
+                Err(VsockError::UnreadableDescriptor)
+            ))
         }
 
         // Test case: header descriptor has insufficient space to hold the packet header.
@@ -462,23 +439,25 @@ mod tests {
                 .len
                 .set(VSOCK_PKT_HDR_SIZE - 1);
             handler_ctx.guest_txvq.dtable[1].len.set(0);
-            expect_asm_error!(
-                tx,
-                test_ctx,
-                handler_ctx,
-                VsockError::DescChainTooShortForHeader(_)
-            );
+            assert!(matches!(
+                VsockPacketTx::default().parse(
+                    &test_ctx.mem,
+                    handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
+                ),
+                Err(VsockError::DescChainTooShortForHeader(_))
+            ))
         }
 
         // Test case: zero-length TX packet.
         {
             create_context!(test_ctx, handler_ctx);
             set_pkt_len(0, &handler_ctx.guest_txvq.dtable[0], &test_ctx.mem);
-            VsockPacket::from_tx_virtq_head(
-                &test_ctx.mem,
-                handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
-            )
-            .unwrap();
+            VsockPacketTx::default()
+                .parse(
+                    &test_ctx.mem,
+                    handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
+                )
+                .unwrap();
         }
 
         // Test case: TX packet has more data than we can handle.
@@ -489,7 +468,13 @@ mod tests {
                 &handler_ctx.guest_txvq.dtable[0],
                 &test_ctx.mem,
             );
-            expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::InvalidPktLen(_));
+            assert!(matches!(
+                VsockPacketTx::default().parse(
+                    &test_ctx.mem,
+                    handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
+                ),
+                Err(VsockError::InvalidPktLen(_))
+            ))
         }
 
         // Test case:
@@ -499,12 +484,13 @@ mod tests {
             create_context!(test_ctx, handler_ctx);
             set_pkt_len(1024, &handler_ctx.guest_txvq.dtable[0], &test_ctx.mem);
             handler_ctx.guest_txvq.dtable[0].flags.set(0);
-            expect_asm_error!(
-                tx,
-                test_ctx,
-                handler_ctx,
-                VsockError::DescChainTooShortForPacket(44, 1024)
-            );
+            assert!(matches!(
+                VsockPacketTx::default().parse(
+                    &test_ctx.mem,
+                    handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
+                ),
+                Err(VsockError::DescChainTooShortForPacket(44, 1024))
+            ))
         }
 
         // Test case: error on write-only buf descriptor.
@@ -513,7 +499,13 @@ mod tests {
             handler_ctx.guest_txvq.dtable[1]
                 .flags
                 .set(VIRTQ_DESC_F_WRITE);
-            expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::UnreadableDescriptor);
+            assert!(matches!(
+                VsockPacketTx::default().parse(
+                    &test_ctx.mem,
+                    handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
+                ),
+                Err(VsockError::UnreadableDescriptor)
+            ))
         }
 
         // Test case: the buffer descriptor cannot fit all the data advertised by the the
@@ -522,12 +514,13 @@ mod tests {
             create_context!(test_ctx, handler_ctx);
             set_pkt_len(8 * 1024, &handler_ctx.guest_txvq.dtable[0], &test_ctx.mem);
             handler_ctx.guest_txvq.dtable[1].len.set(4 * 1024);
-            expect_asm_error!(
-                tx,
-                test_ctx,
-                handler_ctx,
-                VsockError::DescChainTooShortForPacket(4140, 8192)
-            );
+            assert!(matches!(
+                VsockPacketTx::default().parse(
+                    &test_ctx.mem,
+                    handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
+                ),
+                Err(VsockError::DescChainTooShortForPacket(4140, 8192))
+            ))
         }
     }
 
@@ -536,7 +529,8 @@ mod tests {
         // Test case: successful RX packet assembly.
         {
             create_context!(test_ctx, handler_ctx);
-            let pkt = VsockPacket::from_rx_virtq_head(
+            let mut pkt = VsockPacketRx::default();
+            pkt.parse(
                 &test_ctx.mem,
                 handler_ctx.device.queues[RXQ_INDEX].pop().unwrap(),
             )
@@ -548,7 +542,13 @@ mod tests {
         {
             create_context!(test_ctx, handler_ctx);
             handler_ctx.guest_rxvq.dtable[0].flags.set(0);
-            expect_asm_error!(rx, test_ctx, handler_ctx, VsockError::UnwritableDescriptor);
+            assert!(matches!(
+                VsockPacketRx::default().parse(
+                    &test_ctx.mem,
+                    handler_ctx.device.queues[RXQ_INDEX].pop().unwrap(),
+                ),
+                Err(VsockError::UnwritableDescriptor)
+            ))
         }
 
         // Test case: RX descriptor chain cannot fit packet header
@@ -558,12 +558,13 @@ mod tests {
                 .len
                 .set(VSOCK_PKT_HDR_SIZE - 1);
             handler_ctx.guest_rxvq.dtable[1].len.set(0);
-            expect_asm_error!(
-                rx,
-                test_ctx,
-                handler_ctx,
-                VsockError::DescChainTooShortForHeader(_)
-            );
+            assert!(matches!(
+                VsockPacketRx::default().parse(
+                    &test_ctx.mem,
+                    handler_ctx.device.queues[RXQ_INDEX].pop().unwrap(),
+                ),
+                Err(VsockError::DescChainTooShortForHeader(_))
+            ))
         }
     }
 
@@ -581,15 +582,20 @@ mod tests {
         const BUF_ALLOC: u32 = 9;
         const FWD_CNT: u32 = 10;
 
-        create_context!(test_ctx, handler_ctx);
-        let mut pkt = VsockPacket::from_rx_virtq_head(
-            &test_ctx.mem,
-            handler_ctx.device.queues[RXQ_INDEX].pop().unwrap(),
-        )
-        .unwrap();
+        let mut hdr = VsockPacketHeader::default();
+        assert_eq!(hdr.src_cid(), 0);
+        assert_eq!(hdr.dst_cid(), 0);
+        assert_eq!(hdr.src_port(), 0);
+        assert_eq!(hdr.dst_port(), 0);
+        assert_eq!(hdr.len(), 0);
+        assert_eq!(hdr.type_(), 0);
+        assert_eq!(hdr.op(), 0);
+        assert_eq!(hdr.flags(), 0);
+        assert_eq!(hdr.buf_alloc(), 0);
+        assert_eq!(hdr.fwd_cnt(), 0);
 
         // Test field accessors.
-        pkt.set_src_cid(SRC_CID)
+        hdr.set_src_cid(SRC_CID)
             .set_dst_cid(DST_CID)
             .set_src_port(SRC_PORT)
             .set_dst_port(DST_PORT)
@@ -600,33 +606,21 @@ mod tests {
             .set_buf_alloc(BUF_ALLOC)
             .set_fwd_cnt(FWD_CNT);
 
-        assert_eq!(pkt.src_cid(), SRC_CID);
-        assert_eq!(pkt.dst_cid(), DST_CID);
-        assert_eq!(pkt.src_port(), SRC_PORT);
-        assert_eq!(pkt.dst_port(), DST_PORT);
-        assert_eq!(pkt.len(), LEN);
-        assert_eq!(pkt.type_(), TYPE);
-        assert_eq!(pkt.op(), OP);
-        assert_eq!(pkt.flags(), FLAGS);
-        assert_eq!(pkt.buf_alloc(), BUF_ALLOC);
-        assert_eq!(pkt.fwd_cnt(), FWD_CNT);
+        assert_eq!(hdr.src_cid(), SRC_CID);
+        assert_eq!(hdr.dst_cid(), DST_CID);
+        assert_eq!(hdr.src_port(), SRC_PORT);
+        assert_eq!(hdr.dst_port(), DST_PORT);
+        assert_eq!(hdr.len(), LEN);
+        assert_eq!(hdr.type_(), TYPE);
+        assert_eq!(hdr.op(), OP);
+        assert_eq!(hdr.flags(), FLAGS);
+        assert_eq!(hdr.buf_alloc(), BUF_ALLOC);
+        assert_eq!(hdr.fwd_cnt(), FWD_CNT);
 
         // Test individual flag setting.
-        let flags = pkt.flags() | 0b1000;
-        pkt.set_flag(0b1000);
-        assert_eq!(pkt.flags(), flags);
-
-        pkt.hdr = VsockPacketHeader::default();
-        assert_eq!(pkt.src_cid(), 0);
-        assert_eq!(pkt.dst_cid(), 0);
-        assert_eq!(pkt.src_port(), 0);
-        assert_eq!(pkt.dst_port(), 0);
-        assert_eq!(pkt.len(), 0);
-        assert_eq!(pkt.type_(), 0);
-        assert_eq!(pkt.op(), 0);
-        assert_eq!(pkt.flags(), 0);
-        assert_eq!(pkt.buf_alloc(), 0);
-        assert_eq!(pkt.fwd_cnt(), 0);
+        let flags = hdr.flags() | 0b1000;
+        hdr.set_flag(0b1000);
+        assert_eq!(hdr.flags(), flags);
     }
 
     #[test]
@@ -635,12 +629,14 @@ mod tests {
         // create_context gives us an rx descriptor chain and a tx descriptor chain pointing to the
         // same area of memory. We need both a rx-view and a tx-view into the packet, as tx-queue
         // buffers are read only, while rx queue buffers are write-only
-        let mut pkt = VsockPacket::from_rx_virtq_head(
+        let mut pkt = VsockPacketRx::default();
+        pkt.parse(
             &test_ctx.mem,
             handler_ctx.device.queues[RXQ_INDEX].pop().unwrap(),
         )
         .unwrap();
-        let pkt2 = VsockPacket::from_tx_virtq_head(
+        let mut pkt2 = VsockPacketTx::default();
+        pkt2.parse(
             &test_ctx.mem,
             handler_ctx.device.queues[TXQ_INDEX].pop().unwrap(),
         )


### PR DESCRIPTION
## Changes
Make `vsock` reuse packets for RX and TX paths. This removes overhead of creating packets from the virt queues.
This also should prevent regressions from #4799.

## Reason
Improved performance.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
