### PR TITLE
refactor: Unify methods of guest memory creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,8 @@ and this project adheres to
   VMGenID support for microVMs running on ARM hosts with 6.1 guest kernels.
   Support for VMGenID via DeviceTree bindings exists only on mainline 6.10 Linux
   onwards. Users of Firecracker will need to backport the relevant patches on
-  top of their 6.1 kernels to make use of the feature.
+  top of their 6.1 kernels to make use of the feature. As a result, Firecracker
+  snapshot version is now 3.0.0
 - [#4732](https://github.com/firecracker-microvm/firecracker/pull/4732),
   [#4733](https://github.com/firecracker-microvm/firecracker/pull/4733),
   [#4741](https://github.com/firecracker-microvm/firecracker/pull/4741),

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -155,7 +155,6 @@ fn create_vmm_and_vcpus(
     event_manager: &mut EventManager,
     guest_memory: GuestMemoryMmap,
     uffd: Option<Uffd>,
-    track_dirty_pages: bool,
     vcpu_count: u8,
     kvm_capabilities: Vec<KvmCapability>,
 ) -> Result<(Vmm, Vec<Vcpu>), StartMicrovmError> {
@@ -172,7 +171,7 @@ fn create_vmm_and_vcpus(
     kvm.check_memory(&guest_memory)
         .map_err(VmmError::Kvm)
         .map_err(StartMicrovmError::Internal)?;
-    vm.memory_init(&guest_memory, track_dirty_pages)
+    vm.memory_init(&guest_memory)
         .map_err(VmmError::Vm)
         .map_err(StartMicrovmError::Internal)?;
 
@@ -292,7 +291,6 @@ pub fn build_microvm_for_boot(
         event_manager,
         guest_memory,
         None,
-        vm_resources.machine_config.track_dirty_pages,
         vm_resources.machine_config.vcpu_count,
         cpu_template.kvm_capabilities.clone(),
     )?;
@@ -482,7 +480,6 @@ pub fn build_microvm_from_snapshot(
         event_manager,
         guest_memory,
         uffd,
-        vm_resources.machine_config.track_dirty_pages,
         vm_resources.machine_config.vcpu_count,
         microvm_state.kvm_state.kvm_cap_modifiers.clone(),
     )?;
@@ -1139,7 +1136,7 @@ pub(crate) mod tests {
 
         let kvm = Kvm::new(vec![]).unwrap();
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(&guest_memory, false).unwrap();
+        vm.memory_init(&guest_memory).unwrap();
         let mmio_device_manager = MMIODeviceManager::new();
         let acpi_device_manager = ACPIDeviceManager::new();
         #[cfg(target_arch = "x86_64")]
@@ -1393,7 +1390,7 @@ pub(crate) mod tests {
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         #[allow(unused_mut)]
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(&guest_memory, false).unwrap();
+        vm.memory_init(&guest_memory).unwrap();
         let evfd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
 
         #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -664,7 +664,7 @@ mod tests {
         let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(&guest_mem, false).unwrap();
+        vm.memory_init(&guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
         let mut resource_allocator = ResourceAllocator::new().unwrap();
 
@@ -694,7 +694,7 @@ mod tests {
         let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(&guest_mem, false).unwrap();
+        vm.memory_init(&guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
         let mut resource_allocator = ResourceAllocator::new().unwrap();
 
@@ -749,7 +749,7 @@ mod tests {
         let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(&guest_mem, false).unwrap();
+        vm.memory_init(&guest_mem).unwrap();
 
         let mem_clone = guest_mem.clone();
 

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -378,7 +378,7 @@ mod tests {
     use crate::devices::virtio::block::virtio::device::FileEngineType;
     use crate::devices::virtio::mmio::VIRTIO_MMIO_INT_CONFIG;
     use crate::test_utils::create_tmp_socket;
-    use crate::vstate::memory::{FileOffset, GuestAddress, GuestMemoryExtension};
+    use crate::vstate::memory::{GuestAddress, GuestMemoryExtension};
 
     #[test]
     fn test_from_config() {
@@ -778,12 +778,10 @@ mod tests {
         let region_size = 0x10000;
         let file = TempFile::new().unwrap().into_file();
         file.set_len(region_size as u64).unwrap();
-        let regions = vec![(
-            FileOffset::new(file.try_clone().unwrap(), 0x0),
-            GuestAddress(0x0),
-            region_size,
-        )];
-        let guest_memory = GuestMemoryMmap::from_raw_regions_file(regions, false, false).unwrap();
+        let regions = vec![(GuestAddress(0x0), region_size)];
+        let guest_memory =
+            GuestMemoryMmap::create(regions.into_iter(), libc::MAP_PRIVATE, Some(file), false)
+                .unwrap();
 
         // During actiavion of the device features, memory and queues should be set and activated.
         vhost_block.activate(guest_memory).unwrap();

--- a/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
@@ -230,8 +230,12 @@ pub mod tests {
     }
 
     fn create_mem() -> GuestMemoryMmap {
-        GuestMemoryMmap::from_raw_regions(&[(GuestAddress(0), MEM_LEN)], true, HugePageConfig::None)
-            .unwrap()
+        GuestMemoryMmap::anonymous(
+            [(GuestAddress(0), MEM_LEN)].into_iter(),
+            true,
+            HugePageConfig::None,
+        )
+        .unwrap()
     }
 
     fn check_dirty_mem(mem: &GuestMemoryMmap, addr: GuestAddress, len: u32) {

--- a/src/vmm/src/devices/virtio/vhost_user.rs
+++ b/src/vmm/src/devices/virtio/vhost_user.rs
@@ -466,7 +466,7 @@ mod tests {
 
     use super::*;
     use crate::test_utils::create_tmp_socket;
-    use crate::vstate::memory::{FileOffset, GuestAddress, GuestMemoryExtension};
+    use crate::vstate::memory::{GuestAddress, GuestMemoryExtension};
 
     #[test]
     fn test_new() {
@@ -759,19 +759,13 @@ mod tests {
         let file_size = 2 * region_size;
         file.set_len(file_size as u64).unwrap();
         let regions = vec![
-            (
-                FileOffset::new(file.try_clone().unwrap(), 0x0),
-                GuestAddress(0x0),
-                region_size,
-            ),
-            (
-                FileOffset::new(file.try_clone().unwrap(), 0x10000),
-                GuestAddress(0x10000),
-                region_size,
-            ),
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x10000), region_size),
         ];
 
-        let guest_memory = GuestMemoryMmap::from_raw_regions_file(regions, false, false).unwrap();
+        let guest_memory =
+            GuestMemoryMmap::create(regions.into_iter(), libc::MAP_PRIVATE, Some(file), false)
+                .unwrap();
 
         vuh.update_mem_table(&guest_memory).unwrap();
 
@@ -883,13 +877,11 @@ mod tests {
         let region_size = 0x10000;
         let file = TempFile::new().unwrap().into_file();
         file.set_len(region_size as u64).unwrap();
-        let regions = vec![(
-            FileOffset::new(file.try_clone().unwrap(), 0x0),
-            GuestAddress(0x0),
-            region_size,
-        )];
+        let regions = vec![(GuestAddress(0x0), region_size)];
 
-        let guest_memory = GuestMemoryMmap::from_raw_regions_file(regions, false, false).unwrap();
+        let guest_memory =
+            GuestMemoryMmap::create(regions.into_iter(), libc::MAP_PRIVATE, Some(file), false)
+                .unwrap();
 
         let mut queue = Queue::new(69);
         queue.initialize(&guest_memory).unwrap();

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -631,18 +631,6 @@ impl Vmm {
         Ok(bitmap)
     }
 
-    /// Enables or disables KVM dirty page tracking.
-    pub fn set_dirty_page_tracking(&mut self, enable: bool) -> Result<(), VmmError> {
-        // This function _always_ results in an ioctl update. The VMM is stateless in the sense
-        // that it's unaware of the current dirty page tracking setting.
-        // The VMM's consumer will need to cache the dirty tracking setting internally. For
-        // example, if this function were to be exposed through the VMM controller, the VMM
-        // resources should cache the flag.
-        self.vm
-            .set_kvm_memory_regions(&self.guest_memory, enable)
-            .map_err(VmmError::Vm)
-    }
-
     /// Updates the path of the host file backing the emulated block device with id `drive_id`.
     /// We update the disk image on the device and its virtio configuration.
     pub fn update_block_device_path(

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -472,8 +472,8 @@ impl VmResources {
             )
         } else {
             let regions = crate::arch::arch_memory_regions(self.machine_config.mem_size_mib << 20);
-            GuestMemoryMmap::from_raw_regions(
-                &regions,
+            GuestMemoryMmap::anonymous(
+                regions.into_iter(),
                 self.machine_config.track_dirty_pages,
                 self.machine_config.huge_pages,
             )

--- a/src/vmm/src/test_utils/mod.rs
+++ b/src/vmm/src/test_utils/mod.rs
@@ -34,7 +34,7 @@ pub fn single_region_mem_at(at: u64, size: usize) -> GuestMemoryMmap {
 
 /// Creates a [`GuestMemoryMmap`] with multiple regions and without dirty page tracking.
 pub fn multi_region_mem(regions: &[(GuestAddress, usize)]) -> GuestMemoryMmap {
-    GuestMemoryMmap::from_raw_regions(regions, false, HugePageConfig::None)
+    GuestMemoryMmap::anonymous(regions.iter().copied(), false, HugePageConfig::None)
         .expect("Cannot initialize memory")
 }
 


### PR DESCRIPTION
In this day and age, Firecracker supports theoretically 4 different ways of backing guest memory:

1. Normal MAP_ANONYMOUS | MAP_PRIVATE memory
2. memfd backed memory, mapped as shared
3. direct mapping of a snapshot file
4. MAP_ANONYMOUS again, but this time regions are described by snapshot file.

We have 3 different functions for creating these different backing stores, which then call each other and vm_memory's APIs. 

In light of https://github.com/firecracker-microvm/firecracker/issues/4522, which will add yet another way of backing virtual machine guests, this was starting to make my head hurt a bit.

Clean this up by consolidating these into just one function (`GuestMemoryExtensions::create`) that can be called with a description of the memory regions, plus an enum argument stating how each region should be backed. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
