### PR TITLE
fix: boottimer device MMIO address

### DIFF
--- a/resources/overlay/usr/local/bin/init.c
+++ b/resources/overlay/usr/local/bin/init.c
@@ -13,7 +13,7 @@
 // Position on the bus is defined by MMIO_LEN increments, where MMIO_LEN is
 // defined as 0x1000 in vmm/src/device_manager/mmio.rs.
 #ifdef __x86_64__
-#define MAGIC_MMIO_SIGNAL_GUEST_BOOT_COMPLETE 0xd0000000
+#define MAGIC_MMIO_SIGNAL_GUEST_BOOT_COMPLETE 0xc0000000
 #endif
 #ifdef __aarch64__
 #define MAGIC_MMIO_SIGNAL_GUEST_BOOT_COMPLETE 0x40000000

--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -92,7 +92,7 @@ function build_initramfs {
 
     # Report guest boot time back to Firecracker via MMIO
     # See arch/src/lib.rs and the BootTimer device
-    MAGIC_BOOT_ADDRESS=0xd0000000
+    MAGIC_BOOT_ADDRESS=0xc0000000
     if [ $ARCH = "aarch64" ]; then
         MAGIC_BOOT_ADDRESS=0x40000000
     fi

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -94,6 +94,33 @@ def get_systemd_analyze_times(microvm):
     return kernel, userspace, total
 
 
+def launch_vm_with_boot_timer(
+    microvm_factory, guest_kernel_acpi, rootfs_rw, vcpu_count, mem_size_mib
+):
+    """Launches a microVM with guest-timer and returns the reported metrics for it"""
+    vm = microvm_factory.build(guest_kernel_acpi, rootfs_rw)
+    vm.jailer.extra_args.update({"boot-timer": None})
+    vm.spawn()
+    vm.basic_config(
+        vcpu_count=vcpu_count,
+        mem_size_mib=mem_size_mib,
+        boot_args=DEFAULT_BOOT_ARGS + " init=/usr/local/bin/init",
+        enable_entropy_device=True,
+    )
+    vm.add_net_iface()
+    vm.start()
+    vm.pin_threads(0)
+
+    boot_time_us, cpu_boot_time_us = get_boottime_device_info(vm)
+
+    return (vm, boot_time_us, cpu_boot_time_us)
+
+
+def test_boot_timer(microvm_factory, guest_kernel_acpi, rootfs):
+    """Tests that the boot timer device works"""
+    launch_vm_with_boot_timer(microvm_factory, guest_kernel_acpi, rootfs, 1, 128)
+
+
 @pytest.mark.parametrize(
     "vcpu_count,mem_size_mib",
     [(1, 128), (1, 1024), (2, 2048), (4, 4096)],
@@ -105,20 +132,9 @@ def test_boottime(
     """Test boot time with different guest configurations"""
 
     for i in range(10):
-        vm = microvm_factory.build(guest_kernel_acpi, rootfs_rw)
-        vm.jailer.extra_args.update({"boot-timer": None})
-        vm.spawn()
-        vm.basic_config(
-            vcpu_count=vcpu_count,
-            mem_size_mib=mem_size_mib,
-            boot_args=DEFAULT_BOOT_ARGS + " init=/usr/local/bin/init",
-            enable_entropy_device=True,
+        vm, boot_time_us, cpu_boot_time_us = launch_vm_with_boot_timer(
+            microvm_factory, guest_kernel_acpi, rootfs_rw, vcpu_count, mem_size_mib
         )
-        vm.add_net_iface()
-        vm.start()
-        vm.pin_threads(0)
-
-        boot_time_us, cpu_boot_time_us = get_boottime_device_info(vm)
 
         if i == 0:
             metrics.set_dimensions(


### PR DESCRIPTION
## Changes

Update the init.c and initramfs values for the MMIO region of the boot timer device. Also, add a functional test that runs during CI PR tests and makes sure the boot timer works.

## Reason

When we re-arranged the MMIO address space in commit 9a165d17f1ba (arch: define 64-bit capable MMIO memory regions) we moved the MMIO region of the boot timer device for x86 systems, but we didn't update the init scripts that hardcode it and use it to report boot time timestamp back to Firecracker.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
