### PR TITLE
chore: don't update dependencies when with new vX.Y.0-dev version

### DIFF
--- a/tools/bump-version.sh
+++ b/tools/bump-version.sh
@@ -19,7 +19,6 @@ $0 <version>
 
     Bump Firecracker release version:
     1. Updates Cargo.toml / Cargo.lock
-    2. Runs 'cargo update'
 EOF
     exit 1
 fi
@@ -60,5 +59,5 @@ done
 # NOTE: This will break if it finds paths with spaces in them
 find . -path ./build -prune -o -name Cargo.lock -print |while read -r cargo_lock; do
     say "Updating $cargo_lock ..."
-    (cd "$(dirname "$cargo_lock")"; cargo check; cargo update)
+    (cd "$(dirname "$cargo_lock")"; cargo check)
 done


### PR DESCRIPTION
## Reason

We want to do that before creating the release branch so that we can fix issues with new dependencies ahead of the release.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
