### PR TITLE
fix(test): cleanup snapshot files better

### DIFF
--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -92,9 +92,9 @@ def test_valid_handler(uvm_plain, snapshot):
     vm.spawn()
 
     # Spawn page fault handler process.
-    pf_handler = spawn_pf_handler(vm, uffd_handler("on_demand"), snapshot.mem)
+    spawn_pf_handler(vm, uffd_handler("on_demand"), snapshot)
 
-    vm.restore_from_snapshot(snapshot, resume=True, uffd_path=pf_handler.socket_path)
+    vm.restore_from_snapshot(resume=True)
 
     # Inflate balloon.
     vm.api.balloon.patch(amount_mib=200)
@@ -125,15 +125,13 @@ def test_malicious_handler(uvm_plain, snapshot):
     vm.spawn()
 
     # Spawn page fault handler process.
-    pf_handler = spawn_pf_handler(vm, uffd_handler("malicious"), snapshot.mem)
+    spawn_pf_handler(vm, uffd_handler("malicious"), snapshot)
 
     # We expect Firecracker to freeze while resuming from a snapshot
     # due to the malicious handler's unavailability.
     try:
         with Timeout(seconds=30):
-            vm.restore_from_snapshot(
-                snapshot, resume=True, uffd_path=pf_handler.socket_path
-            )
+            vm.restore_from_snapshot(resume=True)
             assert False, "Firecracker should freeze"
     except (TimeoutError, requests.exceptions.ReadTimeout):
         pass

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -93,9 +93,9 @@ def test_hugetlbfs_snapshot(microvm_factory, guest_kernel_linux_5_10, rootfs):
     vm.spawn()
 
     # Spawn page fault handler process.
-    pf_handler = spawn_pf_handler(vm, uffd_handler("on_demand"), snapshot.mem)
+    spawn_pf_handler(vm, uffd_handler("on_demand"), snapshot)
 
-    vm.restore_from_snapshot(snapshot, resume=True, uffd_path=pf_handler.socket_path)
+    vm.restore_from_snapshot(resume=True)
 
     check_hugetlbfs_in_use(vm.firecracker_pid, "/anon_hugepage")
 
@@ -135,11 +135,9 @@ def test_hugetlbfs_diff_snapshot(microvm_factory, uvm_plain):
     vm.spawn()
 
     # Spawn page fault handler process.
-    pf_handler = spawn_pf_handler(vm, uffd_handler("on_demand"), snapshot_merged.mem)
+    spawn_pf_handler(vm, uffd_handler("on_demand"), snapshot_merged)
 
-    vm.restore_from_snapshot(
-        snapshot_merged, resume=True, uffd_path=pf_handler.socket_path
-    )
+    vm.restore_from_snapshot(resume=True)
 
     # Verify if the restored microvm works.
 
@@ -195,12 +193,10 @@ def test_ept_violation_count(
     vm.spawn()
 
     # Spawn page fault handler process.
-    pf_handler = spawn_pf_handler(vm, uffd_handler("fault_all"), snapshot.mem)
+    spawn_pf_handler(vm, uffd_handler("fault_all"), snapshot)
 
     with ftrace_events("kvm:*"):
-        vm.restore_from_snapshot(
-            snapshot, resume=True, uffd_path=pf_handler.socket_path
-        )
+        vm.restore_from_snapshot(resume=True)
 
         # Verify if guest can run commands, and also wake up the fast page fault helper to trigger page faults.
         vm.ssh.check_output(f"kill -s {signal.SIGUSR1} {pid}")


### PR DESCRIPTION
It turns out that some of our snapshot tests are not exactly exemplary at cleaning up snapshot memory files after they're done. This is partly because Microvm.restore_from_snapshot was largely oblivious to the fact that if a snapshot is uffd-restored, it doesn't need to be copied into the jail _again_ for mmaping that will never happen, and also due to me messing up the build_n_from_snapshot function and not cleaning up snapshots in "incremental" mode.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
