### PR TITLE
Functional support of Intel Sapphire Rapids

### DIFF
--- a/docs/cpu_templates/cpuid-normalization.md
+++ b/docs/cpu_templates/cpuid-normalization.md
@@ -36,6 +36,7 @@ See also: [boot protocol settings](boot-protocol.md)
 | Set FDP_EXCPTN_ONLY bit                                        |                0x7                 |   0x0   |   EBX    |   6   |
 | Set "Deprecates FPU CS and FPU DS values" bit                  |                0x7                 |   0x0   |   EBX    |  13   |
 | Disable performance monitoring                                 |                0xa                 |    -    |   all    |  all  |
+| Fill v2 extended topology enumeration leaf                     |                0x1f                |   all   |   all    |  all  |
 | Update brand string to use a default format and real frequency | 0x80000002, 0x80000003, 0x80000004 |    -    |   all    |  all  |
 
 ## AMD-specifc CPUID normalization

--- a/docs/cpu_templates/cpuid-normalization.md
+++ b/docs/cpu_templates/cpuid-normalization.md
@@ -28,15 +28,15 @@ See also: [boot protocol settings](boot-protocol.md)
 
 ## Intel-specific CPUID normalization
 
-| Description                                                    |                Leaf                | Subleaf |      Register      | Bits  |
-| -------------------------------------------------------------- | :--------------------------------: | :-----: | :----------------: | :---: |
-| Update deterministic cache parameters                          |                0x4                 |   all   |        EAX         | 31:14 |
-| Disable Intel Turbo Boost technology                           |                0x6                 |    -    |        EAX         |   1   |
-| Disable frequency selection                                    |                0x6                 |    -    |        ECX         |   3   |
-| Set FDP_EXCPTN_ONLY bit                                        |                0x7                 |   0x0   |        EBX         |   6   |
-| Set "Deprecates FPU CS and FPU DS values" bit                  |                0x7                 |   0x0   |        EBX         |  13   |
-| Disable performance monitoring                                 |                0xa                 |    -    | EAX, EBX, ECX, EDX |  all  |
-| Update brand string to use a default format and real frequency | 0x80000002, 0x80000003, 0x80000004 |    -    | EAX, EBX, ECX, EDX |  all  |
+| Description                                                    |                Leaf                | Subleaf | Register | Bits  |
+| -------------------------------------------------------------- | :--------------------------------: | :-----: | :------: | :---: |
+| Update deterministic cache parameters                          |                0x4                 |   all   |   EAX    | 31:14 |
+| Disable Intel Turbo Boost technology                           |                0x6                 |    -    |   EAX    |   1   |
+| Disable frequency selection                                    |                0x6                 |    -    |   ECX    |   3   |
+| Set FDP_EXCPTN_ONLY bit                                        |                0x7                 |   0x0   |   EBX    |   6   |
+| Set "Deprecates FPU CS and FPU DS values" bit                  |                0x7                 |   0x0   |   EBX    |  13   |
+| Disable performance monitoring                                 |                0xa                 |    -    |   all    |  all  |
+| Update brand string to use a default format and real frequency | 0x80000002, 0x80000003, 0x80000004 |    -    |   all    |  all  |
 
 ## AMD-specifc CPUID normalization
 

