### PR TITLE
Minor test fixes

### DIFF
--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -774,6 +774,13 @@ pub(crate) mod tests {
 
     use super::*;
 
+    // Define custom refill interval to be a bit bigger. This will help
+    // in tests which wait for a limiter refill in 2 stages. This will make it so
+    // second wait will always result in the limiter being refilled. Otherwise
+    // there is a chance for a race condition between limiter refilling and limiter
+    // checking.
+    const TEST_REFILL_TIMER_INTERVAL_MS: u64 = REFILL_TIMER_INTERVAL_MS + 10;
+
     impl TokenBucket {
         // Resets the token bucket: budget set to max capacity and last-updated set to now.
         fn reset(&mut self) {
@@ -1009,11 +1016,11 @@ pub(crate) mod tests {
         // since consume failed, limiter should be blocked now
         assert!(l.is_blocked());
         // wait half the timer period
-        thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
+        thread::sleep(Duration::from_millis(TEST_REFILL_TIMER_INTERVAL_MS / 2));
         // limiter should still be blocked
         assert!(l.is_blocked());
         // wait the other half of the timer period
-        thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
+        thread::sleep(Duration::from_millis(TEST_REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
         l.event_handler().unwrap();
         // limiter should now be unblocked
@@ -1042,11 +1049,11 @@ pub(crate) mod tests {
         // since consume failed, limiter should be blocked now
         assert!(l.is_blocked());
         // wait half the timer period
-        thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
+        thread::sleep(Duration::from_millis(TEST_REFILL_TIMER_INTERVAL_MS / 2));
         // limiter should still be blocked
         assert!(l.is_blocked());
         // wait the other half of the timer period
-        thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
+        thread::sleep(Duration::from_millis(TEST_REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
         l.event_handler().unwrap();
         // limiter should now be unblocked
@@ -1076,11 +1083,11 @@ pub(crate) mod tests {
         // since consume failed, limiter should be blocked now
         assert!(l.is_blocked());
         // wait half the timer period
-        thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
+        thread::sleep(Duration::from_millis(TEST_REFILL_TIMER_INTERVAL_MS / 2));
         // limiter should still be blocked
         assert!(l.is_blocked());
         // wait the other half of the timer period
-        thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
+        thread::sleep(Duration::from_millis(TEST_REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
         l.event_handler().unwrap();
         // limiter should now be unblocked

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -33,9 +33,11 @@ def get_stable_rss_mem_by_pid(pid, percentage_delta=1):
     first_rss = get_rss_from_pmap()
     time.sleep(1)
     second_rss = get_rss_from_pmap()
-    print(f"RSS readings: {first_rss}, {second_rss}")
     abs_diff = abs(first_rss - second_rss)
     abs_delta = 100 * abs_diff / first_rss
+    print(
+        f"RSS readings: old: {first_rss} new: {second_rss} abs_diff: {abs_diff} abs_delta: {abs_delta}"
+    )
     assert abs_delta < percentage_delta or abs_diff < 2**10
     return second_rss
 


### PR DESCRIPTION
## Changes

Add more print info to the rss check for balloon test and define slightly bigger rate limiter refill interval for unit tests.

## Reason

Less intermediate failures and simpler debugging.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
