### PR TITLE
net: revert virtio-net queue size to 256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,6 @@ and this project adheres to
 
 ### Changed
 
-- [#4875](https://github.com/firecracker-microvm/firecracker/pull/4875):
-  Increase default queue size for the `virtio-net` device from 256 to 512. This
-  decreases wait time between guest and vmm threads for network packets
-  processing and allows for more throughput.
 - [#4844](https://github.com/firecracker-microvm/firecracker/pull/4844): Upgrade
   `virtio-net` device to use `readv` syscall to avoid unnecessary memory copies
   on RX path, increasing the RX performance.

--- a/src/vmm/src/devices/virtio/net/mod.rs
+++ b/src/vmm/src/devices/virtio/net/mod.rs
@@ -6,7 +6,7 @@
 use std::io;
 
 /// Maximum size of the queue for network device.
-pub const NET_QUEUE_MAX_SIZE: u16 = 512;
+pub const NET_QUEUE_MAX_SIZE: u16 = 256;
 /// Maximum size of the frame buffers handled by this device.
 pub const MAX_BUFFER_SIZE: usize = 65562;
 /// The number of queues of the network device.


### PR DESCRIPTION
## Changes

Revert the network queue size change from 512 back to 256.

## Reason

Changing the queue size from 256 to 512 increases RX throughput but seems to regress TX throughput by 3% on average. We are not sure what is causing this. We want to take more time to investigate before releasing this change.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
