### PR TITLE
docker update

### DIFF
--- a/tests/integration_tests/build/test_seccomp_no_redundant_rules.py
+++ b/tests/integration_tests/build/test_seccomp_no_redundant_rules.py
@@ -5,8 +5,6 @@
 import platform
 from pathlib import Path
 
-import pytest
-
 from framework import utils
 from framework.static_analysis import (
     determine_unneeded_seccomp_rules,
@@ -15,10 +13,6 @@ from framework.static_analysis import (
 )
 
 
-@pytest.mark.skipif(
-    platform.machine() != "x86_64",
-    reason="aarch64 nightly toolchain does not support flags needed to compile analyzable binary yet",
-)
 def test_redundant_seccomp_rules():
     """Test that fails if static analysis determines redundant seccomp rules"""
     arch = platform.processor()

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -113,7 +113,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-too
     && rustup target add x86_64-unknown-linux-musl \
     && rustup target add aarch64-unknown-linux-musl \
     && rustup component add llvm-tools-preview clippy rustfmt \
-    && cargo install --locked cargo-audit cargo-deny@0.16.1 grcov cargo-sort cargo-afl \
+    && cargo install --locked cargo-audit cargo-deny grcov cargo-sort cargo-afl \
     && cargo install --locked kani-verifier && cargo kani setup \
     \
     && NIGHTLY_TOOLCHAIN=$(rustup toolchain list | grep nightly | tr -d '\n') \
@@ -149,12 +149,18 @@ RUN cd /usr/include/$ARCH-linux-musl \
     && ln -s ../asm-generic asm-generic
 
 # Install static version of libseccomp
-#
+# We need to compile from source because 
+# libseccomp provided by the distribution is not
+# compiled with musl-gcc and we need this
+# for our musl builds.
+# We specify the tag in order to have a fixed version
+# of the library.
 RUN apt-get update \
     && apt-get -y install \
         libtool gperf \
     && git clone https://github.com/seccomp/libseccomp /tmp/libseccomp \
     && cd /tmp/libseccomp \
+    && git checkout tags/v2.5.5 \
     && ./autogen.sh \
     && CC="musl-gcc -static" ./configure --enable-static=yes --enable-shared=false \
     && make install \

--- a/tools/devtool
+++ b/tools/devtool
@@ -68,7 +68,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v76}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v77}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
## Changes
Update kani tool-chain.
Unpin cargo-deny because rust tool-chain has been upgraded.
Specify tag for libseccomp to have a fixed version.
Allow seccomp rules integration test to run on aarch64.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
Unpin cargo-deny because rust tool-chain has been upgraded.
Specify tag for libseccomp to have a fixed version.

Signed-off-by: Egor Lazarchuk <yegorlz@amazon.co.uk>