### PR TITLE
tests: fix doctests in the Python codebase

### DIFF
--- a/tests/framework/gitlint_rules.py
+++ b/tests/framework/gitlint_rules.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """The user defined rules for gitlint."""
 
+import re
+
 from gitlint.rules import CommitRule, RuleViolation
 
 
@@ -22,16 +24,20 @@ class EndsSigned(CommitRule):
     def validate(self, commit):
         r"""Validates Signed-off-by and Co-authored-by tags as Linux's scripts/checkpatch.pl
 
-        >>> from gitlint.tests.base import BaseTestCase
+        >>> from gitlint.git import GitContext
         >>> from gitlint.rules import RuleViolation
         ...
         >>> ends_signed = EndsSigned()
+        >>> miss_sob_follows_coab = "Missing 'Signed-off-by' following 'Co-authored-by'"
+        >>> miss_sob = "'Signed-off-by' not found in commit message body"
+        >>> non_sign = "Non 'Co-authored-by' or 'Signed-off-by' string found following 1st 'Signed-off-by'"
+        >>> email_no_match = "'Co-authored-by' and 'Signed-off-by' name/email do not match"
         ...
         >>> msg1 = (
         ... f"Title\n\nMessage.\n\n"
         ... f"Signed-off-by: name <email@domain>"
         ... )
-        >>> commit1 = BaseTestCase.gitcommit(msg1)
+        >>> commit1 = GitContext.from_commit_msg(msg1).commits[0]
         >>> ends_signed.validate(commit1)
         []
         >>> msg2 = (
@@ -39,52 +45,41 @@ class EndsSigned(CommitRule):
         ... f"Co-authored-by: name <email>\n\n"
         ... f"Signed-off-by: name <email>"
         ... )
-        >>> commit2 = BaseTestCase.gitcommit(msg2)
+        >>> commit2 = GitContext.from_commit_msg(msg2).commits[0]
         >>> ends_signed.validate(commit2)
         []
-        >>> msg3 = (
-        ... f"Title\n\nMessage.\n\n"
-        ... )
-        >>> commit3 = BaseTestCase.gitcommit(msg3)
+        >>> msg3 = f"Title\n\nMessage.\n\n"
+        >>> commit3 = GitContext.from_commit_msg(msg3).commits[0]
         >>> vio3 = ends_signed.validate(commit3)
-        >>> vio_msg3 = (
-        ... f"'Signed-off-by:' not found in commit message body"
-        ... )
-        >>> vio3 == [RuleViolation("UC2", vio_msg3)]
+        >>> vio3 == [RuleViolation("UC2", miss_sob)]
         True
         >>> msg4 = (
         ... f"Title\n\nMessage.\n\n"
         ... f"Signed-off-by: name <email@domain>\n\na sentence"
         ... )
-        >>> commit4 = BaseTestCase.gitcommit(msg4)
+        >>> commit4 = GitContext.from_commit_msg(msg4).commits[0]
         >>> vio4 = ends_signed.validate(commit4)
-        >>> vio_msg4 = (
-        ... f"Non 'Co-authored-by:' or 'Signed-off-by:' string found following 1st 'Signed-off-by:'"
-        ... )
-        >>> vio4 == [RuleViolation("UC2", vio_msg4, None, 5)]
+        >>> vio4 == [RuleViolation("UC2", non_sign, None, 6)]
         True
         >>> msg5 = (
         ... f"Title\n\nMessage.\n\n"
         ... f"Co-authored-by: name <email@domain>"
         ... )
-        >>> commit5 = BaseTestCase.gitcommit(msg5)
+        >>> commit5 = GitContext.from_commit_msg(msg5).commits[0]
         >>> vio5 = ends_signed.validate(commit5)
-        >>> vio_msg5 = (
-        ... f"Missing 'Signed-off-by:' following 'Co-authored-by:'"
-        ... )
-        >>> vio5 == [RuleViolation("UC2", vio_msg5, None, 2)]
+        >>> vio5 == [
+        ...   RuleViolation("UC2", miss_sob, None, None),
+        ...   RuleViolation("UC2", miss_sob_follows_coab, None, 5)
+        ... ]
         True
         >>> msg6 = (
         ... f"Title\n\nMessage.\n\n"
         ... f"Co-authored-by: name <email@domain>\n\n"
         ... f"Signed-off-by: different name <email@domain>"
         ... )
-        >>> commit6 = BaseTestCase.gitcommit(msg6)
+        >>> commit6 = GitContext.from_commit_msg(msg6).commits[0]
         >>> vio6 = ends_signed.validate(commit6)
-        >>> vio_msg6 = (
-        ... f"'Co-authored-by:' and 'Signed-off-by:' name/email do not match"
-        ... )
-        >>> vio6 == [RuleViolation("UC2", vio_msg6, None, 6)]
+        >>> vio6 == [RuleViolation("UC2", email_no_match, None, 6)]
         True
         """
 
