### PR TITLE
test: do not run criterion benchmarks in no_block_pr

### DIFF
--- a/tests/integration_tests/performance/test_benchmarks.py
+++ b/tests/integration_tests/performance/test_benchmarks.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.no_block_pr
+@pytest.mark.nonci
 @pytest.mark.timeout(900)
 def test_no_regression_relative_to_target_branch():
     """


### PR DESCRIPTION
## Changes

With this change, we are disabling them in the PR - Optional step. We will still be able to notice performance regressions from the performance tests, so we're not losing much test coverage. We're not completely deleting them because they can be useful for deep dives and for verifying changes in those particular parts of the codebase.

## Reason

These tests have been failing consistently in our CI for as long as I can remember. While each individual test false positive rate is not high, the fact that we run many of them in a multitude of combinations means that at every CI run at least one fails.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
