### PR TITLE
Tests: Refactor and clean up JailerContext class 

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -349,25 +349,6 @@ pass for the PR to be merged.
 Add a new function annotated with `#[test]` in
 [`integration_tests.rs`](../src/vmm/tests/integration_tests.rs).
 
-## Working With Guest Files
-
-There are helper methods for writing to and reading from a guest filesystem. For
-example, to overwrite the guest init process and later extract a log:
-
-```python
-def test_with_any_microvm_and_my_init(test_microvm_any):
-    # [...]
-    test_microvm_any.slot.fsfiles['mounted_root_fs'].copy_to(my_init, 'sbin/')
-    # [...]
-    test_microvm_any.slot.fsfiles['mounted_root_fs'].copy_from('logs/', 'log')
-```
-
-`copy_to()` source paths are relative to the host root and destination paths are
-relative to the `mounted_root_fs` root. Vice versa for `copy_from()`.
-
-Copying files to/from a guest file system while the guest is running results in
-undefined behavior.
-
 ## Example Manual Testrun
 
 Running on an EC2 `.metal` instance with an `Amazon Linux 2` AMI:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -341,14 +341,12 @@ def microvm_factory(request, record_property, results_dir, netns_factory):
             uvm_data.mkdir()
             uvm_data.joinpath("host-dmesg.log").write_text(dmesg.stdout)
 
-            uvm_root = Path(uvm.chroot())
-            for item in os.listdir(uvm_root):
-                src = uvm_root / item
-                if not os.path.isfile(src):
+            for src in uvm.chroot.iterdir():
+                if not src.is_file():
                     continue
-                dst = uvm_data / item
+                dst = uvm_data / src.name
                 shutil.copy(src, dst)
-                console_data = uvm.console_data
+                console_data = getattr(uvm.jailer, "console_data", None)
                 if console_data:
                     uvm_data.joinpath("guest-console.log").write_text(console_data)
 

--- a/tests/framework/http_api.py
+++ b/tests/framework/http_api.py
@@ -97,7 +97,7 @@ class Api:
 
     def __init__(self, api_usocket_full_name):
         self.socket = api_usocket_full_name
-        url_encoded_path = urllib.parse.quote_plus(api_usocket_full_name)
+        url_encoded_path = urllib.parse.quote_plus(str(self.socket))
         self.endpoint = DEFAULT_SCHEME + url_encoded_path
         self.session = Session()
 

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -127,7 +127,7 @@ class JailerContext:
         """Return the MicroVM API socket path."""
         return self.chroot / self.api_socket_name
 
-    def jailed_path(self, file_path, create=False, subdir="."):
+    def jailed_path(self, file_path, subdir="."):
         """Create a hard link or block special device owned by uid:gid.
 
         Create a hard link or block special device from the specified file,
@@ -138,7 +138,7 @@ class JailerContext:
         global_p = self.chroot / subdir / file_path.name
         global_p.parent.mkdir(parents=True, exist_ok=True)
         jailed_p = Path("/") / subdir / file_path.name
-        if create and not global_p.exists():
+        if not global_p.exists():
             stat_src = file_path.stat()
             if file_path.is_block_device():
                 perms = stat.S_IRUSR | stat.S_IWUSR
@@ -160,7 +160,7 @@ class JailerContext:
         """Set up this jailer context."""
         os.makedirs(self.chroot, exist_ok=True)
         # Copy the /etc/localtime file in the jailer root
-        self.jailed_path("/etc/localtime", create=True, subdir="etc")
+        self.jailed_path("/etc/localtime", subdir="etc")
 
     def cleanup(self):
         """Clean up this jailer context."""

--- a/tests/framework/jailer_screen.py
+++ b/tests/framework/jailer_screen.py
@@ -1,0 +1,204 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the jailer under a screen session"""
+
+import os
+import re
+import select
+import signal
+import time
+from pathlib import Path
+
+import psutil
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
+
+from framework import utils
+
+from .jailer import JailerContext
+
+FLUSH_CMD = 'screen -S {session} -X colon "logfile flush 0^M"'
+
+
+def start_screen_process(screen_log, session_name, binary_path, binary_params):
+    """Start binary process into a screen session."""
+    start_cmd = "screen -L -Logfile {logfile} -dmS {session} {binary} {params}"
+    start_cmd = start_cmd.format(
+        logfile=screen_log,
+        session=session_name,
+        binary=binary_path,
+        params=" ".join(binary_params),
+    )
+
+    utils.check_output(start_cmd)
+
+    # Build a regex object to match (number).session_name
+    regex_object = re.compile(r"([0-9]+)\.{}".format(session_name))
+
+    # Run 'screen -ls' in a retry loop, 30 times with a 1s delay between calls.
+    # If the output of 'screen -ls' matches the regex object, it will return the
+    # PID. Otherwise, a RuntimeError will be raised.
+    for attempt in Retrying(
+        retry=retry_if_exception_type(RuntimeError),
+        stop=stop_after_attempt(30),
+        wait=wait_fixed(1),
+        reraise=True,
+    ):
+        with attempt:
+            screen_pid = utils.search_output_from_cmd(
+                cmd="screen -ls", find_regex=regex_object
+            ).group(1)
+
+    screen_pid = int(screen_pid)
+    # Make sure the screen process launched successfully
+    # As the parent process for the binary.
+    screen_ps = psutil.Process(screen_pid)
+
+    for attempt in Retrying(
+        stop=stop_after_attempt(5),
+        wait=wait_fixed(0.5),
+        reraise=True,
+    ):
+        with attempt:
+            assert screen_ps.is_running()
+
+    # Configure screen to flush stdout to file.
+    utils.check_output(FLUSH_CMD.format(session=session_name))
+
+    return screen_pid
+
+
+class JailerScreen(JailerContext):
+    """Spawn Firecracker under screen"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.daemonize = False
+        self.screen_pid = None
+        self.expect_kill_by_signal = False
+
+    def spawn(self, pre_cmd):
+        """Spawn Firecracker under screen"""
+        self.screen_pid = None
+        cmd = pre_cmd or []
+        cmd += self.construct_param_list()
+        # Run Firecracker under screen. This is used when we want to access
+        # the serial console. The file will collect the output from
+        # 'screen'ed Firecracker.
+        self.screen_pid = start_screen_process(
+            self.screen_log,
+            self.screen_session,
+            cmd[0],
+            cmd[1:],
+        )
+
+        # If `--new-pid-ns` is used, the Firecracker process will detach from
+        # the screen and the screen process will exit. We do not want to
+        # attempt to kill it in that case to avoid a race condition.
+        if self.new_pid_ns:
+            self.screen_pid = None
+
+    def kill(self):
+        """Kill the Firecracker process"""
+        if not self.screen_pid:
+            raise RuntimeError("screen process not started")
+        # Killing screen will send SIGHUP to underlying Firecracker.
+        # Needed to avoid false positives in case kill() is called again.
+        self.expect_kill_by_signal = True
+        os.kill(self.screen_pid, signal.SIGKILL)
+        os.kill(self.pid, signal.SIGKILL)
+
+    @property
+    def console_data(self):
+        """Return the output of microVM's console"""
+        if self.screen_log is None:
+            return None
+        file = Path(self.screen_log)
+        if not file.exists():
+            return None
+        return file.read_text(encoding="utf-8")
+
+    @property
+    def screen_session(self):
+        """The screen session name
+
+        The id of this microVM, which should be unique.
+        """
+        return self.jailer_id
+
+    @property
+    def screen_log(self):
+        """Get the screen log file."""
+        return f"/tmp/screen-{self.screen_session}.log"
+
+    def serial_input(self, input_string):
+        """Send a string to the Firecracker serial console via screen."""
+        input_cmd = f'screen -S {self.screen_session} -p 0 -X stuff "{input_string}"'
+        return utils.check_output(input_cmd)
+
+    def serial(self):
+        """Get a Serial object for this jailer/microvm"""
+        return Serial(self)
+
+
+class Serial:
+    """Class for serial console communication with a Microvm."""
+
+    RX_TIMEOUT_S = 60
+
+    def __init__(self, screen_jailer):
+        """Initialize a new Serial object."""
+        self._poller = None
+        self._screen_jailer = screen_jailer
+
+    def open(self):
+        """Open a serial connection."""
+        # Open the screen log file.
+        if self._poller is not None:
+            # serial already opened
+            return
+
+        attempt = 0
+        while not Path(self._screen_jailer.screen_log).exists() and attempt < 5:
+            time.sleep(0.2)
+            attempt += 1
+
+        screen_log_fd = os.open(self._screen_jailer.screen_log, os.O_RDONLY)
+        self._poller = select.poll()
+        self._poller.register(screen_log_fd, select.POLLIN | select.POLLHUP)
+
+    def tx(self, input_string, end="\n"):
+        # pylint: disable=invalid-name
+        # No need to have a snake_case naming style for a single word.
+        r"""Send a string terminated by an end token (defaulting to "\n")."""
+        self._screen_jailer.serial_input(input_string + end)
+
+    def rx_char(self):
+        """Read a single character."""
+        result = self._poller.poll(0.1)
+
+        for fd, flag in result:
+            if flag & select.POLLHUP:
+                assert False, "Oh! The console vanished before test completed."
+
+            if flag & select.POLLIN:
+                output_char = str(os.read(fd, 1), encoding="utf-8", errors="ignore")
+                return output_char
+
+        return ""
+
+    def rx(self, token="\n"):
+        # pylint: disable=invalid-name
+        # No need to have a snake_case naming style for a single word.
+        r"""Read a string delimited by an end token (defaults to "\n")."""
+        rx_str = ""
+        start = time.time()
+        while True:
+            rx_str += self.rx_char()
+            if rx_str.endswith(token):
+                break
+            if (time.time() - start) >= self.RX_TIMEOUT_S:
+                self._screen_jailer.kill()
+                assert False
+
+        return rx_str

