### PR TITLE
ci: AL2023 Update install script to support vmlinuz 

### DIFF
--- a/resources/hiding_ci/build_and_install_kernel.sh
+++ b/resources/hiding_ci/build_and_install_kernel.sh
@@ -121,11 +121,14 @@ al2023_update_boot() {
   echo "Creating the new ram disk"
   dracut --kver $KERNEL_VERSION -f -v
 
+  # This varies from x86 and ARM so capture what was generated
+  VM_LINUX_LOCATION=$(ls /boot/vmlinu{x,z}-$KERNEL_VERSION 2>/dev/null | head -n1)
+
   echo "Updating GRUB..."
-  grubby --grub2 --add-kernel /boot/vmlinux-$KERNEL_VERSION \
+  grubby --grub2 --add-kernel $VM_LINUX_LOCATION \
     --title="Secret Hiding" \
     --initrd=/boot/initramfs-$KERNEL_VERSION.img --copy-default
-  grubby --set-default /boot/vmlinux-$KERNEL_VERSION
+  grubby --set-default $VM_LINUX_LOCATION
 }
 
 update_boot_config() {


### PR DESCRIPTION
Updated our install script to support vmlinuz as created by the al2023 make on x86
Signed-off-by: Jack Thomson <jackabt@amazon.com>## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
Update the build script to allow us to install the secret hidden kernels
onto Amazon Linux 2023 instances.

We have to as part of this include a script to download and install ena
drivers for the instance to allow us to boot.

Signed-off-by: Jack Thomson <jackabt@amazon.com>