### PR TITLE
feat: reset KVM_REG_ARM_PTIMER_CNT on VM boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to
 
 ### Added
 
+- [#4987](https://github.com/firecracker-microvm/firecracker/pull/4987): Reset
+  physical counter register (`CNTPCT_EL0`) on VM startup. This avoids VM reading
+  the host physical counter value. This is only possible on 6.4 and newer
+  kernels. For older kernels physical counter will still be passed to the guest
+  unmodified. See more info
+  [here](https://github.com/firecracker-microvm/firecracker/blob/main/docs/prod-host-setup.md#arm-only-vm-physical-counter-behaviour)
+
 ### Changed
 
 - [#4913](https://github.com/firecracker-microvm/firecracker/pull/4913): Removed

--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -328,13 +328,16 @@ For vendor-specific recommendations, please consult the resources below:
 - ARM:
   [Speculative Processor Vulnerability](https://developer.arm.com/support/arm-security-updates/speculative-processor-vulnerability)
 
-##### [ARM only] Physical counter directly passed through to the guest
+##### [ARM only] VM Physical counter behaviour
 
-On ARM, the physical counter (i.e `CNTPCT`) it is returning the
-[actual EL1 physical counter value of the host][1]. From the discussions before
-merging this change [upstream][2], this seems like a conscious design decision
-of the ARM code contributors, giving precedence to performance over the ability
-to trap and control this in the hypervisor.
+On ARM, Firecracker tries to reset the `CNTPCT` physical counter on VM boot.
+This is done in order to prevent VM from reading host physical counter value.
+Firecracker will only try to reset the counter if the host KVM contains
+`KVM_CAP_COUNTER_OFFSET` capability. This capability is only present in kernels
+containing
+[this](https://lore.kernel.org/all/20230330174800.2677007-1-maz@kernel.org/)
+patch series (starting from 6.4 and newer). For older kernels the counter value
+will be passed through from the host.
 
 ##### Verification
 
@@ -428,6 +431,3 @@ To validate that the change took effect, the file
 [^1]: Look for `GRUB_CMDLINE_LINUX` in file `/etc/default/grub` in RPM-based
     systems, and
     [this doc for Ubuntu](https://wiki.ubuntu.com/Kernel/KernelBootParameters).
-
-[1]: https://elixir.free-electrons.com/linux/v4.14.203/source/virt/kvm/arm/hyp/timer-sr.c#L63
-[2]: https://lists.cs.columbia.edu/pipermail/kvmarm/2017-January/023323.html

--- a/src/vmm/src/arch/aarch64/regs.rs
+++ b/src/vmm/src/arch/aarch64/regs.rs
@@ -99,6 +99,12 @@ arm64_sys_reg!(SYS_CNTV_CVAL_EL0, 3, 3, 14, 3, 2);
 // https://elixir.bootlin.com/linux/v6.8/source/arch/arm64/include/asm/sysreg.h#L459
 arm64_sys_reg!(SYS_CNTPCT_EL0, 3, 3, 14, 0, 1);
 
+// Physical Timer EL0 count Register
+// The id of this register is same as SYS_CNTPCT_EL0, but KVM defines it
+// separately, so we do as well.
+// https://elixir.bootlin.com/linux/v6.12.6/source/arch/arm64/include/uapi/asm/kvm.h#L259
+arm64_sys_reg!(KVM_REG_ARM_PTIMER_CNT, 3, 3, 14, 0, 1);
+
 // Translation Table Base Register
 // https://developer.arm.com/documentation/ddi0595/2021-03/AArch64-Registers/TTBR1-EL1--Translation-Table-Base-Register-1--EL1-
 arm64_sys_reg!(TTBR1_EL1, 3, 0, 2, 0, 1);

--- a/src/vmm/src/arch/aarch64/vcpu.rs
+++ b/src/vmm/src/arch/aarch64/vcpu.rs
@@ -214,16 +214,16 @@ pub fn set_mpstate(vcpufd: &VcpuFd, state: kvm_mp_state) -> Result<(), VcpuError
 #[cfg(test)]
 mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
-    use kvm_ioctls::Kvm;
 
     use super::*;
     use crate::arch::aarch64::layout;
     use crate::test_utils::arch_mem;
+    use crate::vstate::kvm::Kvm;
 
     #[test]
     fn test_setup_regs() {
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
+        let kvm = Kvm::new(vec![]).unwrap();
+        let vm = kvm.fd.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let mem = arch_mem(layout::FDT_MAX_SIZE + 0x1000);
 
@@ -242,8 +242,8 @@ mod tests {
 
     #[test]
     fn test_read_mpidr() {
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
+        let kvm = Kvm::new(vec![]).unwrap();
+        let vm = kvm.fd.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi).unwrap();
@@ -261,8 +261,8 @@ mod tests {
 
     #[test]
     fn test_get_set_regs() {
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
+        let kvm = Kvm::new(vec![]).unwrap();
+        let vm = kvm.fd.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi).unwrap();
@@ -283,8 +283,8 @@ mod tests {
     fn test_mpstate() {
         use std::os::unix::io::AsRawFd;
 
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
+        let kvm = Kvm::new(vec![]).unwrap();
+        let vm = kvm.fd.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi).unwrap();

--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -244,14 +244,11 @@ impl PortIODeviceManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::single_region_mem;
-    use crate::Vm;
+    use crate::vstate::vm::tests::setup_vm_with_memory;
 
     #[test]
     fn test_register_legacy_devices() {
-        let guest_mem = single_region_mem(0x1000);
-        let mut vm = Vm::new(vec![]).unwrap();
-        vm.memory_init(&guest_mem, false).unwrap();
+        let (_, mut vm, _) = setup_vm_with_memory(0x1000);
         crate::builder::setup_interrupt_controller(&mut vm).unwrap();
         let mut ldm = PortIODeviceManager::new(
             Arc::new(Mutex::new(BusDevice::Serial(SerialDevice {

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -544,6 +544,7 @@ mod tests {
     use crate::devices::virtio::queue::Queue;
     use crate::devices::virtio::ActivateError;
     use crate::test_utils::multi_region_mem;
+    use crate::vstate::kvm::Kvm;
     use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
     use crate::{builder, Vm};
 
@@ -661,7 +662,8 @@ mod tests {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
-        let mut vm = Vm::new(vec![]).unwrap();
+        let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
+        let mut vm = Vm::new(&kvm).unwrap();
         vm.memory_init(&guest_mem, false).unwrap();
         let mut device_manager = MMIODeviceManager::new();
         let mut resource_allocator = ResourceAllocator::new().unwrap();
@@ -690,7 +692,8 @@ mod tests {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
-        let mut vm = Vm::new(vec![]).unwrap();
+        let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
+        let mut vm = Vm::new(&kvm).unwrap();
         vm.memory_init(&guest_mem, false).unwrap();
         let mut device_manager = MMIODeviceManager::new();
         let mut resource_allocator = ResourceAllocator::new().unwrap();
@@ -744,7 +747,8 @@ mod tests {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
-        let mut vm = Vm::new(vec![]).unwrap();
+        let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
+        let mut vm = Vm::new(&kvm).unwrap();
         vm.memory_init(&guest_mem, false).unwrap();
 
         let mem_clone = guest_mem.clone();

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -36,6 +36,7 @@ use crate::vmm_config::machine_config::{HugePageConfig, MachineConfigError, Mach
 use crate::vmm_config::snapshot::{
     CreateSnapshotParams, LoadSnapshotParams, MemBackendType, SnapshotType,
 };
+use crate::vstate::kvm::KvmState;
 use crate::vstate::memory::{
     GuestMemory, GuestMemoryExtension, GuestMemoryMmap, GuestMemoryState, MemoryError,
 };
@@ -77,6 +78,8 @@ pub struct MicrovmState {
     pub vm_info: VmInfo,
     /// Memory state.
     pub memory_state: GuestMemoryState,
+    /// KVM KVM state.
+    pub kvm_state: KvmState,
     /// VM KVM state.
     pub vm_state: VmState,
     /// Vcpu states.
@@ -736,6 +739,7 @@ mod tests {
             device_states: states,
             memory_state,
             vcpu_states,
+            kvm_state: Default::default(),
             vm_info: VmInfo {
                 mem_size_mib: 1u64,
                 ..Default::default()

--- a/src/vmm/src/vstate/kvm.rs
+++ b/src/vmm/src/vstate/kvm.rs
@@ -140,7 +140,13 @@ impl Kvm {
         }
     }
 }
-
+#[cfg(target_arch = "aarch64")]
+/// Optional capabilities.
+#[derive(Debug, Default)]
+pub struct OptionalCapabilities {
+    /// KVM_CAP_COUNTER_OFFSET
+    pub counter_offset: bool,
+}
 #[cfg(target_arch = "aarch64")]
 impl Kvm {
     const DEFAULT_CAPABILITIES: [u32; 7] = [
@@ -152,6 +158,16 @@ impl Kvm {
         kvm_bindings::KVM_CAP_MP_STATE,
         kvm_bindings::KVM_CAP_ONE_REG,
     ];
+
+    /// Returns struct with optional capabilities statuses.
+    pub fn optional_capabilities(&self) -> OptionalCapabilities {
+        OptionalCapabilities {
+            counter_offset: self
+                .fd
+                .check_extension_raw(kvm_bindings::KVM_CAP_COUNTER_OFFSET.into())
+                != 0,
+        }
+    }
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/vstate/kvm.rs
+++ b/src/vmm/src/vstate/kvm.rs
@@ -1,0 +1,205 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use kvm_bindings::KVM_API_VERSION;
+#[cfg(target_arch = "x86_64")]
+use kvm_bindings::{CpuId, MsrList, KVM_MAX_CPUID_ENTRIES};
+use kvm_ioctls::Kvm as KvmFd;
+use serde::{Deserialize, Serialize};
+
+use crate::cpu_config::templates::KvmCapability;
+use crate::vstate::memory::{GuestMemory, GuestMemoryMmap};
+
+/// Errors associated with the wrappers over KVM ioctls.
+/// Needs `rustfmt::skip` to make multiline comments work
+#[rustfmt::skip]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
+pub enum KvmError {
+    /// The host kernel reports an invalid KVM API version: {0}
+    ApiVersion(i32),
+    /// Missing KVM capabilities: {0:#x?}
+    Capabilities(u32),
+    /**  Error creating KVM object: {0} Make sure the user launching the firecracker process is \
+    configured on the /dev/kvm file's ACL. */
+    Kvm(kvm_ioctls::Error),
+    #[cfg(target_arch = "x86_64")]
+    /// Failed to get MSR index list to save into snapshots: {0}
+    GetMsrsToSave(crate::arch::x86_64::msr::MsrError),
+    #[cfg(target_arch = "x86_64")]
+    /// Failed to get supported cpuid: {0}
+    GetSupportedCpuId(kvm_ioctls::Error),
+    /// The number of configured slots is bigger than the maximum reported by KVM
+    NotEnoughMemorySlots,
+}
+
+/// Struct with kvm fd and kvm associated paramenters.
+#[derive(Debug)]
+pub struct Kvm {
+    /// KVM fd.
+    pub fd: KvmFd,
+    /// Maximum number of memory slots allowed by KVM.
+    pub max_memslots: usize,
+    /// Additional capabilities that were specified in cpu template.
+    pub kvm_cap_modifiers: Vec<KvmCapability>,
+
+    #[cfg(target_arch = "x86_64")]
+    /// Supported CpuIds.
+    pub supported_cpuid: CpuId,
+    #[cfg(target_arch = "x86_64")]
+    /// Msrs needed to be saved on snapshot creation.
+    pub msrs_to_save: MsrList,
+}
+
+impl Kvm {
+    /// Create `Kvm` struct.
+    pub fn new(kvm_cap_modifiers: Vec<KvmCapability>) -> Result<Self, KvmError> {
+        let kvm_fd = KvmFd::new().map_err(KvmError::Kvm)?;
+
+        // Check that KVM has the correct version.
+        // Safe to cast because this is a constant.
+        #[allow(clippy::cast_possible_wrap)]
+        if kvm_fd.get_api_version() != KVM_API_VERSION as i32 {
+            return Err(KvmError::ApiVersion(kvm_fd.get_api_version()));
+        }
+
+        let total_caps = Self::combine_capabilities(&kvm_cap_modifiers);
+        // Check that all desired capabilities are supported.
+        Self::check_capabilities(&kvm_fd, &total_caps).map_err(KvmError::Capabilities)?;
+
+        let max_memslots = kvm_fd.get_nr_memslots();
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            Ok(Self {
+                fd: kvm_fd,
+                max_memslots,
+                kvm_cap_modifiers,
+            })
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            let supported_cpuid = kvm_fd
+                .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
+                .map_err(KvmError::GetSupportedCpuId)?;
+            let msrs_to_save = crate::arch::x86_64::msr::get_msrs_to_save(&kvm_fd)
+                .map_err(KvmError::GetMsrsToSave)?;
+
+            Ok(Kvm {
+                fd: kvm_fd,
+                max_memslots,
+                kvm_cap_modifiers,
+                supported_cpuid,
+                msrs_to_save,
+            })
+        }
+    }
+
+    /// Check guest memory does not have more regions than kvm allows.
+    pub fn check_memory(&self, guest_mem: &GuestMemoryMmap) -> Result<(), KvmError> {
+        if guest_mem.num_regions() > self.max_memslots {
+            Err(KvmError::NotEnoughMemorySlots)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn combine_capabilities(kvm_cap_modifiers: &[KvmCapability]) -> Vec<u32> {
+        let mut total_caps = Self::DEFAULT_CAPABILITIES.to_vec();
+        for modifier in kvm_cap_modifiers.iter() {
+            match modifier {
+                KvmCapability::Add(cap) => {
+                    if !total_caps.contains(cap) {
+                        total_caps.push(*cap);
+                    }
+                }
+                KvmCapability::Remove(cap) => {
+                    if let Some(pos) = total_caps.iter().position(|c| c == cap) {
+                        total_caps.swap_remove(pos);
+                    }
+                }
+            }
+        }
+        total_caps
+    }
+
+    fn check_capabilities(kvm_fd: &KvmFd, capabilities: &[u32]) -> Result<(), u32> {
+        for cap in capabilities {
+            // If capability is not supported kernel will return 0.
+            if kvm_fd.check_extension_raw(u64::from(*cap)) == 0 {
+                return Err(*cap);
+            }
+        }
+        Ok(())
+    }
+
+    /// Saves and returns the Kvm state.
+    pub fn save_state(&self) -> KvmState {
+        KvmState {
+            kvm_cap_modifiers: self.kvm_cap_modifiers.clone(),
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+impl Kvm {
+    const DEFAULT_CAPABILITIES: [u32; 7] = [
+        kvm_bindings::KVM_CAP_IOEVENTFD,
+        kvm_bindings::KVM_CAP_IRQFD,
+        kvm_bindings::KVM_CAP_USER_MEMORY,
+        kvm_bindings::KVM_CAP_ARM_PSCI_0_2,
+        kvm_bindings::KVM_CAP_DEVICE_CTRL,
+        kvm_bindings::KVM_CAP_MP_STATE,
+        kvm_bindings::KVM_CAP_ONE_REG,
+    ];
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Kvm {
+    const DEFAULT_CAPABILITIES: [u32; 14] = [
+        kvm_bindings::KVM_CAP_IRQCHIP,
+        kvm_bindings::KVM_CAP_IOEVENTFD,
+        kvm_bindings::KVM_CAP_IRQFD,
+        kvm_bindings::KVM_CAP_USER_MEMORY,
+        kvm_bindings::KVM_CAP_SET_TSS_ADDR,
+        kvm_bindings::KVM_CAP_PIT2,
+        kvm_bindings::KVM_CAP_PIT_STATE2,
+        kvm_bindings::KVM_CAP_ADJUST_CLOCK,
+        kvm_bindings::KVM_CAP_DEBUGREGS,
+        kvm_bindings::KVM_CAP_MP_STATE,
+        kvm_bindings::KVM_CAP_VCPU_EVENTS,
+        kvm_bindings::KVM_CAP_XCRS,
+        kvm_bindings::KVM_CAP_XSAVE,
+        kvm_bindings::KVM_CAP_EXT_CPUID,
+    ];
+}
+
+/// Structure holding an general specific VM state.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct KvmState {
+    /// Additional capabilities that were specified in cpu template.
+    pub kvm_cap_modifiers: Vec<KvmCapability>,
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[test]
+    fn test_combine_capabilities() {
+        // Default caps for x86_64 and aarch64 both have KVM_CAP_IOEVENTFD and don't have
+        // KVM_CAP_IOMMU caps.
+        let additional_capabilities = vec![
+            KvmCapability::Add(kvm_bindings::KVM_CAP_IOMMU),
+            KvmCapability::Remove(kvm_bindings::KVM_CAP_IOEVENTFD),
+        ];
+
+        let combined_caps = Kvm::combine_capabilities(&additional_capabilities);
+        assert!(combined_caps
+            .iter()
+            .any(|c| *c == kvm_bindings::KVM_CAP_IOMMU));
+        assert!(!combined_caps
+            .iter()
+            .any(|c| *c == kvm_bindings::KVM_CAP_IOEVENTFD));
+    }
+}

--- a/src/vmm/src/vstate/mod.rs
+++ b/src/vmm/src/vstate/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Module with Kvm implementation.
+pub mod kvm;
 /// Module with GuestMemory implementation.
 pub mod memory;
 /// Module with Vcpu implementation.

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -1008,6 +1008,7 @@ pub(crate) mod tests {
                     smt: false,
                     cpu_config: crate::cpu_config::aarch64::CpuConfiguration::default(),
                 },
+                &kvm.optional_capabilities(),
             )
             .expect("failed to configure vcpu");
 

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -44,6 +44,8 @@ pub use aarch64::{KvmVcpuError, *};
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{KvmVcpuError, *};
 
+use super::kvm::Kvm;
+
 /// Signal number (SIGRTMIN) used to kick Vcpus.
 pub const VCPU_RTSIG_OFFSET: i32 = 0;
 
@@ -212,10 +214,10 @@ impl Vcpu {
     /// * `index` - Represents the 0-based CPU index between [0, max vcpus).
     /// * `vm` - The vm to which this vcpu will get attached.
     /// * `exit_evt` - An `EventFd` that will be written into when this vcpu exits.
-    pub fn new(index: u8, vm: &Vm, exit_evt: EventFd) -> Result<Self, VcpuError> {
+    pub fn new(index: u8, vm: &Vm, kvm: &Kvm, exit_evt: EventFd) -> Result<Self, VcpuError> {
         let (event_sender, event_receiver) = channel();
         let (response_sender, response_receiver) = channel();
-        let kvm_vcpu = KvmVcpu::new(index, vm).unwrap();
+        let kvm_vcpu = KvmVcpu::new(index, vm, kvm).unwrap();
 
         Ok(Vcpu {
             exit_evt,
@@ -777,13 +779,13 @@ pub(crate) mod tests {
     use crate::utils::signal::validate_signal_num;
     use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
     use crate::vstate::vcpu::VcpuError as EmulationError;
-    use crate::vstate::vm::tests::setup_vm;
+    use crate::vstate::vm::tests::setup_vm_with_memory;
     use crate::vstate::vm::Vm;
     use crate::RECV_TIMEOUT_SEC;
 
     #[test]
     fn test_handle_kvm_exit() {
-        let (_vm, mut vcpu, _vm_mem) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu, _vm_mem) = setup_vcpu(0x1000);
         let res = handle_kvm_exit(&mut vcpu.kvm_vcpu.peripherals, Ok(VcpuExit::Hlt));
         assert_eq!(res.unwrap(), VcpuEmulation::Stopped);
 
@@ -918,14 +920,14 @@ pub(crate) mod tests {
 
     // Auxiliary function being used throughout the tests.
     #[allow(unused_mut)]
-    pub(crate) fn setup_vcpu(mem_size: usize) -> (Vm, Vcpu, GuestMemoryMmap) {
-        let (mut vm, gm) = setup_vm(mem_size);
+    pub(crate) fn setup_vcpu(mem_size: usize) -> (Kvm, Vm, Vcpu, GuestMemoryMmap) {
+        let (kvm, mut vm, gm) = setup_vm_with_memory(mem_size);
 
         let exit_evt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
 
         #[cfg(target_arch = "aarch64")]
         let vcpu = {
-            let mut vcpu = Vcpu::new(1, &vm, exit_evt).unwrap();
+            let mut vcpu = Vcpu::new(1, &vm, &kvm, exit_evt).unwrap();
             vcpu.kvm_vcpu.init(&[]).unwrap();
             vm.setup_irqchip(1).unwrap();
             vcpu
@@ -933,9 +935,9 @@ pub(crate) mod tests {
         #[cfg(target_arch = "x86_64")]
         let vcpu = {
             vm.setup_irqchip().unwrap();
-            Vcpu::new(1, &vm, exit_evt).unwrap()
+            Vcpu::new(1, &vm, &kvm, exit_evt).unwrap()
         };
-        (vm, vcpu, gm)
+        (kvm, vm, vcpu, gm)
     }
 
     fn load_good_kernel(vm_memory: &GuestMemoryMmap) -> GuestAddress {
@@ -970,7 +972,7 @@ pub(crate) mod tests {
         Vcpu::register_kick_signal_handler();
         // Need enough mem to boot linux.
         let mem_size = 64 << 20;
-        let (_vm, mut vcpu, vm_mem) = setup_vcpu(mem_size);
+        let (kvm, _, mut vcpu, vm_mem) = setup_vcpu(mem_size);
 
         let vcpu_exit_evt = vcpu.exit_evt.try_clone().unwrap();
 
@@ -988,7 +990,7 @@ pub(crate) mod tests {
                         vcpu_count: 1,
                         smt: false,
                         cpu_config: CpuConfiguration {
-                            cpuid: Cpuid::try_from(_vm.supported_cpuid().clone()).unwrap(),
+                            cpuid: Cpuid::try_from(kvm.supported_cpuid.clone()).unwrap(),
                             msrs: BTreeMap::new(),
                         },
                     },
@@ -1022,7 +1024,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_set_mmio_bus() {
-        let (_, mut vcpu, _) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu, _) = setup_vcpu(0x1000);
         assert!(vcpu.kvm_vcpu.peripherals.mmio_bus.is_none());
         vcpu.set_mmio_bus(crate::devices::Bus::new());
         assert!(vcpu.kvm_vcpu.peripherals.mmio_bus.is_some());
@@ -1030,7 +1032,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_vcpu_tls() {
-        let (_, mut vcpu, _) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu, _) = setup_vcpu(0x1000);
 
         // Running on the TLS vcpu should fail before we actually initialize it.
         unsafe {
@@ -1061,7 +1063,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_invalid_tls() {
-        let (_, mut vcpu, _) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu, _) = setup_vcpu(0x1000);
         // Initialize vcpu TLS.
         vcpu.init_thread_local_data().unwrap();
         // Trying to initialize non-empty TLS should error.
@@ -1071,7 +1073,7 @@ pub(crate) mod tests {
     #[test]
     fn test_vcpu_kick() {
         Vcpu::register_kick_signal_handler();
-        let (vm, mut vcpu, _) = setup_vcpu(0x1000);
+        let (_, vm, mut vcpu, _) = setup_vcpu(0x1000);
 
         let mut kvm_run =
             kvm_ioctls::KvmRunWrapper::mmap_from_fd(&vcpu.kvm_vcpu.fd, vm.fd().run_size())
@@ -1126,7 +1128,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_immediate_exit_shortcircuits_execution() {
-        let (_vm, mut vcpu, _) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu, _) = setup_vcpu(0x1000);
 
         vcpu.kvm_vcpu.fd.set_kvm_immediate_exit(1);
         // Set a dummy value to be returned by the emulate call


### PR DESCRIPTION
Reset KVM_REG_ARM_PTIMER_CNT physical counter register on VM boot to avoid passing through host physical counter. Note that resetting the register on VM boot does not guarantee that VM will see the counter value 0 at startup because there is a delta in time between register reset and VM boot during which counter continues to advance.


## Reason
Prevent guest from reading host performance counter.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
