### PR TITLE
Refactor: Move `GuestMemoryMmap` into `struct Vm`

### DIFF
--- a/src/vmm/benches/memory_access.rs
+++ b/src/vmm/benches/memory_access.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use vm_memory::GuestMemory;
 use vmm::resources::VmResources;
 use vmm::vmm_config::machine_config::{HugePageConfig, MachineConfig};
 
@@ -14,7 +13,7 @@ fn bench_single_page_fault(c: &mut Criterion, configuration: VmResources) {
                 // Get a pointer to the first memory region (cannot do `.get_slice(GuestAddress(0),
                 // 1)`, because on ARM64 guest memory does not start at physical
                 // address 0).
-                let ptr = memory.iter().next().unwrap().as_ptr();
+                let ptr = memory.first().unwrap().as_ptr();
 
                 // fine to return both here, because ptr is not a reference into `memory` (e.g. no
                 // self-referential structs are happening here)

--- a/src/vmm/src/acpi/mod.rs
+++ b/src/vmm/src/acpi/mod.rs
@@ -188,7 +188,9 @@ mod tests {
     use crate::acpi::{AcpiError, AcpiTableWriter};
     use crate::arch::x86_64::layout::{SYSTEM_MEM_SIZE, SYSTEM_MEM_START};
     use crate::builder::tests::default_vmm;
-    use crate::test_utils::arch_mem;
+    use crate::device_manager::resources::ResourceAllocator;
+    use crate::utils::u64_to_usize;
+    use crate::vstate::vm::tests::setup_vm_with_memory;
 
     struct MockSdt(Vec<u8>);
 
@@ -263,17 +265,10 @@ mod tests {
     // change in the future.
     #[test]
     fn test_write_acpi_table_small_memory() {
-        let mut vmm = default_vmm();
-        vmm.vm
-            .memory_init(arch_mem(
-                (SYSTEM_MEM_START + SYSTEM_MEM_SIZE - 4096)
-                    .try_into()
-                    .unwrap(),
-            ))
-            .unwrap();
+        let (_, vm) = setup_vm_with_memory(u64_to_usize(SYSTEM_MEM_START + SYSTEM_MEM_SIZE - 4096));
         let mut writer = AcpiTableWriter {
-            mem: vmm.vm.guest_memory(),
-            resource_allocator: &mut vmm.resource_allocator,
+            mem: vm.guest_memory(),
+            resource_allocator: &mut ResourceAllocator::new().unwrap(),
         };
 
         let mut sdt = MockSdt(vec![0; usize::try_from(SYSTEM_MEM_SIZE).unwrap()]);

--- a/src/vmm/src/acpi/mod.rs
+++ b/src/vmm/src/acpi/mod.rs
@@ -215,7 +215,7 @@ mod tests {
         // A mocke Vmm object with 128MBs of memory
         let mut vmm = default_vmm();
         let mut writer = AcpiTableWriter {
-            mem: &vmm.guest_memory,
+            mem: vmm.vm.guest_memory(),
             resource_allocator: &mut vmm.resource_allocator,
         };
 
@@ -264,13 +264,15 @@ mod tests {
     #[test]
     fn test_write_acpi_table_small_memory() {
         let mut vmm = default_vmm();
-        vmm.guest_memory = arch_mem(
-            (SYSTEM_MEM_START + SYSTEM_MEM_SIZE - 4096)
-                .try_into()
-                .unwrap(),
-        );
+        vmm.vm
+            .memory_init(arch_mem(
+                (SYSTEM_MEM_START + SYSTEM_MEM_SIZE - 4096)
+                    .try_into()
+                    .unwrap(),
+            ))
+            .unwrap();
         let mut writer = AcpiTableWriter {
-            mem: &vmm.guest_memory,
+            mem: vmm.vm.guest_memory(),
             resource_allocator: &mut vmm.resource_allocator,
         };
 

--- a/src/vmm/src/arch/aarch64/kvm.rs
+++ b/src/vmm/src/arch/aarch64/kvm.rs
@@ -22,8 +22,6 @@ pub struct OptionalCapabilities {
 pub struct Kvm {
     /// KVM fd.
     pub fd: KvmFd,
-    /// Maximum number of memory slots allowed by KVM.
-    pub max_memslots: usize,
     /// Additional capabilities that were specified in cpu template.
     pub kvm_cap_modifiers: Vec<KvmCapability>,
 }
@@ -42,12 +40,10 @@ impl Kvm {
     /// Initialize [`Kvm`] type for Aarch64 architecture
     pub fn init_arch(
         fd: KvmFd,
-        max_memslots: usize,
         kvm_cap_modifiers: Vec<KvmCapability>,
     ) -> Result<Self, KvmArchError> {
         Ok(Self {
             fd,
-            max_memslots,
             kvm_cap_modifiers,
         })
     }

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -89,7 +89,7 @@ pub fn configure_system_for_boot(
     // Configure vCPUs with normalizing and setting the generated CPU configuration.
     for vcpu in vcpus.iter_mut() {
         vcpu.kvm_vcpu.configure(
-            &vmm.guest_memory,
+            vmm.vm.guest_memory(),
             entry_point,
             &vcpu_config,
             &optional_capabilities,
@@ -105,7 +105,7 @@ pub fn configure_system_for_boot(
         .expect("Cannot create cstring from cmdline string");
 
     let fdt = fdt::create_fdt(
-        &vmm.guest_memory,
+        vmm.vm.guest_memory(),
         vcpu_mpidr,
         cmdline,
         vmm.mmio_device_manager.get_device_info(),
@@ -114,8 +114,10 @@ pub fn configure_system_for_boot(
         initrd,
     )?;
 
-    let fdt_address = GuestAddress(get_fdt_addr(&vmm.guest_memory));
-    vmm.guest_memory.write_slice(fdt.as_slice(), fdt_address)?;
+    let fdt_address = GuestAddress(get_fdt_addr(vmm.vm.guest_memory()));
+    vmm.vm
+        .guest_memory()
+        .write_slice(fdt.as_slice(), fdt_address)?;
 
     Ok(())
 }

--- a/src/vmm/src/arch/aarch64/vm.rs
+++ b/src/vmm/src/arch/aarch64/vm.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Kvm;
 use crate::arch::aarch64::gic::GicState;
+use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryState};
 use crate::vstate::vm::{VmCommon, VmError};
 
 /// Structure representing the current architecture's understand of what a "virtual machine" is.
@@ -68,6 +69,7 @@ impl ArchVm {
     /// Saves and returns the Kvm Vm state.
     pub fn save_state(&self, mpidrs: &[u64]) -> Result<VmState, ArchVmError> {
         Ok(VmState {
+            memory: self.common.guest_memory.describe(),
             gic: self
                 .get_irqchip()
                 .save_device(mpidrs)
@@ -84,6 +86,7 @@ impl ArchVm {
         self.get_irqchip()
             .restore_device(mpidrs, &state.gic)
             .map_err(ArchVmError::RestoreGic)?;
+
         Ok(())
     }
 }
@@ -91,6 +94,8 @@ impl ArchVm {
 /// Structure holding an general specific VM state.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct VmState {
+    /// Guest memory state
+    pub memory: GuestMemoryState,
     /// GIC state.
     pub gic: GicState,
 }

--- a/src/vmm/src/arch/aarch64/vm.rs
+++ b/src/vmm/src/arch/aarch64/vm.rs
@@ -1,18 +1,17 @@
 // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use kvm_ioctls::VmFd;
 use serde::{Deserialize, Serialize};
 
 use crate::Kvm;
 use crate::arch::aarch64::gic::GicState;
-use crate::vstate::vm::VmError;
+use crate::vstate::vm::{VmCommon, VmError};
 
 /// Structure representing the current architecture's understand of what a "virtual machine" is.
 #[derive(Debug)]
 pub struct ArchVm {
-    /// KVM file descriptor of microVM
-    pub fd: VmFd,
+    /// Architecture independent parts of a vm.
+    pub common: VmCommon,
     // On aarch64 we need to keep around the fd obtained by creating the VGIC device.
     irqchip_handle: Option<crate::arch::aarch64::gic::GICDevice>,
 }
@@ -31,9 +30,9 @@ pub enum ArchVmError {
 impl ArchVm {
     /// Create a new `Vm` struct.
     pub fn new(kvm: &Kvm) -> Result<ArchVm, VmError> {
-        let fd = Self::create_vm(kvm)?;
+        let common = Self::create_common(kvm)?;
         Ok(ArchVm {
-            fd,
+            common,
             irqchip_handle: None,
         })
     }
@@ -55,7 +54,7 @@ impl ArchVm {
     /// Creates the GIC (Global Interrupt Controller).
     pub fn setup_irqchip(&mut self, vcpu_count: u8) -> Result<(), ArchVmError> {
         self.irqchip_handle = Some(
-            crate::arch::aarch64::gic::create_gic(&self.fd, vcpu_count.into(), None)
+            crate::arch::aarch64::gic::create_gic(self.fd(), vcpu_count.into(), None)
                 .map_err(ArchVmError::VmCreateGIC)?,
         );
         Ok(())

--- a/src/vmm/src/arch/x86_64/kvm.rs
+++ b/src/vmm/src/arch/x86_64/kvm.rs
@@ -21,8 +21,6 @@ pub enum KvmArchError {
 pub struct Kvm {
     /// KVM fd.
     pub fd: KvmFd,
-    /// Maximum number of memory slots allowed by KVM.
-    pub max_memslots: usize,
     /// Additional capabilities that were specified in cpu template.
     pub kvm_cap_modifiers: Vec<KvmCapability>,
     /// Supported CpuIds.
@@ -50,7 +48,6 @@ impl Kvm {
     /// Initialize [`Kvm`] type for x86_64 architecture
     pub fn init_arch(
         fd: KvmFd,
-        max_memslots: usize,
         kvm_cap_modifiers: Vec<KvmCapability>,
     ) -> Result<Self, KvmArchError> {
         request_dynamic_xstate_features().map_err(KvmArchError::XstateFeatures)?;
@@ -61,7 +58,6 @@ impl Kvm {
 
         Ok(Kvm {
             fd,
-            max_memslots,
             kvm_cap_modifiers,
             supported_cpuid,
         })

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -110,17 +110,33 @@ pub const MMIO_MEM_SIZE: u64 = MEM_32BIT_GAP_SIZE;
 /// These should be used to configure the GuestMemoryMmap structure for the platform.
 /// For x86_64 all addresses are valid from the start of the kernel except a
 /// carve out at the end of 32bit address space.
-pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize)> {
+pub fn arch_memory_regions(offset: usize, size: usize) -> Vec<(GuestAddress, usize)> {
+    // If we get here with size == 0 something has seriously gone wrong. Firecracker should never
+    // try to allocate guest memory of size 0
+    assert!(size > 0, "Attempt to allocate guest memory of length 0");
+    assert!(
+        offset.checked_add(size).is_some(),
+        "Attempt to allocate guest memory such that the address space would wrap around"
+    );
+
     // It's safe to cast MMIO_MEM_START to usize because it fits in a u32 variable
     // (It points to an address in the 32 bit space).
-    match size.checked_sub(usize::try_from(MMIO_MEM_START).unwrap()) {
+    match (size + offset).checked_sub(u64_to_usize(MMIO_MEM_START)) {
         // case1: guest memory fits before the gap
-        None | Some(0) => vec![(GuestAddress(0), size)],
-        // case2: guest memory extends beyond the gap
-        Some(remaining) => vec![
-            (GuestAddress(0), usize::try_from(MMIO_MEM_START).unwrap()),
+        None | Some(0) => vec![(GuestAddress(offset as u64), size)],
+        // case2: starts before the gap, but doesn't completely fit
+        Some(remaining) if (offset as u64) < MMIO_MEM_START => vec![
+            (
+                GuestAddress(offset as u64),
+                u64_to_usize(MMIO_MEM_START) - offset,
+            ),
             (GuestAddress(FIRST_ADDR_PAST_32BITS), remaining),
         ],
+        // case3: guest memory start after the gap
+        Some(_) => vec![(
+            GuestAddress(FIRST_ADDR_PAST_32BITS.max(offset as u64)),
+            size,
+        )],
     }
 }
 
@@ -456,6 +472,56 @@ pub fn load_kernel(
     })
 }
 
+#[cfg(kani)]
+mod verification {
+    use crate::arch::x86_64::FIRST_ADDR_PAST_32BITS;
+    use crate::arch::{MMIO_MEM_START, arch_memory_regions};
+
+    #[kani::proof]
+    #[kani::unwind(3)]
+    fn verify_arch_memory_regions() {
+        let offset: u64 = kani::any::<u64>();
+        let len: u64 = kani::any::<u64>();
+
+        kani::assume(len > 0);
+        kani::assume(offset.checked_add(len).is_some());
+
+        let regions = arch_memory_regions(offset as usize, len as usize);
+
+        // There's only one MMIO gap, so we can get either 1 or 2 regions
+        assert!(regions.len() <= 2);
+        assert!(regions.len() >= 1);
+
+        // The total length of all regions is what we requested
+        assert_eq!(
+            regions.iter().map(|&(_, len)| len).sum::<usize>(),
+            len as usize
+        );
+
+        // No region overlaps the MMIO gap
+        assert!(
+            regions
+                .iter()
+                .all(|&(start, len)| start.0 >= FIRST_ADDR_PAST_32BITS
+                    || start.0 + len as u64 <= MMIO_MEM_START)
+        );
+
+        // All regions start after our specified offset
+        assert!(regions.iter().all(|&(start, _)| start.0 >= offset as u64));
+
+        // All regions have non-zero length
+        assert!(regions.iter().all(|&(_, len)| len > 0));
+
+        // If there's two regions, they perfectly snuggle up to the MMIO gap
+        if regions.len() == 2 {
+            kani::cover!();
+
+            assert_eq!(regions[0].0.0 + regions[0].1 as u64, MMIO_MEM_START);
+            assert_eq!(regions[1].0.0, FIRST_ADDR_PAST_32BITS);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use linux_loader::loader::bootparam::boot_e820_entry;
@@ -466,18 +532,41 @@ mod tests {
 
     #[test]
     fn regions_lt_4gb() {
-        let regions = arch_memory_regions(1usize << 29);
+        let regions = arch_memory_regions(0, 1usize << 29);
         assert_eq!(1, regions.len());
         assert_eq!(GuestAddress(0), regions[0].0);
         assert_eq!(1usize << 29, regions[0].1);
+
+        let regions = arch_memory_regions(1 << 28, 1 << 29);
+        assert_eq!(1, regions.len());
+        assert_eq!(regions[0], (GuestAddress(1 << 28), 1 << 29));
     }
 
     #[test]
     fn regions_gt_4gb() {
-        let regions = arch_memory_regions((1usize << 32) + 0x8000);
+        const MEMORY_SIZE: usize = (1 << 32) + 0x8000;
+
+        let regions = arch_memory_regions(0, MEMORY_SIZE);
         assert_eq!(2, regions.len());
         assert_eq!(GuestAddress(0), regions[0].0);
         assert_eq!(GuestAddress(1u64 << 32), regions[1].0);
+
+        let regions = arch_memory_regions(1 << 31, MEMORY_SIZE);
+        assert_eq!(2, regions.len());
+        assert_eq!(
+            regions[0],
+            (
+                GuestAddress(1 << 31),
+                u64_to_usize(MMIO_MEM_START) - (1 << 31)
+            )
+        );
+        assert_eq!(
+            regions[1],
+            (
+                GuestAddress(FIRST_ADDR_PAST_32BITS),
+                MEMORY_SIZE - regions[0].1
+            )
+        )
     }
 
     #[test]

--- a/src/vmm/src/arch/x86_64/vm.rs
+++ b/src/vmm/src/arch/x86_64/vm.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::arch::x86_64::msr::MsrError;
 use crate::utils::u64_to_usize;
+use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryState};
 use crate::vstate::vm::{VmCommon, VmError};
 
 /// Error type for [`Vm::restore_state`]
@@ -185,6 +186,7 @@ impl ArchVm {
             .map_err(ArchVmError::VmGetIrqChip)?;
 
         Ok(VmState {
+            memory: self.common.guest_memory.describe(),
             pitstate,
             clock,
             pic_master,
@@ -207,6 +209,8 @@ impl ArchVm {
 #[derive(Default, Deserialize, Serialize)]
 /// Structure holding VM kvm state.
 pub struct VmState {
+    /// guest memory state
+    pub memory: GuestMemoryState,
     pitstate: kvm_pit_state2,
     clock: kvm_clock_data,
     // TODO: rename this field to adopt inclusive language once Linux updates it, too.

--- a/src/vmm/src/arch/x86_64/vm.rs
+++ b/src/vmm/src/arch/x86_64/vm.rs
@@ -7,12 +7,12 @@ use kvm_bindings::{
     KVM_CLOCK_TSC_STABLE, KVM_IRQCHIP_IOAPIC, KVM_IRQCHIP_PIC_MASTER, KVM_IRQCHIP_PIC_SLAVE,
     KVM_PIT_SPEAKER_DUMMY, MsrList, kvm_clock_data, kvm_irqchip, kvm_pit_config, kvm_pit_state2,
 };
-use kvm_ioctls::{Cap, VmFd};
+use kvm_ioctls::Cap;
 use serde::{Deserialize, Serialize};
 
 use crate::arch::x86_64::msr::MsrError;
 use crate::utils::u64_to_usize;
-use crate::vstate::vm::VmError;
+use crate::vstate::vm::{VmCommon, VmError};
 
 /// Error type for [`Vm::restore_state`]
 #[allow(missing_docs)]
@@ -48,8 +48,8 @@ pub enum ArchVmError {
 /// Structure representing the current architecture's understand of what a "virtual machine" is.
 #[derive(Debug)]
 pub struct ArchVm {
-    /// KVM file descriptor of microVM
-    pub fd: VmFd,
+    /// Architecture independent parts of a vm
+    pub common: VmCommon,
     msrs_to_save: MsrList,
     /// Size in bytes requiring to hold the dynamically-sized `kvm_xsave` struct.
     ///
@@ -60,7 +60,7 @@ pub struct ArchVm {
 impl ArchVm {
     /// Create a new `Vm` struct.
     pub fn new(kvm: &crate::vstate::kvm::Kvm) -> Result<ArchVm, VmError> {
-        let fd = Self::create_vm(kvm)?;
+        let common = Self::create_common(kvm)?;
 
         let msrs_to_save = kvm.msrs_to_save().map_err(ArchVmError::GetMsrsToSave)?;
 
@@ -70,7 +70,7 @@ impl ArchVm {
         // https://github.com/torvalds/linux/commit/be50b2065dfa3d88428fdfdc340d154d96bf6848
         //
         // Cache the value in order not to call it at each vCPU creation.
-        let xsave2_size = match fd.check_extension_int(Cap::Xsave2) {
+        let xsave2_size = match common.fd.check_extension_int(Cap::Xsave2) {
             // Catch all negative values just in case although the possible negative return value
             // of ioctl() is only -1.
             ..=-1 => {
@@ -84,11 +84,13 @@ impl ArchVm {
             ret => Some(usize::try_from(ret).unwrap()),
         };
 
-        fd.set_tss_address(u64_to_usize(crate::arch::x86_64::layout::KVM_TSS_ADDRESS))
+        common
+            .fd
+            .set_tss_address(u64_to_usize(crate::arch::x86_64::layout::KVM_TSS_ADDRESS))
             .map_err(ArchVmError::SetTssAddress)?;
 
         Ok(ArchVm {
-            fd,
+            common,
             msrs_to_save,
             xsave2_size,
         })
@@ -116,19 +118,19 @@ impl ArchVm {
     /// - [`kvm_ioctls::VmFd::set_irqchip`] errors.
     /// - [`kvm_ioctls::VmFd::set_irqchip`] errors.
     pub fn restore_state(&mut self, state: &VmState) -> Result<(), ArchVmError> {
-        self.fd
+        self.fd()
             .set_pit2(&state.pitstate)
             .map_err(ArchVmError::SetPit2)?;
-        self.fd
+        self.fd()
             .set_clock(&state.clock)
             .map_err(ArchVmError::SetClock)?;
-        self.fd
+        self.fd()
             .set_irqchip(&state.pic_master)
             .map_err(ArchVmError::SetIrqChipPicMaster)?;
-        self.fd
+        self.fd()
             .set_irqchip(&state.pic_slave)
             .map_err(ArchVmError::SetIrqChipPicSlave)?;
-        self.fd
+        self.fd()
             .set_irqchip(&state.ioapic)
             .map_err(ArchVmError::SetIrqChipIoAPIC)?;
         Ok(())
@@ -136,7 +138,7 @@ impl ArchVm {
 
     /// Creates the irq chip and an in-kernel device model for the PIT.
     pub fn setup_irqchip(&self) -> Result<(), ArchVmError> {
-        self.fd
+        self.fd()
             .create_irq_chip()
             .map_err(ArchVmError::VmSetIrqChip)?;
         // We need to enable the emulation of a dummy speaker port stub so that writing to port 0x61
@@ -145,16 +147,16 @@ impl ArchVm {
             flags: KVM_PIT_SPEAKER_DUMMY,
             ..Default::default()
         };
-        self.fd
+        self.fd()
             .create_pit2(pit_config)
             .map_err(ArchVmError::VmSetIrqChip)
     }
 
     /// Saves and returns the Kvm Vm state.
     pub fn save_state(&self) -> Result<VmState, ArchVmError> {
-        let pitstate = self.fd.get_pit2().map_err(ArchVmError::VmGetPit2)?;
+        let pitstate = self.fd().get_pit2().map_err(ArchVmError::VmGetPit2)?;
 
-        let mut clock = self.fd.get_clock().map_err(ArchVmError::VmGetClock)?;
+        let mut clock = self.fd().get_clock().map_err(ArchVmError::VmGetClock)?;
         // This bit is not accepted in SET_CLOCK, clear it.
         clock.flags &= !KVM_CLOCK_TSC_STABLE;
 
@@ -162,7 +164,7 @@ impl ArchVm {
             chip_id: KVM_IRQCHIP_PIC_MASTER,
             ..Default::default()
         };
-        self.fd
+        self.fd()
             .get_irqchip(&mut pic_master)
             .map_err(ArchVmError::VmGetIrqChip)?;
 
@@ -170,7 +172,7 @@ impl ArchVm {
             chip_id: KVM_IRQCHIP_PIC_SLAVE,
             ..Default::default()
         };
-        self.fd
+        self.fd()
             .get_irqchip(&mut pic_slave)
             .map_err(ArchVmError::VmGetIrqChip)?;
 
@@ -178,7 +180,7 @@ impl ArchVm {
             chip_id: KVM_IRQCHIP_IOAPIC,
             ..Default::default()
         };
-        self.fd
+        self.fd()
             .get_irqchip(&mut ioapic)
             .map_err(ArchVmError::VmGetIrqChip)?;
 

--- a/src/vmm/src/arch/x86_64/vm.rs
+++ b/src/vmm/src/arch/x86_64/vm.rs
@@ -246,7 +246,7 @@ mod tests {
         // Irqchips, clock and pitstate are not configured so trying to save state should fail.
         vm.save_state().unwrap_err();
 
-        let (_, vm, _mem) = setup_vm_with_memory(0x1000);
+        let (_, vm) = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
         let vm_state = vm.save_state().unwrap();
@@ -259,7 +259,7 @@ mod tests {
         assert_eq!(vm_state.pic_slave.chip_id, KVM_IRQCHIP_PIC_SLAVE);
         assert_eq!(vm_state.ioapic.chip_id, KVM_IRQCHIP_IOAPIC);
 
-        let (_, mut vm, _mem) = setup_vm_with_memory(0x1000);
+        let (_, mut vm) = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
         vm.restore_state(&vm_state).unwrap();
@@ -270,11 +270,11 @@ mod tests {
     fn test_vm_save_restore_state_bad_irqchip() {
         use kvm_bindings::KVM_NR_IRQCHIPS;
 
-        let (_, vm, _mem) = setup_vm_with_memory(0x1000);
+        let (_, vm) = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
         let mut vm_state = vm.save_state().unwrap();
 
-        let (_, mut vm, _mem) = setup_vm_with_memory(0x1000);
+        let (_, mut vm) = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
         // Try to restore an invalid PIC Master chip ID
@@ -299,7 +299,7 @@ mod tests {
     fn test_vmstate_serde() {
         let mut snapshot_data = vec![0u8; 10000];
 
-        let (_, mut vm, _) = setup_vm_with_memory(0x1000);
+        let (_, mut vm) = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
         let state = vm.save_state().unwrap();
         Snapshot::serialize(&mut snapshot_data.as_mut_slice(), &state).unwrap();

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -143,7 +143,6 @@ fn create_vmm_and_vcpus(
     // Set up Kvm Vm and register memory regions.
     // Build custom CPU config if a custom template is provided.
     let mut vm = Vm::new(&kvm)?;
-    kvm.check_memory(&guest_memory)?;
     vm.memory_init(&guest_memory)?;
 
     let resource_allocator = ResourceAllocator::new()?;

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -218,8 +218,6 @@ pub fn build_microvm_for_boot(
         .allocate_guest_memory()
         .map_err(StartMicrovmError::GuestMemory)?;
 
-    let entry_point = load_kernel(&boot_config.kernel_file, &guest_memory)?;
-    let initrd = InitrdConfig::from_config(boot_config, &guest_memory)?;
     // Clone the command-line so that a failed boot doesn't pollute the original.
     #[allow(unused_mut)]
     let mut boot_cmdline = boot_config.cmdline.clone();
@@ -237,6 +235,9 @@ pub fn build_microvm_for_boot(
         vm_resources.machine_config.vcpu_count,
         cpu_template.kvm_capabilities.clone(),
     )?;
+
+    let entry_point = load_kernel(&boot_config.kernel_file, vmm.vm.guest_memory())?;
+    let initrd = InitrdConfig::from_config(boot_config, vmm.vm.guest_memory())?;
 
     #[cfg(feature = "gdb")]
     let (gdb_tx, gdb_rx) = mpsc::channel();

--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn test_register_legacy_devices() {
-        let (_, vm, _) = setup_vm_with_memory(0x1000);
+        let (_, vm) = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
         let mut ldm = PortIODeviceManager::new(
             Arc::new(Mutex::new(BusDevice::Serial(SerialDevice {

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -532,7 +532,7 @@ mod tests {
     use crate::devices::virtio::ActivateError;
     use crate::devices::virtio::device::{IrqTrigger, VirtioDevice};
     use crate::devices::virtio::queue::Queue;
-    use crate::test_utils::multi_region_mem;
+    use crate::test_utils::multi_region_mem_raw;
     use crate::vstate::kvm::Kvm;
     use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
 
@@ -649,10 +649,10 @@ mod tests {
     fn test_register_virtio_device() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
+        let guest_mem = multi_region_mem_raw(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(guest_mem).unwrap();
+        vm.register_memory_regions(guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
         let mut resource_allocator = ResourceAllocator::new().unwrap();
 
@@ -680,10 +680,10 @@ mod tests {
     fn test_register_too_many_devices() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
+        let guest_mem = multi_region_mem_raw(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(guest_mem).unwrap();
+        vm.register_memory_regions(guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
         let mut resource_allocator = ResourceAllocator::new().unwrap();
 
@@ -736,10 +736,10 @@ mod tests {
     fn test_device_info() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
+        let guest_mem = multi_region_mem_raw(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(guest_mem).unwrap();
+        vm.register_memory_regions(guest_mem).unwrap();
 
         #[cfg(target_arch = "x86_64")]
         vm.setup_irqchip().unwrap();

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -652,7 +652,7 @@ mod tests {
         let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(&guest_mem).unwrap();
+        vm.memory_init(guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
         let mut resource_allocator = ResourceAllocator::new().unwrap();
 
@@ -666,7 +666,7 @@ mod tests {
         device_manager
             .register_virtio_test_device(
                 vm.fd(),
-                guest_mem,
+                vm.guest_memory().clone(),
                 &mut resource_allocator,
                 dummy,
                 &mut cmdline,
@@ -683,7 +683,7 @@ mod tests {
         let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(&guest_mem).unwrap();
+        vm.memory_init(guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
         let mut resource_allocator = ResourceAllocator::new().unwrap();
 
@@ -697,7 +697,7 @@ mod tests {
             device_manager
                 .register_virtio_test_device(
                     vm.fd(),
-                    guest_mem.clone(),
+                    vm.guest_memory().clone(),
                     &mut resource_allocator,
                     Arc::new(Mutex::new(DummyDevice::new())),
                     &mut cmdline,
@@ -711,7 +711,7 @@ mod tests {
                 device_manager
                     .register_virtio_test_device(
                         vm.fd(),
-                        guest_mem,
+                        vm.guest_memory().clone(),
                         &mut resource_allocator,
                         Arc::new(Mutex::new(DummyDevice::new())),
                         &mut cmdline,
@@ -739,9 +739,7 @@ mod tests {
         let guest_mem = multi_region_mem(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = Vm::new(&kvm).unwrap();
-        vm.memory_init(&guest_mem).unwrap();
-
-        let mem_clone = guest_mem.clone();
+        vm.memory_init(guest_mem).unwrap();
 
         #[cfg(target_arch = "x86_64")]
         vm.setup_irqchip().unwrap();
@@ -758,7 +756,7 @@ mod tests {
         let addr = device_manager
             .register_virtio_test_device(
                 vm.fd(),
-                guest_mem,
+                vm.guest_memory().clone(),
                 &mut resource_allocator,
                 dummy,
                 &mut cmdline,
@@ -794,7 +792,7 @@ mod tests {
         device_manager
             .register_virtio_test_device(
                 vm.fd(),
-                mem_clone,
+                vm.guest_memory().clone(),
                 &mut resource_allocator,
                 dummy2,
                 &mut cmdline,

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -805,7 +805,7 @@ mod tests {
         let device_states: DeviceStates = Snapshot::deserialize(&mut buf.as_slice()).unwrap();
         let vm_resources = &mut VmResources::default();
         let restore_args = MMIODevManagerConstructorArgs {
-            mem: &vmm.guest_memory,
+            mem: vmm.vm.guest_memory(),
             vm: vmm.vm.fd(),
             event_manager: &mut event_manager,
             resource_allocator: &mut resource_allocator,

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -376,8 +376,9 @@ mod tests {
     use super::*;
     use crate::devices::virtio::block::virtio::device::FileEngineType;
     use crate::devices::virtio::mmio::VIRTIO_MMIO_INT_CONFIG;
+    use crate::devices::virtio::vhost_user::tests::create_mem;
     use crate::test_utils::create_tmp_socket;
-    use crate::vstate::memory::{GuestAddress, GuestMemoryExtension};
+    use crate::vstate::memory::GuestAddress;
 
     #[test]
     fn test_from_config() {
@@ -778,9 +779,7 @@ mod tests {
         let file = TempFile::new().unwrap().into_file();
         file.set_len(region_size as u64).unwrap();
         let regions = vec![(GuestAddress(0x0), region_size)];
-        let guest_memory =
-            GuestMemoryMmap::create(regions.into_iter(), libc::MAP_PRIVATE, Some(file), false)
-                .unwrap();
+        let guest_memory = create_mem(file, &regions);
 
         // During actiavion of the device features, memory and queues should be set and activated.
         vhost_block.activate(guest_memory).unwrap();

--- a/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
@@ -194,7 +194,8 @@ pub mod tests {
     use crate::devices::virtio::block::virtio::device::FileEngineType;
     use crate::utils::u64_to_usize;
     use crate::vmm_config::machine_config::HugePageConfig;
-    use crate::vstate::memory::{Bitmap, Bytes, GuestMemory, GuestMemoryExtension};
+    use crate::vstate::memory;
+    use crate::vstate::memory::{Bitmap, Bytes, GuestMemory};
 
     const FILE_LEN: u32 = 1024;
     // 2 pages of memory should be enough to test read/write ops and also dirty tracking.
@@ -230,10 +231,13 @@ pub mod tests {
     }
 
     fn create_mem() -> GuestMemoryMmap {
-        GuestMemoryMmap::anonymous(
-            [(GuestAddress(0), MEM_LEN)].into_iter(),
-            true,
-            HugePageConfig::None,
+        GuestMemoryMmap::from_regions(
+            memory::anonymous(
+                [(GuestAddress(0), MEM_LEN)].into_iter(),
+                true,
+                HugePageConfig::None,
+            )
+            .unwrap(),
         )
         .unwrap()
     }

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -22,7 +22,7 @@ use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
 pub enum PersistError {
     /// Snapshot state contains invalid queue info.
     InvalidInput,
-    /// Could not restore queue.
+    /// Could not restore queue: {0}
     QueueConstruction(QueueError),
 }
 

--- a/src/vmm/src/devices/virtio/vhost_user.rs
+++ b/src/vmm/src/devices/virtio/vhost_user.rs
@@ -468,14 +468,18 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::test_utils::create_tmp_socket;
-    use crate::vstate::memory::{GuestAddress, GuestMemoryExtension};
+    use crate::vstate::memory;
+    use crate::vstate::memory::GuestAddress;
 
     pub(crate) fn create_mem(file: File, regions: &[(GuestAddress, usize)]) -> GuestMemoryMmap {
-        GuestMemoryMmap::create(
-            regions.iter().copied(),
-            libc::MAP_PRIVATE,
-            Some(file),
-            false,
+        GuestMemoryMmap::from_regions(
+            memory::create(
+                regions.iter().copied(),
+                libc::MAP_PRIVATE,
+                Some(file),
+                false,
+            )
+            .unwrap(),
         )
         .unwrap()
     }

--- a/src/vmm/src/devices/virtio/vhost_user.rs
+++ b/src/vmm/src/devices/virtio/vhost_user.rs
@@ -459,14 +459,26 @@ impl<T: VhostUserHandleBackend> VhostUserHandleImpl<T> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
+
+    use std::fs::File;
 
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
     use crate::test_utils::create_tmp_socket;
     use crate::vstate::memory::{GuestAddress, GuestMemoryExtension};
+
+    pub(crate) fn create_mem(file: File, regions: &[(GuestAddress, usize)]) -> GuestMemoryMmap {
+        GuestMemoryMmap::create(
+            regions.iter().copied(),
+            libc::MAP_PRIVATE,
+            Some(file),
+            false,
+        )
+        .unwrap()
+    }
 
     #[test]
     fn test_new() {
@@ -763,9 +775,7 @@ mod tests {
             (GuestAddress(0x10000), region_size),
         ];
 
-        let guest_memory =
-            GuestMemoryMmap::create(regions.into_iter(), libc::MAP_PRIVATE, Some(file), false)
-                .unwrap();
+        let guest_memory = create_mem(file, &regions);
 
         vuh.update_mem_table(&guest_memory).unwrap();
 
@@ -879,9 +889,7 @@ mod tests {
         file.set_len(region_size as u64).unwrap();
         let regions = vec![(GuestAddress(0x0), region_size)];
 
-        let guest_memory =
-            GuestMemoryMmap::create(regions.into_iter(), libc::MAP_PRIVATE, Some(file), false)
-                .unwrap();
+        let guest_memory = create_mem(file, &regions);
 
         let mut queue = Queue::new(69);
         queue.initialize(&guest_memory).unwrap();

--- a/src/vmm/src/gdb/arch/aarch64.rs
+++ b/src/vmm/src/gdb/arch/aarch64.rs
@@ -63,7 +63,9 @@ const PTE_ADDRESS_MASK: u64 = !0b111u64;
 /// Read a u64 value from a guest memory address
 fn read_address(vmm: &Vmm, address: u64) -> Result<u64, GdbTargetError> {
     let mut buf = [0; 8];
-    vmm.guest_memory.read(&mut buf, GuestAddress(address))?;
+    vmm.vm
+        .guest_memory()
+        .read(&mut buf, GuestAddress(address))?;
 
     Ok(u64::from_le_bytes(buf))
 }

--- a/src/vmm/src/gdb/target.rs
+++ b/src/vmm/src/gdb/target.rs
@@ -399,7 +399,8 @@ impl MultiThreadBase for FirecrackerTarget {
                 GUEST_PAGE_SIZE - (u64_to_usize(gpa) & (GUEST_PAGE_SIZE - 1)),
             );
 
-            vmm.guest_memory
+            vmm.vm
+                .guest_memory()
                 .read(&mut data[..read_len], GuestAddress(gpa as u64))
                 .map_err(|e| {
                     error!("Error reading memory {e:?} gpa is {gpa}");
@@ -433,7 +434,8 @@ impl MultiThreadBase for FirecrackerTarget {
                 GUEST_PAGE_SIZE - (u64_to_usize(gpa) & (GUEST_PAGE_SIZE - 1)),
             );
 
-            vmm.guest_memory
+            vmm.vm
+                .guest_memory()
                 .write(&data[..write_len], GuestAddress(gpa))
                 .map_err(|e| {
                     error!("Error {e:?} writing memory at {gpa:#X}");

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -151,9 +151,7 @@ use crate::rate_limiter::BucketUpdate;
 use crate::snapshot::Persist;
 use crate::utils::u64_to_usize;
 use crate::vmm_config::instance_info::{InstanceInfo, VmState};
-use crate::vstate::memory::{
-    GuestMemory, GuestMemoryExtension, GuestMemoryMmap, GuestMemoryRegion,
-};
+use crate::vstate::memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 use crate::vstate::vcpu::VcpuState;
 pub use crate::vstate::vcpu::{Vcpu, VcpuConfig, VcpuEvent, VcpuHandle, VcpuResponse};
 pub use crate::vstate::vm::Vm;
@@ -520,12 +518,10 @@ impl Vmm {
         };
         let device_states = self.mmio_device_manager.save();
 
-        let memory_state = self.vm.guest_memory().describe();
         let acpi_dev_state = self.acpi_device_manager.save();
 
         Ok(MicrovmState {
             vm_info: vm_info.clone(),
-            memory_state,
             kvm_state,
             vm_state,
             vcpu_states,

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -220,7 +220,7 @@ fn snapshot_memory_to_file(
         .map_err(|err| MemoryBackingFile("open", err))?;
 
     // Determine what size our total memory area is.
-    let mem_size_mib = mem_size_mib(&vmm.guest_memory);
+    let mem_size_mib = mem_size_mib(vmm.vm.guest_memory());
     let expected_size = mem_size_mib * 1024 * 1024;
 
     if file_existed {
@@ -249,15 +249,16 @@ fn snapshot_memory_to_file(
     match snapshot_type {
         SnapshotType::Diff => {
             let dirty_bitmap = vmm.get_dirty_bitmap().map_err(DirtyBitmap)?;
-            vmm.guest_memory
+            vmm.vm
+                .guest_memory()
                 .dump_dirty(&mut file, &dirty_bitmap)
                 .map_err(Memory)
         }
         SnapshotType::Full => {
-            let dump_res = vmm.guest_memory.dump(&mut file).map_err(Memory);
+            let dump_res = vmm.vm.guest_memory().dump(&mut file).map_err(Memory);
             if dump_res.is_ok() {
                 vmm.reset_dirty_bitmap();
-                vmm.guest_memory.reset_dirty();
+                vmm.vm.guest_memory().reset_dirty();
             }
 
             dump_res
@@ -273,7 +274,7 @@ fn snapshot_memory_to_file(
         .for_each_virtio_device(|_, _, _, dev| {
             let d = dev.lock().unwrap();
             if d.is_activated() {
-                d.mark_queue_memory_dirty(&vmm.guest_memory)
+                d.mark_queue_memory_dirty(vmm.vm.guest_memory())
             } else {
                 Ok(())
             }
@@ -754,7 +755,7 @@ mod tests {
         assert!(states.vsock_device.is_some());
         assert!(states.balloon_device.is_some());
 
-        let memory_state = vmm.guest_memory.describe();
+        let memory_state = vmm.vm.guest_memory().describe();
         let vcpu_states = vec![VcpuState::default()];
         #[cfg(target_arch = "aarch64")]
         let mpidrs = construct_kvm_mpidrs(&vcpu_states);

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -535,7 +535,8 @@ fn guest_memory_from_file(
     track_dirty_pages: bool,
 ) -> Result<GuestMemoryMmap, GuestMemoryFromFileError> {
     let mem_file = File::open(mem_file_path)?;
-    let guest_mem = GuestMemoryMmap::snapshot_file(mem_file, mem_state, track_dirty_pages)?;
+    let guest_mem =
+        GuestMemoryMmap::snapshot_file(mem_file, mem_state.regions(), track_dirty_pages)?;
     Ok(guest_mem)
 }
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -134,15 +134,15 @@ pub enum MicrovmStateError {
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum CreateSnapshotError {
     /// Cannot get dirty bitmap: {0}
-    DirtyBitmap(vmm_sys_util::errno::Error),
+    DirtyBitmap(#[from] vmm_sys_util::errno::Error),
     /// Cannot write memory file: {0}
-    Memory(MemoryError),
+    Memory(#[from] MemoryError),
     /// Cannot perform {0} on the memory backing file: {1}
     MemoryBackingFile(&'static str, io::Error),
     /// Cannot save the microVM state: {0}
     MicrovmState(MicrovmStateError),
     /// Cannot serialize the microVM state: {0}
-    SerializeMicrovmState(crate::snapshot::SnapshotError),
+    SerializeMicrovmState(#[from] crate::snapshot::SnapshotError),
     /// Cannot perform {0} on the snapshot backing file: {1}
     SnapshotBackingFile(&'static str, io::Error),
 }
@@ -198,9 +198,7 @@ fn snapshot_state_to_file(
         .map_err(|err| SnapshotBackingFile("open", err))?;
 
     let snapshot = Snapshot::new(SNAPSHOT_VERSION);
-    snapshot
-        .save(&mut snapshot_file, microvm_state)
-        .map_err(SerializeMicrovmState)?;
+    snapshot.save(&mut snapshot_file, microvm_state)?;
     snapshot_file
         .flush()
         .map_err(|err| SnapshotBackingFile("flush", err))?;

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -166,6 +166,23 @@ pub fn create_snapshot(
 
     snapshot_memory_to_file(vmm, &params.mem_file_path, params.snapshot_type)?;
 
+    // We need to mark queues as dirty again for all activated devices. The reason we
+    // do it here is because we don't mark pages as dirty during runtime
+    // for queue objects.
+    // SAFETY:
+    // This should never fail as we only mark pages only if device has already been activated,
+    // and the address validation was already performed on device activation.
+    vmm.mmio_device_manager
+        .for_each_virtio_device(|_, _, _, dev| {
+            let d = dev.lock().unwrap();
+            if d.is_activated() {
+                d.mark_queue_memory_dirty(vmm.vm.guest_memory())
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap();
+
     Ok(())
 }
 
@@ -261,22 +278,6 @@ fn snapshot_memory_to_file(
             dump_res
         }
     }?;
-    // We need to mark queues as dirty again for all activated devices. The reason we
-    // do it here is because we don't mark pages as dirty during runtime
-    // for queue objects.
-    // SAFETY:
-    // This should never fail as we only mark pages only if device has already been activated,
-    // and the address validation was already performed on device activation.
-    vmm.mmio_device_manager
-        .for_each_virtio_device(|_, _, _, dev| {
-            let d = dev.lock().unwrap();
-            if d.is_activated() {
-                d.mark_queue_memory_dirty(vmm.vm.guest_memory())
-            } else {
-                Ok(())
-            }
-        })
-        .unwrap();
 
     file.flush()
         .map_err(|err| MemoryBackingFile("flush", err))?;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -456,15 +456,15 @@ impl VmResources {
         // because that would require running a backend process. If in the future we converge to
         // a single way of backing guest memory for vhost-user and non-vhost-user cases,
         // that would not be worth the effort.
+        let regions =
+            crate::arch::arch_memory_regions(mib_to_bytes(self.machine_config.mem_size_mib));
         if vhost_user_device_used {
             GuestMemoryMmap::memfd_backed(
-                self.machine_config.mem_size_mib,
+                regions.as_ref(),
                 self.machine_config.track_dirty_pages,
                 self.machine_config.huge_pages,
             )
         } else {
-            let regions =
-                crate::arch::arch_memory_regions(mib_to_bytes(self.machine_config.mem_size_mib));
             GuestMemoryMmap::anonymous(
                 regions.into_iter(),
                 self.machine_config.track_dirty_pages,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -29,7 +29,8 @@ use crate::vmm_config::metrics::{MetricsConfig, MetricsConfigError, init_metrics
 use crate::vmm_config::mmds::{MmdsConfig, MmdsConfigError};
 use crate::vmm_config::net::*;
 use crate::vmm_config::vsock::*;
-use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryMmap, MemoryError};
+use crate::vstate::memory;
+use crate::vstate::memory::{GuestRegionMmap, MemoryError};
 
 /// Errors encountered when configuring microVM resources.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -440,7 +441,7 @@ impl VmResources {
     ///
     /// If vhost-user-blk devices are in use, allocates memfd-backed shared memory, otherwise
     /// prefers anonymous memory for performance reasons.
-    pub fn allocate_guest_memory(&self) -> Result<GuestMemoryMmap, MemoryError> {
+    pub fn allocate_guest_memory(&self) -> Result<Vec<GuestRegionMmap>, MemoryError> {
         let vhost_user_device_used = self
             .block
             .devices
@@ -459,13 +460,13 @@ impl VmResources {
         let regions =
             crate::arch::arch_memory_regions(mib_to_bytes(self.machine_config.mem_size_mib));
         if vhost_user_device_used {
-            GuestMemoryMmap::memfd_backed(
+            memory::memfd_backed(
                 regions.as_ref(),
                 self.machine_config.track_dirty_pages,
                 self.machine_config.huge_pages,
             )
         } else {
-            GuestMemoryMmap::anonymous(
+            memory::anonymous(
                 regions.into_iter(),
                 self.machine_config.track_dirty_pages,
                 self.machine_config.huge_pages,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -458,7 +458,7 @@ impl VmResources {
         // a single way of backing guest memory for vhost-user and non-vhost-user cases,
         // that would not be worth the effort.
         let regions =
-            crate::arch::arch_memory_regions(mib_to_bytes(self.machine_config.mem_size_mib));
+            crate::arch::arch_memory_regions(0, mib_to_bytes(self.machine_config.mem_size_mib));
         if vhost_user_device_used {
             memory::memfd_backed(
                 regions.as_ref(),

--- a/src/vmm/src/test_utils/mod.rs
+++ b/src/vmm/src/test_utils/mod.rs
@@ -58,11 +58,11 @@ pub fn multi_region_mem_raw(regions: &[(GuestAddress, usize)]) -> Vec<GuestRegio
 /// Creates a [`GuestMemoryMmap`] of the given size with the contained regions laid out in
 /// accordance with the requirements of the architecture on which the tests are being run.
 pub fn arch_mem(mem_size_bytes: usize) -> GuestMemoryMmap {
-    multi_region_mem(&crate::arch::arch_memory_regions(mem_size_bytes))
+    multi_region_mem(&crate::arch::arch_memory_regions(0, mem_size_bytes))
 }
 
 pub fn arch_mem_raw(mem_size_bytes: usize) -> Vec<GuestRegionMmap> {
-    multi_region_mem_raw(&crate::arch::arch_memory_regions(mem_size_bytes))
+    multi_region_mem_raw(&crate::arch::arch_memory_regions(0, mem_size_bytes))
 }
 
 pub fn create_vmm(

--- a/src/vmm/src/test_utils/mod.rs
+++ b/src/vmm/src/test_utils/mod.rs
@@ -15,7 +15,8 @@ use crate::test_utils::mock_resources::{MockBootSourceConfig, MockVmConfig, Mock
 use crate::vmm_config::boot_source::BootSourceConfig;
 use crate::vmm_config::instance_info::InstanceInfo;
 use crate::vmm_config::machine_config::HugePageConfig;
-use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryMmap};
+use crate::vstate::memory;
+use crate::vstate::memory::{GuestMemoryMmap, GuestRegionMmap};
 use crate::{EventManager, Vmm};
 
 pub mod mock_resources;
@@ -26,15 +27,31 @@ pub fn single_region_mem(region_size: usize) -> GuestMemoryMmap {
     single_region_mem_at(0, region_size)
 }
 
+pub fn single_region_mem_raw(region_size: usize) -> Vec<GuestRegionMmap> {
+    single_region_mem_at_raw(0, region_size)
+}
+
 /// Creates a [`GuestMemoryMmap`] with a single region of the given size starting at the given
 /// guest physical address `at` and without dirty tracking.
 pub fn single_region_mem_at(at: u64, size: usize) -> GuestMemoryMmap {
     multi_region_mem(&[(GuestAddress(at), size)])
 }
 
+pub fn single_region_mem_at_raw(at: u64, size: usize) -> Vec<GuestRegionMmap> {
+    multi_region_mem_raw(&[(GuestAddress(at), size)])
+}
+
 /// Creates a [`GuestMemoryMmap`] with multiple regions and without dirty page tracking.
 pub fn multi_region_mem(regions: &[(GuestAddress, usize)]) -> GuestMemoryMmap {
-    GuestMemoryMmap::anonymous(regions.iter().copied(), false, HugePageConfig::None)
+    GuestMemoryMmap::from_regions(
+        memory::anonymous(regions.iter().copied(), false, HugePageConfig::None)
+            .expect("Cannot initialize memory"),
+    )
+    .unwrap()
+}
+
+pub fn multi_region_mem_raw(regions: &[(GuestAddress, usize)]) -> Vec<GuestRegionMmap> {
+    memory::anonymous(regions.iter().copied(), false, HugePageConfig::None)
         .expect("Cannot initialize memory")
 }
 
@@ -42,6 +59,10 @@ pub fn multi_region_mem(regions: &[(GuestAddress, usize)]) -> GuestMemoryMmap {
 /// accordance with the requirements of the architecture on which the tests are being run.
 pub fn arch_mem(mem_size_bytes: usize) -> GuestMemoryMmap {
     multi_region_mem(&crate::arch::arch_memory_regions(mem_size_bytes))
+}
+
+pub fn arch_mem_raw(mem_size_bytes: usize) -> Vec<GuestRegionMmap> {
+    multi_region_mem_raw(&crate::arch::arch_memory_regions(mem_size_bytes))
 }
 
 pub fn create_vmm(

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -227,7 +227,7 @@ impl GuestMemoryExtension for GuestMemoryMmap {
         let mut writer_offset = 0;
         let page_size = get_page_size().map_err(MemoryError::PageSize)?;
 
-        let write_result = self.iter().enumerate().try_for_each(|(slot, region)| {
+        let write_result = self.iter().zip(0..).try_for_each(|(region, slot)| {
             let kvm_bitmap = dirty_bitmap.get(&slot).unwrap();
             let firecracker_bitmap = region.bitmap();
             let mut write_size = 0;
@@ -291,7 +291,7 @@ impl GuestMemoryExtension for GuestMemoryMmap {
 
     /// Stores the dirty bitmap inside into the internal bitmap
     fn store_dirty_bitmap(&self, dirty_bitmap: &DirtyBitmap, page_size: usize) {
-        self.iter().enumerate().for_each(|(slot, region)| {
+        self.iter().zip(0..).for_each(|(region, slot)| {
             let kvm_bitmap = dirty_bitmap.get(&slot).unwrap();
             let firecracker_bitmap = region.bitmap();
 

--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -958,7 +958,7 @@ pub(crate) mod tests {
         entry_addr.kernel_load
     }
 
-    fn vcpu_configured_for_boot() -> (VcpuHandle, EventFd) {
+    fn vcpu_configured_for_boot() -> (Vm, VcpuHandle, EventFd) {
         Vcpu::register_kick_signal_handler();
         // Need enough mem to boot linux.
         let mem_size = mib_to_bytes(64);
@@ -1013,7 +1013,7 @@ pub(crate) mod tests {
         // Wait for vCPUs to initialize their TLS before moving forward.
         barrier.wait();
 
-        (vcpu_handle, vcpu_exit_evt)
+        (vm, vcpu_handle, vcpu_exit_evt)
     }
 
     #[test]
@@ -1147,7 +1147,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_vcpu_pause_resume() {
-        let (vcpu_handle, vcpu_exit_evt) = vcpu_configured_for_boot();
+        let (_vm, vcpu_handle, vcpu_exit_evt) = vcpu_configured_for_boot();
 
         // Queue a Resume event, expect a response.
         queue_event_expect_response(&vcpu_handle, VcpuEvent::Resume, VcpuResponse::Resumed);
@@ -1179,7 +1179,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_vcpu_save_state_events() {
-        let (vcpu_handle, _vcpu_exit_evt) = vcpu_configured_for_boot();
+        let (_vm, vcpu_handle, _vcpu_exit_evt) = vcpu_configured_for_boot();
 
         // Queue a Resume event, expect a response.
         queue_event_expect_response(&vcpu_handle, VcpuEvent::Resume, VcpuResponse::Resumed);
@@ -1212,7 +1212,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_vcpu_dump_cpu_config() {
-        let (vcpu_handle, _) = vcpu_configured_for_boot();
+        let (_vm, vcpu_handle, _) = vcpu_configured_for_boot();
 
         // Queue a DumpCpuConfig event, expect a DumpedCpuConfig response.
         vcpu_handle

--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -784,7 +784,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_handle_kvm_exit() {
-        let (_, _, mut vcpu, _vm_mem) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu) = setup_vcpu(0x1000);
         let res = handle_kvm_exit(&mut vcpu.kvm_vcpu.peripherals, Ok(VcpuExit::Hlt));
         assert_eq!(res.unwrap(), VcpuEmulation::Stopped);
 
@@ -919,8 +919,8 @@ pub(crate) mod tests {
 
     // Auxiliary function being used throughout the tests.
     #[allow(unused_mut)]
-    pub(crate) fn setup_vcpu(mem_size: usize) -> (Kvm, Vm, Vcpu, GuestMemoryMmap) {
-        let (kvm, mut vm, gm) = setup_vm_with_memory(mem_size);
+    pub(crate) fn setup_vcpu(mem_size: usize) -> (Kvm, Vm, Vcpu) {
+        let (kvm, mut vm) = setup_vm_with_memory(mem_size);
 
         let (mut vcpus, _) = vm.create_vcpus(1).unwrap();
         let mut vcpu = vcpus.remove(0);
@@ -928,7 +928,7 @@ pub(crate) mod tests {
         #[cfg(target_arch = "aarch64")]
         vcpu.kvm_vcpu.init(&[]).unwrap();
 
-        (kvm, vm, vcpu, gm)
+        (kvm, vm, vcpu)
     }
 
     fn load_good_kernel(vm_memory: &GuestMemoryMmap) -> GuestAddress {
@@ -958,17 +958,17 @@ pub(crate) mod tests {
         entry_addr.kernel_load
     }
 
-    fn vcpu_configured_for_boot() -> (VcpuHandle, EventFd, GuestMemoryMmap) {
+    fn vcpu_configured_for_boot() -> (VcpuHandle, EventFd) {
         Vcpu::register_kick_signal_handler();
         // Need enough mem to boot linux.
         let mem_size = mib_to_bytes(64);
-        let (kvm, _, mut vcpu, vm_mem) = setup_vcpu(mem_size);
+        let (kvm, vm, mut vcpu) = setup_vcpu(mem_size);
 
         let vcpu_exit_evt = vcpu.exit_evt.try_clone().unwrap();
 
         // Needs a kernel since we'll actually run this vcpu.
         let entry_point = EntryPoint {
-            entry_addr: load_good_kernel(&vm_mem),
+            entry_addr: load_good_kernel(vm.guest_memory()),
             protocol: BootProtocol::LinuxBoot,
         };
 
@@ -977,7 +977,7 @@ pub(crate) mod tests {
             use crate::cpu_config::x86_64::cpuid::Cpuid;
             vcpu.kvm_vcpu
                 .configure(
-                    &vm_mem,
+                    vm.guest_memory(),
                     entry_point,
                     &VcpuConfig {
                         vcpu_count: 1,
@@ -994,7 +994,7 @@ pub(crate) mod tests {
         #[cfg(target_arch = "aarch64")]
         vcpu.kvm_vcpu
             .configure(
-                &vm_mem,
+                vm.guest_memory(),
                 entry_point,
                 &VcpuConfig {
                     vcpu_count: 1,
@@ -1013,12 +1013,12 @@ pub(crate) mod tests {
         // Wait for vCPUs to initialize their TLS before moving forward.
         barrier.wait();
 
-        (vcpu_handle, vcpu_exit_evt, vm_mem)
+        (vcpu_handle, vcpu_exit_evt)
     }
 
     #[test]
     fn test_set_mmio_bus() {
-        let (_, _, mut vcpu, _) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu) = setup_vcpu(0x1000);
         assert!(vcpu.kvm_vcpu.peripherals.mmio_bus.is_none());
         vcpu.set_mmio_bus(crate::devices::Bus::new());
         assert!(vcpu.kvm_vcpu.peripherals.mmio_bus.is_some());
@@ -1026,7 +1026,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_vcpu_tls() {
-        let (_, _, mut vcpu, _mem) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu) = setup_vcpu(0x1000);
 
         // Running on the TLS vcpu should fail before we actually initialize it.
         unsafe {
@@ -1057,7 +1057,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_invalid_tls() {
-        let (_, _, mut vcpu, _) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu) = setup_vcpu(0x1000);
         // Initialize vcpu TLS.
         vcpu.init_thread_local_data().unwrap();
         // Trying to initialize non-empty TLS should error.
@@ -1067,7 +1067,7 @@ pub(crate) mod tests {
     #[test]
     fn test_vcpu_kick() {
         Vcpu::register_kick_signal_handler();
-        let (_, vm, mut vcpu, _mem) = setup_vcpu(0x1000);
+        let (_, vm, mut vcpu) = setup_vcpu(0x1000);
 
         let mut kvm_run =
             kvm_ioctls::KvmRunWrapper::mmap_from_fd(&vcpu.kvm_vcpu.fd, vm.fd().run_size())
@@ -1122,7 +1122,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_immediate_exit_shortcircuits_execution() {
-        let (_, _, mut vcpu, _mem) = setup_vcpu(0x1000);
+        let (_, _, mut vcpu) = setup_vcpu(0x1000);
 
         vcpu.kvm_vcpu.fd.set_kvm_immediate_exit(1);
         // Set a dummy value to be returned by the emulate call
@@ -1147,7 +1147,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_vcpu_pause_resume() {
-        let (vcpu_handle, vcpu_exit_evt, _mem) = vcpu_configured_for_boot();
+        let (vcpu_handle, vcpu_exit_evt) = vcpu_configured_for_boot();
 
         // Queue a Resume event, expect a response.
         queue_event_expect_response(&vcpu_handle, VcpuEvent::Resume, VcpuResponse::Resumed);
@@ -1179,7 +1179,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_vcpu_save_state_events() {
-        let (vcpu_handle, _vcpu_exit_evt, _mem) = vcpu_configured_for_boot();
+        let (vcpu_handle, _vcpu_exit_evt) = vcpu_configured_for_boot();
 
         // Queue a Resume event, expect a response.
         queue_event_expect_response(&vcpu_handle, VcpuEvent::Resume, VcpuResponse::Resumed);
@@ -1212,7 +1212,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_vcpu_dump_cpu_config() {
-        let (vcpu_handle, _, _mem) = vcpu_configured_for_boot();
+        let (vcpu_handle, _) = vcpu_configured_for_boot();
 
         // Queue a DumpCpuConfig event, expect a DumpedCpuConfig response.
         vcpu_handle

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -261,13 +261,11 @@ impl Vm {
 
         match snapshot_type {
             SnapshotType::Diff => {
-                let dirty_bitmap = self.get_dirty_bitmap().map_err(DirtyBitmap)?;
-                self.guest_memory()
-                    .dump_dirty(&mut file, &dirty_bitmap)
-                    .map_err(Memory)
+                let dirty_bitmap = self.get_dirty_bitmap()?;
+                self.guest_memory().dump_dirty(&mut file, &dirty_bitmap)
             }
             SnapshotType::Full => {
-                let dump_res = self.guest_memory().dump(&mut file).map_err(Memory);
+                let dump_res = self.guest_memory().dump(&mut file);
                 if dump_res.is_ok() {
                     self.reset_dirty_bitmap();
                     self.guest_memory().reset_dirty();

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -262,18 +262,14 @@ impl Vm {
         match snapshot_type {
             SnapshotType::Diff => {
                 let dirty_bitmap = self.get_dirty_bitmap()?;
-                self.guest_memory().dump_dirty(&mut file, &dirty_bitmap)
+                self.guest_memory().dump_dirty(&mut file, &dirty_bitmap)?;
             }
             SnapshotType::Full => {
-                let dump_res = self.guest_memory().dump(&mut file);
-                if dump_res.is_ok() {
-                    self.reset_dirty_bitmap();
-                    self.guest_memory().reset_dirty();
-                }
-
-                dump_res
+                self.guest_memory().dump(&mut file)?;
+                self.reset_dirty_bitmap();
+                self.guest_memory().reset_dirty();
             }
-        }?;
+        };
 
         file.flush()
             .map_err(|err| MemoryBackingFile("flush", err))?;

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -25,7 +25,8 @@ pub struct VmCommon {
     /// The KVM file descriptor used to access this Vm.
     pub fd: VmFd,
     max_memslots: usize,
-    guest_memory: GuestMemoryMmap,
+    /// The guest memory of this Vm.
+    pub guest_memory: GuestMemoryMmap,
 }
 
 /// Errors associated with the wrappers over KVM ioctls.

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -14,8 +14,6 @@ use vmm::rpc_interface::{
 };
 use vmm::seccomp::get_empty_filters;
 use vmm::snapshot::Snapshot;
-#[cfg(target_arch = "x86_64")]
-use vmm::test_utils::dirty_tracking_vmm;
 use vmm::test_utils::mock_resources::{MockVmResources, NOISY_KERNEL_IMAGE};
 use vmm::test_utils::{create_vmm, default_vmm, default_vmm_no_boot};
 use vmm::vmm_config::balloon::BalloonDeviceConfig;
@@ -112,8 +110,13 @@ fn test_dirty_bitmap_error() {
     // with errno 2 (ENOENT) because KVM can't find any guest memory regions with dirty
     // page tracking enabled.
     assert_eq!(
-        format!("{:?}", vmm.lock().unwrap().get_dirty_bitmap().err()),
-        "Some(DirtyBitmap(Error(2)))"
+        vmm.lock()
+            .unwrap()
+            .vm
+            .get_dirty_bitmap()
+            .unwrap_err()
+            .errno(),
+        2
     );
     vmm.lock().unwrap().stop(FcExitCode::Ok);
 }
@@ -122,11 +125,11 @@ fn test_dirty_bitmap_error() {
 #[cfg(target_arch = "x86_64")]
 fn test_dirty_bitmap_success() {
     // The vmm will start with dirty page tracking = ON.
-    let (vmm, _) = dirty_tracking_vmm(Some(NOISY_KERNEL_IMAGE));
+    let (vmm, _) = vmm::test_utils::dirty_tracking_vmm(Some(NOISY_KERNEL_IMAGE));
 
     // Let it churn for a while and dirty some pages...
     thread::sleep(Duration::from_millis(100));
-    let bitmap = vmm.lock().unwrap().get_dirty_bitmap().unwrap();
+    let bitmap = vmm.lock().unwrap().vm.get_dirty_bitmap().unwrap();
     let num_dirty_pages: u32 = bitmap
         .values()
         .map(|bitmap_per_region| {

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -299,7 +299,7 @@ fn test_snapshot_load_sanity_checks() {
     snapshot_state_sanity_check(&microvm_state).unwrap();
 
     // Remove memory regions.
-    microvm_state.memory_state.regions.clear();
+    microvm_state.vm_state.memory.regions.clear();
 
     // Validate sanity checks fail because there is no mem region in state.
     assert_eq!(


### PR DESCRIPTION
## Changes

Move the `GuestMemoryMmap` that keeps track of a Firecracker VM's memory regions into `struct Vm`, from `struct Vmm`, and then update some related functionality (such as various snapshot helper functions) to operate on `struct Vm` instead of `struct Vmm`.

## Reason

So far, Firecracker always dealt with a single collection of homogeneous guest memory regions. However, #5108 introduces a second type of memory regions, which makes the set of memory regions heterogeneous, and other features, such as virtio-pmem support, will come with similar "special" memory regions. By moving the guest memory management into `Vm`, we encapsule this heterogeneity and allow incremental building of guest memory configuration.

Admittedly, there's nothing _right now_ that would benefit from this refactor (it doesn't even reduce LoC :cry:), but it will most certainly make life on the feature branch easier to not have to continuously rebase this :sweat_smile: 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
