### PR TITLE
Builder refactor

### DIFF
--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -12,11 +12,12 @@ use std::fmt::Debug;
 use vm_fdt::{Error as VmFdtError, FdtWriter, FdtWriterNode};
 use vm_memory::GuestMemoryError;
 
-use super::super::{DeviceType, InitrdConfig};
+use super::super::DeviceType;
 use super::cache_info::{CacheEntry, read_cache_config};
 use super::gic::GICDevice;
 use crate::device_manager::mmio::MMIODeviceInfo;
 use crate::devices::acpi::vmgenid::{VMGENID_MEM_SIZE, VmGenId};
+use crate::initrd::InitrdConfig;
 use crate::vstate::memory::{Address, GuestMemory, GuestMemoryMmap};
 
 // This is a value for uniquely identifying the FDT node declaring the interrupt controller.

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -112,7 +112,7 @@ pub fn configure_system_for_boot(
     for vcpu in vcpus.iter_mut() {
         vcpu.kvm_vcpu
             .configure(
-                vmm.guest_memory(),
+                &vmm.guest_memory,
                 entry_point,
                 &vcpu_config,
                 &optional_capabilities,

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -50,9 +50,7 @@ pub enum ConfigurationError {
     /// Cannot load kernel due to invalid memory configuration or invalid kernel image: {0}
     KernelLoader(#[from] linux_loader::loader::Error),
     /// Error creating vcpu configuration: {0}
-    VcpuConfig(CpuConfigurationError),
-    /// Error applying vcpu template: {0}
-    VcpuApplyTemplate(CpuConfigurationError),
+    VcpuConfig(#[from] CpuConfigurationError),
     /// Error configuring the vcpu: {0}
     VcpuConfigure(KvmVcpuError),
 }
@@ -80,12 +78,10 @@ pub fn configure_system_for_boot(
     boot_cmdline: Cmdline,
 ) -> Result<(), ConfigurationError> {
     // Construct the base CpuConfiguration to apply CPU template onto.
-    let cpu_config =
-        CpuConfiguration::new(cpu_template, vcpus).map_err(ConfigurationError::VcpuConfig)?;
+    let cpu_config = CpuConfiguration::new(cpu_template, vcpus)?;
 
     // Apply CPU template to the base CpuConfiguration.
-    let cpu_config = CpuConfiguration::apply_template(cpu_config, cpu_template)
-        .map_err(ConfigurationError::VcpuApplyTemplate)?;
+    let cpu_config = CpuConfiguration::apply_template(cpu_config, cpu_template);
 
     let vcpu_config = VcpuConfig {
         vcpu_count: machine_config.vcpu_count,

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -20,9 +20,10 @@ pub use aarch64::vcpu::*;
 pub use aarch64::vm::{ArchVm, ArchVmError, VmState};
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
-    ConfigurationError, MMIO_MEM_SIZE, MMIO_MEM_START, arch_memory_regions, configure_system,
-    get_kernel_start, initrd_load_addr, layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE,
-    layout::IRQ_MAX, layout::SYSTEM_MEM_SIZE, layout::SYSTEM_MEM_START, load_kernel,
+    ConfigurationError, MMIO_MEM_SIZE, MMIO_MEM_START, arch_memory_regions,
+    configure_system_for_boot, get_kernel_start, initrd_load_addr, layout::CMDLINE_MAX_SIZE,
+    layout::IRQ_BASE, layout::IRQ_MAX, layout::SYSTEM_MEM_SIZE, layout::SYSTEM_MEM_START,
+    load_kernel,
 };
 
 /// Module for x86_64 related functionality.
@@ -35,12 +36,13 @@ pub use x86_64::kvm::{Kvm, KvmArchError};
 pub use x86_64::vcpu::*;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::vm::{ArchVm, ArchVmError, VmState};
+
 #[cfg(target_arch = "x86_64")]
-pub use x86_64::{
-    ConfigurationError, MMIO_MEM_SIZE, MMIO_MEM_START, arch_memory_regions, configure_system,
-    get_kernel_start, initrd_load_addr, layout::APIC_ADDR, layout::CMDLINE_MAX_SIZE,
-    layout::IOAPIC_ADDR, layout::IRQ_BASE, layout::IRQ_MAX, layout::SYSTEM_MEM_SIZE,
-    layout::SYSTEM_MEM_START, load_kernel,
+pub use crate::arch::x86_64::{
+    ConfigurationError, MMIO_MEM_SIZE, MMIO_MEM_START, arch_memory_regions,
+    configure_system_for_boot, get_kernel_start, initrd_load_addr, layout::APIC_ADDR,
+    layout::CMDLINE_MAX_SIZE, layout::IOAPIC_ADDR, layout::IRQ_BASE, layout::IRQ_MAX,
+    layout::SYSTEM_MEM_SIZE, layout::SYSTEM_MEM_START, load_kernel,
 };
 
 /// Types of devices that can get attached to this platform.

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -22,7 +22,7 @@ pub use aarch64::vm::{ArchVm, ArchVmError, VmState};
 pub use aarch64::{
     ConfigurationError, MMIO_MEM_SIZE, MMIO_MEM_START, arch_memory_regions, configure_system,
     get_kernel_start, initrd_load_addr, layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE,
-    layout::IRQ_MAX, layout::SYSTEM_MEM_SIZE, layout::SYSTEM_MEM_START,
+    layout::IRQ_MAX, layout::SYSTEM_MEM_SIZE, layout::SYSTEM_MEM_START, load_kernel,
 };
 
 /// Module for x86_64 related functionality.
@@ -40,7 +40,7 @@ pub use x86_64::{
     ConfigurationError, MMIO_MEM_SIZE, MMIO_MEM_START, arch_memory_regions, configure_system,
     get_kernel_start, initrd_load_addr, layout::APIC_ADDR, layout::CMDLINE_MAX_SIZE,
     layout::IOAPIC_ADDR, layout::IRQ_BASE, layout::IRQ_MAX, layout::SYSTEM_MEM_SIZE,
-    layout::SYSTEM_MEM_START,
+    layout::SYSTEM_MEM_START, load_kernel,
 };
 
 /// Types of devices that can get attached to this platform.

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -58,15 +58,6 @@ pub enum DeviceType {
     BootTimer,
 }
 
-/// Type for passing information about the initrd in the guest memory.
-#[derive(Debug)]
-pub struct InitrdConfig {
-    /// Load address of initrd in guest memory
-    pub address: crate::vstate::memory::GuestAddress,
-    /// Size of initrd in guest memory
-    pub size: usize,
-}
-
 /// Default page size for the guest OS.
 pub const GUEST_PAGE_SIZE: usize = 4096;
 

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -51,7 +51,7 @@ use crate::arch::{BootProtocol, SYSTEM_MEM_SIZE, SYSTEM_MEM_START};
 use crate::cpu_config::templates::{CustomCpuTemplate, GuestConfigError};
 use crate::cpu_config::x86_64::CpuConfiguration;
 use crate::initrd::InitrdConfig;
-use crate::utils::{mib_to_bytes, u64_to_usize};
+use crate::utils::{align_down, mib_to_bytes, u64_to_usize, usize_to_u64};
 use crate::vmm_config::machine_config::MachineConfig;
 use crate::vstate::memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion,
@@ -138,8 +138,10 @@ pub fn initrd_load_addr(guest_mem: &GuestMemoryMmap, initrd_size: usize) -> Opti
         return None;
     }
 
-    let align_to_pagesize = |address| address & !(super::GUEST_PAGE_SIZE - 1);
-    Some(align_to_pagesize(lowmem_size - initrd_size) as u64)
+    Some(align_down(
+        usize_to_u64(lowmem_size - initrd_size),
+        usize_to_u64(super::GUEST_PAGE_SIZE),
+    ))
 }
 
 /// Configures the system for booting Linux.

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -175,7 +175,7 @@ pub fn configure_system_for_boot(
     // Configure vCPUs with normalizing and setting the generated CPU configuration.
     for vcpu in vcpus.iter_mut() {
         vcpu.kvm_vcpu
-            .configure(vmm.guest_memory(), entry_point, &vcpu_config)?;
+            .configure(&vmm.guest_memory, entry_point, &vcpu_config)?;
     }
 
     // Write the kernel command line to guest memory. This is x86_64 specific, since on
@@ -186,7 +186,7 @@ pub fn configure_system_for_boot(
         .expect("Cannot create cstring from cmdline string");
 
     load_cmdline(
-        vmm.guest_memory(),
+        &vmm.guest_memory,
         GuestAddress(crate::arch::x86_64::layout::CMDLINE_START),
         &boot_cmdline,
     )

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -596,7 +596,7 @@ fn attach_virtio_device<T: 'static + VirtioDevice + MutEventSubscriber + Debug>(
     event_manager.add_subscriber(device.clone());
 
     // The device mutex mustn't be locked here otherwise it will deadlock.
-    let device = MmioTransport::new(vmm.guest_memory().clone(), device, is_vhost_user);
+    let device = MmioTransport::new(vmm.guest_memory.clone(), device, is_vhost_user);
     vmm.mmio_device_manager
         .register_mmio_virtio_for_boot(
             vmm.vm.fd(),

--- a/src/vmm/src/cpu_config/aarch64/mod.rs
+++ b/src/vmm/src/cpu_config/aarch64/mod.rs
@@ -46,10 +46,7 @@ impl CpuConfiguration {
     }
 
     /// Creates new guest CPU config based on the provided template
-    pub fn apply_template(
-        mut self,
-        template: &CustomCpuTemplate,
-    ) -> Result<Self, CpuConfigurationError> {
+    pub fn apply_template(mut self, template: &CustomCpuTemplate) -> Self {
         for (modifier, mut reg) in template.reg_modifiers.iter().zip(self.regs.iter_mut()) {
             match reg.size() {
                 RegSize::U32 => {
@@ -70,7 +67,7 @@ impl CpuConfiguration {
                 _ => unreachable!("Only 32, 64 and 128 bit wide registers are supported"),
             }
         }
-        Ok(self)
+        self
     }
 
     /// Returns ids of registers that are changed

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -805,7 +805,7 @@ mod tests {
         let device_states: DeviceStates = Snapshot::deserialize(&mut buf.as_slice()).unwrap();
         let vm_resources = &mut VmResources::default();
         let restore_args = MMIODevManagerConstructorArgs {
-            mem: vmm.guest_memory(),
+            mem: &vmm.guest_memory,
             vm: vmm.vm.fd(),
             event_manager: &mut event_manager,
             resource_allocator: &mut resource_allocator,

--- a/src/vmm/src/devices/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/test_utils.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::devices::virtio::queue::Queue;
 use crate::test_utils::single_region_mem;
-use crate::utils::u64_to_usize;
+use crate::utils::{align_up, u64_to_usize};
 use crate::vstate::memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
 
 #[macro_export]
@@ -250,7 +250,7 @@ impl<'a> VirtQueue<'a> {
         const USED_ALIGN: u64 = 4;
 
         let mut x = avail.end().0;
-        x = (x + USED_ALIGN - 1) & !(USED_ALIGN - 1);
+        x = align_up(x, USED_ALIGN);
 
         let used = VirtqUsed::new(GuestAddress(x), mem, qsize, u64_to_usize(USED_ALIGN));
 

--- a/src/vmm/src/gdb/arch/aarch64.rs
+++ b/src/vmm/src/gdb/arch/aarch64.rs
@@ -63,7 +63,7 @@ const PTE_ADDRESS_MASK: u64 = !0b111u64;
 /// Read a u64 value from a guest memory address
 fn read_address(vmm: &Vmm, address: u64) -> Result<u64, GdbTargetError> {
     let mut buf = [0; 8];
-    vmm.guest_memory().read(&mut buf, GuestAddress(address))?;
+    vmm.guest_memory.read(&mut buf, GuestAddress(address))?;
 
     Ok(u64::from_le_bytes(buf))
 }

--- a/src/vmm/src/gdb/target.rs
+++ b/src/vmm/src/gdb/target.rs
@@ -399,7 +399,7 @@ impl MultiThreadBase for FirecrackerTarget {
                 GUEST_PAGE_SIZE - (u64_to_usize(gpa) & (GUEST_PAGE_SIZE - 1)),
             );
 
-            vmm.guest_memory()
+            vmm.guest_memory
                 .read(&mut data[..read_len], GuestAddress(gpa as u64))
                 .map_err(|e| {
                     error!("Error reading memory {e:?} gpa is {gpa}");
@@ -433,7 +433,7 @@ impl MultiThreadBase for FirecrackerTarget {
                 GUEST_PAGE_SIZE - (u64_to_usize(gpa) & (GUEST_PAGE_SIZE - 1)),
             );
 
-            vmm.guest_memory()
+            vmm.guest_memory
                 .write(&data[..write_len], GuestAddress(gpa))
                 .map_err(|e| {
                     error!("Error {e:?} writing memory at {gpa:#X}");

--- a/src/vmm/src/initrd.rs
+++ b/src/vmm/src/initrd.rs
@@ -1,0 +1,140 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+use std::os::unix::fs::MetadataExt;
+
+use vm_memory::{GuestAddress, GuestMemory, ReadVolatile, VolatileMemoryError};
+
+use crate::arch::initrd_load_addr;
+use crate::utils::u64_to_usize;
+use crate::vmm_config::boot_source::BootConfig;
+use crate::vstate::memory::GuestMemoryMmap;
+
+/// Errors associated with initrd loading.
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum InitrdError {
+    /// Failed to compute the initrd address.
+    Address,
+    /// Cannot load initrd due to an invalid memory configuration.
+    Load,
+    /// Cannot image metadata: {0}
+    Metadata(std::io::Error),
+    /// Cannot copy initrd file fd: {0}
+    CloneFd(std::io::Error),
+    /// Cannot load initrd due to an invalid image: {0}
+    Read(VolatileMemoryError),
+}
+
+/// Type for passing information about the initrd in the guest memory.
+#[derive(Debug)]
+pub struct InitrdConfig {
+    /// Load address of initrd in guest memory
+    pub address: GuestAddress,
+    /// Size of initrd in guest memory
+    pub size: usize,
+}
+
+impl InitrdConfig {
+    /// Load initrd into guest memory based on the boot config.
+    pub fn from_config(
+        boot_cfg: &BootConfig,
+        vm_memory: &GuestMemoryMmap,
+    ) -> Result<Option<Self>, InitrdError> {
+        Ok(match &boot_cfg.initrd_file {
+            Some(f) => {
+                let f = f.try_clone().map_err(InitrdError::CloneFd)?;
+                Some(Self::from_file(vm_memory, f)?)
+            }
+            None => None,
+        })
+    }
+
+    /// Loads the initrd from a file into guest memory.
+    pub fn from_file(vm_memory: &GuestMemoryMmap, mut file: File) -> Result<Self, InitrdError> {
+        let size = file.metadata().map_err(InitrdError::Metadata)?.size();
+        let size = u64_to_usize(size);
+        let Some(address) = initrd_load_addr(vm_memory, size) else {
+            return Err(InitrdError::Address);
+        };
+        let mut slice = vm_memory
+            .get_slice(GuestAddress(address), size)
+            .map_err(|_| InitrdError::Load)?;
+        file.read_exact_volatile(&mut slice)
+            .map_err(InitrdError::Read)?;
+
+        Ok(InitrdConfig {
+            address: GuestAddress(address),
+            size,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Seek, SeekFrom, Write};
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+    use crate::arch::GUEST_PAGE_SIZE;
+    use crate::test_utils::{single_region_mem, single_region_mem_at};
+
+    fn make_test_bin() -> Vec<u8> {
+        let mut fake_bin = Vec::new();
+        fake_bin.resize(1_000_000, 0xAA);
+        fake_bin
+    }
+
+    #[test]
+    // Test that loading the initrd is successful on different archs.
+    fn test_load_initrd() {
+        let image = make_test_bin();
+
+        let mem_size: usize = image.len() * 2 + GUEST_PAGE_SIZE;
+
+        let tempfile = TempFile::new().unwrap();
+        let mut tempfile = tempfile.into_file();
+        tempfile.write_all(&image).unwrap();
+
+        #[cfg(target_arch = "x86_64")]
+        let gm = single_region_mem(mem_size);
+
+        #[cfg(target_arch = "aarch64")]
+        let gm = single_region_mem(mem_size + crate::arch::aarch64::layout::FDT_MAX_SIZE);
+
+        // Need to reset the cursor to read initrd properly.
+        tempfile.seek(SeekFrom::Start(0)).unwrap();
+        let initrd = InitrdConfig::from_file(&gm, tempfile).unwrap();
+        assert!(gm.address_in_range(initrd.address));
+        assert_eq!(initrd.size, image.len());
+    }
+
+    #[test]
+    fn test_load_initrd_no_memory() {
+        let gm = single_region_mem(79);
+        let image = make_test_bin();
+        let tempfile = TempFile::new().unwrap();
+        let mut tempfile = tempfile.into_file();
+        tempfile.write_all(&image).unwrap();
+
+        // Need to reset the cursor to read initrd properly.
+        tempfile.seek(SeekFrom::Start(0)).unwrap();
+        let res = InitrdConfig::from_file(&gm, tempfile);
+        assert!(matches!(res, Err(InitrdError::Address)), "{:?}", res);
+    }
+
+    #[test]
+    fn test_load_initrd_unaligned() {
+        let image = vec![1, 2, 3, 4];
+        let tempfile = TempFile::new().unwrap();
+        let mut tempfile = tempfile.into_file();
+        tempfile.write_all(&image).unwrap();
+        let gm = single_region_mem_at(GUEST_PAGE_SIZE as u64 + 1, image.len() * 2);
+
+        // Need to reset the cursor to read initrd properly.
+        tempfile.seek(SeekFrom::Start(0)).unwrap();
+        let res = InitrdConfig::from_file(&gm, tempfile);
+        assert!(matches!(res, Err(InitrdError::Address)), "{:?}", res);
+    }
+}

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -131,7 +131,7 @@ use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
 use vstate::kvm::Kvm;
-use vstate::vcpu::{self, KvmVcpuConfigureError, StartThreadedError, VcpuSendEventError};
+use vstate::vcpu::{self, StartThreadedError, VcpuSendEventError};
 
 use crate::arch::DeviceType;
 use crate::cpu_config::templates::CpuConfiguration;
@@ -234,17 +234,12 @@ pub enum VmmError {
     Serial(io::Error),
     /// Error creating timer fd: {0}
     TimerFd(io::Error),
-    /// Error configuring the vcpu for boot: {0}
-    VcpuConfigure(KvmVcpuConfigureError),
     /// Error creating the vcpu: {0}
     VcpuCreate(vstate::vcpu::VcpuError),
     /// Cannot send event to vCPU. {0}
     VcpuEvent(vstate::vcpu::VcpuError),
     /// Cannot create a vCPU handle. {0}
     VcpuHandle(vstate::vcpu::VcpuError),
-    #[cfg(target_arch = "aarch64")]
-    /// Error initializing the vcpu: {0}
-    VcpuInit(vstate::vcpu::KvmVcpuError),
     /// Failed to start vCPUs
     VcpuStart(StartVcpusError),
     /// Failed to pause the vCPUs.

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -221,8 +221,6 @@ pub enum VmmError {
     EventFd(io::Error),
     /// I8042 error: {0}
     I8042Error(devices::legacy::I8042DeviceError),
-    /// Cannot access kernel file: {0}
-    KernelFile(io::Error),
     #[cfg(target_arch = "x86_64")]
     /// Cannot add devices to the legacy I/O Bus. {0}
     LegacyIOBus(device_manager::legacy::LegacyDeviceError),

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -111,6 +111,9 @@ pub mod vmm_config;
 /// Module with virtual state structs.
 pub mod vstate;
 
+/// Module with initrd.
+pub mod initrd;
+
 use std::collections::HashMap;
 use std::io;
 use std::os::unix::io::AsRawFd;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -444,11 +444,6 @@ impl Vmm {
         Ok(())
     }
 
-    /// Returns a reference to the inner `GuestMemoryMmap` object.
-    pub fn guest_memory(&self) -> &GuestMemoryMmap {
-        &self.guest_memory
-    }
-
     /// Sets RDA bit in serial console
     pub fn emulate_serial_init(&self) -> Result<(), EmulateSerialInitError> {
         // When restoring from a previously saved state, there is no serial
@@ -526,7 +521,7 @@ impl Vmm {
         };
         let device_states = self.mmio_device_manager.save();
 
-        let memory_state = self.guest_memory().describe();
+        let memory_state = self.guest_memory.describe();
         let acpi_dev_state = self.acpi_device_manager.save();
 
         Ok(MicrovmState {
@@ -741,7 +736,7 @@ impl Vmm {
     pub fn update_balloon_config(&mut self, amount_mib: u32) -> Result<(), BalloonError> {
         // The balloon cannot have a target size greater than the size of
         // the guest memory.
-        if u64::from(amount_mib) > mem_size_mib(self.guest_memory()) {
+        if u64::from(amount_mib) > mem_size_mib(&self.guest_memory) {
             return Err(BalloonError::TooManyPagesRequested);
         }
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -219,7 +219,7 @@ fn snapshot_memory_to_file(
         .map_err(|err| MemoryBackingFile("open", err))?;
 
     // Determine what size our total memory area is.
-    let mem_size_mib = mem_size_mib(vmm.guest_memory());
+    let mem_size_mib = mem_size_mib(&vmm.guest_memory);
     let expected_size = mem_size_mib * 1024 * 1024;
 
     if file_existed {
@@ -248,15 +248,15 @@ fn snapshot_memory_to_file(
     match snapshot_type {
         SnapshotType::Diff => {
             let dirty_bitmap = vmm.get_dirty_bitmap().map_err(DirtyBitmap)?;
-            vmm.guest_memory()
+            vmm.guest_memory
                 .dump_dirty(&mut file, &dirty_bitmap)
                 .map_err(Memory)
         }
         SnapshotType::Full => {
-            let dump_res = vmm.guest_memory().dump(&mut file).map_err(Memory);
+            let dump_res = vmm.guest_memory.dump(&mut file).map_err(Memory);
             if dump_res.is_ok() {
                 vmm.reset_dirty_bitmap();
-                vmm.guest_memory().reset_dirty();
+                vmm.guest_memory.reset_dirty();
             }
 
             dump_res
@@ -272,7 +272,7 @@ fn snapshot_memory_to_file(
         .for_each_virtio_device(|_, _, _, dev| {
             let d = dev.lock().unwrap();
             if d.is_activated() {
-                d.mark_queue_memory_dirty(vmm.guest_memory())
+                d.mark_queue_memory_dirty(&vmm.guest_memory)
             } else {
                 Ok(())
             }
@@ -747,7 +747,7 @@ mod tests {
         assert!(states.vsock_device.is_some());
         assert!(states.balloon_device.is_some());
 
-        let memory_state = vmm.guest_memory().describe();
+        let memory_state = vmm.guest_memory.describe();
         let vcpu_states = vec![VcpuState::default()];
         #[cfg(target_arch = "aarch64")]
         let mpidrs = construct_kvm_mpidrs(&vcpu_states);

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -600,28 +600,6 @@ mod tests {
         }
     }
 
-    impl PartialEq for BootConfig {
-        fn eq(&self, other: &Self) -> bool {
-            self.cmdline.eq(&other.cmdline)
-                && self.kernel_file.metadata().unwrap().st_ino()
-                    == other.kernel_file.metadata().unwrap().st_ino()
-                && self
-                    .initrd_file
-                    .as_ref()
-                    .unwrap()
-                    .metadata()
-                    .unwrap()
-                    .st_ino()
-                    == other
-                        .initrd_file
-                        .as_ref()
-                        .unwrap()
-                        .metadata()
-                        .unwrap()
-                        .st_ino()
-        }
-    }
-
     #[test]
     fn test_from_json() {
         let kernel_file = TempFile::new().unwrap();

--- a/src/vmm/src/utils/mod.rs
+++ b/src/vmm/src/utils/mod.rs
@@ -53,3 +53,15 @@ pub const fn wrap_usize_to_u32(num: usize) -> Wrapping<u32> {
 pub const fn mib_to_bytes(mib: usize) -> usize {
     mib << MIB_TO_BYTES_SHIFT
 }
+
+/// Align address up to the aligment.
+pub const fn align_up(addr: u64, align: u64) -> u64 {
+    debug_assert!(align != 0);
+    (addr + align - 1) & !(align - 1)
+}
+
+/// Align address down to the aligment.
+pub const fn align_down(addr: u64, align: u64) -> u64 {
+    debug_assert!(align != 0);
+    addr & !(align - 1)
+}

--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -771,7 +771,6 @@ pub(crate) mod tests {
     use super::*;
     use crate::RECV_TIMEOUT_SEC;
     use crate::arch::{BootProtocol, EntryPoint};
-    use crate::builder::StartMicrovmError;
     use crate::devices::BusDevice;
     use crate::devices::bus::DummyDevice;
     use crate::seccomp::get_empty_filters;
@@ -952,12 +951,11 @@ pub(crate) mod tests {
             &mut kernel_file,
             Some(GuestAddress(crate::arch::get_kernel_start())),
         )
-        .map_err(StartMicrovmError::KernelLoader);
+        .unwrap();
         #[cfg(target_arch = "aarch64")]
         let entry_addr =
-            linux_loader::loader::pe::PE::load(vm_memory, None, &mut kernel_file, None)
-                .map_err(StartMicrovmError::KernelLoader);
-        entry_addr.unwrap().kernel_load
+            linux_loader::loader::pe::PE::load(vm_memory, None, &mut kernel_file, None).unwrap();
+        entry_addr.kernel_load
     }
 
     fn vcpu_configured_for_boot() -> (VcpuHandle, EventFd, GuestMemoryMmap) {


### PR DESCRIPTION
## Changes
This is another attempt at fixing #4547. 
- Move architecture specific parts from `builder.rs` into `arch` modules. 
- Do slight refactoring on top in the `arch` modules.

## Reason
Less arch specific mess in the codebase.

Fixes: #4411
Previous attempt was: #4910

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
