### PR TITLE
Dump SSH debug level logs if initial connection to guest fails

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -381,7 +381,7 @@ def run_cmd(cmd, check=False, shell=True, cwd=None, timeout=None) -> CommandRetu
 
     :param cmd: command to execute
     :param check: whether a non-zero return code should result in a `ChildProcessError` or not.
-    :param no_shell: don't run the command in a sub-shell
+    :param shell: run the command in a sub-shell
     :param cwd: sets the current directory before the child is executed
     :param timeout: Time before command execution should be aborted with a `TimeoutExpired` exception
     :return: return code, stdout, stderr

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -90,24 +90,33 @@ class SSHConnection:
         We'll keep trying to execute a remote command that can't fail
         (`/bin/true`), until we get a successful (0) exit code.
         """
-        self.check_output("true", timeout=10)
+        self.check_output("true", timeout=10, debug=True)
 
-    def run(self, cmd_string, timeout=None, *, check=False):
-        """Execute the command passed as a string in the ssh context."""
+    def run(self, cmd_string, timeout=None, *, check=False, debug=False):
+        """
+        Execute the command passed as a string in the ssh context.
+
+        If `debug` is set, pass `-vvv` to `ssh`. Note that this will clobber stderr.
+        """
+        command = [
+            "ssh",
+            *self.options,
+            f"{self.user}@{self.host}",
+            cmd_string,
+        ]
+
+        if debug:
+            command.insert(1, "-vvv")
+
         return self._exec(
-            [
-                "ssh",
-                *self.options,
-                f"{self.user}@{self.host}",
-                cmd_string,
-            ],
+            command,
             timeout,
             check=check,
         )
 
-    def check_output(self, cmd_string, timeout=None):
+    def check_output(self, cmd_string, timeout=None, *, debug=False):
         """Same as `run`, but raises an exception on non-zero return code of remote command"""
-        return self.run(cmd_string, timeout, check=True)
+        return self.run(cmd_string, timeout, check=True, debug=debug)
 
     def _exec(self, cmd, timeout=None, check=False):
         """Private function that handles the ssh client invocation."""


### PR DESCRIPTION
When doing `_init_connection`, set SSHs debug level to most verbose, so
that in case a connection failure occurs, we can look at the SSH logs
(both local and remote, see man ssh(1)).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
