### PR TITLE
chore: bump version to 1.12.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "cpu-template-helper"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 dependencies = [
  "clap",
  "displaydoc",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 dependencies = [
  "cargo_toml",
  "displaydoc",
@@ -804,7 +804,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jailer"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 dependencies = [
  "libc",
  "log-instrument",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "rebase-snap"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 dependencies = [
  "displaydoc",
  "libc",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "seccompiler"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 dependencies = [
  "bincode",
  "clap",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "snapshot-editor"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 dependencies = [
  "clap",
  "clap-num",

--- a/src/cpu-template-helper/Cargo.toml
+++ b/src/cpu-template-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpu-template-helper"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 build = "build.rs"

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 1.11.0-dev
+  version: 1.12.0-dev
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 description = "Process for starting Firecracker in production scenarios; applies a cgroup/namespace isolation barrier and then drops privileges."

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rebase-snap"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seccompiler"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 description = "Program that compiles multi-threaded seccomp-bpf filters expressed as JSON into raw BPF programs, serializing them and outputting them to a file."

--- a/src/snapshot-editor/Cargo.toml
+++ b/src/snapshot-editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapshot-editor"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Generated running `./tools/bump-version.sh 1.12.0-dev`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
