### PR TITLE
dependabot: move rust-vmm updates to their own PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
       day: "monday"
     allow:
       - dependency-type: "all"
-    open-pull-requests-limit: 100
     groups:
       rust-vmm:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,17 @@ updates:
       - dependency-type: "all"
     open-pull-requests-limit: 100
     groups:
+      rust-vmm:
+        patterns:
+          - "vmm-sys-util"
+          - "kvm-bindings"
+          - "kvm-ioctls"
+          - "vm-memory"
+          - "vhost"
+          - "linux-loader"
+          - "vm-allocator"
+          - "event-manager"
+          - "vm-superio"
       firecracker:
         patterns:
           - "*"


### PR DESCRIPTION


rust-vmm deps have to be updated in lockstep most of the time, due to
tight inter-dependencies. However, releasing new versions of all
rust-vmm crates often takes time, and having dependabot include partial
rust-vmm updates in its big PR of the week just results in broken
dependabot PRs. Thus, just sort out the rust-vmm dependencies into a
separate PR

I've tested this over in my fork, and it produced https://github.com/roypat/firecracker/pull/124

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
