### PR TITLE
fix: make aarch64_with_sve_and_pac template example work with >=2 vcpus

### DIFF
--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -156,7 +156,7 @@ pub trait VirtioDevice: AsAny + Send {
         let avail_features = self.avail_features();
         let unrequested_features = v & !avail_features;
         if unrequested_features != 0 {
-            warn!("Received acknowledge request for unknown feature: {:x}", v);
+            warn!("Received acknowledge request for unknown feature: {:#x}", v);
             // Don't count these features as acked.
             v &= !unrequested_features;
         }

--- a/src/vmm/src/devices/virtio/mmio.rs
+++ b/src/vmm/src/devices/virtio/mmio.rs
@@ -138,7 +138,7 @@ impl MmioTransport {
             self.with_queue_mut(f);
         } else {
             warn!(
-                "update virtio queue in invalid state 0x{:x}",
+                "update virtio queue in invalid state {:#x}",
                 self.device_status
             );
         }
@@ -227,7 +227,7 @@ impl MmioTransport {
             }
             _ => {
                 warn!(
-                    "invalid virtio driver status transition: 0x{:x} -> 0x{:x}",
+                    "invalid virtio driver status transition: {:#x} -> {:#x}",
                     self.device_status, status
                 );
             }
@@ -282,7 +282,7 @@ impl MmioTransport {
                     0x70 => self.device_status,
                     0xfc => self.config_generation,
                     _ => {
-                        warn!("unknown virtio mmio register read: 0x{:x}", offset);
+                        warn!("unknown virtio mmio register read: {:#x}", offset);
                         return;
                     }
                 };
@@ -290,11 +290,7 @@ impl MmioTransport {
             }
             0x100..=0xfff => self.locked_device().read_config(offset - 0x100, data),
             _ => {
-                warn!(
-                    "invalid virtio mmio read: 0x{:x}:0x{:x}",
-                    offset,
-                    data.len()
-                );
+                warn!("invalid virtio mmio read: {:#x}:{:#x}", offset, data.len());
             }
         };
     }
@@ -324,7 +320,7 @@ impl MmioTransport {
                                 .ack_features_by_page(self.acked_features_select, v);
                         } else {
                             warn!(
-                                "ack virtio features in invalid state 0x{:x}",
+                                "ack virtio features in invalid state {:#x}",
                                 self.device_status
                             );
                         }
@@ -346,7 +342,7 @@ impl MmioTransport {
                     0xa0 => self.update_queue_field(|q| lo(&mut q.used_ring_address, v)),
                     0xa4 => self.update_queue_field(|q| hi(&mut q.used_ring_address, v)),
                     _ => {
-                        warn!("unknown virtio mmio register write: 0x{:x}", offset);
+                        warn!("unknown virtio mmio register write: {:#x}", offset);
                     }
                 }
             }
