### PR TITLE
Fix audit v1.10

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,1 +1,7 @@
 [advisories]
+# The `paste` dependency is transitively included via `gdbstub`.
+# While the crate is archived/unmaintained, the author considers it feature-complete
+# and functionally stable. gdbstub will be update once they migrate 
+# to an alternative solution.
+# See https://github.com/daniel5151/gdbstub/issues/168
+ignore = ["RUSTSEC-2024-0436"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337d1afa126368bbd6a5c328048f71a69a737e9afe7e436b392a8f8d770c9171"
+checksum = "e013ae7fcd2c6a8f384104d16afe7ea02969301ea2bb2a56e44b011ebc907cab"
 dependencies = [
  "bitflags 2.6.0",
  "kvm-bindings",


### PR DESCRIPTION
## Changes

Fixes for `cargo audit`. We backport e7f60511f761e4c622ee0609a71c7b76d3925b6c for ignoring `paste` issue and also run `cargo update` to update `hashbrown` dev dependency.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