--- a/tests/framework/microvm_helpers.py
+++ b/tests/framework/microvm_helpers.py
@@ -9,6 +9,8 @@ import platform
 import subprocess
 from pathlib import Path
 
+from framework.jailer_screen import JailerScreen
+
 
 def docker_apt_install(packages: str | list[str]):
     """Install a package in the Docker devctr"""
@@ -127,13 +129,17 @@ class MicrovmHelpers:
             raise RuntimeError(".spawn already called, too late to enable the console")
         if self.vm.boot_args is None:
             self.vm.boot_args = ""
-        self.vm.boot_args += "console=ttyS0 reboot=k panic=1"
-        self.vm.jailer.daemonize = False
-        self.vm.jailer.new_pid_ns = False
+        self.vm.boot_args += "console=ttyS0 loglevel=4 reboot=k panic=1"
+        self.vm.jailer = JailerScreen(
+            self.vm.id,
+            self.vm.jailer.jailer_bin_path,
+            self.vm.jailer.exec_file,
+            netns=self.vm.netns,
+        )
 
     def how_to_console(self):
         """Print how to connect to the VM console"""
-        return f"screen -dR {self.vm.screen_session}"
+        return f"screen -dR {self.vm.jailer.screen_session}"
 
     def tmux_console(self):
         """Open a tmux window with the console"""

--- a/tests/host_tools/drive.py
+++ b/tests/host_tools/drive.py
@@ -31,7 +31,7 @@ class FilesystemFile:
         if fs_format not in self.KNOWN_FILEFS_FORMATS:
             raise ValueError("Format not in: + " + str(self.KNOWN_FILEFS_FORMATS))
         # Here we append the format as a
-        path = os.path.join(path + "." + fs_format)
+        path = os.path.join(str(path) + "." + fs_format)
 
         if os.path.isfile(path):
             raise FileExistsError("File already exists: " + path)

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -60,7 +60,7 @@ def test_drive_io_engine(uvm_plain):
 
     kwargs = {
         "drive_id": "rootfs",
-        "path_on_host": test_microvm.create_jailed_resource(test_microvm.rootfs_file),
+        "path_on_host": test_microvm.jail_path(test_microvm.rootfs_file),
         "is_root_device": True,
         "is_read_only": True,
     }

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -100,10 +100,10 @@ def test_api_put_update_pre_boot(uvm_plain, io_engine):
     # a root file system with the rw permission.
     test_microvm.basic_config()
 