@@ -361,11 +357,7 @@ impl MmioTransport {
                 }
             }
             _ => {
-                warn!(
-                    "invalid virtio mmio write: 0x{:x}:0x{:x}",
-                    offset,
-                    data.len()
-                );
+                warn!("invalid virtio mmio write: {:#x}:{:#x}", offset, data.len());
             }
         }
     }

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -322,7 +322,7 @@ where
     fn write_config(&mut self, offset: u64, data: &[u8]) {
         METRICS.cfg_fails.inc();
         warn!(
-            "vsock: guest driver attempted to write device config (offset={:x}, len={:x})",
+            "vsock: guest driver attempted to write device config (offset={:#x}, len={:#x})",
             offset,
             data.len()
         );

--- a/src/vmm/src/gdb/target.rs
+++ b/src/vmm/src/gdb/target.rs
@@ -390,7 +390,7 @@ impl MultiThreadBase for FirecrackerTarget {
 
         while !data.is_empty() {
             let gpa = arch::translate_gva(&vcpu_state.vcpu_fd, gva, &vmm).map_err(|e| {
-                error!("Error {e:?} translating gva on read address: {gva:X}");
+                error!("Error {e:?} translating gva on read address: {gva:#X}");
             })?;
 
             // Compute the amount space left in the page after the gpa
@@ -424,7 +424,7 @@ impl MultiThreadBase for FirecrackerTarget {
 
         while !data.is_empty() {
             let gpa = arch::translate_gva(&vcpu_state.vcpu_fd, gva, &vmm).map_err(|e| {
-                error!("Error {e:?} translating gva on read address: {gva:X}");
+                error!("Error {e:?} translating gva on read address: {gva:#X}");
             })?;
 
             // Compute the amount space left in the page after the gpa
@@ -436,7 +436,7 @@ impl MultiThreadBase for FirecrackerTarget {
             vmm.guest_memory()
                 .write(&data[..write_len], GuestAddress(gpa))
                 .map_err(|e| {
-                    error!("Error {e:?} writing memory at {gpa:X}");
+                    error!("Error {e:?} writing memory at {gpa:#X}");
                 })?;
 
             data = &data[write_len..];

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -61,7 +61,7 @@ pub enum KvmVcpuError {
     VcpuGetLapic(kvm_ioctls::Error),
     /// Failed to get KVM vcpu mp state: {0}
     VcpuGetMpState(kvm_ioctls::Error),
-    /// Failed to get KVM vcpu msr: 0x{0:x}
+    /// Failed to get KVM vcpu msr: {0:#x}
     VcpuGetMsr(u32),
     /// Failed to get KVM vcpu msrs: {0}
     VcpuGetMsrs(kvm_ioctls::Error),
@@ -321,7 +321,7 @@ impl KvmVcpu {
                 .filter(|msr| msr.index == MSR_IA32_TSC_DEADLINE && msr.data == 0)
                 .for_each(|msr| {
                     warn!(
-                        "MSR_IA32_TSC_DEADLINE is 0, replacing with {:x}.",
+                        "MSR_IA32_TSC_DEADLINE is 0, replacing with {:#x}.",
                         tsc_value
                     );
                     msr.data = tsc_value;

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -34,7 +34,7 @@ use crate::vstate::memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRe
 pub enum VmError {
     /// The host kernel reports an invalid KVM API version: {0}
     ApiVersion(i32),
-    /// Missing KVM capabilities: {0:x?}
+    /// Missing KVM capabilities: {0:#x?}
     Capabilities(u32),
     /**  Error creating KVM object: {0} Make sure the user launching the firecracker process is \
     configured on the /dev/kvm file's ACL. */

--- a/tests/data/static_cpu_templates/aarch64_with_sve_and_pac.json
+++ b/tests/data/static_cpu_templates/aarch64_with_sve_and_pac.json
@@ -1,4 +1,4 @@
 {
   "kvm_capabilities": ["170", "171", "172"],
-  "vcpu_features": [{ "index": 0, "bitmap": "0b1110000" }]
+  "vcpu_features": [{ "index": 0, "bitmap": "0b111xxxx" }]
 }

--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -29,7 +29,7 @@ def get_supported_cpu_templates():
     match get_cpu_vendor(), global_props.cpu_codename:
         # T2CL template is only supported on Cascade Lake and newer CPUs.
         case CpuVendor.INTEL, CpuModel.INTEL_SKYLAKE:
-            return sorted(set(INTEL_TEMPLATES) - set(["T2CL"]))
+            return sorted(set(INTEL_TEMPLATES) - {"T2CL"})
         case CpuVendor.INTEL, _:
             return INTEL_TEMPLATES
         case CpuVendor.AMD, _:


### PR DESCRIPTION
Setting the least significant 4 bits to zero overwrites some
configuration that Firecracker sets on secondary CPUs that is needed for
them to be able to be booted. With these 4 bits set to 0, the CPUs will
never show up as online inside the guest, and KVM will just infinitely
spin inside KVM_RUN for them. Fix by using 'x' in the template, which
preserves the defaults set by Firecracker.

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
