### PR TITLE
Snap restore test with templates

### DIFF
--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -58,6 +58,8 @@ def get_supported_custom_cpu_templates():
             return ["v1n1", "aarch64_with_sve_and_pac"]
         case CpuVendor.ARM, CpuModel.ARM_NEOVERSE_V1:
             return ["aarch64_with_sve_and_pac"]
+        case CpuVendor.ARM, CpuModel.ARM_NEOVERSE_V2:
+            return ["aarch64_with_sve_and_pac"]
         case _:
             return []
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -121,6 +121,7 @@ def test_5_snapshots(
     rootfs,
     snapshot_type,
     use_snapshot_editor,
+    cpu_template_any,
 ):
     """
     Create and load 5 snapshots.
@@ -136,6 +137,7 @@ def test_5_snapshots(
         mem_size_mib=512,
         track_dirty_pages=diff_snapshots,
     )
+    vm.set_cpu_template(cpu_template_any)
     vm.add_net_iface()
     vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path=VSOCK_UDS_PATH)
     vm.start()


### PR DESCRIPTION
## Changes
Update `test_5_snapshots` test to test with cpu_templates as well. Also enable sve + pac template for G4.

## Reason
We did not have snapshot tests with cpu templates.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
