### PR TITLE
[RFC] Decouple MMDS service from network stack

### DIFF
--- a/src/firecracker/src/api_server/parsed_request.rs
+++ b/src/firecracker/src/api_server/parsed_request.rs
@@ -21,7 +21,9 @@ use super::request::machine_configuration::{
     parse_get_machine_config, parse_patch_machine_config, parse_put_machine_config,
 };
 use super::request::metrics::parse_put_metrics;
-use super::request::mmds::{parse_get_mmds, parse_patch_mmds, parse_put_mmds};
+use super::request::mmds::{
+    parse_get_mmds, parse_patch_mmds, parse_put_mmds, parse_put_mmds_server_config,
+};
 use super::request::net::{parse_patch_net, parse_put_net};
 use super::request::snapshot::{parse_patch_vm_state, parse_put_snapshot};
 use super::request::version::parse_get_version;
@@ -93,6 +95,7 @@ impl TryFrom<&Request> for ParsedRequest {
             (Method::Put, "machine-config", Some(body)) => parse_put_machine_config(body),
             (Method::Put, "metrics", Some(body)) => parse_put_metrics(body),
             (Method::Put, "mmds", Some(body)) => parse_put_mmds(body, path_tokens.next()),
+            (Method::Put, "mmds-server", Some(body)) => parse_put_mmds_server_config(body),
             (Method::Put, "network-interfaces", Some(body)) => {
                 parse_put_net(body, path_tokens.next())
             }

--- a/src/firecracker/src/api_server/request/mmds.rs
+++ b/src/firecracker/src/api_server/request/mmds.rs
@@ -5,7 +5,7 @@ use micro_http::StatusCode;
 use vmm::logger::{IncMetric, METRICS};
 use vmm::mmds::data_store::MmdsVersion;
 use vmm::rpc_interface::VmmAction;
-use vmm::vmm_config::mmds::MmdsConfig;
+use vmm::vmm_config::mmds::{MmdsConfig, MmdsServerConfig};
 
 use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
@@ -32,6 +32,13 @@ fn parse_put_mmds_config(body: &Body) -> Result<ParsedRequest, RequestError> {
     }
 
     Ok(parsed_request)
+}
+
+pub(crate) fn parse_put_mmds_server_config(body: &Body) -> Result<ParsedRequest, RequestError> {
+    let config: MmdsServerConfig = serde_json::from_slice(body.raw())?;
+    Ok(ParsedRequest::new_sync(
+        VmmAction::SetMmdsServerConfiguration(config),
+    ))
 }
 
 pub(crate) fn parse_put_mmds(

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -558,9 +558,11 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 
         // If the snapshot has the mmds version persisted, initialise the data store with it.
         if let Some(mmds_version) = &state.mmds_version {
+            let version = mmds_version.clone().into();
             constructor_args
                 .vm_resources
-                .set_mmds_version(mmds_version.clone().into(), constructor_args.instance_id)?;
+                .set_mmds_version(version, constructor_args.instance_id)
+                .map_err(|err| MmdsConfigError::MmdsVersion(version, err))?;
         } else if state
             .net_devices
             .iter()

--- a/src/vmm/src/mmds/ns.rs
+++ b/src/vmm/src/mmds/ns.rs
@@ -180,7 +180,7 @@ impl MmdsNetworkStack {
                 self.remote_mac_addr = eth.src_mac();
                 let mmds_instance = self.mmds.clone();
                 match &mut self.tcp_handler.receive_packet(&ip, move |request| {
-                    super::convert_to_response(mmds_instance, request)
+                    super::convert_to_response(mmds_instance, &request)
                 }) {
                     Ok(event) => {
                         METRICS.mmds.rx_count.inc();

--- a/src/vmm/src/mmds/server.rs
+++ b/src/vmm/src/mmds/server.rs
@@ -1,0 +1,65 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use micro_http::{HttpServer, Request, Response, ServerError};
+
+use crate::logger::{debug, error};
+use crate::mmds::data_store::Mmds;
+use crate::vmm_config::mmds::MmdsServerConfigError;
+
+#[derive(Debug)]
+pub struct MmdsServer {
+    mmds: Arc<Mutex<Mmds>>,
+}
+
+impl MmdsServer {
+    pub fn new(mmds: Arc<Mutex<Mmds>>) -> Self {
+        MmdsServer { mmds }
+    }
+
+    pub fn run(self, bind_path: PathBuf) -> Result<(), MmdsServerConfigError> {
+        let mut server =
+            HttpServer::new(bind_path).map_err(|_| MmdsServerConfigError::InvalidVsockAddr)?;
+        server
+            .start_server()
+            .expect("Cannot start MMDS HTTP server");
+
+        thread::spawn(move || loop {
+            let request_vec = match server.requests() {
+                Ok(vec) => vec,
+                Err(ServerError::ShutdownEvent) => {
+                    server.flush_outgoing_writes();
+                    debug!("shutdown request received, MMDS server thread ending.");
+                    return;
+                }
+                Err(err) => {
+                    // print request error, but keep server running
+                    error!("MMDS Server error on retrieving incoming request: {}", err);
+                    continue;
+                }
+            };
+            for server_request in request_vec {
+                // Use `self.handle_request()` as the processing callback.
+                let response = server_request.process(|request| self.handle_request(request));
+                if let Err(err) = server.respond(response) {
+                    error!("MMDS Server encountered an error on response: {}", err);
+                };
+            }
+        });
+
+        Ok(())
+    }
+
+    pub fn handle_request(&self, request: &Request) -> Response {
+        crate::mmds::convert_to_response(self.mmds.clone(), request)
+    }
+}
+
+// TODO: Error if failed or launch more than once
+pub fn run(mmds: Arc<Mutex<Mmds>>, bind_path: PathBuf) -> Result<(), MmdsServerConfigError> {
+    MmdsServer::new(mmds).run(bind_path)
+}

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -51,3 +51,26 @@ pub enum MmdsConfigError {
     /// The MMDS could not be configured to version {0}: {1}
     MmdsVersion(MmdsVersion, data_store::MmdsDatastoreError),
 }
+
+/// MMDS server configuration.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MmdsServerConfig {
+    /// MMDS version.
+    #[serde(default)]
+    pub version: MmdsVersion,
+    /// MMDS server's vsock path
+    pub vsock_address: Option<String>,
+    /// MMDS server's vsock port
+    pub port: Option<u32>,
+}
+
+/// MMDS configuration related errors.
+#[rustfmt::skip]
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum MmdsServerConfigError {
+    /// The MMDS vsock address is not available.
+    InvalidVsockAddr,
+    /// The MMDS could not be configured to version {0}: {1}
+    MmdsVersion(MmdsVersion, data_store::MmdsDatastoreError),
+}


### PR DESCRIPTION
## Changes

- Implemented an vsock-based HTTP server for MMDS.
- Optional MMDS server API and configuration.

## Reason

- MMDS traffic is much less frequent than standard network I/O, so it benefits networking-intense application by separating MMDS from the fast data path. And it is acceptable for MMDS to be a bit slower.
- This design simplifies future attempts at `vhost-user-net` or other data-plane offloading by preventing MMDS from interfering with typical network traffic.
- Modularity & Maintainability: allows independent development of MMDS logic and eases the burden of maintaining the complex Dumbo stack.
- The guest can issue requests via `socat` directly or using `curl` by bridging an IP to vsock via `socat`.

Related to #1761

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
