### PR TITLE
devtool: add download_ci_artifacts command

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -878,7 +878,6 @@ cmd_shell() {
 
 cmd_sh() {
     ensure_build_dir
-    ensure_ci_artifacts
     run_devctr \
         --privileged \
         --ulimit nofile=4096:4096 \
@@ -916,6 +915,7 @@ cmd_sandbox_native() {
 }
 
 cmd_test_debug() {
+    ensure_ci_artifacts
     cmd_sh "tmux new ./tools/test.sh --pdb $@"
 }
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -562,7 +562,8 @@ ensure_ci_artifacts() {
 
     # Fetch all the artifacts so they are local
     say "Fetching CI artifacts from S3"
-    S3_URL=s3://spec.ccfc.min/firecracker-ci/v1.11/$(uname -m)
+    FC_VERSION=$(cmd_sh "cd src/firecracker/src; cargo pkgid | cut -d# -f2 | cut -d. -f1-2")
+    S3_URL=s3://spec.ccfc.min/firecracker-ci/v$FC_VERSION/$(uname -m)
     ARTIFACTS=$MICROVM_IMAGES_DIR/$(uname -m)
     if [ ! -d "$ARTIFACTS" ]; then
         mkdir -pv $ARTIFACTS

--- a/tools/devtool
+++ b/tools/devtool
@@ -418,6 +418,10 @@ cmd_help() {
     echo "        Builds the rootfs and guest kernel artifacts we use for our CI."
     echo "        Run './tools/devtool build_ci_artifacts help' for more details about the available commands."
     echo ""
+    echo "    download_ci_artifacts [--force]"
+    echo "        Downloads the CI artifacts used for testing from our S3 bucket. If --force is passed, purges any existing"
+    echo "        artifacts first. Useful for refreshing local artifacts after an update, or if something got messed up."
+    echo ""
 
     cat <<EOF
     test_debug [-- [<pytest args>]]
@@ -553,6 +557,14 @@ cmd_distclean() {
         say "Removing $DEVCTR_IMAGE"
         docker rmi -f "$DEVCTR_IMAGE"
     fi
+}
+
+cmd_download_ci_artifacts() {
+    if [ "$1" = "--force" ]; then
+        rm -rf $FC_BUILD_DIR/img
+    fi
+
+    ensure_ci_artifacts
 }
 
 ensure_ci_artifacts() {


### PR DESCRIPTION
Every now and then, I managed to end up with an empty CI artifacts
folder, for whatever reason (mostly me being silly). The solution is
generally to remove whatever messed up stuff I ended up with in
build/img, and run some arbitrary devtool command that I know will
redownload everything. Similar workflows must happen whenever we do an
in-place update of our CI artifacts.

Abstract this away into a command that deletes the build/img folder, and
then redownloads it.

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
