### PR TITLE
example(uffd): dont panic if read(2) from uffd returns -EAGAIN

### DIFF
--- a/src/firecracker/examples/uffd/fault_all_handler.rs
+++ b/src/firecracker/examples/uffd/fault_all_handler.rs
@@ -35,10 +35,9 @@ fn main() {
     runtime.run(
         |uffd_handler: &mut UffdHandler| {
             // Read an event from the userfaultfd.
-            let event = uffd_handler
-                .read_event()
-                .expect("Failed to read uffd_msg")
-                .expect("uffd_msg not ready");
+            let Some(event) = uffd_handler.read_event().expect("Failed to read uffd_msg") else {
+                return;
+            };
 
             if let userfaultfd::Event::Pagefault { addr, .. } = event {
                 let bit =


### PR DESCRIPTION
Started seeing the below failure in test_population_latency:

thread 'main' panicked at .../uffd/fault_all_handler.rs:41:18: uffd_msg not ready
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

I am not entierly sure how this can happen, because the read from the uffd is supposed to be blocking, but maybe it's a weird interaction with the fault-all behavior (e.g. there was a uffd event queues, but because we faulted everything it got cancelled again?), so let's just try going back to read(2) if we dont read anything.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
