### PR TITLE
Secret Hiding: Skip more huge page tests and run build nightly

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -68,7 +68,7 @@ if not pipeline.args.no_kani and (
     for step in kani_grp["steps"]:
         step["label"] = "🔍 Kani"
 
-if any(x.parent.name == "hiding_ci" for x in changed_files):
+if not changed_files or (any(x.parent.name == "hiding_ci" for x in changed_files)):
     pipeline.build_group_per_arch(
         "🕵️ Build Secret Hiding Kernel",
         pipeline.devtool_test(

--- a/tests/integration_tests/performance/test_snapshot_ab.py
+++ b/tests/integration_tests/performance/test_snapshot_ab.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Performance benchmark for snapshot restore."""
+
 import re
 import signal
 import tempfile
@@ -106,6 +107,15 @@ def test_restore_latency(
 
     We only test a single guest kernel, as the guest kernel does not "participate" in snapshot restore.
     """
+    if (
+        test_setup.huge_pages != HugePagesConfig.NONE
+        and global_props.host_linux_version_tpl > (6, 1)
+        and global_props.cpu_architecture == "aarch64"
+    ):
+        pytest.skip(
+            "huge pages with secret hiding kernels on ARM are currently failing"
+        )
+
     vm = test_setup.boot_vm(microvm_factory, guest_kernel_linux_5_10, rootfs)
 
     metrics.set_dimensions(
@@ -218,6 +228,15 @@ def test_population_latency(
     mem,
 ):
     """Collects population latency metrics (e.g. how long it takes UFFD handler to fault in all memory)"""
+    if (
+        huge_pages != HugePagesConfig.NONE
+        and global_props.host_linux_version_tpl > (6, 1)
+        and global_props.cpu_architecture == "aarch64"
+    ):
+        pytest.skip(
+            "huge pages with secret hiding kernels on ARM are currently failing"
+        )
+
     test_setup = SnapshotRestoreTest(mem=mem, vcpus=vcpus, huge_pages=huge_pages)
     vm = test_setup.boot_vm(microvm_factory, guest_kernel_linux_5_10, rootfs)
 


### PR DESCRIPTION
Skip some more huge pages tests on ARM instances on our newer kernel.

Run our kernel build as part of our nightly pipeline to ensure that it's passing

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
We previously skipped a huge page test which stoppped the test timing
out, but now we get stuck on another. Skipping this and the other
huge page snapshot tests in the file.

Signed-off-by: Jack Thomson <jackabt@amazon.com>