### PR TITLE
test(restore_latency): do not reuse netns

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -1206,13 +1206,20 @@ class MicroVMFactory:
         uffd_handler_name=None,
         incremental=False,
         use_snapshot_editor=True,
+        no_netns_reuse=False,
     ):
         """A generator of `n` microvms restored, either all restored from the same given snapshot
         (incremental=False), or created by taking successive snapshots of restored VMs
         """
         last_snapshot = None
         for _ in range(nr_vms):
-            microvm = self.build()
+            microvm = self.build(
+                **(
+                    {"netns": net_tools.NetNs(str(uuid.uuid4()))}
+                    if no_netns_reuse
+                    else {}
+                )
+            )
             microvm.spawn()
 
             snapshot_copy = microvm.restore_from_snapshot(

--- a/tests/integration_tests/performance/test_snapshot.py
+++ b/tests/integration_tests/performance/test_snapshot.py
@@ -122,7 +122,9 @@ def test_restore_latency(
 
     snapshot = vm.snapshot_full()
     vm.kill()
-    for microvm in microvm_factory.build_n_from_snapshot(snapshot, ITERATIONS):
+    for microvm in microvm_factory.build_n_from_snapshot(
+        snapshot, ITERATIONS, no_netns_reuse=True
+    ):
         value = 0
         # Parse all metric data points in search of load_snapshot time.
         microvm.flush_metrics()


### PR DESCRIPTION
## Changes

Disable netns reuse for test_restore_latency test.

## Reason

This is because with netns reuse, the first test variant spends time on initialising netns, while the subsequent test variants do not. Disable netns reuse to make the performance data consistent.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
