### PR TITLE
test: display the cpu template name

### DIFF
--- a/tests/integration_tests/functional/test_cpu_features_x86_64.py
+++ b/tests/integration_tests/functional/test_cpu_features_x86_64.py
@@ -541,7 +541,7 @@ def test_cpu_cpuid_snapshot(microvm_factory, guest_kernel, rootfs, cpu_template_
     """
     cpu_template_name = get_cpu_template_name(cpu_template_any)
     if cpu_template_name not in MSR_SUPPORTED_TEMPLATES:
-        pytest.skip("This test does not support {cpu_template_name} template.")
+        pytest.skip(f"This test does not support {cpu_template_name} template.")
 
     shared_names = SNAPSHOT_RESTORE_SHARED_NAMES
 
@@ -611,7 +611,7 @@ def test_cpu_cpuid_restore(microvm_factory, guest_kernel, cpu_template_any):
     """
     cpu_template_name = get_cpu_template_name(cpu_template_any)
     if cpu_template_name not in MSR_SUPPORTED_TEMPLATES:
-        pytest.skip("This test does not support {cpu_template_name} template.")
+        pytest.skip(f"This test does not support {cpu_template_name} template.")
 
     shared_names = SNAPSHOT_RESTORE_SHARED_NAMES
     snapshot_artifacts_dir = (
@@ -646,8 +646,8 @@ def test_cpu_template(uvm_plain_any, cpu_template_any, microvm_factory):
     supported CPU templates.
     """
     cpu_template_name = get_cpu_template_name(cpu_template_any)
-    if cpu_template_name not in ["T2", "T2S", "SPR_TO_T2_5.10", "SPR_TO_T2_6.1" "C3"]:
-        pytest.skip("This test does not support {cpu_template_name} template.")
+    if cpu_template_name not in ["T2", "T2S", "SPR_TO_T2_5.10", "SPR_TO_T2_6.1", "C3"]:
+        pytest.skip(f"This test does not support {cpu_template_name} template.")
 
     test_microvm = uvm_plain_any
     test_microvm.spawn()


### PR DESCRIPTION
## Changes
This small PR evaluates the displays the cpu template name in the test skip message.

## Reason

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
