### PR TITLE
Split post-snapshot checks for steal time test

### DIFF
--- a/tests/integration_tests/functional/test_steal_time.py
+++ b/tests/integration_tests/functional/test_steal_time.py
@@ -104,18 +104,19 @@ def test_pvtime_snapshot(uvm_plain, microvm_factory):
     # Steal time just after restoring
     steal_after_snap = get_steal_time_ms(restored_vm)
 
+    # Ensure steal time persisted
+    tolerance = 10000  # 10.0 seconds tolerance for persistence check
+    persisted = (
+        steal_before < steal_after_snap and steal_after_snap - steal_before < tolerance
+    )
+    assert persisted, "Steal time did not persist through snapshot"
+
     time.sleep(2)
 
     # Steal time after running resumed VM
     steal_after_resume = get_steal_time_ms(restored_vm)
 
-    # Ensure steal time persisted and continued increasing
-    tolerance = 10000  # 10.0 seconds tolerance for persistence check
-    persisted = (
-        steal_before < steal_after_snap and steal_after_snap - steal_before < tolerance
-    )
-    increased = steal_after_resume > steal_after_snap
-
+    # Ensure steal time continued increasing
     assert (
-        persisted and increased
-    ), "Steal time did not persist through snapshot or failed to increase after resume"
+        steal_after_resume > steal_after_snap
+    ), "Steal time failed to increase after resume"


### PR DESCRIPTION
## Changes

Split the double assertion in `test_pvtime_snapshot` in two separate ones.

## Reason

`test_pvtime_snapshot` checks that steal time reporting mechanism works on snapshotted microVMs. This includes two checks; first that the old steal time values are saved and restored correctly through snapshots and second that steal time keeps increasing in microVMs resumed from a snapshot.

The test fails intermittently, but we are not sure which of the two invariants causes it to fail because we are checking both in the same assertion

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
