### PR TITLE
refactor(tests): move return code check for ssh into ssh.run

### DIFF
--- a/tests/framework/ab_test.py
+++ b/tests/framework/ab_test.py
@@ -194,7 +194,7 @@ def precompiled_ab_test_guest_command(
 
     def test_runner(bin_dir, _is_a: bool):
         microvm = microvm_factory(bin_dir / "firecracker", bin_dir / "jailer")
-        return microvm.ssh.run(command)
+        return microvm.ssh.run(command, check=False)
 
     (_, old_out, old_err), (_, new_out, new_err), the_same = binary_ab_test(
         test_runner,

--- a/tests/framework/utils_iperf.py
+++ b/tests/framework/utils_iperf.py
@@ -119,7 +119,7 @@ class IPerf3Test:
             .build()
         )
 
-        return self._microvm.ssh.check_output(cmd).stdout
+        return self._microvm.ssh.run(cmd).stdout
 
     def host_command(self, port_offset):
         """Builds the command used for spawning an iperf3 server on the host"""

--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -100,7 +100,7 @@ def start_guest_echo_server(vm):
     Returns a UDS path to connect to the server.
     """
     cmd = f"nohup socat VSOCK-LISTEN:{ECHO_SERVER_PORT},backlog=128,reuseaddr,fork EXEC:'/bin/cat' > /dev/null 2>&1 &"
-    vm.ssh.check_output(cmd)
+    vm.ssh.run(cmd)
 
     # Give the server time to initialise
     time.sleep(1)
@@ -214,8 +214,7 @@ def _copy_vsock_data_to_guest(ssh_connection, blob_path, vm_blob_path, vsock_hel
     # Copy the data file and a vsock helper to the guest.
 
     cmd = "mkdir -p /tmp/vsock"
-    ecode, _, _ = ssh_connection.run(cmd)
-    assert ecode == 0, "Failed to set up tmpfs drive on the guest."
+    ssh_connection.run(cmd)
 
     ssh_connection.scp_put(vsock_helper, "/tmp/vsock_helper")
     ssh_connection.scp_put(blob_path, vm_blob_path)

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -79,7 +79,7 @@ class SSHConnection:
 
     def _scp(self, path1, path2, options):
         """Copy files to/from the VM using scp."""
-        self._exec(["scp", *options, path1, path2], check=True)
+        self._exec(["scp", *options, path1, path2])
 
     def scp_put(self, local_path, remote_path, recursive=False):
         """Copy files to the VM using scp."""
@@ -109,11 +109,12 @@ class SSHConnection:
         We'll keep trying to execute a remote command that can't fail
         (`/bin/true`), until we get a successful (0) exit code.
         """
-        self.check_output("true", timeout=100, debug=True)
+        self.run("true", timeout=100, debug=True)
 
-    def run(self, cmd_string, timeout=None, *, check=False, debug=False):
+    def run(self, cmd_string, timeout=None, *, check=True, debug=False):
         """
         Execute the command passed as a string in the ssh context.
+        By default raises an exception on non-zero return code of remote command.
 
         If `debug` is set, pass `-vvv` to `ssh`. Note that this will clobber stderr.
         """
@@ -124,11 +125,7 @@ class SSHConnection:
 
         return self._exec(command, timeout, check=check)
 
-    def check_output(self, cmd_string, timeout=None, *, debug=False):
-        """Same as `run`, but raises an exception on non-zero return code of remote command"""
-        return self.run(cmd_string, timeout, check=True, debug=debug)
-
-    def _exec(self, cmd, timeout=None, check=False):
+    def _exec(self, cmd, timeout=None, check=True):
         """Private function that handles the ssh client invocation."""
         if self.netns is not None:
             cmd = ["ip", "netns", "exec", self.netns] + cmd

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -51,7 +51,7 @@ def _check_cpu_features_arm(test_microvm, guest_kv, template_name=None):
         case CpuModel.ARM_NEOVERSE_V1, _, None:
             expected_cpu_features = DEFAULT_G3_FEATURES_5_10
 
-    _, stdout, _ = test_microvm.ssh.check_output(CPU_FEATURES_CMD)
+    _, stdout, _ = test_microvm.ssh.run(CPU_FEATURES_CMD)
     flags = set(stdout.strip().split(" "))
     assert flags == expected_cpu_features
 
@@ -77,7 +77,7 @@ def test_host_vs_guest_cpu_features_aarch64(uvm_nano):
     vm.add_net_iface()
     vm.start()
     host_feats = set(utils.check_output(CPU_FEATURES_CMD).stdout.strip().split(" "))
-    guest_feats = set(vm.ssh.check_output(CPU_FEATURES_CMD).stdout.strip().split(" "))
+    guest_feats = set(vm.ssh.run(CPU_FEATURES_CMD).stdout.strip().split(" "))
 
     cpu_model = cpuid_utils.get_cpu_model_name()
     match cpu_model:

--- a/tests/integration_tests/functional/test_cpu_features_x86_64.py
+++ b/tests/integration_tests/functional/test_cpu_features_x86_64.py
@@ -215,7 +215,7 @@ def test_host_vs_guest_cpu_features_x86_64(uvm_nano):
     vm.add_net_iface()
     vm.start()
     host_feats = set(utils.check_output(CPU_FEATURES_CMD).stdout.strip().split(" "))
-    guest_feats = set(vm.ssh.check_output(CPU_FEATURES_CMD).stdout.strip().split(" "))
+    guest_feats = set(vm.ssh.run(CPU_FEATURES_CMD).stdout.strip().split(" "))
 
     cpu_model = cpuid_utils.get_cpu_codename()
     match cpu_model:

--- a/tests/integration_tests/functional/test_drive_vhost_user.py
+++ b/tests/integration_tests/functional/test_drive_vhost_user.py
@@ -15,8 +15,7 @@ def _check_block_size(ssh_connection, dev_path, size):
     """
     Checks the size of the block device.
     """
-    _, stdout, stderr = ssh_connection.run("blockdev --getsize64 {}".format(dev_path))
-    assert stderr == ""
+    _, stdout, _ = ssh_connection.run("blockdev --getsize64 {}".format(dev_path))
     assert stdout.strip() == str(size)
 
 
@@ -297,7 +296,7 @@ def test_config_change(microvm_factory, guest_kernel, rootfs):
     _check_block_size(vm.ssh, "/dev/vdb", orig_size * 1024 * 1024)
 
     # Check that we can create a filesystem and mount it
-    vm.ssh.check_output(mkfs_mount_cmd)
+    vm.ssh.run(mkfs_mount_cmd)
 
     for new_size in new_sizes:
         # Instruct the backend to resize the device.
@@ -312,4 +311,4 @@ def test_config_change(microvm_factory, guest_kernel, rootfs):
         _check_block_size(vm.ssh, "/dev/vdb", new_size * 1024 * 1024)
 
         # Check that we can create a filesystem and mount it
-        vm.ssh.check_output(mkfs_mount_cmd)
+        vm.ssh.run(mkfs_mount_cmd)

--- a/tests/integration_tests/functional/test_kvm_ptp.py
+++ b/tests/integration_tests/functional/test_kvm_ptp.py
@@ -18,7 +18,7 @@ def test_kvm_ptp(uvm_plain_any):
     vm.add_net_iface()
     vm.start()
 
-    vm.ssh.check_output("[ -c /dev/ptp0 ]")
+    vm.ssh.run("[ -c /dev/ptp0 ]")
 
     # phc_ctl[14515.127]: clock time is 1697545854.728335694 or Tue Oct 17 12:30:54 2023
-    vm.ssh.check_output("phc_ctl /dev/ptp0 -- get")
+    vm.ssh.run("phc_ctl /dev/ptp0 -- get")

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -33,7 +33,7 @@ def test_attach_maximum_devices(uvm_plain_any):
     # Test that network devices attached are operational.
     for i in range(MAX_DEVICES_ATTACHED - 1):
         # Verify if guest can run commands.
-        test_microvm.ssh_iface(i).check_output("sync")
+        test_microvm.ssh_iface(i).run("sync")
 
 
 @pytest.mark.skipif(

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -37,7 +37,7 @@ def test_high_ingress_traffic(uvm_plain_any):
     test_microvm.start()
 
     # Start iperf3 server on the guest.
-    test_microvm.ssh.check_output("{} -sD\n".format(IPERF_BINARY_GUEST))
+    test_microvm.ssh.run("{} -sD\n".format(IPERF_BINARY_GUEST))
     time.sleep(1)
 
     # Start iperf3 client on the host. Send 1Gbps UDP traffic.
@@ -53,7 +53,7 @@ def test_high_ingress_traffic(uvm_plain_any):
     # Check if the high ingress traffic broke the net interface.
     # If the net interface still works we should be able to execute
     # ssh commands.
-    test_microvm.ssh.check_output("echo success\n")
+    test_microvm.ssh.run("echo success\n")
 
 
 def test_multi_queue_unsupported(uvm_plain):
@@ -97,8 +97,8 @@ def run_udp_offload_test(vm):
     message = "x"
 
     # Start a UDP server in the guest
-    # vm.ssh.check_output(f"nohup socat UDP-LISTEN:{port} - > {out_filename} &")
-    vm.ssh.check_output(
+    # vm.ssh.run(f"nohup socat UDP-LISTEN:{port} - > {out_filename} &")
+    vm.ssh.run(
         f"nohup socat UDP4-LISTEN:{port} OPEN:{out_filename},creat > /dev/null 2>&1 &"
     )
 
@@ -110,8 +110,8 @@ def run_udp_offload_test(vm):
     assert ret.returncode == 0, f"{ret.stdout=} {ret.stderr=}"
 
     # Check that the server received the message
-    ret = vm.ssh.run(f"cat {out_filename}")
-    assert ret.stdout == message, f"{ret.stdout=} {ret.stderr=}"
+    _, stdout, stderr = vm.ssh.run(f"cat {out_filename}")
+    assert stdout == message, f"{stdout=} {stderr=}"
 
 
 def test_tap_offload_booted(uvm_plain_any):

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -53,7 +53,7 @@ def test_pause_resume(uvm_nano):
 
     # Verify guest is no longer active.
     with pytest.raises(ChildProcessError):
-        microvm.ssh.check_output("true")
+        microvm.ssh.run("true")
 
     # Verify emulation was indeed paused and no events from either
     # guest or host side were handled.
@@ -61,7 +61,7 @@ def test_pause_resume(uvm_nano):
 
     # Verify guest is no longer active.
     with pytest.raises(ChildProcessError):
-        microvm.ssh.check_output("true")
+        microvm.ssh.run("true")
 
     # Pausing the microVM when it is already `Paused` is allowed
     # (microVM remains in `Paused` state).
@@ -152,7 +152,7 @@ def test_kvmclock_ctrl(uvm_plain_any):
     # console. This detail is important as it writing in the console seems to increase the probability
     # that we will pause the execution inside the kernel and cause a lock up. Setting KVM_CLOCK_CTRL
     # bit that informs the guest we're pausing the vCPUs, should avoid that lock up.
-    microvm.ssh.check_output(
+    microvm.ssh.run(
         "timeout 60 sh -c 'while true; do ls -R /; done' > /dev/ttyS0 2>&1 < /dev/null &"
     )
 
@@ -161,7 +161,7 @@ def test_kvmclock_ctrl(uvm_plain_any):
         time.sleep(5)
         microvm.api.vm.patch(state="Resumed")
 
-    dmesg = microvm.ssh.check_output("dmesg").stdout
+    _, dmesg, _ = microvm.ssh.run("dmesg")
     assert "rcu_sched self-detected stall on CPU" not in dmesg
     assert "rcu_preempt detected stalls on CPUs/tasks" not in dmesg
     assert "BUG: soft lockup -" not in dmesg

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -25,18 +25,14 @@ def uvm_with_rng(uvm_plain, request):
 
 def list_rng_available(ssh_connection: SSHConnection) -> list[str]:
     """Returns a list of rng devices available in the VM"""
-    return (
-        ssh_connection.check_output("cat /sys/class/misc/hw_random/rng_available")
-        .stdout.strip()
-        .split()
-    )
+    _, stdout, _ = ssh_connection.run("cat /sys/class/misc/hw_random/rng_available")
+    return stdout.strip().split()
 
 
 def get_rng_current(ssh_connection: SSHConnection) -> str:
     """Returns the current rng device used by hwrng"""
-    return ssh_connection.check_output(
-        "cat /sys/class/misc/hw_random/rng_current"
-    ).stdout.strip()
+    _, stdout, _ = ssh_connection.run("cat /sys/class/misc/hw_random/rng_current")
+    return stdout.strip()
 
 
 def assert_virtio_rng_is_current_hwrng_device(ssh_connection: SSHConnection):
@@ -150,7 +146,7 @@ def _get_throughput(ssh, random_bytes):
     # Issue a `dd` command to request 100 times `random_bytes` from the device.
     # 100 here is used to get enough confidence on the achieved throughput.
     cmd = "dd if=/dev/hwrng of=/dev/null bs={} count=100".format(random_bytes)
-    _, _, stderr = ssh.check_output(cmd)
+    _, _, stderr = ssh.run(cmd)
 
     # dd gives its output on stderr
     return _process_dd_output(stderr)

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -188,15 +188,13 @@ def test_serial_block(uvm_plain_any):
     os.kill(test_microvm.screen_pid, signal.SIGSTOP)
 
     # Generate a random text file.
-    test_microvm.ssh.check_output(
-        "base64 /dev/urandom | head -c 100000 > /tmp/file.txt"
-    )
+    test_microvm.ssh.run("base64 /dev/urandom | head -c 100000 > /tmp/file.txt")
 
     # Dump output to terminal
-    test_microvm.ssh.check_output("cat /tmp/file.txt > /dev/ttyS0")
+    test_microvm.ssh.run("cat /tmp/file.txt > /dev/ttyS0")
 
     # Check that the vCPU isn't blocked.
-    test_microvm.ssh.check_output("cd /")
+    test_microvm.ssh.run("cd /")
 
     # Check the metrics to see if the serial missed bytes.
     fc_metrics = test_microvm.flush_metrics()

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -36,7 +36,7 @@ def check_vmgenid_update_count(vm, resume_count):
     Kernel will emit the DMESG_VMGENID_RESUME every time we resume
     from a snapshot
     """
-    _, stdout, _ = vm.ssh.check_output("dmesg")
+    _, stdout, _ = vm.ssh.run("dmesg")
     assert resume_count == stdout.count(DMESG_VMGENID_RESUME)
 
 
@@ -44,8 +44,7 @@ def _get_guest_drive_size(ssh_connection, guest_dev_name="/dev/vdb"):
     # `lsblk` command outputs 2 lines to STDOUT:
     # "SIZE" and the size of the device, in bytes.
     blksize_cmd = "LSBLK_DEBUG=all lsblk -b {} --output SIZE".format(guest_dev_name)
-    rc, stdout, stderr = ssh_connection.run(blksize_cmd)
-    assert rc == 0, stderr
+    _, stdout, _ = ssh_connection.run(blksize_cmd)
     lines = stdout.split("\n")
     return lines[1].strip()
 
@@ -473,7 +472,7 @@ def test_diff_snapshot_overlay(guest_kernel, rootfs, microvm_factory):
     basevm.resume()
 
     # Run some command to dirty some pages
-    basevm.ssh.check_output("true")
+    basevm.ssh.run("true")
 
     # First copy the base snapshot somewhere else, so we can make sure
     # it will actually get updated

--- a/tests/integration_tests/functional/test_snapshot_phase1.py
+++ b/tests/integration_tests/functional/test_snapshot_phase1.py
@@ -93,7 +93,7 @@ def test_snapshot_phase1(
 
     # Validate MMDS.
     # Configure interface to route MMDS requests
-    vm.ssh.check_output(f"ip route add {IPV4_ADDRESS} dev {NET_IFACE_FOR_MMDS}")
+    vm.ssh.run(f"ip route add {IPV4_ADDRESS} dev {NET_IFACE_FOR_MMDS}")
 
     # Fetch metadata to ensure MMDS is accessible.
     token = generate_mmds_session_token(vm.ssh, IPV4_ADDRESS, token_ttl=60)

--- a/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
+++ b/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
@@ -59,7 +59,7 @@ def _test_mmds(vm, mmds_net_iface):
     cmd = "ip route add {} dev {}".format(
         mmds_net_iface.guest_ip, mmds_net_iface.dev_name
     )
-    vm.ssh.check_output(cmd)
+    vm.ssh.run(cmd)
 
     # The base microVM had MMDS version 2 configured, which was persisted
     # across the snapshot-restore.
@@ -116,7 +116,7 @@ def test_snap_restore_from_artifacts(
     # Test that net devices have connectivity after restore.
     for idx, iface in enumerate(vm.iface.values()):
         logger.info("Testing net device %s...", iface["iface"].dev_name)
-        vm.ssh_iface(idx).check_output("true")
+        vm.ssh_iface(idx).run("true")
 
     logger.info("Testing data store behavior...")
     _test_mmds(vm, vm.iface["eth3"]["iface"])

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -238,7 +238,7 @@ def test_vsock_transport_reset_g2h(uvm_nano, microvm_factory):
         # After snap restore all vsock connections should be
         # dropped. This means guest socat should exit same way
         # as it did after snapshot was taken.
-        code, _, _ = new_vm.ssh.run("pidof socat")
+        code, _, _ = new_vm.ssh.run("pidof socat", check=False)
         assert code == 1
 
         host_socket_path = os.path.join(
@@ -266,15 +266,14 @@ def test_vsock_transport_reset_g2h(uvm_nano, microvm_factory):
         new_vm.ssh.run(guest_socat_commmand)
 
         # socat should be running in the guest now
-        code, _, _ = new_vm.ssh.run("pidof socat")
-        assert code == 0
+        new_vm.ssh.run("pidof socat")
 
         # Create snapshot.
         snapshot = new_vm.snapshot_full()
         new_vm.resume()
 
         # After `create_snapshot` + 'restore' calls, connection should be dropped
-        code, _, _ = new_vm.ssh.run("pidof socat")
+        code, _, _ = new_vm.ssh.run("pidof socat", check=False)
         assert code == 1
 
         # Kill host socat as it is not useful anymore

--- a/tests/integration_tests/performance/test_block_ab.py
+++ b/tests/integration_tests/performance/test_block_ab.py
@@ -28,15 +28,13 @@ GUEST_MEM_MIB = 1024
 def prepare_microvm_for_test(microvm):
     """Prepares the microvm for running a fio-based performance test by tweaking
     various performance related parameters."""
-    _, _, stderr = microvm.ssh.check_output(
-        "echo 'none' > /sys/block/vdb/queue/scheduler"
-    )
+    _, _, stderr = microvm.ssh.run("echo 'none' > /sys/block/vdb/queue/scheduler")
     assert stderr == ""
 
     # First, flush all guest cached data to host, then drop guest FS caches.
-    _, _, stderr = microvm.ssh.check_output("sync")
+    _, _, stderr = microvm.ssh.run("sync")
     assert stderr == ""
-    _, _, stderr = microvm.ssh.check_output("echo 3 > /proc/sys/vm/drop_caches")
+    _, _, stderr = microvm.ssh.run("echo 3 > /proc/sys/vm/drop_caches")
     assert stderr == ""
 
     # Then, flush all host cached data to hardware, also drop host FS caches.
@@ -97,7 +95,7 @@ def run_fio(microvm, mode, block_size):
         assert stderr == ""
 
         microvm.ssh.scp_get("/tmp/*.log", logs_path)
-        microvm.ssh.check_output("rm /tmp/*.log")
+        microvm.ssh.run("rm /tmp/*.log")
 
         return logs_path, cpu_load_future.result()
 

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -128,7 +128,7 @@ def test_hugetlbfs_diff_snapshot(microvm_factory, uvm_plain, uffd_handler_paths)
     uvm_plain.resume()
 
     # Run command to dirty some pages
-    uvm_plain.ssh.check_output("sync")
+    uvm_plain.ssh.run("sync")
 
     snapshot_diff = uvm_plain.snapshot_diff()
     snapshot_merged = snapshot_diff.rebase_snapshot(base_snapshot)
@@ -180,11 +180,11 @@ def test_ept_violation_count(
 
     # Wait for microvm to boot. Then spawn fast_page_fault_helper to setup an environment where we can trigger
     # a lot of fast_page_faults after restoring the snapshot.
-    vm.ssh.check_output(
+    vm.ssh.run(
         "nohup /usr/local/bin/fast_page_fault_helper >/dev/null 2>&1 </dev/null &"
     )
 
-    _, pid, _ = vm.ssh.check_output("pidof fast_page_fault_helper")
+    _, pid, _ = vm.ssh.run("pidof fast_page_fault_helper")
 
     # Give the helper time to initialize
     time.sleep(5)
@@ -208,7 +208,7 @@ def test_ept_violation_count(
         vm.restore_from_snapshot(snapshot, resume=True, uffd_path=SOCKET_PATH)
 
         # Verify if guest can run commands, and also wake up the fast page fault helper to trigger page faults.
-        vm.ssh.check_output(f"kill -s {signal.SIGUSR1} {pid}")
+        vm.ssh.run(f"kill -s {signal.SIGUSR1} {pid}")
 
         # Give the helper time to touch all its pages
         time.sleep(5)

--- a/tests/integration_tests/performance/test_network_ab.py
+++ b/tests/integration_tests/performance/test_network_ab.py
@@ -75,7 +75,7 @@ def test_network_latency(network_microvm, metrics):
     host_ip = network_microvm.iface["eth0"]["iface"].host_ip
 
     for _ in range(rounds):
-        _, ping_output, _ = network_microvm.ssh.check_output(
+        _, ping_output, _ = network_microvm.ssh.run(
             f"ping -c {request_per_round} -i {delay} {host_ip}"
         )
 

--- a/tests/integration_tests/performance/test_rate_limiter.py
+++ b/tests/integration_tests/performance/test_rate_limiter.py
@@ -392,7 +392,7 @@ def _start_iperf_server_on_guest(test_microvm):
 
 def _run_iperf_on_guest(test_microvm, iperf_cmd):
     """Run a client related iperf command through an SSH connection."""
-    return test_microvm.ssh.check_output(iperf_cmd).stdout
+    return test_microvm.ssh.run(iperf_cmd).stdout
 
 
 def _start_iperf_server_on_host(netns_cmd_prefix):

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -399,7 +399,7 @@ def check_vulnerabilities_files_on_guest(microvm):
     """
     # Retrieve a list of vulnerabilities files available inside guests.
     vuln_dir = "/sys/devices/system/cpu/vulnerabilities"
-    _, stdout, _ = microvm.ssh.check_output(f"find -D all {vuln_dir} -type f")
+    _, stdout, _ = microvm.ssh.run(f"find -D all {vuln_dir} -type f")
     vuln_files = stdout.split("\n")
 
     # Fixtures in this file (test_vulnerabilities.py) add this special field.
@@ -415,8 +415,7 @@ def check_vulnerabilities_files_on_guest(microvm):
             assert exceptions[filename] in stdout
         else:
             cmd = f"grep Vulnerable {vuln_file}"
-            ecode, stdout, stderr = microvm.ssh.run(cmd)
-            assert ecode == 1, f"{vuln_file}: stdout:\n{stdout}\nstderr:\n{stderr}\n"
+            microvm.ssh.run(cmd)
 
 
 def check_vulnerabilities_files_ab(builder):


### PR DESCRIPTION
## Changes
Move return code check for ssh into ssh.run.

## Reason
Ssh connection should be considered an error by default. In order to unify handling of this case, move check for non zero return code into the function itself.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
