### PR TITLE
fix(test): remove timeouts from MSR integration tests

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -9,8 +9,8 @@ line-length=72
 
 [ignore-body-lines]
 # Ignore HTTP reference links
-# Ignore lines that start with 'Co-Authored-By' or with 'Signed-off-by'
-regex=(^\[.+\]: http.+)|(^Co-Authored-By)|(^Signed-off-by)
+# Ignore lines that start with 'Co-Authored-By', with 'Signed-off-by' or with 'Fixes'
+regex=(^\[.+\]: http.+)|(^Co-Authored-By)|(^Signed-off-by)|(^Fixes:)
 
 [ignore-by-author-name]
 # Ignore certain rules for commits of which the author name matches a regex

--- a/tests/integration_tests/functional/test_cpu_features_x86_64.py
+++ b/tests/integration_tests/functional/test_cpu_features_x86_64.py
@@ -314,7 +314,7 @@ def test_cpu_rdmsr(
     )
     vm.start()
     vm.ssh.scp_put(DATA_FILES / "msr_reader.sh", "/tmp/msr_reader.sh")
-    _, stdout, stderr = vm.ssh.run("/tmp/msr_reader.sh")
+    _, stdout, stderr = vm.ssh.run("/tmp/msr_reader.sh", timeout=None)
     assert stderr == ""
 
     # Load results read from the microvm
@@ -362,7 +362,9 @@ def dump_msr_state_to_file(dump_fname, ssh_conn, shared_names):
     ssh_conn.scp_put(
         shared_names["msr_reader_host_fname"], shared_names["msr_reader_guest_fname"]
     )
-    _, stdout, stderr = ssh_conn.run(shared_names["msr_reader_guest_fname"])
+    _, stdout, stderr = ssh_conn.run(
+        shared_names["msr_reader_guest_fname"], timeout=None
+    )
     assert stderr == ""
 
     with open(dump_fname, "w", encoding="UTF-8") as file:
@@ -416,7 +418,9 @@ def test_cpu_wrmsr_snapshot(microvm_factory, guest_kernel, rootfs, msr_cpu_templ
     wrmsr_input_guest_fname = "/tmp/wrmsr_input.txt"
     vm.ssh.scp_put(wrmsr_input_host_fname, wrmsr_input_guest_fname)
 
-    _, _, stderr = vm.ssh.run(f"{msr_writer_guest_fname} {wrmsr_input_guest_fname}")
+    _, _, stderr = vm.ssh.run(
+        f"{msr_writer_guest_fname} {wrmsr_input_guest_fname}", timeout=None
+    )
     assert stderr == ""
 
     # Dump MSR state to a file that will be published to S3 for the 2nd part of the test


### PR DESCRIPTION
These run in a nightly pipeline and apparently the read/write MSR scripts take longer than the 100s default timeout added in b99abe1.

Fixes: 36448e94ebf4 ("test: set default timeout of 100s for ssh commands")

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
