### PR TITLE
Miscellaneous PCI fixes and more test coverage

### DIFF
--- a/resources/chroot.sh
+++ b/resources/chroot.sh
@@ -64,6 +64,10 @@ rm -vf /etc/systemd/system/timers.target.wants/*
 
 systemctl enable var-lib-systemd.mount
 
+# disable Predictable Network Interface Names to keep ethN names
+# even with PCI enabled
+ln -s /dev/null /etc/systemd/network/99-default.link
+
 #### trim image https://wiki.ubuntu.com/ReducingDiskFootprint
 # this does not save much, but oh well
 rm -rf /usr/share/{doc,man,info,locale}

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -379,7 +379,7 @@ fn create_virtio_node(fdt: &mut FdtWriter, dev_info: &MMIODeviceInfo) -> Result<
         "interrupts",
         &[
             GIC_FDT_IRQ_TYPE_SPI,
-            dev_info.irq.unwrap(),
+            dev_info.gsi.unwrap(),
             IRQ_TYPE_EDGE_RISING,
         ],
     )?;
@@ -400,7 +400,7 @@ fn create_serial_node(fdt: &mut FdtWriter, dev_info: &MMIODeviceInfo) -> Result<
         "interrupts",
         &[
             GIC_FDT_IRQ_TYPE_SPI,
-            dev_info.irq.unwrap(),
+            dev_info.gsi.unwrap(),
             IRQ_TYPE_EDGE_RISING,
         ],
     )?;

--- a/src/vmm/src/arch/aarch64/gic/gicv2/mod.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv2/mod.rs
@@ -135,9 +135,9 @@ impl GICv2 {
         // On arm there are 3 types of interrupts: SGI (0-15), PPI (16-31), SPI (32-1020).
         // SPIs are used to signal interrupts from various peripherals accessible across
         // the whole system so these are the ones that we increment when adding a new virtio device.
-        // KVM_DEV_ARM_VGIC_GRP_NR_IRQS sets the highest SPI number. Consequently, we will have a
-        // total of `super::layout::IRQ_MAX - 32` usable SPIs in our microVM.
-        let nr_irqs: u32 = super::layout::IRQ_MAX;
+        // KVM_DEV_ARM_VGIC_GRP_NR_IRQS sets the number of interrupts (SGI, PPI, and SPI).
+        // Consequently, we need to add 32 to the number of SPIs ("legacy GSI").
+        let nr_irqs: u32 = crate::arch::GSI_LEGACY_NUM + super::layout::SPI_START;
         let nr_irqs_ptr = &nr_irqs as *const u32;
         Self::set_device_attribute(
             gic_device.device_fd(),

--- a/src/vmm/src/arch/aarch64/gic/gicv2/regs/dist_regs.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv2/regs/dist_regs.rs
@@ -8,7 +8,7 @@ use kvm_ioctls::DeviceFd;
 
 use crate::arch::aarch64::gic::GicError;
 use crate::arch::aarch64::gic::regs::{GicRegState, MmioReg, SimpleReg, VgicRegEngine};
-use crate::arch::{IRQ_BASE, IRQ_MAX};
+use crate::arch::{GSI_LEGACY_NUM, SPI_START};
 
 // Distributor registers as detailed at page 75 from
 // https://developer.arm.com/documentation/ihi0048/latest/.
@@ -62,9 +62,9 @@ impl MmioReg for SharedIrqReg {
         // read-as-zero/write-ignore (RAZ/WI) policy.
         // The first part of a shared-irq register, the one corresponding to the
         // SGI and PPI IRQs (0-32) is RAZ/WI, so we skip it.
-        let start = self.offset + u64::from(IRQ_BASE) * u64::from(self.bits_per_irq) / 8;
+        let start = self.offset + u64::from(SPI_START) * u64::from(self.bits_per_irq) / 8;
 
-        let size_in_bits = u64::from(self.bits_per_irq) * u64::from(IRQ_MAX - IRQ_BASE);
+        let size_in_bits = u64::from(self.bits_per_irq) * u64::from(GSI_LEGACY_NUM);
         let mut size_in_bytes = size_in_bits / 8;
         if size_in_bits % 8 > 0 {
             size_in_bytes += 1;

--- a/src/vmm/src/arch/aarch64/gic/gicv3/mod.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv3/mod.rs
@@ -184,9 +184,9 @@ impl GICv3 {
         // On arm there are 3 types of interrupts: SGI (0-15), PPI (16-31), SPI (32-1020).
         // SPIs are used to signal interrupts from various peripherals accessible across
         // the whole system so these are the ones that we increment when adding a new virtio device.
-        // KVM_DEV_ARM_VGIC_GRP_NR_IRQS sets the highest SPI number. Consequently, we will have a
-        // total of `super::layout::IRQ_MAX - 32` usable SPIs in our microVM.
-        let nr_irqs: u32 = super::layout::IRQ_MAX;
+        // KVM_DEV_ARM_VGIC_GRP_NR_IRQS sets the number of interrupts (SGI, PPI, and SPI).
+        // Consequently, we need to add 32 to the number of SPIs ("legacy GSI").
+        let nr_irqs: u32 = crate::arch::GSI_LEGACY_NUM + super::layout::SPI_START;
         let nr_irqs_ptr = &nr_irqs as *const u32;
         Self::set_device_attribute(
             gic_device.device_fd(),

--- a/src/vmm/src/arch/aarch64/gic/gicv3/regs/dist_regs.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv3/regs/dist_regs.rs
@@ -8,7 +8,7 @@ use kvm_ioctls::DeviceFd;
 
 use crate::arch::aarch64::gic::GicError;
 use crate::arch::aarch64::gic::regs::{GicRegState, MmioReg, SimpleReg, VgicRegEngine};
-use crate::arch::{IRQ_BASE, IRQ_MAX};
+use crate::arch::{GSI_LEGACY_NUM, SPI_START};
 
 // Distributor registers as detailed at page 456 from
 // https://static.docs.arm.com/ihi0069/c/IHI0069C_gic_architecture_specification.pdf.
@@ -64,9 +64,9 @@ impl MmioReg for SharedIrqReg {
         // read-as-zero/write-ignore (RAZ/WI) policy.
         // The first part of a shared-irq register, the one corresponding to the
         // SGI and PPI IRQs (0-32) is RAZ/WI, so we skip it.
-        let start = self.offset + u64::from(IRQ_BASE) * u64::from(self.bits_per_irq) / 8;
+        let start = self.offset + u64::from(SPI_START) * u64::from(self.bits_per_irq) / 8;
 
-        let size_in_bits = u64::from(self.bits_per_irq) * u64::from(IRQ_MAX - IRQ_BASE);
+        let size_in_bits = u64::from(self.bits_per_irq) * u64::from(GSI_LEGACY_NUM);
         let mut size_in_bytes = size_in_bits / 8;
         if size_in_bits % 8 > 0 {
             size_in_bytes += 1;

--- a/src/vmm/src/arch/aarch64/layout.rs
+++ b/src/vmm/src/arch/aarch64/layout.rs
@@ -76,19 +76,25 @@ pub const FDT_MAX_SIZE: usize = 0x20_0000;
 // * bigger than 32
 // * less than 1023 and
 // * a multiple of 32.
-/// The highest usable SPI on aarch64.
-pub const IRQ_MAX: u32 = 128;
-
-/// First usable interrupt on aarch64.
-pub const IRQ_BASE: u32 = 32;
-
-// The Linux kernel automatically shifts the GSI by 32 if it is an SPI,
-// allowing us to start numbering from 0 instead of 32.
-/// The first usable GSI on aarch64.
-pub const GSI_BASE: u32 = 0;
-
-/// The maximum usable GSI on aarch64.
-pub const GSI_MAX: u32 = IRQ_MAX - IRQ_BASE - 1;
+// The first 32 SPIs are reserved, but KVM already shifts the gsi we
+// pass, so we go from 0 to 95 for legacy gsis ("irq") and the remaining
+// we use for MSI.
+/// Offset of first SPI in the GIC
+pub const SPI_START: u32 = 32;
+/// Last possible SPI in the GIC (128 total SPIs)
+pub const SPI_END: u32 = 127;
+/// First usable GSI id on aarch64 (corresponds to SPI #32).
+pub const GSI_LEGACY_START: u32 = 0;
+/// There are 128 SPIs available, but the first 32 are reserved
+pub const GSI_LEGACY_NUM: u32 = SPI_END - SPI_START + 1;
+/// Last available GSI
+pub const GSI_LEGACY_END: u32 = GSI_LEGACY_START + GSI_LEGACY_NUM - 1;
+/// First GSI used by MSI after legacy GSI
+pub const GSI_MSI_START: u32 = GSI_LEGACY_END + 1;
+/// The highest available GSI in KVM (KVM_MAX_IRQ_ROUTES=4096)
+pub const GSI_MSI_END: u32 = 4095;
+/// Number of GSI available for MSI.
+pub const GSI_MSI_NUM: u32 = GSI_MSI_END - GSI_MSI_START + 1;
 
 /// The start of the memory area reserved for MMIO 32-bit accesses.
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -21,13 +21,14 @@ pub use aarch64::vm::{ArchVm, ArchVmError, VmState};
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     ConfigurationError, arch_memory_regions, configure_system_for_boot, get_kernel_start,
-    initrd_load_addr, layout::BOOT_DEVICE_MEM_START, layout::CMDLINE_MAX_SIZE, layout::GSI_BASE,
-    layout::GSI_MAX, layout::IRQ_BASE, layout::IRQ_MAX, layout::MEM_32BIT_DEVICES_SIZE,
+    initrd_load_addr, layout::BOOT_DEVICE_MEM_START, layout::CMDLINE_MAX_SIZE,
+    layout::GSI_LEGACY_END, layout::GSI_LEGACY_NUM, layout::GSI_LEGACY_START, layout::GSI_MSI_END,
+    layout::GSI_MSI_NUM, layout::GSI_MSI_START, layout::MEM_32BIT_DEVICES_SIZE,
     layout::MEM_32BIT_DEVICES_START, layout::MEM_64BIT_DEVICES_SIZE,
     layout::MEM_64BIT_DEVICES_START, layout::MMIO32_MEM_SIZE, layout::MMIO32_MEM_START,
     layout::PCI_MMCONFIG_SIZE, layout::PCI_MMCONFIG_START,
     layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT, layout::RTC_MEM_START, layout::SERIAL_MEM_START,
-    layout::SYSTEM_MEM_SIZE, layout::SYSTEM_MEM_START, load_kernel,
+    layout::SPI_START, layout::SYSTEM_MEM_SIZE, layout::SYSTEM_MEM_START, load_kernel,
 };
 
 /// Module for x86_64 related functionality.
@@ -45,7 +46,8 @@ pub use x86_64::vm::{ArchVm, ArchVmError, VmState};
 pub use crate::arch::x86_64::{
     ConfigurationError, arch_memory_regions, configure_system_for_boot, get_kernel_start,
     initrd_load_addr, layout::APIC_ADDR, layout::BOOT_DEVICE_MEM_START, layout::CMDLINE_MAX_SIZE,
-    layout::GSI_BASE, layout::GSI_MAX, layout::IOAPIC_ADDR, layout::IRQ_BASE, layout::IRQ_MAX,
+    layout::GSI_LEGACY_END, layout::GSI_LEGACY_NUM, layout::GSI_LEGACY_START, layout::GSI_MSI_END,
+    layout::GSI_MSI_NUM, layout::GSI_MSI_START, layout::IOAPIC_ADDR,
     layout::MEM_32BIT_DEVICES_SIZE, layout::MEM_32BIT_DEVICES_START,
     layout::MEM_64BIT_DEVICES_SIZE, layout::MEM_64BIT_DEVICES_START, layout::MMIO32_MEM_SIZE,
     layout::MMIO32_MEM_START, layout::PCI_MMCONFIG_SIZE, layout::PCI_MMCONFIG_START,

--- a/src/vmm/src/arch/x86_64/layout.rs
+++ b/src/vmm/src/arch/x86_64/layout.rs
@@ -21,17 +21,21 @@ pub const CMDLINE_MAX_SIZE: usize = 2048;
 /// Start of the high memory.
 pub const HIMEM_START: u64 = 0x0010_0000; // 1 MB.
 
-// Typically, on x86 systems 24 IRQs are used (0-23).
-/// First usable IRQ ID for virtio device interrupts on x86_64.
-pub const IRQ_BASE: u32 = 5;
-/// Last usable IRQ ID for virtio device interrupts on x86_64.
-pub const IRQ_MAX: u32 = 23;
-
-/// The first usable GSI on x86_64 is the same as the first usable IRQ ID.
-pub const GSI_BASE: u32 = IRQ_BASE;
-
-/// The maximum usable GSI on x86_64 is the same as the last usable IRQ ID.
-pub const GSI_MAX: u32 = IRQ_MAX;
+// Typically, on x86 systems 24 IRQs are used for legacy devices (0-23).
+// However, the first 5 are reserved.
+// We allocate the remaining GSIs to MSIs.
+/// First usable GSI for legacy interrupts (IRQ) on x86_64.
+pub const GSI_LEGACY_START: u32 = 5;
+/// Last usable GSI for legacy interrupts (IRQ) on x86_64.
+pub const GSI_LEGACY_END: u32 = 23;
+/// Number of legacy GSI (IRQ) available on x86_64.
+pub const GSI_LEGACY_NUM: u32 = GSI_LEGACY_END - GSI_LEGACY_START + 1;
+/// First GSI used by MSI after legacy GSI.
+pub const GSI_MSI_START: u32 = GSI_LEGACY_END + 1;
+/// The highest available GSI in KVM (KVM_MAX_IRQ_ROUTES=4096).
+pub const GSI_MSI_END: u32 = 4095;
+/// Number of GSI available for MSI.
+pub const GSI_MSI_NUM: u32 = GSI_MSI_END - GSI_MSI_START + 1;
 
 /// Address for the TSS setup.
 pub const KVM_TSS_ADDRESS: u64 = 0xfffb_d000;

--- a/src/vmm/src/arch/x86_64/mptable.rs
+++ b/src/vmm/src/arch/x86_64/mptable.rs
@@ -13,7 +13,7 @@ use libc::c_char;
 use log::debug;
 use vm_allocator::AllocPolicy;
 
-use crate::arch::IRQ_MAX;
+use crate::arch::GSI_LEGACY_END;
 use crate::arch::x86_64::generated::mpspec;
 use crate::vstate::memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap,
@@ -109,7 +109,7 @@ fn compute_mp_size(num_cpus: u8) -> usize {
         + mem::size_of::<mpspec::mpc_cpu>() * (num_cpus as usize)
         + mem::size_of::<mpspec::mpc_ioapic>()
         + mem::size_of::<mpspec::mpc_bus>()
-        + mem::size_of::<mpspec::mpc_intsrc>() * (IRQ_MAX as usize + 1)
+        + mem::size_of::<mpspec::mpc_intsrc>() * (GSI_LEGACY_END as usize + 1)
         + mem::size_of::<mpspec::mpc_lintsrc>() * 2
 }
 
@@ -225,7 +225,7 @@ pub fn setup_mptable(
         mp_num_entries += 1;
     }
     // Per kvm_setup_default_irq_routing() in kernel
-    for i in 0..=u8::try_from(IRQ_MAX).map_err(|_| MptableError::TooManyIrqs)? {
+    for i in 0..=u8::try_from(GSI_LEGACY_END).map_err(|_| MptableError::TooManyIrqs)? {
         let size = mem::size_of::<mpspec::mpc_intsrc>() as u64;
         let mpc_intsrc = mpspec::mpc_intsrc {
             type_: mpspec::MP_INTSRC.try_into().unwrap(),
@@ -406,7 +406,7 @@ mod tests {
             // ISA Bus
             + 1
             // IRQ
-            + u16::try_from(IRQ_MAX).unwrap() + 1
+            + u16::try_from(GSI_LEGACY_END).unwrap() + 1
             // Interrupt source ExtINT
             + 1
             // Interrupt source NMI

--- a/src/vmm/src/device_manager/acpi.rs
+++ b/src/vmm/src/device_manager/acpi.rs
@@ -64,7 +64,7 @@ impl Aml for ACPIDeviceManager {
                                 // We know that the maximum IRQ number fits in a u8. We have up to
                                 // 32 IRQs in x86 and up to 128 in
                                 // ARM (look into
-                                // `vmm::crate::arch::layout::IRQ_MAX`)
+                                // `vmm::crate::arch::layout::GSI_LEGACY_END`)
                                 #[allow(clippy::cast_possible_truncation)]
                                 &aml::Equal::new(&aml::Arg(0), &(vmgenid.gsi as u8)),
                                 vec![&aml::Notify::new(

--- a/src/vmm/src/devices/acpi/vmgenid.rs
+++ b/src/vmm/src/devices/acpi/vmgenid.rs
@@ -88,7 +88,7 @@ impl VmGenId {
         mem: &GuestMemoryMmap,
         resource_allocator: &mut ResourceAllocator,
     ) -> Result<Self, VmGenIdError> {
-        let gsi = resource_allocator.allocate_gsi(1)?;
+        let gsi = resource_allocator.allocate_gsi_legacy(1)?;
         // The generation ID needs to live in an 8-byte aligned buffer
         let addr = resource_allocator.allocate_system_memory(
             VMGENID_MEM_SIZE,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -252,6 +252,8 @@ pub enum VmmError {
     VmmObserverTeardown(vmm_sys_util::errno::Error),
     /// VMGenID error: {0}
     VMGenID(#[from] VmGenIdError),
+    /// Failed perform action on device: {0}
+    FindDeviceError(#[from] device_manager::FindDeviceError),
 }
 
 /// Shorthand type for KVM dirty page bitmap.
@@ -537,13 +539,12 @@ impl Vmm {
         path_on_host: String,
     ) -> Result<(), VmmError> {
         self.device_manager
-            .mmio_devices
             .with_virtio_device_with_id(TYPE_BLOCK, drive_id, |block: &mut Block| {
                 block
                     .update_disk_image(path_on_host)
                     .map_err(|err| err.to_string())
             })
-            .map_err(VmmError::MmioDeviceManager)
+            .map_err(VmmError::FindDeviceError)
     }
 
     /// Updates the rate limiter parameters for block device with `drive_id` id.
@@ -554,23 +555,21 @@ impl Vmm {
         rl_ops: BucketUpdate,
     ) -> Result<(), VmmError> {
         self.device_manager
-            .mmio_devices
             .with_virtio_device_with_id(TYPE_BLOCK, drive_id, |block: &mut Block| {
                 block
                     .update_rate_limiter(rl_bytes, rl_ops)
                     .map_err(|err| err.to_string())
             })
-            .map_err(VmmError::MmioDeviceManager)
+            .map_err(VmmError::FindDeviceError)
     }
 
     /// Updates the rate limiter parameters for block device with `drive_id` id.
     pub fn update_vhost_user_block_config(&mut self, drive_id: &str) -> Result<(), VmmError> {
         self.device_manager
-            .mmio_devices
             .with_virtio_device_with_id(TYPE_BLOCK, drive_id, |block: &mut Block| {
                 block.update_config().map_err(|err| err.to_string())
             })
-            .map_err(VmmError::MmioDeviceManager)
+            .map_err(VmmError::FindDeviceError)
     }
 
     /// Updates the rate limiter parameters for net device with `net_id` id.
@@ -583,12 +582,11 @@ impl Vmm {
         tx_ops: BucketUpdate,
     ) -> Result<(), VmmError> {
         self.device_manager
-            .mmio_devices
             .with_virtio_device_with_id(TYPE_NET, net_id, |net: &mut Net| {
                 net.patch_rate_limiters(rx_bytes, rx_ops, tx_bytes, tx_ops);
                 Ok(())
             })
-            .map_err(VmmError::MmioDeviceManager)
+            .map_err(VmmError::FindDeviceError)
     }
 
     /// Returns a reference to the balloon device if present.

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -587,7 +587,7 @@ impl Vm {
         let mut irq_routes = HashMap::with_capacity(count as usize);
         for (gsi, i) in vm
             .resource_allocator()
-            .allocate_gsi(count as u32)?
+            .allocate_gsi_msi(count as u32)?
             .iter()
             .zip(0u32..)
         {
@@ -877,7 +877,7 @@ pub(crate) mod tests {
         }
 
         for i in 0..4 {
-            let gsi = crate::arch::GSI_BASE + i;
+            let gsi = crate::arch::GSI_MSI_START + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
             let kvm_route = interrupts.get(&gsi).unwrap();
             assert!(kvm_route.masked);
@@ -894,7 +894,7 @@ pub(crate) mod tests {
         // Simply enabling the vectors should not update the registered IRQ routes
         msix_group.enable().unwrap();
         for i in 0..4 {
-            let gsi = crate::arch::GSI_BASE + i;
+            let gsi = crate::arch::GSI_MSI_START + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
             let kvm_route = interrupts.get(&gsi).unwrap();
             assert!(kvm_route.masked);
@@ -914,7 +914,7 @@ pub(crate) mod tests {
             .update(0, InterruptSourceConfig::MsiIrq(config), false, true)
             .unwrap();
         for i in 0..4 {
-            let gsi = crate::arch::GSI_BASE + i;
+            let gsi = crate::arch::GSI_MSI_START + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
             let kvm_route = interrupts.get(&gsi).unwrap();
             assert_eq!(kvm_route.masked, i != 0);
@@ -989,7 +989,7 @@ pub(crate) mod tests {
         let (gsi, range) = {
             let mut resource_allocator = vm.resource_allocator();
 
-            let gsi = resource_allocator.allocate_gsi(1).unwrap()[0];
+            let gsi = resource_allocator.allocate_gsi_msi(1).unwrap()[0];
             let range = resource_allocator
                 .allocate_32bit_mmio_memory(1024, 1024, AllocPolicy::FirstMatch)
                 .unwrap();
@@ -1003,7 +1003,7 @@ pub(crate) mod tests {
         vm.restore_state(&restored_state).unwrap();
 
         let mut resource_allocator = vm.resource_allocator();
-        let gsi_new = resource_allocator.allocate_gsi(1).unwrap()[0];
+        let gsi_new = resource_allocator.allocate_gsi_msi(1).unwrap()[0];
         assert_eq!(gsi + 1, gsi_new);
 
         resource_allocator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -513,6 +513,18 @@ def uvm_plain(microvm_factory, guest_kernel_linux_5_10, rootfs, pci_enabled):
 
 
 @pytest.fixture
+def uvm_plain_6_1(microvm_factory, guest_kernel_linux_6_1, rootfs, pci_enabled):
+    """Create a vanilla VM, non-parametrized"""
+    return microvm_factory.build(guest_kernel_linux_6_1, rootfs, pci=pci_enabled)
+
+
+@pytest.fixture
+def uvm_plain_acpi(microvm_factory, guest_kernel_acpi, rootfs, pci_enabled):
+    """Create a vanilla VM, non-parametrized"""
+    return microvm_factory.build(guest_kernel_acpi, rootfs, pci=pci_enabled)
+
+
+@pytest.fixture
 def uvm_plain_rw(microvm_factory, guest_kernel_linux_5_10, rootfs_rw):
     """Create a vanilla VM, non-parametrized"""
     return microvm_factory.build(guest_kernel_linux_5_10, rootfs_rw)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -507,9 +507,9 @@ def rootfs_rw():
 
 
 @pytest.fixture
-def uvm_plain(microvm_factory, guest_kernel_linux_5_10, rootfs):
+def uvm_plain(microvm_factory, guest_kernel_linux_5_10, rootfs, pci_enabled):
     """Create a vanilla VM, non-parametrized"""
-    return microvm_factory.build(guest_kernel_linux_5_10, rootfs)
+    return microvm_factory.build(guest_kernel_linux_5_10, rootfs, pci=pci_enabled)
 
 
 @pytest.fixture
@@ -535,12 +535,12 @@ def artifact_dir():
 
 
 @pytest.fixture
-def uvm_plain_any(microvm_factory, guest_kernel, rootfs):
+def uvm_plain_any(microvm_factory, guest_kernel, rootfs, pci_enabled):
     """All guest kernels
     kernel: all
     rootfs: Ubuntu 24.04
     """
-    return microvm_factory.build(guest_kernel, rootfs)
+    return microvm_factory.build(guest_kernel, rootfs, pci=pci_enabled)
 
 
 guest_kernel_6_1_debug = pytest.fixture(
@@ -583,8 +583,8 @@ def uvm_booted(
     mem_size_mib=256,
 ):
     """Return a booted uvm"""
-    uvm = microvm_factory.build(guest_kernel, rootfs)
-    uvm.spawn(pci=pci_enabled)
+    uvm = microvm_factory.build(guest_kernel, rootfs, pci=pci_enabled)
+    uvm.spawn()
     uvm.basic_config(vcpu_count=vcpu_count, mem_size_mib=mem_size_mib)
     uvm.set_cpu_template(cpu_template)
     uvm.add_net_iface()

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -191,6 +191,7 @@ class Microvm:
         jailer_kwargs: Optional[dict] = None,
         numa_node=None,
         custom_cpu_template: Path = None,
+        pci: bool = False,
     ):
         """Set up microVM attributes, paths, and data structures."""
         # pylint: disable=too-many-statements
@@ -198,7 +199,6 @@ class Microvm:
         assert microvm_id is not None
         self._microvm_id = microvm_id
 
-        self.pci_enabled = False
         self.kernel_file = None
         self.rootfs_file = None
         self.ssh_key = None
@@ -221,6 +221,10 @@ class Microvm:
             new_pid_ns=True,
             **jailer_kwargs,
         )
+
+        self.pci_enabled = pci
+        if pci:
+            self.jailer.extra_args["enable-pci"] = None
 
         # Copy the /etc/localtime file in the jailer root
         self.jailer.jailed_path("/etc/localtime", subdir="etc")
@@ -612,7 +616,6 @@ class Microvm:
         log_show_origin=False,
         metrics_path="fc.ndjson",
         emit_metrics: bool = False,
-        pci: bool = False,
     ):
         """Start a microVM as a daemon or in a screen session."""
         # pylint: disable=subprocess-run-check
@@ -657,10 +660,6 @@ class Microvm:
         if log_level != "Debug":
             # Checking the timings requires DEBUG level log messages
             self.time_api_requests = False
-
-        if pci:
-            self.pci_enabled = True
-            self.jailer.extra_args["enable-pci"] = None
 
         cmd = [
             *self._pre_cmd,

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -1,7 +1,7 @@
 {
   "boot-source": {
     "kernel_image_path": "vmlinux.bin",
-    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off",
+    "boot_args": "console=ttyS0 reboot=k panic=1",
     "initrd_path": null
   },
   "drives": [

--- a/tests/framework/vm_config_cpu_template_C3.json
+++ b/tests/framework/vm_config_cpu_template_C3.json
@@ -1,7 +1,7 @@
 {
   "boot-source": {
     "kernel_image_path": "vmlinux.bin",
-    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
+    "boot_args": "console=ttyS0 reboot=k panic=1"
   },
   "drives": [
     {

--- a/tests/framework/vm_config_missing_mem_size_mib.json
+++ b/tests/framework/vm_config_missing_mem_size_mib.json
@@ -1,7 +1,7 @@
 {
   "boot-source": {
     "kernel_image_path": "vmlinux.bin",
-    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
+    "boot_args": "console=ttyS0 reboot=k panic=1"
   },
   "drives": [
     {

--- a/tests/framework/vm_config_missing_vcpu_count.json
+++ b/tests/framework/vm_config_missing_vcpu_count.json
@@ -1,7 +1,7 @@
 {
   "boot-source": {
     "kernel_image_path": "vmlinux.bin",
-    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
+    "boot_args": "console=ttyS0 reboot=k panic=1"
   },
   "drives": [
     {

--- a/tests/framework/vm_config_network.json
+++ b/tests/framework/vm_config_network.json
@@ -1,7 +1,7 @@
 {
   "boot-source": {
     "kernel_image_path": "vmlinux.bin",
-    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off",
+    "boot_args": "console=ttyS0 reboot=k panic=1",
     "initrd_path": null
   },
   "drives": [

--- a/tests/framework/vm_config_smt_true.json
+++ b/tests/framework/vm_config_smt_true.json
@@ -1,7 +1,7 @@
 {
   "boot-source": {
     "kernel_image_path": "vmlinux.bin",
-    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
+    "boot_args": "console=ttyS0 reboot=k panic=1"
   },
   "drives": [
     {

--- a/tests/framework/vm_config_with_mmdsv1.json
+++ b/tests/framework/vm_config_with_mmdsv1.json
@@ -1,7 +1,7 @@
 {
   "boot-source": {
     "kernel_image_path": "vmlinux.bin",
-    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off",
+    "boot_args": "console=ttyS0 reboot=k panic=1",
     "initrd_path": null
   },
   "drives": [

--- a/tests/framework/vm_config_with_mmdsv2.json
+++ b/tests/framework/vm_config_with_mmdsv2.json
@@ -1,7 +1,7 @@
 {
   "boot-source": {
     "kernel_image_path": "vmlinux.bin",
-    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off",
+    "boot_args": "console=ttyS0 reboot=k panic=1",
     "initrd_path": null
   },
   "drives": [

--- a/tests/host_tools/change_net_config_space.c
+++ b/tests/host_tools/change_net_config_space.c
@@ -14,7 +14,7 @@
 #include <unistd.h>
 
 int show_usage() {
-    printf("Usage: ./change_net_config_space.bin [dev_addr_start] [mac_addr]\n");
+    printf("Usage: ./change_net_config_space.bin [dev_addr] [mac_addr]\n");
     printf("Example:\n");
     printf("> ./change_net_config_space.bin 0xd00001000 0x060504030201\n");
     return 0;
@@ -25,18 +25,17 @@ int main(int argc, char *argv[]) {
     uint8_t *map_base;
     volatile uint8_t *virt_addr;
 
-    uint64_t mapped_size, page_size, offset_in_page, target;
+    uint64_t mapped_size, page_size, page_addr, offset_in_page;
     uint64_t width = 6;
 
-    uint64_t config_offset = 0x100;
-    uint64_t device_start_addr = 0x00000000;
+    uint64_t dev_addr = 0x00000000;
     uint64_t mac = 0;
 
     if (argc != 3) {
         return show_usage();
     }
 
-    device_start_addr = strtoull(argv[1], NULL, 0);
+    dev_addr = strtoull(argv[1], NULL, 0);
     mac = strtoull(argv[2], NULL, 0);
 
     fd = open("/dev/mem", O_RDWR | O_SYNC);
@@ -45,11 +44,11 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    target = device_start_addr + config_offset;
     // Get the page size.
     mapped_size = page_size = getpagesize();
     // Get the target address physical frame page offset.
-    offset_in_page = (unsigned) target & (page_size - 1);
+    offset_in_page = (unsigned) dev_addr & (page_size - 1);
+    page_addr = dev_addr & ~(page_size - 1);
     /* If the data length goes out of the current page,
      * double the needed map size. */
     if (offset_in_page + width > page_size) {
@@ -64,7 +63,8 @@ int main(int argc, char *argv[]) {
             PROT_READ | PROT_WRITE,
             MAP_SHARED,
             fd,
-            target & ~(off_t)(page_size - 1));
+            page_addr
+    );
     if (map_base == MAP_FAILED) {
             perror("Failed to mmap '/dev/mem'.");
             return 2;

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -772,7 +772,7 @@ def test_send_ctrl_alt_del(uvm_plain_any):
 def _drive_patch(test_microvm, io_engine):
     """Exercise drive patch test scenarios."""
     # Patches without mandatory fields for virtio block are not allowed.
-    expected_msg = "Unable to patch the block device: MMIO Device manager error: Running method expected different backend. Please verify the request arguments"
+    expected_msg = "Running method expected different backend."
     with pytest.raises(RuntimeError, match=expected_msg):
         test_microvm.api.drive.patch(drive_id="scratch")
 
@@ -814,7 +814,7 @@ def _drive_patch(test_microvm, io_engine):
         )
 
     # Updates to `path_on_host` with an invalid path are not allowed.
