### PR TITLE
Fixing VMM & RNG per-device metrics. (Minor Tap fix)

### DIFF
--- a/src/vmm/src/devices/virtio/net/tap.rs
+++ b/src/vmm/src/devices/virtio/net/tap.rs
@@ -241,10 +241,17 @@ pub mod tests {
             generated::ifreq__bindgen_ty_1::default().ifrn_name.len()
         });
 
-        // Empty name - The tap should be named "tap0" by default
+        // Empty name - The tap should be named by the kernel (e.g., "tap0", "tap1", etc.)
         let tap = Tap::open_named("").unwrap();
-        assert_eq!(b"tap0\0\0\0\0\0\0\0\0\0\0\0\0", &tap.if_name);
-        assert_eq!("tap0", tap.if_name_as_str());
+        let tap_name_str = tap.if_name_as_str();
+
+        // Check that it starts with "tap" and the remainder is numeric.
+        assert!(
+            Regex::new(r"^tap\d+$").unwrap().is_match(tap_name_str),
+            "Generated tap name '{}' does not match expected pattern",
+            tap_name_str
+        );
+
 
         // Test using '%d' to have the kernel assign an unused name,
         // and that we correctly copy back that generated name

--- a/src/vmm/src/devices/virtio/rng/metrics.rs
+++ b/src/vmm/src/devices/virtio/rng/metrics.rs
@@ -38,15 +38,62 @@ use serde::{Serialize, Serializer};
 
 use crate::logger::SharedIncMetric;
 
-/// Stores aggregated entropy metrics
-pub(super) static METRICS: EntropyDeviceMetrics = EntropyDeviceMetrics::new();
+use std::sync::{Arc, RwLock};
+use std::collections::BTreeMap;
 
-/// Called by METRICS.flush(), this function facilitates serialization of entropy device metrics.
+/// This function facilitates aggregation and serialization of
+/// per device vsock metrics. (Can also handle singular)
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
-    let mut seq = serializer.serialize_map(Some(1))?;
-    seq.serialize_entry("entropy", &METRICS)?;
+    let entropy_metrics = METRICS.read().unwrap();
+    let metrics_len = entropy_metrics.metrics.len();
+    // +1 to accomodate aggregate net metrics
+    let mut seq = serializer.serialize_map(Some(1 + metrics_len))?;
+
+    let mut entropy_aggregated: EntropyDeviceMetrics = EntropyDeviceMetrics::default();
+
+    for (name, metrics) in entropy_metrics.metrics.iter() {
+        let devn = format!("entropy_{}", name);
+        // serialization will flush the metrics so aggregate before it.
+        let m: &EntropyDeviceMetrics = metrics;
+        entropy_aggregated.aggregate(m);
+        seq.serialize_entry(&devn, m)?;
+    }
+    seq.serialize_entry("entropy", &entropy_aggregated)?;
     seq.end()
 }
