### PR TITLE
test: move "doing A/B-Test" print statement below ignore-check

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -211,9 +211,6 @@ def analyze_data(
         ), "A and B run produced incomparable data. This is a bug in the test!"
 
         for metric, (values_a, unit) in metrics_a.items():
-            print(
-                f"Doing A/B-test for dimensions {dimension_set} and property {metric}"
-            )
             result = check_regression(
                 values_a, metrics_b[metric][0], n_resamples=n_resamples
             )
@@ -268,6 +265,8 @@ def analyze_data(
     for (dimension_set, metric), (result, unit) in results.items():
         if is_ignored(dict(dimension_set)):
             continue
+
+        print(f"Doing A/B-test for dimensions {dimension_set} and property {metric}")
 
         values_a = processed_emf_a[dimension_set][metric][0]
         baseline_mean = statistics.mean(values_a)


### PR DESCRIPTION
Move the print statement that states which A/B-Tests we're performing below the check that filters out ignored test cases. This way, we avoid claiming to do an A/B-Test for things that are later actually filtered out (meaning no A/B-Test actually happens).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
