### PR TITLE
fix: use temporary buffer for loading vmstate file

### DIFF
--- a/src/vmm/src/arch/aarch64/regs.rs
+++ b/src/vmm/src/arch/aarch64/regs.rs
@@ -547,7 +547,9 @@ mod tests {
         let mut buf = vec![0; 10000];
 
         Snapshot::new(&v).save(&mut buf.as_mut_slice()).unwrap();
-        let restored: Aarch64RegisterVec = Snapshot::load(&mut buf.as_slice()).unwrap().data;
+        let restored: Aarch64RegisterVec = Snapshot::load_without_crc_check(buf.as_slice())
+            .unwrap()
+            .data;
 
         for (old, new) in v.iter().zip(restored.iter()) {
             assert_eq!(old, new);
@@ -576,7 +578,7 @@ mod tests {
 
         // Total size of registers according IDs are 16 + 16 = 32,
         // but actual data size is 8 + 16 = 24.
-        Snapshot::<Aarch64RegisterVec>::load(&mut buf.as_slice()).unwrap_err();
+        Snapshot::<Aarch64RegisterVec>::load_without_crc_check(buf.as_slice()).unwrap_err();
     }
 
     #[test]
@@ -598,7 +600,7 @@ mod tests {
         Snapshot::new(v).save(&mut buf.as_mut_slice()).unwrap();
 
         // 4096 bit wide registers are not supported.
-        Snapshot::<Aarch64RegisterVec>::load(&mut buf.as_slice()).unwrap_err();
+        Snapshot::<Aarch64RegisterVec>::load_without_crc_check(buf.as_slice()).unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/arch/x86_64/vm.rs
+++ b/src/vmm/src/arch/x86_64/vm.rs
@@ -321,7 +321,9 @@ mod tests {
         Snapshot::new(state)
             .save(&mut snapshot_data.as_mut_slice())
             .unwrap();
-        let restored_state: VmState = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
+        let restored_state: VmState = Snapshot::load_without_crc_check(snapshot_data.as_slice())
+            .unwrap()
+            .data;
 
         vm.restore_state(&restored_state).unwrap();
     }

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -659,7 +659,9 @@ mod tests {
         // object and calling default_vmm() is the easiest way to create one.
         let vmm = default_vmm();
         let device_manager_state: device_manager::DevicesState =
-            Snapshot::load(&mut buf.as_slice()).unwrap().data;
+            Snapshot::load_without_crc_check(buf.as_slice())
+                .unwrap()
+                .data;
         let vm_resources = &mut VmResources::default();
         let restore_args = PciDevicesConstructorArgs {
             vm: vmm.vm.clone(),

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -680,7 +680,9 @@ mod tests {
         let mut event_manager = EventManager::new().expect("Unable to create EventManager");
         let vmm = default_vmm();
         let device_manager_state: device_manager::DevicesState =
-            Snapshot::load(&mut buf.as_slice()).unwrap().data;
+            Snapshot::load_without_crc_check(buf.as_slice())
+                .unwrap()
+                .data;
         let vm_resources = &mut VmResources::default();
         let restore_args = MMIODevManagerConstructorArgs {
             mem: vmm.vm.guest_memory(),

--- a/src/vmm/src/devices/virtio/balloon/persist.rs
+++ b/src/vmm/src/devices/virtio/balloon/persist.rs
@@ -196,7 +196,9 @@ mod tests {
                 mem: guest_mem,
                 restored_from_file: true,
             },
-            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -223,7 +223,9 @@ mod tests {
         // Restore the block device.
         let restored_block = VirtioBlock::restore(
             BlockConstructorArgs { mem: guest_mem },
-            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/net/persist.rs
+++ b/src/vmm/src/devices/virtio/net/persist.rs
@@ -175,7 +175,9 @@ mod tests {
                     mem: guest_mem,
                     mmds: mmds_ds,
                 },
-                &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+                &Snapshot::load_without_crc_check(mem.as_slice())
+                    .unwrap()
+                    .data,
             ) {
                 Ok(restored_net) => {
                     // Test that virtio specific fields are the same.

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -366,8 +366,13 @@ mod tests {
             mem,
             is_activated: true,
         };
-        let restored_queue =
-            Queue::restore(ca, &Snapshot::load(&mut bytes.as_slice()).unwrap().data).unwrap();
+        let restored_queue = Queue::restore(
+            ca,
+            &Snapshot::load_without_crc_check(bytes.as_slice())
+                .unwrap()
+                .data,
+        )
+        .unwrap();
 
         assert_eq!(restored_queue, queue);
     }
@@ -380,7 +385,9 @@ mod tests {
         let state = VirtioDeviceState::from_device(&dummy);
         Snapshot::new(&state).save(&mut mem.as_mut_slice()).unwrap();
 
-        let restored_state: VirtioDeviceState = Snapshot::load(&mut mem.as_slice()).unwrap().data;
+        let restored_state: VirtioDeviceState = Snapshot::load_without_crc_check(mem.as_slice())
+            .unwrap()
+            .data;
         assert_eq!(restored_state, state);
     }
 
@@ -419,7 +426,9 @@ mod tests {
         };
         let restored_mmio_transport = MmioTransport::restore(
             restore_args,
-            &Snapshot::load(&mut buf.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(buf.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/rng/persist.rs
+++ b/src/vmm/src/devices/virtio/rng/persist.rs
@@ -92,7 +92,9 @@ mod tests {
         let guest_mem = create_virtio_mem();
         let restored = Entropy::restore(
             EntropyConstructorArgs { mem: guest_mem },
-            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -180,7 +180,9 @@ pub(crate) mod tests {
 
         Snapshot::new(&state).save(&mut mem.as_mut_slice()).unwrap();
 
-        let restored_state: VsockState = Snapshot::load(&mut mem.as_slice()).unwrap().data;
+        let restored_state: VsockState = Snapshot::load_without_crc_check(mem.as_slice())
+            .unwrap()
+            .data;
         let mut restored_device = Vsock::restore(
             VsockConstructorArgs {
                 mem: ctx.mem.clone(),

--- a/src/vmm/src/mmds/persist.rs
+++ b/src/vmm/src/mmds/persist.rs
@@ -68,7 +68,9 @@ mod tests {
 
         let restored_ns = MmdsNetworkStack::restore(
             Arc::new(Mutex::new(Mmds::default())),
-            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -676,8 +676,9 @@ mod tests {
             .save(&mut buf.as_mut_slice())
             .unwrap();
 
-        let restored_microvm_state: MicrovmState =
-            Snapshot::load(&mut buf.as_slice()).unwrap().data;
+        let restored_microvm_state: MicrovmState = Snapshot::load_without_crc_check(buf.as_slice())
+            .unwrap()
+            .data;
 
         assert_eq!(restored_microvm_state.vm_info, microvm_state.vm_info);
         assert_eq!(

--- a/src/vmm/src/rate_limiter/persist.rs
+++ b/src/vmm/src/rate_limiter/persist.rs
@@ -120,8 +120,13 @@ mod tests {
             .save(&mut mem.as_mut_slice())
             .unwrap();
 
-        let restored_tb =
-            TokenBucket::restore((), &Snapshot::load(&mut mem.as_slice()).unwrap().data).unwrap();
+        let restored_tb = TokenBucket::restore(
+            (),
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
+        )
+        .unwrap();
         assert!(tb.partial_eq(&restored_tb));
     }
 
@@ -197,8 +202,13 @@ mod tests {
         Snapshot::new(rate_limiter.save())
             .save(&mut mem.as_mut_slice())
             .unwrap();
-        let restored_rate_limiter =
-            RateLimiter::restore((), &Snapshot::load(&mut mem.as_slice()).unwrap().data).unwrap();
+        let restored_rate_limiter = RateLimiter::restore(
+            (),
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
+        )
+        .unwrap();
 
         assert!(
             rate_limiter

--- a/src/vmm/src/snapshot/mod.rs
+++ b/src/vmm/src/snapshot/mod.rs
@@ -187,7 +187,20 @@ impl<Data: Serialize> Snapshot<Data> {
 
 #[cfg(test)]
 mod tests {
+    use vmm_sys_util::tempfile::TempFile;
+
     use super::*;
+    use crate::persist::MicrovmState;
+
+    #[test]
+    fn test_snapshot_restore() {
+        let state = MicrovmState::default();
+        let file = TempFile::new().unwrap();
+
+        Snapshot::new(state).save(&mut file.as_file()).unwrap();
+        file.as_file().seek(SeekFrom::Start(0)).unwrap();
+        Snapshot::<MicrovmState>::load(&mut file.as_file()).unwrap();
+    }
 
     #[test]
     fn test_parse_version_from_file() {

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -132,7 +132,9 @@ pub(crate) mod tests {
         Snapshot::new(&boot_src_cfg)
             .save(&mut snapshot_data.as_mut_slice())
             .unwrap();
-        let restored_boot_cfg = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
+        let restored_boot_cfg = Snapshot::load_without_crc_check(snapshot_data.as_slice())
+            .unwrap()
+            .data;
         assert_eq!(boot_src_cfg, restored_boot_cfg);
     }
 }

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -436,7 +436,9 @@ mod tests {
         Snapshot::new(&original_state)
             .save(&mut snapshot_data.as_mut_slice())
             .unwrap();
-        let restored_state = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
+        let restored_state = Snapshot::load_without_crc_check(snapshot_data.as_slice())
+            .unwrap()
+            .data;
         assert_eq!(original_state, restored_state);
     }
 

--- a/src/vmm/src/vstate/resources.rs
+++ b/src/vmm/src/vstate/resources.rs
@@ -283,7 +283,9 @@ mod tests {
         Snapshot::new(allocator.save())
             .save(&mut buf.as_mut_slice())
             .unwrap();
-        let restored_state: ResourceAllocator = Snapshot::load(&mut buf.as_slice()).unwrap().data;
+        let restored_state: ResourceAllocator = Snapshot::load_without_crc_check(buf.as_slice())
+            .unwrap()
+            .data;
         ResourceAllocator::restore((), &restored_state).unwrap()
     }
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -1048,7 +1048,9 @@ pub(crate) mod tests {
             .save(&mut snapshot_data.as_mut_slice())
             .unwrap();
 
-        let restored_state: VmState = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
+        let restored_state: VmState = Snapshot::load_without_crc_check(snapshot_data.as_slice())
+            .unwrap()
+            .data;
         vm.restore_state(&restored_state).unwrap();
 
         let mut resource_allocator = vm.resource_allocator();

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -236,8 +236,9 @@ def test_load_snapshot_failure_handling(uvm_plain):
     jailed_vmstate = vm.create_jailed_resource(snapshot_vmstate)
 
     # Load the snapshot
-    expected_msg = 'An error occured during bincode decoding: Io { inner: Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }'
-    with pytest.raises(RuntimeError, match=expected_msg):
+    with pytest.raises(
+        RuntimeError, match="Snapshot file is not long enough to even contain the CRC"
+    ):
         vm.api.snapshot_load.put(mem_file_path=jailed_mem, snapshot_path=jailed_vmstate)
 
     vm.mark_killed()


### PR DESCRIPTION
In commit e7504ae ("refactor: cleanup vmm::snapshot module"),
firecracker started reading the snapshot vmstate file in a single pass
instead of first loading it into a Vec and then deserializing. This
seems to have caused some performance regression due to the deserializer
doing many successive reads, resulting in many read(2) syscalls.
Fix this by going back to first reading the snapshot file into a buffer,
and then deserializing from slice instead.

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
