### PR TITLE
Jailer tweaks

### DIFF
--- a/src/jailer/src/chroot.rs
+++ b/src/jailer/src/chroot.rs
@@ -10,9 +10,9 @@ use vmm_sys_util::syscall::SyscallReturnCode;
 
 use super::{to_cstring, JailerError};
 
-const OLD_ROOT_DIR_NAME_NUL_TERMINATED: &[u8] = b"old_root\0";
-const ROOT_DIR_NUL_TERMINATED: &[u8] = b"/\0";
-const CURRENT_DIR_NUL_TERMINATED: &[u8] = b".\0";
+const OLD_ROOT_DIR: &CStr = c"old_root";
+const ROOT_DIR: &CStr = c"/";
+const CURRENT_DIR: &CStr = c".";
 
 // This uses switching to a new mount namespace + pivot_root(), together with the regular chroot,
 // to provide a hardened jail (at least compared to only relying on chroot).
@@ -24,16 +24,13 @@ pub fn chroot(path: &Path) -> Result<(), JailerError> {
         .into_empty_result()
         .map_err(JailerError::UnshareNewNs)?;
 
-    let root_dir = CStr::from_bytes_with_nul(ROOT_DIR_NUL_TERMINATED)
-        .map_err(JailerError::FromBytesWithNul)?;
-
     // Recursively change the propagation type of all the mounts in this namespace to SLAVE, so
     // we can call pivot_root.
     // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe {
         libc::mount(
             null(),
-            root_dir.as_ptr(),
+            ROOT_DIR.as_ptr(),
             null(),
             libc::MS_SLAVE | libc::MS_REC,
             null(),
@@ -64,25 +61,21 @@ pub fn chroot(path: &Path) -> Result<(), JailerError> {
     // Change current dir to the chroot dir, so we only need to handle relative paths from now on.
     env::set_current_dir(path).map_err(JailerError::SetCurrentDir)?;
 
-    // We use the CStr conversion to make sure the contents of the byte slice would be a
-    // valid C string (and for the as_ptr() method).
-    let old_root_dir = CStr::from_bytes_with_nul(OLD_ROOT_DIR_NAME_NUL_TERMINATED)
-        .map_err(JailerError::FromBytesWithNul)?;
-
     // Create the old_root folder we're going to use for pivot_root, using a relative path.
     // SAFETY: The call is safe because we provide valid arguments.
-    SyscallReturnCode(unsafe { libc::mkdir(old_root_dir.as_ptr(), libc::S_IRUSR | libc::S_IWUSR) })
+    SyscallReturnCode(unsafe { libc::mkdir(OLD_ROOT_DIR.as_ptr(), libc::S_IRUSR | libc::S_IWUSR) })
         .into_empty_result()
         .map_err(JailerError::MkdirOldRoot)?;
-
-    let cwd = CStr::from_bytes_with_nul(CURRENT_DIR_NUL_TERMINATED)
-        .map_err(JailerError::FromBytesWithNul)?;
 
     // We are now ready to call pivot_root. We have to use sys_call because there is no libc
     // wrapper for pivot_root.
     // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe {
-        libc::syscall(libc::SYS_pivot_root, cwd.as_ptr(), old_root_dir.as_ptr())
+        libc::syscall(
+            libc::SYS_pivot_root,
+            CURRENT_DIR.as_ptr(),
+            OLD_ROOT_DIR.as_ptr(),
+        )
     })
     .into_empty_result()
     .map_err(JailerError::PivotRoot)?;
@@ -90,19 +83,19 @@ pub fn chroot(path: &Path) -> Result<(), JailerError> {
     // pivot_root doesn't guarantee that we will be in "/" at this point, so switch to "/"
     // explicitly.
     // SAFETY: Safe because we provide valid parameters.
-    SyscallReturnCode(unsafe { libc::chdir(root_dir.as_ptr()) })
+    SyscallReturnCode(unsafe { libc::chdir(ROOT_DIR.as_ptr()) })
         .into_empty_result()
         .map_err(JailerError::ChdirNewRoot)?;
 
     // Umount the old_root, thus isolating the process from everything outside the jail root folder.
     // SAFETY: Safe because we provide valid parameters.
-    SyscallReturnCode(unsafe { libc::umount2(old_root_dir.as_ptr(), libc::MNT_DETACH) })
+    SyscallReturnCode(unsafe { libc::umount2(OLD_ROOT_DIR.as_ptr(), libc::MNT_DETACH) })
         .into_empty_result()
         .map_err(JailerError::UmountOldRoot)?;
 
     // Remove the no longer necessary old_root directory.
     // SAFETY: Safe because we provide valid parameters.
-    SyscallReturnCode(unsafe { libc::rmdir(old_root_dir.as_ptr()) })
+    SyscallReturnCode(unsafe { libc::rmdir(OLD_ROOT_DIR.as_ptr()) })
         .into_empty_result()
         .map_err(JailerError::RmOldRootDir)
 }

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -305,6 +305,7 @@ pub fn to_cstring<T: AsRef<Path> + Debug>(path: T) -> Result<CString, JailerErro
     CString::new(path_str).map_err(JailerError::CStringParsing)
 }
 
+/// We wrap the actual main in order to pretty print an error with Display trait.
 fn main() -> Result<(), JailerError> {
     let result = main_exec();
     if let Err(e) = result {


### PR DESCRIPTION
## Changes
- Clarify the reason for main function wrapping. This is mainly because I have this question each time I look at this code and each time need to discover the reason again.
- Use Rust feature to create `CStr` constants for paths avoiding runtime conversion.

## Reason
Since Rust 1.77 `CStr` can be created with `c` prefix to string. Use this to simplify the code and remove runtime conversions.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
