### PR TITLE
chore(release): Prepare for v1.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to
   so users need to regenerate snapshots.
 - [#4731](https://github.com/firecracker-microvm/firecracker/pull/4731): Added
   support for modifying the host TAP device name during snapshot restore.
+- [#5146](https://github.com/firecracker-microvm/firecracker/pull/5146): Added
+  Intel Sapphire Rapids as a supported and tested platform for Firecracker.
+- [#5148](https://github.com/firecracker-microvm/firecracker/pull/5148): Added
+  ARM Graviton4 as a supported and tested platform for Firecracker.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.12.0]
 
 ### Added
 
@@ -42,12 +42,10 @@ and this project adheres to
   misnamed, as the value Firecracker sets it to is actually the page size in
   _bytes_, not KiB. It will be removed in Firecracker 2.0.
 
-### Removed
-
 ### Fixed
 
-- #\[[5074](https://github.com/firecracker-microvm/firecracker/pull/5074)\] Fix
-  the `SendCtrlAltDel` command not working for ACPI-enabled guest kernels, by
+- [#5074](https://github.com/firecracker-microvm/firecracker/pull/5074) Fix the
+  `SendCtrlAltDel` command not working for ACPI-enabled guest kernels, by
   dropping the i8042.nopnp argument from the default kernel command line
   Firecracker constructs.
 - [#5122](https://github.com/firecracker-microvm/firecracker/pull/5122): Keep

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -90,8 +90,9 @@ v3.1 will be patched since were the last two Firecracker releases and less than
 
 | Release | Release Date | Latest Patch | Min. end of support | Official end of Support         |
 | ------: | -----------: | -----------: | ------------------: | :------------------------------ |
+|   v1.12 |   2025-05-07 |      v1.12.0 |          2025-11-07 | Supported                       |
 |   v1.11 |   2025-03-18 |      v1.11.0 |          2025-09-18 | Supported                       |
-|   v1.10 |   2024-11-07 |      v1.10.1 |          2025-05-07 | Supported                       |
+|   v1.10 |   2024-11-07 |      v1.10.1 |          2025-05-07 | 2025-05-07 (v1.12 released)     |
 |    v1.9 |   2024-09-02 |       v1.9.1 |          2025-03-02 | 2025-03-18 (v1.11 released)     |
 |    v1.8 |   2024-07-10 |       v1.8.0 |          2025-01-10 | 2025-01-10 (end of 6mo support) |
 |    v1.7 |   2024-03-18 |       v1.7.0 |          2024-09-18 | 2024-09-18 (end of 6mo support) |


### PR DESCRIPTION
## Changes

- Update CHANGELOG with Intel Sapphire Rapids and ARM Graviton4 support declaration.
- Update the release status table

## Reason

We'll make v1.12.0 release tomorrow since v1.10.0 is going to reach EOL tomorrow.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
