### PR TITLE
fix: define metric dimensions as strings in A/B ignore list

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -53,8 +53,8 @@ IGNORED = [
     # boot time metrics
     {"performance_test": "test_boottime", "metric": "resume_time"},
     # block throughput on m8g
-    {"fio_engine": "libaio", "vcpus": 2, "instance": "m8g.metal-24xl"},
-    {"fio_engine": "libaio", "vcpus": 2, "instance": "m8g.metal-48xl"},
+    {"fio_engine": "libaio", "vcpus": "2", "instance": "m8g.metal-24xl"},
+    {"fio_engine": "libaio", "vcpus": "2", "instance": "m8g.metal-48xl"},
 ]
 
 


### PR DESCRIPTION
All EMF dimensions are strings, but the allow list for ignoring block metrics on m8g due to volatility used integers, causing the ignoring to fail. Change to strings.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
