### PR TITLE
[feature/pcie] fix(test_block): correct fixture name s/uvm_any_acpi/uvm_plain_acpi/

### DIFF
--- a/tests/integration_tests/performance/test_block.py
+++ b/tests/integration_tests/performance/test_block.py
@@ -161,7 +161,7 @@ def emit_fio_metrics(logs_dir, metrics):
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 @pytest.mark.parametrize("fio_engine", ["libaio", "psync"])
 def test_block_performance(
-    uvm_any_acpi,
+    uvm_plain_acpi,
     vcpus,
     fio_mode,
     fio_block_size,
@@ -173,7 +173,7 @@ def test_block_performance(
     """
     Execute block device emulation benchmarking scenarios.
     """
-    vm = uvm_any_acpi
+    vm = uvm_plain_acpi
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()
@@ -211,7 +211,7 @@ def test_block_performance(
 @pytest.mark.parametrize("fio_mode", ["randread"])
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_block_vhost_user_performance(
-    uvm_any_acpi,
+    uvm_plain_acpi,
     vcpus,
     fio_mode,
     fio_block_size,
@@ -222,7 +222,7 @@ def test_block_vhost_user_performance(
     Execute block device emulation benchmarking scenarios.
     """
 
-    vm = uvm_any_acpi
+    vm = uvm_plain_acpi
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()


### PR DESCRIPTION
## Changes

Fix the block tests by using the correct fixture name.

## Reason

PCI pipeline is failing :( 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
