### PR TITLE
refactor: cleanup vmm::snapshot module

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -28,7 +28,7 @@ use vmm::persist::SNAPSHOT_VERSION;
 use vmm::resources::VmResources;
 use vmm::seccomp::BpfThreadMap;
 use vmm::signal_handler::register_signal_handlers;
-use vmm::snapshot::{Snapshot, SnapshotError};
+use vmm::snapshot::{SnapshotError, get_format_version};
 use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
 use vmm::vmm_config::metrics::{MetricsConfig, MetricsConfigError, init_metrics};
 use vmm::{EventManager, FcExitCode, HTTP_MAX_PAYLOAD_SIZE};
@@ -546,8 +546,8 @@ fn print_snapshot_data_format(snapshot_path: &str) -> Result<(), SnapshotVersion
     let mut snapshot_reader =
         File::open(snapshot_path).map_err(SnapshotVersionError::OpenSnapshot)?;
 
-    let data_format_version = Snapshot::get_format_version(&mut snapshot_reader)
-        .map_err(SnapshotVersionError::SnapshotVersion)?;
+    let data_format_version =
+        get_format_version(&mut snapshot_reader).map_err(SnapshotVersionError::SnapshotVersion)?;
 
     println!("v{}", data_format_version);
     Ok(())

--- a/src/snapshot-editor/src/edit_vmstate.rs
+++ b/src/snapshot-editor/src/edit_vmstate.rs
@@ -51,8 +51,8 @@ fn edit(
     output_path: &PathBuf,
     f: impl Fn(MicrovmState) -> Result<MicrovmState, EditVmStateError>,
 ) -> Result<(), EditVmStateError> {
-    let (microvm_state, _) = open_vmstate(vmstate_path)?;
-    let microvm_state = f(microvm_state)?;
+    let snapshot = open_vmstate(vmstate_path)?;
+    let microvm_state = f(snapshot.data)?;
     save_vmstate(microvm_state, output_path)?;
     Ok(())
 }

--- a/src/snapshot-editor/src/info.rs
+++ b/src/snapshot-editor/src/info.rs
@@ -4,8 +4,8 @@
 use std::path::PathBuf;
 
 use clap::Subcommand;
-use semver::Version;
 use vmm::persist::MicrovmState;
+use vmm::snapshot::Snapshot;
 
 use crate::utils::*;
 
@@ -50,27 +50,27 @@ pub fn info_vmstate_command(command: InfoVmStateSubCommand) -> Result<(), InfoVm
 
 fn info(
     vmstate_path: &PathBuf,
-    f: impl Fn(&MicrovmState, Version) -> Result<(), InfoVmStateError>,
+    f: impl Fn(&Snapshot<MicrovmState>) -> Result<(), InfoVmStateError>,
 ) -> Result<(), InfoVmStateError> {
-    let (vmstate, version) = open_vmstate(vmstate_path)?;
-    f(&vmstate, version)?;
+    let snapshot = open_vmstate(vmstate_path)?;
+    f(&snapshot)?;
     Ok(())
 }
 
