### PR TITLE
chore: add Graviton4 instances to the bk pipelines

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -25,6 +25,8 @@ DEFAULT_INSTANCES = [
     "m7a.metal-48xl", # AMD Genoa
     "m6g.metal",      # Graviton2
     "m7g.metal",      # Graviton3
+    "m8g.metal-24xl", # Graviton4 1 socket
+    "m8g.metal-48xl", # Graviton4 2 sockets
 ]
 # fmt: on
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ We test all combinations of:
 | m7a.metal-48xl |                  |              |              |
 | m6g.metal      |                  |              |              |
 | m7g.metal      |                  |              |              |
+| m8g.metal-24xl |                  |              |              |
+| m8g.metal-48xl |                  |              |              |
 
 ## Known issues and Limitations
 


### PR DESCRIPTION
## Changes

Add m8g.metal-24/48xl instances to the instances list used by bk pipelines.

## Reason

It is time to test Graviton4 in all pipelines.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
