### PR TITLE
Support FDT setup for CPU caches with high number of sets

### DIFF
--- a/src/vmm/src/arch/aarch64/cache_info.rs
+++ b/src/vmm/src/arch/aarch64/cache_info.rs
@@ -38,7 +38,7 @@ pub(crate) struct CacheEntry {
     // Type of cache: Unified, Data, Instruction.
     pub type_: CacheType,
     pub size_: Option<u32>,
-    pub number_of_sets: Option<u16>,
+    pub number_of_sets: Option<u32>,
     pub line_size: Option<u16>,
     // How many CPUS share this cache.
     pub cpus_per_unit: u16,
@@ -114,7 +114,7 @@ impl CacheEntry {
         }
 
         if let Ok(number_of_sets) = store.get_by_key(index, "number_of_sets") {
-            cache.number_of_sets = Some(number_of_sets.parse::<u16>().map_err(|err| {
+            cache.number_of_sets = Some(number_of_sets.parse::<u32>().map_err(|err| {
                 CacheInfoError::InvalidCacheAttr("number_of_sets".to_string(), err.to_string())
             })?);
         } else {

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -147,7 +147,7 @@ fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &[u64]) -> Result<(), FdtEr
                 fdt.property_u32(cache.type_.of_cache_line_size(), u32::from(line_size))?;
             }
             if let Some(number_of_sets) = cache.number_of_sets {
-                fdt.property_u32(cache.type_.of_cache_sets(), u32::from(number_of_sets))?;
+                fdt.property_u32(cache.type_.of_cache_sets(), number_of_sets)?;
             }
         }
 
@@ -197,7 +197,7 @@ fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &[u64]) -> Result<(), FdtEr
                     fdt.property_u32(cache.type_.of_cache_line_size(), u32::from(line_size))?;
                 }
                 if let Some(number_of_sets) = cache.number_of_sets {
-                    fdt.property_u32(cache.type_.of_cache_sets(), u32::from(number_of_sets))?;
+                    fdt.property_u32(cache.type_.of_cache_sets(), number_of_sets)?;
                 }
                 if let Some(cache_type) = cache.type_.of_cache_type() {
                     fdt.property_null(cache_type)?;

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -28,7 +28,7 @@ use crate::vstate::memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemo
 /// Errors thrown while configuring aarch64 system.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum ConfigurationError {
-    /// Failed to create a Flattened Device Tree for this aarch64 microVM.
+    /// Failed to create a Flattened Device Tree for this aarch64 microVM: {0}
     SetupFDT(#[from] fdt::FdtError),
     /// Failed to compute the initrd address.
     InitrdAddress,


### PR DESCRIPTION
## Changes

The first commit improves the logging/reporting of errors during FDT creation (e.g., failures while parsing CPU cache information from `sysfs`).

The second commit changes the type of field `number_of_sets` in struct `vmm::arch::aarch64::cache_info::CacheEntry` from `u16` to `u32`, thus allowing support for hosts with CPU caches with a number of sets higher than `u16::MAX` (e.g., [NVIDIA GH200 Grace Hopper][gh200]).

## Reason

When we attempted to boot a microVM on a [GH200][gh200] host following the [Getting Started guide](https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md) (with a minor modification, to download the `aarch64` kernel binary), building the microVM failed, and the following was logged:
```text
 . . .
2024-10-22T16:11:02.966071476 [anonymous-instance:fc_api:INFO:src/firecracker/src/api_server/parsed_request.rs:69] The API server received a Put request on "/actions" with body "{\n        \"action_type\": \"InstanceStart\"\n    }".
2024-10-22T16:11:02.966135189 [anonymous-instance:main:DEBUG:src/vmm/src/builder.rs:399] event_start: build microvm for boot
2024-10-22T16:11:02.972842006 [anonymous-instance:main:DEBUG:src/vmm/src/devices/acpi/vmgenid.rs:61] vmgenid: building VMGenID device. Address: 0x801ffff0. IRQ: 36
2024-10-22T16:11:02.972877750 [anonymous-instance:main:DEBUG:src/vmm/src/devices/acpi/vmgenid.rs:69] vmgenid: writing new generation ID to guest: 0xc9a01e17708cc1e2bc0518f9d2cc685e
2024-10-22T16:11:02.973158455 [anonymous-instance:main:INFO:src/vmm/src/lib.rs:833] Vmm is stopping.
2024-10-22T16:11:02.986500410 [anonymous-instance:fc_api:ERROR:src/firecracker/src/api_server/parsed_request.rs:190] Received Error. Status code: 400 Bad Request. Message: Start microvm error: System configuration error: Failed to create a Flattened Device Tree for this aarch64 microVM.
2024-10-22T16:11:02.986543450 [anonymous-instance:fc_api:DEBUG:src/firecracker/src/api_server/mod.rs:114] Total previous API call duration: 20487 us.
```
while this was the response of the API server:
```json
{"fault_message":"Start microvm error: System configuration error: Failed to create a Flattened Device Tree for this aarch64 microVM."}
```

The first commit improves the reporting of failures while setting up FDT, by expanding the doc comments of the `vmm::arch::aarch64::ConfigurationError::SetupFDT` variant (thus also its implementation of `std::fmt::Display`, thanks to crates `thiserror` and `displaydoc`) to include the underlying `vmm::arch::aarch64::fdt::FdtError`.
As a result, the improved logs end up being as follows:
```text
 . . .
2024-10-22T16:16:59.912859809 [anonymous-instance:fc_api:INFO:src/firecracker/src/api_server/parsed_request.rs:69] The API server received a Put request on "/actions" with body "{\n        \"action_type\": \"InstanceStart\"\n    }".
2024-10-22T16:16:59.912930657 [anonymous-instance:main:DEBUG:src/vmm/src/builder.rs:399] event_start: build microvm for boot
2024-10-22T16:16:59.919450370 [anonymous-instance:main:DEBUG:src/vmm/src/devices/acpi/vmgenid.rs:61] vmgenid: building VMGenID device. Address: 0x801ffff0. IRQ: 36
2024-10-22T16:16:59.919484802 [anonymous-instance:main:DEBUG:src/vmm/src/devices/acpi/vmgenid.rs:69] vmgenid: writing new generation ID to guest: 0x9934a6187f502a62579e99b35bed8b8f
2024-10-22T16:16:59.919760995 [anonymous-instance:main:INFO:src/vmm/src/lib.rs:833] Vmm is stopping.
2024-10-22T16:16:59.930398232 [anonymous-instance:fc_api:ERROR:src/firecracker/src/api_server/parsed_request.rs:190] Received Error. Status code: 400 Bad Request. Message: Start microvm error: System configuration error: Failed to create a Flattened Device Tree for this aarch64 microVM: Read cache info error: Invalid cache configuration found for number_of_sets: number too large to fit in target type
2024-10-22T16:16:59.930448408 [anonymous-instance:fc_api:DEBUG:src/firecracker/src/api_server/mod.rs:114] Total previous API call duration: 17606 us.
```
API server's HTTP response becomes more descriptive as well:
```json
{"fault_message":"Start microvm error: System configuration error: Failed to create a Flattened Device Tree for this aarch64 microVM: Read cache info error: Invalid cache configuration found for number_of_sets: number too large to fit in target type"}
```

The second commit fixes the actual bug for the [GH200][gh200] host (unveiled by and shown in the improved logs above). In this case, host CPU's number of sets for the unified L3 cache is higher than `u16::MAX`:
```console
$ bat --style header /sys/devices/system/cpu/cpu0/cache/index3/{level,size,number_of_sets}
File: /sys/devices/system/cpu/cpu0/cache/index3/level
3

File: /sys/devices/system/cpu/cpu0/cache/index3/size
116736K

File: /sys/devices/system/cpu/cpu0/cache/index3/number_of_sets
155648
```
Changing the type of the `number_of_sets` field in struct `vmm::arch::aarch64::cache_info::CacheEntry` from `u16` to `u32` suffices to fit a high number of CPU cache sets, thus allowing the microVM to be built and booted without any problem.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md

[gh200]: https://www.nvidia.com/en-eu/data-center/grace-hopper-superchip/
