### PR TITLE
Increase testing coverage for PCI code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "vm-allocator",
  "vm-device",
  "vm-memory",
+ "vmm-sys-util",
 ]
 
 [[package]]

--- a/src/pci/Cargo.toml
+++ b/src/pci/Cargo.toml
@@ -27,3 +27,4 @@ vm-memory = { version = "0.16.1", features = [
 
 [dev-dependencies]
 serde_test = "1.0.177"
+vmm-sys-util = "0.14.0"

--- a/src/pci/src/bus.rs
+++ b/src/pci/src/bus.rs
@@ -5,7 +5,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::ops::DerefMut;
 use std::sync::{Arc, Barrier, Mutex};
@@ -86,14 +85,6 @@ impl PciDevice for PciRoot {
 
     fn read_config_register(&mut self, reg_idx: usize) -> u32 {
         self.config.read_reg(reg_idx)
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn id(&self) -> Option<String> {
-        None
     }
 }
 

--- a/src/pci/src/bus.rs
+++ b/src/pci/src/bus.rs
@@ -182,11 +182,16 @@ impl PciConfigIo {
             return None;
         }
 
-        let (bus, device, _function, register) =
+        let (bus, device, function, register) =
             parse_io_config_address(self.config_address & !0x8000_0000);
 
         // Only support one bus.
         if bus != 0 {
+            return None;
+        }
+
+        // Don't support multi-function devices.
+        if function > 0 {
             return None;
         }
 
@@ -240,6 +245,16 @@ impl PciConfigIo {
 
 impl BusDevice for PciConfigIo {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        // Only allow reads to the register boundary.
+        let start = offset as usize % 4;
+        let end = start + data.len();
+        if end > 4 {
+            for d in data.iter_mut() {
+                *d = 0xff;
+            }
+            return;
+        }
+
         // `offset` is relative to 0xcf8
         let value = match offset {
             0..=3 => self.config_address,
@@ -247,17 +262,8 @@ impl BusDevice for PciConfigIo {
             _ => 0xffff_ffff,
         };
 
-        // Only allow reads to the register boundary.
-        let start = offset as usize % 4;
-        let end = start + data.len();
-        if end <= 4 {
-            for i in start..end {
-                data[i - start] = (value >> (i * 8)) as u8;
-            }
-        } else {
-            for d in data {
-                *d = 0xff;
-            }
+        for i in start..end {
+            data[i - start] = (value >> (i * 8)) as u8;
         }
     }
 
@@ -285,10 +291,15 @@ impl PciConfigMmio {
     }
 
     fn config_space_read(&self, config_address: u32) -> u32 {
-        let (bus, device, _function, register) = parse_mmio_config_address(config_address);
+        let (bus, device, function, register) = parse_mmio_config_address(config_address);
 
         // Only support one bus.
         if bus != 0 {
+            return 0xffff_ffff;
+        }
+
+        // Don't support multi-function devices.
+        if function > 0 {
             return 0xffff_ffff;
         }
 
@@ -307,10 +318,15 @@ impl PciConfigMmio {
             return;
         }
 
-        let (bus, device, _function, register) = parse_mmio_config_address(config_address);
+        let (bus, device, function, register) = parse_mmio_config_address(config_address);
 
         // Only support one bus.
         if bus != 0 {
+            return;
+        }
+
+        // Don't support multi-function devices.
+        if function > 0 {
             return;
         }
 
@@ -415,14 +431,28 @@ fn parse_io_config_address(config_address: u32) -> (usize, usize, usize, usize) 
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
     use std::sync::{Arc, Mutex};
 
     use vm_device::BusDevice;
 
-    use super::{PciBus, PciConfigIo, PciRoot};
-    use crate::DeviceRelocation;
+    use super::{PciBus, PciConfigIo, PciConfigMmio, PciRoot};
+    use crate::bus::{DEVICE_ID_INTEL_VIRT_PCIE_HOST, VENDOR_ID_INTEL};
+    use crate::{
+        DeviceRelocation, PciBarConfiguration, PciBarPrefetchable, PciBarRegionType, PciClassCode,
+        PciConfiguration, PciDevice, PciHeaderType, PciMassStorageSubclass,
+    };
 
-    struct RelocationMock;
+    #[derive(Debug, Default)]
+    struct RelocationMock {
+        reloc_cnt: AtomicUsize,
+    }
+
+    impl RelocationMock {
+        fn cnt(&self) -> usize {
+            self.reloc_cnt.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
 
     impl DeviceRelocation for RelocationMock {
         fn move_bar(
@@ -433,13 +463,71 @@ mod tests {
             _pci_dev: &mut dyn crate::PciDevice,
             _region_type: crate::PciBarRegionType,
         ) -> std::result::Result<(), std::io::Error> {
+            self.reloc_cnt
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(())
         }
     }
 
+    struct PciDevMock(PciConfiguration);
+
+    impl PciDevMock {
+        fn new() -> Self {
+            let mut config = PciConfiguration::new(
+                0x42,
+                0x0,
+                0x0,
+                PciClassCode::MassStorage,
+                &PciMassStorageSubclass::SerialScsiController,
+                None,
+                PciHeaderType::Device,
+                0x13,
+                0x12,
+                None,
+                None,
+            );
+
+            config
+                .add_pci_bar(&PciBarConfiguration {
+                    addr: 0x1000,
+                    size: 0x1000,
+                    idx: 0,
+                    region_type: PciBarRegionType::Memory32BitRegion,
+                    prefetchable: PciBarPrefetchable::Prefetchable,
+                })
+                .unwrap();
+
+            PciDevMock(config)
+        }
+    }
+
+    impl PciDevice for PciDevMock {
+        fn write_config_register(
+            &mut self,
+            reg_idx: usize,
+            offset: u64,
+            data: &[u8],
+        ) -> Option<Arc<std::sync::Barrier>> {
+            self.0.write_config_register(reg_idx, offset, data);
+            None
+        }
+
+        fn read_config_register(&mut self, reg_idx: usize) -> u32 {
+            self.0.read_reg(reg_idx)
+        }
+
+        fn detect_bar_reprogramming(
+            &mut self,
+            reg_idx: usize,
+            data: &[u8],
+        ) -> Option<crate::BarReprogrammingParams> {
+            self.0.detect_bar_reprogramming(reg_idx, data)
+        }
+    }
+
     #[test]
-    fn test_writing_config_address() {
-        let mock = Arc::new(RelocationMock);
+    fn test_writing_io_config_address() {
+        let mock = Arc::new(RelocationMock::default());
         let root = PciRoot::new(None);
         let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(root, mock))));
 
@@ -480,8 +568,8 @@ mod tests {
     }
 
     #[test]
-    fn test_reading_config_address() {
-        let mock = Arc::new(RelocationMock);
+    fn test_reading_io_config_address() {
+        let mock = Arc::new(RelocationMock::default());
         let root = PciRoot::new(None);
         let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(root, mock))));
 
@@ -526,5 +614,337 @@ mod tests {
         // reading all of it at once
         bus.read(0, 0, &mut buffer);
         assert_eq!(buffer, [0x45, 0x44, 0x43, 0x42]);
+    }
+
+    fn initialize_bus() -> (PciConfigMmio, PciConfigIo, Arc<RelocationMock>) {
+        let mock = Arc::new(RelocationMock::default());
+        let root = PciRoot::new(None);
+        let mut bus = PciBus::new(root, mock.clone());
+        bus.add_device(1, Arc::new(Mutex::new(PciDevMock::new())))
+            .unwrap();
+        let bus = Arc::new(Mutex::new(bus));
+        (PciConfigMmio::new(bus.clone()), PciConfigIo::new(bus), mock)
+    }
+
+    #[test]
+    fn test_invalid_register_boundary_reads() {
+        let (mut mmio_config, mut io_config, _) = initialize_bus();
+
+        // Read crossing register boundaries
+        let mut buffer = [0u8; 4];
+        mmio_config.read(0, 1, &mut buffer);
+        assert_eq!(0xffff_ffff, u32::from_le_bytes(buffer));
+
+        let mut buffer = [0u8; 4];
+        io_config.read(0, 1, &mut buffer);
+        assert_eq!(0xffff_ffff, u32::from_le_bytes(buffer));
+
+        // As well in the config space
+        let mut buffer = [0u8; 4];
+        io_config.read(0, 5, &mut buffer);
+        assert_eq!(0xffff_ffff, u32::from_le_bytes(buffer));
+    }
+
+    // MMIO config addresses are of the form
+    //
+    // | Base address upper bits | Bus Number | Device Number | Function Number | Register number | Byte offset |
+    // |         31-28           |    27-20   |     19-15     |      14-12      |      11-2       |     0-1     |
+    //
+    // Meaning that the offset is built using:
+    //
+    // `bus << 20 | device << 15 | function << 12 | register << 2 | byte`
+    fn mmio_offset(bus: u8, device: u8, function: u8, register: u16, byte: u8) -> u32 {
+        assert!(device < 32);
+        assert!(function < 8);
+        assert!(register < 1024);
+        assert!(byte < 4);
+
+        (bus as u32) << 20
+            | (device as u32) << 15
+            | (function as u32) << 12
+            | (register as u32) << 2
+            | (byte as u32)
+    }
+
+    fn read_mmio_config(
+        config: &mut PciConfigMmio,
+        bus: u8,
+        device: u8,
+        function: u8,
+        register: u16,
+        byte: u8,
+        data: &mut [u8],
+    ) {
+        config.read(
+            0,
+            mmio_offset(bus, device, function, register, byte) as u64,
+            data,
+        );
+    }
+
+    fn write_mmio_config(
+        config: &mut PciConfigMmio,
+        bus: u8,
+        device: u8,
+        function: u8,
+        register: u16,
+        byte: u8,
+        data: &[u8],
+    ) {
+        config.write(
+            0,
+            mmio_offset(bus, device, function, register, byte) as u64,
+            data,
+        );
+    }
+
+    // Similarly, when using the IO mechanism the config addresses have the following format
+    //
+    // | Enabled | zeros | Bus Number | Device Number | Function Number | Register number | zeros |
+    // |    31   | 30-24 |   23-16    |     15-11     |      10-8       |       7-2       |  1-0  |
+    //
+    //
+    // Meaning that the address is built using:
+    //
+    // 0x8000_0000 | bus << 16 | device << 11 | function << 8 | register << 2;
+    //
+    // Only 32-bit aligned accesses are allowed here.
+    fn pio_offset(enabled: bool, bus: u8, device: u8, function: u8, register: u8) -> u32 {
+        assert!(device < 32);
+        assert!(function < 8);
+        assert!(register < 64);
+
+        let offset = if enabled { 0x8000_0000 } else { 0u32 };
+
+        offset
+            | (bus as u32) << 16
+            | (device as u32) << 11
+            | (function as u32) << 8
+            | (register as u32) << 2
+    }
+
+    fn set_io_address(
+        config: &mut PciConfigIo,
+        enabled: bool,
+        bus: u8,
+        device: u8,
+        function: u8,
+        register: u8,
+    ) {
+        let address = u32::to_le_bytes(pio_offset(enabled, bus, device, function, register));
+        config.write(0, 0, &address);
+    }
+
+    fn read_io_config(
+        config: &mut PciConfigIo,
+        enabled: bool,
+        bus: u8,
+        device: u8,
+        function: u8,
+        register: u8,
+        data: &mut [u8],
+    ) {
+        set_io_address(config, enabled, bus, device, function, register);
+        config.read(0, 4, data);
+    }
+
+    fn write_io_config(
+        config: &mut PciConfigIo,
+        enabled: bool,
+        bus: u8,
+        device: u8,
+        function: u8,
+        register: u8,
+        data: &[u8],
+    ) {
+        set_io_address(config, enabled, bus, device, function, register);
+        config.write(0, 4, data);
+    }
+
+    #[test]
+    fn test_mmio_invalid_bus_number() {
+        let (mut mmio_config, _, _) = initialize_bus();
+        let mut buffer = [0u8; 4];
+
+        // Asking for Bus 1 should return all 1s
+        read_mmio_config(&mut mmio_config, 1, 0, 0, 0, 0, &mut buffer);
+        assert_eq!(buffer, u32::to_le_bytes(0xffff_ffff));
+        // Writing the same
+        buffer[0] = 0x42;
+        write_mmio_config(&mut mmio_config, 1, 0, 0, 15, 0, &buffer);
+        read_mmio_config(&mut mmio_config, 1, 0, 0, 15, 0, &mut buffer);
+        assert_eq!(buffer, u32::to_le_bytes(0xffff_ffff));
+        read_mmio_config(&mut mmio_config, 0, 0, 0, 15, 0, &mut buffer);
+        assert_eq!(buffer, u32::to_le_bytes(0x0));
+
+        // Asking for Bus 0 should work
+        read_mmio_config(&mut mmio_config, 0, 0, 0, 0, 0, &mut buffer);
+        assert_eq!(&buffer[..2], &u16::to_le_bytes(VENDOR_ID_INTEL));
+        assert_eq!(
+            &buffer[2..],
+            &u16::to_le_bytes(DEVICE_ID_INTEL_VIRT_PCIE_HOST)
+        );
+    }
+
+    #[test]
+    fn test_io_invalid_bus_number() {
+        let (_, mut pio_config, _) = initialize_bus();
+        let mut buffer = [0u8; 4];
+
+        // Asking for Bus 1 should return all 1s
+        read_io_config(&mut pio_config, true, 1, 0, 0, 0, &mut buffer);
+        assert_eq!(buffer, u32::to_le_bytes(0xffff_ffff));
+
+        // Asking for Bus 0 should work
+        read_io_config(&mut pio_config, true, 0, 0, 0, 0, &mut buffer);
+        assert_eq!(&buffer[..2], &u16::to_le_bytes(VENDOR_ID_INTEL));
+        assert_eq!(
+            &buffer[2..],
+            &u16::to_le_bytes(DEVICE_ID_INTEL_VIRT_PCIE_HOST)
+        );
+    }
+
+    #[test]
+    fn test_mmio_invalid_function() {
+        let (mut mmio_config, _, _) = initialize_bus();
+        let mut buffer = [0u8; 4];
+
+        // Asking for Bus 1 should return all 1s
+        read_mmio_config(&mut mmio_config, 0, 0, 1, 0, 0, &mut buffer);
+        assert_eq!(buffer, u32::to_le_bytes(0xffff_ffff));
+        // Writing the same
+        buffer[0] = 0x42;
+        write_mmio_config(&mut mmio_config, 0, 0, 1, 15, 0, &buffer);
+        read_mmio_config(&mut mmio_config, 0, 0, 1, 15, 0, &mut buffer);
+        assert_eq!(buffer, u32::to_le_bytes(0xffff_ffff));
+        read_mmio_config(&mut mmio_config, 0, 0, 0, 15, 0, &mut buffer);
+        assert_eq!(buffer, u32::to_le_bytes(0x0));
+
+        // Asking for Bus 0 should work
+        read_mmio_config(&mut mmio_config, 0, 0, 0, 0, 0, &mut buffer);
+        assert_eq!(&buffer[..2], &u16::to_le_bytes(VENDOR_ID_INTEL));
+        assert_eq!(
+            &buffer[2..],
+            &u16::to_le_bytes(DEVICE_ID_INTEL_VIRT_PCIE_HOST)
+        );
+    }
+
+    #[test]
+    fn test_io_invalid_function() {
+        let (_, mut pio_config, _) = initialize_bus();
+        let mut buffer = [0u8; 4];
+
+        // Asking for Bus 1 should return all 1s
+        read_io_config(&mut pio_config, true, 0, 0, 1, 0, &mut buffer);
+        assert_eq!(buffer, u32::to_le_bytes(0xffff_ffff));
+
+        // Asking for Bus 0 should work
+        read_io_config(&mut pio_config, true, 0, 0, 0, 0, &mut buffer);
+        assert_eq!(&buffer[..2], &u16::to_le_bytes(VENDOR_ID_INTEL));
+        assert_eq!(
+            &buffer[2..],
+            &u16::to_le_bytes(DEVICE_ID_INTEL_VIRT_PCIE_HOST)
+        );
+    }
+
+    #[test]
+    fn test_io_disabled_reads() {
+        let (_, mut pio_config, _) = initialize_bus();
+        let mut buffer = [0u8; 4];
+
+        // Trying to read without enabling should return all 1s
+        read_io_config(&mut pio_config, false, 0, 0, 0, 0, &mut buffer);
+        assert_eq!(buffer, u32::to_le_bytes(0xffff_ffff));
+
+        // Asking for Bus 0 should work
+        read_io_config(&mut pio_config, true, 0, 0, 0, 0, &mut buffer);
+        assert_eq!(&buffer[..2], &u16::to_le_bytes(VENDOR_ID_INTEL));
+        assert_eq!(
+            &buffer[2..],
+            &u16::to_le_bytes(DEVICE_ID_INTEL_VIRT_PCIE_HOST)
+        );
+    }
+
+    #[test]
+    fn test_io_disabled_writes() {
+        let (_, mut pio_config, _) = initialize_bus();
+
+        // Try to write the IRQ line used for the root port.
+        let mut buffer = [0u8; 4];
+
+        // First read the current value (use `enabled` bit)
+        read_io_config(&mut pio_config, true, 0, 0, 0, 15, &mut buffer);
+        let irq_line = buffer[0];
+
+        // Write without setting the `enabled` bit.
+        buffer[0] = 0x42;
+        write_io_config(&mut pio_config, false, 0, 0, 0, 15, &buffer);
+
+        // IRQ line shouldn't have changed
+        read_io_config(&mut pio_config, true, 0, 0, 0, 15, &mut buffer);
+        assert_eq!(buffer[0], irq_line);
+
+        // Write with `enabled` bit set.
+        buffer[0] = 0x42;
+        write_io_config(&mut pio_config, true, 0, 0, 0, 15, &buffer);
+
+        // IRQ line should change
+        read_io_config(&mut pio_config, true, 0, 0, 0, 15, &mut buffer);
+        assert_eq!(buffer[0], 0x42);
+    }
+
+    #[test]
+    fn test_mmio_writes() {
+        let (mut mmio_config, _, _) = initialize_bus();
+        let mut buffer = [0u8; 4];
+
+        read_mmio_config(&mut mmio_config, 0, 0, 0, 15, 0, &mut buffer);
+        assert_eq!(buffer[0], 0x0);
+        write_mmio_config(&mut mmio_config, 0, 0, 0, 15, 0, &[0x42]);
+        read_mmio_config(&mut mmio_config, 0, 0, 0, 15, 0, &mut buffer);
+        assert_eq!(buffer[0], 0x42);
+    }
+
+    #[test]
+    fn test_bar_reprogramming() {
+        let (mut mmio_config, _, mock) = initialize_bus();
+        let mut buffer = [0u8; 4];
+        assert_eq!(mock.cnt(), 0);
+
+        read_mmio_config(&mut mmio_config, 0, 1, 0, 0x4, 0, &mut buffer);
+        let old_addr = u32::from_le_bytes(buffer) & 0xffff_fff0;
+        assert_eq!(old_addr, 0x1000);
+        write_mmio_config(
+            &mut mmio_config,
+            0,
+            1,
+            0,
+            0x4,
+            0,
+            &u32::to_le_bytes(0x1312_1110),
+        );
+
+        read_mmio_config(&mut mmio_config, 0, 1, 0, 0x4, 0, &mut buffer);
+        let new_addr = u32::from_le_bytes(buffer) & 0xffff_fff0;
+        assert_eq!(new_addr, 0x1312_1110);
+        assert_eq!(mock.cnt(), 1);
+
+        // BAR1 should not be used, so reading its address should return all 0s
+        read_mmio_config(&mut mmio_config, 0, 1, 0, 0x5, 0, &mut buffer);
+        assert_eq!(buffer, [0x0, 0x0, 0x0, 0x0]);
+
+        // and reprogramming shouldn't have any effect
+        write_mmio_config(
+            &mut mmio_config,
+            0,
+            1,
+            0,
+            0x5,
+            0,
+            &u32::to_le_bytes(0x1312_1110),
+        );
+
+        read_mmio_config(&mut mmio_config, 0, 1, 0, 0x5, 0, &mut buffer);
+        assert_eq!(buffer, [0x0, 0x0, 0x0, 0x0]);
     }
 }

--- a/src/pci/src/configuration.rs
+++ b/src/pci/src/configuration.rs
@@ -843,11 +843,14 @@ impl PciConfiguration {
         if let Some(msix_cap_reg_idx) = self.msix_cap_reg_idx {
             if let Some(msix_config) = &self.msix_config {
                 if msix_cap_reg_idx == reg_idx && offset == 2 && data.len() == 2 {
+                    // 2-bytes write in the Message Control field
                     msix_config
                         .lock()
                         .unwrap()
                         .set_msg_ctl(LittleEndian::read_u16(data));
                 } else if msix_cap_reg_idx == reg_idx && offset == 0 && data.len() == 4 {
+                    // 4 bytes write at the beginning. Ignore the first 2 bytes which are the
+                    // capability id and next capability pointer
                     msix_config
                         .lock()
                         .unwrap()

--- a/src/pci/src/device.rs
+++ b/src/pci/src/device.rs
@@ -25,7 +25,7 @@ pub enum Error {
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BarReprogrammingParams {
     pub old_base: u64,
     pub new_base: u64,

--- a/src/pci/src/device.rs
+++ b/src/pci/src/device.rs
@@ -5,14 +5,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::any::Any;
 use std::sync::{Arc, Barrier};
 use std::{io, result};
 
 use vm_allocator::AddressAllocator;
 
 use crate::configuration::{self, PciBarRegionType};
-use crate::PciBarConfiguration;
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum Error {
@@ -42,8 +40,8 @@ pub trait PciDevice: Send {
         &mut self,
         _mmio32_allocator: &mut AddressAllocator,
         _mmio64_allocator: &mut AddressAllocator,
-    ) -> Result<Vec<PciBarConfiguration>> {
-        Ok(Vec::new())
+    ) -> Result<()> {
+        Ok(())
     }
 
     /// Frees the PCI BARs previously allocated with a call to allocate_bars().
@@ -89,12 +87,6 @@ pub trait PciDevice: Send {
     fn move_bar(&mut self, _old_base: u64, _new_base: u64) -> result::Result<(), io::Error> {
         Ok(())
     }
-    /// Provides a mutable reference to the Any trait. This is useful to let
-    /// the caller have access to the underlying type behind the trait.
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-
-    /// Optionally returns a unique identifier.
-    fn id(&self) -> Option<String>;
 }
 
 /// This trait defines a set of functions which can be triggered whenever a

--- a/src/pci/src/lib.rs
+++ b/src/pci/src/lib.rs
@@ -30,10 +30,7 @@ pub use self::configuration::{
 pub use self::device::{
     BarReprogrammingParams, DeviceRelocation, Error as PciDeviceError, PciDevice,
 };
-pub use self::msix::{
-    Error as MsixError, MsixCap, MsixConfig, MsixConfigState, MsixTableEntry, MSIX_CONFIG_ID,
-    MSIX_TABLE_ENTRY_SIZE,
-};
+pub use self::msix::{Error as MsixError, MsixCap, MsixConfig, MsixConfigState, MsixTableEntry};
 
 /// PCI has four interrupt pins A->D.
 #[derive(Copy, Clone)]

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -7,7 +7,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::any::Any;
 use std::cmp;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
@@ -870,7 +869,7 @@ impl PciDevice for VirtioPciDevice {
         &mut self,
         mmio32_allocator: &mut AddressAllocator,
         mmio64_allocator: &mut AddressAllocator,
-    ) -> std::result::Result<Vec<PciBarConfiguration>, PciDeviceError> {
+    ) -> std::result::Result<(), PciDeviceError> {
         let device_clone = self.device.clone();
         let device = device_clone.lock().unwrap();
 
@@ -905,25 +904,6 @@ impl PciDevice for VirtioPciDevice {
         self.add_pci_capabilities()?;
         self.bar_region = bar;
 
-        Ok(vec![bar])
-    }
-
-    fn free_bars(
-        &mut self,
-        mmio32_allocator: &mut AddressAllocator,
-        mmio64_allocator: &mut AddressAllocator,
-    ) -> std::result::Result<(), PciDeviceError> {
-        assert_eq!(
-            self.bar_region.region_type,
-            PciBarRegionType::Memory64BitRegion
-        );
-
-        let range = RangeInclusive::new(
-            self.bar_region.addr,
-            self.bar_region.addr + self.bar_region.size,
-        )
-        .unwrap();
-        mmio64_allocator.free(&range);
         Ok(())
     }
 
@@ -1082,14 +1062,6 @@ impl PciDevice for VirtioPciDevice {
         }
 
         None
-    }
-
-    fn id(&self) -> Option<String> {
-        Some(self.id.clone())
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -783,7 +783,7 @@ impl VirtioInterrupt for VirtioInterruptMsix {
         // device should not inject the interrupt.
         // Instead, the Pending Bit Array table is updated to reflect there
         // is a pending interrupt for this specific vector.
-        if config.masked() || entry.masked() {
+        if config.masked || entry.masked() {
             config.set_pba_bit(vector, false);
             return Ok(());
         }


### PR DESCRIPTION
## Changes

Add tests for PCI-related code within the `pci` crate

Unit tests for PCI configuration space handling, regarding guest accesses within the configuration space and configuration of MSIx interrupts

## Reason

Increase testing coverage

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
