### PR TITLE
test(conftest): move (not copy) vm artifacts

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -337,7 +337,7 @@ def microvm_factory(request, record_property, results_dir, netns_factory):
                 if not os.path.isfile(src):
                     continue
                 dst = uvm_data / item
-                shutil.copy(src, dst)
+                shutil.move(src, dst)
                 console_data = uvm.console_data
                 if console_data:
                     uvm_data.joinpath("guest-console.log").write_text(console_data)


### PR DESCRIPTION
## Changes

Move instead of copying VM artifacts (like mem snapshot files).

## Reason

This is to keep free space in the /srv filesystem.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
