### PR TITLE
fix: Allow jailer to continue with partial CPU cache info

### DIFF
--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -575,17 +575,20 @@ impl Env {
                 let host_cache_file = host_path.join(entry);
                 let jailer_cache_file = jailer_path.join(entry);
 
-                let line = readln_special(&host_cache_file)?;
-                writeln_special(&jailer_cache_file, line)?;
+                if let Ok(line) = readln_special(&host_cache_file) {
+                    writeln_special(&jailer_cache_file, line)?;
 
-                // We now change the permissions.
-                let dest_path_cstr = to_cstring(&jailer_cache_file)?;
-                // SAFETY: Safe because dest_path_cstr is null-terminated.
-                SyscallReturnCode(unsafe {
-                    libc::chown(dest_path_cstr.as_ptr(), self.uid(), self.gid())
-                })
-                .into_empty_result()
-                .map_err(|err| JailerError::ChangeFileOwner(jailer_cache_file.to_owned(), err))?;
+                    // We now change the permissions.
+                    let dest_path_cstr = to_cstring(&jailer_cache_file)?;
+                    // SAFETY: Safe because dest_path_cstr is null-terminated.
+                    SyscallReturnCode(unsafe {
+                        libc::chown(dest_path_cstr.as_ptr(), self.uid(), self.gid())
+                    })
+                    .into_empty_result()
+                    .map_err(|err| {
+                        JailerError::ChangeFileOwner(jailer_cache_file.to_owned(), err)
+                    })?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
## Changes

Allows the `jailer` to continue when files in `/sys/devices/system/cpu/cpuX/cache/indexY/` are missing.

## Reason

Nested virtualization support was added on macOS Sequoia for Apple M3/M4 chips. When using `vz` with [Lima](https://lima-vm.io) a few of the CPU cache information files are missing, namely `size`, `coherency_line_size`, and `number_of_sets`. `firecracker` itself [handles if these files are missing](https://github.com/firecracker-microvm/firecracker/blob/b4cb9d311d026c5e45f13bd56089d2db024ec983/src/vmm/src/arch/aarch64/cache_info.rs#L101-L124), while the `jailer` doesn't . This patch passes whatever is present to the copied cache information, and allows `firecracker` to determine if it is valid or not.

By making this change, we are able to simplify our development environments drastically by not requiring either GitHub Codespaces or AWS EC2 metal instances.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
~- [ ] If a specific issue led to this PR, this PR closes the issue.~
~- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
~- [ ] I have linked an issue to every new `TODO`.~

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
