### PR TITLE
allow specifying custom cpu template inline in config json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
   so users need to regenerate snapshots.
 - [#4731](https://github.com/firecracker-microvm/firecracker/pull/4731): Added
   support for modifying the host TAP device name during snapshot restore.
+- [#5175](https://github.com/firecracker-microvm/firecracker/pull/5175): Allow
+  including a custom cpu template directly in the json configuration file passed
+  to `--config-file` under the `cpu_config` key.
 
 ### Changed
 


### PR DESCRIPTION
When starting firecracker without the API server and configuring it through a config files, specifying a custom cpu template requires writing this cpu template into a separate json file, and then passing the path to this separate json file in the config json file. This is a bit silly, since everything is just json. So additionally allow just directly specifying the custom cpu template inside the config file.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
