### PR TITLE
Tiny integration test fixes to fill accidental gaps in coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,8 +373,6 @@ def cpu_template_any(request, record_property):
 @pytest.fixture(params=["Sync", "Async"])
 def io_engine(request):
     """All supported io_engines"""
-    if request.param == "Async" and not utils.is_io_uring_supported():
-        pytest.skip("io_uring not supported in this kernel")
     return request.param
 
 

--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -33,10 +33,6 @@ DEFAULT_BINARY_DIR = (
     / "release"
 )
 
-# The minimum required host kernel version for which io_uring is supported in
-# Firecracker.
-MIN_KERNEL_VERSION_FOR_IO_URING = "5.10.51"
-
 SUPPORTED_HOST_KERNELS = ["5.10", "6.1"]
 
 IMG_DIR = Path(DEFAULT_TEST_SESSION_ROOT_PATH) / "img"

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -28,8 +28,6 @@ from tenacity import (
     wait_fixed,
 )
 
-from framework.defs import MIN_KERNEL_VERSION_FOR_IO_URING
-
 FLUSH_CMD = 'screen -S {session} -X colon "logfile flush 0^M"'
 CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
 CMDLOG = logging.getLogger("commands")
@@ -453,17 +451,6 @@ def get_kernel_version(level=2):
             linux_version = linux_version[0:idx]
             break
     return linux_version
-
-
-def is_io_uring_supported():
-    """
-    Return whether Firecracker supports io_uring for the running kernel ...
-
-    ...version.
-    """
-    kv = packaging.version.parse(get_kernel_version())
-    min_kv = packaging.version.parse(MIN_KERNEL_VERSION_FOR_IO_URING)
-    return kv >= min_kv
 
 
 def generate_mmds_session_token(ssh_connection, ipv4_address, token_ttl):

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -17,7 +17,7 @@ import pytest
 import host_tools.drive as drive_tools
 import host_tools.network as net_tools
 from framework import utils, utils_cpuid
-from framework.utils import get_firecracker_version_from_toml, is_io_uring_supported
+from framework.utils import get_firecracker_version_from_toml
 
 MEM_LIMIT = 1000000000
 
@@ -46,7 +46,7 @@ def test_api_happy_start(uvm_plain):
         assert "Kernel loaded using PVH boot protocol" in test_microvm.log_data
 
 
