### PR TITLE
Log API socket creation and API server start + Correct startup time metrics timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ and this project adheres to
   the UFFD Unix domain socket open to prevent the race condition between the
   guest memory mappings message and the shutdown event that was sometimes
   causing arrival of an empty message on the UFFD handler side.
+- [#5143](https://github.com/firecracker-microvm/firecracker/pull/5143): Fixed
+  to report `process_startup_time_us` and `process_startup_time_cpu_us` metrics
+  for `api_server` right after the API server starts, while previously reported
+  before applying seccomp filter and starting the API server. Users may observe
+  a bit longer startup time metrics.
 
 ## [1.11.0]
 

--- a/src/firecracker/src/api_server/mod.rs
+++ b/src/firecracker/src/api_server/mod.rs
@@ -86,6 +86,7 @@ impl ApiServer {
         }
 
         server.start_server().expect("Cannot start HTTP server");
+        info!("API server started.");
 
         loop {
             let request_vec = match server.requests() {

--- a/src/firecracker/src/api_server/mod.rs
+++ b/src/firecracker/src/api_server/mod.rs
@@ -70,11 +70,6 @@ impl ApiServer {
         // Set the api payload size limit.
         server.set_payload_max_size(api_payload_limit);
 
-        // Store process start time metric.
-        process_time_reporter.report_start_time();
-        // Store process CPU start time metric.
-        process_time_reporter.report_cpu_start_time();
-
         // Load seccomp filters on the API thread.
         // Execution panics if filters cannot be loaded, use --no-seccomp if skipping filters
         // altogether is the desired behaviour.
@@ -87,6 +82,11 @@ impl ApiServer {
 
         server.start_server().expect("Cannot start HTTP server");
         info!("API server started.");
+
+        // Store process start time metric.
+        process_time_reporter.report_start_time();
+        // Store process CPU start time metric.
+        process_time_reporter.report_cpu_start_time();
 
         loop {
             let request_vec = match server.requests() {

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use event_manager::{EventOps, Events, MutEventSubscriber, SubscriberOps};
-use vmm::logger::{ProcessTimeReporter, error, warn};
+use vmm::logger::{ProcessTimeReporter, error, info, warn};
 use vmm::resources::VmResources;
 use vmm::rpc_interface::{
     ApiRequest, ApiResponse, BuildMicrovmFromRequestsError, PrebootApiController,
@@ -175,6 +175,7 @@ pub(crate) fn run_with_api(
             return Err(ApiServerError::FailedToBindAndRunHttpServer(err));
         }
     };
+    info!("Listening on API socket ({bind_path:?}).");
 
     let api_kill_switch_clone = api_kill_switch
         .try_clone()


### PR DESCRIPTION
## Changes

- Log API socket creation and API server start.
- Emit startup metrics after server start.

## Reason

We found such logs useful to debug Firecracker startup issues.

The startup time metrics were recorded before applying seccomp filter and starting the API server.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
