### PR TITLE
vmm: warn instead of bailing out on unexpected subleaf for leaf 0xB.

### DIFF
--- a/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs
@@ -69,8 +69,6 @@ pub enum ExtendedTopologyError {
     NumLogicalProcs(u32, CheckedAssignError),
     /// Failed to set right-shift bits (CPUID.(EAX=0xB,ECX={0}):EAX[4:0]): {1}
     RightShiftBits(u32, CheckedAssignError),
-    /// Unexpected subleaf: {0}
-    UnexpectedSubleaf(u32)
 }
 
 /// Error type for setting leaf 0x80000006 of Cpuid::normalize().
@@ -372,11 +370,9 @@ impl super::Cpuid {
                             .map_err(|err| ExtendedTopologyError::DomainType(index, err))?;
                     }
                     _ => {
-                        // KVM no longer returns any subleaf numbers greater than 0. The patch was
-                        // merged in v6.2 and backported to v5.10. Subleaves >= 2 should not be
-                        // included.
-                        // https://github.com/torvalds/linux/commit/45e966fcca03ecdcccac7cb236e16eea38cc18af
-                        return Err(ExtendedTopologyError::UnexpectedSubleaf(index));
+                        // We expect here as this is an extremely rare case that is unlikely to ever
+                        // occur.
+                        subleaf.result.ecx = index;
                     }
                 }
             } else {


### PR DESCRIPTION
## Changes

Prints a warning message instead of erroring out on unexpected subleaf detected for CPUID leaf 0xB.

## Reason

Fixes #5213

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- [x] If a specific issue led to this PR, this PR closes the issue.
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
