### PR TITLE
CI: also test amazonlinux:2023 in the popular containers test 

### DIFF
--- a/tools/test-popular-containers/build_rootfs.sh
+++ b/tools/test-popular-containers/build_rootfs.sh
@@ -48,7 +48,6 @@ function make_rootfs {
     systemd-nspawn --timezone=off --pipe -i $IMG /bin/sh <<EOF
 set -x
 . /etc/os-release
-passwd -d root
 case \$ID in
 ubuntu)
     export DEBIAN_FRONTEND=noninteractive
@@ -61,7 +60,15 @@ alpine)
     rc-update add local default
     echo "ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100" >>/etc/inittab
     ;;
+amzn)
+    dnf update
+    dnf install -y openssh-server iproute passwd
+    # re-do this
+    ln -svf /etc/systemd/system/fcnet.service /etc/systemd/system/sysinit.target.wants/fcnet.service
+    rm -fv /etc/systemd/system/getty.target.wants/getty@tty1.service
+    ;;
 esac
+passwd -d root
 EOF
 }
 
@@ -70,3 +77,4 @@ make_rootfs ubuntu:22.04
 make_rootfs ubuntu:24.04
 make_rootfs ubuntu:24.10
 # make_rootfs ubuntu:latest
+make_rootfs amazonlinux:2023


### PR DESCRIPTION
## Changes

Add Amazon Linux 2023 to the list of rootfs we try.

## Reason

We have no RHEL-derivative examples, and it would be good to have some variety.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
