### PR TITLE
fix: Retry KVM_CREATE_VM on EINTR

### DIFF
--- a/src/vmm/src/vstate/vm/aarch64.rs
+++ b/src/vmm/src/vstate/vm/aarch64.rs
@@ -30,7 +30,7 @@ pub enum ArchVmError {
 impl ArchVm {
     /// Create a new `Vm` struct.
     pub fn new(kvm: &Kvm) -> Result<ArchVm, VmError> {
-        let fd = kvm.fd.create_vm().map_err(VmError::CreateVm)?;
+        let fd = Self::create_vm(kvm)?;
         Ok(ArchVm {
             fd,
             irqchip_handle: None,

--- a/src/vmm/src/vstate/vm/aarch64.rs
+++ b/src/vmm/src/vstate/vm/aarch64.rs
@@ -30,7 +30,7 @@ pub enum ArchVmError {
 impl ArchVm {
     /// Create a new `Vm` struct.
     pub fn new(kvm: &Kvm) -> Result<ArchVm, VmError> {
-        let fd = kvm.fd.create_vm().map_err(VmError::VmFd)?;
+        let fd = kvm.fd.create_vm().map_err(VmError::CreateVm)?;
         Ok(ArchVm {
             fd,
             irqchip_handle: None,

--- a/src/vmm/src/vstate/vm/mod.rs
+++ b/src/vmm/src/vstate/vm/mod.rs
@@ -30,8 +30,8 @@ use crate::Vcpu;
 pub enum VmError {
     /// Cannot set the memory regions: {0}
     SetUserMemoryRegion(kvm_ioctls::Error),
-    /// Cannot open the VM file descriptor: {0}
-    VmFd(kvm_ioctls::Error),
+    /// Failed to create VM: {0}
+    CreateVm(kvm_ioctls::Error),
     /// {0}
     Arch(#[from] ArchVmError),
     /// Error during eventfd operations: {0}

--- a/src/vmm/src/vstate/vm/x86_64.rs
+++ b/src/vmm/src/vstate/vm/x86_64.rs
@@ -53,7 +53,7 @@ pub struct ArchVm {
 impl ArchVm {
     /// Create a new `Vm` struct.
     pub fn new(kvm: &crate::vstate::kvm::Kvm) -> Result<ArchVm, VmError> {
-        let fd = kvm.fd.create_vm().map_err(VmError::VmFd)?;
+        let fd = kvm.fd.create_vm().map_err(VmError::CreateVm)?;
         let msrs_to_save = kvm.msrs_to_save().map_err(ArchVmError::GetMsrsToSave)?;
 
         fd.set_tss_address(u64_to_usize(crate::arch::x86_64::layout::KVM_TSS_ADDRESS))

--- a/src/vmm/src/vstate/vm/x86_64.rs
+++ b/src/vmm/src/vstate/vm/x86_64.rs
@@ -53,7 +53,8 @@ pub struct ArchVm {
 impl ArchVm {
     /// Create a new `Vm` struct.
     pub fn new(kvm: &crate::vstate::kvm::Kvm) -> Result<ArchVm, VmError> {
-        let fd = kvm.fd.create_vm().map_err(VmError::CreateVm)?;
+        let fd = Self::create_vm(kvm)?;
+
         let msrs_to_save = kvm.msrs_to_save().map_err(ArchVmError::GetMsrsToSave)?;
 
         fd.set_tss_address(u64_to_usize(crate::arch::x86_64::layout::KVM_TSS_ADDRESS))


### PR DESCRIPTION
## Reason & Changes

It is known that KVM_CREATE_VM occasionally fails with EINTR on heavily loaded machines
with many VMs.

The behavior itself that KVM_CREATE_VM can return EINTR is intentional. This is because
the KVM_CREATE_VM path includes mm_take_all_locks() that is CPU intensive and all CPU
intensive syscalls should check for pending signals and return EINTR immediately to allow
userland to remain interactive.
https://lists.nongnu.org/archive/html/qemu-devel/2014-01/msg01740.html

However, it is empirically confirmed that, even though there is no pending signal,
KVM_CREATE_VM returns EINTR.
https://lore.kernel.org/qemu-devel/8735e0s1zw.wl-maz@kernel.org/

To mitigate it, QEMU does an inifinite retry on EINTR that greatly improves reliabiliy:
- https://github.com/qemu/qemu/commit/94ccff133820552a859c0fb95e33a539e0b90a75
- https://github.com/qemu/qemu/commit/bbde13cd14ad4eec18529ce0bf5876058464e124

Similarly, we do retries up to 5 times. Although Firecracker clients are also able to
retry, they have to start Firecracker from scratch. Doing retries in Firecracker makes
recovery faster and improves reliability.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
