### PR TITLE
ci: print EC2 AMI in the pytest report header

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,11 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_report_header():
+    """Pytest hook to print relevant metadata in the logs"""
+    return f"EC2 AMI: {global_props.ami}"
+
+
 @pytest.hookimpl(wrapper=True, tryfirst=True)
 def pytest_runtest_makereport(item, call):  # pylint:disable=unused-argument
     """Plugin to get test results in fixtures


### PR DESCRIPTION
## Changes

Print the EC2 AMI in the pytest report header.

## Reason

To easily tell which AMI is being used, for validation or troubleshooting

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
