### PR TITLE
chore: Regather fingerprints for x86-64 instance types

### DIFF
--- a/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_5.10host.json
@@ -1,9 +1,9 @@
 {
-  "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.214-202.855.amzn2.x86_64",
-  "microcode_version": "0xa0011d1",
+  "firecracker_version": "1.12.0-dev",
+  "kernel_version": "5.10.234-225.910.amzn2.x86_64",
+  "microcode_version": "0xa0011db",
   "bios_version": "1.0",
-  "bios_revision": "0.69",
+  "bios_revision": "0.90",
   "guest_cpu_config": {
     "kvm_capabilities": [],
     "cpuid_modifiers": [
@@ -290,7 +290,7 @@
         "modifiers": [
           {
             "register": "eax",
-            "bitmap": "0b00000000000000000000000000000111"
+            "bitmap": "0b00000000000000000000000000000101"
           },
           {
             "register": "ebx",

--- a/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_AMD_MILAN_6.1host.json
@@ -1,9 +1,9 @@
 {
-  "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.84-99.169.amzn2023.x86_64",
-  "microcode_version": "0xa0011d1",
+  "firecracker_version": "1.12.0-dev",
+  "kernel_version": "6.1.129-138.220.amzn2023.x86_64",
+  "microcode_version": "0xa0011db",
   "bios_version": "1.0",
-  "bios_revision": "0.69",
+  "bios_revision": "0.90",
   "guest_cpu_config": {
     "kvm_capabilities": [],
     "cpuid_modifiers": [
@@ -290,7 +290,7 @@
         "modifiers": [
           {
             "register": "eax",
-            "bitmap": "0b00000000000000000000000000000111"
+            "bitmap": "0b00000000000000000000000000000101"
           },
           {
             "register": "ebx",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_5.10host.json
@@ -1,9 +1,9 @@
 {
-  "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.215-203.850.amzn2.x86_64",
-  "microcode_version": "0x5003604",
+  "firecracker_version": "1.12.0-dev",
+  "kernel_version": "5.10.234-225.910.amzn2.x86_64",
+  "microcode_version": "0x5003801",
   "bios_version": "1.0",
-  "bios_revision": "3.80",
+  "bios_revision": "4.11",
   "guest_cpu_config": {
     "kvm_capabilities": [],
     "cpuid_modifiers": [
@@ -382,7 +382,7 @@
         "modifiers": [
           {
             "register": "eax",
-            "bitmap": "0b00000000000000000000000000000111"
+            "bitmap": "0b00000000000000000000000000000101"
           },
           {
             "register": "ebx",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_CASCADELAKE_6.1host.json
@@ -1,9 +1,9 @@
 {
-  "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.84-99.169.amzn2023.x86_64",
-  "microcode_version": "0x5003604",
+  "firecracker_version": "1.12.0-dev",
+  "kernel_version": "6.1.129-138.220.amzn2023.x86_64",
+  "microcode_version": "0x5003801",
   "bios_version": "1.0",
-  "bios_revision": "3.80",
+  "bios_revision": "4.11",
   "guest_cpu_config": {
     "kvm_capabilities": [],
     "cpuid_modifiers": [
@@ -382,7 +382,7 @@
         "modifiers": [
           {
             "register": "eax",
-            "bitmap": "0b00000000000000000000000000000111"
+            "bitmap": "0b00000000000000000000000000000101"
           },
           {
             "register": "ebx",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_5.10host.json
@@ -1,9 +1,9 @@
 {
-  "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.215-203.850.amzn2.x86_64",
-  "microcode_version": "0xd0003b9",
+  "firecracker_version": "1.12.0-dev",
+  "kernel_version": "5.10.234-225.910.amzn2.x86_64",
+  "microcode_version": "0xd0003f6",
   "bios_version": "1.0",
-  "bios_revision": "1.36",
+  "bios_revision": "1.40",
   "guest_cpu_config": {
     "kvm_capabilities": [],
     "cpuid_modifiers": [
@@ -405,7 +405,7 @@
         "modifiers": [
           {
             "register": "eax",
-            "bitmap": "0b00000000000000000000000000000111"
+            "bitmap": "0b00000000000000000000000000000101"
           },
           {
             "register": "ebx",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_ICELAKE_6.1host.json
@@ -1,9 +1,9 @@
 {
-  "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.84-99.169.amzn2023.x86_64",
-  "microcode_version": "0xd0003b9",
+  "firecracker_version": "1.12.0-dev",
+  "kernel_version": "6.1.129-138.220.amzn2023.x86_64",
+  "microcode_version": "0xd0003f6",
   "bios_version": "1.0",
-  "bios_revision": "1.36",
+  "bios_revision": "1.40",
   "guest_cpu_config": {
     "kvm_capabilities": [],
     "cpuid_modifiers": [
@@ -428,7 +428,7 @@
         "modifiers": [
           {
             "register": "eax",
-            "bitmap": "0b00000000000000000000000000000111"
+            "bitmap": "0b00000000000000000000000000000101"
           },
           {
             "register": "ebx",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_5.10host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_5.10host.json
@@ -1,9 +1,9 @@
 {
-  "firecracker_version": "1.8.0-dev",
-  "kernel_version": "5.10.215-203.850.amzn2.x86_64",
+  "firecracker_version": "1.12.0-dev",
+  "kernel_version": "5.10.234-225.910.amzn2.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",
-  "bios_revision": "3.80",
+  "bios_revision": "4.11",
   "guest_cpu_config": {
     "kvm_capabilities": [],
     "cpuid_modifiers": [
@@ -382,7 +382,7 @@
         "modifiers": [
           {
             "register": "eax",
-            "bitmap": "0b00000000000000000000000000000111"
+            "bitmap": "0b00000000000000000000000000000101"
           },
           {
             "register": "ebx",

--- a/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json
+++ b/tests/data/cpu_template_helper/fingerprint_INTEL_SKYLAKE_6.1host.json
@@ -1,9 +1,9 @@
 {
-  "firecracker_version": "1.8.0-dev",
-  "kernel_version": "6.1.84-99.169.amzn2023.x86_64",
+  "firecracker_version": "1.12.0-dev",
+  "kernel_version": "6.1.129-138.220.amzn2023.x86_64",
   "microcode_version": "0x2007006",
   "bios_version": "1.0",
-  "bios_revision": "3.80",
+  "bios_revision": "4.11",
   "guest_cpu_config": {
     "kvm_capabilities": [],
     "cpuid_modifiers": [
@@ -382,7 +382,7 @@
         "modifiers": [
           {
             "register": "eax",
-            "bitmap": "0b00000000000000000000000000000111"
+            "bitmap": "0b00000000000000000000000000000101"
           },
           {
             "register": "ebx",


### PR DESCRIPTION
We changed to calculate the right-shift bits to address socket ID based on max number of vCPUs, but I forgot to update fingerprints :(

Fixes: 62207118 ("fix(vmm): Calc right-shift bits to address socket ID")

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