-    fs1 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "scratch"))
+    fs1 = drive_tools.FilesystemFile(test_microvm.chroot / "scratch")
     response = test_microvm.api.drive.put(
         drive_id="scratch",
-        path_on_host=test_microvm.create_jailed_resource(fs1.path),
+        path_on_host=test_microvm.jail_path(fs1.path),
         is_root_device=False,
         is_read_only=False,
         io_engine=io_engine,
@@ -118,7 +118,7 @@ def test_api_put_update_pre_boot(uvm_plain, io_engine):
 
     # Updates to `kernel_image_path` with a valid path are allowed.
     test_microvm.api.boot.put(
-        kernel_image_path=test_microvm.get_jailed_resource(test_microvm.kernel_file)
+        kernel_image_path=test_microvm.jail_path(test_microvm.kernel_file)
     )
 
     # Updates to `path_on_host` with an invalid path are not allowed.
@@ -136,17 +136,17 @@ def test_api_put_update_pre_boot(uvm_plain, io_engine):
     with pytest.raises(RuntimeError, match="A root block device already exists"):
         test_microvm.api.drive.put(
             drive_id="scratch",
-            path_on_host=test_microvm.get_jailed_resource(fs1.path),
+            path_on_host=test_microvm.jail_path(fs1.path),
             is_read_only=False,
             is_root_device=True,
             io_engine=io_engine,
         )
 
     # Valid updates to `path_on_host` and `is_read_only` are allowed.
-    fs2 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "otherscratch"))
+    fs2 = drive_tools.FilesystemFile(test_microvm.chroot / "otherscratch")
     test_microvm.api.drive.put(
         drive_id="scratch",
-        path_on_host=test_microvm.create_jailed_resource(fs2.path),
+        path_on_host=test_microvm.jail_path(fs2.path),
         is_read_only=True,
         is_root_device=False,
         io_engine=io_engine,
@@ -496,7 +496,7 @@ def test_api_put_update_post_boot(uvm_plain, io_engine):
     # Valid updates to `kernel_image_path` are not allowed after boot.
     with pytest.raises(RuntimeError, match=NOT_SUPPORTED_AFTER_START):
         test_microvm.api.boot.put(
-            kernel_image_path=test_microvm.get_jailed_resource(test_microvm.kernel_file)
+            kernel_image_path=test_microvm.jail_path(test_microvm.kernel_file)
         )
 
     # Valid updates to the machine configuration are not allowed after boot.
@@ -542,10 +542,10 @@ def test_rate_limiters_api_config(uvm_plain, io_engine):
     # Test the DRIVE rate limiting API.
 
     # Test drive with bw rate-limiting.
-    fs1 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "bw"))
+    fs1 = drive_tools.FilesystemFile(test_microvm.chroot / "bw")
     test_microvm.api.drive.put(
         drive_id="bw",
-        path_on_host=test_microvm.create_jailed_resource(fs1.path),
+        path_on_host=test_microvm.jail_path(fs1.path),
         is_read_only=False,
         is_root_device=False,
         rate_limiter={"bandwidth": {"size": 1000000, "refill_time": 100}},
@@ -553,10 +553,10 @@ def test_rate_limiters_api_config(uvm_plain, io_engine):
     )
 
     # Test drive with ops rate-limiting.
-    fs2 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "ops"))
+    fs2 = drive_tools.FilesystemFile(test_microvm.chroot / "ops")
     test_microvm.api.drive.put(
         drive_id="ops",
-        path_on_host=test_microvm.create_jailed_resource(fs2.path),
+        path_on_host=test_microvm.jail_path(fs2.path),
         is_read_only=False,
         is_root_device=False,
         rate_limiter={"ops": {"size": 1, "refill_time": 100}},
@@ -564,10 +564,10 @@ def test_rate_limiters_api_config(uvm_plain, io_engine):
     )
 
     # Test drive with bw and ops rate-limiting.
-    fs3 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "bwops"))
+    fs3 = drive_tools.FilesystemFile(test_microvm.chroot / "bwops")
     test_microvm.api.drive.put(
         drive_id="bwops",
-        path_on_host=test_microvm.create_jailed_resource(fs3.path),
+        path_on_host=test_microvm.jail_path(fs3.path),
         is_read_only=False,
         is_root_device=False,
         rate_limiter={
@@ -578,10 +578,10 @@ def test_rate_limiters_api_config(uvm_plain, io_engine):
     )
 
     # Test drive with 'empty' rate-limiting (same as not specifying the field)
-    fs4 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "nada"))
+    fs4 = drive_tools.FilesystemFile(test_microvm.chroot / "nada")
     test_microvm.api.drive.put(
         drive_id="nada",
-        path_on_host=test_microvm.create_jailed_resource(fs4.path),
+        path_on_host=test_microvm.jail_path(fs4.path),
         is_read_only=False,
         is_root_device=False,
         rate_limiter={},
@@ -651,11 +651,11 @@ def test_api_patch_pre_boot(uvm_plain, io_engine):
     # and a root file system with the rw permission.
     test_microvm.basic_config()
 
-    fs1 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "scratch"))
+    fs1 = drive_tools.FilesystemFile(test_microvm.chroot / "scratch")
     drive_id = "scratch"
     test_microvm.api.drive.put(
         drive_id=drive_id,
-        path_on_host=test_microvm.create_jailed_resource(fs1.path),
+        path_on_host=test_microvm.jail_path(fs1.path),
         is_root_device=False,
         is_read_only=False,
         io_engine=io_engine,
@@ -701,10 +701,10 @@ def test_negative_api_patch_post_boot(uvm_plain, io_engine):
     # a root file system with the rw permission.
     test_microvm.basic_config()
 
-    fs1 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "scratch"))
+    fs1 = drive_tools.FilesystemFile(test_microvm.chroot / "scratch")
     test_microvm.api.drive.put(
         drive_id="scratch",
-        path_on_host=test_microvm.create_jailed_resource(fs1.path),
+        path_on_host=test_microvm.jail_path(fs1.path),
         is_root_device=False,
         is_read_only=False,
         io_engine=io_engine,
@@ -743,7 +743,7 @@ def test_drive_patch(uvm_plain):
     # a root file system with the rw permission.
     test_microvm.basic_config(rootfs_io_engine="Sync")
 
-    fs = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "scratch"))
+    fs = drive_tools.FilesystemFile(test_microvm.chroot / "scratch")
     test_microvm.add_drive(
         drive_id="scratch",
         path_on_host=fs.path,
@@ -752,9 +752,7 @@ def test_drive_patch(uvm_plain):
         io_engine="Async" if is_io_uring_supported() else "Sync",
     )
 
