### PR TITLE
fix(test): Handle CPU feature diff between host and guest correctly

### DIFF
--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -10,6 +10,7 @@ import pytest
 
 import framework.utils_cpuid as cpuid_utils
 from framework import utils
+from framework.properties import global_props
 from framework.utils_cpuid import CPU_FEATURES_CMD, CpuModel
 
 PLATFORM = platform.machine()
@@ -81,25 +82,63 @@ def test_host_vs_guest_cpu_features_aarch64(uvm_nano):
     cpu_model = cpuid_utils.get_cpu_model_name()
     match cpu_model:
         case CpuModel.ARM_NEOVERSE_N1:
-            assert host_feats - guest_feats == set()
-            # Kernel should hide this feature, but our guest kernel
-            # currently lacks the commit with this change.
-            # The commit that introduces the change:
-            # https://github.com/torvalds/linux/commit/7187bb7d0b5c7dfa18ca82e9e5c75e13861b1d88
-            assert guest_feats - host_feats == {"ssbs"}
+            expected_guest_minus_host = set()
+            expected_host_minus_guest = set()
+
+            # Upstream kernel v6.11+ hides "ssbs" from "lscpu" on Neoverse-N1 and Neoverse-V1 since
+            # they have an errata whereby an MSR to the SSBS special-purpose register does not
+            # affect subsequent speculative instructions, permitting speculative store bypassing for
+            # a window of time.
+            # https://github.com/torvalds/linux/commit/adeec61a4723fd3e39da68db4cc4d924e6d7f641
+            #
+            # While Amazon Linux kernels (v5.10 and v6.1) backported the above commit, our test
+            # ubuntu kernel (v6.8) and our guest kernels (v5.10 and v6.1) don't pick it.
+            host_has_ssbs = global_props.host_os not in {
+                "amzn2",
+                "amzn2023",
+            } and global_props.host_linux_version_tpl < (6, 11)
+            guest_has_ssbs = vm.guest_kernel_version < (6, 11)
+
+            if host_has_ssbs and not guest_has_ssbs:
+                expected_host_minus_guest |= {"ssbs"}
+            if not host_has_ssbs and guest_has_ssbs:
+                expected_guest_minus_host |= {"ssbs"}
+
+            assert host_feats - guest_feats == expected_host_minus_guest
+            assert guest_feats - host_feats == expected_guest_minus_host
         case CpuModel.ARM_NEOVERSE_V1:
+            expected_guest_minus_host = set()
             # KVM does not enable PAC or SVE features by default
             # and Firecracker does not enable them either.
-            assert host_feats - guest_feats == {
+            expected_host_minus_guest = {
                 "paca",
                 "pacg",
                 "sve",
                 "svebf16",
                 "svei8mm",
             }
-            # kernel should hide this feature, but our guest kernel
-            # is not recent enough for this.
-            assert guest_feats - host_feats == {"ssbs"}
+
+            # Upstream kernel v6.11+ hides "ssbs" from "lscpu" on Neoverse-N1 and Neoverse-V1 since
+            # they have an errata whereby an MSR to the SSBS special-purpose register does not
+            # affect subsequent speculative instructions, permitting speculative store bypassing for
+            # a window of time.
+            # https://github.com/torvalds/linux/commit/adeec61a4723fd3e39da68db4cc4d924e6d7f641
+            #
+            # While Amazon Linux kernels (v5.10 and v6.1) backported the above commit, our test
+            # ubuntu kernel (v6.8) and our guest kernels (v5.10 and v6.1) don't pick it.
+            host_has_ssbs = global_props.host_os not in {
+                "amzn2",
+                "amzn2023",
+            } and global_props.host_linux_version_tpl < (6, 11)
+            guest_has_ssbs = vm.guest_kernel_version < (6, 11)
+
+            if host_has_ssbs and not guest_has_ssbs:
+                expected_host_minus_guest |= {"ssbs"}
+            if not host_has_ssbs and guest_has_ssbs:
+                expected_guest_minus_host |= {"ssbs"}
+
+            assert host_feats - guest_feats == expected_host_minus_guest
+            assert guest_feats - host_feats == expected_guest_minus_host
         case _:
             if os.environ.get("BUILDKITE") is not None:
                 assert False, f"Cpu model {cpu_model} is not supported"

--- a/tests/integration_tests/functional/test_cpu_features_x86_64.py
+++ b/tests/integration_tests/functional/test_cpu_features_x86_64.py
@@ -343,7 +343,7 @@ def test_host_vs_guest_cpu_features_x86_64(uvm_nano):
                 "umip",
             }
         case CpuModel.INTEL_CASCADELAKE:
