### PR TITLE
test(examples/uffd): panic on receiving POLLHUP

### DIFF
--- a/src/firecracker/examples/uffd/uffd_utils.rs
+++ b/src/firecracker/examples/uffd/uffd_utils.rs
@@ -312,6 +312,14 @@ impl Runtime {
                 if nready == 0 {
                     break;
                 }
+                if pollfds[i].revents & libc::POLLHUP != 0 {
+                    let sock_type = if pollfds[i].fd == self.stream.as_raw_fd() {
+                        "listening"
+                    } else {
+                        "connected"
+                    };
+                    panic!("Received POLLHUP on {sock_type} socket");
+                }
                 if pollfds[i].revents & libc::POLLIN != 0 {
                     nready -= 1;
                     if pollfds[i].fd == self.stream.as_raw_fd() {


### PR DESCRIPTION
## Changes

Panic example UFFD handlers on receiving POLLHUP.

## Reason

If Firecracker process disconnects from the socket, the UFFD handler receives a POLLHUP epoll event.  We would like to handle it explicitly to get more precise data when debugging.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
