### PR TITLE
Hiding CI install script store kernel config in boot

### DIFF
--- a/resources/hiding_ci/build_and_install_kernel.sh
+++ b/resources/hiding_ci/build_and_install_kernel.sh
@@ -90,6 +90,15 @@ apply_patch_or_series() {
   esac
 }
 
+check_new_config() {
+  if [[ -e "/boot/config-$KERNEL_VERSION" ]]; then
+    return 0;
+  fi
+
+  echo "Storing new config in /boot/config-$KERNEL_VERSION"
+  cp .config /boot/config-$KERNEL_VERSION
+}
+
 check_override_presence() {
   while IFS= read -r line; do
     if ! grep -Fq "$line" .config; then
@@ -208,6 +217,8 @@ echo "Installing kernel..."
 make INSTALL_MOD_STRIP=1 install
 
 update_boot_config
+
+check_new_config
 
 echo "Kernel built and installed successfully!"
 


### PR DESCRIPTION
The install script on amazon linux isn't storing the .config in our boot directory by default. This is causing our spectre checker script which relies on the config. Updated our script to move this if it has't been done so already.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
