### PR TITLE
test: test ARM CPU templates in Linux host 5.10

### DIFF
--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -42,18 +42,12 @@ def get_supported_cpu_templates():
 
 SUPPORTED_CPU_TEMPLATES = get_supported_cpu_templates()
 
-# Custom CPU templates for Aarch64 for testing
-AARCH64_CUSTOM_CPU_TEMPLATES_G2 = ["v1n1"]
-AARCH64_CUSTOM_CPU_TEMPLATES_G3 = [
-    "aarch64_with_sve_and_pac",
-    "v1n1",
-]
-
 
 def get_supported_custom_cpu_templates():
     """
     Return the list of custom CPU templates supported by the platform.
     """
+    # pylint:disable=too-many-return-statements
     host_linux = global_props.host_linux_version_tpl
 
     match get_cpu_vendor(), global_props.cpu_codename:
@@ -65,9 +59,11 @@ def get_supported_custom_cpu_templates():
         case CpuVendor.AMD, _:
             return AMD_TEMPLATES
         case CpuVendor.ARM, CpuModel.ARM_NEOVERSE_N1 if host_linux >= (6, 1):
-            return AARCH64_CUSTOM_CPU_TEMPLATES_G2
+            return ["v1n1"]
         case CpuVendor.ARM, CpuModel.ARM_NEOVERSE_V1 if host_linux >= (6, 1):
-            return AARCH64_CUSTOM_CPU_TEMPLATES_G3
+            return ["v1n1", "aarch64_with_sve_and_pac"]
+        case CpuVendor.ARM, CpuModel.ARM_NEOVERSE_V1:
+            return ["aarch64_with_sve_and_pac"]
         case _:
             return []
 


### PR DESCRIPTION
Add the SVE CPU template as a valid template in 5.10 since it works.

## Changes

Test ARM CPU templates in host Linux 5.10

## Reason

While not all ARM CPU templates work in 5.10, some simple ones like enabling SVE work.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