@@ -92,59 +87,50 @@ class EndsSigned(CommitRule):
 
         # Utilities
         def vln(stmt, i):
-            return RuleViolation(self.id, stmt, None, i)
+            violations.append(RuleViolation(self.id, stmt, None, i))
 
-        co_auth = "Co-authored-by:"
-        sig = "Signed-off-by:"
+        coab = "Co-authored-by"
+        sob = "Signed-off-by"
 
-        message_iter = enumerate(commit.message.original.split("\n"))
-
-        # Skip ahead to the first signoff or co-author tag
+        # find trailers
+        trailers = []
+        for i, line in enumerate(commit.message.original.splitlines()):
+            # ignore empty lines
+            if not line:
+                continue
+            match = re.match(r"([\w-]+):\s+(.*)", line)
+            if match:
+                key, val = match.groups()
+                trailers.append((i, key, val))
+            else:
+                trailers.append((i, "line", line))
+        # artificial line so we can check any "previous line" rules
+        trailers.append((trailers[-1][0] + 1, None, None))
 
         # Checks commit message contains a `Signed-off-by` string
-        for i, line in message_iter:
-            if line.startswith(sig) or line.startswith(co_auth):
-                break
-        else:
-            # No signature was found in the message (before `message_iter` ended)
-            # This check here can have false-negatives (e.g. if the body ends with only
-            # a 'Co-authored-by' tag), but then below will realize that the co-authored-by
-            # tag isnt followed by a Signed-off-by tag and fail (and also the DCO check will
-            # complain).
-            violations.append(vln(f"'{sig}' not found in commit message body", None))
+        if not [x for x in trailers if x[1] == sob]:
+            vln(f"'{sob}' not found in commit message body", None)
 
-        # Check that from here on out we only have signatures and co-authors, and that
-        # every co-author is immediately followed by a signature with the same name/email.
-        for i, line in message_iter:
-            if line.startswith(co_auth):
-                try:
-                    _, next_line = next(message_iter)
-                except StopIteration:
-                    violations.append(
-                        vln(f"Missing '{sig}' tag following '{co_auth}'", i)
-                    )
-                else:
-                    if not next_line.startswith(sig):
-                        violations.append(
-                            vln(f"Missing '{sig}' tag following '{co_auth}'", i + 1)
-                        )
-                        continue
-
-                    if next_line.split(":")[1].strip() != line.split(":")[1].strip():
-                        violations.append(
-                            vln(f"{co_auth} and {sig} name/email do not match", i + 1)
-                        )
-                continue
-
-            if line.startswith(sig) or not line.strip():
-                continue
-
-            violations.append(
+        prev_trailer, prev_value = None, None
+        sig_trailers = False
+        for i, trailer, value in trailers:
+            if trailer in {sob, coab}:
+                sig_trailers = True
+            elif trailer not in {sob, coab, None} and sig_trailers:
                 vln(
-                    f"Non '{co_auth}' or '{sig}' string found following 1st '{sig}'",
+                    f"Non '{coab}' or '{sob}' string found following 1st '{sob}'",
                     i,
                 )
-            )
+            # Every co-author is immediately followed by a signature
+            if prev_trailer == coab:
+                if trailer != sob:
+                    vln(f"Missing '{sob}' following '{coab}'", i)
+                else:
+                    # with the same name/email.
+                    if value != prev_value:
+                        vln(f"'{coab}' and '{sob}' name/email do not match", i)
+
+            prev_trailer, prev_value = trailer, value
 
         # Return errors
         return violations

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -26,7 +26,7 @@ def get_os_version():
     """Get the OS version
 
     >>> get_os_version()
-    Ubuntu 18.04.6 LTS
+    'Ubuntu 24.04.1 LTS'
     """
 
     os_release = Path("/etc/os-release").read_text(encoding="ascii")
@@ -41,7 +41,7 @@ def get_host_os(kv: str = None):
     This only works for AL2 and AL2023
 
     >>> get_host_os("6.1.41-63.118.amzn2023.x86_64")
-    amzn2023
+    'amzn2023'
     """
     if kv is None:
         kv = platform.release()

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -660,8 +660,8 @@ class Timeout:
     """
     A Context Manager to timeout sections of code.
 
-    >>> with Timeout(30):
-    >>>     time.sleep(35)
+    >>> with Timeout(30):     # doctest: +SKIP
+    ...    time.sleep(35)     # doctest: +SKIP
     """
 
     def __init__(self, seconds, msg="Timed out"):

--- a/tests/framework/utils_imdsv2.py
+++ b/tests/framework/utils_imdsv2.py
@@ -24,7 +24,8 @@ class IMDSv2Client:
     """
     A simple IMDSv2 client.
 
