### PR TITLE
Allow for more MSIs for PCI devices

### DIFF
--- a/src/vmm/src/arch/aarch64/layout.rs
+++ b/src/vmm/src/arch/aarch64/layout.rs
@@ -78,9 +78,12 @@ pub const FDT_MAX_SIZE: usize = 0x20_0000;
 // * a multiple of 32.
 /// The highest usable SPI on aarch64.
 pub const IRQ_MAX: u32 = 128;
-
 /// First usable interrupt on aarch64.
 pub const IRQ_BASE: u32 = 32;
+/// The highest available GSI in KVM (KVM_MAX_IRQ_ROUTES=4096)
+pub const GSI_MAX: u32 = 4095;
+/// First GSI after legacy IRQ on aarch64.
+pub const GSI_BASE: u32 = 129;
 
 /// The start of the memory area reserved for MMIO 32-bit accesses.
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -21,10 +21,11 @@ pub use aarch64::vm::{ArchVm, ArchVmError, VmState};
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     ConfigurationError, arch_memory_regions, configure_system_for_boot, get_kernel_start,
-    initrd_load_addr, layout::BOOT_DEVICE_MEM_START, layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE,
-    layout::IRQ_MAX, layout::MEM_32BIT_DEVICES_SIZE, layout::MEM_32BIT_DEVICES_START,
-    layout::MEM_64BIT_DEVICES_SIZE, layout::MEM_64BIT_DEVICES_START, layout::MMIO32_MEM_SIZE,
-    layout::MMIO32_MEM_START, layout::PCI_MMCONFIG_SIZE, layout::PCI_MMCONFIG_START,
+    initrd_load_addr, layout::BOOT_DEVICE_MEM_START, layout::CMDLINE_MAX_SIZE, layout::GSI_BASE,
+    layout::GSI_MAX, layout::IRQ_BASE, layout::IRQ_MAX, layout::MEM_32BIT_DEVICES_SIZE,
+    layout::MEM_32BIT_DEVICES_START, layout::MEM_64BIT_DEVICES_SIZE,
+    layout::MEM_64BIT_DEVICES_START, layout::MMIO32_MEM_SIZE, layout::MMIO32_MEM_START,
+    layout::PCI_MMCONFIG_SIZE, layout::PCI_MMCONFIG_START,
     layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT, layout::RTC_MEM_START, layout::SERIAL_MEM_START,
     layout::SYSTEM_MEM_SIZE, layout::SYSTEM_MEM_START, load_kernel,
 };
@@ -44,10 +45,10 @@ pub use x86_64::vm::{ArchVm, ArchVmError, VmState};
 pub use crate::arch::x86_64::{
     ConfigurationError, arch_memory_regions, configure_system_for_boot, get_kernel_start,
     initrd_load_addr, layout::APIC_ADDR, layout::BOOT_DEVICE_MEM_START, layout::CMDLINE_MAX_SIZE,
-    layout::IOAPIC_ADDR, layout::IRQ_BASE, layout::IRQ_MAX, layout::MEM_32BIT_DEVICES_SIZE,
-    layout::MEM_32BIT_DEVICES_START, layout::MEM_64BIT_DEVICES_SIZE,
-    layout::MEM_64BIT_DEVICES_START, layout::MMIO32_MEM_SIZE, layout::MMIO32_MEM_START,
-    layout::PCI_MMCONFIG_SIZE, layout::PCI_MMCONFIG_START,
+    layout::GSI_BASE, layout::GSI_MAX, layout::IOAPIC_ADDR, layout::IRQ_BASE, layout::IRQ_MAX,
+    layout::MEM_32BIT_DEVICES_SIZE, layout::MEM_32BIT_DEVICES_START,
+    layout::MEM_64BIT_DEVICES_SIZE, layout::MEM_64BIT_DEVICES_START, layout::MMIO32_MEM_SIZE,
+    layout::MMIO32_MEM_START, layout::PCI_MMCONFIG_SIZE, layout::PCI_MMCONFIG_START,
     layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT, layout::SYSTEM_MEM_SIZE, layout::SYSTEM_MEM_START,
     load_kernel,
 };

--- a/src/vmm/src/arch/x86_64/layout.rs
+++ b/src/vmm/src/arch/x86_64/layout.rs
@@ -26,6 +26,10 @@ pub const HIMEM_START: u64 = 0x0010_0000; // 1 MB.
 pub const IRQ_BASE: u32 = 5;
 /// Last usable IRQ ID for virtio device interrupts on x86_64.
 pub const IRQ_MAX: u32 = 23;
