### PR TITLE
doc(net): remove instruction for nameserver setup via boot_args

### DIFF
--- a/docs/network-setup.md
+++ b/docs/network-setup.md
@@ -435,11 +435,3 @@ section without needing `iproute2` installed in the guest.
 
 As soon as you boot the guest, it will already be connected to the network
 (assuming you correctly performing the other steps).
-
-**Note**: you can also use the `ip` argument to configure a primary DNS server
-and, optionally, a second DNS server without needing to touch
-`/etc/resolv.conf`. As an example:
-
-`ip=172.16.0.2::172.16.0.1:255.255.255.252::eth0:off:8.8.8.8:1.1.1.1` configures
-`8.8.8.8` as the primary DNS server and `1.1.1.1` as the secondary DNS server,
-as well as the rest of the guest-side routing.


### PR DESCRIPTION
## Changes

Remove instruction for nameserver setup via boot_args.
Related issue: https://github.com/firecracker-microvm/firecracker/issues/5172 .

## Reason

It does not work with our current rootfs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
~~- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
~~- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
~~- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
~~- [ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
