### PR TITLE
Enable tracing mode for release.sh and fix release.sh

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -177,7 +177,7 @@ cp -v -t "$RELEASE_DIR" LICENSE NOTICE THIRD-PARTY
 check_swagger_artifact src/firecracker/swagger/firecracker.yaml "$VERSION"
 cp -v src/firecracker/swagger/firecracker.yaml "$RELEASE_DIR/firecracker_spec-$VERSION.yaml"
 
-CPU_TEMPLATES=(c3 t2 t2s t2cl t2a v1n1)
+CPU_TEMPLATES=(C3 T2 T2S T2CL T2A V1N1)
 for template in "${CPU_TEMPLATES[@]}"; do
     cp -v tests/data/custom_cpu_templates/$template.json $RELEASE_DIR/$template-$VERSION.json
 done

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # fail if we encounter an error, uninitialized variable or a pipe breaks
-set -eu -o pipefail
+set -eux -o pipefail
 
 FC_TOOLS_DIR=$(dirname $(realpath $0))
 source "$FC_TOOLS_DIR/functions"


### PR DESCRIPTION
## Changes

- Enable tracing mode (`set -x`) for the future debugability
- Fix release.sh by using upper case custom CPU template file names

## Reason

The release script failed.
This will be forward-ported to the main branch after the release.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