+
+pub struct EntropyMetricsPerDevice {
+    pub metrics: BTreeMap<String, Arc<EntropyDeviceMetrics>>
+}
+
+impl EntropyMetricsPerDevice {
+    /// Allocate `NetDeviceMetrics` for net device having
+    /// id `iface_id`. Also, allocate only if it doesn't
+    /// exist to avoid overwriting previously allocated data.
+    /// lock is always initialized so it is safe the unwrap
+    /// the lock without a check.
+    pub fn alloc(iface_id: String) -> Arc<EntropyDeviceMetrics> {
+        Arc::clone(
+            METRICS
+                .write()
+                .unwrap()
+                .metrics
+                .entry(iface_id)
+                .or_insert_with(|| Arc::new(EntropyDeviceMetrics::default())),
+        )
+    }
+}
+
+static METRICS: RwLock<EntropyMetricsPerDevice> = RwLock::new(EntropyMetricsPerDevice {
+    metrics: {
+        let tree = BTreeMap::new();
+        tree.insert(
+            "global".to_string(),
+            Arc::new(EntropyDeviceMetrics::default()),
+        );
+        tree
+    },
+});
 
 #[derive(Debug, Serialize)]
 pub(super) struct EntropyDeviceMetrics {
@@ -86,15 +133,166 @@ pub mod tests {
     use crate::logger::IncMetric;
 
     #[test]
-    fn test_entropy_dev_metrics() {
-        let entropy_metrics: EntropyDeviceMetrics = EntropyDeviceMetrics::new();
-        let entropy_metrics_local: String = serde_json::to_string(&entropy_metrics).unwrap();
-        // the 1st serialize flushes the metrics and resets values to 0 so that
-        // we can compare the values with local metrics.
-        serde_json::to_string(&METRICS).unwrap();
-        let entropy_metrics_global: String = serde_json::to_string(&METRICS).unwrap();
-        assert_eq!(entropy_metrics_local, entropy_metrics_global);
-        entropy_metrics.entropy_event_count.inc();
-        assert_eq!(entropy_metrics.entropy_event_count.count(), 1);
+    fn test_rng_dev_metrics() {
+        drop(METRICS.read().unwrap());
+        drop(METRICS.write().unwrap());
+
+        for i in 0..5 {
+            let devn: String = format!("entropy{}", i);
+            NetMetricsPerDevice::alloc(devn.clone());
+            METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get(&devn)
+                .unwrap()
+                .activate_fails
+                .inc();
+            METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get(&devn)
+                .unwrap()
+                .entropy_bytes
+                .add(10);
+            METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get(&devn)
+                .unwrap()
+                .host_rng_fails
+                .add(5);
+        }
+
+        for i in 0..5 {
+            let devn: String = format!("entropy{}", i);
+            assert!(
+                METRICS
+                    .read()
+                    .unwrap()
+                    .metrics
+                    .get(&devn)
+                    .unwrap()
+                    .activate_fails
+                    .count()
+                    >= 1
+            );
+            assert!(
+                METRICS
+                    .read()
+                    .unwrap()
+                    .metrics
+                    .get(&devn)
+                    .unwrap()
+                    .entropy_bytes
+                    .count()
+                    >= 10
+            );
+            assert_eq!(
+                METRICS
+                    .read()
+                    .unwrap()
+                    .metrics
+                    .get(&devn)
+                    .unwrap()
+                    .host_rng_fails
+                    .count(),
+                5
+            );
+        }
+    }
+
+    #[test]
+    fn test_single_rng_metrics() {
+        // Use eth0 so that we can check thread safety with the
+        // `test_net_dev_metrics` which also uses the same name.
+        let devn = "entropy0";
+
+        drop(METRICS.read().unwrap());
+        drop(METRICS.write().unwrap());
+
+        NetMetricsPerDevice::alloc(String::from(devn));
+        METRICS.read().unwrap().metrics.get(devn).unwrap();
+
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get(devn)
+            .unwrap()
+            .activate_fails
+            .inc();
+        assert!(
+            METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get(devn)
+                .unwrap()
+                .activate_fails
+                .count()
+                > 0,
+            "{}",
+            METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get(devn)
+                .unwrap()
+                .activate_fails
+                .count()
+        );
+        // we expect only 2 tests (this and test_max_net_dev_metrics)
+        // to update activate_fails count for eth0.
+        assert!(
+            METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get(devn)
+                .unwrap()
+                .activate_fails
+                .count()
+                <= 2,
+            "{}",
+            METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get(devn)
+                .unwrap()
+                .activate_fails
+                .count()
+        );
+
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get(devn)
+            .unwrap()
+            .activate_fails
+            .inc();
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get(devn)
+            .unwrap()
+            .entropy_bytes
+            .add(5);
+        assert!(
+            METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get(devn)
+                .unwrap()
+                .entropy_bytes
+                .count()
+                >= 5
+        );
     }
 }

--- a/src/vmm/src/devices/virtio/vsock/metrics.rs
+++ b/src/vmm/src/devices/virtio/vsock/metrics.rs
@@ -41,15 +41,65 @@ use serde::{Serialize, Serializer};
 
 use crate::logger::SharedIncMetric;
 
-/// Stores aggregate metrics of all Vsock connections/actions
-pub(super) static METRICS: VsockDeviceMetrics = VsockDeviceMetrics::new();
+use std::sync::{Arc, RwLock};
+use std::collections::BTreeMap;
 
-/// Called by METRICS.flush(), this function facilitates serialization of vsock device metrics.
+/// Stores aggregate metrics of all Vsock connections/actions
+// pub(super) static METRICS: VsockDeviceMetrics = VsockDeviceMetrics::new();
+
+/// This function facilitates aggregation and serialization of
+/// per device vsock metrics. (Can also handle singular)
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
-    let mut seq = serializer.serialize_map(Some(1))?;
-    seq.serialize_entry("vsock", &METRICS)?;
+    let vsock_metrics = METRICS.read().unwrap();
+    let metrics_len = vsock_metrics.metrics.len();
+    // +1 to accomodate aggregate net metrics
+    let mut seq = serializer.serialize_map(Some(1 + metrics_len))?;
+
+    let mut vsock_aggregated: VsockDeviceMetrics = VsockDeviceMetrics::default();
+
+    for (name, metrics) in vsock_metrics.metrics.iter() {
+        let devn = format!("vsock_{}", name);
+        // serialization will flush the metrics so aggregate before it.
+        let m: &VsockDeviceMetrics = metrics;
+        vsock_aggregated.aggregate(m);
+        seq.serialize_entry(&devn, m)?;
+    }
+    seq.serialize_entry("vsock", &vsock_aggregated)?;
     seq.end()
 }
+
+pub struct VsockMetricsPerDevice {
+    pub metrics: BTreeMap<String, Arc<VsockDeviceMetrics>>
+}
+
+impl VsockMetricsPerDevice {
+    /// Allocate `NetDeviceMetrics` for net device having
+    /// id `iface_id`. Also, allocate only if it doesn't
+    /// exist to avoid overwriting previously allocated data.
+    /// lock is always initialized so it is safe the unwrap
+    /// the lock without a check.
+    pub fn alloc(iface_id: String) -> Arc<VsockDeviceMetrics> {
+        Arc::clone(
+            METRICS
+                .write()
+                .unwrap()
+                .metrics
+                .entry(iface_id)
+                .or_insert_with(|| Arc::new(VsockDeviceMetrics::default())),
+        )
+    }
+}
+
+static METRICS: RwLock<VsockMetricsPerDevice> = RwLock::new(VsockMetricsPerDevice {
+    metrics: {
+        let tree = BTreeMap::new();
+        tree.insert(
+            "global".to_string(),
+            Arc::new(VsockDeviceMetrics::default()),
+        );
+        tree
+    },
+});
 
 /// Vsock-related metrics.
 #[derive(Debug, Serialize)]
@@ -130,16 +180,178 @@ pub mod tests {
     use super::*;
     use crate::logger::IncMetric;
 
+    // Simple test to test ability to handle different devices based on some id
+    // Mimics the behavior and test of per-device structure in network devices.
     #[test]
     fn test_vsock_dev_metrics() {
-        let vsock_metrics: VsockDeviceMetrics = VsockDeviceMetrics::new();
-        let vsock_metrics_local: String = serde_json::to_string(&vsock_metrics).unwrap();
-        // the 1st serialize flushes the metrics and resets values to 0 so that
-        // we can compare the values with local metrics.
-        serde_json::to_string(&METRICS).unwrap();
-        let vsock_metrics_global: String = serde_json::to_string(&METRICS).unwrap();
-        assert_eq!(vsock_metrics_local, vsock_metrics_global);
-        vsock_metrics.conns_added.inc();
-        assert_eq!(vsock_metrics.conns_added.count(), 1);
+        drop(METRICS.read().unwrap());
+        drop(METRICS.write().unwrap());
+
+        for i in 0..3 {
+            let devn: String = format!("vsock{}", i);
+            VsockMetricsPerDevice::alloc(devn.clone());
+            METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get(&devn)
+                .unwrap()
+                .conns_added
+                .inc();
+        }
+        METRICS
+                .read()
+                .unwrap()
+                .metrics
+                .get("vsock1")
+                .unwrap()
+                .conns_added
+                .add(5);
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get("vsock2")
+            .unwrap()
+            .activate_fails
+            .inc();
+
+        let json_output = serde_json::to_string(&*METRICS.read().unwrap()).unwrap();
+
+        // Optional: print JSON to visually verify structure
+        println!("{}", json_output);
+
+        let parsed: serde_json::Value = serde_json::from_str(&json_output).unwrap();
+        let a_count = parsed["vsock_vsock0"]["conns_added"]["count"].as_u64().unwrap();
+        let b_count = parsed["vsock_vsock1"]["conns_added"]["count"].as_u64().unwrap();
+        let c_count = parsed["vsock_vsock2"]["conns_added"]["count"].as_u64().unwrap();
+        let a_count_2 = parsed["vsock_vsock0"]["activate_fails"]["count"].as_u64().unwrap();
+        let c_count_2 = parsed["vsock_vsock2"]["activate_fails"]["count"].as_u64().unwrap();
+        let aggregated = parsed["vsock"]["conns_added"]["count"].as_u64().unwrap();
+
+        assert_eq!(a_count, 1);
+        assert_eq!(b_count, 6);
+        assert_eq!(c_count, 1);
+        assert_eq!(a_count_2, 0);
+        assert_eq!(c_count_2, 1);
+        assert_eq!(aggregated, 8);
+
+        drop(METRICS.read().unwrap());
+        assert_eq!(METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get("vsock0")
+            .unwrap()
+            .conns_added
+            .count(), 0);
+        assert_eq!(METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get("vsock1")
+            .unwrap()
+            .conns_added
+            .count(), 0);
+
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get("vsock0")
+            .unwrap()
+            .activate_fails
+            .inc();
+    
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get("vsock0")
+            .unwrap()
+            .rx_bytes_count
+            .inc();
+        
+    }
+
+    // Device meant to test capability of retrieving and maintaining
+    // a default vsock for the tree, the default represents the global value.
+    // Also copies thread safety test from net devices.
+    #[test]
+    fn test_vsock_default() {
+        // Use vsock0 so that we can check thread safety with other tests.
+        let devn = "vsock0";
+
+        // Drop any existing read/write lock to avoid deadlocks or stale locks.
+        drop(METRICS.read().unwrap());
+        drop(METRICS.write().unwrap());
+
+        // Allocate metrics for the device.
+        VsockMetricsPerDevice::alloc(String::from(devn));
+        assert!(METRICS.read().unwrap().metrics.get(devn).is_some());
+
+        // Increment a field (e.g. activate_fails) to ensure it's being tracked.
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get(devn)
+            .unwrap()
+            .activate_fails
+            .inc();
+
+        let count = METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get(devn)
+            .unwrap()
+            .activate_fails
+            .count();
+        assert!(
+            count > 0,
+            "Expected activate_fails count > 0 but got {}",
+            count
+        );
+
+        // Ensure only up to 2 tests increment this (if sharing across tests).
+        assert!(
+            count <= 2,
+            "Expected activate_fails count <= 2 but got {}",
+            count
+        );
+
+        // Add more metric changes and assert correctness.
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get(devn)
+            .unwrap()
+            .activate_fails
+            .inc();
+
+        METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get(devn)
+            .unwrap()
+            .rx_bytes_count
+            .add(5);
+
+        let rx_count = METRICS
+            .read()
+            .unwrap()
+            .metrics
+            .get(devn)
+            .unwrap()
+            .rx_bytes_count
+            .count();
+        assert!(
+            rx_count >= 5,
+            "Expected rx_bytes_count >= 5 but got {}",
+            rx_count
+        );
     }
 }


### PR DESCRIPTION
## Changes

Added a new device metric system for both RNG and VMM VIRTIO devices. This includes mapping them through a BTreeMap as mentioned in issue #4145 for the net devices. Handles multiple devices through ID matching while also adding an Arc to each metric to make them thread safe. Also adds some minor tests replicating the ones in the net devices folder to check for thread safety and aggregation functionality. 

Also resolves all former references to metrics within the vsock and rng objects to a reference to the "global" id set to arbitrarily point to the single required vsock and rng devices for their respective files.

Also adds a minor fix to the test_tap_name method allowing for regex matching.

## Reason

Done to allow unit tests to run in parallel to each other. In production one vsock device and one rng device suffice for use, but with this implementation device metrics will overwrite each other during testing and tests would have to be run sequentially. Therefore, support for a global metric and multiple other metrics during testing is needed to ensure functionality for tests and production. This behavior is simply replicated on both vsock and rng.

test_tap_name changed from prior hardcoded value of tap0 to handle any numerical value after 'tap' when passed in.

Closes #4709 

Worked with @gjkeller for this.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
