### PR TITLE
doc: update FAQ to stop saying we dont have ACPI

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -196,9 +196,9 @@ mapping:
 
 ### How can I gracefully reboot the guest? How can I gracefully poweroff the guest?
 
-Firecracker does not implement ACPI and PM devices, therefore operations like
-gracefully rebooting or powering off the guest are supported in unconventional
-ways.
+Firecracker does not virtualize guest power management, therefore operations
+like gracefully rebooting or powering off the guest are supported in
+unconventional ways.
 
 Running the `poweroff` or `halt` commands inside a Linux guest will bring it
 down but Firecracker process remains unaware of the guest shutdown so it lives


### PR DESCRIPTION
We support ACPI nowadays. It doesn't change anything about this FAQ entry, because we don't implement power management using ACPI, but it still needs to be updated to actually say that.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
