### PR TITLE
[1.11 Backport] Revert "fix: test_sec_audit: ignore cargo audit output"

### DIFF
--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -35,6 +35,6 @@ def test_cargo_audit():
         )
 
     git_ab_test_host_command_if_pr(
-        "cargo audit --deny warnings -q --json |grep -Po '{.*}'",
+        "cargo audit --deny warnings -q --json",
         comparator=set_did_not_grow_comparator(set_of_vulnerabilities),
     )

--- a/tools/devtool
+++ b/tools/devtool
@@ -68,7 +68,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v77}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v78}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
This reverts commit d761b013db1caeec046b187927133b7fdac1375d. The output to stdout was fixed in cargo audit 0.21.2, so if we rebuild the docker container the grep is no longer necessary.

In fact, the grep has broken this test in our nightly pipeline because it overwrites the return code of cargo audit itself, meaning the non-PR version of this test (which is supposed to fail if there exist any cargo audit warnings) was never failing.

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>
(cherry picked from commit 1d98a21e087aa4f188f2d6e665b54c6962569199)

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
