### PR TITLE
[WIP] fix(vmm): Do not store UFFD handle in VMM

### DIFF
--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -128,7 +128,6 @@ use device_manager::resources::ResourceAllocator;
 use devices::acpi::vmgenid::VmGenIdError;
 use event_manager::{EventManager as BaseEventManager, EventOps, Events, MutEventSubscriber};
 use seccomp::BpfProgram;
-use userfaultfd::Uffd;
 use vm_memory::GuestAddress;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::EventFd;
@@ -314,8 +313,6 @@ pub struct Vmm {
     kvm: Kvm,
     /// VM object
     pub vm: Vm,
-    // Save UFFD in order to keep it open in the Firecracker process, as well.
-    uffd: Option<Uffd>,
     // Used for userfault communication with the UFFD handler when secret freedom is enabled
     uffd_socket: Option<UnixStream>,
     vcpus_handles: Vec<VcpuHandle>,


### PR DESCRIPTION
## Changes

Do not store UFFD handle in VMM. The UFFD object gets dropped as soon as the last reference to it (in the handler) goes away.

## Reason

This is required to make sure no further UFFD messages will be sent to the handler that is no longer available to avoid an infinite lockup.

This is relevant for Secret Free VMs, because the UFFD handler uses `write` instead of `UFFDIO_COPY` to prepopulate guest memory and is not required to preinstall userspace page tables while doing it.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- ~~[ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.~~
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
