### PR TITLE
fix: rename page_size_kib to page_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to
 
 ### Deprecated
 
+- [#4948](https://github.com/firecracker-microvm/firecracker/pull/4948):
+  Deprecated the `page_size_kib` field in the
+  [UFFD handshake](docs/snapshotting/handling-page-faults-on-snapshot-resume.md#registering-memory-to-be-handled-via-userfault-file-descriptors),
+  and replaced it with a `page_size` field. The `page_size_kib` field is
+  misnamed, as the value Firecracker sets it to is actually the page size in
+  _bytes_, not KiB. It will be removed in Firecracker 2.0.
+
 ### Removed
 
 ### Fixed

--- a/src/firecracker/examples/uffd/uffd_utils.rs
+++ b/src/firecracker/examples/uffd/uffd_utils.rs
@@ -32,7 +32,7 @@ pub struct GuestRegionUffdMapping {
     /// Offset in the backend file/buffer where the region contents are.
     pub offset: u64,
     /// The configured page size for this memory region.
-    pub page_size_kib: usize,
+    pub page_size: usize,
 }
 
 impl GuestRegionUffdMapping {
@@ -79,7 +79,7 @@ impl UffdHandler {
                 mappings.len()
             )
         });
-        let page_size = first_mapping.page_size_kib;
+        let page_size = first_mapping.page_size;
 
         // Make sure memory size matches backing data size.
         assert_eq!(memsize, size);
@@ -152,10 +152,7 @@ impl UffdHandler {
                     return false;
                 }
                 Err(Error::CopyFailed(errno))
-                    if std::io::Error::from(errno).raw_os_error().unwrap() == libc::EEXIST =>
-                {
-                    ()
-                }
+                    if std::io::Error::from(errno).raw_os_error().unwrap() == libc::EEXIST => {}
                 Err(e) => {
                     panic!("Uffd copy failed: {e:?}");
                 }
@@ -364,7 +361,7 @@ mod tests {
             base_host_virt_addr: 0,
             size: 0x1000,
             offset: 0,
-            page_size_kib: 4096,
+            page_size: 4096,
         }];
         let dummy_memory_region_json = serde_json::to_string(&dummy_memory_region).unwrap();
 
@@ -397,7 +394,7 @@ mod tests {
             base_host_virt_addr: 0,
             size: 0,
             offset: 0,
-            page_size_kib: 4096,
+            page_size: 4096,
         }];
         let error_memory_region_json = serde_json::to_string(&error_memory_region).unwrap();
         stream

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -108,6 +108,11 @@ pub struct GuestRegionUffdMapping {
     /// Offset in the backend file/buffer where the region contents are.
     pub offset: u64,
     /// The configured page size for this memory region.
+    pub page_size: usize,
+    /// The configured page size **in bytes** for this memory region. The name is
+    /// wrong but cannot be changed due to being API, so this field is deprecated,
+    /// to be removed in 2.0.
+    #[deprecated]
     pub page_size_kib: usize,
 }
 
@@ -593,11 +598,13 @@ fn create_guest_memory(
     let mut backend_mappings = Vec::with_capacity(guest_memory.num_regions());
     let mut offset = 0;
     for mem_region in guest_memory.iter() {
+        #[allow(deprecated)]
         backend_mappings.push(GuestRegionUffdMapping {
             base_host_virt_addr: mem_region.as_ptr() as u64,
             size: mem_region.size(),
             offset,
-            page_size_kib: huge_pages.page_size_kib(),
+            page_size: huge_pages.page_size(),
+            page_size_kib: huge_pages.page_size(),
         });
         offset += mem_region.size() as u64;
     }
@@ -788,26 +795,26 @@ mod tests {
         assert_eq!(uffd_regions.len(), 1);
         assert_eq!(uffd_regions[0].size, 0x20000);
         assert_eq!(uffd_regions[0].offset, 0);
-        assert_eq!(
-            uffd_regions[0].page_size_kib,
-            HugePageConfig::None.page_size_kib()
-        );
+        assert_eq!(uffd_regions[0].page_size, HugePageConfig::None.page_size());
     }
 
     #[test]
     fn test_send_uffd_handshake() {
+        #[allow(deprecated)]
         let uffd_regions = vec![
             GuestRegionUffdMapping {
                 base_host_virt_addr: 0,
                 size: 0x100000,
                 offset: 0,
-                page_size_kib: HugePageConfig::None.page_size_kib(),
+                page_size: HugePageConfig::None.page_size(),
+                page_size_kib: HugePageConfig::None.page_size(),
             },
             GuestRegionUffdMapping {
                 base_host_virt_addr: 0x100000,
                 size: 0x200000,
                 offset: 0,
-                page_size_kib: HugePageConfig::Hugetlbfs2M.page_size_kib(),
+                page_size: HugePageConfig::Hugetlbfs2M.page_size(),
+                page_size_kib: HugePageConfig::Hugetlbfs2M.page_size(),
             },
         ];
 

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -71,8 +71,8 @@ impl HugePageConfig {
         matches!(self, HugePageConfig::Hugetlbfs2M)
     }
 
-    /// Gets the page size in KiB of this [`HugePageConfig`].
-    pub fn page_size_kib(&self) -> usize {
+    /// Gets the page size in bytes of this [`HugePageConfig`].
+    pub fn page_size(&self) -> usize {
         match self {
             HugePageConfig::None => 4096,
             HugePageConfig::Hugetlbfs2M => 2 * 1024 * 1024,


### PR DESCRIPTION
## Changes
* update `page_size_kib` name to the more accurate `page_size`, since it's actually in bytes, not KiB.
...

We leave the old page_size_kib field in there, but mark it as deprecated to avoid any Firecracker code from accidentally using it (and update everything on the Firecracker side to be called page_size instead of page_size_kib). This way we're backward compatible (and can remove the wrongly named field in 2.0), but have correctly named variables in the code base at least.
...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
