### PR TITLE
test: fix false positive in Microvm.kill check for correct pid 

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -339,7 +339,8 @@ class Microvm:
 
             offenders = []
             for proc in stdout.splitlines():
-                if "firecracker" in proc:
+                _, cmd = proc.lower().split(maxsplit=1)
+                if "firecracker" in proc and not cmd.startswith("screen"):
                     offenders.append(proc)
 
             # make sure firecracker was killed

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -333,13 +333,20 @@ class Microvm:
             # https://github.com/firecracker-microvm/firecracker/pull/4442/commits/d63eb7a65ffaaae0409d15ed55d99ecbd29bc572
 
             # filter ps results for the jailer's unique id
-            _, stdout, stderr = utils.check_output(
-                f"ps ax -o cmd -ww | grep {self.jailer.jailer_id}"
+            _, stdout, stderr = utils.run_cmd(
+                f"ps ax -o pid,cmd -ww | grep {self.jailer.jailer_id}"
             )
+
+            offenders = []
+            for proc in stdout.splitlines():
+                if "firecracker" in proc:
+                    offenders.append(proc)
+
             # make sure firecracker was killed
-            assert (
-                stderr == "" and "firecracker" not in stdout
-            ), f"Firecracker reported its pid {self.firecracker_pid}, which was killed, but there still exist processes using the supposedly dead Firecracker's jailer_id: {stdout}"
+            assert not stderr and not offenders, (
+                f"Firecracker reported its pid {self.firecracker_pid}, which was killed, but there still exist processes using the supposedly dead Firecracker's jailer_id: \n"
+                + "\n".join(offenders)
+            )
 
         if self.uffd_handler and self.uffd_handler.is_running():
             self.uffd_handler.kill()

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -337,6 +337,8 @@ class Microvm:
                 f"ps ax -o pid,cmd -ww | grep {self.jailer.jailer_id}"
             )
 
+            assert not stderr, f"error querying processes using `ps`: {stderr}"
+
             offenders = []
             for proc in stdout.splitlines():
                 _, cmd = proc.lower().split(maxsplit=1)
@@ -344,7 +346,7 @@ class Microvm:
                     offenders.append(proc)
 
             # make sure firecracker was killed
-            assert not stderr and not offenders, (
+            assert not offenders, (
                 f"Firecracker reported its pid {self.firecracker_pid}, which was killed, but there still exist processes using the supposedly dead Firecracker's jailer_id: \n"
                 + "\n".join(offenders)
             )

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -55,4 +55,5 @@ disable = [
     "duplicate-code",
     "too-many-positional-arguments",
     "too-few-public-methods",
+    "too-many-branches",
 ]


### PR DESCRIPTION
## Changes

In Microvm.kill() we have a sanity check for ensuring the firecracker
process wrote the correct pid to its pidfile: We ps | grep for the
jailer id of the supposedly dead firecracker process and see if any
process that has "fircracker" somewhere in its argv is using it (with
the somewhat reasonable assumption that this would be exactly the
firecracker process we just tried to kill). Howver, if the firecracker
process isnt daemonized, then we spawn it under `screen`, and now we
have two processes that contain both the jailer id and the name
"firecracker" in its argv, because screen fork()s into firecracker in
this case. Now if we kill firecracker, screen might stick around a bit
longer (because we only explicitly wait for firecracker to terminate),
and the sanity check might incorrectly pick up the screen process as a
firecracker process and cause a spurious test failure.

Fix this by having the check explicitly ignore all screen processes.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