-    expected_msg = f"Unable to patch the block device: MMIO Device manager error: Virtio backend error: Error manipulating the backing file: No such file or directory (os error 2) {drive_path} Please verify the request arguments"
+    expected_msg = f"Error manipulating the backing file: No such file or directory (os error 2) {drive_path}"
     with pytest.raises(RuntimeError, match=re.escape(expected_msg)):
         test_microvm.api.drive.patch(drive_id="scratch", path_on_host=drive_path)
 

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -449,11 +449,11 @@ def test_stats_update(uvm_plain_any):
     assert next_stats["available_memory"] != final_stats["available_memory"]
 
 
-def test_balloon_snapshot(microvm_factory, guest_kernel, rootfs):
+def test_balloon_snapshot(uvm_plain_any, microvm_factory):
     """
     Test that the balloon works after pause/resume.
     """
-    vm = microvm_factory.build(guest_kernel, rootfs)
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config(
         vcpu_count=2,
@@ -531,11 +531,11 @@ def test_balloon_snapshot(microvm_factory, guest_kernel, rootfs):
     assert stats_after_snap["available_memory"] > latest_stats["available_memory"]
 
 
-def test_memory_scrub(microvm_factory, guest_kernel, rootfs):
+def test_memory_scrub(uvm_plain_any):
     """
     Test that the memory is zeroed after deflate.
     """
-    microvm = microvm_factory.build(guest_kernel, rootfs)
+    microvm = uvm_plain_any
     microvm.spawn()
     microvm.basic_config(vcpu_count=2, mem_size_mib=256)
     microvm.add_net_iface()

--- a/tests/integration_tests/functional/test_concurrency.py
+++ b/tests/integration_tests/functional/test_concurrency.py
@@ -7,13 +7,13 @@ from concurrent.futures import ThreadPoolExecutor
 NO_OF_MICROVMS = 20
 
 
-def test_run_concurrency(microvm_factory, guest_kernel, rootfs):
+def test_run_concurrency(microvm_factory, guest_kernel, rootfs, pci_enabled):
     """
     Check we can spawn multiple microvms.
     """
 
     def launch1():
-        microvm = microvm_factory.build(guest_kernel, rootfs)
+        microvm = microvm_factory.build(guest_kernel, rootfs, pci=pci_enabled)
         microvm.time_api_requests = False  # is flaky because of parallelism
         microvm.spawn()
         microvm.basic_config(vcpu_count=1, mem_size_mib=128)

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -261,9 +261,7 @@ def get_guest_msrs(microvm, msr_index_list):
     ),
 )
 def test_cpu_config_dump_vs_actual(
-    microvm_factory,
-    guest_kernel,
-    rootfs,
+    uvm_plain_any,
     cpu_template_helper,
     tmp_path,
 ):
