### PR TITLE
Add Ubuntu 24.10 to popular containers

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator
 
-import packaging.version
 import pytest
 
 from framework.defs import ARTIFACT_DIR
@@ -98,9 +97,6 @@ class FirecrackerArtifact:
         # independent of Firecracker versions. For these Firecracker versions, use
         # the --snapshot-version Firecracker flag, to figure out which snapshot version
         # it supports.
-        # TODO: remove this check once all version up to (and including) 1.6.0 go out of support.
-        if packaging.version.parse(self.version) < packaging.version.parse("1.7.0"):
-            return self.version_tuple[:2] + (0,)
 
         return (
             check_output([self.path, "--snapshot-version"])

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -5,7 +5,6 @@
 import subprocess
 from pathlib import Path
 
-import packaging.version
 import pytest
 
 from framework.utils import check_output
@@ -21,14 +20,6 @@ def test_describe_snapshot_all_versions(
     For each release create a snapshot and verify the data version of the
     snapshot state file.
     """
-
-    # TODO: remove this check once all versions prior to 1.6.0 go out of support.
-    if packaging.version.parse(firecracker_release.version) < packaging.version.parse(
-        "1.7.0"
-    ):
-        pytest.skip(
-            "We can't parse snapshot files created from Firecracker with version < 1.7.0."
-        )
 
     target_version = firecracker_release.snapshot_version
     vm = microvm_factory.build(

--- a/tools/test-popular-containers/build_rootfs.sh
+++ b/tools/test-popular-containers/build_rootfs.sh
@@ -67,6 +67,6 @@ EOF
 
 make_rootfs alpine:latest
 make_rootfs ubuntu:22.04
-make_rootfs ubuntu:23.10
 make_rootfs ubuntu:24.04
+make_rootfs ubuntu:24.10
 # make_rootfs ubuntu:latest


### PR DESCRIPTION
## Changes

- Add Ubuntu 24.10 to the popular containers test, and remove 23.10
- Drop some dead code supporting old releases.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
