### PR TITLE
feat(ci): add paralellism option to bk pipelines

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -191,6 +191,13 @@ COMMON_PARSER.add_argument(
     action="store_true",
     default=False,
 )
+COMMON_PARSER.add_argument(
+    "--parallelism",
+    help="How many instances of test to create",
+    required=False,
+    default=1,
+    type=int,
+)
 
 
 def random_str(k: int):
@@ -320,6 +327,7 @@ class BKPipeline:
         """
         depends_on_build = kwargs.pop("depends_on_build", True)
         combined = overlay_dict(self.per_instance, kwargs)
+        combined["parallelism"] = self.args.parallelism
         return self.add_step(
             group(*args, **combined), depends_on_build=depends_on_build
         )


### PR DESCRIPTION
## Changes
Add `--parallelism` option to specify how much instances of tests to run.

## Reason
It is useful to run multiple test instances for testing purposes.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