-    >>> IMDSv2Client().get("/meta-data/instance-type")
+    >>> IMDSv2Client().get("/meta-data/instance-type")     # doctest: +SKIP
+    ...
     """
 
     def __init__(self, endpoint="http://169.254.169.254", version="latest"):
@@ -49,8 +50,8 @@ class IMDSv2Client:
         """
         Get a metadata path from IMDSv2
 
-        >>> IMDSv2Client().get("/meta-data/instance-type")
-        >>> m5d.metal
+        >>> IMDSv2Client().get("/meta-data/instance-type") # doctest: +SKIP
+        'm5d.metal'
         """
         headers = {IMDSV2_HDR_TOKEN: self.get_token()}
         url = f"{self.endpoint}/{self.version}{path}"

--- a/tests/host_tools/udp_offload.py
+++ b/tests/host_tools/udp_offload.py
@@ -24,35 +24,37 @@ except ImportError:
     SOL_UDP = 17  # Protocol number for UDP
     UDP_SEGMENT = 103  # Option code for UDP segmentation (non-standard)
 
-# Get the IP and port from command-line arguments
-if len(sys.argv) != 3:
-    eprint("Usage: python3 udp_offload.py <ip_address> <port>")
-    sys.exit(1)
 
-ip_address = sys.argv[1]
-port = int(sys.argv[2])
+if __name__ == "__main__":
+    # Get the IP and port from command-line arguments
+    if len(sys.argv) != 3:
+        eprint("Usage: python3 udp_offload.py <ip_address> <port>")
+        sys.exit(1)
 
-# Create a UDP socket
-sockfd = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    ip_address = sys.argv[1]
+    port = int(sys.argv[2])
 
-# Set the UDP segmentation option (UDP_SEGMENT) to 1400 bytes
-OPTVAL = 1400
-try:
-    sockfd.setsockopt(SOL_UDP, UDP_SEGMENT, OPTVAL)
-except (AttributeError, PermissionError):
-    eprint("Unable to set UDP_SEGMENT option")
-    sys.exit(1)
+    # Create a UDP socket
+    sockfd = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-# Set the destination address and port
-servaddr = (ip_address, port)
+    # Set the UDP segmentation option (UDP_SEGMENT) to 1400 bytes
+    OPTVAL = 1400
+    try:
+        sockfd.setsockopt(SOL_UDP, UDP_SEGMENT, OPTVAL)
+    except (AttributeError, PermissionError):
+        eprint("Unable to set UDP_SEGMENT option")
+        sys.exit(1)
 
-# Send the message to the destination address
-MESSAGE = b"x"
-try:
-    sockfd.sendto(MESSAGE, servaddr)
-    print("Message sent successfully")
-except socket.error as e:
-    eprint(f"Error sending message: {e}")
-    sys.exit(1)
+    # Set the destination address and port
+    servaddr = (ip_address, port)
 
-sockfd.close()
+    # Send the message to the destination address
+    MESSAGE = b"x"
+    try:
+        sockfd.sendto(MESSAGE, servaddr)
+        print("Message sent successfully")
+    except socket.error as e:
+        eprint(f"Error sending message: {e}")
+        sys.exit(1)
+
+    sockfd.close()

--- a/tests/integration_tests/style/test_rust.py
+++ b/tests/integration_tests/style/test_rust.py
@@ -6,11 +6,7 @@ from framework import utils
 
 
 def test_rust_order():
-    """
-    Tests that `Cargo.toml` dependencies are alphabetically ordered.
-
-    @type: style
-    """
+    """Tests that `Cargo.toml` dependencies are alphabetically ordered."""
 
     # Runs `cargo-sort` with the current working directory (`cwd`) as the repository root.
     _, _, _ = utils.check_output(
@@ -19,9 +15,7 @@ def test_rust_order():
 
 
 def test_rust_style():
-    """
-    Test that rust code passes style checks.
-    """
+    """Test that rust code passes style checks."""
 
     #  ../src/io_uring/src/bindings.rs
     config = open("fmt.toml", encoding="utf-8").read().replace("\n", ",")

--- a/tools/devtool
+++ b/tools/devtool
@@ -934,7 +934,8 @@ cmd_mkdocs() {
 }
 
 cmd_checkstyle() {
-    cmd_test --no-build --no-kvm-check -- integration_tests/style -n 4 --dist worksteal
+    cmd_test --no-build --no-kvm-check -- -n 4 --dist worksteal integration_tests/style
+    cmd_test --no-build --no-kvm-check -- -n 4 --doctest-modules framework
 }
 
 # Check if able to run firecracker.


### PR DESCRIPTION
## Changes

With these two changes `./tools/devtool -y test -- --doctest-modules framework` passes

Closes #3035

## Reason

Make sure doctests stay up to date.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