-    fs_vub = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, "scratch_vub")
-    )
+    fs_vub = drive_tools.FilesystemFile(test_microvm.chroot / "scratch_vub")
     test_microvm.add_vhost_user_drive("scratch_vub", fs_vub.path)
 
     # Patching drive before boot is not allowed.
@@ -848,16 +846,16 @@ def _drive_patch(test_microvm):
     with pytest.raises(RuntimeError, match=re.escape(expected_msg)):
         test_microvm.api.drive.patch(drive_id="scratch", path_on_host=drive_path)
 
-    fs = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "scratch_new"))
+    fs = drive_tools.FilesystemFile(test_microvm.chroot / "scratch_new")
     # Updates to `path_on_host` with a valid path are allowed.
     test_microvm.api.drive.patch(
-        drive_id="scratch", path_on_host=test_microvm.create_jailed_resource(fs.path)
+        drive_id="scratch", path_on_host=test_microvm.jail_path(fs.path)
     )
 
     # Updates to valid `path_on_host` and `rate_limiter` are allowed.
     test_microvm.api.drive.patch(
         drive_id="scratch",
-        path_on_host=test_microvm.create_jailed_resource(fs.path),
+        path_on_host=test_microvm.jail_path(fs.path),
         rate_limiter={
             "bandwidth": {"size": 1000000, "refill_time": 100},
             "ops": {"size": 1, "refill_time": 100},
@@ -1169,7 +1167,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
 
     # We expect boot-source to be set with the following values
     expected_cfg["boot-source"] = {
-        "kernel_image_path": uvm_nano.get_jailed_resource(uvm_nano.kernel_file),
+        "kernel_image_path": uvm_nano.jail_path(uvm_nano.kernel_file),
         "initrd_path": None,
         "boot_args": None,
     }

--- a/tests/integration_tests/functional/test_api_server.py
+++ b/tests/integration_tests/functional/test_api_server.py
@@ -4,8 +4,6 @@
 
 import socket
 
-from framework.utils import check_output
-
 
 def test_api_socket_in_use(uvm_plain):
     """
@@ -18,8 +16,7 @@ def test_api_socket_in_use(uvm_plain):
     """
     microvm = uvm_plain
 
-    cmd = "mkdir {}/run".format(microvm.chroot())
-    check_output(cmd)
+    microvm.chroot.joinpath("run").mkdir()
 
     sock = socket.socket(socket.AF_UNIX)
     sock.bind(microvm.jailer.api_socket_path())

--- a/tests/integration_tests/functional/test_api_server.py
+++ b/tests/integration_tests/functional/test_api_server.py
@@ -19,7 +19,7 @@ def test_api_socket_in_use(uvm_plain):
     microvm.chroot.joinpath("run").mkdir()
 
     sock = socket.socket(socket.AF_UNIX)
-    sock.bind(microvm.jailer.api_socket_path())
+    sock.bind(str(microvm.jailer.api_socket_path()))
     microvm.spawn()
     msg = "Failed to open the API socket at: /run/firecracker.socket. Check that it is not already used."
     microvm.check_log_message(msg)

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -3,7 +3,6 @@
 """Tests microvm start with configuration file as command line parameter."""
 
 import json
-import os
 import platform
 import re
 import shutil
@@ -49,7 +48,7 @@ def _add_metadata_file(test_microvm, metadata_file):
     Given a test metadata file this creates a copy of the file and
     uses the copy to configure the microvm.
     """
-    vm_metadata_path = os.path.join(test_microvm.path, os.path.basename(metadata_file))
+    vm_metadata_path = test_microvm.chroot / metadata_file.name
     shutil.copyfile(metadata_file, vm_metadata_path)
     test_microvm.metadata_file = vm_metadata_path
 
@@ -365,9 +364,8 @@ def test_start_with_missing_metadata(uvm_plain):
     Test if a microvm is configured with a missing metadata file.
     """
     test_microvm = uvm_plain
-    metadata_file = "../resources/tests/metadata_nonexisting.json"
-
-    vm_metadata_path = os.path.join(test_microvm.path, os.path.basename(metadata_file))
+    metadata_file = Path("../resources/tests/metadata_nonexisting.json")
+    vm_metadata_path = test_microvm.chroot / metadata_file.name
     test_microvm.metadata_file = vm_metadata_path
 
     try:
@@ -389,7 +387,7 @@ def test_start_with_invalid_metadata(uvm_plain):
     """
     test_microvm = uvm_plain
     metadata_file = DIR / "metadata_invalid.json"
-    vm_metadata_path = os.path.join(test_microvm.path, os.path.basename(metadata_file))
+    vm_metadata_path = test_microvm.chroot / metadata_file.name
     shutil.copy(metadata_file, vm_metadata_path)
     test_microvm.metadata_file = vm_metadata_path
 

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -27,8 +27,8 @@ def _configure_vm_from_json(test_microvm, vm_config_file):
     parameter to this helper function.
     """
     # since we don't use basic-config, we do it by hand
-    test_microvm.create_jailed_resource(test_microvm.kernel_file)
-    test_microvm.create_jailed_resource(test_microvm.rootfs_file)
+    test_microvm.jail_path(test_microvm.kernel_file)
+    test_microvm.jail_path(test_microvm.rootfs_file)
 
     vm_config_file = Path(vm_config_file)
     obj = json.load(vm_config_file.open(encoding="UTF-8"))

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -36,7 +36,7 @@ def _configure_vm_from_json(test_microvm, vm_config_file):
     obj["boot-source"]["kernel_image_path"] = str(test_microvm.kernel_file.name)
     obj["drives"][0]["path_on_host"] = str(test_microvm.rootfs_file.name)
     obj["drives"][0]["is_read_only"] = True
-    vm_config = Path(test_microvm.chroot()) / vm_config_file.name
+    vm_config = test_microvm.chroot / vm_config_file.name
     vm_config.write_text(json.dumps(obj))
     test_microvm.jailer.extra_args = {"config-file": vm_config.name}
     return obj

--- a/tests/integration_tests/functional/test_drive_vhost_user.py
+++ b/tests/integration_tests/functional/test_drive_vhost_user.py
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for vhost-user-block device."""
 
-import os
 import shutil
-from pathlib import Path
 
 import host_tools.drive as drive_tools
 from framework.utils_drive import partuuid_and_disk_path
@@ -142,14 +140,14 @@ def test_device_ordering(microvm_factory, guest_kernel, rootfs):
     vm.add_net_iface()
 
     # Adding first block device.
-    fs1 = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "scratch1"), size=128)
+    fs1 = drive_tools.FilesystemFile(vm.chroot / "scratch1", size=128)
     vm.add_drive("scratch1", fs1.path)
 
     # Adding second block device (rootfs)
     vm.add_vhost_user_drive("rootfs", rootfs, is_root_device=True, is_read_only=True)
 
     # Adding third block device.
-    fs2 = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "scratch2"), size=512)
+    fs2 = drive_tools.FilesystemFile(vm.chroot / "scratch2", size=512)
     vm.add_drive("scratch2", fs2.path)
 
     # Create a rw rootfs file that is unique to the microVM

--- a/tests/integration_tests/functional/test_drive_vhost_user.py
+++ b/tests/integration_tests/functional/test_drive_vhost_user.py
@@ -82,7 +82,7 @@ def test_vhost_user_block_read_write(microvm_factory, guest_kernel, rootfs):
     vm.basic_config(add_root_device=False)
 
     # Create a rw rootfs file that is unique to the microVM
-    rootfs_rw = Path(vm.chroot()) / "rootfs"
+    rootfs_rw = vm.chroot / "rootfs"
     shutil.copy(rootfs, rootfs_rw)
 
     vm.add_vhost_user_drive("rootfs", rootfs_rw, is_root_device=True)
@@ -153,7 +153,7 @@ def test_device_ordering(microvm_factory, guest_kernel, rootfs):
     vm.add_drive("scratch2", fs2.path)
 
     # Create a rw rootfs file that is unique to the microVM
-    rootfs_rw = Path(vm.chroot()) / "rootfs"
+    rootfs_rw = vm.chroot / "rootfs"
     shutil.copy(rootfs, rootfs_rw)
 
     # Adding forth block device.
@@ -213,7 +213,7 @@ def test_partuuid_boot(
     vm.basic_config(add_root_device=False)
 
     # Create a rootfs with partuuid unique to this microVM
-    partuuid, disk_path = partuuid_and_disk_path(rootfs, Path(vm.chroot()) / "disk.img")
+    partuuid, disk_path = partuuid_and_disk_path(rootfs, vm.chroot / "disk.img")
 
     vm.add_vhost_user_drive(
         "1", disk_path, is_root_device=True, partuuid=partuuid, is_read_only=True

--- a/tests/integration_tests/functional/test_drive_virtio.py
+++ b/tests/integration_tests/functional/test_drive_virtio.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for guest-side operations on /drives resources."""
 
-import os
-
 import pytest
 
 import host_tools.drive as drive_tools
@@ -36,9 +34,7 @@ def test_rescan_file(uvm_plain_any, io_engine):
 
     block_size = 2
     # Add a scratch block device.
-    fs = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, "scratch"), size=block_size
-    )
+    fs = drive_tools.FilesystemFile(test_microvm.chroot / "scratch", size=block_size)
     test_microvm.add_drive("scratch", fs.path, io_engine=io_engine)
 
     test_microvm.start()
