### PR TITLE
fix: do not error during pytest teardown after test failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,7 +350,7 @@ def microvm_factory(request, record_property, results_dir, netns_factory):
                 if not os.path.isfile(src):
                     continue
                 dst = uvm_data / item
-                shutil.move(src, dst)
+                shutil.copy(src, dst)
                 console_data = uvm.console_data
                 if console_data:
                     uvm_data.joinpath("guest-console.log").write_text(console_data)


### PR DESCRIPTION
During pytest teardown, we explicitly kill all microvms that a test might have left behind. We do this by reading Firecracker's pid file and then SIGKILL-ing the process. However, if a test fails, we also try to upload its entire jail to S3 as buildkite artifacts, for post-mortem analysis. Here, we are moving instead of copying files, to save on disk space. This is a problem though, as the pid file is inside the jail, and this moving happens _before_ the call to .kill() (and has to happen before, as killing a VM cleans up its jail). This leads to duplicate pytest errors every time a test fails: One for the actual failure, and then a second failure from Microvm.kill() due to the pid file not being found.

Fix this by reverting the commit that changed the copy to a move - we copy outside of the RAM disk, so space is not actually a concern

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
