### PR TITLE
Tests: test_kvm_ptp: wait up to 5s for the device to appear.

### DIFF
--- a/tests/integration_tests/functional/test_kvm_ptp.py
+++ b/tests/integration_tests/functional/test_kvm_ptp.py
@@ -6,19 +6,18 @@
 import pytest
 
 
-def test_kvm_ptp(uvm_plain_any):
+def test_kvm_ptp(uvm_any_booted):
     """Test kvm_ptp is usable"""
 
-    vm = uvm_plain_any
+    vm = uvm_any_booted
     if vm.guest_kernel_version[:2] < (6, 1):
         pytest.skip("Only supported in kernel 6.1 and after")
 
-    vm.spawn()
-    vm.basic_config(vcpu_count=2, mem_size_mib=256)
-    vm.add_net_iface()
-    vm.start()
+    _, dmesg, _ = vm.ssh.check_output("dmesg |grep -i ptp")
+    assert "PTP clock support registered" in dmesg
 
-    vm.ssh.check_output("[ -c /dev/ptp0 ]")
+    # wait up to 5s to see the PTP device
+    vm.ssh.check_output("udevadm wait -t 5 /dev/ptp0")
 
     # phc_ctl[14515.127]: clock time is 1697545854.728335694 or Tue Oct 17 12:30:54 2023
     vm.ssh.check_output("phc_ctl /dev/ptp0 -- get")


### PR DESCRIPTION
## Changes

We have sometimes seen that this test can fail. In theory it could
happen that udev has not created the /dev/ptp0 file before we run the
ssh command.

So let's wait in udev for the device to appear up to 5 seconds.

## Reason

Prevents (rare) test failures.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
