### PR TITLE
doc: clarify kernel configuration usage in our repo

### DIFF
--- a/docs/kernel-policy.md
+++ b/docs/kernel-policy.md
@@ -37,6 +37,19 @@ The guest kernel configs used in our validation pipelines can be found
 [here](../resources/guest_configs/) while a breakdown of the relevant guest
 kernel modules can be found in the next section.
 
+We use these configurations to build microVM-specific kernels vended by Amazon
+Linux. microVM kernel source code is published in the Amazon Linux
+[linux repo](https://github.com/amazonlinux/linux) under tags in the form of
+`microvm-kernel-*`, e.g. 6.1.128-3.201.amazn2023 kernel can be found
+[here](https://github.com/amazonlinux/linux/tree/microvm-kernel-6.1.128-3.201.amzn2023).
+These kernels may have diverged from the equivalent mainline versions, as we
+often backport patches that we require for supporting Firecracker features not
+present in the kernel versions we officially support. As a result, kernel
+configurations found in this repo should be used to build exclusively the
+aforementioned Amazon Linux kernels. We do not guarantee that using these
+configurations to build upstream kernels, will work or produce usable kernel
+images.
+
 ## Guest kernel configuration items
 
 The configuration items that may be relevant for Firecracker are:


### PR DESCRIPTION
## Changes

Clarify in the documentation that the kernel configurations we keep in our repo are meant to be used with kernels provided by Amazon Linux and that we don't guarantee that they can be used to build kernels from upstream Linux.

## Reason

We keep in the repo the kernel configurations from which we build the kernel images we use in our CI pipelines. However, we don't mention what kernel sources we use to build these kernel images.

Fixes #4881

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