-fn info_version(_: &MicrovmState, version: Version) -> Result<(), InfoVmStateError> {
-    println!("v{version}");
+fn info_version(snapshot: &Snapshot<MicrovmState>) -> Result<(), InfoVmStateError> {
+    println!("v{}", snapshot.version());
     Ok(())
 }
 
-fn info_vcpu_states(state: &MicrovmState, _: Version) -> Result<(), InfoVmStateError> {
-    for (i, state) in state.vcpu_states.iter().enumerate() {
+fn info_vcpu_states(snapshot: &Snapshot<MicrovmState>) -> Result<(), InfoVmStateError> {
+    for (i, state) in snapshot.data.vcpu_states.iter().enumerate() {
         println!("vcpu {i}:");
         println!("{state:#?}");
     }
     Ok(())
 }
 
-fn info_vmstate(vmstate: &MicrovmState, _version: Version) -> Result<(), InfoVmStateError> {
-    println!("{vmstate:#?}");
+fn info_vmstate(snapshot: &Snapshot<MicrovmState>) -> Result<(), InfoVmStateError> {
+    println!("{:#?}", snapshot.data);
     Ok(())
 }

--- a/src/vmm/src/arch/aarch64/regs.rs
+++ b/src/vmm/src/arch/aarch64/regs.rs
@@ -546,8 +546,8 @@ mod tests {
 
         let mut buf = vec![0; 10000];
 
-        Snapshot::serialize(&mut buf.as_mut_slice(), &v).unwrap();
-        let restored: Aarch64RegisterVec = Snapshot::deserialize(&mut buf.as_slice()).unwrap();
+        Snapshot::new(&v).save(&mut buf.as_mut_slice()).unwrap();
+        let restored: Aarch64RegisterVec = Snapshot::load(&mut buf.as_slice()).unwrap().data;
 
         for (old, new) in v.iter().zip(restored.iter()) {
             assert_eq!(old, new);
@@ -572,11 +572,11 @@ mod tests {
 
         let mut buf = vec![0; 10000];
 
-        Snapshot::serialize(&mut buf.as_mut_slice(), &v).unwrap();
+        Snapshot::new(&v).save(&mut buf.as_mut_slice()).unwrap();
 
         // Total size of registers according IDs are 16 + 16 = 32,
         // but actual data size is 8 + 16 = 24.
-        Snapshot::deserialize::<_, Aarch64RegisterVec>(&mut buf.as_slice()).unwrap_err();
+        Snapshot::<Aarch64RegisterVec>::load(&mut buf.as_slice()).unwrap_err();
     }
 
     #[test]
@@ -595,10 +595,10 @@ mod tests {
 
         let mut buf = vec![0; 10000];
 
-        Snapshot::serialize(&mut buf.as_mut_slice(), &v).unwrap();
+        Snapshot::new(v).save(&mut buf.as_mut_slice()).unwrap();
 
         // 4096 bit wide registers are not supported.
-        Snapshot::deserialize::<_, Aarch64RegisterVec>(&mut buf.as_slice()).unwrap_err();
+        Snapshot::<Aarch64RegisterVec>::load(&mut buf.as_slice()).unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/arch/x86_64/vm.rs
+++ b/src/vmm/src/arch/x86_64/vm.rs
@@ -318,8 +318,10 @@ mod tests {
         let (_, mut vm) = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
         let state = vm.save_state().unwrap();
-        Snapshot::serialize(&mut snapshot_data.as_mut_slice(), &state).unwrap();
-        let restored_state: VmState = Snapshot::deserialize(&mut snapshot_data.as_slice()).unwrap();
+        Snapshot::new(state)
+            .save(&mut snapshot_data.as_mut_slice())
+            .unwrap();
+        let restored_state: VmState = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
 
         vm.restore_state(&restored_state).unwrap();
     }

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -645,7 +645,9 @@ mod tests {
             let entropy_config = EntropyDeviceConfig::default();
             insert_entropy_device(&mut vmm, &mut cmdline, &mut event_manager, entropy_config);
 
-            Snapshot::serialize(&mut buf.as_mut_slice(), &vmm.device_manager.save()).unwrap();
+            Snapshot::new(vmm.device_manager.save())
+                .save(&mut buf.as_mut_slice())
+                .unwrap();
         }
 
         tmp_sock_file.remove().unwrap();
@@ -657,7 +659,7 @@ mod tests {
         // object and calling default_vmm() is the easiest way to create one.
         let vmm = default_vmm();
         let device_manager_state: device_manager::DevicesState =
-            Snapshot::deserialize(&mut buf.as_slice()).unwrap();
+            Snapshot::load(&mut buf.as_slice()).unwrap().data;
         let vm_resources = &mut VmResources::default();
         let restore_args = PciDevicesConstructorArgs {
             vm: vmm.vm.clone(),

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -676,7 +676,9 @@ mod tests {
             let entropy_config = EntropyDeviceConfig::default();
             insert_entropy_device(&mut vmm, &mut cmdline, &mut event_manager, entropy_config);
 
-            Snapshot::serialize(&mut buf.as_mut_slice(), &vmm.device_manager.save()).unwrap();
+            Snapshot::new(vmm.device_manager.save())
+                .save(&mut buf.as_mut_slice())
+                .unwrap();
         }
 
         tmp_sock_file.remove().unwrap();
@@ -684,7 +686,7 @@ mod tests {
         let mut event_manager = EventManager::new().expect("Unable to create EventManager");
         let vmm = default_vmm();
         let device_manager_state: device_manager::DevicesState =
-            Snapshot::deserialize(&mut buf.as_slice()).unwrap();
+            Snapshot::load(&mut buf.as_slice()).unwrap().data;
         let vm_resources = &mut VmResources::default();
         let restore_args = MMIODevManagerConstructorArgs {
             mem: vmm.vm.guest_memory(),

--- a/src/vmm/src/devices/virtio/balloon/persist.rs
+++ b/src/vmm/src/devices/virtio/balloon/persist.rs
@@ -187,7 +187,9 @@ mod tests {
         // Create and save the balloon device.
         let balloon = Balloon::new(0x42, false, 2, false).unwrap();
 
-        Snapshot::serialize(&mut mem.as_mut_slice(), &balloon.save()).unwrap();
+        Snapshot::new(balloon.save())
+            .save(&mut mem.as_mut_slice())
+            .unwrap();
 
         // Deserialize and restore the balloon device.
         let restored_balloon = Balloon::restore(
@@ -195,7 +197,7 @@ mod tests {
                 mem: guest_mem,
                 restored_from_file: true,
             },
-            &Snapshot::deserialize(&mut mem.as_slice()).unwrap(),
+            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -171,7 +171,9 @@ mod tests {
         // Save the block device.
         let mut mem = vec![0; 4096];
 
-        Snapshot::serialize(&mut mem.as_mut_slice(), &block.save()).unwrap();
+        Snapshot::new(block.save())
+            .save(&mut mem.as_mut_slice())
+            .unwrap();
     }
 
     #[test]
@@ -214,12 +216,14 @@ mod tests {
         // Save the block device.
         let mut mem = vec![0; 4096];
 
-        Snapshot::serialize(&mut mem.as_mut_slice(), &block.save()).unwrap();
+        Snapshot::new(block.save())
+            .save(&mut mem.as_mut_slice())
+            .unwrap();
 
         // Restore the block device.
         let restored_block = VirtioBlock::restore(
             BlockConstructorArgs { mem: guest_mem },
-            &Snapshot::deserialize(&mut mem.as_slice()).unwrap(),
+            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/net/persist.rs
+++ b/src/vmm/src/devices/virtio/net/persist.rs
@@ -153,7 +153,9 @@ mod tests {
 
         // Create and save the net device.
         {
-            Snapshot::serialize(&mut mem.as_mut_slice(), &net.save()).unwrap();
+            Snapshot::new(net.save())
+                .save(&mut mem.as_mut_slice())
+                .unwrap();
 
             // Save some fields that we want to check later.
             id = net.id.clone();
@@ -173,7 +175,7 @@ mod tests {
                     mem: guest_mem,
                     mmds: mmds_ds,
                 },
-                &Snapshot::deserialize(&mut mem.as_slice()).unwrap(),
+                &Snapshot::load(&mut mem.as_slice()).unwrap().data,
             ) {
                 Ok(restored_net) => {
                     // Test that virtio specific fields are the same.

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -358,14 +358,16 @@ mod tests {
 
         let mut bytes = vec![0; 4096];
 
-        Snapshot::serialize(&mut bytes.as_mut_slice(), &queue.save()).unwrap();
+        Snapshot::new(queue.save())
+            .save(&mut bytes.as_mut_slice())
+            .unwrap();
 
         let ca = QueueConstructorArgs {
             mem,
             is_activated: true,
         };
         let restored_queue =
-            Queue::restore(ca, &Snapshot::deserialize(&mut bytes.as_slice()).unwrap()).unwrap();
+            Queue::restore(ca, &Snapshot::load(&mut bytes.as_slice()).unwrap().data).unwrap();
 
         assert_eq!(restored_queue, queue);
     }
@@ -376,9 +378,9 @@ mod tests {
         let mut mem = vec![0; 4096];
 
         let state = VirtioDeviceState::from_device(&dummy);
-        Snapshot::serialize(&mut mem.as_mut_slice(), &state).unwrap();
+        Snapshot::new(&state).save(&mut mem.as_mut_slice()).unwrap();
 
-        let restored_state: VirtioDeviceState = Snapshot::deserialize(&mut mem.as_slice()).unwrap();
+        let restored_state: VirtioDeviceState = Snapshot::load(&mut mem.as_slice()).unwrap().data;
         assert_eq!(restored_state, state);
     }
 
@@ -405,7 +407,9 @@ mod tests {
     ) {
         let mut buf = vec![0; 4096];
 
-        Snapshot::serialize(&mut buf.as_mut_slice(), &mmio_transport.save()).unwrap();
+        Snapshot::new(mmio_transport.save())
+            .save(&mut buf.as_mut_slice())
+            .unwrap();
 
         let restore_args = MmioTransportConstructorArgs {
             mem,
@@ -415,7 +419,7 @@ mod tests {
         };
         let restored_mmio_transport = MmioTransport::restore(
             restore_args,
-            &Snapshot::deserialize(&mut buf.as_slice()).unwrap(),
+            &Snapshot::load(&mut buf.as_slice()).unwrap().data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/rng/persist.rs
+++ b/src/vmm/src/devices/virtio/rng/persist.rs
@@ -85,12 +85,14 @@ mod tests {
         let mut mem = vec![0u8; 4096];
         let entropy = Entropy::new(RateLimiter::default()).unwrap();
 
-        Snapshot::serialize(&mut mem.as_mut_slice(), &entropy.save()).unwrap();
+        Snapshot::new(entropy.save())
+            .save(&mut mem.as_mut_slice())
+            .unwrap();
 
         let guest_mem = create_virtio_mem();
         let restored = Entropy::restore(
             EntropyConstructorArgs { mem: guest_mem },
-            &Snapshot::deserialize(&mut mem.as_slice()).unwrap(),
+            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -178,9 +178,9 @@ pub(crate) mod tests {
             frontend: ctx.device.save(),
         };
 
-        Snapshot::serialize(&mut mem.as_mut_slice(), &state).unwrap();
+        Snapshot::new(&state).save(&mut mem.as_mut_slice()).unwrap();
 
-        let restored_state: VsockState = Snapshot::deserialize(&mut mem.as_slice()).unwrap();
+        let restored_state: VsockState = Snapshot::load(&mut mem.as_slice()).unwrap().data;
         let mut restored_device = Vsock::restore(
             VsockConstructorArgs {
                 mem: ctx.mem.clone(),

--- a/src/vmm/src/mmds/persist.rs
+++ b/src/vmm/src/mmds/persist.rs
@@ -62,11 +62,13 @@ mod tests {
 
         let mut mem = vec![0; 4096];
 
-        Snapshot::serialize(&mut mem.as_mut_slice(), &ns.save()).unwrap();
+        Snapshot::new(ns.save())
+            .save(&mut mem.as_mut_slice())
+            .unwrap();
 
         let restored_ns = MmdsNetworkStack::restore(
             Arc::new(Mutex::new(Mmds::default())),
-            &Snapshot::deserialize(&mut mem.as_slice()).unwrap(),
+            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
         )
         .unwrap();
 

--- a/src/vmm/src/rate_limiter/persist.rs
+++ b/src/vmm/src/rate_limiter/persist.rs
@@ -116,10 +116,12 @@ mod tests {
 
         // Test serialization.
         let mut mem = vec![0; 4096];
-        Snapshot::serialize(&mut mem.as_mut_slice(), &tb.save()).unwrap();
+        Snapshot::new(tb.save())
+            .save(&mut mem.as_mut_slice())
+            .unwrap();
 
         let restored_tb =
-            TokenBucket::restore((), &Snapshot::deserialize(&mut mem.as_slice()).unwrap()).unwrap();
+            TokenBucket::restore((), &Snapshot::load(&mut mem.as_slice()).unwrap().data).unwrap();
         assert!(tb.partial_eq(&restored_tb));
     }
 
@@ -192,9 +194,11 @@ mod tests {
 
         // Test serialization.
         let mut mem = vec![0; 4096];
-        Snapshot::serialize(&mut mem.as_mut_slice(), &rate_limiter.save()).unwrap();
+        Snapshot::new(rate_limiter.save())
+            .save(&mut mem.as_mut_slice())
+            .unwrap();
         let restored_rate_limiter =
-            RateLimiter::restore((), &Snapshot::deserialize(&mut mem.as_slice()).unwrap()).unwrap();
+            RateLimiter::restore((), &Snapshot::load(&mut mem.as_slice()).unwrap().data).unwrap();
 
         assert!(
             rate_limiter

--- a/src/vmm/src/snapshot/crc.rs
+++ b/src/vmm/src/snapshot/crc.rs
@@ -28,7 +28,8 @@ use crc64::crc64;
 /// ```
 #[derive(Debug)]
 pub struct CRC64Reader<T> {
-    reader: T,
+    /// The underlying raw reader. Using this directly will bypass CRC computation!
+    pub reader: T,
     crc64: u64,
 }
 
@@ -77,7 +78,8 @@ where
 /// ```
 #[derive(Debug)]
 pub struct CRC64Writer<T> {
-    writer: T,
+    /// The underlying raw writer. Using this directly will bypass CRC computation!
+    pub writer: T,
     crc64: u64,
 }
 

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -129,8 +129,10 @@ pub(crate) mod tests {
         };
 
         let mut snapshot_data = vec![0u8; 1000];
-        Snapshot::serialize(&mut snapshot_data.as_mut_slice(), &boot_src_cfg).unwrap();
-        let restored_boot_cfg = Snapshot::deserialize(&mut snapshot_data.as_slice()).unwrap();
+        Snapshot::new(&boot_src_cfg)
+            .save(&mut snapshot_data.as_mut_slice())
+            .unwrap();
+        let restored_boot_cfg = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
         assert_eq!(boot_src_cfg, restored_boot_cfg);
     }
 }

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -433,8 +433,10 @@ mod tests {
     fn check_serde(guest_memory: &GuestMemoryMmap) {
         let mut snapshot_data = vec![0u8; 10000];
         let original_state = guest_memory.describe();
-        Snapshot::serialize(&mut snapshot_data.as_mut_slice(), &original_state).unwrap();
-        let restored_state = Snapshot::deserialize(&mut snapshot_data.as_slice()).unwrap();
+        Snapshot::new(&original_state)
+            .save(&mut snapshot_data.as_mut_slice())
+            .unwrap();
+        let restored_state = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
         assert_eq!(original_state, restored_state);
     }
 

--- a/src/vmm/src/vstate/resources.rs
+++ b/src/vmm/src/vstate/resources.rs
@@ -280,8 +280,10 @@ mod tests {
 
     fn clone_allocator(allocator: &ResourceAllocator) -> ResourceAllocator {
         let mut buf = vec![0u8; 1024];
-        Snapshot::serialize(&mut buf.as_mut_slice(), &allocator.save()).unwrap();
-        let restored_state: ResourceAllocator = Snapshot::deserialize(&mut buf.as_slice()).unwrap();
+        Snapshot::new(allocator.save())
+            .save(&mut buf.as_mut_slice())
+            .unwrap();
+        let restored_state: ResourceAllocator = Snapshot::load(&mut buf.as_slice()).unwrap().data;
         ResourceAllocator::restore((), &restored_state).unwrap()
     }
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -1044,9 +1044,11 @@ pub(crate) mod tests {
         };
 
         let state = vm.save_state().unwrap();
-        Snapshot::serialize(&mut snapshot_data.as_mut_slice(), &state).unwrap();
+        Snapshot::new(state)
+            .save(&mut snapshot_data.as_mut_slice())
+            .unwrap();
 
-        let restored_state: VmState = Snapshot::deserialize(&mut snapshot_data.as_slice()).unwrap();
+        let restored_state: VmState = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
         vm.restore_state(&restored_state).unwrap();
 
         let mut resource_allocator = vm.resource_allocator();

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -235,11 +235,8 @@ fn verify_create_snapshot(is_diff: bool, pci_enabled: bool) -> (TempFile, TempFi
     vmm.lock().unwrap().stop(FcExitCode::Ok);
 
     // Check that we can deserialize the microVM state from `snapshot_file`.
-    let snapshot_path = snapshot_file.as_path().to_path_buf();
-    let snapshot_file_metadata = std::fs::metadata(snapshot_path).unwrap();
-    let snapshot_len = snapshot_file_metadata.len().try_into().unwrap();
-    let (restored_microvm_state, _) =
-        Snapshot::load::<_, MicrovmState>(&mut snapshot_file.as_file(), snapshot_len).unwrap();
+    let restored_microvm_state: MicrovmState =
+        Snapshot::load(&mut snapshot_file.as_file()).unwrap().data;
 
     assert_eq!(restored_microvm_state.vm_info, vm_info);
 
@@ -344,11 +341,8 @@ fn get_microvm_state_from_snapshot(pci_enabled: bool) -> MicrovmState {
     let (snapshot_file, _) = verify_create_snapshot(true, pci_enabled);
 
     // Deserialize the microVM state.
-    let snapshot_file_metadata = snapshot_file.as_file().metadata().unwrap();
-    let snapshot_len = snapshot_file_metadata.len() as usize;
     snapshot_file.as_file().seek(SeekFrom::Start(0)).unwrap();
-    let (state, _) = Snapshot::load(&mut snapshot_file.as_file(), snapshot_len).unwrap();
-    state
+    Snapshot::load(&mut snapshot_file.as_file()).unwrap().data
 }
 
 fn verify_load_snap_disallowed_after_boot_resources(res: VmmAction, res_name: &str) {

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -236,11 +236,7 @@ def test_load_snapshot_failure_handling(uvm_plain):
     jailed_vmstate = vm.create_jailed_resource(snapshot_vmstate)
 
     # Load the snapshot
-    expected_msg = (
-        "Load snapshot error: Failed to restore from snapshot: Failed to get snapshot "
-        "state from file: Failed to load snapshot state from file: Snapshot file is smaller "
-        "than CRC length."
-    )
+    expected_msg = 'An error occured during bincode decoding: Io { inner: Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }'
     with pytest.raises(RuntimeError, match=expected_msg):
         vm.api.snapshot_load.put(mem_file_path=jailed_mem, snapshot_path=jailed_vmstate)
 


### PR DESCRIPTION
Implement the suggestions from https://github.com/firecracker-microvm/firecracker/issues/4523 to give a cleaner API for the
snapshot module. Conceptually, the change is that we now store the thing
we are snapshotting inside of the `Snapshot` struct.
Implementation-wise, this allows us to deserialize the snapshot data in
a single pass (instead of having to read it twice, once for
deserialization and once for CRC validation), which means we do not have
to first query the snapshot file for the size of the snapshot.

Closes https://github.com/firecracker-microvm/firecracker/pull/4691, https://github.com/firecracker-microvm/firecracker/issues/4523, https://github.com/firecracker-microvm/firecracker/pull/5195

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
