### PR TITLE
chore(doc): remove arm64 snapshot reg length limitation

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -126,17 +126,6 @@ The snapshot functionality is still in developer preview due to the following:
 
 ### Limitations
 
-- Currently on aarch64 platforms only lower 128 bits of any register are saved
-  due to the limitations of `get/set_one_reg` from `kvm-ioctls` crate that
-  Firecracker uses to interact with KVM. This creates an issue with newer
-  aarch64 CPUs with support for registers with width greater than 128 bits,
-  because these registers will be truncated before being stored in the snapshot.
-  This can lead to uVM failure if restored from such snapshot. Because registers
-  wider than 128 bits are usually used in SVE instructions, the best way to
-  mitigate this issue is to ensure that the software run in uVM does not use SVE
-  instructions during snapshot creation. An alternative way is to use
-  [CPU templates](../cpu_templates/cpu-templates.md) to disable SVE related
-  features in uVM.
 - High snapshot latency on 5.4+ host kernels due to cgroups V1. We strongly
   recommend to deploy snapshots on cgroups V2 enabled hosts for the implied
   kernel versions -


### PR DESCRIPTION
## Changes
We fixed the arm register length limitation in #3787 but never removed this note from the doc.

## Reason
It is time to update the doc.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
