### PR TITLE
test: Don't disable boost on AMD instances

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -628,11 +628,10 @@ apply_linux_61_tweaks() {
 
 # Modifies the processors CPU governor and P-state configuration (x86_64 only) for consistent performance. This means
 # - Disable turbo boost (Intel only) by writing 1 to /sys/devices/system/cpu/intel_pstate/no_turbo
-# - Disable turbo boost (AMD only) by writing 0 to /sys/devices/system/cpu/cpufreq/boost
 # - Lock the CPUs' P-state to the highest non-turbo one (Intel only) by writing 100 to /sys/devices/system/cpu/intel_pstate/{min,max}_perf_pct
 # - Set the cpu frequency governor to performance by writing "performance" to /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 apply_performance_tweaks() {
-  # m6a instances do not support the amd_pstate driver (yet), so nothing we can do there
+  # AMD instances do not support the amd_pstate driver (yet), so nothing we can do there
   if [[ -d /sys/devices/system/cpu/intel_pstate ]]; then
     # Disable turbo boost. Some of our tests are performance tests, and we want minimum variability wrt processor frequency
     # See also https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html
@@ -647,8 +646,6 @@ apply_performance_tweaks() {
     # https://www.kernel.org/doc/html/v4.12/admin-guide/pm/intel_pstate.html
     echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/min_perf_pct &> /dev/null
     echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct &> /dev/null
-  elif [[ -f /sys/devices/system/cpu/cpufreq/boost ]]; then
-    echo 0 |sudo tee /sys/devices/system/cpu/cpufreq/boost &> /dev/null
   fi
 
   # The governor is a linux component that can adjust CPU frequency. "performance" tells it to always run CPUs at
@@ -665,8 +662,6 @@ unapply_performance_tweaks() {
     # restore p-state limits
     echo $MIN_PERF_PCT |sudo tee /sys/devices/system/cpu/intel_pstate/min_perf_pct &> /dev/null
     echo $MAX_PERF_PCT |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct &> /dev/null
-  elif [[ -f /sys/devices/system/cpu/cpufreq/boost ]]; then
-    echo 1 | sudo tee /sys/devices/system/cpu/cpufreq/boost &> /dev/null
   fi
 
   # We do not reset the governor, as keeping track of each CPUs configured governor is not trivial here. On our CI


### PR DESCRIPTION
## Changes

We would like to observer the effect on stability of our performance tests on AMD instances with turbo not disabled.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
