### PR TITLE
chore(aarch64): increase the max_value for timer reset test

### DIFF
--- a/src/vmm/src/arch/aarch64/vcpu.rs
+++ b/src/vmm/src/arch/aarch64/vcpu.rs
@@ -271,8 +271,9 @@ mod tests {
             // We are reading the SYS_CNTPCT_EL0 right after resetting it.
             // If reset did happen successfully, the value should be quite small when we read it.
             // If the reset did not happen, the value will be same as on the host and it surely
-            // will be more that MAX_VALUE.
-            let max_value = 1000;
+            // will be more that `max_value`. Measurements show that usually value is close
+            // to 1000. Use bigger `max_value` just in case.
+            let max_value = 10_000;
 
             assert!(counter_value < max_value);
         }


### PR DESCRIPTION
## Changes
The counter value observed in tests sometimes is a bit larger than 1000 cycles. Adjust max_value to accommodate this.

## Reason
Less intermediate failures.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
