### PR TITLE
tests: compile test_syscall with musl-gcc

### DIFF
--- a/tests/host_tools/test_syscalls.c
+++ b/tests/host_tools/test_syscalls.c
@@ -28,7 +28,6 @@ void install_bpf_filter(char *bpf_file) {
         exit(EXIT_FAILURE);
     }
     size_t size = sb.st_size;
-    size_t insn_len = size / sizeof(struct sock_filter);
     struct sock_filter *filterbuf = (struct sock_filter*)malloc(size);
     if (read(fd, filterbuf, size) == -1) {
         perror("read");
@@ -36,6 +35,7 @@ void install_bpf_filter(char *bpf_file) {
     }
 
     /* Install seccomp filter */
+    size_t insn_len = size / sizeof(struct sock_filter);
     struct sock_fprog prog = {
         .len = (unsigned short)(insn_len),
         .filter = filterbuf,
@@ -60,11 +60,11 @@ int main(int argc, char **argv) {
     char *bpf_file = argv[1];
     long syscall_id = atoi(argv[2]);
     long arg0, arg1, arg2, arg3;
-    arg0 = arg1 = arg2 = arg3 = 0;
-    if (argc > 3) arg0 = atoi(argv[3]);
-    if (argc > 4) arg1 = atoi(argv[4]);
-    if (argc > 5) arg2 = atoi(argv[5]);
-    if (argc > 6) arg3 = atoi(argv[6]);
+    arg0 = arg1 = arg2 = arg3 = 0L;
+    if (argc > 3) arg0 = atol(argv[3]);
+    if (argc > 4) arg1 = atol(argv[4]);
+    if (argc > 5) arg2 = atol(argv[5]);
+    if (argc > 6) arg3 = atol(argv[6]);
 
     /* read seccomp filter from file */
     if (strcmp(bpf_file, "/dev/null") != 0) {
@@ -72,6 +72,5 @@ int main(int argc, char **argv) {
     }
 
     long res = syscall(syscall_id, arg0, arg1, arg2, arg3);
-    printf("%ld\n", res);
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
In addition do a few more cleanups to the test:

- Use `atol` to read longs

- musl makes an ioctl that is not permitted in seccomp. We didn't use the return code anyway, so remove it.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
