### PR TITLE
test(pvtime): split pvtime tests into functional and performance

### DIFF
--- a/tests/integration_tests/functional/test_pvtime.py
+++ b/tests/integration_tests/functional/test_pvtime.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for verifying the PVTime device is enabled on aarch64."""
+
+import pytest
+
+from framework.properties import global_props
+
+
+@pytest.mark.skipif(
+    global_props.cpu_architecture != "aarch64", reason="Only run in aarch64"
+)
+def test_guest_has_pvtime_enabled(uvm_plain):
+    """
+    Check that the guest kernel has enabled PV steal time.
+    """
+    vm = uvm_plain
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+    vm.start()
+
+    _, stdout, _ = vm.ssh.run("dmesg | grep 'stolen time PV'")
+    assert (
+        "stolen time PV" in stdout
+    ), "Guest kernel did not report PV steal time enabled"

--- a/tests/integration_tests/performance/test_steal_time.py
+++ b/tests/integration_tests/performance/test_steal_time.py
@@ -1,13 +1,9 @@
 # Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for verifying the PVTime device behavior under contention and across snapshots."""
+"""Tests for verifying the steal time behavior under contention and across snapshots."""
 
 import time
-
-import pytest
-
-from framework.properties import global_props
 
 
 def get_steal_time_ms(vm):
@@ -16,25 +12,6 @@ def get_steal_time_ms(vm):
     steal_time_tck = int(out.strip().split()[8])
     clk_tck = int(vm.ssh.run("getconf CLK_TCK").stdout)
     return steal_time_tck / clk_tck * 1000
-
-
-@pytest.mark.skipif(
-    global_props.cpu_architecture != "aarch64", reason="Only run in aarch64"
-)
-def test_guest_has_pvtime_enabled(uvm_plain):
-    """
-    Check that the guest kernel has enabled PV steal time.
-    """
-    vm = uvm_plain
-    vm.spawn()
-    vm.basic_config()
-    vm.add_net_iface()
-    vm.start()
-
-    _, stdout, _ = vm.ssh.run("dmesg | grep 'stolen time PV'")
-    assert (
-        "stolen time PV" in stdout
-    ), "Guest kernel did not report PV steal time enabled"
 
 
 def test_pvtime_steal_time_increases(uvm_plain):


### PR DESCRIPTION
## Changes

Move the PVTime tests to the performance folder so that they are run serially.

## Reason

The test contends one physical core to increase the steal time, but if many tests are run in parallel, they all start contending the same core. 
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
