### PR TITLE
doc: update contributing guidelines wrt pre-commit/devtool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,39 +57,23 @@ If you just want to receive feedback for a contribution proposal, open an “RFC
 ## Contribution Quality Standards
 
 Most quality and style standards are enforced automatically during integration
-testing. For ease of use you can setup a git pre-commit hook by running the
-following in the Firecracker root directory:
+testing. To run these quality and style checks, use `devtool`.
 
-```
-cargo install rusty-hook
-rusty-hook init
-```
+```bash
+# Format code (Rust, Python, Markdown)
+./tools/devtool fmt
 
-This project also has linters for Python and Markdown. These will be called by
-the pre-commit when you modify any Python and Markdown files. In order to make
-sure you are setup we recommend you install
-[poetry](https://python-poetry.org/docs/) and
-[pyenv](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation).
-
-Poetry is used by this project and pyenv will help you make sure you have a
-Python version compatible with the poetry python project we use as part of
-`./tools/devctr`.
-
-Once you have these two installed you can run the following to install the dev
-container poetry project:
-
-```
-poetry -C ./tools/devctr install --no-root
+# Check code style and lint warnings
+./tools/devtool checkstyle
 ```
 
-Then, you can activate the poetry virtual environment by running:
+Refer to [docs/getting-started.md](docs/getting-started.md) and run
+`tools/devtool --help` for more information on `devtool`, such as build
+verification, tests, etc.
 
-```
-poetry shell -C ./tools/devctr
-```
-
-Which you will need to do after modifying python or markdown files so that the
-pre-commit can finish successfully.
+> **Note:** The legacy rusty-hook pre-commit script has been deprecated and is
+> unmaintained. Please use `devtool` for formatting, linting, and build checks
+> during your development cycle.
 
 Your contribution needs to meet the following standards:
 


### PR DESCRIPTION
## Changes

Point external contributors to use devtool instead of unmaintained pre-commit script to check code
quality/style in `CONTRIBUTING.md`. This is due to pre-commit script not being maintained anymore.

## Reason

Addresses issue #5201 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
