### PR TITLE
test: use kani built-in --harness-timeout option

### DIFF
--- a/tests/integration_tests/test_kani.py
+++ b/tests/integration_tests/test_kani.py
@@ -34,7 +34,7 @@ def test_kani(results_dir):
     # --output-format terse is required by -j
     # -Z unstable-options is needed to enable the other `-Z` flags
     _, stdout, _ = utils.check_output(
-        "cargo kani -Z unstable-options -Z stubbing -Z function-contracts -Z restrict-vtable -j --output-format terse",
+        "cargo kani -Z unstable-options -Z stubbing -Z function-contracts -Z restrict-vtable -j --output-format terse --harness-timeout 30m",
         timeout=TIMEOUT,
     )
 


### PR DESCRIPTION
Set a per-harness timeout of 30 minutes. This should hopefully make it easier to debug scenarios where proofs end up hanging indefinitely, as we now no longer hit the pytest timeout, but instead a timeout built into kani (which should tell us what exact harness timed out).

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