@@ -75,9 +71,7 @@ def test_device_ordering(uvm_plain_any, io_engine):
     test_microvm.spawn()
 
     # Add first scratch block device.
-    fs1 = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, "scratch1"), size=128
-    )
+    fs1 = drive_tools.FilesystemFile(test_microvm.chroot / "scratch1", size=128)
     test_microvm.add_drive("scratch1", fs1.path, io_engine=io_engine)
 
     # Set up the microVM with 1 vCPUs, 256 MiB of RAM and a root file system
@@ -86,9 +80,7 @@ def test_device_ordering(uvm_plain_any, io_engine):
     test_microvm.add_net_iface()
 
     # Add the third block device.
-    fs2 = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, "scratch2"), size=512
-    )
+    fs2 = drive_tools.FilesystemFile(test_microvm.chroot / "scratch2", size=512)
     test_microvm.add_drive("scratch2", fs2.path, io_engine=io_engine)
 
     test_microvm.start()
@@ -123,16 +115,14 @@ def test_rescan_dev(uvm_plain_any, io_engine):
     test_microvm.add_net_iface()
 
     # Add a scratch block device.
-    fs1 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "fs1"))
+    fs1 = drive_tools.FilesystemFile(test_microvm.chroot / "fs1")
     test_microvm.add_drive("scratch", fs1.path, io_engine=io_engine)
 
     test_microvm.start()
 
     _check_block_size(test_microvm.ssh, "/dev/vdb", fs1.size())
 
-    fs2 = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, "fs2"), size=512
-    )
+    fs2 = drive_tools.FilesystemFile(test_microvm.chroot / "fs2", size=512)
 
     losetup = ["losetup", "--find", "--show", fs2.path]
     rc, stdout, _ = utils.check_output(losetup)
@@ -163,7 +153,7 @@ def test_non_partuuid_boot(uvm_plain_any, io_engine):
     test_microvm.add_net_iface()
 
     # Add another read-only block device.
-    fs = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "readonly"))
+    fs = drive_tools.FilesystemFile(test_microvm.chroot / "readonly")
     test_microvm.add_drive("scratch", fs.path, is_read_only=True, io_engine=io_engine)
 
     test_microvm.start()
@@ -262,7 +252,7 @@ def test_patch_drive(uvm_plain_any, io_engine):
     test_microvm.basic_config()
     test_microvm.add_net_iface()
 
-    fs1 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "scratch"))
+    fs1 = drive_tools.FilesystemFile(test_microvm.chroot / "scratch")
     test_microvm.add_drive("scratch", fs1.path, io_engine=io_engine)
 
     test_microvm.start()
@@ -270,9 +260,7 @@ def test_patch_drive(uvm_plain_any, io_engine):
     _check_mount(test_microvm.ssh, "/dev/vdb")
 
     # Updates to `path_on_host` with a valid path are allowed.
