### PR TITLE
fix: add vcpu_features and kvm_capabilites to swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to
 
 ### Fixed
 
+- [#4921](https://github.com/firecracker-microvm/firecracker/pull/4921): Fixed
+  swagger `CpuConfig` definition to include missing aarch64-specific fields.
+
 ## \[1.10.1\]
 
 ### Changed

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -840,7 +840,7 @@ definitions:
     default: "None"
 
   CpuConfig:
-    type: string
+    type: object
     description:
       The CPU configuration template defines a set of bit maps as modifiers of flags accessed by register
       to be disabled/enabled for the microvm.
@@ -854,6 +854,12 @@ definitions:
       reg_modifiers:
         type: object
         description: A collection of registers to be modified. (aarch64)
+      vcpu_features:
+        type: object
+        description: A collection of vcpu features to be modified. (aarch64)
+      kvm_capabilities:
+        type: object
+        description: A collection of kvm capabilities to be modified. (aarch64)
 
   Drive:
     type: object


### PR DESCRIPTION
## Changes
- Add vcpu_features and kvm_capabilites to swagger `CpuConfig`
- Also, the field type is changed from "string" to "object", as it has properties and thus can't be a string.

## Reason
These fields were added in #3967 but the Swagger API definition was not updated. This patch fixes the API definition.

Also, the field was incorrectly marked as string. I've verified that changing to object doesn't lead to any changes in the generated client code, as it was already considering it as an object.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] (N/A) I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] (N/A) I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] (N/A) If a specific issue led to this PR, this PR closes the issue.
- [ ] (N/A) When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] (N/A) I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] (N/A)I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
