### PR TITLE
fix: Rare failure in pause resume test

### DIFF
--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -141,7 +141,12 @@ def test_kvmclock_ctrl(uvm_plain_any):
     microvm = uvm_plain_any
     microvm.help.enable_console()
     microvm.spawn()
-    microvm.basic_config()
+
+    # With 2 vCPUs under certain conditions soft lockup warnings can rarely be in dmesg causing this test to fail.
+    # Example of the warning: `watchdog: BUG: soft lockup - CPU#0 stuck for (x)s! [(udev-worker):758]`
+    # With 1 vCPU this intermittent issue doesn't occur. If the KVM_CLOCK_CTRL IOCTL is not made
+    # the test will fail with 1 vCPU, so we can assert the call to the IOCTL is made.
+    microvm.basic_config(vcpu_count=1)
     microvm.add_net_iface()
     microvm.start()
 


### PR DESCRIPTION
## Changes

Test with 1 vCPU when running the KVMCLOCK_CTRL tests so we don't fail on intermittent issue with clock.

Confirmed with the KVMCLOCK_CTR call removed the test still fails after the update.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
