### PR TITLE
chore: Clarify user action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to
 
 - [#4913](https://github.com/firecracker-microvm/firecracker/pull/4913): Removed
   unnecessary fields (`max_connections` and `max_pending_resets`) from the
-  snapshot format, bumping the snapshot version to 5.0.0.
+  snapshot format, bumping the snapshot version to 5.0.0. Users need to
+  regenerate snapshots.
 
 ### Deprecated
 
@@ -26,8 +27,8 @@ and this project adheres to
 
 ### Changed
 
-- [#4907](https://github.com/firecracker-microvm/firecracker/pull/4907): Bump
-  snapshot version to 4.0.0.
+- [#4907](https://github.com/firecracker-microvm/firecracker/pull/4907): Bumped
+  the snapshot version to 4.0.0, so users need to regenerate snapshots.
 
 ## \[1.10.0\]
 


### PR DESCRIPTION
**follow-up for https://github.com/firecracker-microvm/firecracker/pull/4913#discussion_r1841969632**

## Changes / Reason

We bumped the snapshot version up twice recently, requiring users to regenerate their snapshot, but the user action isn't clearly stated.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
