### PR TITLE
Simplify microvm builder code and make uffd test failures easier to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to
 - [#4916](https://github.com/firecracker-microvm/firecracker/pull/4916): Fixed
   `IovDeque` implementation to work with any host page size. This fixes
   virtio-net device on non 4K host kernels.
+- [#4991](https://github.com/firecracker-microvm/firecracker/pull/4991): Fixed
+  `mem_size_mib` and `track_dirty_pages` being mandatory for all
+  `PATCH /machine-config` requests. Now, they can be omitted which leaves these
+  parts of the machine configuration unchanged.
 
 ## [1.10.1]
 

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -161,7 +161,7 @@ fn run(cli: Cli) -> Result<(), HelperError> {
                 let (vmm, vm_resources) = utils::build_microvm_from_config(config, template)?;
 
                 let cpu_template = vm_resources
-                    .vm_config
+                    .machine_config
                     .cpu_template
                     .get_cpu_template()?
                     .into_owned();

--- a/src/firecracker/examples/uffd/fault_all_handler.rs
+++ b/src/firecracker/examples/uffd/fault_all_handler.rs
@@ -24,6 +24,7 @@ fn main() {
     let (stream, _) = listener.accept().expect("Cannot listen on UDS socket");
 
     let mut runtime = Runtime::new(stream, file);
+    runtime.install_panic_hook();
     runtime.run(|uffd_handler: &mut UffdHandler| {
         // Read an event from the userfaultfd.
         let event = uffd_handler

--- a/src/firecracker/examples/uffd/valid_handler.rs
+++ b/src/firecracker/examples/uffd/valid_handler.rs
@@ -24,6 +24,7 @@ fn main() {
     let (stream, _) = listener.accept().expect("Cannot listen on UDS socket");
 
     let mut runtime = Runtime::new(stream, file);
+    runtime.install_panic_hook();
     runtime.run(|uffd_handler: &mut UffdHandler| {
         // Read an event from the userfaultfd.
         let event = uffd_handler

--- a/src/firecracker/src/api_server/parsed_request.rs
+++ b/src/firecracker/src/api_server/parsed_request.rs
@@ -163,8 +163,8 @@ impl ParsedRequest {
                     info!("The request was executed successfully. Status code: 204 No Content.");
                     Response::new(Version::Http11, StatusCode::NoContent)
                 }
-                VmmData::MachineConfiguration(vm_config) => {
-                    Self::success_response_with_data(vm_config)
+                VmmData::MachineConfiguration(machine_config) => {
+                    Self::success_response_with_data(machine_config)
                 }
                 VmmData::MmdsValue(value) => Self::success_response_with_mmds_value(value),
                 VmmData::BalloonConfig(balloon_config) => {

--- a/src/firecracker/src/api_server/request/machine_configuration.rs
+++ b/src/firecracker/src/api_server/request/machine_configuration.rs
@@ -31,7 +31,8 @@ pub(crate) fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Req
     let config_update = MachineConfigUpdate::from(config);
 
     // Construct the `ParsedRequest` object.
-    let mut parsed_req = ParsedRequest::new_sync(VmmAction::UpdateVmConfiguration(config_update));
+    let mut parsed_req =
+        ParsedRequest::new_sync(VmmAction::UpdateMachineConfiguration(config_update));
     // If `cpu_template` was present, set the deprecation message in `parsing_info`.
     if let Some(msg) = deprecation_message {
         parsed_req.parsing_info().append_deprecation_message(msg);
@@ -60,7 +61,8 @@ pub(crate) fn parse_patch_machine_config(body: &Body) -> Result<ParsedRequest, R
     }
 
     // Construct the `ParsedRequest` object.
-    let mut parsed_req = ParsedRequest::new_sync(VmmAction::UpdateVmConfiguration(config_update));
+    let mut parsed_req =
+        ParsedRequest::new_sync(VmmAction::UpdateMachineConfiguration(config_update));
     // If `cpu_template` was present, set the deprecation message in `parsing_info`.
     if let Some(msg) = deprecation_message {
         parsed_req.parsing_info().append_deprecation_message(msg);
@@ -124,7 +126,7 @@ mod tests {
             };
             assert_eq!(
                 vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
-                VmmAction::UpdateVmConfiguration(expected_config)
+                VmmAction::UpdateMachineConfiguration(expected_config)
             );
         }
 
@@ -143,7 +145,7 @@ mod tests {
         };
         assert_eq!(
             vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
-            VmmAction::UpdateVmConfiguration(expected_config)
+            VmmAction::UpdateMachineConfiguration(expected_config)
         );
 
         let body = r#"{
@@ -162,7 +164,7 @@ mod tests {
         };
         assert_eq!(
             vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
-            VmmAction::UpdateVmConfiguration(expected_config)
+            VmmAction::UpdateMachineConfiguration(expected_config)
         );
 
         // 4. Test that applying a CPU template is successful on x86_64 while on aarch64, it is not.
@@ -185,7 +187,7 @@ mod tests {
             };
             assert_eq!(
                 vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
-                VmmAction::UpdateVmConfiguration(expected_config)
+                VmmAction::UpdateMachineConfiguration(expected_config)
             );
         }
         #[cfg(target_arch = "aarch64")]
@@ -210,7 +212,7 @@ mod tests {
         };
         assert_eq!(
             vmm_action_from_request(parse_put_machine_config(&Body::new(body)).unwrap()),
-            VmmAction::UpdateVmConfiguration(expected_config)
+            VmmAction::UpdateMachineConfiguration(expected_config)
         );
 
         // 6. Test nonsense values for huge page size

--- a/src/vmm/benches/memory_access.rs
+++ b/src/vmm/benches/memory_access.rs
@@ -4,7 +4,7 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use vm_memory::GuestMemory;
 use vmm::resources::VmResources;
-use vmm::vmm_config::machine_config::{HugePageConfig, VmConfig};
+use vmm::vmm_config::machine_config::{HugePageConfig, MachineConfig};
 
 fn bench_single_page_fault(c: &mut Criterion, configuration: VmResources) {
     c.bench_function("page_fault", |b| {
@@ -33,7 +33,7 @@ pub fn bench_4k_page_fault(c: &mut Criterion) {
     bench_single_page_fault(
         c,
         VmResources {
-            vm_config: VmConfig {
+            machine_config: MachineConfig {
                 vcpu_count: 1,
                 mem_size_mib: 2,
                 ..Default::default()
@@ -47,7 +47,7 @@ pub fn bench_2m_page_fault(c: &mut Criterion) {
     bench_single_page_fault(
         c,
         VmResources {
-            vm_config: VmConfig {
+            machine_config: MachineConfig {
                 vcpu_count: 1,
                 mem_size_mib: 2,
                 huge_pages: HugePageConfig::Hugetlbfs2M,

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -472,7 +472,7 @@ pub fn build_microvm_from_snapshot(
     let (mut vmm, mut vcpus) = create_vmm_and_vcpus(
         instance_info,
         event_manager,
-        guest_memory.clone(),
+        guest_memory,
         uffd,
         vm_resources.machine_config.track_dirty_pages,
         vm_resources.machine_config.vcpu_count,
@@ -517,7 +517,7 @@ pub fn build_microvm_from_snapshot(
 
     // Restore devices states.
     let mmio_ctor_args = MMIODevManagerConstructorArgs {
-        mem: &guest_memory,
+        mem: &vmm.guest_memory,
         vm: vmm.vm.fd(),
         event_manager,
         resource_allocator: &mut vmm.resource_allocator,
@@ -532,7 +532,7 @@ pub fn build_microvm_from_snapshot(
 
     {
         let acpi_ctor_args = ACPIDeviceManagerConstructorArgs {
-            mem: &guest_memory,
+            mem: &vmm.guest_memory,
             resource_allocator: &mut vmm.resource_allocator,
             vm: vmm.vm.fd(),
         };

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -32,7 +32,7 @@ use crate::snapshot::Snapshot;
 use crate::utils::u64_to_usize;
 use crate::vmm_config::boot_source::BootSourceConfig;
 use crate::vmm_config::instance_info::InstanceInfo;
-use crate::vmm_config::machine_config::{HugePageConfig, MachineConfigUpdate, VmConfigError};
+use crate::vmm_config::machine_config::{HugePageConfig, MachineConfigError, MachineConfigUpdate};
 use crate::vmm_config::snapshot::{
     CreateSnapshotParams, LoadSnapshotParams, MemBackendType, SnapshotType,
 };
@@ -61,11 +61,11 @@ pub struct VmInfo {
 impl From<&VmResources> for VmInfo {
     fn from(value: &VmResources) -> Self {
         Self {
-            mem_size_mib: value.vm_config.mem_size_mib as u64,
-            smt: value.vm_config.smt,
-            cpu_template: StaticCpuTemplate::from(&value.vm_config.cpu_template),
+            mem_size_mib: value.machine_config.mem_size_mib as u64,
+            smt: value.machine_config.smt,
+            cpu_template: StaticCpuTemplate::from(&value.machine_config.cpu_template),
             boot_source: value.boot_source.config.clone(),
-            huge_pages: value.vm_config.huge_pages,
+            huge_pages: value.machine_config.huge_pages,
         }
     }
 }
@@ -422,11 +422,11 @@ pub fn restore_from_snapshot(
         .vcpu_states
         .len()
         .try_into()
-        .map_err(|_| VmConfigError::InvalidVcpuCount)
+        .map_err(|_| MachineConfigError::InvalidVcpuCount)
         .map_err(BuildMicrovmFromSnapshotError::VmUpdateConfig)?;
 
     vm_resources
-        .update_vm_config(&MachineConfigUpdate {
+        .update_machine_config(&MachineConfigUpdate {
             vcpu_count: Some(vcpu_count),
             mem_size_mib: Some(u64_to_usize(microvm_state.vm_info.mem_size_mib)),
             smt: Some(microvm_state.vm_info.smt),
@@ -450,7 +450,7 @@ pub fn restore_from_snapshot(
                 mem_backend_path,
                 mem_state,
                 track_dirty_pages,
-                vm_resources.vm_config.huge_pages,
+                vm_resources.machine_config.huge_pages,
             )
             .map_err(RestoreFromSnapshotGuestMemoryError::File)?,
             None,
@@ -462,7 +462,7 @@ pub fn restore_from_snapshot(
             // We enable the UFFD_FEATURE_EVENT_REMOVE feature only if a balloon device
             // is present in the microVM state.
             microvm_state.device_states.balloon_device.is_some(),
-            vm_resources.vm_config.huge_pages,
+            vm_resources.machine_config.huge_pages,
         )
         .map_err(RestoreFromSnapshotGuestMemoryError::Uffd)?,
     };

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -26,7 +26,7 @@ use crate::vmm_config::boot_source::{BootSourceConfig, BootSourceConfigError};
 use crate::vmm_config::drive::{BlockDeviceConfig, BlockDeviceUpdateConfig, DriveError};
 use crate::vmm_config::entropy::{EntropyDeviceConfig, EntropyDeviceError};
 use crate::vmm_config::instance_info::InstanceInfo;
-use crate::vmm_config::machine_config::{MachineConfig, MachineConfigUpdate, VmConfigError};
+use crate::vmm_config::machine_config::{MachineConfig, MachineConfigError, MachineConfigUpdate};
 use crate::vmm_config::metrics::{MetricsConfig, MetricsConfigError};
 use crate::vmm_config::mmds::{MmdsConfig, MmdsConfigError};
 use crate::vmm_config::net::{
@@ -120,7 +120,7 @@ pub enum VmmAction {
     UpdateNetworkInterface(NetworkInterfaceUpdateConfig),
     /// Update the microVM configuration (memory & vcpu) using `VmUpdateConfig` as input. This
     /// action can only be called before the microVM has booted.
-    UpdateVmConfiguration(MachineConfigUpdate),
+    UpdateMachineConfiguration(MachineConfigUpdate),
 }
 
 /// Wrapper for all errors associated with VMM actions.
@@ -145,7 +145,7 @@ pub enum VmmActionError {
     /// Logger error: {0}
     Logger(#[from] crate::logger::LoggerUpdateError),
     /// Machine config error: {0}
-    MachineConfig(#[from] VmConfigError),
+    MachineConfig(#[from] MachineConfigError),
     /// Metrics error: {0}
     Metrics(#[from] MetricsConfigError),
     #[from(ignore)]
@@ -415,9 +415,9 @@ impl<'a> PrebootApiController<'a> {
                 Ok(VmmData::FullVmConfig((&*self.vm_resources).into()))
             }
             GetMMDS => self.get_mmds(),
-            GetVmMachineConfig => Ok(VmmData::MachineConfiguration(MachineConfig::from(
-                &self.vm_resources.vm_config,
-            ))),
+            GetVmMachineConfig => Ok(VmmData::MachineConfiguration(
+                self.vm_resources.machine_config.clone(),
+            )),
             GetVmInstanceInfo => Ok(VmmData::InstanceInformation(self.instance_info.clone())),
             GetVmmVersion => Ok(VmmData::VmmVersion(self.instance_info.vmm_version.clone())),
             InsertBlockDevice(config) => self.insert_block_device(config),
@@ -434,7 +434,7 @@ impl<'a> PrebootApiController<'a> {
             SetVsockDevice(config) => self.set_vsock_device(config),
             SetMmdsConfiguration(config) => self.set_mmds_config(config),
             StartMicroVm => self.start_microvm(),
-            UpdateVmConfiguration(config) => self.update_vm_config(config),
+            UpdateMachineConfiguration(config) => self.update_machine_config(config),
             SetEntropyDevice(config) => self.set_entropy_device(config),
             // Operations not allowed pre-boot.
             CreateSnapshot(_)
@@ -502,10 +502,13 @@ impl<'a> PrebootApiController<'a> {
             .map_err(VmmActionError::MmdsConfig)
     }
 
-    fn update_vm_config(&mut self, cfg: MachineConfigUpdate) -> Result<VmmData, VmmActionError> {
+    fn update_machine_config(
+        &mut self,
+        cfg: MachineConfigUpdate,
+    ) -> Result<VmmData, VmmActionError> {
         self.boot_path = true;
         self.vm_resources
-            .update_vm_config(&cfg)
+            .update_machine_config(&cfg)
             .map(|()| VmmData::Empty)
             .map_err(VmmActionError::MachineConfig)
     }
@@ -641,9 +644,9 @@ impl RuntimeApiController {
                 .map_err(|err| VmmActionError::BalloonConfig(BalloonConfigError::from(err))),
             GetFullVmConfig => Ok(VmmData::FullVmConfig((&self.vm_resources).into())),
             GetMMDS => self.get_mmds(),
-            GetVmMachineConfig => Ok(VmmData::MachineConfiguration(MachineConfig::from(
-                &self.vm_resources.vm_config,
-            ))),
+            GetVmMachineConfig => Ok(VmmData::MachineConfiguration(
+                self.vm_resources.machine_config.clone(),
+            )),
             GetVmInstanceInfo => Ok(VmmData::InstanceInformation(
                 self.vmm.lock().expect("Poisoned lock").instance_info(),
             )),
@@ -686,7 +689,7 @@ impl RuntimeApiController {
             | SetMmdsConfiguration(_)
             | SetEntropyDevice(_)
             | StartMicroVm
-            | UpdateVmConfiguration(_) => Err(VmmActionError::OperationNotSupportedPostBoot),
+            | UpdateMachineConfiguration(_) => Err(VmmActionError::OperationNotSupportedPostBoot),
         }
     }
 
@@ -753,7 +756,7 @@ impl RuntimeApiController {
         log_dev_preview_warning("Virtual machine snapshots", None);
 
         if create_params.snapshot_type == SnapshotType::Diff
-            && !self.vm_resources.vm_config.track_dirty_pages
+            && !self.vm_resources.machine_config.track_dirty_pages
         {
             return Err(VmmActionError::NotSupported(
                 "Diff snapshots are not allowed on uVMs with dirty page tracking disabled."
@@ -1254,7 +1257,7 @@ mod tests {
                 network_interfaces: Vec::new(),
             },
         )));
-        check_unsupported(runtime_request(VmmAction::UpdateVmConfiguration(
+        check_unsupported(runtime_request(VmmAction::UpdateMachineConfiguration(
             MachineConfigUpdate::from(MachineConfig::default()),
         )));
         check_unsupported(runtime_request(VmmAction::LoadSnapshot(

--- a/src/vmm/src/test_utils/mock_resources/mod.rs
+++ b/src/vmm/src/test_utils/mock_resources/mod.rs
@@ -81,12 +81,12 @@ impl MockVmResources {
 
     pub fn with_vm_config(mut self, vm_config: MachineConfig) -> Self {
         let machine_config = MachineConfigUpdate::from(vm_config);
-        self.0.update_vm_config(&machine_config).unwrap();
+        self.0.update_machine_config(&machine_config).unwrap();
         self
     }
 
     pub fn set_cpu_template(&mut self, cpu_template: CustomCpuTemplate) {
-        self.0.vm_config.set_custom_cpu_template(cpu_template);
+        self.0.machine_config.set_custom_cpu_template(cpu_template);
     }
 }
 

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -136,6 +136,7 @@ pub struct MachineConfigUpdate {
     #[serde(default)]
     pub vcpu_count: Option<u8>,
     /// The memory size in MiB.
+    #[serde(default)]
     pub mem_size_mib: Option<usize>,
     /// Enables or disabled SMT.
     #[serde(default)]
@@ -144,6 +145,7 @@ pub struct MachineConfigUpdate {
     #[serde(default)]
     pub cpu_template: Option<StaticCpuTemplate>,
     /// Enables or disables dirty page tracking. Enabling allows incremental snapshots.
+    #[serde(default)]
     pub track_dirty_pages: Option<bool>,
     /// Configures what page size Firecracker should use to back guest memory.
     #[serde(default)]

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -129,30 +129,28 @@ impl Default for MachineConfig {
 /// All fields are optional, but at least one needs to be specified.
 /// If a field is `Some(value)` then we assume an update is requested
 /// for that field.
-#[derive(Clone, Default, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MachineConfigUpdate {
     /// Number of vcpu to start.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub vcpu_count: Option<u8>,
     /// The memory size in MiB.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mem_size_mib: Option<usize>,
     /// Enables or disabled SMT.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub smt: Option<bool>,
     /// A CPU template that it is used to filter the CPU features exposed to the guest.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub cpu_template: Option<StaticCpuTemplate>,
     /// Enables or disables dirty page tracking. Enabling allows incremental snapshots.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub track_dirty_pages: Option<bool>,
     /// Configures what page size Firecracker should use to back guest memory.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub huge_pages: Option<HugePageConfig>,
     /// GDB socket address.
     #[cfg(feature = "gdb")]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub gdb_socket_path: Option<String>,
 }
 

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -22,7 +22,7 @@ use vmm::vmm_config::balloon::BalloonDeviceConfig;
 use vmm::vmm_config::boot_source::BootSourceConfig;
 use vmm::vmm_config::drive::BlockDeviceConfig;
 use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
-use vmm::vmm_config::machine_config::{MachineConfig, MachineConfigUpdate, VmConfig};
+use vmm::vmm_config::machine_config::{MachineConfig, MachineConfigUpdate};
 use vmm::vmm_config::net::NetworkInterfaceConfig;
 use vmm::vmm_config::snapshot::{
     CreateSnapshotParams, LoadSnapshotParams, MemBackendConfig, MemBackendType, SnapshotType,
@@ -188,7 +188,7 @@ fn verify_create_snapshot(is_diff: bool) -> (TempFile, TempFile) {
 
     let (vmm, _) = create_vmm(Some(NOISY_KERNEL_IMAGE), is_diff, true);
     let resources = VmResources {
-        vm_config: VmConfig {
+        machine_config: MachineConfig {
             mem_size_mib: 1,
             track_dirty_pages: is_diff,
             ..Default::default()
@@ -403,6 +403,7 @@ fn test_preboot_load_snap_disallowed_after_boot_resources() {
     });
     verify_load_snap_disallowed_after_boot_resources(req, "SetVsockDevice");
 
-    let req = VmmAction::UpdateVmConfiguration(MachineConfigUpdate::from(MachineConfig::default()));
+    let req =
+        VmmAction::UpdateMachineConfiguration(MachineConfigUpdate::from(MachineConfig::default()));
     verify_load_snap_disallowed_after_boot_resources(req, "SetVmConfiguration");
 }

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -310,6 +310,9 @@ class Microvm:
             if self.screen_pid:
                 os.kill(self.screen_pid, signal.SIGKILL)
         except:
+            LOG.error(
+                "Failed to kill Firecracker Process. Did it already die (or did the UFFD handler process die and take it down)?"
+            )
             LOG.error(self.log_data)
             raise
 


### PR DESCRIPTION
This PR is an assortment of 5 small changes that are only connected by the fact that I ran into 4 of them while playing around with guest_memfd in Firecracker (the odd one out is the UFFD one, which is related to #4601). Roughly, we can group these changes into 3 categories:

- Remove an unneeded .clone() operation
- Ensure that a panic in the example UFFD handlers does not cause pytest to hang for 5 minutes because suddenly it's waiting indefinitely for page faults to be served, by having it take down Firecracker with it (and improvement of error messages in this case)
- Refactor some handling behind the /machine-config endpoint because the duplication of the same data/fields across VmConfig/MachineConfig was already confusing me when working on huge pages, and now that I had to touch this endpoint again I've reached my breaking point :joy: 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
