### PR TITLE
devtool: stop asking for user confirmation on container pull

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -127,10 +127,6 @@ PRIV_KEY_PATH=/root/.ssh/id_rsa
 # Path to the linux kernel directory, as bind-mounted in the container.
 CTR_KERNEL_DIR="${CTR_FC_ROOT_DIR}/.kernel"
 
-# Global options received by $0
-# These options are not command-specific, so we store them as global vars
-OPT_UNATTENDED=false
-
 # Get the target prefix to avoid repeated calls to uname -m
 TARGET_PREFIX="$(uname -m)-unknown-linux-"
 
@@ -195,7 +191,6 @@ ensure_devctr() {
     # download it, if we don't.
     [[ $(docker images -q "$DEVCTR_IMAGE" | wc -l) -gt 0 ]] || {
         say "About to pull docker image $DEVCTR_IMAGE"
-        get_user_confirmation || die "Aborted."
 
         # Run docker pull 5 times in case it fails - sleep 3 seconds
         # between attempts
@@ -1235,7 +1230,8 @@ main() {
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help)              { cmd_help; exit 1;     } ;;
-            -y|--unattended)        { OPT_UNATTENDED=true;  } ;;
+            -y|--unattended)        # purposefully ignored
+                ;;
             -*)
                 die "Unknown arg: $1. Please use \`$0 help\` for help."
             ;;

--- a/tools/functions
+++ b/tools/functions
@@ -71,12 +71,7 @@ function SGR {
 #   exit code 0 for successful confirmation
 #   exit code != 0 if the user declined
 #
-OPT_UNATTENDED=false
 get_user_confirmation() {
-
-    # Pass if running unattended
-    [[ "$OPT_UNATTENDED" = true ]] && return 0
-
     # Fail if STDIN is not a terminal (there's no user to confirm anything)
     [[ -t 0 ]] || return 1
 


### PR DESCRIPTION
Whenever devtool notices that its container is not cached locally, it requests user input to confirm the new devctr version should indeed be downloaded. In practice, I do not remember ever saying "no" here. On the other hand, forgetting to explicitly disable these confirmations in buildkite pipelines has lead to a myriad of "stuck pipeline" issues. Thus, remove this confirmation step altogether, as it does more harm than good.

To avoid having to fix all pipelines that do pass `-y` today, simply treat the `-y` parameter as a no-op (suggested by Pablo, thanks!).

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
