### PR TITLE
test: dump debug information if http request to firecracker fails

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -694,14 +694,14 @@ class Microvm:
         # 1 sec since we are rechecking the existence of the socket 5 times
         # and leave 0.2 delay between them.
         if "no-api" not in self.jailer.extra_args:
-            self._wait_create()
+            self._wait_for_api_socket()
         if "config-file" in self.jailer.extra_args and self.iface:
             self.wait_for_ssh_up()
         if self.log_file and log_level in ("Trace", "Debug", "Info"):
             self.check_log_message("Running Firecracker")
 
     @retry(wait=wait_fixed(0.2), stop=stop_after_attempt(5), reraise=True)
-    def _wait_create(self):
+    def _wait_for_api_socket(self):
         """Wait until the API socket and chroot folder are available."""
         os.stat(self.jailer.api_socket_path())
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -615,7 +615,12 @@ class Microvm:
         # pylint: disable=subprocess-run-check
         # pylint: disable=too-many-branches
         self.jailer.setup()
-        self.api = Api(self.jailer.api_socket_path())
+        self.api = Api(
+            self.jailer.api_socket_path(),
+            on_error=lambda verb, uri, err_msg: self._dump_debug_information(
+                f"Error during {verb} {uri}: {err_msg}"
+            ),
+        )
 
         if log_file is not None:
             self.log_file = Path(self.path) / log_file

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -688,21 +688,33 @@ class Microvm:
         if emit_metrics:
             self.monitors.append(FCMetricsMonitor(self))
 
-        # Wait for the jailer to create resources needed, and Firecracker to
-        # create its API socket.
-        # We expect the jailer to start within 80 ms. However, we wait for
-        # 1 sec since we are rechecking the existence of the socket 5 times
-        # and leave 0.2 delay between them.
-        if "no-api" not in self.jailer.extra_args:
-            self._wait_for_api_socket()
+        # Ensure Firecracker is in as good a state as possible wrts guest
+        # responsiveness / API availability.
+        # If we are using a config file and it has a network device specified,
+        # use SSH to wait until guest userspace is available. If we are
+        # using the API, wait until the log message indicating the API server
+        # has finished initializing is printed (if logging is enabled), or
+        # until the API socket file has been created.
+        # If none of these apply, do a last ditch effort to make sure the
+        # Firecracker process itself at least came up by checking
+        # for the startup log message. Otherwise, you're on your own kid.
         if "config-file" in self.jailer.extra_args and self.iface:
             self.wait_for_ssh_up()
-        if self.log_file and log_level in ("Trace", "Debug", "Info"):
+        elif "no-api" not in self.jailer.extra_args:
+            if self.log_file and log_level in ("Trace", "Debug", "Info"):
+                self.check_log_message("API server started.")
+            else:
+                self._wait_for_api_socket()
+        elif self.log_file and log_level in ("Trace", "Debug", "Info"):
             self.check_log_message("Running Firecracker")
 
     @retry(wait=wait_fixed(0.2), stop=stop_after_attempt(5), reraise=True)
     def _wait_for_api_socket(self):
         """Wait until the API socket and chroot folder are available."""
+
+        # We expect the jailer to start within 80 ms. However, we wait for
+        # 1 sec since we are rechecking the existence of the socket 5 times
+        # and leave 0.2 delay between them.
         os.stat(self.jailer.api_socket_path())
 
     @retry(wait=wait_fixed(0.2), stop=stop_after_attempt(5), reraise=True)

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -1101,10 +1101,12 @@ class Microvm:
         backtraces = []
         for thread_name, thread_pids in utils.get_threads(self.firecracker_pid).items():
             for pid in thread_pids:
-                backtraces.append(
-                    f"{thread_name} ({pid=}):\n"
-                    f"{utils.check_output(f'cat /proc/{pid}/stack').stdout}"
-                )
+                try:
+                    stack = Path(f"/proc/{pid}/stack").read_text("UTF-8")
+                except FileNotFoundError:
+                    continue  # process might've gone away between get_threads() call and here
+
+                backtraces.append(f"{thread_name} ({pid=}):\n{stack}")
         return "\n".join(backtraces)
 
     def _dump_debug_information(self, what: str):

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -34,11 +34,15 @@ GET_CPU_LOAD = "top -bn1 -H -p {} -w512 | tail -n+8"
 
 def get_threads(pid: int) -> dict:
     """Return dict consisting of child threads."""
-    threads_map = defaultdict(list)
-    proc = psutil.Process(pid)
-    for thread in proc.threads():
-        threads_map[psutil.Process(thread.id).name()].append(thread.id)
-    return threads_map
+    try:
+        proc = psutil.Process(pid)
+
+        threads_map = defaultdict(list)
+        for thread in proc.threads():
+            threads_map[psutil.Process(thread.id).name()].append(thread.id)
+        return threads_map
+    except psutil.NoSuchProcess:
+        return {}
 
 
 def get_cpu_affinity(pid: int) -> list:

--- a/tests/integration_tests/functional/test_api_server.py
+++ b/tests/integration_tests/functional/test_api_server.py
@@ -23,7 +23,7 @@ def test_api_socket_in_use(uvm_plain):
 
     sock = socket.socket(socket.AF_UNIX)
     sock.bind(microvm.jailer.api_socket_path())
-    microvm.spawn()
+    microvm.spawn(log_level="warn")
     msg = "Failed to open the API socket at: /run/firecracker.socket. Check that it is not already used."
     microvm.check_log_message(msg)
 

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -28,7 +28,8 @@ def test_describe_snapshot_all_versions(
         fc_binary_path=firecracker_release.path,
         jailer_binary_path=firecracker_release.jailer,
     )
-    vm.spawn()
+    # FIXME: Once only FC versions >= 1.12 are supported, drop log_level="warn"
+    vm.spawn(log_level="warn")
     vm.basic_config(track_dirty_pages=True)
     vm.start()
     snapshot = vm.snapshot_diff()

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -371,7 +371,7 @@ def test_start_with_missing_metadata(uvm_plain):
 
     try:
         test_microvm.spawn()
-    except FileNotFoundError:
+    except:  # pylint: disable=bare-except
         pass
     finally:
         test_microvm.check_log_message(
@@ -394,7 +394,7 @@ def test_start_with_invalid_metadata(uvm_plain):
 
     try:
         test_microvm.spawn()
-    except FileNotFoundError:
+    except:  # pylint: disable=bare-except
         pass
     finally:
         test_microvm.check_log_message("MMDS error: metadata provided not valid json")


### PR DESCRIPTION
Sometimes, we intermittently see `ConnectionRefused` errors when doing
http requests to the firecracker API in integration tests. Have the test
framework dump relevant logs in these cases.

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