-    fs2 = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, "otherscratch"), size=512
-    )
+    fs2 = drive_tools.FilesystemFile(test_microvm.chroot / "otherscratch", size=512)
     test_microvm.api.drive.patch(
         drive_id="scratch", path_on_host=test_microvm.create_jailed_resource(fs2.path)
     )

--- a/tests/integration_tests/functional/test_drive_virtio.py
+++ b/tests/integration_tests/functional/test_drive_virtio.py
@@ -54,7 +54,7 @@ def test_rescan_file(uvm_plain_any, io_engine):
 
     test_microvm.api.drive.patch(
         drive_id="scratch",
-        path_on_host=test_microvm.create_jailed_resource(fs.path),
+        path_on_host=test_microvm.jail_path(fs.path),
     )
 
     _check_block_size(test_microvm.ssh, "/dev/vdb", fs.size())
@@ -132,7 +132,7 @@ def test_rescan_dev(uvm_plain_any, io_engine):
     try:
         test_microvm.api.drive.patch(
             drive_id="scratch",
-            path_on_host=test_microvm.create_jailed_resource(loopback_device),
+            path_on_host=test_microvm.jail_path(loopback_device),
         )
 
         _check_block_size(test_microvm.ssh, "/dev/vdb", fs2.size())
@@ -262,7 +262,7 @@ def test_patch_drive(uvm_plain_any, io_engine):
     # Updates to `path_on_host` with a valid path are allowed.
     fs2 = drive_tools.FilesystemFile(test_microvm.chroot / "otherscratch", size=512)
     test_microvm.api.drive.patch(
-        drive_id="scratch", path_on_host=test_microvm.create_jailed_resource(fs2.path)
+        drive_id="scratch", path_on_host=test_microvm.jail_path(fs2.path)
     )
 
     _check_mount(test_microvm.ssh, "/dev/vdb")

--- a/tests/integration_tests/functional/test_kernel_cmdline.py
+++ b/tests/integration_tests/functional/test_kernel_cmdline.py
@@ -3,8 +3,6 @@
 
 """Test kernel commandline behavior."""
 
-from framework.microvm import Serial
-
 
 def test_init_params(uvm_plain):
     """Correct propagation of boot args to the kernel's command line.
@@ -26,7 +24,7 @@ def test_init_params(uvm_plain):
     )
 
     vm.start()
-    serial = Serial(vm)
+    serial = vm.jailer.serial()
     serial.open()
     # If the string does not show up, the test will fail.
     serial.rx(token="Ubuntu 24.04")

--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -7,7 +7,6 @@ up in the configured logging file.
 """
 
 import re
-from pathlib import Path
 from time import strptime
 
 import pytest
@@ -101,10 +100,10 @@ def test_api_requests_logs(uvm_plain):
     microvm.basic_config()
 
     # Configure logging.
-    log_path = Path(microvm.path) / "log"
+    log_path = microvm.chroot / "log"
     log_path.touch()
     microvm.api.logger.put(
-        log_path=microvm.create_jailed_resource(log_path),
+        log_path=microvm.jail_path(log_path),
         level="Info",
         show_level=True,
         show_log_origin=True,
@@ -135,10 +134,10 @@ def test_api_requests_logs(uvm_plain):
     )
 
     # Re-configure logging.
-    log_path = Path(microvm.path) / "new_log"
+    log_path = microvm.chroot / "new_log"
     log_path.touch()
     microvm.api.logger.put(
-        log_path=microvm.create_jailed_resource(log_path),
+        log_path=microvm.jail_path(log_path),
         level="Info",
         show_level=True,
         show_log_origin=True,

--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests the metrics system."""
 
-import os
-
 import host_tools.drive as drive_tools
 from host_tools.fcmetrics import FcDeviceMetrics, validate_fc_metrics
 
@@ -63,9 +61,7 @@ def test_block_metrics(uvm_plain):
     test_microvm.spawn()
 
     # Add first scratch block device.
-    fs1 = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, "scratch1"), size=128
-    )
+    fs1 = drive_tools.FilesystemFile(test_microvm.chroot / "scratch1", size=128)
     test_microvm.add_drive("scratch1", fs1.path)
 
     # Set up a basic microVM.
@@ -73,9 +69,7 @@ def test_block_metrics(uvm_plain):
     test_microvm.basic_config()
 
     # Add the third block device.
-    fs2 = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, "scratch2"), size=512
-    )
+    fs2 = drive_tools.FilesystemFile(test_microvm.chroot / "scratch2", size=512)
     test_microvm.add_drive("scratch2", fs2.path)
 
     num_block_devices = 3

--- a/tests/integration_tests/functional/test_rtc.py
+++ b/tests/integration_tests/functional/test_rtc.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Check the well functioning af the RTC device on aarch64 platforms."""
+"""Check the well functioning of the RTC device on aarch64 platforms."""
 import platform
 import re
 

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -10,7 +10,6 @@ import termios
 import time
 
 from framework import utils
-from framework.microvm import Serial
 from framework.state_machine import TestState
 
 PLATFORM = platform.machine()
@@ -57,7 +56,7 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
         mem_size_mib=256,
         boot_args="console=ttyS0 reboot=k panic=1 pci=off",
     )
-    serial = Serial(microvm)
+    serial = microvm.jailer.serial()
     serial.open()
     microvm.start()
 
@@ -74,7 +73,7 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
     vm.help.enable_console()
     vm.spawn()
     vm.restore_from_snapshot(snapshot, resume=True)
-    serial = Serial(vm)
+    serial = vm.jailer.serial()
     serial.open()
     # We need to send a newline to signal the serial to flush
     # the login content.
@@ -105,7 +104,7 @@ def test_serial_console_login(uvm_plain_any):
 
     microvm.start()
 
-    serial = Serial(microvm)
+    serial = microvm.jailer.serial()
     serial.open()
     current_state = WaitTerminal("ubuntu-fc-uvm:")
 
@@ -185,7 +184,7 @@ def test_serial_block(uvm_plain_any):
     init_count = fc_metrics["uart"]["missed_write_count"]
 
     # Stop `screen` process which captures stdout so we stop consuming stdout.
