### PR TITLE
Make bpf filter compilation deterministic

### DIFF
--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{Read, Seek};
 use std::os::fd::{AsRawFd, FromRawFd};
@@ -91,7 +91,7 @@ pub fn compile_bpf(
     // SAFETY: Safe because the parameters are valid.
     let mut memfd = unsafe { File::from_raw_fd(memfd_fd) };
 
-    let mut bpf_map: HashMap<String, Vec<u64>> = HashMap::new();
+    let mut bpf_map: BTreeMap<String, Vec<u64>> = BTreeMap::new();
     for (name, filter) in bpf_map_json.0.iter() {
         let default_action = filter.default_action.to_scmp_type();
         let filter_action = filter.filter_action.to_scmp_type();


### PR DESCRIPTION
## Changes

replaced HashMap with BTreeMap in the bpf filter compiler

## Reason

In order to have reproducible builds on `seccomp_filter.bpf` (and so in the final binary package) . Followup from [#3439](https://github.com/firecracker-microvm/firecracker/issues/3439)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md