-            expected = {
+            expected_host_minus_guest = {
                 "acpi",
                 "aperfmperf",
                 "arch_perfmon",
@@ -392,19 +392,32 @@ def test_host_vs_guest_cpu_features_x86_64(uvm_nano):
                 "vpid",
                 "xtpr",
             }
+            expected_guest_minus_host = {
+                "hypervisor",
+                "tsc_known_freq",
+                "umip",
+            }
+
             # Linux kernel v6.4+ passes through the CPUID bit for "flush_l1d" to guests.
             # https://github.com/torvalds/linux/commit/45cf86f26148e549c5ba4a8ab32a390e4bde216e
             #
             # Our test ubuntu host kernel is v6.8 and has the commit.
             if global_props.host_linux_version_tpl >= (6, 4):
-                expected -= {"flush_l1d"}
-            assert host_feats - guest_feats == expected
+                expected_host_minus_guest -= {"flush_l1d"}
 
-            assert guest_feats - host_feats == {
-                "hypervisor",
-                "tsc_known_freq",
-                "umip",
-            }
+            # Linux kernel v6.6+ drops the "invpcid_single" synthetic feature bit.
+            # https://github.com/torvalds/linux/commit/54e3d9434ef61b97fd3263c141b928dc5635e50d
+            #
+            # Our test ubuntu host kernel is v6.8 and has the commit.
+            host_has_invpcid_single = global_props.host_linux_version_tpl < (6, 6)
+            guest_has_invpcid_single = vm.guest_kernel_version < (6, 6)
+            if host_has_invpcid_single and not guest_has_invpcid_single:
+                expected_host_minus_guest |= {"invpcid_single"}
+            if not host_has_invpcid_single and guest_has_invpcid_single:
+                expected_guest_minus_host |= {"invpcid_single"}
+
+            assert host_feats - guest_feats == expected_host_minus_guest
+            assert guest_feats - host_feats == expected_guest_minus_host
         case CpuModel.INTEL_ICELAKE:
             host_guest_diff_5_10 = {
                 "dtes64",

--- a/tests/integration_tests/functional/test_cpu_features_x86_64.py
+++ b/tests/integration_tests/functional/test_cpu_features_x86_64.py
@@ -343,7 +343,7 @@ def test_host_vs_guest_cpu_features_x86_64(uvm_nano):
                 "umip",
             }
         case CpuModel.INTEL_CASCADELAKE:
-            assert host_feats - guest_feats == {
+            expected = {
                 "acpi",
                 "aperfmperf",
                 "arch_perfmon",
@@ -392,6 +392,14 @@ def test_host_vs_guest_cpu_features_x86_64(uvm_nano):
                 "vpid",
                 "xtpr",
             }
+            # Linux kernel v6.4+ passes through the CPUID bit for "flush_l1d" to guests.
+            # https://github.com/torvalds/linux/commit/45cf86f26148e549c5ba4a8ab32a390e4bde216e
+            #
+            # Our test ubuntu host kernel is v6.8 and has the commit.
+            if global_props.host_linux_version_tpl >= (6, 4):
+                expected -= {"flush_l1d"}
+            assert host_feats - guest_feats == expected
+
             assert guest_feats - host_feats == {
                 "hypervisor",
                 "tsc_known_freq",


### PR DESCRIPTION
## Reason

PR #4884 introduced a test that ensures CPU feature diff between host and guest hasn't been changed.

However, the expected diff can vary depending on a combination of host kernel version and guest kernel version.

The current our setting is as follows:
- Host
  - Amazon Linux 2 (v5.10)
  - Amazon Linux 2023 (v6.1)
  - Ubuntu 24.04 (v6.8)
- Guest
  - Amazon Linux microvm kernel (v5.10)
  - Amazon Linux microvm kernel (v6.1)

## Changes

- aarch64
  - Add "ssbs" to the expected diff if needed.
- x86_64
  - Remove "flush_l1d" from the expected diff if the host passes through it.
  - Add "invpcd_single" to the expected diff if needed.

**Note that I implemented it in a general way as possible because we might want to support more host and guest kernels in the future.**

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