-def test_drive_io_engine(uvm_plain):
+def test_drive_io_engine(uvm_plain, io_engine):
     """
     Test io_engine configuration.
 
@@ -59,8 +59,6 @@ def test_drive_io_engine(uvm_plain):
     test_microvm.basic_config(add_root_device=False)
     test_microvm.add_net_iface()
 
-    supports_io_uring = is_io_uring_supported()
-
     kwargs = {
         "drive_id": "rootfs",
         "path_on_host": test_microvm.create_jailed_resource(test_microvm.rootfs_file),
@@ -68,26 +66,13 @@ def test_drive_io_engine(uvm_plain):
         "is_read_only": True,
     }
 
-    # Test the opposite of the default backend type.
-    if supports_io_uring:
-        test_microvm.api.drive.put(io_engine="Sync", **kwargs)
-
-    if not supports_io_uring:
-        with pytest.raises(RuntimeError):
-            test_microvm.api.drive.put(io_engine="Async", **kwargs)
-        # The Async engine is not supported for older kernels.
-        test_microvm.check_log_message(
-            "Received Error. Status code: 400 Bad Request. Message: Drive config error: "
-            "Unable to create the virtio block device: Virtio backend error: "
-            "Error coming from the IO engine: Unsupported engine type: Async"
-        )
-
-        # Now configure the default engine type and check that it works.
-        test_microvm.api.drive.put(**kwargs)
+    test_microvm.api.drive.put(io_engine=io_engine, **kwargs)
 
     test_microvm.start()
 
-    assert test_microvm.api.vm_config.get().json()["drives"][0]["io_engine"] == "Sync"
+    assert (
+        test_microvm.api.vm_config.get().json()["drives"][0]["io_engine"] == io_engine
+    )
 
 
 def test_api_put_update_pre_boot(uvm_plain, io_engine):
@@ -735,7 +720,7 @@ def test_negative_api_patch_post_boot(uvm_plain, io_engine):
         test_microvm.api.logger.patch(level="Error")
 
 
-def test_drive_patch(uvm_plain):
+def test_drive_patch(uvm_plain, io_engine):
     """
     Extensively test drive PATCH scenarios before and after boot.
     """
@@ -752,7 +737,7 @@ def test_drive_patch(uvm_plain):
         path_on_host=fs.path,
         is_root_device=False,
         is_read_only=False,
-        io_engine="Async" if is_io_uring_supported() else "Sync",
+        io_engine=io_engine,
     )
 
     fs_vub = drive_tools.FilesystemFile(
@@ -766,7 +751,7 @@ def test_drive_patch(uvm_plain):
 
     test_microvm.start()
 
-    _drive_patch(test_microvm)
+    _drive_patch(test_microvm, io_engine)
 
 
 @pytest.mark.skipif(
@@ -802,7 +787,7 @@ def test_send_ctrl_alt_del(uvm_plain):
         pass
 
 
-def _drive_patch(test_microvm):
+def _drive_patch(test_microvm, io_engine):
     """Exercise drive patch test scenarios."""
     # Patches without mandatory fields for virtio block are not allowed.
     expected_msg = "Unable to patch the block device: Device manager error: Running method expected different backend. Please verify the request arguments"
@@ -912,7 +897,7 @@ def _drive_patch(test_microvm):
                 "bandwidth": {"size": 5000, "one_time_burst": None, "refill_time": 100},
                 "ops": {"size": 500, "one_time_burst": None, "refill_time": 100},
             },
-            "io_engine": "Async" if is_io_uring_supported() else "Sync",
+            "io_engine": io_engine,
             "socket": None,
         },
         {

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -757,13 +757,13 @@ def test_drive_patch(uvm_plain, io_engine):
 @pytest.mark.skipif(
     platform.machine() != "x86_64", reason="not yet implemented on aarch64"
 )
-def test_send_ctrl_alt_del(uvm_plain):
+def test_send_ctrl_alt_del(uvm_plain_any):
     """
     Test shutting down the microVM gracefully on x86, by sending CTRL+ALT+DEL.
     """
     # This relies on the i8042 device and AT Keyboard support being present in
     # the guest kernel.
-    test_microvm = uvm_plain
+    test_microvm = uvm_plain_any
     test_microvm.spawn()
 
     test_microvm.basic_config()

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -104,7 +104,7 @@ def test_api_put_update_pre_boot(uvm_plain, io_engine):
     test_microvm.basic_config()
 
     fs1 = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "scratch"))
-    response = test_microvm.api.drive.put(
+    test_microvm.api.drive.put(
         drive_id="scratch",
         path_on_host=test_microvm.create_jailed_resource(fs1.path),
         is_root_device=False,

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -253,7 +253,7 @@ def test_api_mmds_config(uvm_plain):
         "The list of network interface IDs that allow "
         "forwarding MMDS requests is empty."
     )
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match=err_msg):
         test_microvm.api.mmds_config.put(network_interfaces=[])
 
     # Setting MMDS config when no network device has been attached

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -7,6 +7,7 @@ import time
 from subprocess import TimeoutExpired
 
 import pytest
+import requests
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from framework.utils import check_output, get_free_mem_ssh
@@ -209,7 +210,7 @@ def test_deflate_on_oom(uvm_plain_any, deflate_on_oom):
 
     try:
         balloon_size_after = test_microvm.api.balloon_stats.get().json()["actual_mib"]
-    except ConnectionError:
+    except requests.exceptions.ConnectionError:
         assert (
             not deflate_on_oom
         ), "Guest died even though it should have deflated balloon to alleviate memory pressure"


### PR DESCRIPTION
Fixes a handful of small issues discovered in integration tests, such as
- specific tests that were supposed to cover all io engines only testing the async engine
- tests not asserting error messages even though that was clearly the intention
- test duplicating functionality for which we have helper functions

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
