### PR TITLE
snapshot: Remove max_connections and max_pending_resets fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 ### Changed
 
+- [#4913](https://github.com/firecracker-microvm/firecracker/pull/4913): Removed
+  unnecessary fields (`max_connections` and `max_pending_resets`) from the
+  snapshot format, bumping the snapshot version to 5.0.0.
+
 ### Deprecated
 
 ### Removed

--- a/src/vmm/src/mmds/ns.rs
+++ b/src/vmm/src/mmds/ns.rs
@@ -553,14 +553,8 @@ mod tests {
         let ip = Ipv4Addr::from(DEFAULT_IPV4_ADDR);
         let other_ip = Ipv4Addr::new(5, 6, 7, 8);
         let mac = MacAddr::from_bytes_unchecked(&[0; 6]);
-        let mut ns = MmdsNetworkStack::new(
-            mac,
-            ip,
-            DEFAULT_TCP_PORT,
-            NonZeroUsize::new(DEFAULT_MAX_CONNECTIONS).unwrap(),
-            NonZeroUsize::new(DEFAULT_MAX_PENDING_RESETS).unwrap(),
-            Arc::new(Mutex::new(Mmds::default())),
-        );
+        let mut ns =
+            MmdsNetworkStack::new_with_defaults(Some(ip), Arc::new(Mutex::new(Mmds::default())));
 
         let mut eth =
             EthernetFrame::write_incomplete(buf.as_mut(), mac, mac, ETHERTYPE_ARP).unwrap();
@@ -580,14 +574,8 @@ mod tests {
         let ip = Ipv4Addr::from(DEFAULT_IPV4_ADDR);
         let other_ip = Ipv4Addr::new(5, 6, 7, 8);
         let mac = MacAddr::from_bytes_unchecked(&[0; 6]);
-        let ns = MmdsNetworkStack::new(
-            mac,
-            ip,
-            DEFAULT_TCP_PORT,
-            NonZeroUsize::new(DEFAULT_MAX_CONNECTIONS).unwrap(),
-            NonZeroUsize::new(DEFAULT_MAX_PENDING_RESETS).unwrap(),
-            Arc::new(Mutex::new(Mmds::default())),
-        );
+        let ns =
+            MmdsNetworkStack::new_with_defaults(Some(ip), Arc::new(Mutex::new(Mmds::default())));
 
         let mut eth =
             EthernetFrame::write_incomplete(buf.as_mut(), mac, mac, ETHERTYPE_IPV4).unwrap();
@@ -606,14 +594,8 @@ mod tests {
         let ip = Ipv4Addr::from(DEFAULT_IPV4_ADDR);
         let other_ip = Ipv4Addr::new(5, 6, 7, 8);
         let mac = MacAddr::from_bytes_unchecked(&[0; 6]);
-        let mut ns = MmdsNetworkStack::new(
-            mac,
-            ip,
-            DEFAULT_TCP_PORT,
-            NonZeroUsize::new(DEFAULT_MAX_CONNECTIONS).unwrap(),
-            NonZeroUsize::new(DEFAULT_MAX_PENDING_RESETS).unwrap(),
-            Arc::new(Mutex::new(Mmds::default())),
-        );
+        let mut ns =
+            MmdsNetworkStack::new_with_defaults(Some(ip), Arc::new(Mutex::new(Mmds::default())));
 
         // try IPv4 with detour_arp
         let mut eth =

--- a/src/vmm/src/mmds/ns.rs
+++ b/src/vmm/src/mmds/ns.rs
@@ -81,8 +81,6 @@ impl MmdsNetworkStack {
         mac_addr: MacAddr,
         ipv4_addr: Ipv4Addr,
         tcp_port: u16,
-        max_connections: NonZeroUsize,
-        max_pending_resets: NonZeroUsize,
         mmds: Arc<Mutex<Mmds>>,
     ) -> Self {
         MmdsNetworkStack {
@@ -93,8 +91,8 @@ impl MmdsNetworkStack {
             tcp_handler: TcpIPv4Handler::new(
                 ipv4_addr,
                 tcp_port,
-                max_connections,
-                max_pending_resets,
+                NonZeroUsize::new(DEFAULT_MAX_CONNECTIONS).unwrap(),
+                NonZeroUsize::new(DEFAULT_MAX_PENDING_RESETS).unwrap(),
             ),
             mmds,
         }
@@ -105,14 +103,7 @@ impl MmdsNetworkStack {
         let ipv4_addr = mmds_ipv4_addr.unwrap_or_else(|| Ipv4Addr::from(DEFAULT_IPV4_ADDR));
 
         // The unwrap()s are safe because the given literals are greater than 0.
-        Self::new(
-            mac_addr,
-            ipv4_addr,
-            DEFAULT_TCP_PORT,
-            NonZeroUsize::new(DEFAULT_MAX_CONNECTIONS).unwrap(),
-            NonZeroUsize::new(DEFAULT_MAX_PENDING_RESETS).unwrap(),
-            mmds,
-        )
+        Self::new(mac_addr, ipv4_addr, DEFAULT_TCP_PORT, mmds)
     }
 
     pub fn set_ipv4_addr(&mut self, ipv4_addr: Ipv4Addr) {

--- a/src/vmm/src/mmds/persist.rs
+++ b/src/vmm/src/mmds/persist.rs
@@ -4,7 +4,6 @@
 //! Defines the structures needed for saving/restoring MmdsNetworkStack.
 
 use std::net::Ipv4Addr;
-use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
@@ -20,8 +19,6 @@ pub struct MmdsNetworkStackState {
     mac_addr: [u8; MAC_ADDR_LEN as usize],
     ipv4_addr: u32,
     tcp_port: u16,
-    max_connections: NonZeroUsize,
-    max_pending_resets: NonZeroUsize,
 }
 
 impl Persist<'_> for MmdsNetworkStack {
@@ -37,8 +34,6 @@ impl Persist<'_> for MmdsNetworkStack {
             mac_addr,
             ipv4_addr: self.ipv4_addr.into(),
             tcp_port: self.tcp_handler.local_port(),
-            max_connections: self.tcp_handler.max_connections(),
-            max_pending_resets: self.tcp_handler.max_pending_resets(),
         }
     }
 
@@ -50,8 +45,6 @@ impl Persist<'_> for MmdsNetworkStack {
             MacAddr::from_bytes_unchecked(&state.mac_addr),
             Ipv4Addr::from(state.ipv4_addr),
             state.tcp_port,
-            state.max_connections,
-            state.max_pending_resets,
             mmds,
         ))
     }
@@ -82,14 +75,6 @@ mod tests {
         assert_eq!(
             restored_ns.tcp_handler.local_port(),
             ns.tcp_handler.local_port()
-        );
-        assert_eq!(
-            restored_ns.tcp_handler.max_connections(),
-            ns.tcp_handler.max_connections()
-        );
-        assert_eq!(
-            restored_ns.tcp_handler.max_pending_resets(),
-            ns.tcp_handler.max_pending_resets()
         );
     }
 }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -157,7 +157,7 @@ pub enum CreateSnapshotError {
 }
 
 /// Snapshot version
-pub const SNAPSHOT_VERSION: Version = Version::new(4, 0, 0);
+pub const SNAPSHOT_VERSION: Version = Version::new(5, 0, 0);
 
 /// Creates a Microvm snapshot.
 pub fn create_snapshot(


### PR DESCRIPTION
## Changes

Remove `max_connections` and `max_pending_resets` fields from snapshot.

**Note that I only focused on removing them in this PR although I might open another PR to refactor more later.**

## Reason

`TcpIPv4Handler` for MMDS network stack preallocates several buffers
whose sizes are saved into a snapshot as `max_connections` and
`max_pending_resets` in `MmdsNetworkStackState`. But they are always the
same constant hardcoded values (`DEFAULT_MAX_CONNECTIONS` and
`DEFAULT_MAX_PENDING_RESETS`) as of today, which means there is no need
to save them into a snapshot. Even if we change the hardcoded sizes
across Firecracker versions, that should not be a problem. This is
because the snapshot feature does not support migration of network
connections and those buffers are initialized with empty on snapshot
restoration. When migrating from a Firecracker version with larger
buffers to another version with smaller ones, guest workloads that
worked previously might start to fail due to the less buffer spaces.
However, the issue is not a problem of the snapshot feature and it
should also occur even on a purely booted microVM (not restored from a
snapshot). Thus, it is fine to remove those fields from a snapshot.

Since this is a breaking change of the snapshot format, bumps the major
version.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
