### PR TITLE
chore(test): Double refill time for RX rate limiter

### DIFF
--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -2153,7 +2153,7 @@ pub mod tests {
         // Test RX bandwidth rate limiting
         {
             // create bandwidth rate limiter that allows 2000 bytes/s with bucket size 1000 bytes
-            let mut rl = RateLimiter::new(1000, 0, 500, 0, 0, 0).unwrap();
+            let mut rl = RateLimiter::new(1000, 0, 1000, 0, 0, 0).unwrap();
 
             // set up RX
             assert!(th.net().rx_buffer.used_descriptors == 0);
@@ -2195,9 +2195,9 @@ pub mod tests {
                 assert_eq!(th.net().metrics.rx_rate_limiter_throttled.count(), 2);
             }
 
-            // wait for 500ms to give the rate-limiter timer a chance to replenish
-            // wait for an extra 500ms to make sure the timerfd event makes its way from the kernel
-            thread::sleep(Duration::from_millis(1000));
+            // wait for 1000ms to give the rate-limiter timer a chance to replenish
+            // wait for an extra 1000ms to make sure the timerfd event makes its way from the kernel
+            thread::sleep(Duration::from_millis(2000));
 
             // following RX procedure should succeed because bandwidth should now be available
             {
@@ -2276,7 +2276,7 @@ pub mod tests {
         // Test RX ops rate limiting
         {
             // create ops rate limiter that allows 2 ops/s with bucket size 1 ops
-            let mut rl = RateLimiter::new(0, 0, 0, 1, 0, 500).unwrap();
+            let mut rl = RateLimiter::new(0, 0, 0, 1, 0, 1000).unwrap();
 
             // set up RX
             assert!(th.net().rx_buffer.used_descriptors == 0);
@@ -2319,9 +2319,9 @@ pub mod tests {
                 assert_eq!(th.rxq.used.idx.get(), 0);
             }
 
-            // wait for 500ms to give the rate-limiter timer a chance to replenish
-            // wait for an extra 500ms to make sure the timerfd event makes its way from the kernel
-            thread::sleep(Duration::from_millis(1000));
+            // wait for 1000ms to give the rate-limiter timer a chance to replenish
+            // wait for an extra 1000ms to make sure the timerfd event makes its way from the kernel
+            thread::sleep(Duration::from_millis(2000));
 
             // following RX procedure should succeed because ops should now be available
             {


### PR DESCRIPTION
## Changes

Double the refill time for RX rate limiter.

## Reason

Although we increased the refill time in the past in commit 347f877ec2a9 ("unittest: net: eliminate ReadTapMock::MockFrame") to avoid intermittent issues, it still fails rarely (maybe due to resource contention). We are not sure the enough refill time, but it's worth doubling it and may reduce the chance of kicking the retry of the whole unit tests manually.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this
  PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet
  [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
