### PR TITLE
test(popular-containters): use ecr instead of docker.io

### DIFF
--- a/tools/test-popular-containers/build_rootfs.sh
+++ b/tools/test-popular-containers/build_rootfs.sh
@@ -14,8 +14,8 @@ function make_rootfs {
     local rootfs=$LABEL
     local IMG=$LABEL.ext4
     mkdir $LABEL
-    ctr image pull docker.io/library/$LABEL
-    ctr image mount --rw docker.io/library/$LABEL $LABEL
+    ctr image pull public.ecr.aws/docker/library/$LABEL
+    ctr image mount --rw public.ecr.aws/docker/library/$LABEL $LABEL
     MNT_SIZE=$(du -sb $LABEL |cut -f1)
     SIZE=$(( $MNT_SIZE + 512 * 2**20 ))
 


### PR DESCRIPTION
## Changes

Use ECR instead of docker.io to pull popular container images for tests.

## Reason

This is to avoid rate limiter hits on the DockerHub side.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
