### PR TITLE
chore: update CHANGELOG with virtio-net changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to
 
 ### Changed
 
+- [#4875](https://github.com/firecracker-microvm/firecracker/pull/4875):
+  Increase default queue size for the `virtio-net` device from 256 to 512. This
+  decreases wait time between guest and vmm threads for network packets
+  processing and allows for more throughput.
+- [#4844](https://github.com/firecracker-microvm/firecracker/pull/4844): Upgrade
+  `virtio-net` device to use `readv` syscall to avoid unnecessary memory copies
+  on RX path, increasing the RX performance.
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
## Changes
Add `readv` and queue size increase changes in virtio-net device to the CHANGELOG.

## Reason
We forgot to add them initially.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