--- a/src/vmm/src/cpu_config/x86_64/cpuid/intel/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/intel/normalize.rs
@@ -99,7 +99,7 @@ impl super::IntelCpuid {
 
                 // CPUID.04H:EAX[7:5]
                 // Cache Level (Starts at 1)
-                let cache_level = get_range(subleaf.result.eax, 5..8);
+                let cache_level = get_range(subleaf.result.eax, 5..=7);
 
                 // CPUID.04H:EAX[25:14]
                 // Maximum number of addressable IDs for logical processors sharing this cache.
@@ -116,7 +116,7 @@ impl super::IntelCpuid {
                     // The L1 & L2 cache is shared by at most 2 hyperthreads
                     1 | 2 => {
                         let sub = u32::from(cpus_per_core.checked_sub(1).unwrap());
-                        set_range(&mut subleaf.result.eax, 14..26, sub)
+                        set_range(&mut subleaf.result.eax, 14..=25, sub)
                             .map_err(DeterministicCacheError::MaxCpusPerCore)?;
                     }
                     // L3 Cache
@@ -127,7 +127,7 @@ impl super::IntelCpuid {
                                 .checked_sub(1)
                                 .ok_or(DeterministicCacheError::MaxCpusPerCoreUnderflow)?,
                         );
-                        set_range(&mut subleaf.result.eax, 14..26, sub)
+                        set_range(&mut subleaf.result.eax, 14..=25, sub)
                             .map_err(DeterministicCacheError::MaxCpusPerCore)?;
                     }
                     _ => (),
@@ -150,7 +150,7 @@ impl super::IntelCpuid {
                 let sub = u32::from(cores)
                     .checked_sub(1)
                     .ok_or(DeterministicCacheError::MaxCorePerPackageUnderflow)?;
-                set_range(&mut subleaf.result.eax, 26..32, sub)
+                set_range(&mut subleaf.result.eax, 26..=31, sub)
                     .map_err(DeterministicCacheError::MaxCorePerPackage)?;
             } else {
                 break;

--- a/src/vmm/src/cpu_config/x86_64/cpuid/intel/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/intel/normalize.rs
@@ -34,14 +34,14 @@ pub enum NormalizeCpuidError {
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error, displaydoc::Display, Eq, PartialEq)]
 pub enum DeterministicCacheError {
-    /// Failed to set `Maximum number of addressable IDs for logical processors sharing this cache` due to underflow in cpu count.
-    MaxCpusPerCoreUnderflow,
-    /// Failed to set `Maximum number of addressable IDs for logical processors sharing this cache`: {0}.
-    MaxCpusPerCore(CheckedAssignError),
-    /// Failed to set `Maximum number of addressable IDs for processor cores in the physical package` due to underflow in cores.
-    MaxCorePerPackageUnderflow,
-    /// Failed to set `Maximum number of addressable IDs for processor cores in the physical package`: {0}.
+    /// Failed to set max addressable core ID in physical package (CPUID.04H:EAX[31:26]): {0}.
     MaxCorePerPackage(CheckedAssignError),
+    /// Failed to set max addressable core ID in physical package (CPUID.04H:EAX[31:26]) due to underflow in cores.
+    MaxCorePerPackageUnderflow,
+    /// Failed to set max addressable processor ID sharing cache (CPUID.04H:EAX[25:14]): {0}.
+    MaxCpusPerCore(CheckedAssignError),
+    /// Failed to set max addressable processor ID sharing cache (CPUID.04H:EAX[25:14]) due to underflow in cpu count.
+    MaxCpusPerCoreUnderflow,
 }
 
 /// We always use this brand string.

--- a/src/vmm/src/cpu_config/x86_64/cpuid/intel/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/intel/normalize.rs
@@ -398,22 +398,21 @@ mod tests {
 
     #[test]
     fn test_update_extended_feature_flags_entry() {
-        let mut cpuid =
-            crate::cpu_config::x86_64::cpuid::IntelCpuid(std::collections::BTreeMap::from([(
-                crate::cpu_config::x86_64::cpuid::CpuidKey {
-                    leaf: 0x7,
-                    subleaf: 0,
-                },
-                crate::cpu_config::x86_64::cpuid::CpuidEntry {
-                    flags: crate::cpu_config::x86_64::cpuid::KvmCpuidFlags::SIGNIFICANT_INDEX,
-                    ..Default::default()
-                },
-            )]));
+        let mut cpuid = IntelCpuid(BTreeMap::from([(
+            CpuidKey {
+                leaf: 0x7,
+                subleaf: 0,
+            },
+            CpuidEntry {
+                flags: KvmCpuidFlags::SIGNIFICANT_INDEX,
+                ..Default::default()
+            },
+        )]));
 
         cpuid.update_extended_feature_flags_entry().unwrap();
 
         let leaf_7_0 = cpuid
-            .get(&crate::cpu_config::x86_64::cpuid::CpuidKey {
+            .get(&CpuidKey {
                 leaf: 0x7,
                 subleaf: 0,
             })

--- a/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
@@ -317,47 +317,37 @@ impl super::Cpuid {
                 subleaf.result.edx = u32::from(cpu_index);
                 subleaf.flags = KvmCpuidFlags::SIGNIFICANT_INDEX;
 
-                // "If SMT is not present in a processor implementation but CPUID leaf 0BH is
-                // supported, CPUID.EAX=0BH, ECX=0 will return EAX = 0, EBX = 1 and
-                // level type = 1. Number of logical processors at the core level is
-                // reported at level type = 2." (Intel® 64 Architecture x2APIC
-                // Specification, Ch. 2.8)
                 match index {
                     // CPUID.(EAX=0BH,ECX=N):EAX[4:0]
-                    // Number of bits to shift right on x2APIC ID to get a unique topology ID of the
-                    // next level type*. All logical processors with the same
-                    // next level ID share current level.
-                    //
-                    // *Software should use this field (EAX[4:0]) to enumerate processor topology of
-                    // the system.
+                    // The number of bits that the x2APIC ID must be shifted to the right to address
+                    // instances of the next higher-scoped domain. When logical processor is not
+                    // supported by the processor, the value of this field at the Logical Processor
+                    // domain sub-leaf may be returned as either 0 (no allocated bits in the x2APIC
+                    // ID) or 1 (one allocated bit in the x2APIC ID); software should plan
+                    // accordingly.
 
                     // CPUID.(EAX=0BH,ECX=N):EBX[15:0]
-                    // Number of logical processors at this level type. The number reflects
-                    // configuration as shipped by Intel**.
-                    //
-                    // **Software must not use EBX[15:0] to enumerate processor topology of the
-                    // system. This value in this field (EBX[15:0]) is only
-                    // intended for display/diagnostic purposes. The actual
-                    // number of  logical processors available to BIOS/OS/Applications may be
-                    // different from the value of  EBX[15:0], depending on
-                    // software and platform hardware configurations.
+                    // The number of logical processors across all instances of this domain within
+                    // the next-higher scoped domain. (For example, in a processor socket/package
+                    // comprising "M" dies of "N" cores each, where each core has "L" logical
+                    // processors, the "die" domain sub-leaf value of this field would be M*N*L.)
+                    // This number reflects configuration as shipped by Intel. Note, software must
+                    // not use this field to enumerate processor topology.
 
                     // CPUID.(EAX=0BH,ECX=N):ECX[7:0]
-                    // Level number. Same value in ECX input.
+                    // The input ECX sub-leaf index.
 
                     // CPUID.(EAX=0BH,ECX=N):ECX[15:8]
-                    // Level type***
+                    // Domain Type. This field provides an identification value which indicates the
+                    // domain as shown below. Although domains are ordered, their assigned
+                    // identification values are not and software should not depend on it.
                     //
-                    // If an input value n in ECX returns the invalid level-type of 0 in ECX[15:8],
-                    // other input values with ECX>n also return 0 in ECX[15:8].
+                    // Hierarchy    Domain              Domain Type Identification Value
+                    // -----------------------------------------------------------------
+                    // Lowest       Logical Processor   1
+                    // Highest      Core                2
                     //
-                    // ***The value of the “level type” field is not related to level numbers in any
-                    // way, higher “level type” values do not mean higher
-                    // levels. Level type field has the following encoding:
-                    // - 0: Invalid.
-                    // - 1: SMT.
-                    // - 2: Core.
-                    // - 3-255: Reserved.
+                    // (Note that enumeration values of 0 and 3-255 are reserved.)
 
                     // Thread Level Topology; index = 0
                     0 => {

--- a/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
@@ -221,26 +221,13 @@ impl super::Cpuid {
         cpu_index: u8,
         cpu_count: u8,
     ) -> Result<(), FeatureInformationError> {
-        // Flush a cache line size.
-        const EBX_CLFLUSH_CACHELINE: u32 = 8;
-
-        // PDCM: Perfmon and Debug Capability.
-        const ECX_PDCM_BITINDEX: u8 = 15;
-
-        // TSC-Deadline.
-        const ECX_TSC_DEADLINE_BITINDEX: u8 = 24;
-
-        // CPU is running on a hypervisor.
-        const ECX_HYPERVISOR_BITINDEX: u8 = 31;
-
         let leaf_1 = self
             .get_mut(&CpuidKey::leaf(0x1))
             .ok_or(FeatureInformationError::MissingLeaf1)?;
 
         // CPUID.01H:EBX[15:08]
         // CLFLUSH line size (Value * 8 = cache line size in bytes; used also by CLFLUSHOPT).
-        set_range(&mut leaf_1.result.ebx, 8..16, EBX_CLFLUSH_CACHELINE)
-            .map_err(FeatureInformationError::Clflush)?;
+        set_range(&mut leaf_1.result.ebx, 8..16, 8).map_err(FeatureInformationError::Clflush)?;
 
         // CPUID.01H:EBX[23:16]
         // Maximum number of addressable IDs for logical processors in this physical package.
@@ -266,15 +253,15 @@ impl super::Cpuid {
         // CPUID.01H:ECX[15] (Mnemonic: PDCM)
         // Performance and Debug Capability: A value of 1 indicates the processor supports the
         // performance and debug feature indication MSR IA32_PERF_CAPABILITIES.
-        set_bit(&mut leaf_1.result.ecx, ECX_PDCM_BITINDEX, false);
+        set_bit(&mut leaf_1.result.ecx, 15, false);
 
         // CPUID.01H:ECX[24] (Mnemonic: TSC-Deadline)
         // A value of 1 indicates that the processor’s local APIC timer supports one-shot operation
         // using a TSC deadline value.
-        set_bit(&mut leaf_1.result.ecx, ECX_TSC_DEADLINE_BITINDEX, true);
+        set_bit(&mut leaf_1.result.ecx, 24, true);
 
         // CPUID.01H:ECX[31] (Mnemonic: Hypervisor)
-        set_bit(&mut leaf_1.result.ecx, ECX_HYPERVISOR_BITINDEX, true);
+        set_bit(&mut leaf_1.result.ecx, 31, true);
 
         // CPUID.01H:EDX[28] (Mnemonic: HTT)
         // Max APIC IDs reserved field is Valid. A value of 0 for HTT indicates there is only a

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -157,10 +157,12 @@ AMD_GENOA_HOST_ONLY_FEATS_6_1 = AMD_MILAN_HOST_ONLY_FEATS_6_1 - {"brs"} | {
 }
 
 
-def test_host_vs_guest_cpu_features(uvm_nano):
+def test_host_vs_guest_cpu_features(uvm_plain_any):
     """Check CPU features host vs guest"""
 
-    vm = uvm_nano
+    vm = uvm_plain_any
+    vm.spawn()
+    vm.basic_config()
     vm.add_net_iface()
     vm.start()
     host_feats = set(utils.check_output(CPU_FEATURES_CMD).stdout.split())

--- a/tests/integration_tests/functional/test_cpu_features_x86_64.py
+++ b/tests/integration_tests/functional/test_cpu_features_x86_64.py
@@ -150,6 +150,8 @@ def test_brand_string(uvm_plain_any):
 
     * For Intel CPUs, the guest brand string should be:
         Intel(R) Xeon(R) Processor @ {host frequency}
+    or
+        Intel(R) Xeon(R) Processor
     where {host frequency} is the frequency reported by the host CPUID
     (e.g. 4.01GHz)
     * For AMD CPUs, the guest brand string should be:
@@ -184,7 +186,9 @@ def test_brand_string(uvm_plain_any):
         cif = open("/proc/cpuinfo", "r", encoding="utf-8")
         cpu_info = cif.read()
         mo = re.search("model name.*:.* ([0-9]*.[0-9]*[G|M|T]Hz)", cpu_info)
-        assert mo
+        # Skip if host frequency is not reported
+        if mo is None:
+            return
         host_frequency = mo.group(1)
 
         # Assert the model name matches "Intel(R) Xeon(R) Processor @ "

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -188,6 +188,9 @@ MSR_EXCEPTION_LIST = [
     0x48,
     # MSR_IA32_SMBASE is not accessible outside of System Management Mode.
     0x9E,
+    # MSR_IA32_UMWAIT_CONTROL is R/W MSR that guest OS modifies after boot to
+    # control UMWAIT feature.
+    0xE1,
     # MSR_IA32_TSX_CTRL is R/W MSR to disable Intel TSX feature as a mitigation
     # against TAA vulnerability.
     0x122,

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -200,6 +200,10 @@ MSR_EXCEPTION_LIST = [
     0x174,
     0x175,
     0x176,
+    # MSR_IA32_XFD is R/W MSR for guest OS to control which XSAVE-enabled
+    # features are temporarily disabled. Guest OS disables TILEDATA by default
+    # using the MSR.
+    0x1C4,
     # MSR_IA32_TSC_DEADLINE specifies the time at which a timer interrupt
     # should occur and depends on the elapsed time.
     0x6E0,

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -133,6 +133,10 @@ UNAVAILABLE_CPUID_ON_DUMP_LIST = [
     # support it, the userspace cpuid command in ubuntu 22 reports not only
     # the subleaf 0 but also the subleaf 1.
     (0x1B, 0x1),
+    # CPUID.1Fh is a preferred superset to CPUID.0Bh. For the same reason as
+    # CPUID.Bh, the subleaf 2 should be skipped when the guest userspace cpuid
+    # enumerates it.
+    (0x1F, 0x2),
     # CPUID.20000000h is not documented in Intel SDM and AMD APM. KVM doesn't
     # report it, but the userspace cpuid command in ubuntu 22 does.
     (0x20000000, 0x0),

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -85,7 +85,10 @@ class SpectreMeltdownChecker:
         Since we have a test on host and the exception in guest is not valid,
         we add a check to ignore this exception.
         """
-        if global_props.cpu_codename == "INTEL_ICELAKE" and cpu_template_name is None:
+        if (
+            global_props.cpu_codename in ["INTEL_ICELAKE", "INTEL_SAPPHIRE_RAPIDS"]
+            and cpu_template_name is None
+        ):
             return {
                 '{"NAME": "REPTAR", "CVE": "CVE-2023-23583", "VULNERABLE": true, "INFOS": "Your microcode is too old to mitigate the vulnerability"}'
             }


### PR DESCRIPTION
## Changes

- Do refactoring of the existing CPUID normalization in the first 11 commits (not related to Intel Sapphire Rapids support, so I can open another PR for this but this PR touches the same doc.)
- Add CPUID leaf 0x1F normalization
- Make functional integration tests support Intel Sapphire Rapids

## Reason

Intel Sapphire Rapids reports more CPUID leaves (0x1C - 0x1F) than Intel Ice Lake:
- 0x1C: Last Branch Records Information Leaf (filled with 0 since not supported in guest)
- 0x1D: Tile Information Main Leaf (passed through since it's for Intel AMX)
- 0x1E: TMUL Information Main Leaf (passed through since it's for Intel AMX)
- 0x1F: V2 Extended Topology Enumeration Leaf (same contents with leaf 0xB since leaf 0x1F is a preferred superset to leaf 0xB)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
