### PR TITLE
[feature/pcie] feat: add swiotlb=noforce to default kernel command line

### DIFF
--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -14,8 +14,9 @@ use serde::{Deserialize, Serialize};
 /// - `i8042.noaux` do not probe the i8042 controller for an attached mouse (save boot time);
 /// - `i8042.nomux` do not probe i8042 for a multiplexing controller (save boot time);
 /// - `i8042.dumbkbd` do not attempt to control kbd state via the i8042 (save boot time).
-pub const DEFAULT_KERNEL_CMDLINE: &str =
-    "reboot=k panic=1 nomodule 8250.nr_uarts=0 i8042.noaux i8042.nomux i8042.dumbkbd";
+/// - `swiotlb=noforce` disable software bounce buffers (SWIOTLB)
+pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 nomodule 8250.nr_uarts=0 i8042.noaux \
+                                          i8042.nomux i8042.dumbkbd swiotlb=noforce";
 
 /// Strongly typed data structure used to configure the boot source of the
 /// microvm.

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -807,7 +807,7 @@ class Microvm:
 
         If boot_args is None, the default boot_args in Firecracker is
             reboot=k panic=1 nomodule 8250.nr_uarts=0 i8042.noaux i8042.nomux
-            i8042.nopnp i8042.dumbkbd
+            i8042.nopnp i8042.dumbkbd swiotlb=noforce
 
         if PCI is disabled, Firecracker also passes to the guest pci=off
 

--- a/tests/framework/microvm_helpers.py
+++ b/tests/framework/microvm_helpers.py
@@ -127,7 +127,7 @@ class MicrovmHelpers:
             raise RuntimeError(".spawn already called, too late to enable the console")
         if self.vm.boot_args is None:
             self.vm.boot_args = ""
-        self.vm.boot_args += "console=ttyS0 reboot=k panic=1"
+        self.vm.boot_args += "console=ttyS0 reboot=k panic=1 swiotlb=noforce"
         self.vm.jailer.daemonize = False
         self.vm.jailer.new_pid_ns = False
 

--- a/tests/framework/vm_config_missing_vcpu_count.json
+++ b/tests/framework/vm_config_missing_vcpu_count.json
@@ -1,7 +1,7 @@
 {
   "boot-source": {
     "kernel_image_path": "vmlinux.bin",
-    "boot_args": "console=ttyS0 reboot=k panic=1"
+    "boot_args": "console=ttyS0 reboot=k panic=1 swiotlb=noforce"
   },
   "drives": [
     {

--- a/tests/integration_tests/functional/test_error_code.py
+++ b/tests/integration_tests/functional/test_error_code.py
@@ -25,7 +25,7 @@ def test_enosys_error_code(uvm_plain):
     vm.memory_monitor = None
     vm.basic_config(
         vcpu_count=1,
-        boot_args="reboot=k panic=1 init=/usr/local/bin/devmemread",
+        boot_args="reboot=k panic=1 swiotlb=noforce init=/usr/local/bin/devmemread",
     )
     vm.start()
 

--- a/tests/integration_tests/functional/test_kernel_cmdline.py
+++ b/tests/integration_tests/functional/test_kernel_cmdline.py
@@ -21,7 +21,7 @@ def test_init_params(uvm_plain):
     # Ubuntu version from the /etc/issue file.
     vm.basic_config(
         vcpu_count=1,
-        boot_args="console=ttyS0 reboot=k panic=1 init=/bin/cat -- /etc/issue",
+        boot_args="console=ttyS0 reboot=k panic=1 swiotlb=noforce init=/bin/cat -- /etc/issue",
     )
 
     vm.start()

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -55,7 +55,7 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
     microvm.basic_config(
         vcpu_count=2,
         mem_size_mib=256,
-        boot_args="console=ttyS0 reboot=k panic=1",
+        boot_args="console=ttyS0 reboot=k panic=1 swiotlb=noforce",
     )
     serial = Serial(microvm)
     serial.open()
@@ -99,7 +99,9 @@ def test_serial_console_login(uvm_plain_any):
     microvm.memory_monitor = None
 
     # Set up the microVM with 1 vCPU and a serial console.
-    microvm.basic_config(vcpu_count=1, boot_args="console=ttyS0 reboot=k panic=1")
+    microvm.basic_config(
+        vcpu_count=1, boot_args="console=ttyS0 reboot=k panic=1 swiotlb=noforce"
+    )
 
     microvm.start()
 
@@ -144,7 +146,7 @@ def test_serial_dos(uvm_plain_any):
     # Set up the microVM with 1 vCPU and a serial console.
     microvm.basic_config(
         vcpu_count=1,
-        boot_args="console=ttyS0 reboot=k panic=1",
+        boot_args="console=ttyS0 reboot=k panic=1 swiotlb=noforce",
     )
     microvm.add_net_iface()
     microvm.start()
@@ -178,7 +180,7 @@ def test_serial_block(uvm_plain_any):
     test_microvm.basic_config(
         vcpu_count=1,
         mem_size_mib=512,
-        boot_args="console=ttyS0 reboot=k panic=1",
+        boot_args="console=ttyS0 reboot=k panic=1 swiotlb=noforce",
     )
     test_microvm.add_net_iface()
     test_microvm.start()

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -12,7 +12,7 @@ import pytest
 
 DEFAULT_BOOT_ARGS = (
     "reboot=k panic=1 nomodule 8250.nr_uarts=0"
-    " i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd"
+    " i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd swiotlb=noforce"
 )
 
 

--- a/tests/integration_tests/performance/test_initrd.py
+++ b/tests/integration_tests/performance/test_initrd.py
@@ -35,7 +35,7 @@ def test_microvm_initrd_with_serial(uvm_with_initrd, huge_pages):
     vm.basic_config(
         add_root_device=False,
         vcpu_count=1,
-        boot_args="console=ttyS0 reboot=k panic=1",
+        boot_args="console=ttyS0 reboot=k panic=1 swiotlb=noforce",
         use_initrd=True,
         huge_pages=huge_pages,
     )


### PR DESCRIPTION
## Changes

Add `iommu=off` to the default command line to disable SWIOTLB.

## Reason

The kernel enables SWIOTLB when the physical address range exceeds 32b, which ends up wasting 64MB of the VM memory, which translates to higher RSS.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
