### PR TITLE
fix: dont fail silently on awscli errors during artifact setup

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -575,6 +575,7 @@ ensure_ci_artifacts() {
     if [ ! -d "$ARTIFACTS" ]; then
         mkdir -pv $ARTIFACTS
         aws s3 sync --no-sign-request "$S3_URL" "$ARTIFACTS"
+        ok_or_die "Failed to download CI artifacts using awscli!"
         cmd_sh "./tools/setup-ci-artifacts.sh"
     fi
 }


### PR DESCRIPTION
If something goes wrong during aws s3 cp, exit early with an error message instead of quietly trying to soldier on. A common(-ish) cause of something going wrong here is having installed the aws cli for the wrong CPU architecture (e.g. x86 awscli on ARM64), as the awscli installer apparently doesnt not check the architecture, and its easy to copy the wrong command from the website.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
