### PR TITLE
doc: move diff snapshot dev preview warning

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -42,11 +42,6 @@ workload at that particular point in time.
 The Firecracker snapshot feature is supported on all CPU micro-architectures
 listed in [README](../../README.md#supported-platforms).
 
-[!WARNING]
-
-Diff snapshot support is in developer preview. See
-[this section](#developer-preview-status) for more info.
-
 ### Overview
 
 A Firecracker microVM snapshot can be used for loading it later in a different
@@ -203,6 +198,11 @@ the microVM in the `Paused` state. **Effects**:
 - _on failure_: no side-effects.
 
 ### Creating snapshots
+
+> [!WARNING]
+>
+> Diff snapshot support is in developer preview. See
+> [this section](#developer-preview-status) for more info.
 
 Now that the microVM is paused, you can create a snapshot, which can be either a
 `full`one or a `diff` one. Full snapshots always create a complete, resume-able


### PR DESCRIPTION
Move the dev preview warning to the "creating snapshots" section, as that's where diff snapshots are mentioned. Also fix the markdown rendering (needs `>` at the beginning of each line so that GitHub renders it as a proper warning).

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
