### PR TITLE
chore: remove 1.10.1 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,13 +159,6 @@ and this project adheres to
   the empty seccomp policy as default for debug builds to avoid crashes on
   syscalls introduced by debug assertions from Rust 1.80.0.
 
-## [1.10.1]
-
-### Changed
-
-- [#4907](https://github.com/firecracker-microvm/firecracker/pull/4907): Bumped
-  the snapshot version to 4.0.0, so users need to regenerate snapshots.
-
 ## [1.10.0]
 
 ### Added


### PR DESCRIPTION
## Changes
Remove 1.10.1 CHANGELOG entry

## Reason
We only track changes to major/minor releases in the CHANGELOG on main branch. Changes in patch versions are listed in the CHANGELOG of the corresponding branch. (firecracker-v1.10 in this case)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
