### PR TITLE
Fix(test): have codecov uploader exit with non-zero code on error

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -95,7 +95,9 @@ def test_coverage(monkeypatch):
         if not branch:
             branch = utils.check_output("git rev-parse --abbrev-ref HEAD").stdout
 
-        codecov_cmd = f"codecov -f {lcov_file} -F {global_props.host_linux_version}-{global_props.instance}"
+        # -Z flag means "fail on error". There's supposed to be a more descriptive long form in
+        # --fail-on-error, but it doesnt work.
+        codecov_cmd = f"codecov -Z -f {lcov_file} -F {global_props.host_linux_version}-{global_props.instance}"
 
         if pr_number and pr_number != "false":
             codecov_cmd += f" -P {pr_number}"


### PR DESCRIPTION
Pass the `-Z` flag (fail on error) to the codecov uploader. According to
the docs, without this flag upload failures will be silently ignored
(why isn't this the default??) [1]. We can also see this from the logs,
which contain:

```
[2025-01-28T12:10:57.973Z] ['info'] Codecov will exit with status code
0. If you are expecting a non-zero exit code, please pass in the `-Z`
flag
```

The docs say that a long form `--fail-on-error` is available, but actually
it doesnt seem to work, so we have to use `-Z`.

example of it failing: https://buildkite.com/firecracker/firecracker-pr/builds/12416#0194ad35-9532-409d-b90b-1a05c3f80cc1

[1]: https://docs.codecov.com/docs/cli-options

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
