### PR TITLE
Move huge pages support out of developer preview.

### DIFF
--- a/docs/hugepages.md
+++ b/docs/hugepages.md
@@ -39,7 +39,6 @@ Currently, hugetlbfs support is mutually exclusive with the following
 Firecracker features:
 
 - Memory Ballooning via the [Balloon Device](./ballooning.md)
-- Initrd
 
 ## FAQ
 

--- a/docs/hugepages.md
+++ b/docs/hugepages.md
@@ -1,10 +1,5 @@
 # Backing Guest Memory by Huge Pages
 
-> [!WARNING]
->
-> Support is currently in **developer preview**. See
-> [this section](RELEASE_POLICY.md#developer-preview-features) for more info.
-
 Firecracker supports backing the guest memory of a VM by 2MB hugetlbfs pages.
 This can be enabled by setting the `huge_pages` field of `PUT` or `PATCH`
 requests to the `/machine-config` endpoint to `2M`.

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -264,13 +264,6 @@ impl VmResources {
         if self.balloon.get().is_some() && updated.huge_pages != HugePageConfig::None {
             return Err(MachineConfigError::BalloonAndHugePages);
         }
-
-        if self.boot_source.config.initrd_path.is_some()
-            && updated.huge_pages != HugePageConfig::None
-        {
-            return Err(MachineConfigError::InitrdAndHugePages);
-        }
-
         self.machine_config = updated;
 
         Ok(())
@@ -337,12 +330,6 @@ impl VmResources {
         &mut self,
         boot_source_cfg: BootSourceConfig,
     ) -> Result<(), BootSourceConfigError> {
-        if boot_source_cfg.initrd_path.is_some()
-            && self.machine_config.huge_pages != HugePageConfig::None
-        {
-            return Err(BootSourceConfigError::HugePagesAndInitRd);
-        }
-
         self.boot_source = BootSource {
             builder: Some(BootConfig::new(&boot_source_cfg)?),
             config: boot_source_cfg,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cpu_config::templates::CustomCpuTemplate;
 use crate::device_manager::persist::SharedDeviceType;
-use crate::logger::{info, log_dev_preview_warning};
+use crate::logger::info;
 use crate::mmds;
 use crate::mmds::data_store::{Mmds, MmdsVersion};
 use crate::mmds::ns::MmdsNetworkStack;
@@ -246,10 +246,6 @@ impl VmResources {
         &mut self,
         update: &MachineConfigUpdate,
     ) -> Result<(), MachineConfigError> {
-        if update.huge_pages.is_some() && update.huge_pages != Some(HugePageConfig::None) {
-            log_dev_preview_warning("Huge pages support", None);
-        }
-
         let updated = self.machine_config.update(update)?;
 
         // The VM cannot have a memory size smaller than the target size

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -42,8 +42,6 @@ pub enum BootSourceConfigError {
     InvalidInitrdPath(io::Error),
     /// The kernel command line is invalid: {0}
     InvalidKernelCommandLine(String),
-    /// Firecracker's huge pages support is incompatible with initrds.
-    HugePagesAndInitRd,
 }
 
 /// Holds the kernel specification (both configuration as well as runtime details).

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -31,8 +31,6 @@ pub enum MachineConfigError {
     KernelVersion,
     /// Firecracker's huge pages support is incompatible with memory ballooning.
     BalloonAndHugePages,
-    /// Firecracker's huge pages support is incompatible with initrds.
-    InitrdAndHugePages,
 }
 
 /// Describes the possible (huge)page configurations for a microVM's memory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -499,20 +499,6 @@ def uvm_plain_debug(microvm_factory, guest_kernel_6_1_debug, rootfs_rw):
 
 
 @pytest.fixture
-def uvm_with_initrd(
-    microvm_factory, guest_kernel_linux_5_10, record_property, artifact_dir
-):
-    """
-    See file:../docs/initrd.md
-    """
-    fs = artifact_dir / "initramfs.cpio"
-    record_property("rootfs", fs.name)
-    uvm = microvm_factory.build(guest_kernel_linux_5_10)
-    uvm.initrd_file = fs
-    yield uvm
-
-
-@pytest.fixture
 def vcpu_count():
     """Return default vcpu_count. Use indirect parametrization to override."""
     return 2

--- a/tests/integration_tests/performance/test_initrd.py
+++ b/tests/integration_tests/performance/test_initrd.py
@@ -1,13 +1,27 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for initrd."""
+import pytest
 
-from framework.microvm import Serial
+from framework.microvm import HugePagesConfig, Serial
 
 INITRD_FILESYSTEM = "rootfs"
 
 
-def test_microvm_initrd_with_serial(uvm_with_initrd):
+@pytest.fixture
+def uvm_with_initrd(microvm_factory, guest_kernel, record_property, artifact_dir):
+    """
+    See file:../docs/initrd.md
+    """
+    fs = artifact_dir / "initramfs.cpio"
+    record_property("rootfs", fs.name)
+    uvm = microvm_factory.build(guest_kernel)
+    uvm.initrd_file = fs
+    yield uvm
+
+
+@pytest.mark.parametrize("huge_pages", HugePagesConfig)
+def test_microvm_initrd_with_serial(uvm_with_initrd, huge_pages):
     """
     Test that a boot using initrd successfully loads the root filesystem.
     """
@@ -21,6 +35,7 @@ def test_microvm_initrd_with_serial(uvm_with_initrd):
         vcpu_count=1,
         boot_args="console=ttyS0 reboot=k panic=1 pci=off",
         use_initrd=True,
+        huge_pages=huge_pages,
     )
 
     vm.start()


### PR DESCRIPTION
We have decided to move hugepages support out of developer preview,
despite missing support for memory ballooning.

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
