### PR TITLE
fix(vmm): Bump snapshot version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to
   Linux kernels newer than 5.0 compiled with `CONFIG_PVH=y` set this ELF Note,
   as do FreeBSD kernels.
 - [#5065](https://github.com/firecracker-microvm/firecracker/pull/5065) Added
-  support for Intel AMX (Advanced Matrix Extensions).
+  support for Intel AMX (Advanced Matrix Extensions). To be able to take and
+  restore a snapshot of Intel AMX state, `Xsave` is used instead of `kvm_xsave`,
+  so users need to regenerate snapshots.
 - [#4731](https://github.com/firecracker-microvm/firecracker/pull/4731): Added
   support for modifying the host TAP device name during snapshot restore.
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -148,7 +148,7 @@ pub enum CreateSnapshotError {
 }
 
 /// Snapshot version
-pub const SNAPSHOT_VERSION: Version = Version::new(5, 0, 0);
+pub const SNAPSHOT_VERSION: Version = Version::new(6, 0, 0);
 
 /// Creates a Microvm snapshot.
 pub fn create_snapshot(


### PR DESCRIPTION

## Changes & Reason

To support the snapshot feature for Intel AMX, we changed to use `Xsave` struct instead of `kvm_xsave` struct. We should have bumped the snapshot version.

Fixes: 803140d8249d ("feat(vmm): Use structs and methods for KVM_CAP_XSAVE2")

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
