### PR TITLE
add initial Graviton 4 support

### DIFF
--- a/tests/framework/utils_cpuid.py
+++ b/tests/framework/utils_cpuid.py
@@ -28,6 +28,7 @@ class CpuModel(str, Enum):
     AMD_GENOA = "AMD_GENOA"
     ARM_NEOVERSE_N1 = "ARM_NEOVERSE_N1"
     ARM_NEOVERSE_V1 = "ARM_NEOVERSE_V1"
+    ARM_NEOVERSE_V2 = "ARM_NEOVERSE_V2"
     INTEL_SKYLAKE = "INTEL_SKYLAKE"
     INTEL_CASCADELAKE = "INTEL_CASCADELAKE"
     INTEL_ICELAKE = "INTEL_ICELAKE"
@@ -41,7 +42,11 @@ CPU_DICT = {
         "Intel(R) Xeon(R) Platinum 8375C CPU": "INTEL_ICELAKE",
     },
     CpuVendor.AMD: {"AMD EPYC 7R13": "AMD_MILAN", "AMD EPYC 9R14": "AMD_GENOA"},
-    CpuVendor.ARM: {"0xd0c": "ARM_NEOVERSE_N1", "0xd40": "ARM_NEOVERSE_V1"},
+    CpuVendor.ARM: {
+        "0xd0c": "ARM_NEOVERSE_N1",
+        "0xd40": "ARM_NEOVERSE_V1",
+        "0xd4f": "ARM_NEOVERSE_V2",
+    },
 }
 
 

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -24,6 +24,8 @@ G3_FEATS = G2_FEATS | set(
 
 G3_SVE_AND_PAC = set("paca pacg sve svebf16 svei8mm".split())
 
+G4_FEATS = (G3_FEATS | set("bti flagm2 frint sb".split())) - set("sm3 sm4".split())
+
 
 def test_guest_cpu_features(uvm_any):
     """Check the CPU features for a microvm with different CPU templates"""
@@ -43,6 +45,8 @@ def test_guest_cpu_features(uvm_any):
             expected_cpu_features = G3_FEATS | G3_SVE_AND_PAC
         case CpuModel.ARM_NEOVERSE_V1, None:
             expected_cpu_features = G3_FEATS
+        case CpuModel.ARM_NEOVERSE_V2, None:
+            expected_cpu_features = G4_FEATS
 
     guest_feats = set(vm.ssh.check_output(CPU_FEATURES_CMD).stdout.split())
     assert guest_feats == expected_cpu_features

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -257,11 +257,20 @@ def test_host_vs_guest_cpu_features(uvm_nano):
             assert host_feats - guest_feats == expected_host_minus_guest
             assert guest_feats - host_feats == expected_guest_minus_host
 
-        case CpuModel.ARM_NEOVERSE_V1:
+        case CpuModel.ARM_NEOVERSE_V1 | CpuModel.ARM_NEOVERSE_V2:
             expected_guest_minus_host = set()
             # KVM does not enable PAC or SVE features by default
             # and Firecracker does not enable them either.
             expected_host_minus_guest = {"paca", "pacg", "sve", "svebf16", "svei8mm"}
+
+            if CPU_MODEL == CpuModel.ARM_NEOVERSE_V2:
+                expected_host_minus_guest |= {
+                    "svebitperm",
+                    "svesha3",
+                    "sveaes",
+                    "sve2",
+                    "svepmull",
+                }
 
             # Upstream kernel v6.11+ hides "ssbs" from "lscpu" on Neoverse-N1 and Neoverse-V1 since
             # they have an errata whereby an MSR to the SSBS special-purpose register does not


### PR DESCRIPTION
## Changes
Add ability to detect Graviton 4 (neoverse v2) and adjust host and guest feature checks with new features.

## Reason
Graviton 4 on-boarding.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
