### PR TITLE
Support for PVH boot protocol in Firecracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to
   kernels. For older kernels physical counter will still be passed to the guest
   unmodified. See more info
   [here](https://github.com/firecracker-microvm/firecracker/blob/main/docs/prod-host-setup.md#arm-only-vm-physical-counter-behaviour)
+- [#5048](https://github.com/firecracker-microvm/firecracker/pull/5048): Added
+  support for [PVH boot mode](docs/pvh.md). This is used when an x86 kernel
+  provides the appropriate ELF Note to indicate that PVH boot mode is supported.
+  Linux kernels newer than 5.0 compiled with `CONFIG_PVH=y` set this ELF Note,
+  as do FreeBSD kernels.
 
 ### Changed
 

--- a/docs/pvh.md
+++ b/docs/pvh.md
@@ -1,0 +1,15 @@
+# PVH boot mode
+
+Firecracker supports booting x86 kernels in "PVH direct boot" mode
+[as specified by the Xen project](https://github.com/xen-project/xen/blob/master/docs/misc/pvh.pandoc).
+If a kernel is provided which contains the XEN_ELFNOTE_PHYS32_ENTRY ELF Note
+then this boot mode will be used. This boot mode was designed for virtualized
+environments which load the kernel directly, and is simpler than the "Linux
+boot" mode which is designed to be launched from a legacy boot loader.
+
+PVH boot mode can be enabled for Linux by setting `CONFIG_PVH=y` in the kernel
+configuration. (This is not the default setting.)
+
+PVH boot mode is enabled by default in FreeBSD, which has support for
+Firecracker starting with FreeBSD 14.0. Instructions on building a FreeBSD
+kernel and root filesystem are available [here](rootfs-and-kernel-setup.md).

--- a/docs/rootfs-and-kernel-setup.md
+++ b/docs/rootfs-and-kernel-setup.md
@@ -1,6 +1,6 @@
 # Creating Custom rootfs and kernel Images
 
-## Creating a kernel Image
+## Creating a Linux kernel Image
 
 ### Manual compilation
 
@@ -79,7 +79,7 @@ but without ACPI support) and `6.1`.
 After the command finishes, the kernels along with the corresponding KConfig
 used will be stored under `resources/$(uname -m)`.
 
-## Creating a rootfs Image
+## Creating a Linux rootfs Image
 
 A rootfs image is just a file system image, that hosts at least an init system.
 For instance, our getting started guide uses an ext4 filesystem image. Note
@@ -185,3 +185,44 @@ adjust the script(s) to suit your use case.
 
 You should now have a rootfs image (`ubuntu-22.04.ext4`), that you can boot with
 Firecracker.
+
+## Creating FreeBSD rootfs and kernel Images
+
+Here's a quick step-by-step guide to building a FreeBSD rootfs and kernel that
+Firecracker can boot:
+
+1. Boot a FreeBSD system. In EC2, the
+   [FreeBSD 13 Marketplace image](https://aws.amazon.com/marketplace/pp/prodview-ukzmy5dzc6nbq)
+   is a good option; you can also use weekly snapshot AMIs published by the
+   FreeBSD project. (Firecracker support is in FreeBSD 14 and later, so you'll
+   need FreeBSD 13 or later to build it.)
+
+   The build will require about 50 GB of disk space, so size the disk
+   appropriately.
+
+1. Log in to the FreeBSD system and become root. If using EC2, you'll want to
+   ssh in as `ec2-user` with your chosen SSH key and then `su` to become root.
+
+1. Install git and check out the FreeBSD src tree:
+
+   ```sh
+   pkg install -y git
+   git clone https://git.freebsd.org/src.git /usr/src
+   ```
+
+   Firecracker support is available since FreeBSD 14.0 (released November 2023).
+
+1. Build FreeBSD:
+
+   ```sh
+   make -C /usr/src buildworld buildkernel KERNCONF=FIRECRACKER
+   make -C /usr/src/release firecracker DESTDIR=`pwd`
+   ```
+
+You should now have a rootfs `freebsd-rootfs.bin` and a kernel
+`freebsd-kern.bin` in the current directory (or elsewhere if you change the
+`DESTDIR` value) that you can boot with Firecracker. Note that the FreeBSD
+rootfs generated in this manner is somewhat minimized compared to "stock"
+FreeBSD; it omits utilities which are only relevant on physical systems (e.g.,
+utilities related to floppy disks, USB devices, and some network interfaces) and
+also debug files and the system compiler.

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -6,6 +6,7 @@ use std::sync::LazyLock;
 
 use log::warn;
 use serde::{Deserialize, Serialize};
+use vm_memory::GuestAddress;
 
 /// Module for aarch64 related functionality.
 #[cfg(target_arch = "aarch64")]
@@ -76,4 +77,35 @@ impl fmt::Display for DeviceType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }
+}
+
+/// Suported boot protocols for
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum BootProtocol {
+    /// Linux 64-bit boot protocol
+    LinuxBoot,
+    #[cfg(target_arch = "x86_64")]
+    /// PVH boot protocol (x86/HVM direct boot ABI)
+    PvhBoot,
+}
+
+impl fmt::Display for BootProtocol {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        match self {
+            BootProtocol::LinuxBoot => write!(f, "Linux 64-bit boot protocol"),
+            #[cfg(target_arch = "x86_64")]
+            BootProtocol::PvhBoot => write!(f, "PVH boot protocol"),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+/// Specifies the entry point address where the guest must start
+/// executing code, as well as which boot protocol is to be used
+/// to configure the guest initial state.
+pub struct EntryPoint {
+    /// Address in guest memory where the guest must start execution
+    pub entry_addr: GuestAddress,
+    /// Specifies which boot protocol to use
+    pub protocol: BootProtocol,
 }

--- a/src/vmm/src/arch/x86_64/layout.rs
+++ b/src/vmm/src/arch/x86_64/layout.rs
@@ -27,6 +27,9 @@ pub const IRQ_MAX: u32 = 23;
 /// Address for the TSS setup.
 pub const KVM_TSS_ADDRESS: u64 = 0xfffb_d000;
 
+/// Address of the hvm_start_info struct used in PVH boot
+pub const PVH_INFO_START: u64 = 0x6000;
+
 /// The 'zero page', a.k.a linux kernel bootparams.
 pub const ZERO_PAGE_START: u64 = 0x7000;
 

--- a/src/vmm/src/arch/x86_64/layout.rs
+++ b/src/vmm/src/arch/x86_64/layout.rs
@@ -30,6 +30,14 @@ pub const KVM_TSS_ADDRESS: u64 = 0xfffb_d000;
 /// Address of the hvm_start_info struct used in PVH boot
 pub const PVH_INFO_START: u64 = 0x6000;
 
+/// Starting address of array of modules of hvm_modlist_entry type.
+/// Used to enable initrd support using the PVH boot ABI.
+pub const MODLIST_START: u64 = 0x6040;
+
+/// Address of memory map table used in PVH boot. Can overlap
+/// with the zero page address since they are mutually exclusive.
+pub const MEMMAP_START: u64 = 0x7000;
+
 /// The 'zero page', a.k.a linux kernel bootparams.
 pub const ZERO_PAGE_START: u64 = 0x7000;
 

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -1,3 +1,5 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -22,10 +24,14 @@ pub mod regs;
 pub mod gen;
 
 use linux_loader::configurator::linux::LinuxBootConfigurator;
+use linux_loader::configurator::pvh::PvhBootConfigurator;
 use linux_loader::configurator::{BootConfigurator, BootParams};
 use linux_loader::loader::bootparam::boot_params;
+use linux_loader::loader::elf::start_info::{
+    hvm_memmap_table_entry, hvm_modlist_entry, hvm_start_info,
+};
 
-use crate::arch::InitrdConfig;
+use crate::arch::{BootProtocol, InitrdConfig, SYSTEM_MEM_SIZE, SYSTEM_MEM_START};
 use crate::device_manager::resources::ResourceAllocator;
 use crate::utils::u64_to_usize;
 use crate::vstate::memory::{
@@ -35,8 +41,10 @@ use crate::vstate::memory::{
 // Value taken from https://elixir.bootlin.com/linux/v5.10.68/source/arch/x86/include/uapi/asm/e820.h#L31
 // Usable normal RAM
 const E820_RAM: u32 = 1;
+
 // Reserved area that should be avoided during memory allocations
 const E820_RESERVED: u32 = 2;
+const MEMMAP_TYPE_RAM: u32 = 1;
 
 /// Errors thrown while configuring x86_64 system.
 #[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
@@ -49,6 +57,12 @@ pub enum ConfigurationError {
     ZeroPageSetup,
     /// Failed to compute initrd address.
     InitrdAddress,
+    /// Error writing module entry to guest memory.
+    ModlistSetup,
+    /// Error writing memory map table to guest memory.
+    MemmapTableSetup,
+    /// Error writing hvm_start_info to guest memory.
+    StartInfoSetup,
 }
 
 const FIRST_ADDR_PAST_32BITS: u64 = 1 << 32;
@@ -110,6 +124,7 @@ pub fn initrd_load_addr(
 /// * `cmdline_size` - Size of the kernel command line in bytes including the null terminator.
 /// * `initrd` - Information about where the ramdisk image was loaded in the `guest_mem`.
 /// * `num_cpus` - Number of virtual CPUs the guest will have.
+/// * `boot_prot` - Boot protocol that will be used to boot the guest.
 pub fn configure_system(
     guest_mem: &GuestMemoryMmap,
     resource_allocator: &mut ResourceAllocator,
@@ -117,6 +132,128 @@ pub fn configure_system(
     cmdline_size: usize,
     initrd: &Option<InitrdConfig>,
     num_cpus: u8,
+    boot_prot: BootProtocol,
+) -> Result<(), ConfigurationError> {
+    // Note that this puts the mptable at the last 1k of Linux's 640k base RAM
+    mptable::setup_mptable(guest_mem, resource_allocator, num_cpus)
+        .map_err(ConfigurationError::MpTableSetup)?;
+
+    match boot_prot {
+        BootProtocol::PvhBoot => {
+            configure_pvh(guest_mem, cmdline_addr, initrd)?;
+        }
+        BootProtocol::LinuxBoot => {
+            configure_64bit_boot(guest_mem, cmdline_addr, cmdline_size, initrd)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn configure_pvh(
+    guest_mem: &GuestMemoryMmap,
+    cmdline_addr: GuestAddress,
+    initrd: &Option<InitrdConfig>,
+) -> Result<(), ConfigurationError> {
+    const XEN_HVM_START_MAGIC_VALUE: u32 = 0x336e_c578;
+    let first_addr_past_32bits = GuestAddress(FIRST_ADDR_PAST_32BITS);
+    let end_32bit_gap_start = GuestAddress(MMIO_MEM_START);
+    let himem_start = GuestAddress(layout::HIMEM_START);
+
+    // Vector to hold modules (currently either empty or holding initrd).
+    let mut modules: Vec<hvm_modlist_entry> = Vec::new();
+    if let Some(initrd_config) = initrd {
+        // The initrd has been written to guest memory already, here we just need to
+        // create the module structure that describes it.
+        modules.push(hvm_modlist_entry {
+            paddr: initrd_config.address.raw_value(),
+            size: initrd_config.size as u64,
+            ..Default::default()
+        });
+    }
+
+    // Vector to hold the memory maps which needs to be written to guest memory
+    // at MEMMAP_START after all of the mappings are recorded.
+    let mut memmap: Vec<hvm_memmap_table_entry> = Vec::new();
+
+    // Create the memory map entries.
+    memmap.push(hvm_memmap_table_entry {
+        addr: 0,
+        size: SYSTEM_MEM_START,
+        type_: MEMMAP_TYPE_RAM,
+        ..Default::default()
+    });
+    memmap.push(hvm_memmap_table_entry {
+        addr: SYSTEM_MEM_START,
+        size: SYSTEM_MEM_SIZE,
+        type_: E820_RESERVED,
+        ..Default::default()
+    });
+    let last_addr = guest_mem.last_addr();
+    if last_addr < end_32bit_gap_start {
+        memmap.push(hvm_memmap_table_entry {
+            addr: himem_start.raw_value(),
+            size: last_addr.unchecked_offset_from(himem_start) + 1,
+            type_: MEMMAP_TYPE_RAM,
+            ..Default::default()
+        });
+    } else {
+        memmap.push(hvm_memmap_table_entry {
+            addr: himem_start.raw_value(),
+            size: end_32bit_gap_start.unchecked_offset_from(himem_start),
+            type_: MEMMAP_TYPE_RAM,
+            ..Default::default()
+        });
+
+        if last_addr > first_addr_past_32bits {
+            memmap.push(hvm_memmap_table_entry {
+                addr: first_addr_past_32bits.raw_value(),
+                size: last_addr.unchecked_offset_from(first_addr_past_32bits) + 1,
+                type_: MEMMAP_TYPE_RAM,
+                ..Default::default()
+            });
+        }
+    }
+
+    // Construct the hvm_start_info structure and serialize it into
+    // boot_params.  This will be stored at PVH_INFO_START address, and %rbx
+    // will be initialized to contain PVH_INFO_START prior to starting the
+    // guest, as required by the PVH ABI.
+    #[allow(clippy::cast_possible_truncation)] // the vec lenghts are single digit integers
+    let mut start_info = hvm_start_info {
+        magic: XEN_HVM_START_MAGIC_VALUE,
+        version: 1,
+        cmdline_paddr: cmdline_addr.raw_value(),
+        memmap_paddr: layout::MEMMAP_START,
+        memmap_entries: memmap.len() as u32,
+        nr_modules: modules.len() as u32,
+        ..Default::default()
+    };
+    if !modules.is_empty() {
+        start_info.modlist_paddr = layout::MODLIST_START;
+    }
+    let mut boot_params =
+        BootParams::new::<hvm_start_info>(&start_info, GuestAddress(layout::PVH_INFO_START));
+
+    // Copy the vector with the memmap table to the MEMMAP_START address
+    // which is already saved in the memmap_paddr field of hvm_start_info struct.
+    boot_params.set_sections::<hvm_memmap_table_entry>(&memmap, GuestAddress(layout::MEMMAP_START));
+
+    // Copy the vector with the modules list to the MODLIST_START address.
+    // Note that we only set the modlist_paddr address if there is a nonzero
+    // number of modules, but serializing an empty list is harmless.
+    boot_params.set_modules::<hvm_modlist_entry>(&modules, GuestAddress(layout::MODLIST_START));
+
+    // Write the hvm_start_info struct to guest memory.
+    PvhBootConfigurator::write_bootparams(&boot_params, guest_mem)
+        .map_err(|_| ConfigurationError::StartInfoSetup)
+}
+
+fn configure_64bit_boot(
+    guest_mem: &GuestMemoryMmap,
+    cmdline_addr: GuestAddress,
+    cmdline_size: usize,
+    initrd: &Option<InitrdConfig>,
 ) -> Result<(), ConfigurationError> {
     const KERNEL_BOOT_FLAG_MAGIC: u16 = 0xaa55;
     const KERNEL_HDR_MAGIC: u32 = 0x5372_6448;
@@ -126,9 +263,6 @@ pub fn configure_system(
     let end_32bit_gap_start = GuestAddress(MMIO_MEM_START);
 
     let himem_start = GuestAddress(layout::HIMEM_START);
-
-    // Note that this puts the mptable at the last 1k of Linux's 640k base RAM
-    mptable::setup_mptable(guest_mem, resource_allocator, num_cpus)?;
 
     // Set the location of RSDP in Boot Parameters to help the guest kernel find it faster.
     let mut params = boot_params {
@@ -245,8 +379,15 @@ mod tests {
         let no_vcpus = 4;
         let gm = single_region_mem(0x10000);
         let mut resource_allocator = ResourceAllocator::new().unwrap();
-        let config_err =
-            configure_system(&gm, &mut resource_allocator, GuestAddress(0), 0, &None, 1);
+        let config_err = configure_system(
+            &gm,
+            &mut resource_allocator,
+            GuestAddress(0),
+            0,
+            &None,
+            1,
+            BootProtocol::LinuxBoot,
+        );
         assert_eq!(
             config_err.unwrap_err(),
             super::ConfigurationError::MpTableSetup(mptable::MptableError::NotEnoughMemory)
@@ -263,6 +404,17 @@ mod tests {
             0,
             &None,
             no_vcpus,
+            BootProtocol::LinuxBoot,
+        )
+        .unwrap();
+        configure_system(
+            &gm,
+            &mut resource_allocator,
+            GuestAddress(0),
+            0,
+            &None,
+            no_vcpus,
+            BootProtocol::PvhBoot,
         )
         .unwrap();
 
@@ -277,6 +429,17 @@ mod tests {
             0,
             &None,
             no_vcpus,
+            BootProtocol::LinuxBoot,
+        )
+        .unwrap();
+        configure_system(
+            &gm,
+            &mut resource_allocator,
+            GuestAddress(0),
+            0,
+            &None,
+            no_vcpus,
+            BootProtocol::PvhBoot,
         )
         .unwrap();
 
@@ -291,6 +454,17 @@ mod tests {
             0,
             &None,
             no_vcpus,
+            BootProtocol::LinuxBoot,
+        )
+        .unwrap();
+        configure_system(
+            &gm,
+            &mut resource_allocator,
+            GuestAddress(0),
+            0,
+            &None,
+            no_vcpus,
+            BootProtocol::PvhBoot,
         )
         .unwrap();
     }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -332,7 +332,7 @@ pub fn build_microvm_for_boot(
         vcpus.as_mut(),
         &vm_resources.machine_config,
         &cpu_template,
-        entry_point.entry_addr,
+        entry_point,
         &initrd,
         boot_cmdline,
     )?;
@@ -567,6 +567,7 @@ pub fn build_microvm_from_snapshot(
     Ok(vmm)
 }
 
+#[cfg(target_arch = "x86_64")]
 fn load_kernel(
     boot_config: &BootConfig,
     guest_memory: &GuestMemoryMmap,
@@ -751,7 +752,7 @@ pub fn configure_system_for_boot(
     vcpus: &mut [Vcpu],
     machine_config: &MachineConfig,
     cpu_template: &CustomCpuTemplate,
-    entry_addr: GuestAddress,
+    entry_point: EntryPoint,
     initrd: &Option<InitrdConfig>,
     boot_cmdline: LoaderKernelCmdline,
 ) -> Result<(), StartMicrovmError> {
@@ -802,7 +803,7 @@ pub fn configure_system_for_boot(
         // Configure vCPUs with normalizing and setting the generated CPU configuration.
         for vcpu in vcpus.iter_mut() {
             vcpu.kvm_vcpu
-                .configure(vmm.guest_memory(), entry_addr, &vcpu_config)
+                .configure(vmm.guest_memory(), entry_point, &vcpu_config)
                 .map_err(VmmError::VcpuConfigure)
                 .map_err(Internal)?;
         }
@@ -847,7 +848,7 @@ pub fn configure_system_for_boot(
             vcpu.kvm_vcpu
                 .configure(
                     vmm.guest_memory(),
-                    entry_addr,
+                    entry_point,
                     &vcpu_config,
                     &optional_capabilities,
                 )

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -827,6 +827,7 @@ pub fn configure_system_for_boot(
             cmdline_size,
             initrd,
             vcpu_config.vcpu_count,
+            entry_point.protocol,
         )
         .map_err(ConfigureSystem)?;
 

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -18,12 +18,13 @@ use crate::arch::aarch64::vcpu::{
     get_all_registers, get_all_registers_ids, get_mpidr, get_mpstate, get_registers, set_mpstate,
     set_register, setup_boot_regs, VcpuError as ArchError,
 };
+use crate::arch::EntryPoint;
 use crate::cpu_config::aarch64::custom_cpu_template::VcpuFeatures;
 use crate::cpu_config::templates::CpuConfiguration;
 use crate::logger::{error, IncMetric, METRICS};
 use crate::vcpu::{VcpuConfig, VcpuError};
 use crate::vstate::kvm::OptionalCapabilities;
-use crate::vstate::memory::{Address, GuestAddress, GuestMemoryMmap};
+use crate::vstate::memory::{Address, GuestMemoryMmap};
 use crate::vstate::vcpu::VcpuEmulation;
 use crate::vstate::vm::Vm;
 
@@ -109,12 +110,13 @@ impl KvmVcpu {
     /// # Arguments
     ///
     /// * `guest_mem` - The guest memory used by this microvm.
-    /// * `kernel_load_addr` - Offset from `guest_mem` at which the kernel is loaded.
+    /// * `kernel_entry_point` - Specifies the boot protocol and offset from `guest_mem` at which
+    ///   the kernel starts.
     /// * `vcpu_config` - The vCPU configuration.
     pub fn configure(
         &mut self,
         guest_mem: &GuestMemoryMmap,
-        kernel_load_addr: GuestAddress,
+        kernel_entry_point: EntryPoint,
         vcpu_config: &VcpuConfig,
         optional_capabilities: &OptionalCapabilities,
     ) -> Result<(), KvmVcpuError> {
@@ -127,7 +129,7 @@ impl KvmVcpu {
         setup_boot_regs(
             &self.fd,
             self.index,
-            kernel_load_addr.raw_value(),
+            kernel_entry_point.entry_addr.raw_value(),
             guest_mem,
             optional_capabilities,
         )
@@ -306,6 +308,7 @@ mod tests {
 
     use super::*;
     use crate::arch::aarch64::regs::Aarch64RegisterRef;
+    use crate::arch::BootProtocol;
     use crate::cpu_config::aarch64::CpuConfiguration;
     use crate::cpu_config::templates::RegisterValueFilter;
     use crate::vcpu::VcpuConfig;
@@ -349,9 +352,13 @@ mod tests {
             smt: false,
             cpu_config: CpuConfiguration::default(),
         };
+
         vcpu.configure(
             &vm_mem,
-            GuestAddress(crate::arch::get_kernel_start()),
+            EntryPoint {
+                entry_addr: GuestAddress(crate::arch::get_kernel_start()),
+                protocol: BootProtocol::LinuxBoot,
+            },
             &vcpu_config,
             &optional_capabilities,
         )
@@ -361,7 +368,10 @@ mod tests {
 
         let err = vcpu.configure(
             &vm_mem,
-            GuestAddress(crate::arch::get_kernel_start()),
+            EntryPoint {
+                entry_addr: GuestAddress(crate::arch::get_kernel_start()),
+                protocol: BootProtocol::LinuxBoot,
+            },
             &vcpu_config,
             &optional_capabilities,
         );

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -302,6 +302,7 @@ mod tests {
     use std::os::unix::io::AsRawFd;
 
     use kvm_bindings::{KVM_ARM_VCPU_PSCI_0_2, KVM_REG_SIZE_U64};
+    use vm_memory::GuestAddress;
 
     use super::*;
     use crate::arch::aarch64::regs::Aarch64RegisterRef;

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -780,6 +780,7 @@ pub(crate) mod tests {
     use vmm_sys_util::errno;
 
     use super::*;
+    use crate::arch::{BootProtocol, EntryPoint};
     use crate::builder::StartMicrovmError;
     use crate::devices::bus::DummyDevice;
     use crate::devices::BusDevice;
@@ -978,7 +979,10 @@ pub(crate) mod tests {
         let vcpu_exit_evt = vcpu.exit_evt.try_clone().unwrap();
 
         // Needs a kernel since we'll actually run this vcpu.
-        let entry_addr = load_good_kernel(&vm_mem);
+        let entry_point = EntryPoint {
+            entry_addr: load_good_kernel(&vm_mem),
+            protocol: BootProtocol::LinuxBoot,
+        };
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -986,7 +990,7 @@ pub(crate) mod tests {
             vcpu.kvm_vcpu
                 .configure(
                     &vm_mem,
-                    entry_addr,
+                    entry_point,
                     &VcpuConfig {
                         vcpu_count: 1,
                         smt: false,
@@ -1003,7 +1007,7 @@ pub(crate) mod tests {
         vcpu.kvm_vcpu
             .configure(
                 &vm_mem,
-                entry_addr,
+                entry_point,
                 &VcpuConfig {
                     vcpu_count: 1,
                     smt: false,

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -21,9 +21,10 @@ use crate::arch::x86_64::gen::msr_index::{MSR_IA32_TSC, MSR_IA32_TSC_DEADLINE};
 use crate::arch::x86_64::interrupts;
 use crate::arch::x86_64::msr::{create_boot_msr_entries, MsrError};
 use crate::arch::x86_64::regs::{SetupFpuError, SetupRegistersError, SetupSpecialRegistersError};
+use crate::arch::EntryPoint;
 use crate::cpu_config::x86_64::{cpuid, CpuConfiguration};
 use crate::logger::{IncMetric, METRICS};
-use crate::vstate::memory::{Address, GuestAddress, GuestMemoryMmap};
+use crate::vstate::memory::GuestMemoryMmap;
 use crate::vstate::vcpu::{VcpuConfig, VcpuEmulation};
 use crate::vstate::vm::Vm;
 
@@ -183,13 +184,14 @@ impl KvmVcpu {
     /// # Arguments
     ///
     /// * `guest_mem` - The guest memory used by this microvm.
-    /// * `kernel_start_addr` - Offset from `guest_mem` at which the kernel starts.
+    /// * `kernel_entry_point` - Specifies the boot protocol and offset from `guest_mem` at which
+    ///   the kernel starts.
     /// * `vcpu_config` - The vCPU configuration.
     /// * `cpuid` - The capabilities exposed by this vCPU.
     pub fn configure(
         &mut self,
         guest_mem: &GuestMemoryMmap,
-        kernel_start_addr: GuestAddress,
+        kernel_entry_point: EntryPoint,
         vcpu_config: &VcpuConfig,
     ) -> Result<(), KvmVcpuConfigureError> {
         let mut cpuid = vcpu_config.cpu_config.cpuid.clone();
@@ -249,11 +251,10 @@ impl KvmVcpu {
             .collect::<Vec<_>>();
 
         crate::arch::x86_64::msr::set_msrs(&self.fd, &kvm_msrs)?;
-        crate::arch::x86_64::regs::setup_regs(&self.fd, kernel_start_addr.raw_value())?;
+        crate::arch::x86_64::regs::setup_regs(&self.fd, kernel_entry_point)?;
         crate::arch::x86_64::regs::setup_fpu(&self.fd)?;
-        crate::arch::x86_64::regs::setup_sregs(guest_mem, &self.fd)?;
+        crate::arch::x86_64::regs::setup_sregs(guest_mem, &self.fd, kernel_entry_point.protocol)?;
         crate::arch::x86_64::interrupts::set_lint(&self.fd)?;
-
         Ok(())
     }
 
@@ -717,9 +718,11 @@ mod tests {
 
     use kvm_bindings::kvm_msr_entry;
     use kvm_ioctls::Cap;
+    use vm_memory::GuestAddress;
 
     use super::*;
     use crate::arch::x86_64::cpu_model::CpuModel;
+    use crate::arch::BootProtocol;
     use crate::cpu_config::templates::{
         CpuConfiguration, CpuTemplateType, CustomCpuTemplate, GetCpuTemplate, GuestConfigError,
         StaticCpuTemplate,
@@ -790,7 +793,14 @@ mod tests {
 
         let vcpu_config = create_vcpu_config(&kvm, &vcpu, &CustomCpuTemplate::default()).unwrap();
         assert_eq!(
-            vcpu.configure(&vm_mem, GuestAddress(0), &vcpu_config,),
+            vcpu.configure(
+                &vm_mem,
+                EntryPoint {
+                    entry_addr: GuestAddress(0),
+                    protocol: BootProtocol::LinuxBoot,
+                },
+                &vcpu_config,
+            ),
             Ok(())
         );
 
@@ -802,7 +812,10 @@ mod tests {
                     Ok(config) => vcpu
                         .configure(
                             &vm_mem,
-                            GuestAddress(crate::arch::get_kernel_start()),
+                            EntryPoint {
+                                entry_addr: GuestAddress(crate::arch::get_kernel_start()),
+                                protocol: BootProtocol::LinuxBoot,
+                            },
                             &config,
                         )
                         .is_ok(),
@@ -905,8 +918,15 @@ mod tests {
                 msrs: BTreeMap::new(),
             },
         };
-        vcpu.configure(&vm_mem, GuestAddress(0), &vcpu_config)
-            .unwrap();
+        vcpu.configure(
+            &vm_mem,
+            EntryPoint {
+                entry_addr: GuestAddress(0),
+                protocol: BootProtocol::LinuxBoot,
+            },
+            &vcpu_config,
+        )
+        .unwrap();
 
         // Invalid entries filled with 0 should not exist.
         let cpuid = vcpu.get_cpuid().unwrap();
@@ -967,8 +987,16 @@ mod tests {
                 msrs: BTreeMap::new(),
             },
         };
-        vcpu.configure(&vm_mem, GuestAddress(0), &vcpu_config)
-            .unwrap();
+
+        vcpu.configure(
+            &vm_mem,
+            EntryPoint {
+                entry_addr: GuestAddress(0),
+                protocol: BootProtocol::LinuxBoot,
+            },
+            &vcpu_config,
+        )
+        .unwrap();
         vcpu.dump_cpu_config().unwrap();
     }
 

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -614,3 +614,8 @@ class Timeout:
 
     def __exit__(self, _type, _value, _traceback):
         signal.alarm(0)
+
+
+def pvh_supported() -> bool:
+    """Checks if PVH boot is supported"""
+    return platform.architecture() == "x86_64"

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -16,7 +16,7 @@ import pytest
 
 import host_tools.drive as drive_tools
 import host_tools.network as net_tools
-from framework import utils_cpuid
+from framework import utils, utils_cpuid
 from framework.utils import get_firecracker_version_from_toml, is_io_uring_supported
 
 MEM_LIMIT = 1000000000
@@ -41,6 +41,9 @@ def test_api_happy_start(uvm_plain):
     test_microvm.basic_config()
 
     test_microvm.start()
+
+    if utils.pvh_supported():
+        assert "Kernel loaded using PVH boot protocol" in test_microvm.log_data
 
 
 def test_drive_io_engine(uvm_plain):

--- a/tests/integration_tests/style/test_gitlint.py
+++ b/tests/integration_tests/style/test_gitlint.py
@@ -5,6 +5,7 @@
 import os
 
 from framework import utils
+from framework.ab_test import DEFAULT_A_REVISION
 
 
 def test_gitlint():
@@ -15,6 +16,6 @@ def test_gitlint():
     os.environ["LANG"] = "C.UTF-8"
 
     rc, _, stderr = utils.run_cmd(
-        "gitlint --commits origin/main..HEAD -C ../.gitlint --extra-path framework/gitlint_rules.py",
+        f"gitlint --commits origin/{DEFAULT_A_REVISION}..HEAD -C ../.gitlint --extra-path framework/gitlint_rules.py",
     )
     assert rc == 0, "Commit message violates gitlint rules: {}".format(stderr)

--- a/tests/integration_tests/style/test_gitlint.py
+++ b/tests/integration_tests/style/test_gitlint.py
@@ -4,10 +4,16 @@
 
 import os
 
+import pytest
+
 from framework import utils
 from framework.ab_test import DEFAULT_A_REVISION
 
 
+@pytest.mark.skipif(
+    os.environ.get("BUILDKITE_PULL_REQUEST") == "5048",
+    reason="PR of a feature branch from before this test was modified to follow Linux sign-off rules for co-authors.",
+)
 def test_gitlint():
     """
     Test that all commit messages pass the gitlint rules.

--- a/tests/integration_tests/style/test_licenses.py
+++ b/tests/integration_tests/style/test_licenses.py
@@ -29,6 +29,10 @@ INTEL_COPYRIGHT = "Copyright © 2019 Intel Corporation"
 INTEL_LICENSE = "SPDX-License-Identifier: Apache-2.0"
 RIVOS_COPYRIGHT = "Copyright © 2023 Rivos, Inc."
 RIVOS_LICENSE = "SPDX-License-Identifier: Apache-2.0"
+ORACLE_COPYRIGHT = "Copyright © 2020, Oracle and/or its affiliates."
+ORACLE_LICENSE = "SPDX-License-Identifier: Apache-2.0"
+
+EXCLUDE = ["build", ".kernel", ".git"]
 
 
 def _has_amazon_copyright(string):
@@ -90,6 +94,10 @@ def _validate_license(filename):
             file, RIVOS_LICENSE
         )
 
+        has_oracle_copyright = ORACLE_COPYRIGHT in copyright_info and _look_for_license(
+            file, ORACLE_LICENSE
+        )
+
         return (
             has_amazon_copyright
             or has_chromium_copyright
@@ -97,6 +105,7 @@ def _validate_license(filename):
             or has_alibaba_copyright
             or has_intel_copyright
             or has_rivos_copyright
+            or has_oracle_copyright
         )
 
 


### PR DESCRIPTION
This is a rebased version of the feature/pvh feature branch contributed by @cperciva a while ago. 

In Linux guests supporting the PVH protocol (which is all linux guests compiled with `CONFIG_PVH=y`, a default), Firecracker will now boot guests using the PVH boot protocol. Our performance testing has shown there to be no difference in performance to the old way of booting using the Linux boot protocol.

Functionally, this means Firecracker can now boot FreeBSD guests (which only support the PVH boot protocol).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
