### PR TITLE
fix(test): resolve regex library warnings

### DIFF
--- a/tests/host_tools/proc.py
+++ b/tests/host_tools/proc.py
@@ -13,7 +13,7 @@ def proc_type():
     lines = result.stdout.strip().splitlines()
     for line in lines:
         if "model name" in line:
-            return re.sub(".*model name.*:", "", line, 1)
+            return re.sub(".*model name.*:", "", line, count=1)
 
     cmd = "uname -m"
     result = utils.check_output(cmd).stdout.strip()


### PR DESCRIPTION
## Changes
This small PR resolves the regex library warnings showing in Python3.13:
```python
DeprecationWarning: 'count' is passed as positional argument
```

## Reason

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
