### PR TITLE
fix: fail physical counter test if phy counter reg isn't in snapshot

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -552,7 +552,7 @@ def test_vmgenid(guest_kernel_linux_6_1, rootfs, microvm_factory, snapshot_type)
     platform.machine() != "aarch64" or global_props.host_linux_version_tpl < (6, 4),
     reason="This is aarch64 specific test and should only be run on 6.4 and later kernels",
 )
-def test_physical_couter_reset_aarch64(uvm_nano):
+def test_physical_counter_reset_aarch64(uvm_nano):
     """
     Test that the CNTPCT_EL0 register is reset on VM boot.
     We assume the smallest VM will not consume more than
@@ -597,3 +597,6 @@ def test_physical_couter_reset_aarch64(uvm_nano):
             reg_id, reg_value = parts
             if reg_id == cntpct_el0:
                 assert int(reg_value, 16) < max_value
+                break
+    else:
+        raise RuntimeError("Did not find CNTPCT_EL0 register in snapshot")


### PR DESCRIPTION
Right now the test would pass on stock AL kernels, because without the commits from 6.4 backported the CNTPCT_EL0 register won't even be included in the snapshot, and thus the assert is never reached.

Fix this by failing the test if the register isnt found.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
