### PR TITLE
chore: Add CHANGELOG entry for retrying KVM_CREATE_VM on EINTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to
   Firecracker no longer overwrites CPUID leaf 0x80000000 when running AMD
   hardware, meaning the guest can now discover a greater range of CPUID leaves
   in the extended function range (this range is host kernel dependent).
+- [#5046](https://github.com/firecracker-microvm/firecracker/pull/5046): Retry
+  KVM_CREATE_VM on EINTR that occasionally happen on heavily loaded hosts to
+  improve reliability of microVM creation.
 
 ## [1.10.1]
 


### PR DESCRIPTION
No reason not to have it in CHANGELOG.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