@@ -277,7 +275,7 @@ def test_cpu_config_dump_vs_actual(
     dump_cpu_config = build_cpu_config_dict(cpu_config_path)
 
     # Retrieve actual CPU config from guest
-    microvm = microvm_factory.build(guest_kernel, rootfs)
+    microvm = uvm_plain_any
     microvm.spawn()
     microvm.basic_config(vcpu_count=1)
     microvm.add_net_iface()

--- a/tests/integration_tests/functional/test_error_code.py
+++ b/tests/integration_tests/functional/test_error_code.py
@@ -25,7 +25,7 @@ def test_enosys_error_code(uvm_plain):
     vm.memory_monitor = None
     vm.basic_config(
         vcpu_count=1,
-        boot_args="reboot=k panic=1 pci=off init=/usr/local/bin/devmemread",
+        boot_args="reboot=k panic=1 init=/usr/local/bin/devmemread",
     )
     vm.start()
 

--- a/tests/integration_tests/functional/test_feat_parity.py
+++ b/tests/integration_tests/functional/test_feat_parity.py
@@ -28,16 +28,11 @@ def inst_set_cpu_template_fxt(request):
 
 
 @pytest.fixture(name="vm")
-def vm_fxt(
-    microvm_factory,
-    inst_set_cpu_template,
-    guest_kernel,
-    rootfs,
-):
+def vm_fxt(uvm_plain_any, inst_set_cpu_template):
     """
     Create a VM, using the normal CPU templates
     """
-    vm = microvm_factory.build(guest_kernel, rootfs)
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config(vcpu_count=1, mem_size_mib=1024, cpu_template=inst_set_cpu_template)
     vm.add_net_iface()

--- a/tests/integration_tests/functional/test_kernel_cmdline.py
+++ b/tests/integration_tests/functional/test_kernel_cmdline.py
@@ -21,8 +21,7 @@ def test_init_params(uvm_plain):
     # Ubuntu version from the /etc/issue file.
     vm.basic_config(
         vcpu_count=1,
-        boot_args="console=ttyS0 reboot=k panic=1 pci=off"
-        " init=/bin/cat -- /etc/issue",
+        boot_args="console=ttyS0 reboot=k panic=1 init=/bin/cat -- /etc/issue",
     )
 
     vm.start()

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -6,63 +6,78 @@ import platform
 
 import pytest
 
-# On x86_64, IRQs are available from 5 to 23. We always use one IRQ for VMGenID
-# device, so the maximum number of devices supported at the same time is 18.
 
-# On aarch64, IRQs are available from 32 to 127. We always use one IRQ each for
-# the VMGenID and RTC devices, so the maximum number of devices supported
-# at the same time is 94.
-MAX_DEVICES_ATTACHED = {"x86_64": 18, "aarch64": 94}.get(platform.machine())
+def max_devices(uvm):
+    """
+    Returns the maximum number of devices supported by the platform.
+    """
+    if uvm.pci_enabled:
+        # On PCI, we only have one bus, so 32 minus the bus itself
+        return 31
+
+    match platform.machine():
+        case "aarch64":
+            # On aarch64, IRQs are available from 32 to 127. We always use one IRQ each for
+            # the VMGenID and RTC devices, so the maximum number of devices supported
+            # at the same time is 94.
+            return 94
+        case "x86_64":
+            # IRQs are available from 5 to 23. We always use one IRQ for VMGenID device, so
+            # the maximum number of devices supported at the same time is 18.
+            return 18
+        case _:
+            raise ValueError("Unknown platform")
 
 
-def test_attach_maximum_devices(microvm_factory, guest_kernel, rootfs):
+def test_attach_maximum_devices(microvm_factory, guest_kernel, rootfs, pci_enabled):
     """
     Test attaching maximum number of devices to the microVM.
     """
-    if MAX_DEVICES_ATTACHED is None:
-        pytest.skip("Unsupported platform for this test.")
-
     test_microvm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
-    test_microvm.spawn()
+    test_microvm.spawn(pci=pci_enabled)
 
     # The default 256mib is not enough for 94 ssh connections on aarch64.
     test_microvm.basic_config(mem_size_mib=512)
 
+    max_devices_attached = max_devices(test_microvm)
     # Add (`MAX_DEVICES_ATTACHED` - 1) devices because the rootfs
     # has already been configured in the `basic_config()`function.
-    for _ in range(MAX_DEVICES_ATTACHED - 1):
+    for _ in range(max_devices_attached - 1):
         test_microvm.add_net_iface()
     test_microvm.start()
 
     # Test that network devices attached are operational.
-    for i in range(MAX_DEVICES_ATTACHED - 1):
+    for i in range(max_devices_attached - 1):
         # Verify if guest can run commands.
         test_microvm.ssh_iface(i).check_output("sync")
 
 
-def test_attach_too_many_devices(microvm_factory, guest_kernel, rootfs):
+def test_attach_too_many_devices(microvm_factory, guest_kernel, rootfs, pci_enabled):
     """
     Test attaching to a microVM more devices than available IRQs.
     """
-    if MAX_DEVICES_ATTACHED is None:
-        pytest.skip("Unsupported platform for this test.")
-
     test_microvm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
-    test_microvm.spawn()
+    test_microvm.spawn(pci=pci_enabled)
 
     # Set up a basic microVM.
     test_microvm.basic_config()
 
+    max_devices_attached = max_devices(test_microvm)
+
     # Add `MAX_DEVICES_ATTACHED` network devices on top of the
     # already configured rootfs.
-    for _ in range(MAX_DEVICES_ATTACHED):
+    for _ in range(max_devices_attached):
         test_microvm.add_net_iface()
 
     # Attempting to start a microVM with more than
     # `MAX_DEVICES_ATTACHED` devices should fail.
     error_str = (
-        "Failed to allocate requested resource: The requested resource"
-        " is not available."
+        ("Could not find an available device slot on the PCI bus.")
+        if pci_enabled
+        else (
+            "Failed to allocate requested resource: The requested resource"
+            " is not available."
+        )
     )
     with pytest.raises(RuntimeError, match=error_str):
         test_microvm.start()

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -29,12 +29,13 @@ def max_devices(uvm):
             raise ValueError("Unknown platform")
 
 
-def test_attach_maximum_devices(microvm_factory, guest_kernel, rootfs, pci_enabled):
+def test_attach_maximum_devices(uvm_plain_any):
     """
     Test attaching maximum number of devices to the microVM.
     """
-    test_microvm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
-    test_microvm.spawn(pci=pci_enabled)
+    test_microvm = uvm_plain_any
+    test_microvm.memory_monitor = None
+    test_microvm.spawn()
 
     # The default 256mib is not enough for 94 ssh connections on aarch64.
     test_microvm.basic_config(mem_size_mib=512)
@@ -52,12 +53,13 @@ def test_attach_maximum_devices(microvm_factory, guest_kernel, rootfs, pci_enabl
         test_microvm.ssh_iface(i).check_output("sync")
 
 
-def test_attach_too_many_devices(microvm_factory, guest_kernel, rootfs, pci_enabled):
+def test_attach_too_many_devices(uvm_plain):
     """
     Test attaching to a microVM more devices than available IRQs.
     """
-    test_microvm = microvm_factory.build(guest_kernel, rootfs, monitor_memory=False)
-    test_microvm.spawn(pci=pci_enabled)
+    test_microvm = uvm_plain
+    test_microvm.memory_monitor = None
+    test_microvm.spawn()
 
     # Set up a basic microVM.
     test_microvm.basic_config()
@@ -73,7 +75,7 @@ def test_attach_too_many_devices(microvm_factory, guest_kernel, rootfs, pci_enab
     # `MAX_DEVICES_ATTACHED` devices should fail.
     error_str = (
         ("Could not find an available device slot on the PCI bus.")
-        if pci_enabled
+        if test_microvm.pci_enabled
         else (
             "Failed to allocate requested resource: The requested resource"
             " is not available."

--- a/tests/integration_tests/functional/test_net_config_space.py
+++ b/tests/integration_tests/functional/test_net_config_space.py
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests on devices config space."""
 
-import platform
 import random
-import re
 import string
 import subprocess
 from threading import Thread
@@ -15,14 +13,16 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 PAYLOAD_DATA_SIZE = 20
 
 
-def test_net_change_mac_address(uvm_plain_any, change_net_config_space_bin):
+def test_net_change_mac_address(
+    uvm_plain_any, pci_enabled, change_net_config_space_bin
+):
     """
     Test changing the MAC address of the network device.
     """
 
     test_microvm = uvm_plain_any
     test_microvm.help.enable_console()
-    test_microvm.spawn()
+    test_microvm.spawn(pci=pci_enabled)
     test_microvm.basic_config(boot_args="ipv6.disable=1")
 
     # Data exchange interface ('eth0' in guest).
@@ -64,6 +64,8 @@ def test_net_change_mac_address(uvm_plain_any, change_net_config_space_bin):
 
     net_addr_base = _get_net_mem_addr_base(ssh_conn, guest_if1_name)
     assert net_addr_base is not None
+    config_offset = 0x4000 if test_microvm.pci_enabled else 0x100
+    dev_addr = net_addr_base + config_offset
 
     # Write into '/dev/mem' the same mac address, byte by byte.
     # This changes the MAC address physically, in the network device registers.
@@ -72,7 +74,7 @@ def test_net_change_mac_address(uvm_plain_any, change_net_config_space_bin):
     # `tx_spoofed_mac_count` metric shouldn't be incremented later on.
     rmt_path = "/tmp/change_net_config_space"
     test_microvm.ssh.scp_put(change_net_config_space_bin, rmt_path)
-    cmd = f"chmod u+x {rmt_path} && {rmt_path} {net_addr_base} {mac_hex}"
+    cmd = f"chmod u+x {rmt_path} && {rmt_path} {dev_addr} {mac_hex}"
 
     # This should be executed successfully.
     _, stdout, _ = ssh_conn.check_output(cmd)
@@ -219,8 +221,7 @@ def _find_iomem_range(ssh_connection, dev_name):
     # its contents and grep for the VirtIO device name, which
     # with ACPI is "LNRO0005:XY".
     cmd = f"cat /proc/iomem | grep -m 1 {dev_name}"
-    rc, stdout, stderr = ssh_connection.run(cmd)
-    assert rc == 0, stderr
+    _, stdout, _ = ssh_connection.check_output(cmd)
 
     # Take range in the form 'start-end' from line. The line looks like this:
     # d00002000-d0002fff : LNRO0005:02
@@ -231,89 +232,16 @@ def _find_iomem_range(ssh_connection, dev_name):
     return (int(tokens[0], 16), int(tokens[1], 16))
 
 
-def _get_net_mem_addr_base_x86_acpi(ssh_connection, if_name):
-    """Check for net device memory start address via ACPI info"""
-    # On x86 we define VirtIO devices through ACPI AML bytecode. VirtIO devices
-    # are identified as "LNRO0005" and appear under /sys/devices/platform
-    sys_virtio_mmio_cmdline = "/sys/devices/platform/"
-    cmd = "ls {}"
-    _, stdout, _ = ssh_connection.check_output(cmd.format(sys_virtio_mmio_cmdline))
-    virtio_devs = list(filter(lambda x: "LNRO0005" in x, stdout.strip().split()))
-
-    # For virtio-net LNRO0005 devices, we should have a path like:
-    # /sys/devices/platform/LNRO0005::XY/virtioXY/net which is a directory
-    # that includes a subdirectory `ethZ` which represents the network device
-    # that corresponds to the virtio-net device.
-    cmd = "ls {}/{}/virtio{}/net"
-    for idx, dev in enumerate(virtio_devs):
-        _, guest_if_name, _ = ssh_connection.run(
-            cmd.format(sys_virtio_mmio_cmdline, dev, idx)
-        )
-        if guest_if_name.strip() == if_name:
-            return _find_iomem_range(ssh_connection, dev)[0]
-
-    return None
-
-
-def _get_net_mem_addr_base_x86_cmdline(ssh_connection, if_name):
-    """Check for net device memory start address via command line arguments"""
-    sys_virtio_mmio_cmdline = "/sys/devices/virtio-mmio-cmdline/"
-    cmd = "ls {} | grep virtio-mmio. | sed 's/virtio-mmio.//'"
-    exit_code, stdout, stderr = ssh_connection.run(cmd.format(sys_virtio_mmio_cmdline))
-    assert exit_code == 0, stderr
-    virtio_devs_idx = stdout.strip().split()
-
-    cmd = "cat /proc/cmdline"
-    _, cmd_line, _ = ssh_connection.check_output(cmd)
-    pattern_dev = re.compile("(virtio_mmio.device=4K@0x[0-9a-f]+:[0-9]+)+")
-    pattern_addr = re.compile("virtio_mmio.device=4K@(0x[0-9a-f]+):[0-9]+")
-    devs_addr = []
-    for dev in re.findall(pattern_dev, cmd_line):
-        matched_addr = pattern_addr.search(dev)
-        # The 1st group which matches this pattern
-        # is the device start address. `0` group is
-        # full match
-        addr = matched_addr.group(1)
-        devs_addr.append(addr)
-
-    cmd = "ls {}/virtio-mmio.{}/virtio{}/net"
-    for idx in virtio_devs_idx:
-        _, guest_if_name, _ = ssh_connection.run(
-            cmd.format(sys_virtio_mmio_cmdline, idx, idx)
-        )
-        if guest_if_name.strip() == if_name:
-            return devs_addr[int(idx)]
-
-    return None
-
-
 def _get_net_mem_addr_base(ssh_connection, if_name):
     """Get the net device memory start address."""
-    if platform.machine() == "x86_64":
-        acpi_info = _get_net_mem_addr_base_x86_acpi(ssh_connection, if_name)
-        if acpi_info is not None:
-            return acpi_info
-
-        return _get_net_mem_addr_base_x86_cmdline(ssh_connection, if_name)
-
-    if platform.machine() == "aarch64":
-        sys_virtio_mmio_cmdline = "/sys/devices/platform"
-        cmd = "ls {} | grep .virtio_mmio".format(sys_virtio_mmio_cmdline)
-        rc, stdout, _ = ssh_connection.run(cmd)
-        assert rc == 0
-
-        virtio_devs = stdout.split()
-        devs_addr = list(map(lambda dev: dev.split(".")[0], virtio_devs))
-
-        cmd = "ls {}/{}/virtio{}/net"
-        # Device start addresses lack the hex prefix and are not interpreted
-        # accordingly when parsed inside `change_config_space.c`.
-        hex_prefix = "0x"
-        for idx, dev in enumerate(virtio_devs):
-            _, guest_if_name, _ = ssh_connection.run(
-                cmd.format(sys_virtio_mmio_cmdline, dev, idx)
-            )
-            if guest_if_name.strip() == if_name:
-                return hex_prefix + devs_addr[int(idx)]
-
-    return None
+    _, stdout, _ = ssh_connection.check_output(f"find /sys/devices -name {if_name}")
+    device_paths = stdout.strip().split("\n")
+    assert (
+        len(device_paths) == 1
+    ), f"No or multiple devices found for {if_name}:\n{stdout}"
+    device_path = device_paths[0]
+    parts = device_path.split("/")
+    assert len(parts) >= 6, f"Unexpected device path: {device_path}"
+    device = parts[-4]
+    start_addr, _ = _find_iomem_range(ssh_connection, device)
+    return start_addr

--- a/tests/integration_tests/functional/test_net_config_space.py
+++ b/tests/integration_tests/functional/test_net_config_space.py
@@ -13,16 +13,14 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 PAYLOAD_DATA_SIZE = 20
 
 
-def test_net_change_mac_address(
-    uvm_plain_any, pci_enabled, change_net_config_space_bin
-):
+def test_net_change_mac_address(uvm_plain_any, change_net_config_space_bin):
     """
     Test changing the MAC address of the network device.
     """
 
     test_microvm = uvm_plain_any
     test_microvm.help.enable_console()
-    test_microvm.spawn(pci=pci_enabled)
+    test_microvm.spawn()
     test_microvm.basic_config(boot_args="ipv6.disable=1")
 
     # Data exchange interface ('eth0' in guest).

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -8,12 +8,11 @@ from framework.utils import check_entropy
 from host_tools.network import SSHConnection
 
 
-def uvm_with_rng_booted(
-    microvm_factory, guest_kernel, rootfs, rate_limiter, pci_enabled
-):
+def uvm_with_rng_booted(uvm_plain_any, microvm_factory, rate_limiter):
     """Return a booted microvm with virtio-rng configured"""
-    uvm = microvm_factory.build(guest_kernel, rootfs)
-    uvm.spawn(log_level="INFO", pci=pci_enabled)
+    # pylint: disable=unused-argument
+    uvm = uvm_plain_any
+    uvm.spawn(log_level="INFO")
     uvm.basic_config(vcpu_count=2, mem_size_mib=256)
     uvm.add_net_iface()
     uvm.api.entropy.put(rate_limiter=rate_limiter)
@@ -23,13 +22,9 @@ def uvm_with_rng_booted(
     return uvm
 
 
-def uvm_with_rng_restored(
-    microvm_factory, guest_kernel, rootfs, rate_limiter, pci_enabled
-):
+def uvm_with_rng_restored(uvm_plain_any, microvm_factory, rate_limiter):
     """Return a restored uvm with virtio-rng configured"""
-    uvm = uvm_with_rng_booted(
-        microvm_factory, guest_kernel, rootfs, rate_limiter, pci_enabled
-    )
+    uvm = uvm_with_rng_booted(uvm_plain_any, microvm_factory, rate_limiter)
     snapshot = uvm.snapshot_full()
     uvm.kill()
     uvm2 = microvm_factory.build_from_snapshot(snapshot)
@@ -50,9 +45,9 @@ def rate_limiter(request):
 
 
 @pytest.fixture
-def uvm_any(microvm_factory, uvm_ctor, guest_kernel, rootfs, rate_limiter, pci_enabled):
+def uvm_any(microvm_factory, uvm_ctor, uvm_plain_any, rate_limiter):
     """Return booted and restored uvms"""
-    return uvm_ctor(microvm_factory, guest_kernel, rootfs, rate_limiter, pci_enabled)
+    return uvm_ctor(uvm_plain_any, microvm_factory, rate_limiter)
 
 
 def list_rng_available(ssh_connection: SSHConnection) -> list[str]:

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -55,7 +55,7 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
     microvm.basic_config(
         vcpu_count=2,
         mem_size_mib=256,
-        boot_args="console=ttyS0 reboot=k panic=1 pci=off",
+        boot_args="console=ttyS0 reboot=k panic=1",
     )
     serial = Serial(microvm)
     serial.open()
@@ -99,9 +99,7 @@ def test_serial_console_login(uvm_plain_any):
     microvm.memory_monitor = None
 
     # Set up the microVM with 1 vCPU and a serial console.
-    microvm.basic_config(
-        vcpu_count=1, boot_args="console=ttyS0 reboot=k panic=1 pci=off"
-    )
+    microvm.basic_config(vcpu_count=1, boot_args="console=ttyS0 reboot=k panic=1")
 
     microvm.start()
 
@@ -144,7 +142,7 @@ def test_serial_dos(uvm_plain_any):
     # Set up the microVM with 1 vCPU and a serial console.
     microvm.basic_config(
         vcpu_count=1,
-        boot_args="console=ttyS0 reboot=k panic=1 pci=off",
+        boot_args="console=ttyS0 reboot=k panic=1",
     )
     microvm.add_net_iface()
     microvm.start()
@@ -176,7 +174,7 @@ def test_serial_block(uvm_plain_any):
     test_microvm.basic_config(
         vcpu_count=1,
         mem_size_mib=512,
-        boot_args="console=ttyS0 reboot=k panic=1 pci=off",
+        boot_args="console=ttyS0 reboot=k panic=1",
     )
     test_microvm.add_net_iface()
     test_microvm.start()

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -498,11 +498,11 @@ def test_snapshot_overwrite_self(uvm_plain_any, microvm_factory):
     # restored, with a new snapshot of this vm, does not break the VM
 
 
-def test_vmgenid(guest_kernel_linux_6_1, rootfs, microvm_factory, snapshot_type):
+def test_vmgenid(uvm_plain_6_1, microvm_factory, snapshot_type):
     """
     Test VMGenID device upon snapshot resume
     """
-    base_vm = microvm_factory.build(guest_kernel_linux_6_1, rootfs)
+    base_vm = uvm_plain_6_1
     base_vm.spawn()
     base_vm.basic_config(track_dirty_pages=True)
     base_vm.add_net_iface()

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -115,9 +115,8 @@ def test_snapshot_current_version(uvm_nano):
 def test_cycled_snapshot_restore(
     bin_vsock_path,
     tmp_path,
+    uvm_plain_any,
     microvm_factory,
-    guest_kernel,
-    rootfs,
     snapshot_type,
     use_snapshot_editor,
     cpu_template_any,
@@ -133,7 +132,7 @@ def test_cycled_snapshot_restore(
     logger = logging.getLogger("snapshot_sequence")
     diff_snapshots = snapshot_type == SnapshotType.DIFF
 
-    vm = microvm_factory.build(guest_kernel, rootfs)
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config(
         vcpu_count=2,
@@ -249,7 +248,7 @@ def test_load_snapshot_failure_handling(uvm_plain):
     vm.mark_killed()
 
 
-def test_cmp_full_and_first_diff_mem(microvm_factory, guest_kernel, rootfs):
+def test_cmp_full_and_first_diff_mem(uvm_plain_any):
     """
     Compare memory of 2 consecutive full and diff snapshots.
 
@@ -260,7 +259,7 @@ def test_cmp_full_and_first_diff_mem(microvm_factory, guest_kernel, rootfs):
     """
     logger = logging.getLogger("snapshot_sequence")
 
-    vm = microvm_factory.build(guest_kernel, rootfs)
+    vm = uvm_plain_any
     vm.spawn()
     vm.basic_config(
         vcpu_count=2,
@@ -430,12 +429,12 @@ def test_create_large_diff_snapshot(uvm_plain):
     # process would have been taken down.
 
 
-def test_diff_snapshot_overlay(guest_kernel, rootfs, microvm_factory):
+def test_diff_snapshot_overlay(uvm_plain_any, microvm_factory):
     """
     Tests that if we take a diff snapshot and direct firecracker to write it on
     top of an existing snapshot file, it will successfully merge them.
     """
-    basevm = microvm_factory.build(guest_kernel, rootfs)
+    basevm = uvm_plain_any
     basevm.spawn()
     basevm.basic_config(track_dirty_pages=True)
     basevm.add_net_iface()
@@ -467,7 +466,7 @@ def test_diff_snapshot_overlay(guest_kernel, rootfs, microvm_factory):
     # Check that the restored VM works
 
 
-def test_snapshot_overwrite_self(guest_kernel, rootfs, microvm_factory):
+def test_snapshot_overwrite_self(uvm_plain_any, microvm_factory):
     """Tests that if we try to take a snapshot that would overwrite the
     very file from which the current VM is stored, nothing happens.
 
@@ -475,7 +474,7 @@ def test_snapshot_overwrite_self(guest_kernel, rootfs, microvm_factory):
     of mmap does not specify what should happen if the file is changed after being
     mmap'd (https://man7.org/linux/man-pages/man2/mmap.2.html). It seems that
     these changes can propagate to the mmap'd memory region."""
-    base_vm = microvm_factory.build(guest_kernel, rootfs)
+    base_vm = uvm_plain_any
     base_vm.spawn()
     base_vm.basic_config()
     base_vm.add_net_iface()

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -37,7 +37,7 @@ NEGATIVE_TEST_CONNECTION_COUNT = 100
 TEST_WORKER_COUNT = 10
 
 
-def test_vsock(uvm_plain_any, pci_enabled, bin_vsock_path, test_fc_session_root_path):
+def test_vsock(uvm_plain_any, bin_vsock_path, test_fc_session_root_path):
     """
     Test guest and host vsock initiated connections.
 
@@ -45,7 +45,7 @@ def test_vsock(uvm_plain_any, pci_enabled, bin_vsock_path, test_fc_session_root_
     """
 
     vm = uvm_plain_any
-    vm.spawn(pci=pci_enabled)
+    vm.spawn()
 
     vm.basic_config()
     vm.add_net_iface()
@@ -102,12 +102,12 @@ def negative_test_host_connections(vm, blob_path, blob_hash):
     validate_fc_metrics(metrics)
 
 
-def test_vsock_epipe(uvm_plain, pci_enabled, bin_vsock_path, test_fc_session_root_path):
+def test_vsock_epipe(uvm_plain_any, bin_vsock_path, test_fc_session_root_path):
     """
     Vsock negative test to validate SIGPIPE/EPIPE handling.
     """
-    vm = uvm_plain
-    vm.spawn(pci=pci_enabled)
+    vm = uvm_plain_any
+    vm.spawn()
     vm.basic_config()
     vm.add_net_iface()
     vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path=f"/{VSOCK_UDS_PATH}")
@@ -129,7 +129,7 @@ def test_vsock_epipe(uvm_plain, pci_enabled, bin_vsock_path, test_fc_session_roo
 
 
 def test_vsock_transport_reset_h2g(
-    uvm_plain, pci_enabled, microvm_factory, bin_vsock_path, test_fc_session_root_path
+    uvm_plain_any, microvm_factory, bin_vsock_path, test_fc_session_root_path
 ):
     """
     Vsock transport reset test.
@@ -146,8 +146,8 @@ def test_vsock_transport_reset_h2g(
     6. Close VM -> Load VM from Snapshot -> check that vsock
        device is still working.
     """
-    test_vm = uvm_plain
-    test_vm.spawn(pci=pci_enabled)
+    test_vm = uvm_plain_any
+    test_vm.spawn()
     test_vm.basic_config(vcpu_count=2, mem_size_mib=256)
     test_vm.add_net_iface()
     test_vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path=f"/{VSOCK_UDS_PATH}")
@@ -215,12 +215,12 @@ def test_vsock_transport_reset_h2g(
     validate_fc_metrics(metrics)
 
 
-def test_vsock_transport_reset_g2h(uvm_plain, pci_enabled, microvm_factory):
+def test_vsock_transport_reset_g2h(uvm_plain_any, microvm_factory):
     """
     Vsock transport reset test.
     """
-    test_vm = uvm_plain
-    test_vm.spawn(pci=pci_enabled)
+    test_vm = uvm_plain_any
+    test_vm.spawn()
     test_vm.basic_config(vcpu_count=2, mem_size_mib=256)
     test_vm.add_net_iface()
     test_vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path=f"/{VSOCK_UDS_PATH}")

--- a/tests/integration_tests/performance/test_block.py
+++ b/tests/integration_tests/performance/test_block.py
@@ -176,8 +176,10 @@ def test_block_performance(
     """
     Execute block device emulation benchmarking scenarios.
     """
-    vm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
-    vm.spawn(log_level="Info", emit_metrics=True, pci=pci_enabled)
+    vm = microvm_factory.build(
+        guest_kernel_acpi, rootfs, monitor_memory=False, pci=pci_enabled
+    )
+    vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()
     # Add a secondary block device for benchmark tests.

--- a/tests/integration_tests/performance/test_block.py
+++ b/tests/integration_tests/performance/test_block.py
@@ -161,14 +161,11 @@ def emit_fio_metrics(logs_dir, metrics):
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 @pytest.mark.parametrize("fio_engine", ["libaio", "psync"])
 def test_block_performance(
-    microvm_factory,
-    guest_kernel_acpi,
-    rootfs,
+    uvm_any_acpi,
     vcpus,
     fio_mode,
     fio_block_size,
     fio_engine,
-    pci_enabled,
     io_engine,
     metrics,
     results_dir,
@@ -176,9 +173,7 @@ def test_block_performance(
     """
     Execute block device emulation benchmarking scenarios.
     """
-    vm = microvm_factory.build(
-        guest_kernel_acpi, rootfs, monitor_memory=False, pci=pci_enabled
-    )
+    vm = uvm_any_acpi
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()
@@ -216,9 +211,7 @@ def test_block_performance(
 @pytest.mark.parametrize("fio_mode", ["randread"])
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_block_vhost_user_performance(
-    microvm_factory,
-    guest_kernel_acpi,
-    rootfs,
+    uvm_any_acpi,
     vcpus,
     fio_mode,
     fio_block_size,
@@ -229,7 +222,7 @@ def test_block_vhost_user_performance(
     Execute block device emulation benchmarking scenarios.
     """
 
-    vm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
+    vm = uvm_any_acpi
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -98,14 +98,13 @@ def launch_vm_with_boot_timer(
     microvm_factory, guest_kernel_acpi, rootfs_rw, vcpu_count, mem_size_mib, pci_enabled
 ):
     """Launches a microVM with guest-timer and returns the reported metrics for it"""
-    boot_args = DEFAULT_BOOT_ARGS if pci_enabled else DEFAULT_BOOT_ARGS + " pci=off"
     vm = microvm_factory.build(guest_kernel_acpi, rootfs_rw)
     vm.jailer.extra_args.update({"boot-timer": None})
     vm.spawn(pci=pci_enabled)
     vm.basic_config(
         vcpu_count=vcpu_count,
         mem_size_mib=mem_size_mib,
-        boot_args=boot_args + " init=/usr/local/bin/init",
+        boot_args=DEFAULT_BOOT_ARGS + " init=/usr/local/bin/init",
         enable_entropy_device=True,
     )
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -98,9 +98,9 @@ def launch_vm_with_boot_timer(
     microvm_factory, guest_kernel_acpi, rootfs_rw, vcpu_count, mem_size_mib, pci_enabled
 ):
     """Launches a microVM with guest-timer and returns the reported metrics for it"""
-    vm = microvm_factory.build(guest_kernel_acpi, rootfs_rw)
+    vm = microvm_factory.build(guest_kernel_acpi, rootfs_rw, pci=pci_enabled)
     vm.jailer.extra_args.update({"boot-timer": None})
-    vm.spawn(pci=pci_enabled)
+    vm.spawn()
     vm.basic_config(
         vcpu_count=vcpu_count,
         mem_size_mib=mem_size_mib,

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -68,13 +68,13 @@ def test_hugetlbfs_boot(uvm_plain):
     )
 
 
-def test_hugetlbfs_snapshot(microvm_factory, guest_kernel_linux_5_10, rootfs):
+def test_hugetlbfs_snapshot(microvm_factory, uvm_plain):
     """
     Test hugetlbfs snapshot restore via uffd
     """
 
     ### Create Snapshot ###
-    vm = microvm_factory.build(guest_kernel_linux_5_10, rootfs)
+    vm = uvm_plain
     vm.memory_monitor = None
     vm.spawn()
     vm.basic_config(huge_pages=HugePagesConfig.HUGETLBFS_2MB, mem_size_mib=128)
@@ -138,8 +138,7 @@ def test_hugetlbfs_diff_snapshot(microvm_factory, uvm_plain):
 @pytest.mark.parametrize("huge_pages", HugePagesConfig)
 def test_ept_violation_count(
     microvm_factory,
-    guest_kernel_linux_5_10,
-    rootfs,
+    uvm_plain,
     metrics,
     huge_pages,
 ):
@@ -149,7 +148,7 @@ def test_ept_violation_count(
     """
 
     ### Create Snapshot ###
-    vm = microvm_factory.build(guest_kernel_linux_5_10, rootfs)
+    vm = uvm_plain
     vm.memory_monitor = None
     vm.spawn()
     vm.basic_config(huge_pages=huge_pages, mem_size_mib=256)

--- a/tests/integration_tests/performance/test_initrd.py
+++ b/tests/integration_tests/performance/test_initrd.py
@@ -33,7 +33,7 @@ def test_microvm_initrd_with_serial(uvm_with_initrd, huge_pages):
     vm.basic_config(
         add_root_device=False,
         vcpu_count=1,
-        boot_args="console=ttyS0 reboot=k panic=1 pci=off",
+        boot_args="console=ttyS0 reboot=k panic=1",
         use_initrd=True,
         huge_pages=huge_pages,
     )

--- a/tests/integration_tests/performance/test_initrd.py
+++ b/tests/integration_tests/performance/test_initrd.py
@@ -9,13 +9,15 @@ INITRD_FILESYSTEM = "rootfs"
 
 
 @pytest.fixture
-def uvm_with_initrd(microvm_factory, guest_kernel, record_property, artifact_dir):
+def uvm_with_initrd(
+    microvm_factory, guest_kernel, pci_enabled, record_property, artifact_dir
+):
     """
     See file:../docs/initrd.md
     """
     fs = artifact_dir / "initramfs.cpio"
     record_property("rootfs", fs.name)
-    uvm = microvm_factory.build(guest_kernel)
+    uvm = microvm_factory.build(guest_kernel, pci=pci_enabled)
     uvm.initrd_file = fs
     yield uvm
 

--- a/tests/integration_tests/performance/test_memory_overhead.py
+++ b/tests/integration_tests/performance/test_memory_overhead.py
@@ -30,7 +30,13 @@ X86_MEMORY_GAP_START = 3328 * 2**20
 )
 @pytest.mark.nonci
 def test_memory_overhead(
-    microvm_factory, guest_kernel_acpi, rootfs, vcpu_count, mem_size_mib, metrics
+    microvm_factory,
+    guest_kernel_acpi,
+    rootfs,
+    vcpu_count,
+    mem_size_mib,
+    pci_enabled,
+    metrics,
 ):
     """Track Firecracker memory overhead.
 
@@ -38,7 +44,9 @@ def test_memory_overhead(
     """
 
     for _ in range(5):
-        microvm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
+        microvm = microvm_factory.build(
+            guest_kernel_acpi, rootfs, pci=pci_enabled, monitor_memory=False
+        )
         microvm.spawn(emit_metrics=True)
         microvm.basic_config(vcpu_count=vcpu_count, mem_size_mib=mem_size_mib)
         microvm.add_net_iface()

--- a/tests/integration_tests/performance/test_network.py
+++ b/tests/integration_tests/performance/test_network.py
@@ -45,8 +45,10 @@ def network_microvm(request, microvm_factory, guest_kernel_acpi, rootfs, pci_ena
     guest_mem_mib = 1024
     guest_vcpus = request.param
 
-    vm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
-    vm.spawn(log_level="Info", emit_metrics=True, pci=pci_enabled)
+    vm = microvm_factory.build(
+        guest_kernel_acpi, rootfs, monitor_memory=False, pci=pci_enabled
+    )
+    vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=guest_vcpus, mem_size_mib=guest_mem_mib)
     vm.add_net_iface()
     vm.start()

--- a/tests/integration_tests/performance/test_network.py
+++ b/tests/integration_tests/performance/test_network.py
@@ -38,16 +38,14 @@ def consume_ping_output(ping_putput, request_per_round):
 
 
 @pytest.fixture
-def network_microvm(request, microvm_factory, guest_kernel_acpi, rootfs, pci_enabled):
+def network_microvm(request, uvm_plain_acpi):
     """Creates a microvm with the networking setup used by the performance tests in this file.
     This fixture receives its vcpu count via indirect parameterization"""
 
     guest_mem_mib = 1024
     guest_vcpus = request.param
 
-    vm = microvm_factory.build(
-        guest_kernel_acpi, rootfs, monitor_memory=False, pci=pci_enabled
-    )
+    vm = uvm_plain_acpi
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=guest_vcpus, mem_size_mib=guest_mem_mib)
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_snapshot.py
+++ b/tests/integration_tests/performance/test_snapshot.py
@@ -255,15 +255,13 @@ def test_population_latency(
 
 @pytest.mark.nonci
 def test_snapshot_create_latency(
-    microvm_factory,
-    guest_kernel_linux_5_10,
-    rootfs,
+    uvm_plain,
     metrics,
     snapshot_type,
 ):
     """Measure the latency of creating a Full snapshot"""
 
-    vm = microvm_factory.build(guest_kernel_linux_5_10, rootfs, monitor_memory=False)
+    vm = uvm_plain
     vm.spawn()
     vm.basic_config(
         vcpu_count=2,

--- a/tests/integration_tests/performance/test_snapshot.py
+++ b/tests/integration_tests/performance/test_snapshot.py
@@ -44,12 +44,13 @@ class SnapshotRestoreTest:
         """Computes a unique id for this test instance"""
         return "all_dev" if self.all_devices else f"{self.vcpus}vcpu_{self.mem}mb"
 
-    def boot_vm(self, microvm_factory, guest_kernel, rootfs) -> Microvm:
+    def boot_vm(self, microvm_factory, guest_kernel, rootfs, pci_enabled) -> Microvm:
         """Creates the initial snapshot that will be loaded repeatedly to sample latencies"""
         vm = microvm_factory.build(
             guest_kernel,
             rootfs,
             monitor_memory=False,
+            pci=pci_enabled,
         )
         vm.spawn(log_level="Info", emit_metrics=True)
         vm.time_api_requests = False
@@ -96,7 +97,7 @@ class SnapshotRestoreTest:
     ids=lambda x: x.id,
 )
 def test_restore_latency(
-    microvm_factory, rootfs, guest_kernel_linux_5_10, test_setup, metrics
+    microvm_factory, guest_kernel_linux_5_10, rootfs, pci_enabled, test_setup, metrics
 ):
     """
     Restores snapshots with vcpu/memory configuration, roughly scaling according to mem = (vcpus - 1) * 2048MB,
@@ -105,7 +106,9 @@ def test_restore_latency(
 
     We only test a single guest kernel, as the guest kernel does not "participate" in snapshot restore.
     """
-    vm = test_setup.boot_vm(microvm_factory, guest_kernel_linux_5_10, rootfs)
+    vm = test_setup.boot_vm(
+        microvm_factory, guest_kernel_linux_5_10, rootfs, pci_enabled
+    )
 
     metrics.set_dimensions(
         {
@@ -147,6 +150,7 @@ def test_post_restore_latency(
     microvm_factory,
     rootfs,
     guest_kernel_linux_5_10,
+    pci_enabled,
     metrics,
     uffd_handler,
     huge_pages,
@@ -156,7 +160,9 @@ def test_post_restore_latency(
         pytest.skip("huge page snapshots can only be restored using uffd")
 
     test_setup = SnapshotRestoreTest(mem=1024, vcpus=2, huge_pages=huge_pages)
-    vm = test_setup.boot_vm(microvm_factory, guest_kernel_linux_5_10, rootfs)
+    vm = test_setup.boot_vm(
+        microvm_factory, guest_kernel_linux_5_10, rootfs, pci_enabled
+    )
 
     metrics.set_dimensions(
         {
@@ -204,6 +210,7 @@ def test_population_latency(
     microvm_factory,
     rootfs,
     guest_kernel_linux_5_10,
+    pci_enabled,
     metrics,
     huge_pages,
     vcpus,
@@ -211,7 +218,9 @@ def test_population_latency(
 ):
     """Collects population latency metrics (e.g. how long it takes UFFD handler to fault in all memory)"""
     test_setup = SnapshotRestoreTest(mem=mem, vcpus=vcpus, huge_pages=huge_pages)
-    vm = test_setup.boot_vm(microvm_factory, guest_kernel_linux_5_10, rootfs)
+    vm = test_setup.boot_vm(
+        microvm_factory, guest_kernel_linux_5_10, rootfs, pci_enabled
+    )
 
     metrics.set_dimensions(
         {

--- a/tests/integration_tests/performance/test_vhost_user_metrics.py
+++ b/tests/integration_tests/performance/test_vhost_user_metrics.py
@@ -10,9 +10,7 @@ import host_tools.drive as drive_tools
 
 
 @pytest.mark.parametrize("vcpu_count", [1, 2], ids=["1vcpu", "2vcpu"])
-def test_vhost_user_block_metrics(
-    microvm_factory, guest_kernel_acpi, rootfs, vcpu_count, metrics
-):
+def test_vhost_user_block_metrics(uvm_plain_acpi, vcpu_count, metrics):
     """
     This test tries to boot a VM with vhost-user-block
     as a scratch device, resize the vhost-user scratch drive to have
@@ -28,7 +26,7 @@ def test_vhost_user_block_metrics(
     # low->high->low->high and so the numbers are not in monotonic sequence.
     new_sizes = [20, 10, 30]  # MB
 
-    vm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
+    vm = uvm_plain_acpi
     vm.spawn(log_level="Info")
     vm.basic_config(vcpu_count=vcpu_count)
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_vsock.py
+++ b/tests/integration_tests/performance/test_vsock.py
@@ -75,12 +75,9 @@ class VsockIPerf3Test(IPerf3Test):
 @pytest.mark.parametrize("payload_length", ["64K", "1024K"], ids=["p64K", "p1024K"])
 @pytest.mark.parametrize("mode", ["g2h", "h2g", "bd"])
 def test_vsock_throughput(
-    microvm_factory,
-    guest_kernel_acpi,
-    rootfs,
+    uvm_plain_acpi,
     vcpus,
     payload_length,
-    pci_enabled,
     mode,
     metrics,
     results_dir,
@@ -95,9 +92,7 @@ def test_vsock_throughput(
         pytest.skip("bidrectional test only done with at least 2 vcpus")
 
     mem_size_mib = 1024
-    vm = microvm_factory.build(
-        guest_kernel_acpi, rootfs, monitor_memory=False, pci=pci_enabled
-    )
+    vm = uvm_plain_acpi
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=mem_size_mib)
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_vsock.py
+++ b/tests/integration_tests/performance/test_vsock.py
@@ -95,8 +95,10 @@ def test_vsock_throughput(
         pytest.skip("bidrectional test only done with at least 2 vcpus")
 
     mem_size_mib = 1024
-    vm = microvm_factory.build(guest_kernel_acpi, rootfs, monitor_memory=False)
-    vm.spawn(log_level="Info", emit_metrics=True, pci=pci_enabled)
+    vm = microvm_factory.build(
+        guest_kernel_acpi, rootfs, monitor_memory=False, pci=pci_enabled
+    )
+    vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=mem_size_mib)
     vm.add_net_iface()
     # Create a vsock device


### PR DESCRIPTION
## Changes

Fix miscellaneous bugs introduced by PCI:
 - PCI devices could only use 24 IRQ lines on x86, greatly limiting the amount of possible devices on the bus
 - virtio-pci devices couldn't be patched
 - virtio-pci balloon device couldn't be found 
 - virtio-pci network couldn't be renamed on restore

Also, add additional test coverage that would have caught the bugs above by moving the PCI configuration to the VM factory so that we can have uvm_plain* fixtures also run the tests on PCIe kernels. 

Additionally, also run more tests on PCI: ideally all tests should be run on PCI, unless there's a specific reason to.

## Reason

Not all tests were running on PCIe, hiding some issues.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
