### PR TITLE
chore: update mmap series to v14

### DIFF
--- a/resources/hiding_ci/linux_patches/05-mmap-support/0001-KVM-Rename-CONFIG_KVM_PRIVATE_MEM-to-CONFIG_KVM_GMEM.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0001-KVM-Rename-CONFIG_KVM_PRIVATE_MEM-to-CONFIG_KVM_GMEM.patch
@@ -1,7 +1,7 @@
-From fc57b8c1deda99bc1e64d45dd7f97a1b9259d16e Mon Sep 17 00:00:00 2001
+From 000264f8823f76fb6cf91dc40ace84a29a0fa089 Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:27 +0100
-Subject: [PATCH 01/45] KVM: Rename CONFIG_KVM_PRIVATE_MEM to CONFIG_KVM_GMEM
+Date: Tue, 15 Jul 2025 10:33:30 +0100
+Subject: [PATCH 01/46] KVM: Rename CONFIG_KVM_PRIVATE_MEM to CONFIG_KVM_GMEM
 
 Rename the Kconfig option CONFIG_KVM_PRIVATE_MEM to CONFIG_KVM_GMEM. The
 original name implied that the feature only supported "private" memory.
@@ -32,10 +32,10 @@ Signed-off-by: Fuad Tabba <tabba@google.com>
  6 files changed, 17 insertions(+), 17 deletions(-)
 
 diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
-index 639d9bcee842..66bdd0759d27 100644
+index f7af967aa16f..acb25f935d84 100644
 --- a/arch/x86/include/asm/kvm_host.h
 +++ b/arch/x86/include/asm/kvm_host.h
