### PR TITLE
Test gdb feature is not enabled in release

### DIFF
--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -130,7 +130,8 @@ def mac_from_ip(ip_address):
     """Create a MAC address based on the provided IP.
 
     Algorithm:
-    - the first 2 bytes are fixed to 06:00
+    - the first 2 bytes are fixed to 06:00, which is in an LAA range
+      - https://en.wikipedia.org/wiki/MAC_address#Ranges_of_group_and_locally_administered_addresses
     - the next 4 bytes are the IP address
 
     Example of function call:

--- a/tests/integration_tests/functional/test_binary.py
+++ b/tests/integration_tests/functional/test_binary.py
@@ -46,3 +46,22 @@ def test_release_debuginfo(microvm_factory):
     }
     missing_sections = needed_sections - matches
     assert missing_sections == set()
+
+
+def test_release_no_gdb(microvm_factory):
+    """Ensure the gdb feature is not enabled in releases"""
+    fc_binary = microvm_factory.fc_binary_path
+    # We use C++ demangle since there's no Rust support, but it's good enough
+    # for our purposes.
+    stdout = subprocess.check_output(
+        ["readelf", "-W", "--demangle", "-s", str(fc_binary)],
+        encoding="ascii",
+    )
+    gdb_symbols = []
+    for line in stdout.splitlines():
+        parts = line.split(maxsplit=7)
+        if len(parts) == 8:
+            symbol_name = parts[-1]
+            if "gdb" in symbol_name:
+                gdb_symbols.append(symbol_name)
+    assert not gdb_symbols


### PR DESCRIPTION
## Changes

Ensure the gdb feature is not enabled in releases.

## Reason

We want to prevent accidentally running a gdb/debug build in production.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
