### PR TITLE
fix(test): kill uffd handler when microvm gets killed 

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -986,7 +986,7 @@ class Microvm:
         jailed_snapshot = snapshot.copy_to_chroot(Path(self.chroot()))
 
         if uffd_handler_name:
-            spawn_pf_handler(
+            self.uffd_handler = spawn_pf_handler(
                 self,
                 uffd_handler(uffd_handler_name, binary_dir=self.fc_binary_path.parent),
                 jailed_snapshot,

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -341,6 +341,9 @@ class Microvm:
                 stderr == "" and "firecracker" not in stdout
             ), f"Firecracker reported its pid {self.firecracker_pid}, which was killed, but there still exist processes using the supposedly dead Firecracker's jailer_id: {stdout}"
 
+        if self.uffd_handler and self.uffd_handler.is_running():
+            self.uffd_handler.kill()
+
         # Mark the microVM as not spawned, so we avoid trying to kill twice.
         self._spawned = False
         self._killed = True

--- a/tests/framework/utils_uffd.py
+++ b/tests/framework/utils_uffd.py
@@ -83,10 +83,9 @@ class UffdHandler:
             self.proc.kill()
 
 
-def spawn_pf_handler(vm, handler_path, snapshot):
+def spawn_pf_handler(vm, handler_path, jailed_snapshot):
     """Spawn page fault handler process."""
     # Copy snapshot memory file into chroot of microVM.
-    jailed_snapshot = snapshot.copy_to_chroot(Path(vm.chroot()))
     # Copy the valid page fault binary into chroot of microVM.
     jailed_handler = vm.create_jailed_resource(handler_path)
     handler_name = os.path.basename(jailed_handler)

--- a/tests/framework/utils_uffd.py
+++ b/tests/framework/utils_uffd.py
@@ -77,10 +77,22 @@ class UffdHandler:
             return ""
         return self.log_file.read_text(encoding="utf-8")
 
+    def kill(self):
+        """Kills the uffd handler process"""
+        assert self.is_running()
+
+        self.proc.kill()
+
+    def mark_killed(self):
+        """Marks the uffd handler as already dead"""
+        assert not self.is_running()
+
+        self._proc = None
+
     def __del__(self):
         """Tear down the UFFD handler process."""
-        if self.proc is not None:
-            self.proc.kill()
+        if self.is_running():
+            self.kill()
 
 
 def spawn_pf_handler(vm, handler_path, jailed_snapshot):

--- a/tests/framework/utils_uffd.py
+++ b/tests/framework/utils_uffd.py
@@ -94,7 +94,6 @@ def spawn_pf_handler(vm, handler_path, jailed_snapshot):
         handler_name, SOCKET_PATH, jailed_snapshot, vm.chroot(), "uffd.log"
     )
     uffd_handler.spawn(vm.jailer.uid, vm.jailer.gid)
-    vm.uffd_handler = uffd_handler
 
     return uffd_handler
 

--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -128,4 +128,4 @@ def test_malicious_handler(uvm_plain, snapshot):
             )
             assert False, "Firecracker should freeze"
     except (TimeoutError, requests.exceptions.ReadTimeout):
-        pass
+        vm.uffd_handler.mark_killed()


### PR DESCRIPTION
By not killing the uffd handler, we are leaking the resources associated
with the uffd handler, which can be undesirable and cose gradual
slowdown in in snapshot performance tests that restore snapshots using
uffd in a loop.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
