### PR TITLE
test: Print log of iperf server running in guest

### DIFF
--- a/tests/integration_tests/performance/test_rate_limiter.py
+++ b/tests/integration_tests/performance/test_rate_limiter.py
@@ -144,7 +144,7 @@ def _check_tx_rate_limiting(test_microvm):
 
     # First step: get the transfer rate when no rate limiting is enabled.
     # We are receiving the result in KBytes from iperf.
-    print("Run guest TX iperf with no rate-limit")
+    print("Run guest TX iperf for no rate limiting")
     rate_no_limit_kbps = _get_tx_bandwidth_with_duration(
         test_microvm, eth0.host_ip, IPERF_TRANSMIT_TIME
     )
@@ -160,11 +160,12 @@ def _check_tx_rate_limiting(test_microvm):
     assert _get_percentage_difference(rate_no_limit_kbps, expected_kbps) > 100
 
     # Second step: check bandwidth when rate limiting is on.
+    print("Run guest TX iperf for rate limiting without burst")
     _check_tx_bandwidth(test_microvm, eth1.host_ip, expected_kbps)
 
     # Third step: get the number of bytes when rate limiting is on and there is
     # an initial burst size from where to consume.
-    print("Run guest TX iperf with exact burst size")
+    print("Run guest TX iperf for rate limiting with burst")
     # Use iperf to obtain the bandwidth when there is burst to consume from,
     # send exactly BURST_SIZE packets.
     iperf_cmd = "{} -c {} -n {} -f KBytes -w {} -N".format(
@@ -192,7 +193,7 @@ def _check_rx_rate_limiting(test_microvm):
 
     # First step: get the transfer rate when no rate limiting is enabled.
     # We are receiving the result in KBytes from iperf.
-    print("Run guest RX iperf with no rate-limit")
+    print("Run guest RX iperf with no rate limiting")
     rate_no_limit_kbps = _get_rx_bandwidth_with_duration(
         test_microvm, eth0.guest_ip, IPERF_TRANSMIT_TIME
     )
@@ -208,11 +209,12 @@ def _check_rx_rate_limiting(test_microvm):
     assert _get_percentage_difference(rate_no_limit_kbps, expected_kbps) > 100
 
     # Second step: check bandwidth when rate limiting is on.
+    print("Run guest RX iperf for rate limiting without burst")
     _check_rx_bandwidth(test_microvm, eth1.guest_ip, expected_kbps)
 
     # Third step: get the number of bytes when rate limiting is on and there is
     # an initial burst size from where to consume.
-    print("Run guest RX iperf with exact burst size")
+    print("Run guest RX iperf for rate limiting with burst")
     # Use iperf to obtain the bandwidth when there is burst to consume from,
     # send exactly BURST_SIZE packets.
     iperf_cmd = "{} {} -c {} -n {} -f KBytes -w {} -N".format(


### PR DESCRIPTION
## Changes

Print log of iperf server running in a guest if the iperf command fails.

## Reason

We occasionally see failures of `test_rx_rate_limiting` with the following error:
```
iperf3: error - unable to connect to server - server may have stopped running or use a different port, firewall issue, etc.: Connection refused
```
However, we didn't have any diagnostic info about what happened inside a guest.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
