### PR TITLE
Update test_deflate_on_oom test

### DIFF
--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -200,10 +200,10 @@ def test_deflate_on_oom(uvm_plain_any, deflate_on_oom):
 
     # We get an initial reading of the RSS, then calculate the amount
     # we need to inflate the balloon with by subtracting it from the
-    # VM size and adding an offset of 10 MiB in order to make sure we
+    # VM size and adding an offset of 50 MiB in order to make sure we
     # get a lower reading than the initial one.
     initial_rss = get_stable_rss_mem_by_pid(firecracker_pid)
-    inflate_size = 256 - int(initial_rss / 1024) + 10
+    inflate_size = 256 - (int(initial_rss / 1024) + 50)
 
     # Inflate the balloon
     test_microvm.api.balloon.patch(amount_mib=inflate_size)
@@ -213,7 +213,7 @@ def test_deflate_on_oom(uvm_plain_any, deflate_on_oom):
     # Check that using memory leads to the balloon device automatically
     # deflate (or not).
     balloon_size_before = test_microvm.api.balloon_stats.get().json()["actual_mib"]
-    make_guest_dirty_memory(test_microvm.ssh, 64)
+    make_guest_dirty_memory(test_microvm.ssh, 128)
 
     balloon_size_after = test_microvm.api.balloon_stats.get().json()["actual_mib"]
     print(f"size before: {balloon_size_before} size after: {balloon_size_after}")


### PR DESCRIPTION
Updated the deflate on oom test to attempt to increase stability of the test. 

Making the a balloon less aggressive size, but allocating a larger chunk of memory, we are still able to test the functionality of the balloon device (it will deflate if the flag is enabled and not if disabled.) With this setup it means the guest is less likely to crash and cause the test to fail

I ran the flaky test look as seen here: https://github.com/firecracker-microvm/firecracker/tree/main/tests#how-to-reproduce-intermittent-aka-flaky-tests for over an hour on my machine with no failures


## Changes

Altered configuration of the balloon deflate on oom tests

## Reason

Attempt to fix deflate on oom flaky test

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
