### PR TITLE
fix(tests/cpu-monitor): use psutil.Process for threads to fix errors

### DIFF
--- a/tests/host_tools/cpu_load.py
+++ b/tests/host_tools/cpu_load.py
@@ -4,6 +4,8 @@
 import time
 from threading import Thread
 
+import psutil
+
 from framework import utils
 
 
@@ -61,8 +63,9 @@ class CpuLoadMonitor(Thread):
 
         It is up to the caller to check the queue.
         """
+        process = psutil.Process(self._process_pid)
         while not self._should_stop:
-            utilization = utils.get_cpu_utilization(self._process_pid)
+            utilization = utils.get_cpu_utilization(process)
 
             try:
                 fc_thread_util = utilization["firecracker"]


### PR DESCRIPTION
## Changes
Use a single psutil.Process to verify the process still exists, and extend it with better support for threads using psutil.Process to retrieve their information.

## Reason

The previous fix didn't work because the read can also return `ProcessLookupError`. There is also the issue of pid recycling.

## Testing
Example:
```
integration_tests/performance/test_block.py::test_block_performance[Sync-vmlinux-5.10.238-True-libaio-bs4096-randwrite-1vcpu] defaultdict(<class 'list'>, {'fc_vcpu 0': [99.95329178526431, 99.95998553854952, 100.91893865958598, 99.95372053973948, 99.95989024751518, 99.96019994404158, 99.96074787336654, 99.9602237669306, 99.96100992864535, 99.95634078590423, 99.96043817344481, 99.96077169651657, 99.95996171577396, 99.96024758983143, 99.9610575752075, 99.959890247515, 99.96036670450454, 99.9598902475152, 99.96053346552394, 99.96077169651662, 99.96105757520755, 99.95905645871258, 99.96046199644755, 99.960152298297, 97.96083252045239, 100.95780491065754, 99.96086698923239, 99.95917557054712, 99.96003318413437, 99.96017612116383], 'firecracker': [75.96450175680081, 75.96958900929774, 74.93980593533604, 74.96529040480463, 74.96991768563629, 75.96975195747163, 75.9701683837586, 74.9701678251981, 76.96997764505684, 75.96681899728692, 74.97032863008363, 75.97018648935281, 74.96997128683046, 75.96978816827192, 75.9704037571575, 75.96951658811142, 74.97027502837844, 74.96991768563629, 75.97000543379829, 75.97018648935264, 75.97040375715775, 74.96929234403441, 75.96995111730011, 75.9697157467057, 74.97002488810134, 75.96824923970296, 75.9702589118162, 74.96938167791045, 75.9696252199425, 74.97013209087298], 'fc_api': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]})
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
