### PR TITLE
test(ab): unignore m6g/5.10 block

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -44,13 +44,6 @@ from host_tools.metrics import (
 IGNORED = [
     # Network throughput on m6a.metal
     {"instance": "m6a.metal", "performance_test": "test_network_tcp_throughput"},
-    # Block throughput for 1 vcpu on m6g.metal/5.10
-    {
-        "performance_test": "test_block_performance",
-        "instance": "m6g.metal",
-        "host_kernel": "linux-5.10",
-        "vcpus": "1",
-    },
 ]
 
 


### PR DESCRIPTION
## Changes

m6g/5.10 block throughput results are no longer volatile, so we can reinsert it to the A/B testing.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