+/// First GSI after legacy interrupts/
+pub const GSI_BASE: u32 = 24;
+/// The highest available GSI in KVM (KVM_MAX_IRQ_ROUTES=4096)
+pub const GSI_MAX: u32 = 4095;
 
 /// Address for the TSS setup.
 pub const KVM_TSS_ADDRESS: u64 = 0xfffb_d000;

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -157,7 +157,7 @@ impl MMIODeviceManager {
         resource_allocator: &mut ResourceAllocator,
         irq_count: u32,
     ) -> Result<MMIODeviceInfo, MmioError> {
-        let irq = match resource_allocator.allocate_gsi(irq_count)?[..] {
+        let irq = match resource_allocator.allocate_irq(irq_count)?[..] {
             [] => None,
             [irq] => NonZeroU32::new(irq),
             _ => return Err(MmioError::InvalidIrqConfig),
@@ -277,11 +277,11 @@ impl MMIODeviceManager {
         let device_info = if let Some(device_info) = device_info_opt {
             device_info
         } else {
-            let gsi = vm.resource_allocator().allocate_gsi(1)?;
+            let irq = vm.resource_allocator().allocate_irq(1)?;
             MMIODeviceInfo {
                 addr: SERIAL_MEM_START,
                 len: MMIO_LEN,
-                irq: NonZeroU32::new(gsi[0]),
+                irq: NonZeroU32::new(irq[0]),
             }
         };
 
@@ -336,11 +336,11 @@ impl MMIODeviceManager {
         let device_info = if let Some(device_info) = device_info_opt {
             device_info
         } else {
-            let gsi = vm.resource_allocator().allocate_gsi(1)?;
+            let irq = vm.resource_allocator().allocate_irq(1)?;
             MMIODeviceInfo {
                 addr: RTC_MEM_START,
                 len: MMIO_LEN,
-                irq: NonZeroU32::new(gsi[0]),
+                irq: NonZeroU32::new(irq[0]),
             }
         };
 

--- a/src/vmm/src/devices/acpi/vmgenid.rs
+++ b/src/vmm/src/devices/acpi/vmgenid.rs
@@ -88,7 +88,7 @@ impl VmGenId {
         mem: &GuestMemoryMmap,
         resource_allocator: &mut ResourceAllocator,
     ) -> Result<Self, VmGenIdError> {
-        let gsi = resource_allocator.allocate_gsi(1)?;
+        let irq = resource_allocator.allocate_irq(1)?;
         // The generation ID needs to live in an 8-byte aligned buffer
         let addr = resource_allocator.allocate_system_memory(
             VMGENID_MEM_SIZE,
@@ -96,7 +96,7 @@ impl VmGenId {
             vm_allocator::AllocPolicy::LastMatch,
         )?;
 
-        Self::from_parts(GuestAddress(addr), gsi[0], mem)
+        Self::from_parts(GuestAddress(addr), irq[0], mem)
     }
 
     // Create a 16-bytes random number

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -877,7 +877,7 @@ pub(crate) mod tests {
         }
 
         for i in 0..4 {
-            let gsi = crate::arch::IRQ_BASE + i;
+            let gsi = crate::arch::GSI_BASE + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
             let kvm_route = interrupts.get(&gsi).unwrap();
             assert!(kvm_route.masked);
@@ -894,7 +894,7 @@ pub(crate) mod tests {
         // Simply enabling the vectors should not update the registered IRQ routes
         msix_group.enable().unwrap();
         for i in 0..4 {
-            let gsi = crate::arch::IRQ_BASE + i;
+            let gsi = crate::arch::GSI_BASE + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
             let kvm_route = interrupts.get(&gsi).unwrap();
             assert!(kvm_route.masked);
@@ -914,7 +914,7 @@ pub(crate) mod tests {
             .update(0, InterruptSourceConfig::MsiIrq(config), false, true)
             .unwrap();
         for i in 0..4 {
-            let gsi = crate::arch::IRQ_BASE + i;
+            let gsi = crate::arch::GSI_BASE + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
             let kvm_route = interrupts.get(&gsi).unwrap();
             assert_eq!(kvm_route.masked, i != 0);

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -6,59 +6,82 @@ import platform
 
 import pytest
 
+
 # IRQs are available from 5 to 23. We always use one IRQ for VMGenID device, so
 # the maximum number of devices supported at the same time is 18.
-MAX_DEVICES_ATTACHED = 18
+def max_devices(uvm):
+    """
+    Returns the maximum number of devices supported by the platform.
+    """
+    if uvm.pci_enabled:
+        return 31
+
+    match platform.machine():
+        case "aarch64":
+            return 64
+        case "x86_64":
+            return 18
+        case _:
+            raise ValueError("Unknown platform")
 
 
-@pytest.mark.skipif(
-    platform.machine() != "x86_64", reason="Firecracker supports 24 IRQs on x86_64."
-)
-def test_attach_maximum_devices(uvm_plain_any):
+def test_attach_maximum_devices(microvm_factory, guest_kernel, rootfs, pci_enabled):
     """
     Test attaching maximum number of devices to the microVM.
     """
-    test_microvm = uvm_plain_any
-    test_microvm.spawn()
+    test_microvm = microvm_factory.build(
+        kernel=guest_kernel, rootfs=rootfs, monitor_memory=False
+    )
+    test_microvm.spawn(pci=pci_enabled)
 
     # Set up a basic microVM.
-    test_microvm.basic_config()
+    test_microvm.basic_config(mem_size_mib=1024)
 
+    max_devices_attached = max_devices(test_microvm)
     # Add (`MAX_DEVICES_ATTACHED` - 1) devices because the rootfs
     # has already been configured in the `basic_config()`function.
-    for _ in range(MAX_DEVICES_ATTACHED - 1):
+    for _ in range(max_devices_attached - 1):
         test_microvm.add_net_iface()
     test_microvm.start()
 
     # Test that network devices attached are operational.
-    for i in range(MAX_DEVICES_ATTACHED - 1):
+    for i in range(max_devices_attached - 1):
         # Verify if guest can run commands.
         test_microvm.ssh_iface(i).check_output("sync")
 
 
 @pytest.mark.skipif(
-    platform.machine() != "x86_64", reason="Firecracker supports 24 IRQs on x86_64."
+    platform.machine() != "x86_64",
+    reason="Firecracker has a bug in aarch that limits devices to 64, from the theoretical 96.",
 )
-def test_attach_too_many_devices(uvm_plain):
+def test_attach_too_many_devices(microvm_factory, guest_kernel, rootfs, pci_enabled):
     """
     Test attaching to a microVM more devices than available IRQs.
     """
-    test_microvm = uvm_plain
-    test_microvm.spawn()
+    test_microvm = microvm_factory.build(
+        kernel=guest_kernel, rootfs=rootfs, monitor_memory=False
+    )
+    test_microvm.spawn(pci=pci_enabled)
 
     # Set up a basic microVM.
-    test_microvm.basic_config()
+    test_microvm.basic_config(mem_size_mib=1024)
+
+    max_devices_attached = max_devices(test_microvm)
 
     # Add `MAX_DEVICES_ATTACHED` network devices on top of the
     # already configured rootfs.
-    for _ in range(MAX_DEVICES_ATTACHED):
+    for _ in range(max_devices_attached):
         test_microvm.add_net_iface()
 
     # Attempting to start a microVM with more than
     # `MAX_DEVICES_ATTACHED` devices should fail.
     error_str = (
-        "Failed to allocate requested resource: The requested resource"
-        " is not available."
+        ("Could not find an available device slot on the PCI bus.")
+        if pci_enabled
+        else (
+            "Failed to allocate requested resource: The requested resource"
+            " is not available."
+        )
     )
     with pytest.raises(RuntimeError, match=error_str):
         test_microvm.start()


### PR DESCRIPTION
## Changes

Distinguish between interrupt lines for legacy devices ("irq") and GSIs used by MSIs for PCI devices ("gsi"). This means:
 - creating a new allocator for irq ([5, 23] on x86, [32, 127] on aarch64)
 - changing gsi allocator to wider range, right after irq ([24, 4095] on x86, [128, 4095] on aarch64)
 - allocating legacy devices from irq instead of gsi allocator
 - updating test to ensure we can now create 31 devices on pci enabled, regardless of arch.

**TODO**: rebase pci branch and this PR on top of ARM max irq number fix (#5283) 

## Reason

Since we were still only using legacy IRQs for PCI devices, but each used one interrupt per queue plus one for the config, this meant we were limited to a handful of devices and not the expected 32.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
