### PR TITLE
[1.11] chore(metric): add per-test metric dimension for coarse grained metrics

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,13 @@ def pytest_runtest_logreport(report):
             "cpu_model": global_props.cpu_model,
             "host_kernel": "linux-" + global_props.host_linux_version,
         },
+        # per coarse-grained test name, dropping parameters and other dimensions to reduce metric count for dashboard
+        # Note: noideid is formatted as below
+        # - with parameters: "path/to/test.py::test_name[parameter0,parameter1]"
+        # - without parameters: "path/to/test.py::test_name"
+        {
+            "test_name": report.nodeid.split("[")[0],
+        },
         # per phase
         {"phase": report.when},
         # per host kernel


### PR DESCRIPTION
The current metric dimensions are so that we have 13k+ different sets of dimensions for each metric, which makes it impossible to plot in CloudWatch.
This change adds a new set of dimensions with just the test name so that we reduce it to a few hundreds and are able to plot them (CW limit is 500).


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
