### PR TITLE
fix(mmds): Set token TTL header in response to PUT /latest/api/token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ and this project adheres to
 - [#5290](https://github.com/firecracker-microvm/firecracker/pull/5290): Fixed
   MMDS to reject PUT requests containing `X-Forwarded-For` header regardless of
   its casing (e.g. `x-forwarded-for`).
+- [#5328](https://github.com/firecracker-microvm/firecracker/pull/5328): Fixed
+  MMDS to set the token TTL header (i.e. "X-metadata-token-ttl-seconds" or
+  "X-aws-ec2-metadata-token-ttl-seconds") in the response to "PUT
+  /latest/api/token", as EC2 IMDS does.
 
 ## [1.12.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http#11cc5da16ac86f9107d3f45791944fa6b964a6a9"
+source = "git+https://github.com/firecracker-microvm/micro-http#98d85677ba603d16c40103c09059b54c38d71825"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/resources/overlay/usr/local/bin/fillmem.c
+++ b/resources/overlay/usr/local/bin/fillmem.c
@@ -19,9 +19,9 @@
 
 
 int fill_mem(int mb_count) {
-    int i, j;
+    int i;
     char *ptr = NULL;
-    for(j = 0; j < mb_count; j++) {
+    for(i = 0; i < mb_count; i++) {
         do {
             // We can't map the whole chunk of memory at once because
             // in case the system is already in a memory pressured
@@ -50,7 +50,7 @@ int main(int argc, char *const argv[]) {
         printf("Usage: ./fillmem mb_count\n");
         return -1;
     }
-    
+
     int mb_count = atoi(argv[1]);
 
     int pid = fork();

--- a/resources/overlay/usr/local/bin/go_sdk_cred_provider.go/main.go
+++ b/resources/overlay/usr/local/bin/go_sdk_cred_provider.go/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+func main() {
+	cfg, err := config.LoadDefaultConfig(
+		context.TODO(),
+		config.WithClientLogMode(
+			aws.LogSigning|
+				aws.LogRetries|
+				aws.LogRequest|
+				aws.LogRequestWithBody|
+				aws.LogResponse|
+				aws.LogResponseWithBody,
+		),
+	)
+	if err != nil {
+		log.Fatalf("Unable to load config: %v", err)
+	}
+
+	cred, err := cfg.Credentials.Retrieve(context.TODO())
+	if err != nil {
+		log.Fatalf("Unable to retrieve credentials: %v", err)
+	}
+
+	fmt.Printf("%v,%v,%v\n", cred.AccessKeyID, cred.SecretAccessKey, cred.SessionToken)
+}

--- a/resources/overlay/usr/local/bin/go_sdk_cred_provider_with_custom_endpoint.go/main.go
+++ b/resources/overlay/usr/local/bin/go_sdk_cred_provider_with_custom_endpoint.go/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/endpointcreds"
+)
+
+const mmdsBaseUrl = "http://169.254.169.254"
+
+func main() {
+	// Get MMDS token
+	token, err := getMmdsToken()
+	if err != nil {
+		log.Fatalf("Failed to get MMDS token: %v", err)
+	}
+
+	// Construct a client
+	client := &http.Client{
+		Transport: &tokenInjector{
+			token: token,
+			next: &loggingRoundTripper{
+				next: http.DefaultTransport,
+			},
+		},
+	}
+
+	// Construct a credential provider
+	endpoint := fmt.Sprintf("%s/latest/meta-data/iam/security-credentials/role", mmdsBaseUrl)
+	provider := endpointcreds.New(endpoint, func(o *endpointcreds.Options) {
+		o.HTTPClient = client
+	})
+
+	// Load config with the custom provider
+	cfg, err := config.LoadDefaultConfig(
+		context.TODO(),
+		config.WithCredentialsProvider(provider),
+	)
+	if err != nil {
+		log.Fatalf("Unable to load config: %v", err)
+	}
+
+	// Retrieve credentials
+	cred, err := cfg.Credentials.Retrieve(context.TODO())
+	if err != nil {
+		log.Fatalf("Unable to retrieve credentials: %v", err)
+	}
+
+	fmt.Printf("%v,%v,%v\n", cred.AccessKeyID, cred.SecretAccessKey, cred.SessionToken)
+}
+
+func getMmdsToken() (string, error) {
+	client := &http.Client{}
+
+	// Construct a request
+	req, err := http.NewRequest("PUT", mmdsBaseUrl + "/latest/api/token", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("x-aws-ec2-metadata-token-ttl-seconds", "21600")
+
+	// Log the request
+	dumpReq, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintf(os.Stderr, "REQUEST:\n%s\n", dumpReq)
+
+	// Perform the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Log the response
+	dumpResp, err := httputil.DumpResponse(resp, true)
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintf(os.Stderr, "RESPONSE:\n%s\n", dumpResp)
+
+	// Check the response status code.
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Status: %s", resp.Status)
+	}
+
+	// Read the body
+	body, _ := ioutil.ReadAll(resp.Body)
+	return string(body), nil
+}
+
+// tokenInjector adds the token header on every metadata request
+type tokenInjector struct {
+	token string
+	next http.RoundTripper
+}
+
+func (t *tokenInjector) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("x-aws-ec2-metadata-token", t.token)
+	return t.next.RoundTrip(req)
+}
+
+// logginRoundTripper logs requests and responses
+type loggingRoundTripper struct {
+	next http.RoundTripper
+}
+
+func (l *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Log the request
+	dumpReq, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(os.Stderr, "REQUEST:\n%s\n", dumpReq)
+
+	// Perform the request
+	resp, err := l.next.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Log the response
+	dumpResp, err := httputil.DumpResponse(resp, true)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(os.Stderr, "RESPONSE:\n%s\n", dumpResp)
+
+	return resp, nil
+}

--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -65,12 +65,6 @@ for d in $dirs; do tar c "/$d" | tar x -C $rootfs; done
 mkdir -pv $rootfs/{dev,proc,sys,run,tmp,var/lib/systemd}
 # So apt works
 mkdir -pv $rootfs/var/lib/dpkg/
-
-# Install AWS CLI v2
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-./aws/install --install-dir $rootfs/usr/local/aws-cli --bin-dir $rootfs/usr/local/bin
-rm -rf awscliv2.zip aws
 EOF
 
     # TBD what abt /etc/hosts?

--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -18,6 +18,18 @@ source "$GIT_ROOT_DIR/tools/functions"
 function install_dependencies {
     apt update
     apt install -y bc flex bison gcc make libelf-dev libssl-dev squashfs-tools busybox-static tree cpio curl patch docker.io
+
+    # Install Go
+    version=$(curl -s https://go.dev/VERSION?m=text | head -n 1)
+    case $ARCH in
+        x86_64) archive="${version}.linux-amd64.tar.gz" ;;
+        aarch64) archive="${version}.linux-arm64.tar.gz" ;;
+    esac
+    curl -LO http://go.dev/dl/${archive}
+    tar -C /usr/local -xzf $archive
+    export PATH=$PATH:/usr/local/go/bin
+    go version
+    rm $archive
 }
 
 function prepare_docker {

--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -200,7 +200,7 @@ function build_al_kernel {
 function prepare_and_build_rootfs {
     BIN_DIR=overlay/usr/local/bin
 
-    SRCS=(init.c fillmem.c fast_page_fault_helper.c readmem.c go_sdk_cred_provider.go)
+    SRCS=(init.c fillmem.c fast_page_fault_helper.c readmem.c go_sdk_cred_provider.go go_sdk_cred_provider_with_custom_endpoint.go)
     if [ $ARCH == "aarch64" ]; then
         SRCS+=(devmemread.c)
     fi

--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -40,11 +40,9 @@ function prepare_docker {
 }
 
 function compile_and_install {
-    local C_FILE=$1
-    local BIN_FILE=$2
-    local OUTPUT_DIR=$(dirname $BIN_FILE)
-    mkdir -pv $OUTPUT_DIR
-    gcc -Wall -o $BIN_FILE $C_FILE
+    local SRC=$1
+    local BIN="${SRC%.*}"
+    gcc -Wall -o $BIN $SRC
 }
 
 # Build a rootfs
@@ -190,22 +188,23 @@ function build_al_kernel {
 }
 
 function prepare_and_build_rootfs {
-    BIN=overlay/usr/local/bin
+    BIN_DIR=overlay/usr/local/bin
 
-    tools=(init fillmem fast_page_fault_helper readmem)
+    SRCS=(init.c fillmem.c fast_page_fault_helper.c readmem.c)
     if [ $ARCH == "aarch64" ]; then
-        tools+=(devmemread)
+        SRCS+=(devmemread.c)
     fi
 
-    for tool in ${tools[@]}; do
-        compile_and_install $BIN/$tool.c $BIN/$tool
+    for SRC in ${SRCS[@]}; do
+        compile_and_install $BIN_DIR/$SRC
     done
 
     build_rootfs ubuntu-24.04 noble
     build_initramfs
 
-    for tool in ${tools[@]}; do
-        rm $BIN/$tool
+    for SRC in ${SRCS[@]}; do
+        BIN="${SRC%.*}"
+        rm $BIN_DIR/$BIN
     done
 }
 

--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -200,7 +200,7 @@ function build_al_kernel {
 function prepare_and_build_rootfs {
     BIN_DIR=overlay/usr/local/bin
 
-    SRCS=(init.c fillmem.c fast_page_fault_helper.c readmem.c)
+    SRCS=(init.c fillmem.c fast_page_fault_helper.c readmem.c go_sdk_cred_provider.go)
     if [ $ARCH == "aarch64" ]; then
         SRCS+=(devmemread.c)
     fi

--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -42,7 +42,17 @@ function prepare_docker {
 function compile_and_install {
     local SRC=$1
     local BIN="${SRC%.*}"
-    gcc -Wall -o $BIN $SRC
+    if [[ $SRC == *.c ]]; then
+        gcc -Wall -o $BIN $SRC
+    elif [[ $SRC == *.go ]]; then
+        pushd $SRC
+        local MOD=$(basename $BIN)
+        go mod init $MOD
+        go mod tidy
+        go build -o ../$MOD
+        rm go.mod go.sum
+        popd
+    fi
 }
 
 # Build a rootfs

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -750,7 +750,8 @@ def test_deprecated_mmds_config(uvm_plain):
 
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
 @pytest.mark.parametrize("imds_compat", [None, False, True])
-def test_aws_credential_provider(uvm_plain, version, imds_compat):
+@pytest.mark.parametrize("sdk", ["py", "go"])
+def test_aws_credential_provider(uvm_plain, version, imds_compat, sdk):
     """
     Test AWS SDK's credential provider works on MMDS
     """
@@ -789,7 +790,9 @@ def test_aws_credential_provider(uvm_plain, version, imds_compat):
 
     run_guest_cmd(ssh_connection, f"ip route add {DEFAULT_IPV4} dev eth0", "")
 
-    cmd = r"""python3 - <<EOF
+    match sdk:
+        case "py":
+            cmd = r"""python3 - <<EOF
 import logging
 import sys
 
@@ -808,5 +811,7 @@ cred = sess.get_credentials()
 print(f"{cred.access_key},{cred.secret_key},{cred.token}")
 EOF
 """
+        case "go":
+            cmd = "/usr/local/bin/go_sdk_cred_provider"
     _, stdout, stderr = ssh_connection.check_output(cmd)
     assert stdout == "AAA,BBB,CCC\n", stderr

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -752,7 +752,7 @@ def test_deprecated_mmds_config(uvm_plain):
 @pytest.mark.parametrize("imds_compat", [None, False, True])
 def test_aws_credential_provider(uvm_plain, version, imds_compat):
     """
-    Test AWS CLI credential provider
+    Test AWS SDK's credential provider works on MMDS
     """
     test_microvm = uvm_plain
     test_microvm.spawn()

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -748,20 +748,13 @@ def test_deprecated_mmds_config(uvm_plain):
     )
 
 
-@pytest.mark.parametrize("version", MMDS_VERSIONS)
-@pytest.mark.parametrize("imds_compat", [None, False, True])
-@pytest.mark.parametrize("sdk", ["py", "go"])
-def test_aws_credential_provider(uvm_plain, version, imds_compat, sdk):
-    """
-    Test AWS SDK's credential provider works on MMDS
-    """
-    test_microvm = uvm_plain
-    test_microvm.spawn()
-    test_microvm.basic_config()
-    test_microvm.add_net_iface()
+def _configure_with_aws_credentials(microvm, version, imds_compat):
+    microvm.spawn()
+    microvm.basic_config()
+    microvm.add_net_iface()
     # V2 requires session tokens for GET requests
     configure_mmds(
-        test_microvm, iface_ids=["eth0"], version=version, imds_compat=imds_compat
+        microvm, iface_ids=["eth0"], version=version, imds_compat=imds_compat
     )
     now = datetime.now(timezone.utc)
     credentials = {
@@ -783,12 +776,23 @@ def test_aws_credential_provider(uvm_plain, version, imds_compat, sdk):
             }
         }
     }
-    populate_data_store(test_microvm, data_store)
-    test_microvm.start()
+    populate_data_store(microvm, data_store)
+    microvm.start()
 
-    ssh_connection = test_microvm.ssh
-
+    ssh_connection = microvm.ssh
     run_guest_cmd(ssh_connection, f"ip route add {DEFAULT_IPV4} dev eth0", "")
+
+    return ssh_connection
+
+
+@pytest.mark.parametrize("version", MMDS_VERSIONS)
+@pytest.mark.parametrize("imds_compat", [None, False, True])
+@pytest.mark.parametrize("sdk", ["py", "go"])
+def test_aws_credential_provider(uvm_plain, version, imds_compat, sdk):
+    """
+    Test AWS SDK's credential provider works on MMDS
+    """
+    ssh_connection = _configure_with_aws_credentials(uvm_plain, version, imds_compat)
 
     match sdk:
         case "py":
@@ -815,3 +819,35 @@ EOF
             cmd = "/usr/local/bin/go_sdk_cred_provider"
     _, stdout, stderr = ssh_connection.check_output(cmd)
     assert stdout == "AAA,BBB,CCC\n", stderr
+
+
+@pytest.mark.parametrize("version", MMDS_VERSIONS)
+@pytest.mark.parametrize("imds_compat", [None, False, True])
+def test_go_sdk_credential_provider_with_custom_endpoint(
+    uvm_plain, version, imds_compat
+):
+    """
+    Test AWS SDK's credential provider with custom endpoint.
+
+    It sets "Accept: application/json" in a request to retrieve AWS credentials.
+    If imds_compat is True, it should work. If False, it should NOT work,
+    because MMDS responds a string of a JSON object containing the credentials
+    (i.e. wrapped with doublequotes) with "Content-Type: application/json" but
+    AWS SDK for Go expects only the inner JSON object.
+    """
+    ssh_connection = _configure_with_aws_credentials(uvm_plain, version, imds_compat)
+
+    cmd = "/usr/local/bin/go_sdk_cred_provider_with_custom_endpoint"
+    ret, stdout, stderr = ssh_connection.run(cmd)
+    if imds_compat:
+        assert ret == 0
+        assert stdout == "AAA,BBB,CCC\n", stderr
+    else:
+        assert ret == 1
+        assert (
+            "Unable to retrieve credentials: "
+            "failed to refresh cached credentials, "
+            "failed to load credentials, deserialization failed, "
+            "failed to deserialize json response, "
+            "json: cannot unmarshal string into Go value of type client.GetCredentialsOutput"
+        ) in stderr

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -790,7 +790,17 @@ def test_aws_credential_provider(uvm_plain, version, imds_compat):
     run_guest_cmd(ssh_connection, f"ip route add {DEFAULT_IPV4} dev eth0", "")
 
     cmd = r"""python3 - <<EOF
+import logging
+import sys
+
+import boto3
 from botocore.session import get_session
+
+logging.basicConfig(
+    stream=sys.stderr,
+    level=logging.DEBUG,
+)
+boto3.set_stream_logger('', logging.DEBUG)
 
 sess = get_session()
 cred = sess.get_credentials()


### PR DESCRIPTION
## Changes

- Set the token TTL header in the MMDS response to "PUT /latest/api/token".
- Add integration tests using AWS SDK for GO to ensure the token TTL header is set in the response and MMDS responds as EC2 IMDS does if `imds_compat` flag is true.

## Reason

EC2 IMDS sets X-Aws-Ec2-Metadata-Token-Ttl-Seconds header in the
response to PUT /latest/api/token, while MMDS didn't. AWS SDK for Go
tries to parse it as integer (i.e. tries to parse an empty string "" as
integer) [4].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
[4]: https://github.com/aws/aws-sdk-go-v2/blob/7a614d9fcccd492af3b87aa43c7c203cb636804e/feature/ec2/imds/api_op_GetToken.go#L82-L85
