### PR TITLE
dependabot: explicitly exclude rust-vmm deps from firecracker group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,13 @@ updates:
       firecracker:
         patterns:
           - "*"
+        exclude-patterns:
+          - "vmm-sys-util"
+          - "kvm-bindings"
+          - "kvm-ioctls"
+          - "vm-memory"
+          - "vhost"
+          - "linux-loader"
+          - "vm-allocator"
+          - "event-manager"
+          - "vm-superio"


### PR DESCRIPTION
Apparently, if a rust-vmm dep (currently vmm-sys-util) is included in a
PR for the firecracker group _once_, it will indefinitely be stuck in
there. So explicitly exclude these deps from that group, in hopes of
getting dependabot to understand that it should split the current PR
into two.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
