### PR TITLE
[RFC] Remove/hook unused metrics #2901

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test_results/*
 /resources/linux
 /resources/x86_64
 /resources/aarch64
+/src/check_metrics.py

--- a/src/vmm/src/devices/virtio/net/metrics.rs
+++ b/src/vmm/src/devices/virtio/net/metrics.rs
@@ -161,8 +161,6 @@ pub struct NetDeviceMetrics {
     pub rx_queue_event_count: SharedIncMetric,
     /// Number of events associated with the rate limiter installed on the receiving path.
     pub rx_event_rate_limiter_count: SharedIncMetric,
-    /// Number of RX partial writes to guest.
-    pub rx_partial_writes: SharedIncMetric,
     /// Number of RX rate limiter throttling events.
     pub rx_rate_limiter_throttled: SharedIncMetric,
     /// Number of events received on the associated tap.
@@ -233,8 +231,6 @@ impl NetDeviceMetrics {
             .add(other.rx_queue_event_count.fetch_diff());
         self.rx_event_rate_limiter_count
             .add(other.rx_event_rate_limiter_count.fetch_diff());
-        self.rx_partial_writes
-            .add(other.rx_partial_writes.fetch_diff());
         self.rx_rate_limiter_throttled
             .add(other.rx_rate_limiter_throttled.fetch_diff());
         self.rx_tap_event_count

--- a/src/vmm/src/devices/virtio/net/metrics.rs
+++ b/src/vmm/src/devices/virtio/net/metrics.rs
@@ -189,8 +189,6 @@ pub struct NetDeviceMetrics {
     pub tx_count: SharedIncMetric,
     /// Number of transmitted packets.
     pub tx_packets_count: SharedIncMetric,
-    /// Number of TX partial reads from guest.
-    pub tx_partial_reads: SharedIncMetric,
     /// Number of events associated with the transmitting queue.
     pub tx_queue_event_count: SharedIncMetric,
     /// Number of events associated with the rate limiter installed on the transmitting path.
@@ -252,8 +250,6 @@ impl NetDeviceMetrics {
         self.tx_count.add(other.tx_count.fetch_diff());
         self.tx_packets_count
             .add(other.tx_packets_count.fetch_diff());
-        self.tx_partial_reads
-            .add(other.tx_partial_reads.fetch_diff());
         self.tx_queue_event_count
             .add(other.tx_queue_event_count.fetch_diff());
         self.tx_rate_limiter_event_count

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -354,8 +354,6 @@ pub struct ApiServerMetrics {
     pub process_startup_time_us: SharedStoreMetric,
     /// Measures the cpu's startup time in microseconds.
     pub process_startup_time_cpu_us: SharedStoreMetric,
-    /// Number of failures on API requests triggered by internal errors.
-    pub sync_response_fails: SharedIncMetric,
     /// Number of timeouts during communication with the VMM.
     pub sync_vmm_send_timeout_count: SharedIncMetric,
 }

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -354,8 +354,6 @@ pub struct ApiServerMetrics {
     pub process_startup_time_us: SharedStoreMetric,
     /// Measures the cpu's startup time in microseconds.
     pub process_startup_time_cpu_us: SharedStoreMetric,
-    /// Number of timeouts during communication with the VMM.
-    pub sync_vmm_send_timeout_count: SharedIncMetric,
 }
 impl ApiServerMetrics {
     /// Const default construction.
@@ -363,8 +361,6 @@ impl ApiServerMetrics {
         Self {
             process_startup_time_us: SharedStoreMetric::new(),
             process_startup_time_cpu_us: SharedStoreMetric::new(),
-            sync_response_fails: SharedIncMetric::new(),
-            sync_vmm_send_timeout_count: SharedIncMetric::new(),
         }
     }
 }

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -799,8 +799,6 @@ impl VcpuMetrics {
 /// Metrics specific to the machine manager as a whole.
 #[derive(Debug, Default, Serialize)]
 pub struct VmmMetrics {
-    /// Number of device related events received for a VM.
-    pub device_events: SharedIncMetric,
     /// Metric for signaling a panic has occurred.
     pub panic_count: SharedStoreMetric,
 }
@@ -808,7 +806,6 @@ impl VmmMetrics {
     /// Const default construction.
     pub const fn new() -> Self {
         Self {
-            device_events: SharedIncMetric::new(),
             panic_count: SharedStoreMetric::new(),
         }
     }

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -502,15 +502,12 @@ impl PatchRequestsMetrics {
 pub struct DeprecatedApiMetrics {
     /// Total number of calls to deprecated HTTP endpoints.
     pub deprecated_http_api_calls: SharedIncMetric,
-    /// Total number of calls to deprecated CMD line parameters.
-    pub deprecated_cmd_line_api_calls: SharedIncMetric,
 }
 impl DeprecatedApiMetrics {
     /// Const default construction.
     pub const fn new() -> Self {
         Self {
             deprecated_http_api_calls: SharedIncMetric::new(),
-            deprecated_cmd_line_api_calls: SharedIncMetric::new(),
         }
     }
 }

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -521,8 +521,6 @@ pub struct LoggerSystemMetrics {
     pub metrics_fails: SharedIncMetric,
     /// Number of misses on logging human readable content.
     pub missed_log_count: SharedIncMetric,
-    /// Number of errors while trying to log human readable content.
-    pub log_fails: SharedIncMetric,
 }
 impl LoggerSystemMetrics {
     /// Const default construction.
@@ -531,7 +529,6 @@ impl LoggerSystemMetrics {
             missed_metrics_count: SharedIncMetric::new(),
             metrics_fails: SharedIncMetric::new(),
             missed_log_count: SharedIncMetric::new(),
-            log_fails: SharedIncMetric::new(),
         }
     }
 }

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -104,7 +104,6 @@ def validate_fc_metrics(metrics):
         "event_fails",
         "rx_queue_event_count",
         "rx_event_rate_limiter_count",
-        "rx_partial_writes",
         "rx_rate_limiter_throttled",
         "rx_tap_event_count",
         "rx_bytes_count",

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -131,8 +131,6 @@ def validate_fc_metrics(metrics):
         "api_server": [
             "process_startup_time_us",
             "process_startup_time_cpu_us",
-            "sync_response_fails",
-            "sync_vmm_send_timeout_count",
         ],
         "balloon": [
             "activate_fails",

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -143,7 +143,6 @@ def validate_fc_metrics(metrics):
         "block": block_metrics,
         "deprecated_api": [
             "deprecated_http_api_calls",
-            "deprecated_cmd_line_api_calls",
         ],
         "get_api_requests": [
             "instance_info_count",

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -237,7 +237,6 @@ def validate_fc_metrics(metrics):
             {"exit_mmio_write_agg": latency_agg_metrics_fields},
         ],
         "vmm": [
-            "device_events",
             "panic_count",
         ],
         "uart": [

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -174,7 +174,6 @@ def validate_fc_metrics(metrics):
             "missed_metrics_count",
             "metrics_fails",
             "missed_log_count",
-            "log_fails",
         ],
         "mmds": [
             "rx_accepted",

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -117,7 +117,6 @@ def validate_fc_metrics(metrics):
         "tx_fails",
         "tx_count",
         "tx_packets_count",
-        "tx_partial_reads",
         "tx_queue_event_count",
         "tx_rate_limiter_event_count",
         "tx_rate_limiter_throttled",

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -13,7 +13,6 @@ def verify_net_emulation_paused(metrics):
     """Verify net emulation is paused based on provided metrics."""
     net_metrics = metrics["net"]
     assert net_metrics["rx_queue_event_count"] == 0
-    assert net_metrics["rx_partial_writes"] == 0
     assert net_metrics["rx_tap_event_count"] == 0
     assert net_metrics["rx_bytes_count"] == 0
     assert net_metrics["rx_packets_count"] == 0

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -51,6 +51,9 @@ IGNORED = [
     {"fio_engine": "libaio", "metric": "clat_write"},
     # boot time metrics
     {"performance_test": "test_boottime", "metric": "resume_time"},
+    # block throughput on m8g
+    {"fio_engine": "libaio", "vcpus": 2, "instance": "m8g.metal-24xl"},
+    {"fio_engine": "libaio", "vcpus": 2, "instance": "m8g.metal-48xl"},
 ]
 
 


### PR DESCRIPTION
Opening this as a Draft PR

## Changes
Removed unused metrics; used this [script](https://gist.github.com/mdhaduk/97636632806443c0623d77e9d199a831 "script") to generally identify which metrics **might** not be used, then manually removed them 

To identify unused metrics, I used the following convention

For **SharedIncMetric**:

- Not incremented/added to
- Not stored
- Not fetched

For **LatencyAggregateMetrics**:

- Not calling record_latency_metrics

**Metrics Removed**:
- sync_response_fails
- sync_vmm_send_timeout_count
- deprecated_cmd_line_api_calls
- log_fails
- device_events
- rx_partial_writes
- tx_partial_reads

## Reason

Resolving issue #2901 - Remove/hook unused metrics


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
