### PR TITLE
secret_freedom: Use fixed size bounce buffer for loading kernel

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -267,7 +267,10 @@ pub fn build_microvm_for_boot(
     vmm.vm.set_memory_private().map_err(VmmError::Vm)?;
 
     let entry_point = load_kernel(
-        MaybeBounce::new(boot_config.kernel_file.try_clone().unwrap(), secret_free),
+        MaybeBounce::<_, 4096>::new_persistent(
+            boot_config.kernel_file.try_clone().unwrap(),
+            secret_free,
+        ),
         vmm.vm.guest_memory(),
     )?;
     let initrd = match &boot_config.initrd_file {
@@ -279,7 +282,7 @@ pub fn build_microvm_for_boot(
 
             Some(InitrdConfig::from_reader(
                 vmm.vm.guest_memory(),
-                MaybeBounce::new(initrd_file.as_fd(), secret_free),
+                MaybeBounce::<_, 4096>::new_persistent(initrd_file.as_fd(), secret_free),
                 u64_to_usize(size),
             )?)
         }


### PR DESCRIPTION
By using a MaybeBounce with N=0 we are allocating a bounce buffer that matches exactly the number of bytes that need to be copied into guest memory, e.g. the size of the kernel file. This is fairly expensive performance wise, and the spike in memory usage from the firecracker process is also unwanted. Thus, just use a 4096 byte fixed size buffer through which we repeatedly read+memcpy. This has slightly better performance (10ms faster for cold boots) and makes Firecracker's memory usage during InstanceStart go back into its O(1) bound.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
