### PR TITLE
test(conftest): dump VM metrics on test failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -337,6 +337,11 @@ def microvm_factory(request, record_property, results_dir, netns_factory):
     report = request.node.stash[PHASE_REPORT_KEY]
     if "call" in report and report["call"].failed:
         for uvm in uvm_factory.vms:
+            # This is best effort. We want to proceed even if the VM is not responding.
+            try:
+                uvm.flush_metrics()
+            except:  # pylint: disable=bare-except
+                pass
             uvm_data = results_dir / uvm.id
             uvm_data.mkdir()
             uvm_data.joinpath("host-dmesg.log").write_text(


### PR DESCRIPTION
## Changes

Dump VM metrics on test failure.

## Reason

This is to have latest VM metrics available when analysing failures.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
