### PR TITLE
Add CHANGELOG entry on support of ARM systems with big caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to
   set, it won't trigger the lockup condition. Calling the ioctl for guests that
   don't use kvmclock will fail. These failures are not fatal. We log the failure
   and increase the `vcpu.kvmclock_ctrl_fails` metric.
+- [#4869](https://github.com/firecracker-microvm/firecracker/pull/4869): Added
+  support for Aarch64 systems which feature CPU caches with a number of sets
+  higher than `u16::MAX`.
 
 ### Changed
 


### PR DESCRIPTION
## Changes

Add a CHANGELOG entry for changes in #4869 

## Reason

https://github.com/firecracker-microvm/firecracker/pull/4869 changed the type that holds the number of sets of a CPU cache from `u16` to `u32`. This allows us to support ARM systems with CPU caches with sets more than `u16::MAX`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
