### PR TITLE
[feature/pcie] prevent unnecessary fmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ exit = "warn"
 tests_outside_test_module = "warn"
 assertions_on_result_states = "warn"
 error_impl_error = "warn"
+or_fun_call = "warn"
 
 [profile.dev]
 panic = "abort"

--- a/src/clippy-tracing/src/main.rs
+++ b/src/clippy-tracing/src/main.rs
@@ -260,7 +260,7 @@ impl Error for ExecError {}
 fn exec() -> Result<Option<(PathBuf, usize, usize)>, ExecError> {
     let args = CommandLineArgs::parse();
 
-    let path = args.path.unwrap_or(PathBuf::from("."));
+    let path = args.path.unwrap_or_else(|| PathBuf::from("."));
     for entry_res in WalkDir::new(path).follow_links(true) {
         let entry = entry_res.map_err(ExecError::Entry)?;
         let entry_path = entry.into_path();

--- a/src/cpu-template-helper/src/template/verify/mod.rs
+++ b/src/cpu-template-helper/src/template/verify/mod.rs
@@ -43,7 +43,7 @@ where
     for (key, template_value_filter) in template {
         let config_value_filter = config
             .get(&key)
-            .ok_or(VerifyError::KeyNotFound(key.to_string()))?;
+            .ok_or_else(|| VerifyError::KeyNotFound(key.to_string()))?;
 
         let template_value = template_value_filter.value & template_value_filter.filter;
         let config_value = config_value_filter.value & template_value_filter.filter;

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -170,9 +170,9 @@ impl InterruptSourceGroup for MsiVectorGroup {
 
     fn trigger(&self, index: InterruptIndex) -> vm_device::interrupt::Result<()> {
         self.notifier(index)
-            .ok_or_else(|| std::io::Error::other(format!(
-                "trigger: invalid interrupt index {index}"
-            )))?
+            .ok_or_else(|| {
+                std::io::Error::other(format!("trigger: invalid interrupt index {index}"))
+            })?
             .write(1)
     }
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -170,7 +170,7 @@ impl InterruptSourceGroup for MsiVectorGroup {
 
     fn trigger(&self, index: InterruptIndex) -> vm_device::interrupt::Result<()> {
         self.notifier(index)
-            .ok_or(std::io::Error::other(format!(
+            .ok_or_else(|| std::io::Error::other(format!(
                 "trigger: invalid interrupt index {index}"
             )))?
             .write(1)


### PR DESCRIPTION
## Changes

Use `.ok_or_else` when the `Error` needs to be computed by a function call, which may be expensive.
I fixed it in these places:
 - MSI interrupt trigger
 - clippy tracing
 - cpu template helper

And I've added a clippy rule for the future.

## Reason

I was looking at perf traces for a different thing and noticed an unexpected String format in a good path during interrupt trigger:
```
-    1.16%     0.29%  firecracker  firecracker        [.] <vmm::devices::virtio::transport::pci::device::VirtioInterruptMsix as vmm::devices::virtio::transport::VirtioInterrupt>::trigger                                                     ▒
   - 0.88% <vmm::devices::virtio::transport::pci::device::VirtioInterruptMsix as vmm::devices::virtio::transport::VirtioInterrupt>::trigger                                                                                                    ▒
      - <vmm::vstate::vm::MsiVectorGroup as vm_device::interrupt::InterruptSourceGroup>::trigger                                                                                                                                               ▒
         + 0.71% alloc::fmt::format::format_inner                                                                                                                                                                                              ▒
           0.05% enframe                                                                                                                                                                                                                       ▒
           0.05% __lock                                                                                                                                                                                                                        ▒
           0.01% __libc_malloc_impl                                                                                                                                                                                                            ▒
           0.01% size_to_class                                                                                                                                                                                                                 ▒
           0.00% get_stride                                                                                                                                                                                                                    ▒
           0.00% rdlock                                                                                                                                                                                                                        ▒
           0.00% core::ptr::drop_in_place<alloc::boxed::convert::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<dyn core::error::Error+core::marker::Sync+core::marker::Send>>::from::StringError>                     ▒
           0.00% default_malloc                                                                                                                                                                                                                ▒
           0.00% core::fmt::write                                                                                                                                                                                                              ▒
   + 0.28% libc_start_main_stage2                                                                                                                                                                                                              ▒
   + 0.00% 0x500007ffe                                                                                                                                                                                                                         ▒
```

This wastes 0.71% of the CPU consumed by Firecracker during the block io performance tests, which is very little, but the change is also a one-liner.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
