### PR TITLE
ci: fix passing simple values to step parameters

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -139,7 +139,8 @@ class DictAction(argparse.Action):
         res = getattr(namespace, self.dest, {})
         key_str, val = value.split("=", maxsplit=1)
         keys = key_str.split("/")
-        update = {keys[-1]: ast.literal_eval(val)}
+        # Interpret it as a literal iff it starts like one
+        update = {keys[-1]: ast.literal_eval(val) if val[0] in "[{'" else val}
         for key in list(reversed(keys))[1:]:
             update = {key: update}
         res = overlay_dict(res, update)


### PR DESCRIPTION
In c6add4fccf27cd0522a7e49a2c5dc67ab7067980 while adding support for more complex parameters we broke passing simple strings.

While it can be worked around by quoting the string with '', that makes the simple case more complex than it was before, and breaks previous pipeline definitions.

Fix it so if the first character does not look like a python expression, take the value verbatim.

Fixes: c6add4fccf27cd0522a7e49a2c5dc67ab7067980

## Changes

Tested with:

```
.buildkite/pipeline_perf.py --step-param env/foo1=foo --step-param env/foo2=[1,2]
```

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
