### PR TITLE
test: catch correct exception in memory.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,11 +336,12 @@ def microvm_factory(request, record_property, results_dir, netns_factory):
     # if the test failed, save important files from the root of the uVM into `test_results` for troubleshooting
     report = request.node.stash[PHASE_REPORT_KEY]
     if "call" in report and report["call"].failed:
-        dmesg = utils.run_cmd(["dmesg", "-dPx"])
         for uvm in uvm_factory.vms:
             uvm_data = results_dir / uvm.id
             uvm_data.mkdir()
-            uvm_data.joinpath("host-dmesg.log").write_text(dmesg.stdout)
+            uvm_data.joinpath("host-dmesg.log").write_text(
+                utils.run_cmd(["dmesg", "-dPx"]).stdout
+            )
             shutil.copy(f"/firecracker/build/img/{platform.machine()}/id_rsa", uvm_data)
 
             uvm_root = Path(uvm.chroot())

--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -62,7 +62,7 @@ class MemoryMonitor(Thread):
         guest_mem_bytes = self._vm.mem_size_bytes
         try:
             ps = psutil.Process(self._vm.firecracker_pid)
-        except psutil.NoSuchProcess:
+        except (psutil.NoSuchProcess, FileNotFoundError):
             return
         while not self._should_stop:
             try:

--- a/tools/devtool
+++ b/tools/devtool
@@ -228,7 +228,7 @@ cmd_fix_perms() {
     run_devctr \
         --workdir "$CTR_FC_ROOT_DIR" \
         -- \
-        chown -f -R "$(id -u):$(id -g)" "$CTR_FC_BUILD_DIR" "$CTR_TEST_RESULTS_DIR" "$CTR_CI_ARTIFACTS_PATH"
+        chown -f -R "$(id -u):$(id -g)" "$CTR_FC_BUILD_DIR" "$CTR_TEST_RESULTS_DIR" "$CTR_CI_ARTIFACTS_PATH" $@
 }
 
 # Builds the development container from its Dockerfile.
@@ -890,6 +890,7 @@ cmd_sandbox() {
     cmd_build --release
     ensure_ci_artifacts
     cmd_sh "tmux new env PYTEST_ADDOPTS=--pdbcls=IPython.terminal.debugger:TerminalPdb PYTHONPATH=tests IPYTHONDIR=\$PWD/.ipython ipython -i ./tools/sandbox.py $@"
+    cmd_fix_perms ".ipython"
 }
 
 cmd_sandbox_native() {


### PR DESCRIPTION
The access to the `firecracker_pid` property causes a read to the vm's
pid file. This means that in the scenario where the VM is already dead
by the time the monitor starts running, we won't get a `NoSuchProcess`
error, we potentially get a `FileNotFoundError` (if the jail is already
cleaned up). Thus, to avoid spurious failures, also catch
`FileNotFoundError`.

We leave the catch for `NoSuchProcess` error in case a VM exits between
reading the pid file and the call to the`psutils.Process` constructor
(race condition).

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
