### PR TITLE
fix(doc): Update normalization for extended topology leaf

### DIFF
--- a/docs/cpu_templates/cpuid-normalization.md
+++ b/docs/cpu_templates/cpuid-normalization.md
@@ -21,7 +21,7 @@ See also: [boot protocol settings](boot-protocol.md)
 | Enable TSC_DEADLINE                                                                  |    0x1     |    -    |      ECX      |  24   |
 | Enable HYPERVISOR                                                                    |    0x1     |    -    |      ECX      |  31   |
 | Set HTT value if the microVM's CPU count is greater than 1                           |    0x1     |    -    |      EDX      |  28   |
-| Insert leaf 0xb, subleaf 0x1 filled with `0` if it is not already present            |    0xb     |   0x1   |      all      |  all  |
+| Insert leaf 0xb, subleaf 0x1 if not present                                          |    0xb     |   0x1   |      all      |  all  |
 | Update extended topology enumeration                                                 |    0xb     |   all   |      EAX      |  4:0  |
 | Update extended topology enumeration                                                 |    0xb     |   all   |      EBX      | 15:0  |
 | Update extended topology enumeration                                                 |    0xb     |   all   |      ECX      | 15:8  |

--- a/docs/cpu_templates/cpuid-normalization.md
+++ b/docs/cpu_templates/cpuid-normalization.md
@@ -22,9 +22,7 @@ See also: [boot protocol settings](boot-protocol.md)
 | Enable HYPERVISOR                                                                    |    0x1     |    -    |      ECX      |  31   |
 | Set HTT value if the microVM's CPU count is greater than 1                           |    0x1     |    -    |      EDX      |  28   |
 | Insert leaf 0xb, subleaf 0x1 if not present                                          |    0xb     |   0x1   |      all      |  all  |
-| Update extended topology enumeration                                                 |    0xb     |   all   |      EAX      |  4:0  |
-| Update extended topology enumeration                                                 |    0xb     |   all   |      EBX      | 15:0  |
-| Update extended topology enumeration                                                 |    0xb     |   all   |      ECX      | 15:8  |
+| Fill extended topology enumeration leaf                                              |    0xb     |   all   |      all      |  all  |
 | Pass through L1 cache and TLB information from host                                  | 0x80000005 |    -    |      all      |  all  |
 | Pass through L2 cache and TLB and L3 cache information from host                     | 0x80000006 |    -    |      all      |  all  |
 


### PR DESCRIPTION
## Changes

- Avoid confusion of CPUID.(EAX=0xB,ECX=1) normalization
- Simplify explanation of extended topology leaf

## Reason

See commit messages.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
