### PR TITLE
chore: unpin m6i/6.1 ami

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -124,8 +124,6 @@ for test in tests:
 pins = {
     # TODO: Unpin when performance instability on m6i/5.10 has gone.
     "linux_5.10-pinned": {"instance": "m6i.metal", "kv": "linux_5.10"},
-    # TODO: Unpin when performance instability on m6i/6.1 has gone.
-    "linux_6.1-pinned": {"instance": "m6i.metal", "kv": "linux_6.1"},
 }
 
 


### PR DESCRIPTION
## Changes

Unpin m6i/6.1 AMI.

## Reason

The volatility is not visible on the latest AMI.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- ~~[ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.~~
- ~~[ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.~~
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
