### PR TITLE
test(vulnerabilities): ignore host checks on ubuntu

### DIFF
--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -110,6 +110,11 @@ def download_spectre_meltdown_checker(tmp_path_factory):
     global_props.buildkite_pr,
     reason="Test depends solely on factors external to GitHub repository",
 )
+# Temporary suppression for Ubuntu 6.14 kernel
+@pytest.mark.skipif(
+    "Ubuntu" in global_props.os and global_props.host_linux_version == "6.14",
+    reason="Ubuntu does not enable CONFIG_MITIGATION_GDS on 6.14 kernel",
+)
 def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
     """Test with the spectre / meltdown checker on host."""
     report = spectre_meltdown_checker.get_report_for_host()
@@ -120,6 +125,11 @@ def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
 @pytest.mark.skipif(
     global_props.buildkite_pr,
     reason="Test depends solely on factors external to GitHub repository",
+)
+# Temporary suppression for Ubuntu 6.14 kernel
+@pytest.mark.skipif(
+    "Ubuntu" in global_props.os and global_props.host_linux_version == "6.14",
+    reason="Ubuntu does not enable CONFIG_MITIGATION_GDS on 6.14 kernel",
 )
 def test_vulnerabilities_on_host():
     """Test vulnerability files on host."""


### PR DESCRIPTION
## Changes

Suppress the check until the distro updates the kernel configuration.

## Reason

Ubuntu 6.14 kernel is configured with `CONFIG_MITIGATION_GDS` making `/sys/devices/system/cpu/vulnerabilities/gather_data_sampling` report `Vulnerable`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- ~~[ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.~~
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