-@@ -2269,7 +2269,7 @@ void kvm_configure_mmu(bool enable_tdp, int tdp_forced_root_level,
+@@ -2275,7 +2275,7 @@ void kvm_configure_mmu(bool enable_tdp, int tdp_forced_root_level,
  		       int tdp_max_root_level, int tdp_huge_page_level);
  
  
@@ -137,10 +137,10 @@ index 724c89af78af..8d00918d4c8b 100644
 -kvm-$(CONFIG_KVM_PRIVATE_MEM) += $(KVM)/guest_memfd.o
 +kvm-$(CONFIG_KVM_GMEM) += $(KVM)/guest_memfd.o
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index eec82775c5bf..898c3d5a7ba8 100644
+index 222f0e894a0c..d5f0ec2d321f 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
-@@ -4910,7 +4910,7 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
+@@ -4913,7 +4913,7 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
  	case KVM_CAP_MEMORY_ATTRIBUTES:
  		return kvm_supported_mem_attributes(kvm);
  #endif
@@ -149,7 +149,7 @@ index eec82775c5bf..898c3d5a7ba8 100644
  	case KVM_CAP_GUEST_MEMFD:
  		return !kvm || kvm_arch_has_private_mem(kvm);
  #endif
-@@ -5344,7 +5344,7 @@ static long kvm_vm_ioctl(struct file *filp,
+@@ -5347,7 +5347,7 @@ static long kvm_vm_ioctl(struct file *filp,
  	case KVM_GET_STATS_FD:
  		r = kvm_vm_ioctl_get_stats_fd(kvm);
  		break;
@@ -180,5 +180,5 @@ index acef3f5c582a..ec311c0d6718 100644
  
  #endif /* __KVM_MM_H__ */
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0002-KVM-Rename-CONFIG_KVM_GENERIC_PRIVATE_MEM-to-CONFIG_.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0002-KVM-Rename-CONFIG_KVM_GENERIC_PRIVATE_MEM-to-CONFIG_.patch
@@ -1,7 +1,7 @@
-From 2ce4cc59bb3e067e019842870824d7a459d140f0 Mon Sep 17 00:00:00 2001
+From 05cf45cc4528079db3c40c021947ae0cc28eec82 Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:28 +0100
-Subject: [PATCH 02/45] KVM: Rename CONFIG_KVM_GENERIC_PRIVATE_MEM to
+Date: Tue, 15 Jul 2025 10:33:31 +0100
+Subject: [PATCH 02/46] KVM: Rename CONFIG_KVM_GENERIC_PRIVATE_MEM to
  CONFIG_KVM_GENERIC_GMEM_POPULATE
 
 The original name was vague regarding its functionality. This Kconfig
@@ -99,5 +99,5 @@ index b2aa6bf24d3a..befea51bbc75 100644
  		       kvm_gmem_populate_cb post_populate, void *opaque)
  {
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0003-KVM-Introduce-kvm_arch_supports_gmem.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0003-KVM-Introduce-kvm_arch_supports_gmem.patch
@@ -1,7 +1,7 @@
-From 85b1525e138e76dd43f58e8b5cfd2f0f861ae6a6 Mon Sep 17 00:00:00 2001
+From fd6bbab2fcae663ac196e4c68c8bcd8393b99d6a Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:29 +0100
-Subject: [PATCH 03/45] KVM: Introduce kvm_arch_supports_gmem()
+Date: Tue, 15 Jul 2025 10:33:32 +0100
+Subject: [PATCH 03/46] KVM: Introduce kvm_arch_supports_gmem()
 
 Introduce kvm_arch_supports_gmem() to explicitly indicate whether an
 architecture supports guest_memfd.
@@ -30,10 +30,10 @@ Signed-off-by: Fuad Tabba <tabba@google.com>
  3 files changed, 16 insertions(+), 3 deletions(-)
 
 diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
-index 66bdd0759d27..09f4f6240d9d 100644
+index acb25f935d84..bde811b2d303 100644
 --- a/arch/x86/include/asm/kvm_host.h
 +++ b/arch/x86/include/asm/kvm_host.h
-@@ -2271,8 +2271,10 @@ void kvm_configure_mmu(bool enable_tdp, int tdp_forced_root_level,
+@@ -2277,8 +2277,10 @@ void kvm_configure_mmu(bool enable_tdp, int tdp_forced_root_level,
  
  #ifdef CONFIG_KVM_GMEM
  #define kvm_arch_has_private_mem(kvm) ((kvm)->arch.has_private_mem)
@@ -44,7 +44,7 @@ index 66bdd0759d27..09f4f6240d9d 100644
  #endif
  
  #define kvm_arch_has_readonly_mem(kvm) (!(kvm)->arch.has_protected_state)
-@@ -2325,7 +2327,7 @@ enum {
+@@ -2331,7 +2333,7 @@ enum {
  #define HF_SMM_INSIDE_NMI_MASK	(1 << 2)
  
  # define KVM_MAX_NR_ADDRESS_SPACES	2
@@ -76,7 +76,7 @@ index 359baaae5e9f..ab1bde048034 100644
  static inline bool kvm_arch_has_readonly_mem(struct kvm *kvm)
  {
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index 898c3d5a7ba8..afbc025ce4d3 100644
+index d5f0ec2d321f..162e2a69cc49 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
 @@ -1588,7 +1588,7 @@ static int check_memory_region_flags(struct kvm *kvm,
@@ -88,7 +88,7 @@ index 898c3d5a7ba8..afbc025ce4d3 100644
  		valid_flags |= KVM_MEM_GUEST_MEMFD;
  
  	/* Dirty logging private memory is not currently supported. */
-@@ -4912,7 +4912,7 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
+@@ -4915,7 +4915,7 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
  #endif
  #ifdef CONFIG_KVM_GMEM
  	case KVM_CAP_GUEST_MEMFD:
@@ -98,5 +98,5 @@ index 898c3d5a7ba8..afbc025ce4d3 100644
  	default:
  		break;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0004-KVM-x86-Introduce-kvm-arch.supports_gmem.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0004-KVM-x86-Introduce-kvm-arch.supports_gmem.patch
@@ -1,7 +1,7 @@
-From 50a700bdda054eaa3f86c79a1510a1d60325f2be Mon Sep 17 00:00:00 2001
+From 76851fca367e2d7666c3e709eab8cc016406f91b Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:30 +0100
-Subject: [PATCH 04/45] KVM: x86: Introduce kvm->arch.supports_gmem
+Date: Tue, 15 Jul 2025 10:33:33 +0100
+Subject: [PATCH 04/46] KVM: x86: Introduce kvm->arch.supports_gmem
 
 Introduce a new boolean member, supports_gmem, to kvm->arch.
 
@@ -31,10 +31,10 @@ Signed-off-by: Fuad Tabba <tabba@google.com>
  4 files changed, 6 insertions(+), 3 deletions(-)
 
 diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
-index 09f4f6240d9d..ebddedf0a1f2 100644
+index bde811b2d303..938b5be03d33 100644
 --- a/arch/x86/include/asm/kvm_host.h
 +++ b/arch/x86/include/asm/kvm_host.h
-@@ -1342,6 +1342,7 @@ struct kvm_arch {
+@@ -1348,6 +1348,7 @@ struct kvm_arch {
  	u8 mmu_valid_gen;
  	u8 vm_type;
  	bool has_private_mem;
@@ -42,7 +42,7 @@ index 09f4f6240d9d..ebddedf0a1f2 100644
  	bool has_protected_state;
  	bool pre_fault_allowed;
  	struct hlist_head mmu_page_hash[KVM_NUM_MMU_PAGES];
-@@ -2271,7 +2272,7 @@ void kvm_configure_mmu(bool enable_tdp, int tdp_forced_root_level,
+@@ -2277,7 +2278,7 @@ void kvm_configure_mmu(bool enable_tdp, int tdp_forced_root_level,
  
  #ifdef CONFIG_KVM_GMEM
  #define kvm_arch_has_private_mem(kvm) ((kvm)->arch.has_private_mem)
@@ -64,10 +64,10 @@ index ab9b947dbf4f..d1c484eaa8ad 100644
  	}
  
 diff --git a/arch/x86/kvm/vmx/tdx.c b/arch/x86/kvm/vmx/tdx.c
-index 1ad20c273f3b..c227516e6a02 100644
+index f31ccdeb905b..a3db6df245ee 100644
 --- a/arch/x86/kvm/vmx/tdx.c
 +++ b/arch/x86/kvm/vmx/tdx.c
-@@ -625,6 +625,7 @@ int tdx_vm_init(struct kvm *kvm)
+@@ -632,6 +632,7 @@ int tdx_vm_init(struct kvm *kvm)
  
  	kvm->arch.has_protected_state = true;
  	kvm->arch.has_private_mem = true;
@@ -76,10 +76,10 @@ index 1ad20c273f3b..c227516e6a02 100644
  
  	/*
 diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
-index a9d992d5652f..b34236029383 100644
+index 357b9e3a6cef..adbdc2cc97d4 100644
 --- a/arch/x86/kvm/x86.c
 +++ b/arch/x86/kvm/x86.c
-@@ -12778,8 +12778,8 @@ int kvm_arch_init_vm(struct kvm *kvm, unsigned long type)
+@@ -12780,8 +12780,8 @@ int kvm_arch_init_vm(struct kvm *kvm, unsigned long type)
  		return -EINVAL;
  
  	kvm->arch.vm_type = type;
@@ -91,5 +91,5 @@ index a9d992d5652f..b34236029383 100644
  	kvm->arch.pre_fault_allowed =
  		type == KVM_X86_DEFAULT_VM || type == KVM_X86_SW_PROTECTED_VM;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0005-KVM-Rename-kvm_slot_can_be_private-to-kvm_slot_has_g.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0005-KVM-Rename-kvm_slot_can_be_private-to-kvm_slot_has_g.patch
@@ -1,7 +1,7 @@
-From c16d4a48f6fbad7bdb9024c1c91c38b6d9bdc4e8 Mon Sep 17 00:00:00 2001
+From a56ba2f9a2ec7436126f23997e502543e0e4bbe0 Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:31 +0100
-Subject: [PATCH 05/45] KVM: Rename kvm_slot_can_be_private() to
+Date: Tue, 15 Jul 2025 10:33:34 +0100
+Subject: [PATCH 05/46] KVM: Rename kvm_slot_can_be_private() to
  kvm_slot_has_gmem()
 
 Rename kvm_slot_can_be_private() to kvm_slot_has_gmem() to improve
@@ -54,10 +54,10 @@ index 4e06e2e89a8f..213904daf1e5 100644
  		return -EFAULT;
  	}
 diff --git a/arch/x86/kvm/svm/sev.c b/arch/x86/kvm/svm/sev.c
-index 459c3b791fd4..ade7a5b36c68 100644
+index b201f77fcd49..687392c5bf5d 100644
 --- a/arch/x86/kvm/svm/sev.c
 +++ b/arch/x86/kvm/svm/sev.c
-@@ -2319,7 +2319,7 @@ static int snp_launch_update(struct kvm *kvm, struct kvm_sev_cmd *argp)
+@@ -2323,7 +2323,7 @@ static int snp_launch_update(struct kvm *kvm, struct kvm_sev_cmd *argp)
  	mutex_lock(&kvm->slots_lock);
  
  	memslot = gfn_to_memslot(kvm, params.gfn_start);
@@ -66,7 +66,7 @@ index 459c3b791fd4..ade7a5b36c68 100644
  		ret = -EINVAL;
  		goto out;
  	}
-@@ -4670,7 +4670,7 @@ void sev_handle_rmp_fault(struct kvm_vcpu *vcpu, gpa_t gpa, u64 error_code)
+@@ -4678,7 +4678,7 @@ void sev_handle_rmp_fault(struct kvm_vcpu *vcpu, gpa_t gpa, u64 error_code)
  	}
  
  	slot = gfn_to_memslot(kvm, gfn);
@@ -102,5 +102,5 @@ index befea51bbc75..6db515833f61 100644
  
  	file = kvm_gmem_get_file(slot);
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0006-KVM-Fix-comments-that-refer-to-slots_lock.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0006-KVM-Fix-comments-that-refer-to-slots_lock.patch
@@ -1,7 +1,7 @@
-From 4e0120bc233422b398683f708873242163972916 Mon Sep 17 00:00:00 2001
+From ffbe742826fa64c4af474398ce274b58338f3e48 Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:32 +0100
-Subject: [PATCH 06/45] KVM: Fix comments that refer to slots_lock
+Date: Tue, 15 Jul 2025 10:33:35 +0100
+Subject: [PATCH 06/46] KVM: Fix comments that refer to slots_lock
 
 Fix comments so that they refer to slots_lock instead of slots_locks
 (remove trailing s).
@@ -31,7 +31,7 @@ index ed00c2b40e4b..9c654dfb6dce 100644
  #endif
  	char stats_id[KVM_STATS_NAME_SIZE];
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index afbc025ce4d3..81bb18fa8655 100644
+index 162e2a69cc49..46bddac1dacd 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
 @@ -331,7 +331,7 @@ void kvm_flush_remote_tlbs_memslot(struct kvm *kvm,
@@ -44,5 +44,5 @@ index afbc025ce4d3..81bb18fa8655 100644
  	 */
  	lockdep_assert_held(&kvm->slots_lock);
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0007-KVM-Fix-comment-that-refers-to-kvm-uapi-header-path.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0007-KVM-Fix-comment-that-refers-to-kvm-uapi-header-path.patch
@@ -1,7 +1,7 @@
-From b9cc809ebdf2e73ebdd42300d3d1b0702aed3d21 Mon Sep 17 00:00:00 2001
+From 2b0fd6a86bfa830aee045aaab2cd21616ee2df7d Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:33 +0100
-Subject: [PATCH 07/45] KVM: Fix comment that refers to kvm uapi header path
+Date: Tue, 15 Jul 2025 10:33:36 +0100
+Subject: [PATCH 07/46] KVM: Fix comment that refers to kvm uapi header path
 
 The comment that points to the path where the user-visible memslot flags
 are refers to an outdated path and has a typo.
@@ -31,5 +31,5 @@ index 9c654dfb6dce..1ec71648824c 100644
  #define KVM_MEMSLOT_INVALID	(1UL << 16)
  
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0008-KVM-guest_memfd-Allow-host-to-map-guest_memfd-pages.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0008-KVM-guest_memfd-Allow-host-to-map-guest_memfd-pages.patch
@@ -1,7 +1,7 @@
-From 58c6400113b15dce2c25f61927c0572e85c497c4 Mon Sep 17 00:00:00 2001
+From 86e455716787a2e9361fb48458d38f5731e8666c Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:34 +0100
-Subject: [PATCH 08/45] KVM: guest_memfd: Allow host to map guest_memfd pages
+Date: Tue, 15 Jul 2025 10:33:37 +0100
+Subject: [PATCH 08/46] KVM: guest_memfd: Allow host to map guest_memfd pages
 
 Introduce the core infrastructure to enable host userspace to mmap()
 guest_memfd-backed memory. This is needed for several evolving KVM use
@@ -96,10 +96,10 @@ index 1ec71648824c..9ac21985f3b5 100644
  static inline bool kvm_arch_has_readonly_mem(struct kvm *kvm)
  {
 diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
-index 37891580d05d..c71348db818f 100644
+index 7a4c35ff03fe..3beafbf306af 100644
 --- a/include/uapi/linux/kvm.h
 +++ b/include/uapi/linux/kvm.h
-@@ -1592,6 +1592,7 @@ struct kvm_memory_attributes {
+@@ -1596,6 +1596,7 @@ struct kvm_memory_attributes {
  #define KVM_MEMORY_ATTRIBUTE_PRIVATE           (1ULL << 3)
  
  #define KVM_CREATE_GUEST_MEMFD	_IOWR(KVMIO,  0xd4, struct kvm_create_guest_memfd)
@@ -212,5 +212,5 @@ index 6db515833f61..07a4b165471d 100644
  		return -EINVAL;
  
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0009-KVM-guest_memfd-Track-guest_memfd-mmap-support-in-me.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0009-KVM-guest_memfd-Track-guest_memfd-mmap-support-in-me.patch
@@ -1,7 +1,7 @@
-From e841f1cf86506f567df73da1a9429fe8586f90a5 Mon Sep 17 00:00:00 2001
+From 09759854a3fbd70fc5c8c1f44da8c11c12cd3ac2 Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:35 +0100
-Subject: [PATCH 09/45] KVM: guest_memfd: Track guest_memfd mmap support in
+Date: Tue, 15 Jul 2025 10:33:38 +0100
+Subject: [PATCH 09/46] KVM: guest_memfd: Track guest_memfd mmap support in
  memslot
 
 Add a new internal flag, KVM_MEMSLOT_GMEM_ONLY, to the top half of
@@ -16,6 +16,7 @@ information directly in the memslot, we reduce overhead and simplify the
 logic involved in handling guest_memfd-backed pages for host mappings.
 
 Reviewed-by: Gavin Shan <gshan@redhat.com>
+Reviewed-by: Shivank Garg <shivankg@amd.com>
 Acked-by: David Hildenbrand <david@redhat.com>
 Suggested-by: David Hildenbrand <david@redhat.com>
 Signed-off-by: Fuad Tabba <tabba@google.com>
@@ -67,5 +68,5 @@ index 07a4b165471d..2b00f8796a15 100644
  	xa_store_range(&gmem->bindings, start, end - 1, slot, GFP_KERNEL);
  	filemap_invalidate_unlock(inode->i_mapping);
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0010-KVM-x86-mmu-Generalize-private_max_mapping_level-x86.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0010-KVM-x86-mmu-Generalize-private_max_mapping_level-x86.patch
@@ -1,7 +1,7 @@
-From 1405fe03056846a5f0cebe06721a290a0f436094 Mon Sep 17 00:00:00 2001
+From 79a313d6ad47fed8265d9a2c39b84d057b48eddd Mon Sep 17 00:00:00 2001
 From: Ackerley Tng <ackerleytng@google.com>
-Date: Wed, 9 Jul 2025 11:59:36 +0100
-Subject: [PATCH 10/45] KVM: x86/mmu: Generalize private_max_mapping_level x86
+Date: Tue, 15 Jul 2025 10:33:39 +0100
+Subject: [PATCH 10/46] KVM: x86/mmu: Generalize private_max_mapping_level x86
  op to max_mapping_level
 
 Generalize the private_max_mapping_level x86 operation to
@@ -33,6 +33,7 @@ indicating no specific platform-imposed mapping level limits for
 non-private pages. This allows the core MMU to continue determining the
 mapping level based on generic rules for such cases.
 
+Acked-by: David Hildenbrand <david@redhat.com>
 Suggested-by: Sean Christoperson <seanjc@google.com>
 Signed-off-by: Ackerley Tng <ackerleytng@google.com>
 Signed-off-by: Fuad Tabba <tabba@google.com>
@@ -62,10 +63,10 @@ index 8d50e3e0a19b..02301fbad449 100644
  
  #undef KVM_X86_OP
 diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
-index ebddedf0a1f2..4c764faa12f3 100644
+index 938b5be03d33..543d09fd4bca 100644
 --- a/arch/x86/include/asm/kvm_host.h
 +++ b/arch/x86/include/asm/kvm_host.h
-@@ -1901,7 +1901,7 @@ struct kvm_x86_ops {
+@@ -1907,7 +1907,7 @@ struct kvm_x86_ops {
  	void *(*alloc_apic_backing_page)(struct kvm_vcpu *vcpu);
  	int (*gmem_prepare)(struct kvm *kvm, kvm_pfn_t pfn, gfn_t gfn, int max_order);
  	void (*gmem_invalidate)(kvm_pfn_t start, kvm_pfn_t end);
@@ -112,7 +113,7 @@ index 213904daf1e5..bb925994cbc5 100644
  	return RET_PF_CONTINUE;
  }
 diff --git a/arch/x86/kvm/svm/sev.c b/arch/x86/kvm/svm/sev.c
-index ade7a5b36c68..58116439d7c0 100644
+index 687392c5bf5d..dd470e26f6a0 100644
 --- a/arch/x86/kvm/svm/sev.c
 +++ b/arch/x86/kvm/svm/sev.c
 @@ -29,6 +29,7 @@
@@ -123,7 +124,7 @@ index ade7a5b36c68..58116439d7c0 100644
  #include "mmu.h"
  #include "x86.h"
  #include "svm.h"
-@@ -4898,7 +4899,7 @@ void sev_gmem_invalidate(kvm_pfn_t start, kvm_pfn_t end)
+@@ -4906,7 +4907,7 @@ void sev_gmem_invalidate(kvm_pfn_t start, kvm_pfn_t end)
  	}
  }
  
@@ -132,7 +133,7 @@ index ade7a5b36c68..58116439d7c0 100644
  {
  	int level, rc;
  	bool assigned;
-@@ -4906,7 +4907,10 @@ int sev_private_max_mapping_level(struct kvm *kvm, kvm_pfn_t pfn)
+@@ -4914,7 +4915,10 @@ int sev_private_max_mapping_level(struct kvm *kvm, kvm_pfn_t pfn)
  	if (!sev_snp_guest(kvm))
  		return 0;
  
@@ -206,10 +207,10 @@ index d1e02e567b57..8e53554932ba 100644
  
  struct kvm_x86_init_ops vt_init_ops __initdata = {
 diff --git a/arch/x86/kvm/vmx/tdx.c b/arch/x86/kvm/vmx/tdx.c
-index c227516e6a02..1607b1f6be21 100644
+index a3db6df245ee..7f652241491a 100644
 --- a/arch/x86/kvm/vmx/tdx.c
 +++ b/arch/x86/kvm/vmx/tdx.c
-@@ -3292,8 +3292,11 @@ int tdx_vcpu_ioctl(struct kvm_vcpu *vcpu, void __user *argp)
+@@ -3322,8 +3322,11 @@ int tdx_vcpu_ioctl(struct kvm_vcpu *vcpu, void __user *argp)
  	return ret;
  }
  
@@ -236,5 +237,5 @@ index b4596f651232..ca7bc9e0fce5 100644
  
  #endif /* __KVM_X86_VMX_X86_OPS_H */
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0011-KVM-x86-mmu-Allow-NULL-able-fault-in-kvm_max_private.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0011-KVM-x86-mmu-Allow-NULL-able-fault-in-kvm_max_private.patch
@@ -1,7 +1,7 @@
-From 0bbaadd1753792a845481f48cbc9c524cf85d2ea Mon Sep 17 00:00:00 2001
+From 2c056af79dfa13aae23431c1c200b7cad1e57449 Mon Sep 17 00:00:00 2001
 From: Ackerley Tng <ackerleytng@google.com>
-Date: Wed, 9 Jul 2025 11:59:37 +0100
-Subject: [PATCH 11/45] KVM: x86/mmu: Allow NULL-able fault in
+Date: Tue, 15 Jul 2025 10:33:40 +0100
+Subject: [PATCH 11/46] KVM: x86/mmu: Allow NULL-able fault in
  kvm_max_private_mapping_level
 
 Refactor kvm_max_private_mapping_level() to accept a NULL kvm_page_fault
@@ -26,15 +26,16 @@ Optimize max_level checks: Introduce a check in the caller to skip
 querying for max_mapping_level if the current max_level is already
 PG_LEVEL_4K, as no further reduction is possible.
 
+Acked-by: David Hildenbrand <david@redhat.com>
 Suggested-by: Sean Christoperson <seanjc@google.com>
 Signed-off-by: Ackerley Tng <ackerleytng@google.com>
 Signed-off-by: Fuad Tabba <tabba@google.com>
 ---
- arch/x86/kvm/mmu/mmu.c | 17 ++++++++---------
- 1 file changed, 8 insertions(+), 9 deletions(-)
+ arch/x86/kvm/mmu/mmu.c | 16 +++++++---------
+ 1 file changed, 7 insertions(+), 9 deletions(-)
 
 diff --git a/arch/x86/kvm/mmu/mmu.c b/arch/x86/kvm/mmu/mmu.c
-index bb925994cbc5..495dcedaeafa 100644
+index bb925994cbc5..6bd28fda0fd3 100644
 --- a/arch/x86/kvm/mmu/mmu.c
 +++ b/arch/x86/kvm/mmu/mmu.c
 @@ -4467,17 +4467,13 @@ static inline u8 kvm_max_level_for_order(int order)
@@ -59,18 +60,17 @@ index bb925994cbc5..495dcedaeafa 100644
  	if (max_level == PG_LEVEL_4K)
  		return PG_LEVEL_4K;
  
-@@ -4513,7 +4509,10 @@ static int kvm_mmu_faultin_pfn_private(struct kvm_vcpu *vcpu,
+@@ -4513,7 +4509,9 @@ static int kvm_mmu_faultin_pfn_private(struct kvm_vcpu *vcpu,
  	}
  
  	fault->map_writable = !(fault->slot->flags & KVM_MEM_READONLY);
 -	fault->max_level = kvm_max_private_mapping_level(vcpu->kvm, fault, max_order);
-+	if (fault->max_level >= PG_LEVEL_4K) {
++	if (fault->max_level >= PG_LEVEL_4K)
 +		fault->max_level = kvm_gmem_max_mapping_level(vcpu->kvm,
 +							      max_order, fault);
-+	}
  
  	return RET_PF_CONTINUE;
  }
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0012-KVM-x86-mmu-Consult-guest_memfd-when-computing-max_m.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0012-KVM-x86-mmu-Consult-guest_memfd-when-computing-max_m.patch
@@ -1,7 +1,7 @@
-From b8f1e64371756c75ef3d952f76342a48203b93fd Mon Sep 17 00:00:00 2001
+From 778110c1ae955ac98afac67c71c66ab5931238fd Mon Sep 17 00:00:00 2001
 From: Ackerley Tng <ackerleytng@google.com>
-Date: Wed, 9 Jul 2025 11:59:38 +0100
-Subject: [PATCH 12/45] KVM: x86/mmu: Consult guest_memfd when computing
+Date: Tue, 15 Jul 2025 10:33:41 +0100
+Subject: [PATCH 12/46] KVM: x86/mmu: Consult guest_memfd when computing
  max_mapping_level
 
 Modify kvm_mmu_max_mapping_level() to consult guest_memfd for memory
@@ -41,7 +41,7 @@ Signed-off-by: Fuad Tabba <tabba@google.com>
  3 files changed, 79 insertions(+), 35 deletions(-)
 
 diff --git a/arch/x86/kvm/mmu/mmu.c b/arch/x86/kvm/mmu/mmu.c
-index 495dcedaeafa..6d997063f76f 100644
+index 6bd28fda0fd3..94be15cde6da 100644
 --- a/arch/x86/kvm/mmu/mmu.c
 +++ b/arch/x86/kvm/mmu/mmu.c
 @@ -3282,13 +3282,67 @@ static int __kvm_mmu_max_mapping_level(struct kvm *kvm,
@@ -208,5 +208,5 @@ index 2b00f8796a15..d01bd7a2c2bd 100644
  long kvm_gmem_populate(struct kvm *kvm, gfn_t start_gfn, void __user *src, long npages,
  		       kvm_gmem_populate_cb post_populate, void *opaque)
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0013-KVM-x86-mmu-Handle-guest-page-faults-for-guest_memfd.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0013-KVM-x86-mmu-Handle-guest-page-faults-for-guest_memfd.patch
@@ -1,7 +1,7 @@
-From f83651ebccced465c3d399cf9df2705c6bb70e9c Mon Sep 17 00:00:00 2001
+From 42491fccb59ae63c35c2f38a363479fa186867e1 Mon Sep 17 00:00:00 2001
 From: Ackerley Tng <ackerleytng@google.com>
-Date: Wed, 9 Jul 2025 11:59:39 +0100
-Subject: [PATCH 13/45] KVM: x86/mmu: Handle guest page faults for guest_memfd
+Date: Tue, 15 Jul 2025 10:33:42 +0100
+Subject: [PATCH 13/46] KVM: x86/mmu: Handle guest page faults for guest_memfd
  with shared memory
 
 Update the KVM MMU fault handler to service guest page faults
@@ -28,7 +28,7 @@ Signed-off-by: Fuad Tabba <tabba@google.com>
  1 file changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/arch/x86/kvm/mmu/mmu.c b/arch/x86/kvm/mmu/mmu.c
-index 6d997063f76f..cc4cdfea343b 100644
+index 94be15cde6da..ad5f337b496c 100644
 --- a/arch/x86/kvm/mmu/mmu.c
 +++ b/arch/x86/kvm/mmu/mmu.c
 @@ -4511,8 +4511,8 @@ static void kvm_mmu_finish_page_fault(struct kvm_vcpu *vcpu,
@@ -42,7 +42,7 @@ index 6d997063f76f..cc4cdfea343b 100644
  {
  	int max_order, r;
  
-@@ -4537,13 +4537,18 @@ static int kvm_mmu_faultin_pfn_private(struct kvm_vcpu *vcpu,
+@@ -4536,13 +4536,18 @@ static int kvm_mmu_faultin_pfn_private(struct kvm_vcpu *vcpu,
  	return RET_PF_CONTINUE;
  }
  
@@ -64,5 +64,5 @@ index 6d997063f76f..cc4cdfea343b 100644
  	foll |= FOLL_NOWAIT;
  	fault->pfn = __kvm_faultin_pfn(fault->slot, fault->gfn, foll,
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0014-KVM-x86-Enable-guest_memfd-mmap-for-default-VM-type.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0014-KVM-x86-Enable-guest_memfd-mmap-for-default-VM-type.patch
@@ -1,7 +1,7 @@
-From 793235f72611c1bcf25801391fbe1aab6fb2373b Mon Sep 17 00:00:00 2001
+From aa1e5ba0e2a75236ad66c224f24a3f311cdee7b1 Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:40 +0100
-Subject: [PATCH 14/45] KVM: x86: Enable guest_memfd mmap for default VM type
+Date: Tue, 15 Jul 2025 10:33:43 +0100
+Subject: [PATCH 14/46] KVM: x86: Enable guest_memfd mmap for default VM type
 
 Enable host userspace mmap support for guest_memfd-backed memory when
 running KVM with the KVM_X86_DEFAULT_VM type:
@@ -41,10 +41,10 @@ Signed-off-by: Fuad Tabba <tabba@google.com>
  3 files changed, 12 insertions(+), 1 deletion(-)
 
 diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
-index 4c764faa12f3..4c89feaa1910 100644
+index 543d09fd4bca..e1426adfa93e 100644
 --- a/arch/x86/include/asm/kvm_host.h
 +++ b/arch/x86/include/asm/kvm_host.h
-@@ -2273,9 +2273,18 @@ void kvm_configure_mmu(bool enable_tdp, int tdp_forced_root_level,
+@@ -2279,9 +2279,18 @@ void kvm_configure_mmu(bool enable_tdp, int tdp_forced_root_level,
  #ifdef CONFIG_KVM_GMEM
  #define kvm_arch_has_private_mem(kvm) ((kvm)->arch.has_private_mem)
  #define kvm_arch_supports_gmem(kvm)  ((kvm)->arch.supports_gmem)
@@ -64,22 +64,22 @@ index 4c764faa12f3..4c89feaa1910 100644
  
  #define kvm_arch_has_readonly_mem(kvm) (!(kvm)->arch.has_protected_state)
 diff --git a/arch/x86/kvm/Kconfig b/arch/x86/kvm/Kconfig
-index df1fdbb4024b..239637b663dc 100644
+index df1fdbb4024b..1ba959b9eadc 100644
 --- a/arch/x86/kvm/Kconfig
 +++ b/arch/x86/kvm/Kconfig
 @@ -47,6 +47,7 @@ config KVM_X86
  	select KVM_GENERIC_HARDWARE_ENABLING
  	select KVM_GENERIC_PRE_FAULT_MEMORY
  	select KVM_GENERIC_GMEM_POPULATE if KVM_SW_PROTECTED_VM
-+	select KVM_GMEM_SUPPORTS_MMAP
++	select KVM_GMEM_SUPPORTS_MMAP if X86_64
  	select KVM_WERROR if WERROR
  
  config KVM
 diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
-index b34236029383..17c655e5716e 100644
+index adbdc2cc97d4..ca99187a566e 100644
 --- a/arch/x86/kvm/x86.c
 +++ b/arch/x86/kvm/x86.c
-@@ -12779,7 +12779,8 @@ int kvm_arch_init_vm(struct kvm *kvm, unsigned long type)
+@@ -12781,7 +12781,8 @@ int kvm_arch_init_vm(struct kvm *kvm, unsigned long type)
  
  	kvm->arch.vm_type = type;
  	kvm->arch.has_private_mem = (type == KVM_X86_SW_PROTECTED_VM);
@@ -90,5 +90,5 @@ index b34236029383..17c655e5716e 100644
  	kvm->arch.pre_fault_allowed =
  		type == KVM_X86_DEFAULT_VM || type == KVM_X86_SW_PROTECTED_VM;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0015-KVM-arm64-Refactor-user_mem_abort.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0015-KVM-arm64-Refactor-user_mem_abort.patch
@@ -1,7 +1,7 @@
-From 560781ab8f7341d20675678bf4b4bf8bcee2e438 Mon Sep 17 00:00:00 2001
+From f6ccdf1e1e958348fade9a66470e3f2783bd0875 Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:41 +0100
-Subject: [PATCH 15/45] KVM: arm64: Refactor user_mem_abort()
+Date: Tue, 15 Jul 2025 10:33:44 +0100
+Subject: [PATCH 15/46] KVM: arm64: Refactor user_mem_abort()
 
 Refactor user_mem_abort() to improve code clarity and simplify
 assumptions within the function.
@@ -31,16 +31,15 @@ These changes primarily aim to simplify user_mem_abort() and make its
 logic easier to understand and maintain, setting the stage for future
 modifications.
 
-No functional change intended.
-
 Reviewed-by: Gavin Shan <gshan@redhat.com>
+Reviewed-by: Marc Zyngier <maz@kernel.org>
 Signed-off-by: Fuad Tabba <tabba@google.com>
 ---
- arch/arm64/kvm/mmu.c | 100 ++++++++++++++++++++++++-------------------
- 1 file changed, 55 insertions(+), 45 deletions(-)
+ arch/arm64/kvm/mmu.c | 110 +++++++++++++++++++++++--------------------
+ 1 file changed, 59 insertions(+), 51 deletions(-)
 
 diff --git a/arch/arm64/kvm/mmu.c b/arch/arm64/kvm/mmu.c
-index 2942ec92c5a4..58662e0ef13e 100644
+index 2942ec92c5a4..b3eacb400fab 100644
 --- a/arch/arm64/kvm/mmu.c
 +++ b/arch/arm64/kvm/mmu.c
 @@ -1470,13 +1470,56 @@ static bool kvm_vma_mte_allowed(struct vm_area_struct *vma)
@@ -109,18 +108,26 @@ index 2942ec92c5a4..58662e0ef13e 100644
  	long vma_pagesize, fault_granule;
  	enum kvm_pgtable_prot prot = KVM_PGTABLE_PROT_R;
  	struct kvm_pgtable *pgt;
-@@ -1505,28 +1549,16 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
- 		return -EFAULT;
- 	}
- 
+@@ -1498,17 +1542,7 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+ 		fault_granule = kvm_vcpu_trap_get_perm_fault_granule(vcpu);
+ 	write_fault = kvm_is_write_fault(vcpu);
+ 	exec_fault = kvm_vcpu_trap_is_exec_fault(vcpu);
+-	VM_BUG_ON(write_fault && exec_fault);
+-
+-	if (fault_is_perm && !write_fault && !exec_fault) {
+-		kvm_err("Unexpected L2 read permission error\n");
+-		return -EFAULT;
+-	}
+-
 -	if (!is_protected_kvm_enabled())
 -		memcache = &vcpu->arch.mmu_page_cache;
 -	else
 -		memcache = &vcpu->arch.pkvm_memcache;
--
++	VM_WARN_ON_ONCE(write_fault && exec_fault);
+ 
  	/*
  	 * Permission faults just need to update the existing leaf entry,
- 	 * and so normally don't require allocations from the memcache. The
+@@ -1516,17 +1550,10 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  	 * only exception to this is when dirty logging is enabled at runtime
  	 * and a write fault needs to collapse a block entry into a table.
  	 */
@@ -142,7 +149,7 @@ index 2942ec92c5a4..58662e0ef13e 100644
  
  	/*
  	 * Let's check if we will get back a huge page backed by hugetlbfs, or
-@@ -1540,16 +1572,10 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+@@ -1540,16 +1567,10 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  		return -EFAULT;
  	}
  
@@ -161,7 +168,7 @@ index 2942ec92c5a4..58662e0ef13e 100644
  
  	switch (vma_shift) {
  #ifndef __PAGETABLE_PMD_FOLDED
-@@ -1601,7 +1627,7 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+@@ -1601,7 +1622,7 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  			max_map_size = PAGE_SIZE;
  
  		force_pte = (max_map_size == PAGE_SIZE);
@@ -170,7 +177,7 @@ index 2942ec92c5a4..58662e0ef13e 100644
  	}
  
  	/*
-@@ -1630,7 +1656,7 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+@@ -1630,7 +1651,7 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  	 * Rely on mmap_read_unlock() for an implicit smp_rmb(), which pairs
  	 * with the smp_wmb() in kvm_mmu_invalidate_end().
  	 */
@@ -179,7 +186,7 @@ index 2942ec92c5a4..58662e0ef13e 100644
  	mmap_read_unlock(current->mm);
  
  	pfn = __kvm_faultin_pfn(memslot, gfn, write_fault ? FOLL_WRITE : 0,
-@@ -1665,24 +1691,8 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+@@ -1665,24 +1686,8 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  	if (exec_fault && device)
  		return -ENOEXEC;
  
@@ -206,6 +213,16 @@ index 2942ec92c5a4..58662e0ef13e 100644
  
  	kvm_fault_lock(kvm);
  	pgt = vcpu->arch.hw_mmu->pgt;
+@@ -1953,6 +1958,9 @@ int kvm_handle_guest_abort(struct kvm_vcpu *vcpu)
+ 		goto out_unlock;
+ 	}
+ 
++	VM_WARN_ON_ONCE(kvm_vcpu_trap_is_permission_fault(vcpu) &&
++			!write_fault && !kvm_vcpu_trap_is_exec_fault(vcpu));
++
+ 	ret = user_mem_abort(vcpu, fault_ipa, nested, memslot, hva,
+ 			     esr_fsc_is_permission_fault(esr));
+ 	if (ret == 0)
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0016-KVM-arm64-Handle-guest_memfd-backed-guest-page-fault.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0016-KVM-arm64-Handle-guest_memfd-backed-guest-page-fault.patch
@@ -1,7 +1,7 @@
-From 7ad514bb5df2e781f742c113cae15f1169ac99f5 Mon Sep 17 00:00:00 2001
+From 5dc88aa0c38b04dc510ef6bb8208813479602e28 Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:42 +0100
-Subject: [PATCH 16/45] KVM: arm64: Handle guest_memfd-backed guest page faults
+Date: Tue, 15 Jul 2025 10:33:45 +0100
+Subject: [PATCH 16/46] KVM: arm64: Handle guest_memfd-backed guest page faults
 
 Add arm64 architecture support for handling guest page faults on memory
 slots backed by guest_memfd.
@@ -19,14 +19,14 @@ Reviewed-by: Gavin Shan <gshan@redhat.com>
 Reviewed-by: James Houghton <jthoughton@google.com>
 Signed-off-by: Fuad Tabba <tabba@google.com>
 ---
- arch/arm64/kvm/mmu.c | 82 ++++++++++++++++++++++++++++++++++++++++++--
- 1 file changed, 79 insertions(+), 3 deletions(-)
+ arch/arm64/kvm/mmu.c | 86 ++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 83 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm64/kvm/mmu.c b/arch/arm64/kvm/mmu.c
-index 58662e0ef13e..71f8b53683e7 100644
+index b3eacb400fab..8c82df80a835 100644
 --- a/arch/arm64/kvm/mmu.c
 +++ b/arch/arm64/kvm/mmu.c
-@@ -1512,6 +1512,78 @@ static void adjust_nested_fault_perms(struct kvm_s2_trans *nested,
+@@ -1512,6 +1512,82 @@ static void adjust_nested_fault_perms(struct kvm_s2_trans *nested,
  	*prot |= kvm_encode_nested_level(nested);
  }
  
@@ -40,6 +40,7 @@ index 58662e0ef13e..71f8b53683e7 100644
 +	enum kvm_pgtable_walk_flags flags = KVM_PGTABLE_WALK_MEMABORT_FLAGS;
 +	enum kvm_pgtable_prot prot = KVM_PGTABLE_PROT_R;
 +	struct kvm_pgtable *pgt = vcpu->arch.hw_mmu->pgt;
++	unsigned long mmu_seq;
 +	struct page *page;
 +	struct kvm *kvm = vcpu->kvm;
 +	void *memcache;
@@ -59,15 +60,11 @@ index 58662e0ef13e..71f8b53683e7 100644
 +	write_fault = kvm_is_write_fault(vcpu);
 +	exec_fault = kvm_vcpu_trap_is_exec_fault(vcpu);
 +
-+	if (write_fault && exec_fault) {
-+		kvm_err("Simultaneous write and execution fault\n");
-+		return -EFAULT;
-+	}
++	VM_WARN_ON_ONCE(write_fault && exec_fault);
 +
-+	if (is_perm && !write_fault && !exec_fault) {
-+		kvm_err("Unexpected L2 read permission error\n");
-+		return -EFAULT;
-+	}
++	mmu_seq = kvm->mmu_invalidate_seq;
++	/* Pairs with the smp_wmb() in kvm_mmu_invalidate_end(). */
++	smp_rmb();
 +
 +	ret = kvm_gmem_get_pfn(kvm, memslot, gfn, &pfn, &page, NULL);
 +	if (ret) {
@@ -90,9 +87,16 @@ index 58662e0ef13e..71f8b53683e7 100644
 +		prot |= KVM_PGTABLE_PROT_X;
 +
 +	kvm_fault_lock(kvm);
++	if (mmu_invalidate_retry(kvm, mmu_seq)) {
++		ret = -EAGAIN;
++		goto out_unlock;
++	}
++
 +	ret = KVM_PGT_FN(kvm_pgtable_stage2_map)(pgt, fault_ipa, PAGE_SIZE,
 +						 __pfn_to_phys(pfn), prot,
 +						 memcache, flags);
++
++out_unlock:
 +	kvm_release_faultin_page(kvm, page, !!ret, writable);
 +	kvm_fault_unlock(kvm);
 +
@@ -105,7 +109,7 @@ index 58662e0ef13e..71f8b53683e7 100644
  static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  			  struct kvm_s2_trans *nested,
  			  struct kvm_memory_slot *memslot, unsigned long hva,
-@@ -1536,7 +1608,7 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+@@ -1536,7 +1612,7 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  	enum kvm_pgtable_prot prot = KVM_PGTABLE_PROT_R;
  	struct kvm_pgtable *pgt;
  	struct page *page;
@@ -114,9 +118,9 @@ index 58662e0ef13e..71f8b53683e7 100644
  
  	if (fault_is_perm)
  		fault_granule = kvm_vcpu_trap_get_perm_fault_granule(vcpu);
-@@ -1963,8 +2035,12 @@ int kvm_handle_guest_abort(struct kvm_vcpu *vcpu)
- 		goto out_unlock;
- 	}
+@@ -1961,8 +2037,12 @@ int kvm_handle_guest_abort(struct kvm_vcpu *vcpu)
+ 	VM_WARN_ON_ONCE(kvm_vcpu_trap_is_permission_fault(vcpu) &&
+ 			!write_fault && !kvm_vcpu_trap_is_exec_fault(vcpu));
  
 -	ret = user_mem_abort(vcpu, fault_ipa, nested, memslot, hva,
 -			     esr_fsc_is_permission_fault(esr));
@@ -130,5 +134,5 @@ index 58662e0ef13e..71f8b53683e7 100644
  		ret = 1;
  out:
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0017-KVM-arm64-nv-Handle-VNCR_EL2-triggered-faults-backed.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0017-KVM-arm64-nv-Handle-VNCR_EL2-triggered-faults-backed.patch
@@ -1,0 +1,110 @@
+From 802e435b18d56efe200a6e02bb3d0939e032afbc Mon Sep 17 00:00:00 2001
+From: Fuad Tabba <tabba@google.com>
+Date: Tue, 15 Jul 2025 10:33:46 +0100
+Subject: [PATCH 17/46] KVM: arm64: nv: Handle VNCR_EL2-triggered faults backed
+ by guest_memfd
+
+Handle faults for memslots backed by guest_memfd in arm64 nested
+virtualization triggerred by VNCR_EL2.
+
+* Introduce is_gmem output parameter to kvm_translate_vncr(), indicating
+  whether the faulted memory slot is backed by guest_memfd.
+
+* Dispatch faults backed by guest_memfd to kvm_gmem_get_pfn().
+
+* Update kvm_handle_vncr_abort() to handle potential guest_memfd errors.
+  Some of the guest_memfd errors need to be handled by userspace,
+  instead of attempting to (implicitly) retry by returning to the guest.
+
+Suggested-by: Marc Zyngier <maz@kernel.org>
+Signed-off-by: Fuad Tabba <tabba@google.com>
+---
+ arch/arm64/kvm/nested.c | 41 +++++++++++++++++++++++++++++++++++------
+ 1 file changed, 35 insertions(+), 6 deletions(-)
+
+diff --git a/arch/arm64/kvm/nested.c b/arch/arm64/kvm/nested.c
+index dc1d26559bfa..b3edd7f7c8cd 100644
+--- a/arch/arm64/kvm/nested.c
++++ b/arch/arm64/kvm/nested.c
+@@ -1172,8 +1172,9 @@ static u64 read_vncr_el2(struct kvm_vcpu *vcpu)
+ 	return (u64)sign_extend64(__vcpu_sys_reg(vcpu, VNCR_EL2), 48);
+ }
+ 
+-static int kvm_translate_vncr(struct kvm_vcpu *vcpu)
++static int kvm_translate_vncr(struct kvm_vcpu *vcpu, bool *is_gmem)
+ {
++	struct kvm_memory_slot *memslot;
+ 	bool write_fault, writable;
+ 	unsigned long mmu_seq;
+ 	struct vncr_tlb *vt;
+@@ -1216,10 +1217,25 @@ static int kvm_translate_vncr(struct kvm_vcpu *vcpu)
+ 	smp_rmb();
+ 
+ 	gfn = vt->wr.pa >> PAGE_SHIFT;
+-	pfn = kvm_faultin_pfn(vcpu, gfn, write_fault, &writable, &page);
+-	if (is_error_noslot_pfn(pfn) || (write_fault && !writable))
++	memslot = gfn_to_memslot(vcpu->kvm, gfn);
++	if (!memslot)
+ 		return -EFAULT;
+ 
++	*is_gmem = kvm_slot_has_gmem(memslot);
++	if (!*is_gmem) {
++		pfn = __kvm_faultin_pfn(memslot, gfn, write_fault ? FOLL_WRITE : 0,
++					&writable, &page);
++		if (is_error_noslot_pfn(pfn) || (write_fault && !writable))
++			return -EFAULT;
++	} else {
++		ret = kvm_gmem_get_pfn(vcpu->kvm, memslot, gfn, &pfn, &page, NULL);
++		if (ret) {
++			kvm_prepare_memory_fault_exit(vcpu, vt->wr.pa, PAGE_SIZE,
++					      write_fault, false, false);
++			return ret;
++		}
++	}
++
+ 	scoped_guard(write_lock, &vcpu->kvm->mmu_lock) {
+ 		if (mmu_invalidate_retry(vcpu->kvm, mmu_seq))
+ 			return -EAGAIN;
+@@ -1292,23 +1308,36 @@ int kvm_handle_vncr_abort(struct kvm_vcpu *vcpu)
+ 	if (esr_fsc_is_permission_fault(esr)) {
+ 		inject_vncr_perm(vcpu);
+ 	} else if (esr_fsc_is_translation_fault(esr)) {
+-		bool valid;
++		bool valid, is_gmem = false;
+ 		int ret;
+ 
+ 		scoped_guard(read_lock, &vcpu->kvm->mmu_lock)
+ 			valid = kvm_vncr_tlb_lookup(vcpu);
+ 
+ 		if (!valid)
+-			ret = kvm_translate_vncr(vcpu);
++			ret = kvm_translate_vncr(vcpu, &is_gmem);
+ 		else
+ 			ret = -EPERM;
+ 
+ 		switch (ret) {
+ 		case -EAGAIN:
+-		case -ENOMEM:
+ 			/* Let's try again... */
+ 			break;
++		case -ENOMEM:
++			/*
++			 * For guest_memfd, this indicates that it failed to
++			 * create a folio to back the memory. Inform userspace.
++			 */
++			if (is_gmem)
++				return 0;
++			/* Otherwise, let's try again... */
++			break;
+ 		case -EFAULT:
++		case -EIO:
++		case -EHWPOISON:
++			if (is_gmem)
++				return 0;
++			fallthrough;
+ 		case -EINVAL:
+ 		case -ENOENT:
+ 		case -EACCES:
+-- 
+2.50.1
+

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0018-KVM-arm64-Enable-host-mapping-of-shared-guest_memfd-.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0018-KVM-arm64-Enable-host-mapping-of-shared-guest_memfd-.patch
@@ -1,7 +1,7 @@
-From 1b1ada64197d513955774384c6589c51d9f84569 Mon Sep 17 00:00:00 2001
+From 21f32f583ea8384ea7ae90a49e7642ce7b1e912a Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:43 +0100
-Subject: [PATCH 17/45] KVM: arm64: Enable host mapping of shared guest_memfd
+Date: Tue, 15 Jul 2025 10:33:47 +0100
+Subject: [PATCH 18/46] KVM: arm64: Enable host mapping of shared guest_memfd
  memory
 
 Enable host userspace mmap support for guest_memfd-backed memory on
@@ -20,9 +20,9 @@ memory at the host directly from guest_memfd:
 
 * Select CONFIG_KVM_GMEM_SUPPORTS_MMAP in arm64 Kconfig.
 
-* Enforce KVM_MEMSLOT_GMEM_ONLY for guest_memfd on arm64: Compile and
-  runtime checks are added to ensure that if guest_memfd is enabled on
-  arm64, KVM_GMEM_SUPPORTS_MMAP must also be enabled. This means
+* Enforce KVM_MEMSLOT_GMEM_ONLY for guest_memfd on arm64: Checks are
+  added to ensure that if guest_memfd is enabled on arm64,
+  KVM_GMEM_SUPPORTS_MMAP must also be enabled. This means
   guest_memfd-backed memory slots on arm64 are currently only supported
   if they are intended for shared memory use cases (i.e.,
   kvm_memslot_is_gmem_only() is true). This design reflects the current
@@ -35,15 +35,15 @@ Acked-by: David Hildenbrand <david@redhat.com>
 Signed-off-by: Fuad Tabba <tabba@google.com>
 ---
  arch/arm64/include/asm/kvm_host.h | 4 ++++
- arch/arm64/kvm/Kconfig            | 1 +
- arch/arm64/kvm/mmu.c              | 8 ++++++++
+ arch/arm64/kvm/Kconfig            | 2 ++
+ arch/arm64/kvm/mmu.c              | 7 +++++++
  3 files changed, 13 insertions(+)
 
 diff --git a/arch/arm64/include/asm/kvm_host.h b/arch/arm64/include/asm/kvm_host.h
-index d27079968341..bd2af5470c66 100644
+index 3e41a880b062..63f7827cfa1b 100644
 --- a/arch/arm64/include/asm/kvm_host.h
 +++ b/arch/arm64/include/asm/kvm_host.h
-@@ -1675,5 +1675,9 @@ void compute_fgu(struct kvm *kvm, enum fgt_group_id fgt);
+@@ -1674,5 +1674,9 @@ void compute_fgu(struct kvm *kvm, enum fgt_group_id fgt);
  void get_reg_fixed_bits(struct kvm *kvm, enum vcpu_sysreg reg, u64 *res0, u64 *res1);
  void check_feature_map(void);
  
@@ -54,22 +54,23 @@ index d27079968341..bd2af5470c66 100644
  
  #endif /* __ARM64_KVM_HOST_H__ */
 diff --git a/arch/arm64/kvm/Kconfig b/arch/arm64/kvm/Kconfig
-index 713248f240e0..28539479f083 100644
+index 713248f240e0..323b46b7c82f 100644
 --- a/arch/arm64/kvm/Kconfig
 +++ b/arch/arm64/kvm/Kconfig
-@@ -37,6 +37,7 @@ menuconfig KVM
+@@ -37,6 +37,8 @@ menuconfig KVM
  	select HAVE_KVM_VCPU_RUN_PID_CHANGE
  	select SCHED_INFO
  	select GUEST_PERF_EVENTS if PERF_EVENTS
++	select KVM_GMEM
 +	select KVM_GMEM_SUPPORTS_MMAP
  	help
  	  Support hosting virtualized guest machines.
  
 diff --git a/arch/arm64/kvm/mmu.c b/arch/arm64/kvm/mmu.c
-index 71f8b53683e7..b92ce4d9b4e0 100644
+index 8c82df80a835..85559b8a0845 100644
 --- a/arch/arm64/kvm/mmu.c
 +++ b/arch/arm64/kvm/mmu.c
-@@ -2274,6 +2274,14 @@ int kvm_arch_prepare_memory_region(struct kvm *kvm,
+@@ -2276,6 +2276,13 @@ int kvm_arch_prepare_memory_region(struct kvm *kvm,
  	if ((new->base_gfn + new->npages) > (kvm_phys_size(&kvm->arch.mmu) >> PAGE_SHIFT))
  		return -EFAULT;
  
@@ -77,7 +78,6 @@ index 71f8b53683e7..b92ce4d9b4e0 100644
 +	 * Only support guest_memfd backed memslots with mappable memory, since
 +	 * there aren't any CoCo VMs that support only private memory on arm64.
 +	 */
-+	BUILD_BUG_ON(IS_ENABLED(CONFIG_KVM_GMEM) && !IS_ENABLED(CONFIG_KVM_GMEM_SUPPORTS_MMAP));
 +	if (kvm_slot_has_gmem(new) && !kvm_memslot_is_gmem_only(new))
 +		return -EINVAL;
 +
@@ -85,5 +85,5 @@ index 71f8b53683e7..b92ce4d9b4e0 100644
  	reg_end = hva + (new->npages << PAGE_SHIFT);
  
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0019-KVM-Introduce-the-KVM-capability-KVM_CAP_GMEM_MMAP.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0019-KVM-Introduce-the-KVM-capability-KVM_CAP_GMEM_MMAP.patch
@@ -1,7 +1,7 @@
-From 7bbe202f36cc3e670d47f353398f434063323169 Mon Sep 17 00:00:00 2001
+From c9392e6f8240d3da85fb65cfd82f592fa415ba21 Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:44 +0100
-Subject: [PATCH 18/45] KVM: Introduce the KVM capability KVM_CAP_GMEM_MMAP
+Date: Tue, 15 Jul 2025 10:33:48 +0100
+Subject: [PATCH 19/46] KVM: Introduce the KVM capability KVM_CAP_GMEM_MMAP
 
 Introduce the new KVM capability KVM_CAP_GMEM_MMAP. This capability
 signals to userspace that a KVM instance supports host userspace mapping
@@ -17,6 +17,7 @@ information regarding support for mmap in guest_memfd.
 
 Reviewed-by: David Hildenbrand <david@redhat.com>
 Reviewed-by: Gavin Shan <gshan@redhat.com>
+Reviewed-by: Shivank Garg <shivankg@amd.com>
 Signed-off-by: Fuad Tabba <tabba@google.com>
 ---
  Documentation/virt/kvm/api.rst | 9 +++++++++
@@ -25,7 +26,7 @@ Signed-off-by: Fuad Tabba <tabba@google.com>
  3 files changed, 14 insertions(+)
 
 diff --git a/Documentation/virt/kvm/api.rst b/Documentation/virt/kvm/api.rst
-index 9abf93ee5f65..70261e189162 100644
+index 43ed57e048a8..5169066b53b2 100644
 --- a/Documentation/virt/kvm/api.rst
 +++ b/Documentation/virt/kvm/api.rst
 @@ -6407,6 +6407,15 @@ most one mapping per page, i.e. binding multiple memory regions to a single
@@ -45,10 +46,10 @@ index 9abf93ee5f65..70261e189162 100644
  
  4.143 KVM_PRE_FAULT_MEMORY
 diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
-index c71348db818f..cbf28237af79 100644
+index 3beafbf306af..698dd407980f 100644
 --- a/include/uapi/linux/kvm.h
 +++ b/include/uapi/linux/kvm.h
-@@ -956,6 +956,7 @@ struct kvm_enable_cap {
+@@ -960,6 +960,7 @@ struct kvm_enable_cap {
  #define KVM_CAP_ARM_EL2 240
  #define KVM_CAP_ARM_EL2_E2H0 241
  #define KVM_CAP_RISCV_MP_STATE_RESET 242
@@ -57,10 +58,10 @@ index c71348db818f..cbf28237af79 100644
  struct kvm_irq_routing_irqchip {
  	__u32 irqchip;
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index 81bb18fa8655..5463e81b08b9 100644
+index 46bddac1dacd..f1ac872e01e9 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
-@@ -4913,6 +4913,10 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
+@@ -4916,6 +4916,10 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
  #ifdef CONFIG_KVM_GMEM
  	case KVM_CAP_GUEST_MEMFD:
  		return !kvm || kvm_arch_supports_gmem(kvm);
@@ -72,5 +73,5 @@ index 81bb18fa8655..5463e81b08b9 100644
  	default:
  		break;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0020-KVM-selftests-guest_memfd-mmap-test-when-mmap-is-sup.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0020-KVM-selftests-guest_memfd-mmap-test-when-mmap-is-sup.patch
@@ -1,7 +1,7 @@
-From 942e67ffcabf0218347c6e61a0656d58ac12f365 Mon Sep 17 00:00:00 2001
+From 15b9df9fc94222e6bbdab3ffcf5bfc936a4c3bba Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:46 +0100
-Subject: [PATCH 20/45] KVM: selftests: guest_memfd mmap() test when mmap is
+Date: Tue, 15 Jul 2025 10:33:50 +0100
+Subject: [PATCH 20/46] KVM: selftests: guest_memfd mmap() test when mmap is
  supported
 
 Expand the guest_memfd selftests to comprehensively test host userspace
@@ -47,7 +47,7 @@ Signed-off-by: Fuad Tabba <tabba@google.com>
  1 file changed, 176 insertions(+), 21 deletions(-)
 
 diff --git a/tools/testing/selftests/kvm/guest_memfd_test.c b/tools/testing/selftests/kvm/guest_memfd_test.c
-index 341ba616cf55..1252e74fbb8f 100644
+index ce687f8d248f..beb556293590 100644
 --- a/tools/testing/selftests/kvm/guest_memfd_test.c
 +++ b/tools/testing/selftests/kvm/guest_memfd_test.c
 @@ -13,6 +13,8 @@
@@ -176,7 +176,7 @@ index 341ba616cf55..1252e74fbb8f 100644
  }
  
  static void test_create_guest_memfd_multiple(struct kvm_vm *vm)
-@@ -171,30 +237,119 @@ static void test_create_guest_memfd_multiple(struct kvm_vm *vm)
+@@ -170,30 +236,119 @@ static void test_create_guest_memfd_multiple(struct kvm_vm *vm)
  	close(fd1);
  }
  
@@ -305,5 +305,5 @@ index 341ba616cf55..1252e74fbb8f 100644
 +#endif
  }
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/05-mmap-support/0021-KVM-selftests-Do-not-use-hardcoded-page-sizes-in-gue.patch
+++ b/resources/hiding_ci/linux_patches/05-mmap-support/0021-KVM-selftests-Do-not-use-hardcoded-page-sizes-in-gue.patch
@@ -1,7 +1,7 @@
-From 5ad1a2fce09c242511f3ce9de606016542a7c390 Mon Sep 17 00:00:00 2001
+From f02cb2c4f0d67cfb5a9efc69da258ab60077eb4b Mon Sep 17 00:00:00 2001
 From: Fuad Tabba <tabba@google.com>
-Date: Wed, 9 Jul 2025 11:59:45 +0100
-Subject: [PATCH 19/45] KVM: selftests: Do not use hardcoded page sizes in
+Date: Tue, 15 Jul 2025 10:33:49 +0100
+Subject: [PATCH 21/46] KVM: selftests: Do not use hardcoded page sizes in
  guest_memfd test
 
 Update the guest_memfd_test selftest to use getpagesize() instead of
@@ -37,10 +37,10 @@ index 38b95998e1e6..e11ed9e59ab5 100644
  TEST_GEN_PROGS_arm64 += memslot_perf_test
  TEST_GEN_PROGS_arm64 += mmu_stress_test
 diff --git a/tools/testing/selftests/kvm/guest_memfd_test.c b/tools/testing/selftests/kvm/guest_memfd_test.c
-index ce687f8d248f..341ba616cf55 100644
+index beb556293590..1252e74fbb8f 100644
 --- a/tools/testing/selftests/kvm/guest_memfd_test.c
 +++ b/tools/testing/selftests/kvm/guest_memfd_test.c
-@@ -146,24 +146,25 @@ static void test_create_guest_memfd_multiple(struct kvm_vm *vm)
+@@ -212,24 +212,25 @@ static void test_create_guest_memfd_multiple(struct kvm_vm *vm)
  {
  	int fd1, fd2, ret;
  	struct stat st1, st2;
@@ -72,5 +72,5 @@ index ce687f8d248f..341ba616cf55 100644
  
  	close(fd2);
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0022-filemap-Pass-address_space-mapping-to-free_folio.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0022-filemap-Pass-address_space-mapping-to-free_folio.patch
@@ -1,7 +1,7 @@
-From dfd8fbdb2145de31f39d3a6e0a290e3c9b6a1bbe Mon Sep 17 00:00:00 2001
+From 3ce2b54021d5ef77509e40929eff63b7686ec566 Mon Sep 17 00:00:00 2001
 From: Elliot Berman <quic_eberman@quicinc.com>
 Date: Fri, 22 Nov 2024 09:29:38 -0800
-Subject: [PATCH 21/45] filemap: Pass address_space mapping to ->free_folio()
+Subject: [PATCH 22/46] filemap: Pass address_space mapping to ->free_folio()
 
 When guest_memfd removes memory from the host kernel's direct map,
 direct map entries must be restored before the memory is freed again. To
@@ -210,5 +210,5 @@ index d01bd7a2c2bd..0ac1c3a5a433 100644
  	struct page *page = folio_page(folio, 0);
  	kvm_pfn_t pfn = page_to_pfn(page);
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0023-arch-export-set_direct_map_valid_noflush-to-KVM-modu.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0023-arch-export-set_direct_map_valid_noflush-to-KVM-modu.patch
@@ -1,7 +1,7 @@
-From 7a5e5c1d8bb2fe2d28205e89070d55f21e965d8d Mon Sep 17 00:00:00 2001
+From 7a443341bf7db1d1b8f9c5c7cc2e74993bd71990 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <roypat@amazon.co.uk>
 Date: Mon, 2 Jun 2025 12:06:10 +0100
-Subject: [PATCH 22/45] arch: export set_direct_map_valid_noflush to KVM module
+Subject: [PATCH 23/46] arch: export set_direct_map_valid_noflush to KVM module
 
 Use the new per-module export functionality to allow KVM (and only KVM)
 access to set_direct_map_valid_noflush(). This allows guest_memfd to
@@ -81,5 +81,5 @@ index 8834c76f91c9..ab469de18c4d 100644
  #ifdef CONFIG_DEBUG_PAGEALLOC
  void __kernel_map_pages(struct page *page, int numpages, int enable)
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0024-mm-introduce-AS_NO_DIRECT_MAP.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0024-mm-introduce-AS_NO_DIRECT_MAP.patch
@@ -1,7 +1,7 @@
-From 77947852711525793cd470b1c1cae0b82ffc3cce Mon Sep 17 00:00:00 2001
+From 3c77f823f4dd019b81cb4f3895a85db50dabd2d8 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <roypat@amazon.co.uk>
 Date: Fri, 7 Feb 2025 11:16:06 +0000
-Subject: [PATCH 23/45] mm: introduce AS_NO_DIRECT_MAP
+Subject: [PATCH 24/46] mm: introduce AS_NO_DIRECT_MAP
 
 Add AS_NO_DIRECT_MAP for mappings where direct map entries of folios are
 set to not present . Currently, mappings that match this description are
@@ -204,5 +204,5 @@ index 4d2d6c0e342f..d85c0225b7f4 100644
  	inode->i_op = &secretmem_iops;
  	inode->i_mapping->a_ops = &secretmem_aops;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0025-KVM-guest_memfd-Add-flag-to-remove-from-direct-map.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0025-KVM-guest_memfd-Add-flag-to-remove-from-direct-map.patch
@@ -1,7 +1,7 @@
-From 9df5ae94f7773b773d1b22032a7a5e35ef377f8d Mon Sep 17 00:00:00 2001
+From a00f94321c740ed71e81e452626150545da2c288 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <roypat@amazon.co.uk>
 Date: Fri, 7 Feb 2025 14:33:01 +0000
-Subject: [PATCH 24/45] KVM: guest_memfd: Add flag to remove from direct map
+Subject: [PATCH 25/46] KVM: guest_memfd: Add flag to remove from direct map
 
 Add KVM_GMEM_NO_DIRECT_MAP flag for KVM_CREATE_GUEST_MEMFD() ioctl. When
 set, guest_memfd folios will be removed from the direct map after
@@ -56,7 +56,7 @@ Signed-off-by: Patrick Roy <roypat@amazon.co.uk>
  5 files changed, 50 insertions(+), 5 deletions(-)
 
 diff --git a/arch/arm64/include/asm/kvm_host.h b/arch/arm64/include/asm/kvm_host.h
-index bd2af5470c66..ee2324c971c9 100644
+index 63f7827cfa1b..1f564f6a332f 100644
 --- a/arch/arm64/include/asm/kvm_host.h
 +++ b/arch/arm64/include/asm/kvm_host.h
 @@ -19,6 +19,7 @@
@@ -67,7 +67,7 @@ index bd2af5470c66..ee2324c971c9 100644
  #include <asm/arch_gicv3.h>
  #include <asm/barrier.h>
  #include <asm/cpufeature.h>
-@@ -1678,6 +1679,15 @@ void check_feature_map(void);
+@@ -1677,6 +1678,15 @@ void check_feature_map(void);
  #ifdef CONFIG_KVM_GMEM
  #define kvm_arch_supports_gmem(kvm) true
  #define kvm_arch_supports_gmem_mmap(kvm) IS_ENABLED(CONFIG_KVM_GMEM_SUPPORTS_MMAP)
@@ -110,10 +110,10 @@ index 662271314778..7dc9190d2fef 100644
  static inline bool kvm_arch_has_readonly_mem(struct kvm *kvm)
  {
 diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
-index cbf28237af79..edaba6966cad 100644
+index 698dd407980f..33b368564b1f 100644
 --- a/include/uapi/linux/kvm.h
 +++ b/include/uapi/linux/kvm.h
-@@ -957,6 +957,7 @@ struct kvm_enable_cap {
+@@ -961,6 +961,7 @@ struct kvm_enable_cap {
  #define KVM_CAP_ARM_EL2_E2H0 241
  #define KVM_CAP_RISCV_MP_STATE_RESET 242
  #define KVM_CAP_GMEM_MMAP 243
@@ -121,7 +121,7 @@ index cbf28237af79..edaba6966cad 100644
  
  struct kvm_irq_routing_irqchip {
  	__u32 irqchip;
-@@ -1594,6 +1595,7 @@ struct kvm_memory_attributes {
+@@ -1598,6 +1599,7 @@ struct kvm_memory_attributes {
  
  #define KVM_CREATE_GUEST_MEMFD	_IOWR(KVMIO,  0xd4, struct kvm_create_guest_memfd)
  #define GUEST_MEMFD_FLAG_MMAP	(1ULL << 0)
@@ -215,7 +215,7 @@ index 0ac1c3a5a433..d70ee66bb96d 100644
  		return -EINVAL;
  
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index 5463e81b08b9..a0d14659ee2c 100644
+index f1ac872e01e9..d92dd84cca8e 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
 @@ -65,6 +65,7 @@
@@ -226,7 +226,7 @@ index 5463e81b08b9..a0d14659ee2c 100644
  
  
  /* Worst case buffer size needed for holding an integer. */
-@@ -4911,6 +4912,10 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
+@@ -4914,6 +4915,10 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
  		return kvm_supported_mem_attributes(kvm);
  #endif
  #ifdef CONFIG_KVM_GMEM
@@ -238,5 +238,5 @@ index 5463e81b08b9..a0d14659ee2c 100644
  		return !kvm || kvm_arch_supports_gmem(kvm);
  #endif
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/11-kvm-clock/0026-de-gpc-ify-kvm-clock.patch
+++ b/resources/hiding_ci/linux_patches/11-kvm-clock/0026-de-gpc-ify-kvm-clock.patch
@@ -1,7 +1,7 @@
-From 34c70a6d6eb856050b755c1db905ae8fcc34309d Mon Sep 17 00:00:00 2001
+From 4ef5b49cbbe248dd9a7a783c1339c577f1b9635c Mon Sep 17 00:00:00 2001
 From: Patrick Roy <roypat@amazon.co.uk>
 Date: Tue, 3 Jun 2025 13:57:15 +0100
-Subject: [PATCH 25/45] de-gpc-ify kvm-clock
+Subject: [PATCH 26/46] de-gpc-ify kvm-clock
 
 Signed-off-by: Patrick Roy <roypat@amazon.co.uk>
 ---
@@ -10,10 +10,10 @@ Signed-off-by: Patrick Roy <roypat@amazon.co.uk>
  2 files changed, 15 insertions(+), 34 deletions(-)
 
 diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
-index 4c89feaa1910..e709a54fb935 100644
+index e1426adfa93e..d93b291a7d31 100644
 --- a/arch/x86/include/asm/kvm_host.h
 +++ b/arch/x86/include/asm/kvm_host.h
-@@ -924,7 +924,7 @@ struct kvm_vcpu_arch {
+@@ -930,7 +930,7 @@ struct kvm_vcpu_arch {
  	s8  pvclock_tsc_shift;
  	u32 pvclock_tsc_mul;
  	unsigned int hw_tsc_khz;
@@ -23,7 +23,7 @@ index 4c89feaa1910..e709a54fb935 100644
  	bool pvclock_set_guest_stopped_request;
  
 diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
-index 17c655e5716e..6f3bd41f048d 100644
+index ca99187a566e..8b7ae1db9fd0 100644
 --- a/arch/x86/kvm/x86.c
 +++ b/arch/x86/kvm/x86.c
 @@ -2349,12 +2349,9 @@ static void kvm_write_system_time(struct kvm_vcpu *vcpu, gpa_t system_time,
@@ -97,7 +97,7 @@ index 17c655e5716e..6f3bd41f048d 100644
  
  	trace_kvm_pvclock_update(vcpu->vcpu_id, &hv_clock);
  }
-@@ -3280,7 +3263,7 @@ int kvm_guest_time_update(struct kvm_vcpu *v)
+@@ -3282,7 +3265,7 @@ int kvm_guest_time_update(struct kvm_vcpu *v)
  	if (use_master_clock)
  		hv_clock.flags |= PVCLOCK_TSC_STABLE_BIT;
  
@@ -106,7 +106,7 @@ index 17c655e5716e..6f3bd41f048d 100644
  		/*
  		 * GUEST_STOPPED is only supported by kvmclock, and KVM's
  		 * historic behavior is to only process the request if kvmclock
-@@ -3290,7 +3273,7 @@ int kvm_guest_time_update(struct kvm_vcpu *v)
+@@ -3292,7 +3275,7 @@ int kvm_guest_time_update(struct kvm_vcpu *v)
  			hv_clock.flags |= PVCLOCK_GUEST_STOPPED;
  			vcpu->pvclock_set_guest_stopped_request = false;
  		}
@@ -115,7 +115,7 @@ index 17c655e5716e..6f3bd41f048d 100644
  
  		hv_clock.flags &= ~PVCLOCK_GUEST_STOPPED;
  	}
-@@ -3606,7 +3589,7 @@ static int kvm_pv_enable_async_pf_int(struct kvm_vcpu *vcpu, u64 data)
+@@ -3608,7 +3591,7 @@ static int kvm_pv_enable_async_pf_int(struct kvm_vcpu *vcpu, u64 data)
  
  static void kvmclock_reset(struct kvm_vcpu *vcpu)
  {
@@ -124,7 +124,7 @@ index 17c655e5716e..6f3bd41f048d 100644
  	vcpu->arch.time = 0;
  }
  
-@@ -5727,7 +5710,7 @@ static int kvm_vcpu_ioctl_x86_set_xcrs(struct kvm_vcpu *vcpu,
+@@ -5729,7 +5712,7 @@ static int kvm_vcpu_ioctl_x86_set_xcrs(struct kvm_vcpu *vcpu,
   */
  static int kvm_set_guest_paused(struct kvm_vcpu *vcpu)
  {
@@ -133,7 +133,7 @@ index 17c655e5716e..6f3bd41f048d 100644
  		return -EINVAL;
  	vcpu->arch.pvclock_set_guest_stopped_request = true;
  	kvm_make_request(KVM_REQ_CLOCK_UPDATE, vcpu);
-@@ -12334,8 +12317,6 @@ int kvm_arch_vcpu_create(struct kvm_vcpu *vcpu)
+@@ -12336,8 +12319,6 @@ int kvm_arch_vcpu_create(struct kvm_vcpu *vcpu)
  	vcpu->arch.regs_avail = ~0;
  	vcpu->arch.regs_dirty = ~0;
  
@@ -143,5 +143,5 @@ index 17c655e5716e..6f3bd41f048d 100644
  		kvm_set_mp_state(vcpu, KVM_MP_STATE_RUNNABLE);
  	else
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0027-KVM-Add-KVM_MEM_USERFAULT-memslot-flag-and-bitmap.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0027-KVM-Add-KVM_MEM_USERFAULT-memslot-flag-and-bitmap.patch
@@ -1,7 +1,7 @@
-From fca809bc76438579b831ecaef7b56731888b5c2c Mon Sep 17 00:00:00 2001
+From 3cb19e4da39630a3e1ab34d9daed24fcb1c441d3 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:17 +0000
-Subject: [PATCH 26/45] KVM: Add KVM_MEM_USERFAULT memslot flag and bitmap
+Subject: [PATCH 27/46] KVM: Add KVM_MEM_USERFAULT memslot flag and bitmap
 
 Use one of the 14 reserved u64s in struct kvm_userspace_memory_region2
 for the user to provide `userfault_bitmap`.
@@ -57,7 +57,7 @@ index 7dc9190d2fef..ad37db1bed39 100644
 +
  #endif
 diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
-index edaba6966cad..eea58b3d99e8 100644
+index 33b368564b1f..c871e2a76e90 100644
 --- a/include/uapi/linux/kvm.h
 +++ b/include/uapi/linux/kvm.h
 @@ -40,7 +40,8 @@ struct kvm_userspace_memory_region2 {
@@ -90,7 +90,7 @@ index fa4acbedb953..fd46bc7d194a 100644
 +config HAVE_KVM_USERFAULT
 +       bool
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index a0d14659ee2c..fe203a518ddb 100644
+index d92dd84cca8e..9208ec56a26b 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
 @@ -1605,6 +1605,9 @@ static int check_memory_region_flags(struct kvm *kvm,
@@ -126,7 +126,7 @@ index a0d14659ee2c..fe203a518ddb 100644
  
  	r = kvm_set_memslot(kvm, old, new, change);
  	if (r)
-@@ -6545,3 +6557,26 @@ void kvm_exit(void)
+@@ -6548,3 +6560,26 @@ void kvm_exit(void)
  	kvm_irqfd_exit();
  }
  EXPORT_SYMBOL_GPL(kvm_exit);
@@ -154,5 +154,5 @@ index a0d14659ee2c..fe203a518ddb 100644
 +	return !!(bitmap_chunk & (1ul << (offset % BITS_PER_LONG)));
 +}
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0028-KVM-Add-KVM_MEMORY_EXIT_FLAG_USERFAULT.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0028-KVM-Add-KVM_MEMORY_EXIT_FLAG_USERFAULT.patch
@@ -1,7 +1,7 @@
-From e592af4f9956ac0ee72e2d7472da4cea5d873408 Mon Sep 17 00:00:00 2001
+From 264248675db749124ca67b3c7b4e724480b4ee24 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:18 +0000
-Subject: [PATCH 27/45] KVM: Add KVM_MEMORY_EXIT_FLAG_USERFAULT
+Subject: [PATCH 28/46] KVM: Add KVM_MEMORY_EXIT_FLAG_USERFAULT
 
 This flag is used for vCPU memory faults caused by KVM Userfault; i.e.,
 the bit in `userfault_bitmap` corresponding to the faulting gfn was set.
@@ -12,7 +12,7 @@ Signed-off-by: James Houghton <jthoughton@google.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
-index eea58b3d99e8..c75b7c183140 100644
+index c871e2a76e90..24070a4d13a1 100644
 --- a/include/uapi/linux/kvm.h
 +++ b/include/uapi/linux/kvm.h
 @@ -446,6 +446,7 @@ struct kvm_run {
@@ -24,5 +24,5 @@ index eea58b3d99e8..c75b7c183140 100644
  			__u64 gpa;
  			__u64 size;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0029-KVM-Allow-late-setting-of-KVM_MEM_USERFAULT-on-guest.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0029-KVM-Allow-late-setting-of-KVM_MEM_USERFAULT-on-guest.patch
@@ -1,7 +1,7 @@
-From 9978794ee7f6b3130f4e82daca38c1b073e35828 Mon Sep 17 00:00:00 2001
+From f1d9e28902fdf448ed89e6a3d7c94853e13e7188 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:19 +0000
-Subject: [PATCH 28/45] KVM: Allow late setting of KVM_MEM_USERFAULT on
+Subject: [PATCH 29/46] KVM: Allow late setting of KVM_MEM_USERFAULT on
  guest_memfd memslot
 
 Currently guest_memfd memslots can only be deleted. Slightly change the
@@ -14,7 +14,7 @@ Signed-off-by: James Houghton <jthoughton@google.com>
  1 file changed, 11 insertions(+), 4 deletions(-)
 
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index fe203a518ddb..bd9e5fb6cc80 100644
+index 9208ec56a26b..fee5a233ee03 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
 @@ -2081,9 +2081,6 @@ static int kvm_set_memory_region(struct kvm *kvm,
@@ -54,5 +54,5 @@ index fe203a518ddb..bd9e5fb6cc80 100644
  		if (r)
  			goto out;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0030-KVM-x86-mmu-Add-support-for-KVM_MEM_USERFAULT.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0030-KVM-x86-mmu-Add-support-for-KVM_MEM_USERFAULT.patch
@@ -1,7 +1,7 @@
-From fbe3a7384aa789c32aa1aa034ece2180a7b970ad Mon Sep 17 00:00:00 2001
+From 6513e6746526d2c56aaf560ea27ca173202132b4 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:21 +0000
-Subject: [PATCH 29/45] KVM: x86/mmu: Add support for KVM_MEM_USERFAULT
+Subject: [PATCH 30/46] KVM: x86/mmu: Add support for KVM_MEM_USERFAULT
 
 Adhering to the requirements of KVM Userfault:
 
@@ -20,18 +20,19 @@ WARN_ON() that was there.
 Signed-off-by: James Houghton <jthoughton@google.com>
 ---
  arch/arm64/kvm/mmu.c            |  2 +-
+ arch/arm64/kvm/nested.c         |  2 +-
  arch/x86/kvm/Kconfig            |  1 +
  arch/x86/kvm/mmu/mmu.c          | 12 +++++++++++
  arch/x86/kvm/mmu/mmu_internal.h | 20 +++++++++++++++---
  arch/x86/kvm/x86.c              | 36 ++++++++++++++++++++++++---------
  include/linux/kvm_host.h        |  5 ++++-
- 6 files changed, 61 insertions(+), 15 deletions(-)
+ 7 files changed, 62 insertions(+), 16 deletions(-)
 
 diff --git a/arch/arm64/kvm/mmu.c b/arch/arm64/kvm/mmu.c
-index b92ce4d9b4e0..dae1f3fea842 100644
+index 85559b8a0845..f0fc1f59cd6d 100644
 --- a/arch/arm64/kvm/mmu.c
 +++ b/arch/arm64/kvm/mmu.c
-@@ -1554,7 +1554,7 @@ static int gmem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+@@ -1551,7 +1551,7 @@ static int gmem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  	ret = kvm_gmem_get_pfn(kvm, memslot, gfn, &pfn, &page, NULL);
  	if (ret) {
  		kvm_prepare_memory_fault_exit(vcpu, fault_ipa, PAGE_SIZE,
@@ -40,23 +41,36 @@ index b92ce4d9b4e0..dae1f3fea842 100644
  		return ret;
  	}
  
+diff --git a/arch/arm64/kvm/nested.c b/arch/arm64/kvm/nested.c
+index b3edd7f7c8cd..2e2d03e578b5 100644
+--- a/arch/arm64/kvm/nested.c
++++ b/arch/arm64/kvm/nested.c
+@@ -1231,7 +1231,7 @@ static int kvm_translate_vncr(struct kvm_vcpu *vcpu, bool *is_gmem)
+ 		ret = kvm_gmem_get_pfn(vcpu->kvm, memslot, gfn, &pfn, &page, NULL);
+ 		if (ret) {
+ 			kvm_prepare_memory_fault_exit(vcpu, vt->wr.pa, PAGE_SIZE,
+-					      write_fault, false, false);
++					      write_fault, false, false, false);
+ 			return ret;
+ 		}
+ 	}
 diff --git a/arch/x86/kvm/Kconfig b/arch/x86/kvm/Kconfig
-index 239637b663dc..1f3e359a58d0 100644
+index 1ba959b9eadc..aa215d0df63b 100644
 --- a/arch/x86/kvm/Kconfig
 +++ b/arch/x86/kvm/Kconfig
 @@ -49,6 +49,7 @@ config KVM_X86
  	select KVM_GENERIC_GMEM_POPULATE if KVM_SW_PROTECTED_VM
- 	select KVM_GMEM_SUPPORTS_MMAP
+ 	select KVM_GMEM_SUPPORTS_MMAP if X86_64
  	select KVM_WERROR if WERROR
 +	select HAVE_KVM_USERFAULT
  
  config KVM
  	tristate "Kernel-based Virtual Machine (KVM) support"
 diff --git a/arch/x86/kvm/mmu/mmu.c b/arch/x86/kvm/mmu/mmu.c
-index cc4cdfea343b..bd19b2f2acc1 100644
+index ad5f337b496c..eb746b183ab2 100644
 --- a/arch/x86/kvm/mmu/mmu.c
 +++ b/arch/x86/kvm/mmu/mmu.c
-@@ -4546,6 +4546,18 @@ static int __kvm_mmu_faultin_pfn(struct kvm_vcpu *vcpu,
+@@ -4545,6 +4545,18 @@ static int __kvm_mmu_faultin_pfn(struct kvm_vcpu *vcpu,
  				 struct kvm_page_fault *fault)
  {
  	unsigned int foll = fault->write ? FOLL_WRITE : 0;
@@ -110,10 +124,10 @@ index db8f33e4de62..84e4bb34abed 100644
  
  static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
 diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
-index 6f3bd41f048d..947980f6c337 100644
+index 8b7ae1db9fd0..0cbdb8874ed1 100644
 --- a/arch/x86/kvm/x86.c
 +++ b/arch/x86/kvm/x86.c
-@@ -13134,12 +13134,36 @@ static void kvm_mmu_slot_apply_flags(struct kvm *kvm,
+@@ -13136,12 +13136,36 @@ static void kvm_mmu_slot_apply_flags(struct kvm *kvm,
  	u32 new_flags = new ? new->flags : 0;
  	bool log_dirty_pages = new_flags & KVM_MEM_LOG_DIRTY_PAGES;
  
@@ -152,7 +166,7 @@ index 6f3bd41f048d..947980f6c337 100644
  
  	/*
  	 * Nothing more to do for RO slots (which can't be dirtied and can't be
-@@ -13159,14 +13183,6 @@ static void kvm_mmu_slot_apply_flags(struct kvm *kvm,
+@@ -13161,14 +13185,6 @@ static void kvm_mmu_slot_apply_flags(struct kvm *kvm,
  	if ((change != KVM_MR_FLAGS_ONLY) || (new_flags & KVM_MEM_READONLY))
  		return;
  
@@ -191,5 +205,5 @@ index ad37db1bed39..fb9cdfe3a2cd 100644
  
  static inline bool kvm_memslot_is_gmem_only(const struct kvm_memory_slot *slot)
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0031-KVM-Advertise-KVM_CAP_USERFAULT-in-KVM_CHECK_EXTENSI.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0031-KVM-Advertise-KVM_CAP_USERFAULT-in-KVM_CHECK_EXTENSI.patch
@@ -1,7 +1,7 @@
-From e8911baf94b5da0d0aa4da2fcea758ea7c61b24d Mon Sep 17 00:00:00 2001
+From 6cb18bc91ffe494bae887176b63a173e3cf53668 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:20 +0000
-Subject: [PATCH 30/45] KVM: Advertise KVM_CAP_USERFAULT in KVM_CHECK_EXTENSION
+Subject: [PATCH 31/46] KVM: Advertise KVM_CAP_USERFAULT in KVM_CHECK_EXTENSION
 
 Advertise support for KVM_CAP_USERFAULT when kvm_has_userfault() returns
 true. Currently this is merely IS_ENABLED(CONFIG_HAVE_KVM_USERFAULT), so
@@ -14,10 +14,10 @@ Signed-off-by: James Houghton <jthoughton@google.com>
  2 files changed, 5 insertions(+)
 
 diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
-index c75b7c183140..f3f6de7c33d2 100644
+index 24070a4d13a1..bae2fc737759 100644
 --- a/include/uapi/linux/kvm.h
 +++ b/include/uapi/linux/kvm.h
-@@ -961,6 +961,7 @@ struct kvm_enable_cap {
+@@ -965,6 +965,7 @@ struct kvm_enable_cap {
  #define KVM_CAP_RISCV_MP_STATE_RESET 242
  #define KVM_CAP_GMEM_MMAP 243
  #define KVM_CAP_GMEM_NO_DIRECT_MAP 244
@@ -26,10 +26,10 @@ index c75b7c183140..f3f6de7c33d2 100644
  struct kvm_irq_routing_irqchip {
  	__u32 irqchip;
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index bd9e5fb6cc80..94c8799ba4c3 100644
+index fee5a233ee03..f2e88fb9d4bb 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
-@@ -4941,6 +4941,10 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
+@@ -4944,6 +4944,10 @@ static int kvm_vm_ioctl_check_extension_generic(struct kvm *kvm, long arg)
  #ifdef CONFIG_KVM_GMEM_SUPPORTS_MMAP
  	case KVM_CAP_GMEM_MMAP:
  		return !kvm || kvm_arch_supports_gmem_mmap(kvm);
@@ -41,5 +41,5 @@ index bd9e5fb6cc80..94c8799ba4c3 100644
  	default:
  		break;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0032-KVM-arm64-Add-support-for-KVM_MEM_USERFAULT.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0032-KVM-arm64-Add-support-for-KVM_MEM_USERFAULT.patch
@@ -1,7 +1,7 @@
-From 17eb3696822641bdb78a7a75f135b28d6399deff Mon Sep 17 00:00:00 2001
+From 3bf9f7353147f7aa5fc766846b7632f7117c0bef Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:22 +0000
-Subject: [PATCH 31/45] KVM: arm64: Add support for KVM_MEM_USERFAULT
+Subject: [PATCH 32/46] KVM: arm64: Add support for KVM_MEM_USERFAULT
 
 Adhering to the requirements of KVM Userfault:
 1. When it is toggled on, zap the second stage with
@@ -19,24 +19,24 @@ Signed-off-by: James Houghton <jthoughton@google.com>
  2 files changed, 33 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/kvm/Kconfig b/arch/arm64/kvm/Kconfig
-index 28539479f083..1eb76db26f28 100644
+index 323b46b7c82f..ce3bd1a1ac89 100644
 --- a/arch/arm64/kvm/Kconfig
 +++ b/arch/arm64/kvm/Kconfig
-@@ -38,6 +38,7 @@ menuconfig KVM
- 	select SCHED_INFO
+@@ -39,6 +39,7 @@ menuconfig KVM
  	select GUEST_PERF_EVENTS if PERF_EVENTS
+ 	select KVM_GMEM
  	select KVM_GMEM_SUPPORTS_MMAP
 +	select HAVE_KVM_USERFAULT
  	help
  	  Support hosting virtualized guest machines.
  
 diff --git a/arch/arm64/kvm/mmu.c b/arch/arm64/kvm/mmu.c
-index dae1f3fea842..f122c3786525 100644
+index f0fc1f59cd6d..3e7eb08cd133 100644
 --- a/arch/arm64/kvm/mmu.c
 +++ b/arch/arm64/kvm/mmu.c
-@@ -1551,6 +1551,13 @@ static int gmem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
- 		return -EFAULT;
- 	}
+@@ -1548,6 +1548,13 @@ static int gmem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+ 	/* Pairs with the smp_wmb() in kvm_mmu_invalidate_end(). */
+ 	smp_rmb();
  
 +	if (kvm_gfn_userfault(kvm, memslot, gfn)) {
 +		kvm_prepare_memory_fault_exit(vcpu, gfn << PAGE_SHIFT,
@@ -48,7 +48,7 @@ index dae1f3fea842..f122c3786525 100644
  	ret = kvm_gmem_get_pfn(kvm, memslot, gfn, &pfn, &page, NULL);
  	if (ret) {
  		kvm_prepare_memory_fault_exit(vcpu, fault_ipa, PAGE_SIZE,
-@@ -1644,7 +1651,7 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+@@ -1643,7 +1650,7 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  		return -EFAULT;
  	}
  
@@ -57,7 +57,7 @@ index dae1f3fea842..f122c3786525 100644
  		vma_shift = PAGE_SHIFT;
  	else
  		vma_shift = get_vma_page_shift(vma, hva);
-@@ -1731,6 +1738,13 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
+@@ -1730,6 +1737,13 @@ static int user_mem_abort(struct kvm_vcpu *vcpu, phys_addr_t fault_ipa,
  	mmu_seq = kvm->mmu_invalidate_seq;
  	mmap_read_unlock(current->mm);
  
@@ -71,7 +71,7 @@ index dae1f3fea842..f122c3786525 100644
  	pfn = __kvm_faultin_pfn(memslot, gfn, write_fault ? FOLL_WRITE : 0,
  				&writable, &page);
  	if (pfn == KVM_PFN_ERR_HWPOISON) {
-@@ -2217,6 +2231,23 @@ void kvm_arch_commit_memory_region(struct kvm *kvm,
+@@ -2219,6 +2233,23 @@ void kvm_arch_commit_memory_region(struct kvm *kvm,
  				   enum kvm_mr_change change)
  {
  	bool log_dirty_pages = new && new->flags & KVM_MEM_LOG_DIRTY_PAGES;
@@ -96,5 +96,5 @@ index dae1f3fea842..f122c3786525 100644
  	/*
  	 * At this point memslot has been committed and there is an
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0033-KVM-selftests-Fix-vm_mem_region_set_flags-docstring.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0033-KVM-selftests-Fix-vm_mem_region_set_flags-docstring.patch
@@ -1,7 +1,7 @@
-From 301f08c231f8643eae8dbbb8106492cc3807c0fe Mon Sep 17 00:00:00 2001
+From 955d6fe23e81d0574b96ee7f0c3540f2e98dbb7d Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:23 +0000
-Subject: [PATCH 32/45] KVM: selftests: Fix vm_mem_region_set_flags docstring
+Subject: [PATCH 33/46] KVM: selftests: Fix vm_mem_region_set_flags docstring
 
 `flags` is what region->region.flags gets set to.
 
@@ -24,5 +24,5 @@ index a055343a7bf7..ca1aa1699f8a 100644
   * Output Args: None
   *
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0034-KVM-selftests-Fix-prefault_mem-logic.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0034-KVM-selftests-Fix-prefault_mem-logic.patch
@@ -1,7 +1,7 @@
-From 8d6b56ab8dd935c34063b88bde731a95c234357b Mon Sep 17 00:00:00 2001
+From e1557fa30edfe01a34ef5becc0124d8a67f4e284 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:24 +0000
-Subject: [PATCH 33/45] KVM: selftests: Fix prefault_mem logic
+Subject: [PATCH 34/46] KVM: selftests: Fix prefault_mem logic
 
 The previous logic didn't handle the case where memory was partitioned
 AND we were using a single userfaultfd. It would only prefault the first
@@ -33,5 +33,5 @@ index 0202b78f8680..315f5c9037b4 100644
  	}
  
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0035-KVM-selftests-Add-va_start-end-into-uffd_desc.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0035-KVM-selftests-Add-va_start-end-into-uffd_desc.patch
@@ -1,7 +1,7 @@
-From 297809c9cd184698d1b92da1ece0ab9cd36cbfca Mon Sep 17 00:00:00 2001
+From f15d0613d406ff7940656054615672948b6a21a8 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:25 +0000
-Subject: [PATCH 34/45] KVM: selftests: Add va_start/end into uffd_desc
+Subject: [PATCH 35/46] KVM: selftests: Add va_start/end into uffd_desc
 
 This will be used for the self-test to look up which userfaultfd we
 should be using when handling a KVM Userfault (in the event KVM
@@ -40,5 +40,5 @@ index 5bde176cedd5..31d38b3a9d12 100644
  		int pipes[2];
  
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0036-KVM-selftests-Inform-set_memory_region_test-of-KVM_M.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0036-KVM-selftests-Inform-set_memory_region_test-of-KVM_M.patch
@@ -1,7 +1,7 @@
-From eadccd3481d3c5eff60143480be9076a1c8b57bb Mon Sep 17 00:00:00 2001
+From da111a044428b5d1f413c63b8ae4d25cf2ad98ee Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:27 +0000
-Subject: [PATCH 35/45] KVM: selftests: Inform set_memory_region_test of
+Subject: [PATCH 36/46] KVM: selftests: Inform set_memory_region_test of
  KVM_MEM_USERFAULT
 
 The KVM_MEM_USERFAULT flag is supported iff KVM_CAP_USERFAULT is
@@ -27,5 +27,5 @@ index ce3ac0fd6dfb..ba3fe8a53b33 100644
  		if ((supported_flags & BIT(i)) && !(v2_only_flags & BIT(i)))
  			continue;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0037-KVM-selftests-Add-KVM-Userfault-mode-to-demand_pagin.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0037-KVM-selftests-Add-KVM-Userfault-mode-to-demand_pagin.patch
@@ -1,7 +1,7 @@
-From 24eda5ec46fce47d5f4aec35fcf1919b3ee1eee8 Mon Sep 17 00:00:00 2001
+From ba7239056fb3dc13c1dc0c394a1a468ead5a18f7 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:26 +0000
-Subject: [PATCH 36/45] KVM: selftests: Add KVM Userfault mode to
+Subject: [PATCH 37/46] KVM: selftests: Add KVM Userfault mode to
  demand_paging_test
 
 Add a way for the KVM_RUN loop to handle -EFAULT exits when they are for
@@ -377,5 +377,5 @@ index ca1aa1699f8a..3c215df1d2d8 100644
   * VM Memory Region Move
   *
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0038-KVM-selftests-Add-KVM_MEM_USERFAULT-guest_memfd-togg.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0038-KVM-selftests-Add-KVM_MEM_USERFAULT-guest_memfd-togg.patch
@@ -1,7 +1,7 @@
-From de25686b2ed59bc7e2269d06cfa17649b8b3c50e Mon Sep 17 00:00:00 2001
+From 2feda9131e1f2b87f22bbc4234f55def8ec9b4ac Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:28 +0000
-Subject: [PATCH 37/45] KVM: selftests: Add KVM_MEM_USERFAULT + guest_memfd
+Subject: [PATCH 38/46] KVM: selftests: Add KVM_MEM_USERFAULT + guest_memfd
  toggle tests
 
 Make sure KVM_MEM_USERFAULT can be toggled on and off for
@@ -61,5 +61,5 @@ index ba3fe8a53b33..20a03cb57acf 100644
  		pr_info("Skipping tests for KVM_MEM_GUEST_MEMFD memory regions\n");
  	}
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/20-gmem-write/0039-KVM-guest_memfd-add-generic-population-via-write.patch
+++ b/resources/hiding_ci/linux_patches/20-gmem-write/0039-KVM-guest_memfd-add-generic-population-via-write.patch
@@ -1,7 +1,7 @@
-From 1aaa001d27626a7f53cac6590e827eddd10e14df Mon Sep 17 00:00:00 2001
+From 859e9756eb70cfc8cf4fb4f0870908e55521cc7f Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 3 Mar 2025 13:08:37 +0000
-Subject: [PATCH 38/45] KVM: guest_memfd: add generic population via write
+Subject: [PATCH 39/46] KVM: guest_memfd: add generic population via write
 
 write syscall populates guest_memfd with user-supplied data in a generic
 way, ie no vendor-specific preparation is performed.  This is supposed
@@ -129,5 +129,5 @@ index d70ee66bb96d..809da2a2fb37 100644
  	inode = file->f_inode;
  	WARN_ON(file->f_mapping != inode->i_mapping);
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/20-gmem-write/0040-KVM-selftests-update-guest_memfd-write-tests.patch
+++ b/resources/hiding_ci/linux_patches/20-gmem-write/0040-KVM-selftests-update-guest_memfd-write-tests.patch
@@ -1,7 +1,7 @@
-From 548fccdfb8036d53e5a4053ac7e4a031bc40a07e Mon Sep 17 00:00:00 2001
+From 205f30ad3c9fa142c34ab2ac6a3f6a762f6fc6b1 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 3 Mar 2025 13:08:38 +0000
-Subject: [PATCH 39/45] KVM: selftests: update guest_memfd write tests
+Subject: [PATCH 40/46] KVM: selftests: update guest_memfd write tests
 
 This is to reflect that the write syscall is now implemented for
 guest_memfd.
@@ -122,5 +122,5 @@ index 1252e74fbb8f..3965a842896e 100644
  	if (expect_mmap_allowed) {
  		test_mmap_supported(fd, page_size, total_size);
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0041-mm-userfaultfd-generic-continue-for-non-hugetlbfs.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0041-mm-userfaultfd-generic-continue-for-non-hugetlbfs.patch
@@ -1,7 +1,7 @@
-From 4725838afbca877e0fb8ac428370f0d16b73f3a1 Mon Sep 17 00:00:00 2001
+From cb3a4587ef307f7cd3205e502abe3b5663c5c877 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 31 Mar 2025 10:15:35 +0000
-Subject: [PATCH 40/45] mm: userfaultfd: generic continue for non hugetlbfs
+Subject: [PATCH 41/46] mm: userfaultfd: generic continue for non hugetlbfs
 
 Remove shmem-specific code from UFFDIO_CONTINUE implementation for
 non-huge pages by calling vm_ops->fault().  A new VMF flag,
@@ -40,10 +40,10 @@ index d6b91e8a66d6..d4c35a50058c 100644
  
  typedef unsigned int __bitwise zap_flags_t;
 diff --git a/mm/hugetlb.c b/mm/hugetlb.c
-index 9dc95eac558c..6ac2c763b3ec 100644
+index a0d285d20992..7921c08fd529 100644
 --- a/mm/hugetlb.c
 +++ b/mm/hugetlb.c
-@@ -6533,7 +6533,7 @@ static vm_fault_t hugetlb_no_page(struct address_space *mapping,
+@@ -6536,7 +6536,7 @@ static vm_fault_t hugetlb_no_page(struct address_space *mapping,
  		}
  
  		/* Check for page in userfault range. */
@@ -149,5 +149,5 @@ index 8253978ee0fb..46380f262c4d 100644
  		ret = -EIO;
  		goto out_release;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0042-mm-provide-can_userfault-vma-operation.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0042-mm-provide-can_userfault-vma-operation.patch
@@ -1,7 +1,7 @@
-From 4cda7eded3f46f118c4053803921964210819b62 Mon Sep 17 00:00:00 2001
+From 0aa0ceee2a842559241467722237002b4b9101f8 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 4 Apr 2025 14:15:18 +0000
-Subject: [PATCH 41/45] mm: provide can_userfault vma operation
+Subject: [PATCH 42/46] mm: provide can_userfault vma operation
 
 The new operation allows to decouple the userfaulfd code from
 dependencies to VMA types, specifically, shmem and hugetlb.  The
@@ -17,7 +17,7 @@ Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
  3 files changed, 20 insertions(+)
 
 diff --git a/include/linux/mm.h b/include/linux/mm.h
-index 0ef2ba0c667a..72a29c83a7cd 100644
+index fa538feaa8d9..b0dafe4c84ad 100644
 --- a/include/linux/mm.h
 +++ b/include/linux/mm.h
 @@ -653,6 +653,11 @@ struct vm_operations_struct {
@@ -33,10 +33,10 @@ index 0ef2ba0c667a..72a29c83a7cd 100644
  
  #ifdef CONFIG_NUMA_BALANCING
 diff --git a/mm/hugetlb.c b/mm/hugetlb.c
-index 6ac2c763b3ec..d7f70adda621 100644
+index 7921c08fd529..de57d4c8972b 100644
 --- a/mm/hugetlb.c
 +++ b/mm/hugetlb.c
-@@ -5447,6 +5447,12 @@ static unsigned long hugetlb_vm_op_pagesize(struct vm_area_struct *vma)
+@@ -5450,6 +5450,12 @@ static unsigned long hugetlb_vm_op_pagesize(struct vm_area_struct *vma)
  	return huge_page_size(hstate_vma(vma));
  }
  
@@ -49,7 +49,7 @@ index 6ac2c763b3ec..d7f70adda621 100644
  /*
   * We cannot handle pagefaults against hugetlb pages at all.  They cause
   * handle_mm_fault() to try to instantiate regular-sized pages in the
-@@ -5472,6 +5478,7 @@ const struct vm_operations_struct hugetlb_vm_ops = {
+@@ -5475,6 +5481,7 @@ const struct vm_operations_struct hugetlb_vm_ops = {
  	.close = hugetlb_vm_op_close,
  	.may_split = hugetlb_vm_op_split,
  	.pagesize = hugetlb_vm_op_pagesize,
@@ -91,5 +91,5 @@ index 01e20e0216bc..296bca653f77 100644
  
  int shmem_init_fs_context(struct fs_context *fc)
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0043-mm-userfaultfd-use-can_userfault-vma-operation.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0043-mm-userfaultfd-use-can_userfault-vma-operation.patch
@@ -1,7 +1,7 @@
-From 2318ed356c02e81c205e9f73f37f2ee2beac0e94 Mon Sep 17 00:00:00 2001
+From b41e9aeb778fe03d0779d2ac3891ab3463ccc3eb Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 4 Apr 2025 14:16:49 +0000
-Subject: [PATCH 42/45] mm: userfaultfd: use can_userfault vma operation
+Subject: [PATCH 43/46] mm: userfaultfd: use can_userfault vma operation
 
 Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
 ---
@@ -75,5 +75,5 @@ index 46380f262c4d..d900dfd03bbe 100644
  
  	while (src_addr < src_start + len) {
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0044-KVM-guest_memfd-add-support-for-userfaultfd-minor.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0044-KVM-guest_memfd-add-support-for-userfaultfd-minor.patch
@@ -1,7 +1,7 @@
-From 8b3a8e678098839da1e54f60cea7991a157a4c0e Mon Sep 17 00:00:00 2001
+From b8139ee748086f421b16251e1d0c4ab2b9fed591 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Tue, 1 Apr 2025 15:02:56 +0000
-Subject: [PATCH 43/45] KVM: guest_memfd: add support for userfaultfd minor
+Subject: [PATCH 44/46] KVM: guest_memfd: add support for userfaultfd minor
 
 Add support for sending a pagefault event if userfaultfd is registered.
 Only page minor event is currently supported.
@@ -37,5 +37,5 @@ index 809da2a2fb37..e7fcd422c801 100644
  
  out_folio:
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0045-mm-userfaultfd-add-UFFD_FEATURE_MINOR_GUEST_MEMFD.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0045-mm-userfaultfd-add-UFFD_FEATURE_MINOR_GUEST_MEMFD.patch
@@ -1,7 +1,7 @@
-From 7b9d0141ede5557c7609b2fadf79be7e103c0917 Mon Sep 17 00:00:00 2001
+From d1e4c970e57a9fed70ab2667fb840fc656d53cfa Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 4 Apr 2025 14:18:03 +0000
-Subject: [PATCH 44/45] mm: userfaultfd: add UFFD_FEATURE_MINOR_GUEST_MEMFD
+Subject: [PATCH 45/46] mm: userfaultfd: add UFFD_FEATURE_MINOR_GUEST_MEMFD
 
 Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
 ---
@@ -57,5 +57,5 @@ index 2841e4ea8f2c..ed688797eba7 100644
  
  	__u64 ioctls;
 -- 
-2.49.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0046-fixup-for-guest_memfd-uffd-v3.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0046-fixup-for-guest_memfd-uffd-v3.patch
@@ -1,7 +1,7 @@
-From 46a18cd195d8c68e319ba7142cd923db7ccff967 Mon Sep 17 00:00:00 2001
+From 8bfc3443eeb52ebb0c018c2f93f782407c68282e Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Thu, 10 Apr 2025 14:18:53 +0000
-Subject: [PATCH 45/45] fixup for guest_memfd uffd v3
+Subject: [PATCH 46/46] fixup for guest_memfd uffd v3
 
  - implement can_userfault for guest_memfd
  - check vma->vm_ops pointer before dereferencing
@@ -67,5 +67,5 @@ index e7fcd422c801..0226086a1a01 100644
  
  static int kvm_gmem_mmap(struct file *file, struct vm_area_struct *vma)
 -- 
-2.49.0
+2.50.1
 


### PR DESCRIPTION
Update base series used for secret hiding CI kernels to be Fuad's v14 [1].

[1]: https://lore.kernel.org/kvm/20250715093350.2584932-1-tabba@google.com/

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
