### PR TITLE
Enable running kani on ARM

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -56,7 +56,7 @@ if not changed_files or any(
         "./tools/devtool -y test --no-build -- ../tests/integration_tests/test_kani.py -n auto",
         # Kani step default
         # Kani runs fastest on m6a.metal
-        instances=["m6a.metal"],
+        instances=["m6a.metal", "m7g.metal"],
         platforms=[("al2", "linux_5.10")],
         timeout_in_minutes=300,
         **DEFAULTS_PERF,

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -107,7 +107,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOL
     && rustup target add aarch64-unknown-linux-musl \
     && rustup component add llvm-tools-preview \
     && cargo install --locked cargo-audit cargo-deny grcov cargo-sort cargo-afl \
-    && (if [ "$ARCH" = "x86_64" ]; then cargo install --locked kani-verifier && cargo kani setup; else true; fi) \
+    && cargo install --locked kani-verifier && cargo kani setup \
     \
     && apt-get update \
     && apt-get -y install --no-install-recommends \


### PR DESCRIPTION
Kani supports verification on ARM since version 0.37.0 [1], so enable it in our CI.

[1]: https://github.com/model-checking/kani/blob/main/CHANGELOG.md#0370

Merging this required rebuilding the docker container, so this commit should get picked up the next time we do that.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
