### PR TITLE
devtool: Build A and B binaries if $do_build is true

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -142,6 +142,21 @@ above when run on a PR will fail iff a newly added dependency has a known open
 RustSec advisory. If run outside a PR, it will fail if any existing dependency
 has an open RustSec advisory).
 
+### Functional A/B-Tests
+
+Firecracker has some functional A/B-tests (for example, in
+`test_vulnerabilities.py`), which generally compare the state of the pull
+request target branch (e.g. `main`), with the PR head. However, when running
+these locally, pytest does not know anything about potential PRs that the commit
+the tests are being run on are contained in, and as such cannot do this
+A/B-Test. To run functional A/B-Tests locally, you need to create a "fake" PR
+environment by setting the `BUILDKITE_PULL_REQUEST` and
+`BUILDKITE_PULL_REQUEST_BASE_BRANCH` environment variables:
+
+```
+BUILDKITE_PULL_REQUEST=true BUILDKITE_PULL_REQUEST_BASE_BRANCH=main ./tools/devtool test -- integration_tests/security/test_vulnerabilities.py
+```
+
 ### Performance A/B-Tests
 
 Firecracker has a special framework for orchestrating long-running A/B-tests

--- a/tools/devtool
+++ b/tools/devtool
@@ -722,7 +722,12 @@ cmd_test() {
     ensure_devctr
     ensure_build_dir
     ensure_ci_artifacts
-    [ $do_build != 0 ] && cmd_build --release
+    if [ $do_build != 0 ]; then
+      cmd_build --release
+      if [ -n "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]; then
+        cmd_build --release --rev "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
+      fi
+    fi
 
     apply_linux_61_tweaks
 


### PR DESCRIPTION
If `cmd_test` is instructed to build its own binaries (e.g. being ran
outside of CI), and the environment specifies that A/B-tests should
be ran, then we not only need to build the currently checked out commit
(the "B" revision), but also an "A" binary based on the value of the
`BUILDKITE_PULL_REQUEST_BASE_BRANCH` environment variable.

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
