### PR TITLE
fix(test): ensure socat gets killed in test_5_snapshots

### DIFF
--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -142,53 +142,55 @@ def check_guest_connections(vm, server_port_path, blob_path, blob_hash):
         ["socat", f"UNIX-LISTEN:{server_port_path},fork,backlog=5", "exec:'/bin/cat'"]
     )
 
-    # Link the listening Unix socket into the VM's jail, so that
-    # Firecracker can connect to it.
-    attempt = 0
-    # But 1st, give socat a bit of time to create the socket
-    while not Path(server_port_path).exists() and attempt < 3:
-        time.sleep(0.2)
-        attempt += 1
-    vm.create_jailed_resource(server_port_path)
+    try:
+        # Link the listening Unix socket into the VM's jail, so that
+        # Firecracker can connect to it.
+        attempt = 0
+        # But 1st, give socat a bit of time to create the socket
+        while not Path(server_port_path).exists() and attempt < 3:
+            time.sleep(0.2)
+            attempt += 1
+        vm.create_jailed_resource(server_port_path)
 
-    # Increase maximum process count for the ssh service.
-    # Avoids: "bash: fork: retry: Resource temporarily unavailable"
-    # Needed to execute the bash script that tests for concurrent
-    # vsock guest initiated connections.
-    pids_max_file = "/sys/fs/cgroup/system.slice/ssh.service/pids.max"
-    ecode, _, _ = vm.ssh.run(f"echo 1024 > {pids_max_file}")
-    assert ecode == 0, "Unable to set max process count for guest ssh service."
+        # Increase maximum process count for the ssh service.
+        # Avoids: "bash: fork: retry: Resource temporarily unavailable"
+        # Needed to execute the bash script that tests for concurrent
+        # vsock guest initiated connections.
+        pids_max_file = "/sys/fs/cgroup/system.slice/ssh.service/pids.max"
+        ecode, _, _ = vm.ssh.run(f"echo 1024 > {pids_max_file}")
+        assert ecode == 0, "Unable to set max process count for guest ssh service."
 
-    # Build the guest worker sub-command.
-    # `vsock_helper` will read the blob file from STDIN and send the echo
-    # server response to STDOUT. This response is then hashed, and the
-    # hash is compared against `blob_hash` (computed on the host). This
-    # comparison sets the exit status of the worker command.
-    worker_cmd = "hash=$("
-    worker_cmd += "cat {}".format(blob_path)
-    worker_cmd += " | /tmp/vsock_helper echo 2 {}".format(ECHO_SERVER_PORT)
-    worker_cmd += " | md5sum | cut -f1 -d\\ "
-    worker_cmd += ")"
-    worker_cmd += ' && [[ "$hash" = "{}" ]]'.format(blob_hash)
+        # Build the guest worker sub-command.
+        # `vsock_helper` will read the blob file from STDIN and send the echo
+        # server response to STDOUT. This response is then hashed, and the
+        # hash is compared against `blob_hash` (computed on the host). This
+        # comparison sets the exit status of the worker command.
+        worker_cmd = "hash=$("
+        worker_cmd += "cat {}".format(blob_path)
+        worker_cmd += " | /tmp/vsock_helper echo 2 {}".format(ECHO_SERVER_PORT)
+        worker_cmd += " | md5sum | cut -f1 -d\\ "
+        worker_cmd += ")"
+        worker_cmd += ' && [[ "$hash" = "{}" ]]'.format(blob_hash)
 
-    # Run `TEST_CONNECTION_COUNT` concurrent workers, using the above
-    # worker sub-command.
-    # If any worker fails, this command will fail. If all worker sub-commands
-    # succeed, this will also succeed.
-    cmd = 'workers="";'
-    cmd += "for i in $(seq 1 {}); do".format(TEST_CONNECTION_COUNT)
-    cmd += "  ({})& ".format(worker_cmd)
-    cmd += '  workers="$workers $!";'
-    cmd += "done;"
-    cmd += "for w in $workers; do wait $w || (wait; exit 1); done"
+        # Run `TEST_CONNECTION_COUNT` concurrent workers, using the above
+        # worker sub-command.
+        # If any worker fails, this command will fail. If all worker sub-commands
+        # succeed, this will also succeed.
+        cmd = 'workers="";'
+        cmd += "for i in $(seq 1 {}); do".format(TEST_CONNECTION_COUNT)
+        cmd += "  ({})& ".format(worker_cmd)
+        cmd += '  workers="$workers $!";'
+        cmd += "done;"
+        cmd += "for w in $workers; do wait $w || (wait; exit 1); done"
 
-    ecode, _, stderr = vm.ssh.run(cmd)
-    echo_server.terminate()
-    rc = echo_server.wait()
-    # socat exits with 128 + 15 (SIGTERM)
-    assert rc == 143
+        ecode, _, stderr = vm.ssh.run(cmd)
 
-    assert ecode == 0, stderr
+        assert ecode == 0, stderr
+    finally:
+        echo_server.terminate()
+        rc = echo_server.wait()
+        # socat exits with 128 + 15 (SIGTERM)
+        assert rc == 143
 
 
 def make_host_port_path(uds_path, port):

--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -156,9 +156,9 @@ def check_guest_connections(vm, server_port_path, blob_path, blob_hash):
         # Avoids: "bash: fork: retry: Resource temporarily unavailable"
         # Needed to execute the bash script that tests for concurrent
         # vsock guest initiated connections.
-        pids_max_file = "/sys/fs/cgroup/system.slice/ssh.service/pids.max"
-        ecode, _, _ = vm.ssh.run(f"echo 1024 > {pids_max_file}")
-        assert ecode == 0, "Unable to set max process count for guest ssh service."
+        vm.ssh.check_output(
+            "echo 1024 > /sys/fs/cgroup/system.slice/ssh.service/pids.max"
+        )
 
         # Build the guest worker sub-command.
         # `vsock_helper` will read the blob file from STDIN and send the echo
@@ -183,9 +183,7 @@ def check_guest_connections(vm, server_port_path, blob_path, blob_hash):
         cmd += "done;"
         cmd += "for w in $workers; do wait $w || (wait; exit 1); done"
 
-        ecode, _, stderr = vm.ssh.run(cmd)
-
-        assert ecode == 0, stderr
+        vm.ssh.check_output(cmd)
     finally:
         echo_server.terminate()
         rc = echo_server.wait()


### PR DESCRIPTION
Use a try-finally block inside check_guest_connection to make sure that
socat gets killed even if something inside check_guest_connection fails
and raises an exception.

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
