### PR TITLE
Add Steal Time support in ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- [#5139](https://github.com/firecracker-microvm/firecracker/pull/5139): Added
+  support for [PVTime](https://docs.kernel.org/virt/kvm/arm/pvtime.html). This
+  is used to support steal time on ARM machines.
 - [#5048](https://github.com/firecracker-microvm/firecracker/pull/5048): Added
   support for [PVH boot mode](docs/pvh.md). This is used when an x86 kernel
   provides the appropriate ELF Note to indicate that PVH boot mode is supported.

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -148,7 +148,7 @@ pub enum CreateSnapshotError {
 }
 
 /// Snapshot version
-pub const SNAPSHOT_VERSION: Version = Version::new(6, 0, 0);
+pub const SNAPSHOT_VERSION: Version = Version::new(7, 0, 0);
 
 /// Creates a Microvm snapshot.
 pub fn create_snapshot(

--- a/tests/integration_tests/functional/test_steal_time.py
+++ b/tests/integration_tests/functional/test_steal_time.py
@@ -1,0 +1,121 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for verifying the PVTime device behavior under contention and across snapshots."""
+
+import time
+
+import pytest
+
+from framework.properties import global_props
+
+
+def get_steal_time_ms(vm):
+    """Returns total steal time of vCPUs in VM in milliseconds"""
+    _, out, _ = vm.ssh.run("grep -w '^cpu' /proc/stat")
+    steal_time_tck = int(out.strip().split()[8])
+    clk_tck = int(vm.ssh.run("getconf CLK_TCK").stdout)
+    return steal_time_tck / clk_tck * 1000
+
+
+@pytest.mark.skipif(
+    global_props.cpu_architecture != "aarch64", reason="Only run in aarch64"
+)
+def test_guest_has_pvtime_enabled(uvm_plain):
+    """
+    Check that the guest kernel has enabled PV steal time.
+    """
+    vm = uvm_plain
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+    vm.start()
+
+    _, stdout, _ = vm.ssh.run("dmesg | grep 'stolen time PV'")
+    assert (
+        "stolen time PV" in stdout
+    ), "Guest kernel did not report PV steal time enabled"
+
+
+def test_pvtime_steal_time_increases(uvm_plain):
+    """
+    Test that PVTime steal time increases when both vCPUs are contended on the same pCPU.
+    """
+    vm = uvm_plain
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+    vm.start()
+
+    # Pin both vCPUs to the same physical CPU to induce contention
+    vm.pin_vcpu(0, 0)
+    vm.pin_vcpu(1, 0)
+
+    # Start two infinite loops to hog CPU time
+    hog_cmd = "nohup bash -c 'while true; do :; done' >/dev/null 2>&1 &"
+    vm.ssh.run(hog_cmd)
+    vm.ssh.run(hog_cmd)
+
+    # Measure before and after steal time
+    steal_before = get_steal_time_ms(vm)
+    time.sleep(2)
+    steal_after = get_steal_time_ms(vm)
+
+    # Require increase in steal time
+    assert (
+        steal_after > steal_before
+    ), f"Steal time did not increase as expected. Before: {steal_before}, After: {steal_after}"
+
+
+def test_pvtime_snapshot(uvm_plain, microvm_factory):
+    """
+    Test that PVTime steal time is preserved across snapshot/restore
+    and continues increasing post-resume.
+    """
+    vm = uvm_plain
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+    vm.start()
+
+    vm.pin_vcpu(0, 0)
+    vm.pin_vcpu(1, 0)
+
+    hog_cmd = "nohup bash -c 'while true; do :; done' >/dev/null 2>&1 &"
+    vm.ssh.run(hog_cmd)
+    vm.ssh.run(hog_cmd)
+
+    # Snapshot pre-steal time
+    steal_before = get_steal_time_ms(vm)
+
+    snapshot = vm.snapshot_full()
+    vm.kill()
+
+    # Restore microVM from snapshot and resume
+    restored_vm = microvm_factory.build()
+    restored_vm.spawn()
+    restored_vm.restore_from_snapshot(snapshot, resume=False)
+    snapshot.delete()
+
+    restored_vm.pin_vcpu(0, 0)
+    restored_vm.pin_vcpu(1, 0)
+    restored_vm.resume()
+
+    # Steal time just after restoring
+    steal_after_snap = get_steal_time_ms(restored_vm)
+
+    time.sleep(2)
+
+    # Steal time after running resumed VM
+    steal_after_resume = get_steal_time_ms(restored_vm)
+
+    # Ensure steal time persisted and continued increasing
+    tolerance = 2000  # 2.0 seconds tolerance for persistence check
+    persisted = (
+        steal_before < steal_after_snap and steal_after_snap - steal_before < tolerance
+    )
+    increased = steal_after_resume > steal_after_snap
+
+    assert (
+        persisted and increased
+    ), "Steal time did not persist through snapshot or failed to increase after resume"


### PR DESCRIPTION
Opening this PR as a draft as we continue working on this issue to add steal time support for ARM. Please see below for the changes we have implemented so far.

## Changes

- Added PVTime struct in `src/vmm/src/arch/aarch64/pvtime/mod.rs` that allocates and stores per-vCPU stolen_time regions
  - It offers a `new` constructor to create the device (allocating system memory and storing regions per vcpu), and `register_vcpu` which attempts to use `kvm_set_device_attr` to register the corresponding IPA for a vcpu
- Created a function `setup_pv_time` in `src/vmm/src/builder.rs` which is invoked in `build_microvm_for_boot`
  - Checks if PVTime is supported using `kvm_has_device_attr`
  - Creates a PVTime device
  - Iterates over vcpu fd's to register their IPAs for steal_time struct

- Started using debug/info logs while booting microvm for testing

### Current problems:

 
### Future Progress
- We hope to continue making progress on this PR by:
  - Getting feedback on our current design of the PVTime device and `setup_pv_time`
  - Support snapshotting
  - Any other things we need to address

## Reason

Attempting to resolve issue #4866 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
