### PR TITLE
refactor(virtio-block): use a type for config space

### DIFF
--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -18,8 +18,6 @@ pub use self::request::*;
 pub use crate::devices::virtio::block::CacheType;
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
 
-/// Size of config space for block device.
-pub const BLOCK_CONFIG_SPACE_SIZE: usize = 8;
 /// Sector shift for block device.
 pub const SECTOR_SHIFT: u8 = 9;
 /// Size of block sector.

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -6,6 +6,7 @@
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
+use device::ConfigSpace;
 use serde::{Deserialize, Serialize};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -122,10 +123,14 @@ impl Persist<'_> for VirtioBlock {
             DeviceState::Inactive
         };
 
+        let config_space = ConfigSpace {
+            capacity: disk_properties.nsectors.to_le(),
+        };
+
         Ok(VirtioBlock {
             avail_features,
             acked_features,
-            config_space: disk_properties.virtio_block_config_space(),
+            config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
             queues,


### PR DESCRIPTION
## Changes
Instead of using a vector of bytes as a config space it is better to use a proper type. This was already done in the virtio-net device, so just repeat same in block device.

## Reason
Less manual bytes manipulations.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
