### PR TITLE
refactor(metrics): avoid temporary buffer when serializing metrics

### DIFF
--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -141,28 +141,11 @@ impl<T: Serialize + Debug, M: Write + Send + Debug> Metrics<T, M> {
     /// known deadlock potential.
     pub fn write(&self) -> Result<bool, MetricsError> {
         if let Some(lock) = self.metrics_buf.get() {
-            match serde_json::to_string(&self.app_metrics) {
-                Ok(msg) => {
-                    if let Ok(mut guard) = lock.lock() {
-                        // No need to explicitly call flush because the underlying LineWriter
-                        // flushes automatically whenever a newline is
-                        // detected (and we always end with a newline the
-                        // current write).
-                        guard
-                            .write_all(format!("{msg}\n",).as_bytes())
-                            .map_err(MetricsError::Write)
-                            .map(|_| true)
-                    } else {
-                        // We have not incremented `missed_metrics_count` as there is no way to push
-                        // metrics if destination lock got poisoned.
-                        panic!(
-                            "Failed to write to the provided metrics destination due to poisoned \
-                             lock"
-                        );
-                    }
-                }
-                Err(err) => Err(MetricsError::Serde(err.to_string())),
-            }
+            let mut writer = lock.lock().expect("poisoned lock");
+            serde_json::to_writer(writer.by_ref(), &self.app_metrics)
+                .map_err(|err| MetricsError::Serde(err.to_string()))?;
+            writer.write_all(b"\n").map_err(MetricsError::Write)?;
+            Ok(true)
         } else {
             // If the metrics are not initialized, no error is thrown but we do let the user know
             // that metrics were not written.


### PR DESCRIPTION
## Changes

Metrics are currently serialized in a temporary buffer (String) before being written to the line buffered writer, which then writes finally to the file.
There is no need for this temporary buffer, as the metrics can be serialized directly into the writer.
We also need to manually write a newline as serde doesn't do that and we need it to separate the metric lines and flush the line writer.

## Reason

I found this as I saw Firecracker was allocating and freeing memory every minute, causing pages to be mmap/munmap-ed periodically (and unnecessarily). This change removes these extra allocations, although the benefits are marginal at best as this action is only performed once a minute. Nonetheless, it's just 5 lines, so why not.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