-    os.kill(test_microvm.screen_pid, signal.SIGSTOP)
+    os.kill(test_microvm.jailer.screen_pid, signal.SIGSTOP)
 
     # Generate a random text file.
     test_microvm.ssh.check_output(

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -463,7 +463,7 @@ def test_diff_snapshot_overlay(guest_kernel, rootfs, microvm_factory):
 
     # First copy the base snapshot somewhere else, so we can make sure
     # it will actually get updated
-    first_snapshot_backup = Path(basevm.chroot()) / "mem.old"
+    first_snapshot_backup = basevm.chroot / "mem.old"
     shutil.copyfile(full_snapshot.mem, first_snapshot_backup)
 
     # One Microvm object will always write its snapshot files to the same location
@@ -498,7 +498,7 @@ def test_snapshot_overwrite_self(guest_kernel, rootfs, microvm_factory):
 
     # When restoring a snapshot, vm.restore_from_snapshot first copies
     # the memory file (inside of the jailer) to /mem.src
-    currently_loaded = Path(vm.chroot()) / "mem.src"
+    currently_loaded = vm.chroot / "mem.src"
 
     assert currently_loaded.exists()
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -239,8 +239,8 @@ def test_load_snapshot_failure_handling(uvm_plain):
     snapshot_vmstate.touch()
 
     # Hardlink the snapshot files into the microvm jail.
-    jailed_mem = vm.create_jailed_resource(snapshot_mem)
-    jailed_vmstate = vm.create_jailed_resource(snapshot_vmstate)
+    jailed_mem = vm.jail_path(snapshot_mem)
+    jailed_vmstate = vm.jail_path(snapshot_vmstate)
 
     # Load the snapshot
     expected_msg = (

--- a/tests/integration_tests/functional/test_snapshot_not_losing_dirty_pages.py
+++ b/tests/integration_tests/functional/test_snapshot_not_losing_dirty_pages.py
@@ -42,11 +42,9 @@ def test_diff_snapshot_works_after_error(
     uvm.add_net_iface()
     uvm.start()
 
-    chroot = Path(uvm.chroot())
-
     # Create a large file dynamically based on available space
-    fill = chroot / "fill"
-    disk_usage = psutil.disk_usage(chroot)
+    fill = uvm.chroot / "fill"
+    disk_usage = psutil.disk_usage(uvm.chroot)
     target_size = round(disk_usage.free * 0.9)  # Attempt to fill 90% of free space
 
     subprocess.check_call(f"fallocate -l {target_size} {fill}", shell=True)

--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -45,7 +45,7 @@ def spawn_pf_handler(vm, handler_path, mem_path):
     handler_name = os.path.basename(jailed_handler)
 
     uffd_handler = UffdHandler(
-        handler_name, SOCKET_PATH, jailed_mem, vm.chroot(), "uffd.log"
+        handler_name, SOCKET_PATH, jailed_mem, vm.chroot, "uffd.log"
     )
     uffd_handler.spawn(vm.jailer.uid, vm.jailer.gid)
 

--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -8,7 +8,7 @@ import re
 import pytest
 import requests
 
-from framework.utils import Timeout, UffdHandler, check_output
+from framework.utils import Timeout, UffdHandler
 
 SOCKET_PATH = "/firecracker-uffd.sock"
 
@@ -82,9 +82,9 @@ def test_unbinded_socket(uvm_plain, snapshot):
     vm.spawn()
 
     jailed_vmstate = vm.create_jailed_resource(snapshot.vmstate)
-    socket_path = os.path.join(vm.path, "firecracker-uffd.sock")
-    check_output("touch {}".format(socket_path))
-    jailed_sock_path = vm.create_jailed_resource(socket_path)
+    socket_path = vm.chroot / "firecracker-uffd.sock"
+    socket_path.touch()
+    jailed_sock_path = vm.jail_path(socket_path)
 
     expected_msg = re.escape(
         "Load snapshot error: Failed to restore from snapshot: Failed to load guest "

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -203,11 +203,11 @@ def test_vsock_transport_reset_h2g(
 
     # Check that vsock device still works.
     # Test guest-initiated connections.
-    path = os.path.join(vm2.path, make_host_port_path(VSOCK_UDS_PATH, ECHO_SERVER_PORT))
+    path = vm2.chroot / make_host_port_path(VSOCK_UDS_PATH, ECHO_SERVER_PORT)
     check_guest_connections(vm2, path, vm_blob_path, blob_hash)
 
     # Test host-initiated connections.
-    path = os.path.join(vm2.jailer.chroot_path(), VSOCK_UDS_PATH)
+    path = vm2.chroot / VSOCK_UDS_PATH
     check_host_connections(path, blob_path, blob_hash)
     metrics = vm2.flush_metrics()
     validate_fc_metrics(metrics)
@@ -236,9 +236,7 @@ def test_vsock_transport_reset_g2h(uvm_nano, microvm_factory):
         code, _, _ = new_vm.ssh.run("pidof socat")
         assert code == 1
 
-        host_socket_path = os.path.join(
-            new_vm.path, f"{VSOCK_UDS_PATH}_{ECHO_SERVER_PORT}"
-        )
+        host_socket_path = new_vm.chroot / f"{VSOCK_UDS_PATH}_{ECHO_SERVER_PORT}"
         host_socat_commmand = [
             "socat",
             "-dddd",

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -250,7 +250,7 @@ def test_vsock_transport_reset_g2h(uvm_nano, microvm_factory):
         # Give some time for host socat to create socket
         time.sleep(0.5)
         assert Path(host_socket_path).exists()
-        new_vm.create_jailed_resource(host_socket_path)
+        new_vm.jail_path(host_socket_path)
 
         # Create a socat process in the guest which will connect to the host socat
         guest_socat_commmand = (

--- a/tests/integration_tests/performance/test_drive_rate_limiter.py
+++ b/tests/integration_tests/performance/test_drive_rate_limiter.py
@@ -3,7 +3,6 @@
 
 """Tests for checking the rate limiter on /drives resources."""
 import json
-import os
 
 import host_tools.drive as drive_tools
 
@@ -41,12 +40,10 @@ def test_patch_drive_limiter(uvm_plain):
     test_microvm.basic_config(vcpu_count=2, mem_size_mib=512)
     test_microvm.add_net_iface()
 
-    fs1 = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, "scratch"), size=512
-    )
+    fs1 = drive_tools.FilesystemFile(test_microvm.chroot / "scratch", size=512)
     test_microvm.api.drive.put(
         drive_id="scratch",
-        path_on_host=test_microvm.create_jailed_resource(fs1.path),
+        path_on_host=test_microvm.jail_path(fs1.path),
         is_root_device=False,
         is_read_only=False,
         rate_limiter={

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -7,6 +7,7 @@ import time
 import pytest
 
 from framework import utils
+from framework.jailer_screen import JailerScreen
 from framework.microvm import HugePagesConfig
 from framework.properties import global_props
 from framework.utils_ftrace import ftrace_events
@@ -195,7 +196,9 @@ def test_ept_violation_count(
 
     ### Restore Snapshot ###
     vm = microvm_factory.build()
-    vm.jailer.daemonize = False
+    vm.jailer = JailerScreen(
+        vm.id, vm.jailer.jailer_bin_path, vm.jailer.exec_file, netns=vm.netns
+    )
     vm.jailer.extra_args.update({"no-seccomp": None})
     vm.spawn()
 

--- a/tests/integration_tests/performance/test_initrd.py
+++ b/tests/integration_tests/performance/test_initrd.py
@@ -3,7 +3,7 @@
 """Tests for initrd."""
 import pytest
 
-from framework.microvm import HugePagesConfig, Serial
+from framework.microvm import HugePagesConfig
 
 INITRD_FILESYSTEM = "rootfs"
 
@@ -39,7 +39,7 @@ def test_microvm_initrd_with_serial(uvm_with_initrd, huge_pages):
     )
 
     vm.start()
-    serial = Serial(vm)
+    serial = vm.jailer.serial()
     serial.open()
     serial.rx(token="# ")
     serial.tx("mount |grep rootfs")

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Test that the process startup time up to socket bind is within spec."""
 
-import os
 import time
 
 from host_tools.cargo_build import run_seccompiler_bin
@@ -79,9 +78,7 @@ def _test_startup_time(microvm, metrics, test_suffix: str):
 
 
 def _custom_filter_setup(test_microvm):
-    bpf_path = os.path.join(test_microvm.path, "bpf.out")
-
+    bpf_path = test_microvm.chroot / "bpf.out"
     run_seccompiler_bin(bpf_path)
-
     test_microvm.create_jailed_resource(bpf_path)
     test_microvm.jailer.extra_args.update({"seccomp-filter": "bpf.out"})

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -80,5 +80,5 @@ def _test_startup_time(microvm, metrics, test_suffix: str):
 def _custom_filter_setup(test_microvm):
     bpf_path = test_microvm.chroot / "bpf.out"
     run_seccompiler_bin(bpf_path)
-    test_microvm.create_jailed_resource(bpf_path)
+    test_microvm.jail_path(bpf_path)
     test_microvm.jailer.extra_args.update({"seccomp-filter": "bpf.out"})

--- a/tests/integration_tests/performance/test_vsock_ab.py
+++ b/tests/integration_tests/performance/test_vsock_ab.py
@@ -52,7 +52,7 @@ class VsockIPerf3Test(IPerf3Test):
         uds_path = self._microvm.chroot / make_host_port_path(
             VSOCK_UDS_PATH, self._base_port + client_idx
         )
-        self._microvm.create_jailed_resource(uds_path)
+        self._microvm.jail_path(uds_path)
         # The rootfs does not have iperf3-vsock
         iperf3_guest = "/tmp/iperf3-vsock"
 

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -114,14 +114,14 @@ def test_invalid_bpf(uvm_plain):
     test_microvm.create_jailed_resource(test_microvm.rootfs_file)
 
     vm_config_file = Path("framework/vm_config.json")
-    test_microvm.create_jailed_resource(vm_config_file)
-    test_microvm.jailer.extra_args = {"config-file": vm_config_file.name}
-    test_microvm.jailer.extra_args.update({"no-api": None})
+    vm_config_jailed_path = test_microvm.create_jailed_resource(vm_config_file)
+    test_microvm.jailer.extra_args = {"config-file": vm_config_jailed_path}
+    test_microvm.jailer.extra_args["no-api"] = None
 
-    bpf_path = Path(test_microvm.path) / "bpf.out"
+    bpf_path = test_microvm.chroot / "bpf.out"
     bpf_path.write_bytes(b"Invalid BPF!")
-    test_microvm.create_jailed_resource(bpf_path)
-    test_microvm.jailer.extra_args.update({"seccomp-filter": bpf_path.name})
+    bpf_jail_path = test_microvm.jail_path(bpf_path)
+    test_microvm.jailer.extra_args["seccomp-filter"] = bpf_jail_path
 
     test_microvm.spawn()
     # give time for the process to get killed

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -13,7 +13,7 @@ from framework import utils
 
 def install_filter(microvm, bpf_path):
     """Install seccomp filter in microvm."""
-    microvm.create_jailed_resource(bpf_path)
+    microvm.jail_path(bpf_path)
     microvm.jailer.extra_args.update({"seccomp-filter": bpf_path.name})
 
 
@@ -110,11 +110,11 @@ def test_invalid_bpf(uvm_plain):
 
     # Configure VM from JSON. Otherwise, the test will error because
     # the process will be killed before configuring the API socket.
-    test_microvm.create_jailed_resource(test_microvm.kernel_file)
-    test_microvm.create_jailed_resource(test_microvm.rootfs_file)
+    test_microvm.jail_path(test_microvm.kernel_file)
+    test_microvm.jail_path(test_microvm.rootfs_file)
 
     vm_config_file = Path("framework/vm_config.json")
-    vm_config_jailed_path = test_microvm.create_jailed_resource(vm_config_file)
+    vm_config_jailed_path = test_microvm.jail_path(vm_config_file)
     test_microvm.jailer.extra_args = {"config-file": vm_config_jailed_path}
     test_microvm.jailer.extra_args["no-api"] = None
 


### PR DESCRIPTION
## Changes

In the integration tests support classes, the Jailer and the Microvm are very coupled, and the logic is spread over the two classes with things like screen support directly in the Microvm class.

This change cleanly separates the Jailer(s) and extracts the screen handling into a new handler, `JailerScreen`.

There's some other simplifications of the Microvm class for example avoiding creating files in two different places.

## Reason

Simplifying the support classes so they can be re-used in other contexts.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
