### PR TITLE
Add a devtool command for build CI artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ test_results/*
 *.profraw
 .DS_Store
 *.bin
+/resources/linux
+/resources/x86_64
+/resources/aarch64

--- a/docs/rootfs-and-kernel-setup.md
+++ b/docs/rootfs-and-kernel-setup.md
@@ -56,21 +56,28 @@ For a list of currently supported kernel versions, check out the
 ### Use the provided recipe
 
 The kernel images used in our CI to test Firecracker's features are obtained by
-using the recipe inside devtool:
+running the script `resources/rebuild.sh`.
+
+Users can build those locally by running:
 
 ```bash
-config="resources/guest_configs/microvm-kernel-x86_64-4.14.config"
-./tools/devtool build_kernel -c $config -n 8
+./tools/devtool build_ci_artifacts kernels
 ```
 
-or
+This will build all versions that we currently use in our CI. `kernels`
+subcommand allows passing a specific kernel version to build. For example:
 
 ```bash
-config="resources/guest_configs/microvm-kernel-arm64-4.14.config"
-./tools/devtool build_kernel -c $config -n 8
+./tools/devtool build_ci_artifacts kernels 6.1
 ```
 
-on an aarch64 machine.
+will build only the 6.1 kernel.
+
+Currently supported kernel versions are: `5.10`, `5.10-no-acpi` (same as 5.10
+but without ACPI support) and `6.1`.
+
+After the command finishes, the kernels along with the corresponding KConfig
+used will be stored under `resources/$(uname -m)`.
 
 ## Creating a rootfs Image
 
@@ -170,11 +177,11 @@ The disk images used in our CI to test Firecracker's features are obtained by
 using the recipe (in a Ubuntu 22.04 host):
 
 ```bash
-./resources/rebuild.sh
+./tools/devtool build_ci_artifacts rootfs
 ```
 
 The images resulting using this method are minimized Ubuntu 22.04. Feel free to
 adjust the script(s) to suit your use case.
 
-You should now have a kernel image (`vmlinux`) and a rootfs image
-(`rootfs.ext4`), that you can boot with Firecracker.
+You should now have a rootfs image (`ubuntu-22.04.ext4`), that you can boot with
+Firecracker.

--- a/tools/devtool
+++ b/tools/devtool
@@ -134,6 +134,8 @@ OPT_UNATTENDED=false
 # Get the target prefix to avoid repeated calls to uname -m
 TARGET_PREFIX="$(uname -m)-unknown-linux-"
 
+# Container path to directory where we store built CI artifacts.
+CTR_CI_ARTIFACTS_PATH="${CTR_FC_ROOT_DIR}/resources/$(uname -m)"
 
 # Check if Docker is available and exit if it's not.
 # Upon returning from this call, the caller can be certain Docker is available.
@@ -231,7 +233,7 @@ cmd_fix_perms() {
     run_devctr \
         --workdir "$CTR_FC_ROOT_DIR" \
         -- \
-        chown -R "$(id -u):$(id -g)" "$CTR_FC_BUILD_DIR"  "$CTR_TEST_RESULTS_DIR"
+        chown -R "$(id -u):$(id -g)" "$CTR_FC_BUILD_DIR" "$CTR_TEST_RESULTS_DIR" "$CTR_CI_ARTIFACTS_PATH"
 }
 
 # Builds the development container from its Dockerfile.
@@ -412,6 +414,10 @@ cmd_help() {
     echo "            --performance            Tweak various setting of the host running the tests (such as C- and P-states)"
     echo "                                     to achieve consistent performance. Used for running performance tests in CI."
     echo ""
+    echo "    build_ci_artifacts [all|rootfs|kernels]"
+    echo "        Builds the rootfs and guest kernel artifacts we use for our CI."
+    echo "        Run './tools/devtool build_ci_artifacts help' for more details about the available commands."
+    echo ""    
 
     cat <<EOF
     test_debug [-- [<pytest args>]]
@@ -1159,6 +1165,20 @@ cmd_install() {
         say "Installing $binary in $install_path"
         install -m 755 "$( build_bin_path "$target" "$profile" "$binary" )" "$install_path"
     done
+}
+
+cmd_build_ci_artifacts() {
+    # Check prerequisites
+    ensure_devctr
+
+    # We need to run nested Docker here, so run this container as privileged.
+    run_devctr \
+        --privileged \
+        --workdir "$CTR_FC_ROOT_DIR" \
+        -- \
+        ./resources/rebuild.sh "$@"
+
+    cmd_fix_perms
 }
 
 


### PR DESCRIPTION
## Changes

Add a devtool command to build CI artifacts. The command calls `resources/rebuild.sh` within the dev container, since the script itself assumes an Ubuntu host environment.

Also, update the documentation about building guest kernels to point to this script

## Reason

Add a command that allows us to build CI artifact kernels locally and also fix the broken documentation about building guest kernels.

Fixes #4757 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
