### PR TITLE
kani: fix infinite loop unwinding in dumbo harnesses

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -51,6 +51,7 @@ if any(
 if not pipeline.args.no_kani and (
     not changed_files
     or any(x.suffix in [".rs", ".toml", ".lock"] for x in changed_files)
+    or any(x.parent.name == "devctr" for x in changed_files)
 ):
     kani_grp = pipeline.build_group(
         "🔍 Kani",

--- a/src/vmm/src/arch/x86_64/interrupts.rs
+++ b/src/vmm/src/arch/x86_64/interrupts.rs
@@ -7,6 +7,7 @@
 
 use kvm_bindings::kvm_lapic_state;
 use kvm_ioctls::VcpuFd;
+use zerocopy::IntoBytes;
 
 use crate::utils::byte_order;
 
@@ -28,13 +29,13 @@ const APIC_MODE_EXTINT: u32 = 0x7;
 fn get_klapic_reg(klapic: &kvm_lapic_state, reg_offset: usize) -> u32 {
     let range = reg_offset..reg_offset + 4;
     let reg = klapic.regs.get(range).expect("get_klapic_reg range");
-    byte_order::read_le_u32_from_i8(reg)
+    byte_order::read_le_u32(reg.as_bytes())
 }
 
 fn set_klapic_reg(klapic: &mut kvm_lapic_state, reg_offset: usize, value: u32) {
     let range = reg_offset..reg_offset + 4;
     let reg = klapic.regs.get_mut(range).expect("set_klapic_reg range");
-    byte_order::write_le_u32_to_i8(reg, value)
+    byte_order::write_le_u32(reg.as_mut_bytes(), value);
 }
 
 fn set_apic_delivery_mode(reg: u32, mode: u32) -> u32 {

--- a/src/vmm/src/dumbo/pdu/ethernet.rs
+++ b/src/vmm/src/dumbo/pdu/ethernet.rs
@@ -255,16 +255,6 @@ mod kani_proofs {
         }
     }
 
-    mod stubs {
-        // The current implementation of read_be_u16 function leads to a significant
-        // performance degradation given a necessary loop unrolling. Using this stub,
-        // we read the same information from the buffer while avoiding the loop, thus,
-        // notably improving performance.
-        pub fn read_be_u16(input: &[u8]) -> u16 {
-            u16::from_be_bytes([input[0], input[1]])
-        }
-    }
-
     // We consider the MMDS Network Stack spec for all postconditions in the harnesses.
     // See https://github.com/firecracker-microvm/firecracker/blob/main/docs/mmds/mmds-design.md#mmds-network-stack
 
@@ -519,7 +509,6 @@ mod kani_proofs {
 
     #[kani::proof]
     #[kani::solver(cadical)]
-    #[kani::stub(crate::utils::byte_order::read_be_u16, stubs::read_be_u16)]
     fn verify_with_payload_len_unchecked() {
         // Create non-deterministic stream of bytes up to MAX_FRAME_SIZE
         let mut bytes: [u8; MAX_FRAME_SIZE] = kani::Arbitrary::any_array::<MAX_FRAME_SIZE>();

--- a/tests/integration_tests/test_kani.py
+++ b/tests/integration_tests/test_kani.py
@@ -29,12 +29,12 @@ def test_kani(results_dir):
     """
     # -Z stubbing is required to enable the stubbing feature
     # -Z function-contracts is required to enable the function contracts feature
-    # --restrict-vtable is required for some virtio queue proofs, which go out of memory otherwise
+    # -Z restrict-vtable is required for some virtio queue proofs, which go out of memory otherwise
     # -j enables kani harnesses to be verified in parallel (required to keep CI time low)
     # --output-format terse is required by -j
-    # --enable-unstable is needed to enable `-Z` flags
+    # -Z unstable-options is needed to enable the other `-Z` flags
     _, stdout, _ = utils.check_output(
-        "cargo kani --enable-unstable -Z stubbing -Z function-contracts --restrict-vtable -j --output-format terse",
+        "cargo kani -Z unstable-options -Z stubbing -Z function-contracts -Z restrict-vtable -j --output-format terse",
         timeout=TIMEOUT,
     )
 


### PR DESCRIPTION
Since 0.58.0 kani gets stuck unwinding loops in the dumbo proofs. The exact loops were the ones in the `byte_order` module. We've previously seen this with a subset of the `byte_order` functions, which is why some of them were already stubbed out in kani. However, instead of just doing more stubbing, let's just eliminate the loops. The were just a handrolled memcpy (the reason we need these convoluted byte_order functions in the first place is that the stdlib functions cannot deal with buffers that are "too small", while we for some reason want to support that).

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
