### PR TITLE
test: Modernize test_send_ctrl_alt_del

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to
 
 ### Fixed
 
+- #\[[5074](https://github.com/firecracker-microvm/firecracker/pull/5074)\] Fix
+  the `SendCtrlAltDel` command not working for ACPI-enabled guest kernels, by
+  dropping the i8042.nopnp argument from the default kernel command line
+  Firecracker constructs.
+
 ## [1.11.0]
 
 ### Added

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -14,10 +14,9 @@ use serde::{Deserialize, Serialize};
 /// - `8250.nr_uarts=0` disable 8250 serial interface;
 /// - `i8042.noaux` do not probe the i8042 controller for an attached mouse (save boot time);
 /// - `i8042.nomux` do not probe i8042 for a multiplexing controller (save boot time);
-/// - `i8042.nopnp` do not use ACPIPnP to discover KBD/AUX controllers (save boot time);
 /// - `i8042.dumbkbd` do not attempt to control kbd state via the i8042 (save boot time).
-pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodule 8250.nr_uarts=0 \
-                                          i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd";
+pub const DEFAULT_KERNEL_CMDLINE: &str =
+    "reboot=k panic=1 pci=off nomodule 8250.nr_uarts=0 i8042.noaux i8042.nomux i8042.dumbkbd";
 
 /// Strongly typed data structure used to configure the boot source of the
 /// microvm.

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -767,24 +767,14 @@ def test_send_ctrl_alt_del(uvm_plain_any):
     test_microvm.spawn()
 
     test_microvm.basic_config()
+    test_microvm.add_net_iface()
     test_microvm.start()
-
-    # Wait around for the guest to boot up and initialize the user space
-    time.sleep(2)
 
     test_microvm.api.actions.put(action_type="SendCtrlAltDel")
 
-    firecracker_pid = test_microvm.firecracker_pid
-
     # If everything goes as expected, the guest OS will issue a reboot,
     # causing Firecracker to exit.
-    # waitpid should block until the Firecracker process has exited. If
-    # it has already exited by the time we call waitpid, WNOHANG causes
-    # waitpid to raise a ChildProcessError exception.
-    try:
-        os.waitpid(firecracker_pid, os.WNOHANG)
-    except ChildProcessError:
-        pass
+    test_microvm.mark_killed()
 
 
 def _drive_patch(test_microvm, io_engine):


### PR DESCRIPTION
Instead of sleeping for 2 seconds to wait for booting, add a network device and wait for ssh availability (happens automatically in .start()). Use mark_killed() to assert that Firecracker exited instead of "waitpid". Using `waitpid(2)` here is wrong, because it only works on child processes, and Firecracker is no child of the pytest process (it is daemonized, for starters). The reason we never caught this being broken is because the test also simply ignores all exceptions raised.

But there's more issues here: The test never caused _killed to be set to `True`, so if Firecracker really did exit, then we would have been seeing intermittent failures during microvm teardown (as Microvm.kill() asserts that the process is still alive if _killed is False). In fact, our guest kernels do not have the required drivers compiled in to support CTRL+ALT+DEL (thanks Riccardo for figuring this part out).

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
