### PR TITLE
docs: fix Firecracker version and rootfs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,21 +100,23 @@ kernel image with a Ubuntu 24.04 rootfs from our CI:
 ```bash
 ARCH="$(uname -m)"
 
-latest=$(wget "http://spec.ccfc.min.s3.amazonaws.com/?prefix=firecracker-ci/v1.10/$ARCH/vmlinux-5.10&list-type=2" -O - 2>/dev/null | grep -oP "(?<=<Key>)(firecracker-ci/v1.10/$ARCH/vmlinux-5\.10\.[0-9]{1,3})(?=</Key>)")
+latest=$(wget "http://spec.ccfc.min.s3.amazonaws.com/?prefix=firecracker-ci/v1.11/$ARCH/vmlinux-5.10&list-type=2" -O - 2>/dev/null | grep -oP "(?<=<Key>)(firecracker-ci/v1.11/$ARCH/vmlinux-5\.10\.[0-9]{1,3})(?=</Key>)")
 
 # Download a linux kernel binary
 wget "https://s3.amazonaws.com/spec.ccfc.min/${latest}"
 
 # Download a rootfs
-wget -O ubuntu-24.04.squashfs.upstream "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.10/${ARCH}/ubuntu-24.04.squashfs"
+wget -O ubuntu-24.04.squashfs.upstream "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.11/${ARCH}/ubuntu-24.04.squashfs"
 
 # Create an ssh key for the rootfs
 unsquashfs ubuntu-24.04.squashfs.upstream
 ssh-keygen -f id_rsa -N ""
 cp -v id_rsa.pub squashfs-root/root/.ssh/authorized_keys
 mv -v id_rsa ./ubuntu-24.04.id_rsa
-# re-squash
-mksquashfs squashfs-root ubuntu-24.04.squashfs -all-root -noappend -comp zstd
+# create ext4 filesystem image
+sudo chown -R root:root squashfs-root
+truncate -s 400M ubuntu-24.04.ext4
+sudo mkfs.ext4 -d squashfs-root -F ubuntu-24.04.ext4
 ```
 
 ### Getting a Firecracker Binary


### PR DESCRIPTION
During the last change we missed updating the Firecracker CI version.

Also keep the rootfs as ext4 for the rest of the guide.

Fixes: a69595f5f03757bd990318e7aa4f23409355ae13

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
