### PR TITLE
fix(tests): save snapshot metadata when saving to disk

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -150,6 +150,7 @@ class Snapshot:
             "disks": new_disks,
             "ssh_key": self.ssh_key.name,
             "snapshot_type": self.snapshot_type.value,
+            "meta": self.meta,
         }
         snap_json = dst / "snapshot.json"
         snap_json.write_text(json.dumps(obj))
@@ -937,7 +938,7 @@ class Microvm:
             ssh_key=self.ssh_key,
             snapshot_type=snapshot_type,
             meta={
-                "kernel_file": self.kernel_file,
+                "kernel_file": str(self.kernel_file),
             },
         )
 
@@ -978,6 +979,8 @@ class Microvm:
 
         for key, value in snapshot.meta.items():
             setattr(self, key, value)
+        # Adjust things just in case
+        self.kernel_file = Path(self.kernel_file)
 
         self.api.snapshot_load.put(
             mem_backend=mem_backend,


### PR DESCRIPTION
We missed saving metadata when saving to disk

Fixes: 426790e4001ac7315554f876637298fb37fb85a8

## Changes

Save the metadata when storing snapshot on disk

## Reason

Fix pipelines that started failing because of the previous change

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
