### PR TITLE
Fix mmio interrupts

### DIFF
--- a/src/vmm/src/devices/virtio/transport/mmio.rs
+++ b/src/vmm/src/devices/virtio/transport/mmio.rs
@@ -190,10 +190,7 @@ impl MmioTransport {
 
                         // Section 2.1.2 of the specification states that we need to send a device
                         // configuration change interrupt
-                        let _ = self
-                            .locked_device()
-                            .interrupt_trigger()
-                            .trigger(VirtioInterruptType::Config);
+                        let _ = self.interrupt.trigger(VirtioInterruptType::Config);
 
                         error!("Failed to activate virtio device: {}", err)
                     }


### PR DESCRIPTION
## Reason

According to the VirtIO spec section 2.1.2, when we enter a failed state we need to to set `DEVICE_NEEDS_RESET` status field and if `DRIVER_OK` is set we need to must send a device configuration change interrupt to the driver.

In MMIO code we were trying to follow this logic, but we were trying to get the interrupt object from the device, which fails (and panics) because interrupts are only set in the device upon successful activation. In the PCI transport, instead, we were not doing this at all.


## Changes

For VirtIO devices, the transport layer always holds a reference to the interrupt object of the device. Use this reference in cases that we need to send an interrupt from the transport emulation logic. Moreover, add the missing logic in PCI transport to send a configuration update interrupt to the driver when we enter a failed state due to activation errors.


Also, there are places in VirtIO-MMIO code that takes and releases the virtio device lock multiple times within the same code branch. Change the logic to only do this once.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
