### PR TITLE
query correct metric for diff snapshots in snap creation perf test

### DIFF
--- a/tests/integration_tests/performance/test_snapshot.py
+++ b/tests/integration_tests/performance/test_snapshot.py
@@ -279,9 +279,15 @@ def test_snapshot_create_latency(
         }
     )
 
+    match snapshot_type:
+        case SnapshotType.FULL:
+            metric = "full_create_snapshot"
+        case SnapshotType.DIFF:
+            metric = "diff_create_snapshot"
+
     for _ in range(ITERATIONS):
         vm.make_snapshot(snapshot_type)
         fc_metrics = vm.flush_metrics()
 
-        value = fc_metrics["latencies_us"]["full_create_snapshot"] / USEC_IN_MSEC
+        value = fc_metrics["latencies_us"][metric] / USEC_IN_MSEC
         metrics.put_metric("latency", value, "Milliseconds")


### PR DESCRIPTION
We have different metrics for snapshot creation latency for full and diff snapshots (why? Good question), so if we're measuring diff snapshot creation latency we need to query diff_create_snapshot instead of full_create_snapshot.

Just inline this logic into the test instead of adding a property to SnapshotType because there is literally no other use of this pattern in our tests (if there ever will be, which I doubt, we can still abstract it away).

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
