### PR TITLE
fix: stop `dup(2)`-ing fds when setting up guest memory

### DIFF
--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -7,6 +7,7 @@
 
 use std::fs::File;
 use std::io::SeekFrom;
+use std::sync::Arc;
 
 use libc::c_int;
 use serde::{Deserialize, Serialize};
@@ -35,8 +36,6 @@ pub type GuestMmapRegion = vm_memory::MmapRegion<Option<AtomicBitmap>>;
 /// Errors associated with dumping guest memory to file.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum MemoryError {
-    /// Cannot access file: {0}
-    FileError(std::io::Error),
     /// Cannot create memory: {0}
     CreateMemory(VmMemoryError),
     /// Cannot create memory region: {0}
@@ -173,6 +172,7 @@ impl GuestMemoryExtension for GuestMemoryMmap {
         track_dirty_pages: bool,
     ) -> Result<Self, MemoryError> {
         let mut offset = 0;
+        let file = file.map(Arc::new);
         let regions = regions
             .map(|(start, size)| {
                 let mut builder = MmapRegionBuilder::new_with_bitmap(
@@ -183,8 +183,7 @@ impl GuestMemoryExtension for GuestMemoryMmap {
                 .with_mmap_flags(libc::MAP_NORESERVE | mmap_flags);
 
                 if let Some(ref file) = file {
-                    let file_offset =
-                        FileOffset::new(file.try_clone().map_err(MemoryError::FileError)?, offset);
+                    let file_offset = FileOffset::from_arc(Arc::clone(file), offset);
 
                     builder = builder.with_file_offset(file_offset);
                 }


### PR DESCRIPTION
Currently, when backing guest memory by memfd or when mmaping a snapshot file, we duplicate the file descriptor once per memslot. This is not necessary: KVM will happily accept the same fd into multiple memslots, and even rust-vmm supports APIs for this (by storing `Arc<File>` instead of just `File` in `FileOffset`, we can actually share the same `File` reference between multiple memory regions). So let's make use of this capability.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
