### PR TITLE
tests: Report kernels newer than 6.12 as next

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def pytest_runtest_logreport(report):
             "test": report.nodeid,
             "instance": global_props.instance,
             "cpu_model": global_props.cpu_model,
-            "host_kernel": "linux-" + global_props.host_linux_version,
+            "host_kernel": "linux-" + global_props.host_linux_version_metrics,
             "phase": report.when,
         },
         # per test
@@ -141,12 +141,12 @@ def pytest_runtest_logreport(report):
             "test": report.nodeid,
             "instance": global_props.instance,
             "cpu_model": global_props.cpu_model,
-            "host_kernel": "linux-" + global_props.host_linux_version,
+            "host_kernel": "linux-" + global_props.host_linux_version_metrics,
         },
         # per phase
         {"phase": report.when},
         # per host kernel
-        {"host_kernel": "linux-" + global_props.host_linux_version},
+        {"host_kernel": "linux-" + global_props.host_linux_version_metrics},
         # per CPU
         {"cpu_model": global_props.cpu_model},
         # and global

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -457,7 +457,7 @@ class Microvm:
         return {
             "instance": global_props.instance,
             "cpu_model": global_props.cpu_model,
-            "host_kernel": f"linux-{global_props.host_linux_version}",
+            "host_kernel": f"linux-{global_props.host_linux_version_metrics}",
             "guest_kernel": self.kernel_file.stem[2:],
             "rootfs": self.rootfs_file.name,
             "vcpus": str(self.vcpus_count),

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -103,6 +103,13 @@ class GlobalProps:
         return tuple(int(x) for x in self.host_linux_version.split("."))
 
     @property
+    def host_linux_version_metrics(self):
+        """Host Linux version to be reported in metrics"""
+        return (
+            "next" if self.host_linux_version_tpl > (6, 12) else self.host_linux_version
+        )
+
+    @property
     def is_ec2(self):
         """Are we running on an EC2 instance?"""
         return self.environment == "ec2"

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -508,7 +508,7 @@ class FCMetricsMonitor(Thread):
         self.metrics_logger.set_dimensions(
             {
                 "instance": global_props.instance,
-                "host_kernel": "linux-" + global_props.host_linux_version,
+                "host_kernel": "linux-" + global_props.host_linux_version_metrics,
                 "guest_kernel": vm.kernel_file.stem[2:],
             }
         )

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -23,7 +23,7 @@ DIMENSIONS = {
     "instance": global_props.instance,
     "cpu_model": global_props.cpu_model,
     "host_os": global_props.host_os,
-    "host_kernel": "linux-" + global_props.host_linux_version,
+    "host_kernel": "linux-" + global_props.host_linux_version_metrics,
 }
 
 


### PR DESCRIPTION
When emitting metrics for host kernels greater than 6.12 (latest LTS) we will report them as "next" kernels to make them easier to track in our dashboards

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
