### PR TITLE
Revert "chore: unpin 5.10/m6i ami"

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -119,7 +119,10 @@ for test in tests:
 # }
 # will pin steps running on instances "m6i.metal" with kernel version tagged "linux_6.1"
 # to a new kernel version tagged "linux_6.1-pinned"
-pins = {}
+pins = {
+    # TODO: Unpin when performance instability on m6i/5.10 has gone.
+    "linux_5.10-pinned": {"instance": "m6i.metal", "kv": "linux_5.10"},
+}
 
 
 def apply_pins(steps):


### PR DESCRIPTION
The instability is still there, so we revert firecracker-microvm/firecracker#4865
