### PR TITLE
test(net): use iperf3-vsock to avoid iperf crashes on aarch64

### DIFF
--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -10,7 +10,11 @@ import pytest
 from framework import utils
 
 # The iperf version to run this tests with
-IPERF_BINARY = "iperf3"
+IPERF_BINARY_GUEST = "iperf3"
+# We are using iperf3-vsock instead of a regular iperf3,
+# because iperf3 3.16+ crashes on aarch64 sometimes
+# when running this test.
+IPERF_BINARY_HOST = "iperf3-vsock"
 
 
 def test_high_ingress_traffic(uvm_plain_any):
@@ -33,7 +37,7 @@ def test_high_ingress_traffic(uvm_plain_any):
     test_microvm.start()
 
     # Start iperf3 server on the guest.
-    test_microvm.ssh.check_output("{} -sD\n".format(IPERF_BINARY))
+    test_microvm.ssh.check_output("{} -sD\n".format(IPERF_BINARY_GUEST))
     time.sleep(1)
 
     # Start iperf3 client on the host. Send 1Gbps UDP traffic.
@@ -41,7 +45,7 @@ def test_high_ingress_traffic(uvm_plain_any):
     utils.check_output(
         "timeout 31 {} {} -c {} -u -V -b 1000000000 -t 30".format(
             test_microvm.netns.cmd_prefix(),
-            IPERF_BINARY,
+            IPERF_BINARY_HOST,
             guest_ip,
         ),
     )

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -33,13 +33,13 @@ def test_high_ingress_traffic(uvm_plain_any):
     test_microvm.start()
 
     # Start iperf3 server on the guest.
-    test_microvm.ssh.run("{} -sD\n".format(IPERF_BINARY))
+    test_microvm.ssh.check_output("{} -sD\n".format(IPERF_BINARY))
     time.sleep(1)
 
     # Start iperf3 client on the host. Send 1Gbps UDP traffic.
     # If the net device breaks, iperf will freeze. We have to use a timeout.
-    utils.run_cmd(
-        "timeout 30 {} {} -c {} -u -V -b 1000000000 -t 30".format(
+    utils.check_output(
+        "timeout 31 {} {} -c {} -u -V -b 1000000000 -t 30".format(
             test_microvm.netns.cmd_prefix(),
             IPERF_BINARY,
             guest_ip,


### PR DESCRIPTION
## Changes

Use iperf3-vsock on host for the `test_high_ingress_traffic` test instead of iperf3.

## Reason

We see crashes inside `test_high_ingress_traffic` on aarch64 with both iperf3 3.16 (currently in devctr) and 3.17 (latest release).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
