### PR TITLE
Post-release doc updates and other miscellanea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ### Added
 
+- [#5048](https://github.com/firecracker-microvm/firecracker/pull/5048): Added
+  support for [PVH boot mode](docs/pvh.md). This is used when an x86 kernel
+  provides the appropriate ELF Note to indicate that PVH boot mode is supported.
+  Linux kernels newer than 5.0 compiled with `CONFIG_PVH=y` set this ELF Note,
+  as do FreeBSD kernels.
 - [#5065](https://github.com/firecracker-microvm/firecracker/pull/5065) Added
   support for Intel AMX (Advanced Matrix Extensions).
 - [#4731](https://github.com/firecracker-microvm/firecracker/pull/4731): Added
@@ -38,11 +43,6 @@ and this project adheres to
   kernels. For older kernels physical counter will still be passed to the guest
   unmodified. See more info
   [here](https://github.com/firecracker-microvm/firecracker/blob/main/docs/prod-host-setup.md#arm-only-vm-physical-counter-behaviour)
-- [#5048](https://github.com/firecracker-microvm/firecracker/pull/5048): Added
-  support for [PVH boot mode](docs/pvh.md). This is used when an x86 kernel
-  provides the appropriate ELF Note to indicate that PVH boot mode is supported.
-  Linux kernels newer than 5.0 compiled with `CONFIG_PVH=y` set this ELF Note,
-  as do FreeBSD kernels.
 - [#5088](https://github.com/firecracker-microvm/firecracker/pull/5088): Added
   AMD Genoa as a supported and tested platform for Firecracker.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -36,6 +36,7 @@ Contributors to the Firecracker repository:
 - Alexandru Cihodaru <cihodar@amazon.com>
 - Alexandru-Cezar Sardan <alsardan@amazon.com>
 - Alin Dima <alindima@amazon.com>
+- Anatoli Babenia <anatoli@rainforce.org>
 - Andrea Manzini <ilmanzo@gmail.com>
 - Andreea Florescu <fandree@amazon.com>
 - Andrei Casu-Pop <cpo@amazon.com>
@@ -73,6 +74,7 @@ Contributors to the Firecracker repository:
 - Chris Christensen <christianchristensen@gmail.com>
 - Christian González <cgonzalez@opennebula.io>
 - Christopher Diehl <diehl.chris24@gmail.com>
+- Christos Katsakioris <ckatsak@cslab.ece.ntua.gr>
 - cneira <cneirabustos@gmail.com>
 - Colin Percival <cperciva@tarsnap.com>
 - Colton J. McCurdy <mccurdyc22@gmail.com>
@@ -125,6 +127,7 @@ Contributors to the Firecracker repository:
 - Iulian Barbu <iul@amazon.com>
 - Ives van Hoorne <ives@codesandbox.io>
 - Jack Thomson <jackabt@amazon.co.uk>
+- jackabald <jwarchibald@wisc.edu>
 - James Curtis <jxcurtis@amazon.co.uk>
 - James Turnbull <james@lovedthanlost.net>
 - Javier Romero <xavinux@gmail.com>
@@ -142,6 +145,7 @@ Contributors to the Firecracker repository:
 - Julian Stecklina <js@alien8.de>
 - Justus Adam <justbldr@amazon.com>
 - Ján Mochňak <mochja@users.noreply.github.com>
+- kanpov <karpovanton729@gmail.com>
 - karthik nedunchezhiyan <karthik.n@zohocorp.com>
 - KarthikVelayutham <karthik.velayutham@gmail.com>
 - Kazuyoshi Kato <katokazu@amazon.com>
@@ -156,6 +160,7 @@ Contributors to the Firecracker repository:
 - Liviu Berciu <lberciu@amazon.com>
 - Lloyd <lloydmeta@gmail.com>
 - lloydmeta <lloydmeta@gmail.com>
+- longxiangqiao <longxiangqiao@qq.com>
 - Lorenzo Fontana <fontanalorenz@gmail.com>
 - LOU Xun <aquarhead@ela.build>
 - Lucas Zanela <me@lucaszanella.com>
@@ -172,6 +177,7 @@ Contributors to the Firecracker repository:
 - Massimiliano Torromeo <massimiliano.torromeo@gmail.com>
 - Matias Teragni <mteragni@amazon.com>
 - Matt Wilson <msw@amazon.com>
+- Matthew Buckingham-Bishop <matthew@morph.so>
 - Matthew Schlebusch <schlebus@amazon.com>
 - Max Wittek <wimax@graplsecurity.com>
 - Mehrdad Arshad Rad <arshad.rad@gmail.com>
@@ -212,6 +218,7 @@ Contributors to the Firecracker repository:
 - Ria <juthi_paul@utexas.edu>
 - Riccardo Mancini <mancio@amazon.com>
 - Richard Case <richard@weave.works>
+- River Phillips <riverphillips1@gmail.com>
 - Rob Devereux <robdevereux92@gmail.com>
 - Robert Grimes <rmzgrimes@gmail.com>
 - Rodrigue Chakode <rodrigue.chakode@continental-corporation.com>
@@ -234,6 +241,7 @@ Contributors to the Firecracker repository:
 - Sripracha <ramsri@amazon.com>
 - Stefan Nita <32079871+stefannita01@users.noreply.github.com>
 - StemCll <lydjotj6f@mozmail.com>
+- Steven Wirges <steven.wirges@gmail.com>
 - Sudan Landge <sudanl@amazon.co.uk>
 - sundar.preston.789@gmail.com <sundar.preston.789@gmail.com>
 - Takahiro Itazuri <itazur@amazon.com>
@@ -245,6 +253,7 @@ Contributors to the Firecracker repository:
 - timvisee <tim@visee.me>
 - Tobias Pfandzelter <pfandzelter@campus.tu-berlin.de>
 - Tomas Valenta <valenta.and.thomas@gmail.com>
+- tommady <tommady@users.noreply.github.com>
 - Tomoya Iwata <iwata.tomoya@classmethod.jp>
 - Trăistaru Andrei Cristian <atc@amazon.com>
 - Tyler Anton <tyler@debian.anton>

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -90,8 +90,9 @@ v3.1 will be patched since were the last two Firecracker releases and less than
 
 | Release | Release Date | Latest Patch | Min. end of support | Official end of Support         |
 | ------: | -----------: | -----------: | ------------------: | :------------------------------ |
+|   v1.11 |   2025-03-18 |      v1.11.0 |          2025-09-18 | Supported                       |
 |   v1.10 |   2024-11-07 |      v1.10.1 |          2025-05-07 | Supported                       |
-|    v1.9 |   2024-09-02 |       v1.9.1 |          2025-03-02 | Supported                       |
+|    v1.9 |   2024-09-02 |       v1.9.1 |          2025-03-02 | 2025-03-18 (v1.11 released)     |
 |    v1.8 |   2024-07-10 |       v1.8.0 |          2025-01-10 | 2025-01-10 (end of 6mo support) |
 |    v1.7 |   2024-03-18 |       v1.7.0 |          2024-09-18 | 2024-09-18 (end of 6mo support) |
 |    v1.6 |   2023-12-20 |       v1.6.0 |          2024-06-20 | 2024-07-10 (v1.8 released)      |

--- a/docs/kernel-policy.md
+++ b/docs/kernel-policy.md
@@ -7,26 +7,31 @@ related changes.
 
 We are continuously validating the currently supported Firecracker releases (as
 per [Firecracker’s release policy](../docs/RELEASE_POLICY.md)) using a
-combination of:
-
-- host linux kernel versions 5.10, and 6.1;
-- guest linux kernel versions 5.10 and 6.1. Guest linux kernels 4.14 are
-  deprecated with Firecracker v1.9 and we will drop support for them with
-  Firecracker v1.10.
+combination of all supported host and guest kernel versions in the table below.
 
 While other versions and other kernel configs might work, they are not
 periodically validated in our test suite, and using them might result in
 unexpected behaviour. Starting with release `v1.0` each major and minor release
 will specify the supported kernel versions.
 
-Once a kernel version is officially enabled, it is supported for a **minimum of
-2 years**. Adding support for a new kernel version will result in a Firecracker
-release only if compatibility changes are required.
+Once a kernel version is officially added, it is supported for a **minimum of 2
+years**. At least 2 major guest and host versions will be supported at any time.
+When support is added for a third kernel version, the oldest will be deprecated
+and removed in a following release, after its minimum end of support date.
 
-| Host kernel | Guest kernel v4.14 (deprecated) | Guest kernel v5.10 | Guest kernel v6.1 | Min. end of support |
-| ----------: | :-----------------------------: | :----------------: | :---------------: | ------------------: |
-|       v5.10 |         Y (deprecated)          |         Y          |         Y         |          2024-01-31 |
-|        v6.1 |         Y (deprecated)          |         Y          |         Y         |          2025-10-12 |
+### Host Kernel
+
+| Host kernel | Min. version | Min. end of support |
+| ----------: | -----------: | ------------------: |
+|       v5.10 |       v1.0.0 |          2024-01-31 |
+|        v6.1 |       v1.5.0 |          2025-10-12 |
+
+### Guest Kernel
+
+| Guest kernel | Min. version | Min. end of support |
+| -----------: | -----------: | ------------------: |
+|        v5.10 |       v1.0.0 |          2024-01-31 |
+|         v6.1 |       v1.9.0 |          2026-09-02 |
 
 The guest kernel configs used in our validation pipelines can be found
 [here](../resources/guest_configs/) while a breakdown of the relevant guest

--- a/tools/release-notes.py
+++ b/tools/release-notes.py
@@ -21,14 +21,14 @@ if __name__ == "__main__":
     iterator = iter(changelog_lines)
 
     for line in iterator:
-        if line.startswith(f"## \\[{cur_version}\\]"):
+        if line.startswith(f"## [{cur_version}]"):
             break
     else:
         print(f"Could not find changelog entry for version {cur_version}!")
         sys.exit(1)
 
     for line in iterator:
-        if line.startswith("## \\["):
+        if line.startswith("## ["):
             break
 
         if line.startswith("#"):


### PR DESCRIPTION
## Changes

1. Make quickstart guide detect the right CI artifacts depending on the latest release
    - I've tested it locally to make sure it works
3. Update and improve kernel-policy.md
4. Fix release note script
5. Update release policy with 1.11
6. Move PVH changelog to right section
7. Update the credits file

## Reason

1. I needed to update the quickstart guide and thought it'd be best to just have it detect the latest versions as we do for the bnaries
2. There were still references to 4.14
3. the script wasn't working
4. it's now being released, wohoo
5. it was marked as 1.11
6. for the glory

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x]] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] NA I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] NA If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
