### PR TITLE
[do-not-merge] Rebase feature/virtio-mem on top of main

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -178,22 +178,6 @@ them according to your needs.
 The relatively high FD usage is expected and correct. Firecracker heavily relies
 on event file descriptors to drive device emulation.
 
-### How does network interface numbering work?
-
-There is no relation between the numbering of the `/network-interface` API calls
-and the number of the network interface in the guest. Rather, it is usually the
-order of network interface creation that determines the number in the guest (but
-this depends on the distribution).
-
-For example, when you create two network interfaces by calling
-`/network-interfaces/1` and then `/network-interfaces/0`, it may result in this
-mapping:
-
-```console
-/network-interfaces/1 -> eth0
-/network-interfaces/0 -> eth1
-```
-
 ### How can I gracefully reboot the guest? How can I gracefully poweroff the guest?
 
 Firecracker does not virtualize guest power management, therefore operations

--- a/docs/api_requests/actions.md
+++ b/docs/api_requests/actions.md
@@ -44,15 +44,15 @@ i8042 controller. Driver support for both these devices needs to be present in
 the guest OS. For Linux, that means the guest kernel needs `CONFIG_SERIO_I8042`
 and `CONFIG_KEYBOARD_ATKBD`.
 
-**Note1**: at boot time, the Linux driver for i8042 spends a few tens of
-milliseconds probing the device. This can be disabled by using these kernel
-command line parameters:
-
-```console
-i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd
-```
-
-**Note2** This action is only supported on `x86_64` architecture.
+> [!NOTE]
+>
+> At boot time, the Linux driver for i8042 spends a few tens of milliseconds
+> probing the device. This can be disabled by using these kernel command line
+> parameters:
+>
+> ```console
+> i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd
+> ```
 
 ### SendCtrlAltDel Example
 

--- a/docs/api_requests/block-io-engine.md
+++ b/docs/api_requests/block-io-engine.md
@@ -25,8 +25,10 @@ with the `io_engine` field taking two possible values:
 The `Sync` variant is the default, in order to provide backwards compatibility
 with older Firecracker versions.
 
-**Note** [vhost-user block device](./block-vhost-user.md) is another option for
-block IO that requires an external backend process.
+> [!NOTE]
+>
+> [vhost-user block device](./block-vhost-user.md) is another option for block
+> IO that requires an external backend process.
 
 ## Example configuration
 

--- a/docs/api_requests/block-vhost-user.md
+++ b/docs/api_requests/block-vhost-user.md
@@ -154,9 +154,11 @@ potential for the guest to exercise issues in the backend codebase to trigger
 undesired behaviours. Users should consider running their backend in a jailer or
 applying other adequate security measures to restrict it.
 
-**Note** [Firecracker jailer](../jailer.md) is currently only capable of running
-Firecracker as the binary. Vhost-user block device users are expected to use
-another jailer to run the backend.
+> [!NOTE]
+>
+> [Firecracker jailer](../jailer.md) is currently only capable of running
+> Firecracker as the binary. Vhost-user block device users are expected to use
+> another jailer to run the backend.
 
 It is also recommended to use proactive security measures like running a
 Virtio-level fuzzer in the guest during testing to make sure that the backend
@@ -221,12 +223,16 @@ curl --unix-socket ${fc_socket} -i \
          }"
 ```
 
-**Note** Unlike Virtio block device, there is no way to configure a `readonly`
-vhost-user drive on the Firecracker side. Instead, this configuration belongs to
-the backend. Whenever the backend advertises the `VIRTIO_BLK_F_RO` feature,
-Firecracker will accept it, and the device will act as readonly.
+> [!NOTE]
+>
+> Unlike Virtio block device, there is no way to configure a `readonly`
+> vhost-user drive on the Firecracker side. Instead, this configuration belongs
+> to the backend. Whenever the backend advertises the `VIRTIO_BLK_F_RO` feature,
+> Firecracker will accept it, and the device will act as readonly.
 
-**Note** Whenever a `PUT` request is sent to the `/drives` endpoint for a
-vhost-user device with the `id` that already exists, Firecracker will close the
-existing connection to the backend and will open a new one. Users may need to
-restart their backend if they do so.
+> [!NOTE]
+>
+> Whenever a `PUT` request is sent to the `/drives` endpoint for a vhost-user
+> device with the `id` that already exists, Firecracker will close the existing
+> connection to the backend and will open a new one. Users may need to restart
+> their backend if they do so.

--- a/docs/api_requests/patch-network-interface.md
+++ b/docs/api_requests/patch-network-interface.md
@@ -58,9 +58,11 @@ Accept: application/json
 The full specification of the data structures available for this call can be
 found in our [OpenAPI spec](../../src/firecracker/swagger/firecracker.yaml).
 
-**Note**: The data provided for the update is merged with the existing data. In
-the above example, the RX rate limit is updated, but the TX rate limit remains
-unchanged.
+> [!NOTE]
+>
+> The data provided for the update is merged with the existing data. In the
+> above example, the RX rate limit is updated, but the TX rate limit remains
+> unchanged.
 
 ## Removing Rate Limiting
 

--- a/docs/cpu_templates/cpu-template-helper.md
+++ b/docs/cpu_templates/cpu-template-helper.md
@@ -38,14 +38,17 @@ process as Firecacker and capturing them in the state just before booting a
 guest. More details about the preboot process can be found
 [here](boot-protocol.md) and [here](cpuid-normalization.md).
 
-> **Note** Some MSRs and ARM registers are not included in the output, since
-> they are not reasonable to modify with CPU templates. The full list of them
-> can be found in [Appendix](#appendix).
+> [!NOTE]
+>
+> Some MSRs and ARM registers are not included in the output, since they are not
+> reasonable to modify with CPU templates. The full list of them can be found in
+> [Appendix](#appendix).
 
-> **Note** Since the output depends on underlying hardware and software stack
-> (BIOS, CPU, kernel, Firecracker), it is required to dump guest CPU
-> configuration on each combination when creating a custom CPU template
-> targetting them all.
+> [!NOTE]
+>
+> Since the output depends on underlying hardware and software stack (BIOS, CPU,
+> kernel, Firecracker), it is required to dump guest CPU configuration on each
+> combination when creating a custom CPU template targeting them all.
 
 #### Strip command
 
@@ -85,9 +88,11 @@ When a template is specified both through `--template` and in Firecracker
 configuration file provided via `--config`, the template specified with
 `--template` takes precedence.
 
-> **Note** This command does not ensure that the contents of the template are
-> sensible. Thus, users need to make sure that the template does not have any
-> inconsistent entries and does not crash guests.
+> [!NOTE]
+>
+> This command does not ensure that the contents of the template are sensible.
+> Thus, users need to make sure that the template does not have any inconsistent
+> entries and does not crash guests.
 
 ### Fingerprint-related commands
 
@@ -177,9 +182,11 @@ CPU features to a heterogeneous fleet consisting of multiple CPU models.
    revisions to the CPU template, and replace the fingerprint file with the new
    one.
 
-> **Note** It is recommended to review the update process of the underlying
-> stack on your infrastructure. This can help identify points that may require
-> the above validation check.
+> [!NOTE]
+>
+> It is recommended to review the update process of the underlying stack on your
+> infrastructure. This can help identify points that may require the above
+> validation check.
 
 ## Appendix
 

--- a/docs/cpu_templates/cpu-templates.md
+++ b/docs/cpu_templates/cpu-templates.md
@@ -16,13 +16,17 @@ guest. A real world use case for this is representing a heterogeneous fleet (a
 fleet consisting of multiple CPU models) as a homogeneous fleet, so the guests
 will experience a consistent feature set supported by the host.
 
-> **Note** Representing one CPU vendor as another CPU vendor is not supported.
+> [!NOTE]
+>
+> Representing one CPU vendor as another CPU vendor is not supported.
 
-> **Note** CPU templates shall not be used as a security protection against
-> malicious guests. Disabling a feature in a CPU template does not generally
-> make it completely unavailable to the guest. For example, disabling a feature
-> related to an instruction set will indicate to the guest that the feature is
-> not supported, but the guest may still be able to execute corresponding
+> [!NOTE]
+>
+> CPU templates shall not be used as a security protection against malicious
+> guests. Disabling a feature in a CPU template does not generally make it
+> completely unavailable to the guest. For example, disabling a feature related
+> to an instruction set will indicate to the guest that the feature is not
+> supported, but the guest may still be able to execute corresponding
 > instructions if it does not obey the feature bit.
 
 Firecracker supports two types of CPU templates:
@@ -32,15 +36,19 @@ Firecracker supports two types of CPU templates:
 - Custom CPU templates - users can create their own CPU templates in json format
   and pass them to Firecracker
 
-> **Note** Static CPU templates are deprecated starting from v1.5.0 and will be
-> removed in accordance with our deprecation policy. Even after the removal,
-> custom CPU templates are available as an improved iteration of static CPU
-> templates. For more information about the transition from static CPU templates
-> to custom CPU templates, please refer to
+> [!NOTE]
+>
+> Static CPU templates are deprecated starting from v1.5.0 and will be removed
+> in accordance with our deprecation policy. Even after the removal, custom CPU
+> templates are available as an improved iteration of static CPU templates. For
+> more information about the transition from static CPU templates to custom CPU
+> templates, please refer to
 > [this GitHub discussion](https://github.com/firecracker-microvm/firecracker/discussions/4135).
 
-> **Note** CPU templates for ARM (both static and custom) require the following
-> patch to be available in the host kernel:
+> [!NOTE]
+>
+> CPU templates for ARM (both static and custom) require the following patch to
+> be available in the host kernel:
 > [Support writable CPU ID registers from userspace](https://lore.kernel.org/kvm/20230212215830.2975485-1-jingzhangos@google.com/#t).
 > Otherwise KVM will fail to write to the ARM registers.
 
@@ -104,21 +112,27 @@ curl --unix-socket /tmp/firecracker.socket -i  \
 Users can create their own CPU templates by creating a json file containing
 modifiers for CPUID, MSRs or ARM registers.
 
-> **Note** Creating custom CPU templates requires expert knowledge of CPU
-> architectures. Custom CPU templates must be tested thoroughly before use in
-> production. An inappropriate configuration may lead to guest crashes or making
-> guests vulnerable to security attacks. For example, if a CPU template signals
-> a hardware vulnerability mitigation to the guest while the mitigation is in
-> fact not supported by the hardware, the guest may decide to disable
-> corresponding software mitigations which will make the guest vulnerable.
+> [!NOTE]
+>
+> Creating custom CPU templates requires expert knowledge of CPU architectures.
+> Custom CPU templates must be tested thoroughly before use in production. An
+> inappropriate configuration may lead to guest crashes or making guests
+> vulnerable to security attacks. For example, if a CPU template signals a
+> hardware vulnerability mitigation to the guest while the mitigation is in fact
+> not supported by the hardware, the guest may decide to disable corresponding
+> software mitigations which will make the guest vulnerable.
 
-> **Note** Having MSRs or ARM registers in the custom CPU template does not
-> affect access permissions that guests will have to those registers. The access
-> control is handled by KVM and is not influenced by CPU templates.
+> [!NOTE]
+>
+> Having MSRs or ARM registers in the custom CPU template does not affect access
+> permissions that guests will have to those registers. The access control is
+> handled by KVM and is not influenced by CPU templates.
 
-> **Note** When setting guest configuration, KVM may reject setting some bits
-> quietly. This is user's responsibility to make sure that their custom CPU
-> template is applied as expected even if Firecracker does not report an error.
+> [!NOTE]
+>
+> When setting guest configuration, KVM may reject setting some bits quietly.
+> This is user's responsibility to make sure that their custom CPU template is
+> applied as expected even if Firecracker does not report an error.
 
 In order to assist with creation and usage of CPU templates, there exists a CPU
 template helper tool. More details can be found [here](cpu-template-helper.md).
@@ -216,8 +230,10 @@ the
 The full description of the custom CPU templates language can be found
 [here](schema.json).
 
-> **Note** You can also use `_` to visually separate parts of a bitmap. So
-> instead of writing: `0b0000xxxx`, it can be `0b0000_xxxx`.
+> [!NOTE]
+>
+> You can also use `_` to visually separate parts of a bitmap. So instead of
+> writing: `0b0000xxxx`, it can be `0b0000_xxxx`.
 
 #### Expansion of contracted bitmaps
 

--- a/docs/kernel-policy.md
+++ b/docs/kernel-policy.md
@@ -14,10 +14,12 @@ years**. At least 2 major guest and host versions will be supported at any time.
 When support is added for a third kernel version, the oldest will be deprecated
 and removed in a following release, after its minimum end of support date.
 
-**Note** While other versions and other kernel configs might work, they are not
-periodically validated in our test suite, and using them might result in
-unexpected behaviour. Starting with release `v1.0` each major and minor release
-will specify the supported kernel versions.
+> [!NOTE]
+>
+> While other versions and other kernel configs might work, they are not
+> periodically validated in our test suite, and using them might result in
+> unexpected behaviour. Starting with release `v1.0` each major and minor
+> release will specify the supported kernel versions.
 
 ### Host Kernel
 
@@ -116,8 +118,10 @@ configurations for the guest kernel are:
 - `CONFIG_ACPI=y`
 - `CONFIG_PCI=y`
 
-Please note that Firecracker does not support PCI devices. The `CONFIG_PCI`
-option is needed for ACPI initialization inside the guest.
+> [!NOTE]
+>
+> Firecracker does not support PCI devices. The `CONFIG_PCI` option is needed
+> for ACPI initialization inside the guest.
 
 ACPI supersedes the legacy way of booting a microVM, i.e. via MPTable and
 command line parameters for VirtIO devices.

--- a/docs/rootfs-and-kernel-setup.md
+++ b/docs/rootfs-and-kernel-setup.md
@@ -33,8 +33,10 @@ can boot:
    make menuconfig
    ```
 
-   *Note*: there are many ways of building a kernel config file, other than
-   `menuconfig`. You are free to use whichever one you choose.
+> [!NOTE]
+>
+> There are many ways of building a kernel config file, other than `menuconfig`.
+> You are free to use whichever one you choose.
 
 1. Build the kernel image:
 

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -38,15 +38,19 @@ also included in the respective release archive, viewable on the
 
 ## Custom filters (advanced users only)
 
-**Note 1**: This feature overrides the default filters and can be dangerous.
-Filter misconfiguration can result in abruptly terminating the process or
-disabling the seccomp security boundary altogether. We recommend using the
-default filters instead.
+> [!NOTE]
+>
+> This feature overrides the default filters and can be dangerous. Filter
+> misconfiguration can result in abruptly terminating the process or disabling
+> the seccomp security boundary altogether. We recommend using the default
+> filters instead.
 
-**Note 2**: The user is fully responsible for managing the filter files. We
-recommend using integrity checks whenever transferring/downloading files, for
-example checksums, as well as for the Firecracker binary or other artifacts, in
-order to mitigate potential man-in-the-middle attacks.
+> [!NOTE]
+>
+> The user is fully responsible for managing the filter files. We recommend
+> using integrity checks whenever transferring/downloading files, for example
+> checksums, as well as for the Firecracker binary or other artifacts, in order
+> to mitigate potential man-in-the-middle attacks.
 
 Firecracker exposes a way for advanced users to override the default filters
 with fully customisable alternatives, leveraging the same JSON/seccompiler

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -257,9 +257,11 @@ curl --unix-socket /tmp/firecracker.socket -i \
 Details about the required and optional fields can be found in the
 [swagger definition](../../src/firecracker/swagger/firecracker.yaml).
 
-*Note*: If the files indicated by `snapshot_path` and `mem_file_path` don't
-exist at the specified paths, then they will be created right before generating
-the snapshot. If they exist, the files will be truncated and overwritten.
+> [!NOTE]
+>
+> If the files indicated by `snapshot_path` and `mem_file_path` don't exist at
+> the specified paths, then they will be created right before generating the
+> snapshot. If they exist, the files will be truncated and overwritten.
 
 **Prerequisites**: The microVM is `Paused`.
 
@@ -293,19 +295,21 @@ the snapshot. If they exist, the files will be truncated and overwritten.
 For creating a diff snapshot, you should use the same API command, but with
 `snapshot_type` field set to `Diff`.
 
-*Note*: If not specified, `snapshot_type` is by default `Full`.
-
-```bash
-curl --unix-socket /tmp/firecracker.socket -i \
-    -X PUT 'http://localhost/snapshot/create' \
-    -H  'Accept: application/json' \
-    -H  'Content-Type: application/json' \
-    -d '{
-            "snapshot_type": "Diff",
-            "snapshot_path": "./snapshot_file",
-            "mem_file_path": "./mem_file",
-    }'
-```
+> [!NOTE]
+>
+> If not specified, `snapshot_type` is by default `Full`.
+>
+> ```bash
+> curl --unix-socket /tmp/firecracker.socket -i \
+>     -X PUT 'http://localhost/snapshot/create' \
+>     -H  'Accept: application/json' \
+>     -H  'Content-Type: application/json' \
+>     -d '{
+>             "snapshot_type": "Diff",
+>             "snapshot_path": "./snapshot_file",
+>             "mem_file_path": "./mem_file",
+>     }'
+> ```
 
 **Prerequisites**: The microVM is `Paused`.
 
@@ -321,8 +325,10 @@ to swap to be "in core". This potentially results in bigger memory files
 (although they are still sparse), but avoids the runtime overhead of dirty page
 logging.
 
-*Note*: Dirty page tracking negates most of the benefits of
-[huge pages](../hugepages.md#known-limitations).
+> [!NOTE]
+>
+> Dirty page tracking negates most of the benefits of
+> [huge pages](../hugepages.md#known-limitations).
 
 **Effects**:
 
@@ -337,20 +343,22 @@ logging.
     full snapshots** section apply here.
 - _on failure_: no side-effects.
 
-*Note*: This is an example of an API command that enables dirty page tracking:
-
-```bash
-curl --unix-socket /tmp/firecracker.socket -i  \
-    -X PUT 'http://localhost/machine-config' \
-    -H 'Accept: application/json'            \
-    -H 'Content-Type: application/json'      \
-    -d '{
-            "vcpu_count": 2,
-            "mem_size_mib": 1024,
-            "smt": false,
-            "track_dirty_pages": true
-    }'
-```
+> [!NOTE]
+>
+> This is an example of an API command that enables dirty page tracking:
+>
+> ```bash
+> curl --unix-socket /tmp/firecracker.socket -i  \
+>     -X PUT 'http://localhost/machine-config' \
+>     -H 'Accept: application/json'            \
+>     -H 'Content-Type: application/json'      \
+>     -d '{
+>             "vcpu_count": 2,
+>             "mem_size_mib": 1024,
+>             "smt": false,
+>             "track_dirty_pages": true
+>     }'
+> ```
 
 Enabling this support enables KVM dirty page tracking, so it comes at a cost
 (which consists of CPU cycles spent by KVM accounting for dirtied pages); it

--- a/src/vmm/src/arch/aarch64/regs.rs
+++ b/src/vmm/src/arch/aarch64/regs.rs
@@ -547,7 +547,9 @@ mod tests {
         let mut buf = vec![0; 10000];
 
         Snapshot::new(&v).save(&mut buf.as_mut_slice()).unwrap();
-        let restored: Aarch64RegisterVec = Snapshot::load(&mut buf.as_slice()).unwrap().data;
+        let restored: Aarch64RegisterVec = Snapshot::load_without_crc_check(buf.as_slice())
+            .unwrap()
+            .data;
 
         for (old, new) in v.iter().zip(restored.iter()) {
             assert_eq!(old, new);
@@ -576,7 +578,7 @@ mod tests {
 
         // Total size of registers according IDs are 16 + 16 = 32,
         // but actual data size is 8 + 16 = 24.
-        Snapshot::<Aarch64RegisterVec>::load(&mut buf.as_slice()).unwrap_err();
+        Snapshot::<Aarch64RegisterVec>::load_without_crc_check(buf.as_slice()).unwrap_err();
     }
 
     #[test]
@@ -598,7 +600,7 @@ mod tests {
         Snapshot::new(v).save(&mut buf.as_mut_slice()).unwrap();
 
         // 4096 bit wide registers are not supported.
-        Snapshot::<Aarch64RegisterVec>::load(&mut buf.as_slice()).unwrap_err();
+        Snapshot::<Aarch64RegisterVec>::load_without_crc_check(buf.as_slice()).unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/arch/x86_64/vm.rs
+++ b/src/vmm/src/arch/x86_64/vm.rs
@@ -321,7 +321,9 @@ mod tests {
         Snapshot::new(state)
             .save(&mut snapshot_data.as_mut_slice())
             .unwrap();
-        let restored_state: VmState = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
+        let restored_state: VmState = Snapshot::load_without_crc_check(snapshot_data.as_slice())
+            .unwrap()
+            .data;
 
         vm.restore_state(&restored_state).unwrap();
     }

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -659,7 +659,9 @@ mod tests {
         // object and calling default_vmm() is the easiest way to create one.
         let vmm = default_vmm();
         let device_manager_state: device_manager::DevicesState =
-            Snapshot::load(&mut buf.as_slice()).unwrap().data;
+            Snapshot::load_without_crc_check(buf.as_slice())
+                .unwrap()
+                .data;
         let vm_resources = &mut VmResources::default();
         let restore_args = PciDevicesConstructorArgs {
             vm: vmm.vm.clone(),

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -680,7 +680,9 @@ mod tests {
         let mut event_manager = EventManager::new().expect("Unable to create EventManager");
         let vmm = default_vmm();
         let device_manager_state: device_manager::DevicesState =
-            Snapshot::load(&mut buf.as_slice()).unwrap().data;
+            Snapshot::load_without_crc_check(buf.as_slice())
+                .unwrap()
+                .data;
         let vm_resources = &mut VmResources::default();
         let restore_args = MMIODevManagerConstructorArgs {
             mem: vmm.vm.guest_memory(),

--- a/src/vmm/src/devices/virtio/balloon/persist.rs
+++ b/src/vmm/src/devices/virtio/balloon/persist.rs
@@ -196,7 +196,9 @@ mod tests {
                 mem: guest_mem,
                 restored_from_file: true,
             },
-            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -223,7 +223,9 @@ mod tests {
         // Restore the block device.
         let restored_block = VirtioBlock::restore(
             BlockConstructorArgs { mem: guest_mem },
-            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/net/persist.rs
+++ b/src/vmm/src/devices/virtio/net/persist.rs
@@ -175,7 +175,9 @@ mod tests {
                     mem: guest_mem,
                     mmds: mmds_ds,
                 },
-                &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+                &Snapshot::load_without_crc_check(mem.as_slice())
+                    .unwrap()
+                    .data,
             ) {
                 Ok(restored_net) => {
                     // Test that virtio specific fields are the same.

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -366,8 +366,13 @@ mod tests {
             mem,
             is_activated: true,
         };
-        let restored_queue =
-            Queue::restore(ca, &Snapshot::load(&mut bytes.as_slice()).unwrap().data).unwrap();
+        let restored_queue = Queue::restore(
+            ca,
+            &Snapshot::load_without_crc_check(bytes.as_slice())
+                .unwrap()
+                .data,
+        )
+        .unwrap();
 
         assert_eq!(restored_queue, queue);
     }
@@ -380,7 +385,9 @@ mod tests {
         let state = VirtioDeviceState::from_device(&dummy);
         Snapshot::new(&state).save(&mut mem.as_mut_slice()).unwrap();
 
-        let restored_state: VirtioDeviceState = Snapshot::load(&mut mem.as_slice()).unwrap().data;
+        let restored_state: VirtioDeviceState = Snapshot::load_without_crc_check(mem.as_slice())
+            .unwrap()
+            .data;
         assert_eq!(restored_state, state);
     }
 
@@ -419,7 +426,9 @@ mod tests {
         };
         let restored_mmio_transport = MmioTransport::restore(
             restore_args,
-            &Snapshot::load(&mut buf.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(buf.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/rng/persist.rs
+++ b/src/vmm/src/devices/virtio/rng/persist.rs
@@ -92,7 +92,9 @@ mod tests {
         let guest_mem = create_virtio_mem();
         let restored = Entropy::restore(
             EntropyConstructorArgs { mem: guest_mem },
-            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/devices/virtio/transport/mmio.rs
+++ b/src/vmm/src/devices/virtio/transport/mmio.rs
@@ -511,7 +511,7 @@ pub(crate) mod tests {
             }
         }
 
-        fn set_avail_features(&mut self, avail_features: u64) {
+        pub fn set_avail_features(&mut self, avail_features: u64) {
             self.avail_features = avail_features;
         }
     }

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Barrier, Mutex};
 
 use anyhow::anyhow;
 use kvm_ioctls::{IoEventAddress, NoDatamatch};
+use log::warn;
 use pci::{
     BarReprogrammingParams, MsixCap, MsixConfig, MsixConfigState, PciBarConfiguration,
     PciBarRegionType, PciBdf, PciCapability, PciCapabilityId, PciClassCode, PciConfiguration,
@@ -53,16 +54,6 @@ const DEVICE_DRIVER_OK: u8 = 0x04;
 const DEVICE_FEATURES_OK: u8 = 0x08;
 const DEVICE_FAILED: u8 = 0x80;
 
-const VIRTIO_F_RING_INDIRECT_DESC: u32 = 28;
-const VIRTIO_F_RING_EVENT_IDX: u32 = 29;
-const VIRTIO_F_VERSION_1: u32 = 32;
-const VIRTIO_F_IOMMU_PLATFORM: u32 = 33;
-const VIRTIO_F_IN_ORDER: u32 = 35;
-const VIRTIO_F_ORDER_PLATFORM: u32 = 36;
-#[allow(dead_code)]
-const VIRTIO_F_SR_IOV: u32 = 37;
-const VIRTIO_F_NOTIFICATION_DATA: u32 = 38;
-
 /// Vector value used to disable MSI for a queue.
 pub const VIRTQ_MSI_NO_VECTOR: u16 = 0xffff;
 
@@ -83,14 +74,13 @@ enum PciCapabilityType {
 // fields cap_vndr (1 byte) and cap_next (1 byte) defined in the virtio spec.
 const VIRTIO_PCI_CAP_OFFSET: usize = 2;
 
-#[allow(dead_code)]
 #[repr(C, packed)]
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct VirtioPciCap {
     cap_len: u8,      // Generic PCI field: capability length
     cfg_type: u8,     // Identifies the structure.
     pci_bar: u8,      // Where to find it.
-    id: u8,           // Multiple capabilities of the same type
+    id: u8,           // Multiple capabilities of the same type.
     padding: [u8; 2], // Pad to full dword.
     offset: Le32,     // Offset within bar.
     length: Le32,     // Length of the structure, in bytes.
@@ -126,7 +116,6 @@ impl VirtioPciCap {
     }
 }
 
-#[allow(dead_code)]
 #[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
 struct VirtioPciNotifyCap {
@@ -164,49 +153,8 @@ impl VirtioPciNotifyCap {
     }
 }
 
-#[allow(dead_code)]
 #[repr(C, packed)]
-#[derive(Clone, Copy, Default)]
-struct VirtioPciCap64 {
-    cap: VirtioPciCap,
-    offset_hi: Le32,
-    length_hi: Le32,
-}
-// SAFETY: All members are simple numbers and any value is valid.
-unsafe impl ByteValued for VirtioPciCap64 {}
-
-impl PciCapability for VirtioPciCap64 {
-    fn bytes(&self) -> &[u8] {
-        self.as_slice()
-    }
-
-    fn id(&self) -> PciCapabilityId {
-        PciCapabilityId::VendorSpecific
-    }
-}
-
-impl VirtioPciCap64 {
-    pub fn new(cfg_type: PciCapabilityType, pci_bar: u8, id: u8, offset: u64, length: u64) -> Self {
-        VirtioPciCap64 {
-            cap: VirtioPciCap {
-                cap_len: u8::try_from(std::mem::size_of::<VirtioPciCap64>()).unwrap()
-                    + VIRTIO_PCI_CAP_LEN_OFFSET,
-                cfg_type: cfg_type as u8,
-                pci_bar,
-                id,
-                padding: [0; 2],
-                offset: Le32::from((offset & 0xffff_ffff) as u32),
-                length: Le32::from((length & 0xffff_ffff) as u32),
-            },
-            offset_hi: Le32::from((offset >> 32) as u32),
-            length_hi: Le32::from((length >> 32) as u32),
-        }
-    }
-}
-
-#[allow(dead_code)]
-#[repr(C, packed)]
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct VirtioPciCfgCap {
     cap: VirtioPciCap,
     pci_cfg_data: [u8; 4],
@@ -227,7 +175,15 @@ impl PciCapability for VirtioPciCfgCap {
 impl VirtioPciCfgCap {
     fn new() -> Self {
         VirtioPciCfgCap {
-            cap: VirtioPciCap::new(PciCapabilityType::Pci, 0, 0),
+            cap: VirtioPciCap {
+                cap_len: u8::try_from(size_of::<Self>()).unwrap() + VIRTIO_PCI_CAP_LEN_OFFSET,
+                cfg_type: PciCapabilityType::Pci as u8,
+                pci_bar: VIRTIO_BAR_INDEX,
+                id: 0,
+                padding: [0; 2],
+                offset: Le32::from(0),
+                length: Le32::from(0),
+            },
             ..Default::default()
         }
     }
@@ -239,7 +195,6 @@ struct VirtioPciCfgCapInfo {
     cap: VirtioPciCfgCap,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Copy, Clone)]
 pub enum PciVirtioSubclass {
     NonTransitionalBase = 0xff,
@@ -282,20 +237,9 @@ const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;
 const VIRTIO_PCI_DEVICE_ID_BASE: u16 = 0x1040; // Add to device type to get device ID.
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueueState {
-    max_size: u16,
-    size: u16,
-    ready: bool,
-    desc_table: u64,
-    avail_ring: u64,
-    used_ring: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VirtioPciDeviceState {
     pub pci_device_bdf: PciBdf,
     pub device_activated: bool,
-    pub interrupt_status: usize,
     pub cap_pci_cfg_offset: usize,
     pub cap_pci_cfg: Vec<u8>,
     pub pci_configuration_state: PciConfigurationState,
@@ -337,7 +281,6 @@ pub struct VirtioPciDevice {
     device_activated: Arc<AtomicBool>,
 
     // PCI interrupts.
-    interrupt_status: Arc<AtomicUsize>,
     virtio_interrupt: Option<Arc<dyn VirtioInterrupt>>,
     interrupt_source_group: Arc<MsiVectorGroup>,
 
@@ -458,7 +401,6 @@ impl VirtioPciDevice {
             msix_num: msi_vectors.num_vectors(),
             device,
             device_activated: Arc::new(AtomicBool::new(false)),
-            interrupt_status: Arc::new(AtomicUsize::new(0)),
             virtio_interrupt: Some(interrupt),
             memory,
             interrupt_source_group: msi_vectors,
@@ -509,7 +451,6 @@ impl VirtioPciDevice {
             msix_num: msi_vectors.num_vectors(),
             device,
             device_activated: Arc::new(AtomicBool::new(state.device_activated)),
-            interrupt_status: Arc::new(AtomicUsize::new(state.interrupt_status)),
             virtio_interrupt: Some(interrupt),
             memory: memory.clone(),
             interrupt_source_group: msi_vectors,
@@ -627,10 +568,14 @@ impl VirtioPciDevice {
                     .unwrap();
             }
         } else {
-            let bar_offset: u32 =
-                // SAFETY: we know self.cap_pci_cfg_info.cap.cap.offset is 32bits long.
-                unsafe { std::mem::transmute(self.cap_pci_cfg_info.cap.cap.offset) };
-            self.read_bar(0, bar_offset as u64, data)
+            let bar_offset: u32 = self.cap_pci_cfg_info.cap.cap.offset.into();
+            let len = u32::from(self.cap_pci_cfg_info.cap.cap.length) as usize;
+            // BAR reads expect that the buffer has the exact size of the field that
+            // offset is pointing to. So, do some check that the `length` has a meaningful value
+            // and only use the part of the buffer we actually need.
+            if len <= 4 {
+                self.read_bar(0, bar_offset as u64, &mut data[..len]);
+            }
         }
     }
 
@@ -648,10 +593,16 @@ impl VirtioPciDevice {
             right[..data_len].copy_from_slice(data);
             None
         } else {
-            let bar_offset: u32 =
-                // SAFETY: we know self.cap_pci_cfg_info.cap.cap.offset is 32bits long.
-                unsafe { std::mem::transmute(self.cap_pci_cfg_info.cap.cap.offset) };
-            self.write_bar(0, bar_offset as u64, data)
+            let bar_offset: u32 = self.cap_pci_cfg_info.cap.cap.offset.into();
+            let len = u32::from(self.cap_pci_cfg_info.cap.cap.length) as usize;
+            // BAR writes expect that the buffer has the exact size of the field that
+            // offset is pointing to. So, do some check that the `length` has a meaningful value
+            // and only use the part of the buffer we actually need.
+            if len <= 4 {
+                self.write_bar(0, bar_offset as u64, &data[..len])
+            } else {
+                None
+            }
         }
     }
 
@@ -682,34 +633,10 @@ impl VirtioPciDevice {
         Ok(())
     }
 
-    /// Unregister the IoEvent notification for a VirtIO device
-    pub fn unregister_notification_ioevent(
-        &self,
-        vm: &Vm,
-    ) -> std::result::Result<(), errno::Error> {
-        let bar_addr = self.config_bar_addr();
-        for (i, queue_evt) in self
-            .device
-            .lock()
-            .expect("Poisoned lock")
-            .queue_events()
-            .iter()
-            .enumerate()
-        {
-            let notify_base = bar_addr + NOTIFICATION_BAR_OFFSET;
-            let io_addr =
-                IoEventAddress::Mmio(notify_base + i as u64 * NOTIFY_OFF_MULTIPLIER as u64);
-            vm.fd()
-                .unregister_ioevent(queue_evt, &io_addr, NoDatamatch)?;
-        }
-        Ok(())
-    }
-
     pub fn state(&self) -> VirtioPciDeviceState {
         VirtioPciDeviceState {
             pci_device_bdf: self.pci_device_bdf,
             device_activated: self.device_activated.load(Ordering::Acquire),
-            interrupt_status: self.interrupt_status.load(Ordering::Acquire),
             cap_pci_cfg_offset: self.cap_pci_cfg_info.offset,
             cap_pci_cfg: self.cap_pci_cfg_info.cap.bytes().to_vec(),
             pci_configuration_state: self.configuration.state(),
@@ -850,8 +777,13 @@ impl PciDevice for VirtioPciDevice {
         {
             let offset = base - self.cap_pci_cfg_info.offset;
             let mut data = [0u8; 4];
-            self.read_cap_pci_cfg(offset, &mut data);
-            u32::from_le_bytes(data)
+            let len = u32::from(self.cap_pci_cfg_info.cap.cap.length) as usize;
+            if len <= 4 {
+                self.read_cap_pci_cfg(offset, &mut data[..len]);
+                u32::from_le_bytes(data)
+            } else {
+                0
+            }
         } else {
             self.configuration.read_reg(reg_idx)
         }
@@ -928,14 +860,9 @@ impl PciDevice for VirtioPciDevice {
                     .read(o - COMMON_CONFIG_BAR_OFFSET, data, self.device.clone())
             }
             o if (ISR_CONFIG_BAR_OFFSET..ISR_CONFIG_BAR_OFFSET + ISR_CONFIG_SIZE).contains(&o) => {
-                if let Some(v) = data.get_mut(0) {
-                    // Reading this register resets it to 0.
-                    *v = self
-                        .interrupt_status
-                        .swap(0, Ordering::AcqRel)
-                        .try_into()
-                        .unwrap();
-                }
+                // We don't actually support legacy INT#x interrupts for VirtIO PCI devices
+                warn!("pci: read access to unsupported ISR status field");
+                data.fill(0);
             }
             o if (DEVICE_CONFIG_BAR_OFFSET..DEVICE_CONFIG_BAR_OFFSET + DEVICE_CONFIG_SIZE)
                 .contains(&o) =>
@@ -947,6 +874,7 @@ impl PciDevice for VirtioPciDevice {
                 .contains(&o) =>
             {
                 // Handled with ioeventfds.
+                warn!("pci: unexpected read to notification BAR. Offset {o:#x}");
             }
             o if (MSIX_TABLE_BAR_OFFSET..MSIX_TABLE_BAR_OFFSET + MSIX_TABLE_SIZE).contains(&o) => {
                 if let Some(msix_config) = &self.msix_config {
@@ -975,10 +903,8 @@ impl PciDevice for VirtioPciDevice {
                     .write(o - COMMON_CONFIG_BAR_OFFSET, data, self.device.clone())
             }
             o if (ISR_CONFIG_BAR_OFFSET..ISR_CONFIG_BAR_OFFSET + ISR_CONFIG_SIZE).contains(&o) => {
-                if let Some(v) = data.first() {
-                    self.interrupt_status
-                        .fetch_and(!(*v as usize), Ordering::AcqRel);
-                }
+                // We don't actually support legacy INT#x interrupts for VirtIO PCI devices
+                warn!("pci: access to unsupported ISR status field");
             }
             o if (DEVICE_CONFIG_BAR_OFFSET..DEVICE_CONFIG_BAR_OFFSET + DEVICE_CONFIG_SIZE)
                 .contains(&o) =>
@@ -990,7 +916,7 @@ impl PciDevice for VirtioPciDevice {
                 .contains(&o) =>
             {
                 // Handled with ioeventfds.
-                error!("Unexpected write to notification BAR: offset = 0x{:x}", o);
+                warn!("pci: unexpected write to notification BAR. Offset {o:#x}");
             }
             o if (MSIX_TABLE_BAR_OFFSET..MSIX_TABLE_BAR_OFFSET + MSIX_TABLE_SIZE).contains(&o) => {
                 if let Some(msix_config) = &self.msix_config {
@@ -1081,19 +1007,28 @@ mod tests {
 
     use event_manager::MutEventSubscriber;
     use linux_loader::loader::Cmdline;
-    use pci::{PciBdf, PciClassCode, PciDevice, PciSubclass};
+    use pci::{
+        MsixCap, PciBdf, PciCapability, PciCapabilityId, PciClassCode, PciDevice, PciSubclass,
+    };
+    use vm_memory::{ByteValued, Le32};
 
-    use super::VirtioPciDevice;
-    use crate::Vm;
+    use super::{PciCapabilityType, VirtioPciDevice};
     use crate::arch::MEM_64BIT_DEVICES_START;
     use crate::builder::tests::default_vmm;
     use crate::devices::virtio::device::VirtioDevice;
+    use crate::devices::virtio::generated::virtio_ids;
     use crate::devices::virtio::rng::Entropy;
-    use crate::devices::virtio::transport::pci::device::PciVirtioSubclass;
+    use crate::devices::virtio::transport::pci::device::{
+        COMMON_CONFIG_BAR_OFFSET, COMMON_CONFIG_SIZE, DEVICE_CONFIG_BAR_OFFSET, DEVICE_CONFIG_SIZE,
+        ISR_CONFIG_BAR_OFFSET, ISR_CONFIG_SIZE, NOTIFICATION_BAR_OFFSET, NOTIFICATION_SIZE,
+        NOTIFY_OFF_MULTIPLIER, PciVirtioSubclass, VirtioPciCap, VirtioPciCfgCap,
+        VirtioPciNotifyCap,
+    };
     use crate::rate_limiter::RateLimiter;
+    use crate::utils::u64_to_usize;
+    use crate::{Vm, Vmm};
 
-    #[test]
-    fn test_pci_device_config() {
+    fn create_vmm_with_virtio_pci_device() -> Vmm {
         let mut vmm = default_vmm();
         vmm.device_manager.enable_pci(&vmm.vm);
         let entropy = Arc::new(Mutex::new(Entropy::new(RateLimiter::default()).unwrap()));
@@ -1106,13 +1041,21 @@ mod tests {
                 false,
             )
             .unwrap();
+        vmm
+    }
 
-        let device = vmm
-            .device_manager
+    fn get_virtio_device(vmm: &Vmm) -> Arc<Mutex<VirtioPciDevice>> {
+        vmm.device_manager
             .pci_devices
-            .get_virtio_device(entropy.lock().unwrap().device_type(), "rng")
-            .unwrap();
+            .get_virtio_device(virtio_ids::VIRTIO_ID_RNG, "rng")
+            .unwrap()
+            .clone()
+    }
 
+    #[test]
+    fn test_pci_device_config() {
+        let mut vmm = create_vmm_with_virtio_pci_device();
+        let device = get_virtio_device(&vmm);
         let mut locked_virtio_pci_device = device.lock().unwrap();
 
         // For more information for the values we are checking here look into the VirtIO spec here:
@@ -1212,25 +1155,8 @@ mod tests {
 
     #[test]
     fn test_reading_bars() {
-        let mut vmm = default_vmm();
-        vmm.device_manager.enable_pci(&vmm.vm);
-        let entropy = Arc::new(Mutex::new(Entropy::new(RateLimiter::default()).unwrap()));
-        vmm.device_manager
-            .attach_virtio_device(
-                &vmm.vm,
-                "rng".to_string(),
-                entropy.clone(),
-                &mut Cmdline::new(1024).unwrap(),
-                false,
-            )
-            .unwrap();
-
-        let device = vmm
-            .device_manager
-            .pci_devices
-            .get_virtio_device(entropy.lock().unwrap().device_type(), "rng")
-            .unwrap();
-
+        let mut vmm = create_vmm_with_virtio_pci_device();
+        let device = get_virtio_device(&vmm);
         let mut locked_virtio_pci_device = device.lock().unwrap();
 
         // According to OSdev wiki (https://wiki.osdev.org/PCI#Configuration_Space):
@@ -1282,5 +1208,309 @@ mod tests {
 
         // We create a capabilities BAR region of 0x80000 bytes
         assert_eq!(bar_size, 0x80000);
+    }
+
+    fn read_virtio_pci_cap(
+        device: &mut VirtioPciDevice,
+        offset: u32,
+    ) -> (PciCapabilityId, u8, VirtioPciCap) {
+        let word1 = device.read_config_register((offset >> 2) as usize);
+        let word2 = device.read_config_register((offset >> 2) as usize + 1);
+        let word3 = device.read_config_register((offset >> 2) as usize + 2);
+        let word4 = device.read_config_register((offset >> 2) as usize + 3);
+
+        let id = PciCapabilityId::from((word1 & 0xff) as u8);
+        let next = ((word1 >> 8) & 0xff) as u8;
+
+        let cap = VirtioPciCap {
+            cap_len: ((word1 >> 16) & 0xff) as u8,
+            cfg_type: ((word1 >> 24) & 0xff) as u8,
+            pci_bar: (word2 & 0xff) as u8,
+            id: ((word2 >> 8) & 0xff) as u8,
+            padding: [0u8; 2],
+            offset: Le32::from(word3),
+            length: Le32::from(word4),
+        };
+
+        // We only ever set a single capability of a type. It's ID is 0.
+        assert_eq!(cap.id, 0);
+
+        (id, next, cap)
+    }
+
+    fn read_virtio_notification_cap(
+        device: &mut VirtioPciDevice,
+        offset: u32,
+    ) -> (PciCapabilityId, u8, VirtioPciNotifyCap) {
+        let (id, next, cap) = read_virtio_pci_cap(device, offset);
+        let word5 = device.read_config_register((offset >> 2) as usize + 4);
+
+        let notification_cap = VirtioPciNotifyCap {
+            cap,
+            notify_off_multiplier: Le32::from(word5),
+        };
+
+        (id, next, notification_cap)
+    }
+
+    fn read_virtio_pci_config_cap(
+        device: &mut VirtioPciDevice,
+        offset: u32,
+    ) -> (PciCapabilityId, u8, VirtioPciCfgCap) {
+        let (id, next, cap) = read_virtio_pci_cap(device, offset);
+        let word5 = device.read_config_register((offset >> 2) as usize + 4);
+
+        let pci_cfg_cap = VirtioPciCfgCap {
+            cap,
+            pci_cfg_data: word5.as_slice().try_into().unwrap(),
+        };
+
+        (id, next, pci_cfg_cap)
+    }
+
+    fn read_msix_cap(device: &mut VirtioPciDevice, offset: u32) -> (PciCapabilityId, u8, MsixCap) {
+        let word1 = device.read_config_register((offset >> 2) as usize);
+        let table = device.read_config_register((offset >> 2) as usize + 1);
+        let pba = device.read_config_register((offset >> 2) as usize + 2);
+
+        let id = PciCapabilityId::from((word1 & 0xff) as u8);
+        let next = ((word1 >> 8) & 0xff) as u8;
+
+        let cap = MsixCap {
+            msg_ctl: (word1 & 0xffff) as u16,
+            table,
+            pba,
+        };
+
+        (id, next, cap)
+    }
+
+    fn capabilities_start(device: &mut VirtioPciDevice) -> u32 {
+        device.read_config_register(0xd) & 0xfc
+    }
+
+    #[test]
+    fn test_capabilities() {
+        let mut vmm = create_vmm_with_virtio_pci_device();
+        let device = get_virtio_device(&vmm);
+        let mut locked_virtio_pci_device = device.lock().unwrap();
+
+        // VirtIO devices need to expose a set of mandatory capabilities:
+        // * Common configuration
+        // * Notifications
+        // * ISR status
+        // * PCI configuration access
+        //
+        // and, optionally, a device-specific configuration area for those devices that need it.
+        //
+        // We always expose all 5 capabilities, so check that the capabilities are present
+
+        // Common config
+        let common_config_cap_offset = capabilities_start(&mut locked_virtio_pci_device);
+        let (id, next, cap) =
+            read_virtio_pci_cap(&mut locked_virtio_pci_device, common_config_cap_offset);
+        assert_eq!(id, PciCapabilityId::VendorSpecific);
+        assert_eq!(cap.cap_len as usize, size_of::<VirtioPciCap>() + 2);
+        assert_eq!(cap.cfg_type, PciCapabilityType::Common as u8);
+        assert_eq!(cap.pci_bar, 0);
+        assert_eq!(u32::from(cap.offset) as u64, COMMON_CONFIG_BAR_OFFSET);
+        assert_eq!(u32::from(cap.length) as u64, COMMON_CONFIG_SIZE);
+        assert_eq!(next as u32, common_config_cap_offset + cap.cap_len as u32);
+
+        // ISR
+        let isr_cap_offset = next as u32;
+        let (id, next, cap) = read_virtio_pci_cap(&mut locked_virtio_pci_device, isr_cap_offset);
+        assert_eq!(id, PciCapabilityId::VendorSpecific);
+        assert_eq!(cap.cap_len as usize, size_of::<VirtioPciCap>() + 2);
+        assert_eq!(cap.cfg_type, PciCapabilityType::Isr as u8);
+        assert_eq!(cap.pci_bar, 0);
+        assert_eq!(u32::from(cap.offset) as u64, ISR_CONFIG_BAR_OFFSET);
+        assert_eq!(u32::from(cap.length) as u64, ISR_CONFIG_SIZE);
+        assert_eq!(next as u32, isr_cap_offset + cap.cap_len as u32);
+
+        // Device config
+        let device_config_cap_offset = next as u32;
+        let (id, next, cap) =
+            read_virtio_pci_cap(&mut locked_virtio_pci_device, device_config_cap_offset);
+        assert_eq!(id, PciCapabilityId::VendorSpecific);
+        assert_eq!(cap.cap_len as usize, size_of::<VirtioPciCap>() + 2);
+        assert_eq!(cap.cfg_type, PciCapabilityType::Device as u8);
+        assert_eq!(cap.pci_bar, 0);
+        assert_eq!(u32::from(cap.offset) as u64, DEVICE_CONFIG_BAR_OFFSET);
+        assert_eq!(u32::from(cap.length) as u64, DEVICE_CONFIG_SIZE);
+        assert_eq!(next as u32, device_config_cap_offset + cap.cap_len as u32);
+
+        let notification_cap_offset = next as u32;
+        let (id, next, cap) =
+            read_virtio_notification_cap(&mut locked_virtio_pci_device, notification_cap_offset);
+        assert_eq!(id, PciCapabilityId::VendorSpecific);
+        assert_eq!(
+            cap.cap.cap_len as usize,
+            size_of::<VirtioPciNotifyCap>() + 2
+        );
+        assert_eq!(cap.cap.cfg_type, PciCapabilityType::Notify as u8);
+        assert_eq!(cap.cap.pci_bar, 0);
+        assert_eq!(u32::from(cap.cap.offset) as u64, NOTIFICATION_BAR_OFFSET);
+        assert_eq!(u32::from(cap.cap.length) as u64, NOTIFICATION_SIZE);
+        assert_eq!(
+            next as u32,
+            notification_cap_offset + cap.cap.cap_len as u32
+        );
+        assert_eq!(u32::from(cap.notify_off_multiplier), NOTIFY_OFF_MULTIPLIER);
+
+        let pci_config_cap_offset = next as u32;
+        let (id, next, cap) =
+            read_virtio_pci_config_cap(&mut locked_virtio_pci_device, pci_config_cap_offset);
+        assert_eq!(id, PciCapabilityId::VendorSpecific);
+        assert_eq!(cap.cap.cap_len as usize, size_of::<VirtioPciCfgCap>() + 2);
+        assert_eq!(cap.cap.cfg_type, PciCapabilityType::Pci as u8);
+        assert_eq!(cap.cap.pci_bar, 0);
+        assert_eq!(u32::from(cap.cap.offset) as u64, 0);
+        assert_eq!(u32::from(cap.cap.length) as u64, 0);
+        assert_eq!(
+            locked_virtio_pci_device.cap_pci_cfg_info.offset,
+            pci_config_cap_offset as usize + 2
+        );
+        assert_eq!(locked_virtio_pci_device.cap_pci_cfg_info.cap, cap);
+        assert_eq!(next as u32, pci_config_cap_offset + cap.cap.cap_len as u32);
+
+        let msix_cap_offset = next as u32;
+        let (id, next, cap) = read_msix_cap(&mut locked_virtio_pci_device, msix_cap_offset);
+        assert_eq!(id, PciCapabilityId::MsiX);
+        assert_eq!(next, 0);
+    }
+
+    fn cap_pci_cfg_read(device: &mut VirtioPciDevice, bar_offset: u32, length: u32) -> u32 {
+        let pci_config_cap_offset = capabilities_start(device) as usize
+            + 3 * (size_of::<VirtioPciCap>() + 2)
+            + (size_of::<VirtioPciNotifyCap>() + 2);
+
+        // To program the access through the PCI config capability mechanism, we need to write the
+        // bar offset and read length in the `VirtioPciCfgCap::cap.offset` and
+        // `VirtioPciCfgCap::length` fields. These are the third and fourth word respectively
+        // within the capability. The fifth word of the capability should contain the data
+        let offset_register = (pci_config_cap_offset + 8) >> 2;
+        let length_register = (pci_config_cap_offset + 12) >> 2;
+        let data_register = (pci_config_cap_offset + 16) >> 2;
+
+        device.write_config_register(offset_register, 0, bar_offset.as_slice());
+        device.write_config_register(length_register, 0, length.as_slice());
+        device.read_config_register(data_register)
+    }
+
+    fn cap_pci_cfg_write(device: &mut VirtioPciDevice, bar_offset: u32, length: u32, data: u32) {
+        let pci_config_cap_offset = capabilities_start(device) as usize
+            + 3 * (size_of::<VirtioPciCap>() + 2)
+            + (size_of::<VirtioPciNotifyCap>() + 2);
+
+        // To program the access through the PCI config capability mechanism, we need to write the
+        // bar offset and read length in the `VirtioPciCfgCap::cap.offset` and
+        // `VirtioPciCfgCap::length` fields. These are the third and fourth word respectively
+        // within the capability. The fifth word of the capability should contain the data
+        let offset_register = (pci_config_cap_offset + 8) >> 2;
+        let length_register = (pci_config_cap_offset + 12) >> 2;
+        let data_register = (pci_config_cap_offset + 16) >> 2;
+
+        device.write_config_register(offset_register, 0, bar_offset.as_slice());
+        device.write_config_register(length_register, 0, length.as_slice());
+        device.write_config_register(data_register, 0, data.as_slice());
+    }
+
+    #[test]
+    fn test_pci_configuration_cap() {
+        let mut vmm = create_vmm_with_virtio_pci_device();
+        let device = get_virtio_device(&vmm);
+        let mut locked_virtio_pci_device = device.lock().unwrap();
+
+        // Let's read the number of queues of the entropy device
+        // That information is located at offset 0x12 past the BAR region belonging to the common
+        // config capability.
+        let bar_offset = u32::try_from(COMMON_CONFIG_BAR_OFFSET).unwrap() + 0x12;
+        let len = 2u32;
+        let num_queues = cap_pci_cfg_read(&mut locked_virtio_pci_device, bar_offset, len);
+        assert_eq!(num_queues, 1);
+
+        // Let's update the driver features and see if that takes effect
+        let bar_offset = u32::try_from(COMMON_CONFIG_BAR_OFFSET).unwrap() + 0x14;
+        let len = 1u32;
+        let device_status = cap_pci_cfg_read(&mut locked_virtio_pci_device, bar_offset, len);
+        assert_eq!(device_status, 0);
+        cap_pci_cfg_write(&mut locked_virtio_pci_device, bar_offset, len, 0x42);
+        let device_status = cap_pci_cfg_read(&mut locked_virtio_pci_device, bar_offset, len);
+        assert_eq!(device_status, 0x42);
+
+        // reads with out-of-bounds lengths should return 0s
+        assert_eq!(
+            cap_pci_cfg_read(&mut locked_virtio_pci_device, bar_offset, 8),
+            0
+        );
+        // writes out-of-bounds lengths should have no effect
+        cap_pci_cfg_write(&mut locked_virtio_pci_device, bar_offset, 8, 0x84);
+        assert_eq!(
+            cap_pci_cfg_read(&mut locked_virtio_pci_device, bar_offset, 1),
+            0x42
+        );
+    }
+
+    fn isr_status_read(device: &mut VirtioPciDevice) -> u32 {
+        let mut data = 0u32;
+        device.read_bar(0, ISR_CONFIG_BAR_OFFSET, data.as_mut_slice());
+        data
+    }
+
+    fn isr_status_write(device: &mut VirtioPciDevice, data: u32) {
+        device.write_bar(0, ISR_CONFIG_BAR_OFFSET, data.as_slice());
+    }
+
+    #[test]
+    fn test_isr_capability() {
+        let mut vmm = create_vmm_with_virtio_pci_device();
+        let device = get_virtio_device(&vmm);
+        let mut locked_virtio_pci_device = device.lock().unwrap();
+
+        // We don't support legacy interrupts so reads to ISR BAR should always return 0s and
+        // writes to it should not have any effect
+        assert_eq!(isr_status_read(&mut locked_virtio_pci_device), 0);
+        isr_status_write(&mut locked_virtio_pci_device, 0x1312);
+        assert_eq!(isr_status_read(&mut locked_virtio_pci_device), 0);
+    }
+
+    #[test]
+    fn test_notification_capability() {
+        let mut vmm = create_vmm_with_virtio_pci_device();
+        let device = get_virtio_device(&vmm);
+        let mut locked_virtio_pci_device = device.lock().unwrap();
+
+        let notification_cap_offset = (capabilities_start(&mut locked_virtio_pci_device) as usize
+            + 3 * (size_of::<VirtioPciCap>() + 2))
+            .try_into()
+            .unwrap();
+
+        let (_, _, notify_cap) =
+            read_virtio_notification_cap(&mut locked_virtio_pci_device, notification_cap_offset);
+
+        // We do not offer `VIRTIO_F_NOTIFICATION_DATA` so:
+        // * `cap.offset` MUST by 2-byte aligned
+        assert_eq!(u32::from(notify_cap.cap.offset) & 0x3, 0);
+        // * The device MUST either present notify_off_multiplier as an even power of 2, or present
+        //   notify_off_multiplier as 0.
+        let multiplier = u32::from(notify_cap.notify_off_multiplier);
+        assert!(multiplier.is_power_of_two() && multiplier.trailing_zeros() % 2 == 0);
+        // * For all queues, the value cap.length presented by the device MUST satisfy:
+        //
+        //   `cap.length >= queue_notify_off * notify_off_multiplier + 2`
+        //
+        // The spec allows for up to 65536 queues, but in reality the device we are using with most
+        // queues is vsock (3). Let's check here for 16, projecting for future devices and
+        // use-cases such as multiple queue pairs in network devices
+        assert!(u32::from(notify_cap.cap.length) >= 15 * multiplier + 2);
+
+        // Reads and writes to the notification region of the BAR are handled by IoEvent file
+        // descriptors. Any such accesses should have no effects.
+        let data = [0x42u8; u64_to_usize(NOTIFICATION_SIZE)];
+        locked_virtio_pci_device.write_bar(0, NOTIFICATION_BAR_OFFSET, &data);
+        let mut buffer = [0x0; u64_to_usize(NOTIFICATION_SIZE)];
+        locked_virtio_pci_device.read_bar(0, NOTIFICATION_BAR_OFFSET, &mut buffer);
+        assert_eq!(buffer, [0u8; u64_to_usize(NOTIFICATION_SIZE)]);
     }
 }

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -180,7 +180,9 @@ pub(crate) mod tests {
 
         Snapshot::new(&state).save(&mut mem.as_mut_slice()).unwrap();
 
-        let restored_state: VsockState = Snapshot::load(&mut mem.as_slice()).unwrap().data;
+        let restored_state: VsockState = Snapshot::load_without_crc_check(mem.as_slice())
+            .unwrap()
+            .data;
         let mut restored_device = Vsock::restore(
             VsockConstructorArgs {
                 mem: ctx.mem.clone(),

--- a/src/vmm/src/mmds/persist.rs
+++ b/src/vmm/src/mmds/persist.rs
@@ -68,7 +68,9 @@ mod tests {
 
         let restored_ns = MmdsNetworkStack::restore(
             Arc::new(Mutex::new(Mmds::default())),
-            &Snapshot::load(&mut mem.as_slice()).unwrap().data,
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
         )
         .unwrap();
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -676,8 +676,9 @@ mod tests {
             .save(&mut buf.as_mut_slice())
             .unwrap();
 
-        let restored_microvm_state: MicrovmState =
-            Snapshot::load(&mut buf.as_slice()).unwrap().data;
+        let restored_microvm_state: MicrovmState = Snapshot::load_without_crc_check(buf.as_slice())
+            .unwrap()
+            .data;
 
         assert_eq!(restored_microvm_state.vm_info, microvm_state.vm_info);
         assert_eq!(

--- a/src/vmm/src/rate_limiter/persist.rs
+++ b/src/vmm/src/rate_limiter/persist.rs
@@ -120,8 +120,13 @@ mod tests {
             .save(&mut mem.as_mut_slice())
             .unwrap();
 
-        let restored_tb =
-            TokenBucket::restore((), &Snapshot::load(&mut mem.as_slice()).unwrap().data).unwrap();
+        let restored_tb = TokenBucket::restore(
+            (),
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
+        )
+        .unwrap();
         assert!(tb.partial_eq(&restored_tb));
     }
 
@@ -197,8 +202,13 @@ mod tests {
         Snapshot::new(rate_limiter.save())
             .save(&mut mem.as_mut_slice())
             .unwrap();
-        let restored_rate_limiter =
-            RateLimiter::restore((), &Snapshot::load(&mut mem.as_slice()).unwrap().data).unwrap();
+        let restored_rate_limiter = RateLimiter::restore(
+            (),
+            &Snapshot::load_without_crc_check(mem.as_slice())
+                .unwrap()
+                .data,
+        )
+        .unwrap();
 
         assert!(
             rate_limiter

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -132,7 +132,9 @@ pub(crate) mod tests {
         Snapshot::new(&boot_src_cfg)
             .save(&mut snapshot_data.as_mut_slice())
             .unwrap();
-        let restored_boot_cfg = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
+        let restored_boot_cfg = Snapshot::load_without_crc_check(snapshot_data.as_slice())
+            .unwrap()
+            .data;
         assert_eq!(boot_src_cfg, restored_boot_cfg);
     }
 }

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -436,7 +436,9 @@ mod tests {
         Snapshot::new(&original_state)
             .save(&mut snapshot_data.as_mut_slice())
             .unwrap();
-        let restored_state = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
+        let restored_state = Snapshot::load_without_crc_check(snapshot_data.as_slice())
+            .unwrap()
+            .data;
         assert_eq!(original_state, restored_state);
     }
 

--- a/src/vmm/src/vstate/resources.rs
+++ b/src/vmm/src/vstate/resources.rs
@@ -283,7 +283,9 @@ mod tests {
         Snapshot::new(allocator.save())
             .save(&mut buf.as_mut_slice())
             .unwrap();
-        let restored_state: ResourceAllocator = Snapshot::load(&mut buf.as_slice()).unwrap().data;
+        let restored_state: ResourceAllocator = Snapshot::load_without_crc_check(buf.as_slice())
+            .unwrap()
+            .data;
         ResourceAllocator::restore((), &restored_state).unwrap()
     }
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -1048,7 +1048,9 @@ pub(crate) mod tests {
             .save(&mut snapshot_data.as_mut_slice())
             .unwrap();
 
-        let restored_state: VmState = Snapshot::load(&mut snapshot_data.as_slice()).unwrap().data;
+        let restored_state: VmState = Snapshot::load_without_crc_check(snapshot_data.as_slice())
+            .unwrap()
+            .data;
         vm.restore_state(&restored_state).unwrap();
 
         let mut resource_allocator = vm.resource_allocator();

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -236,8 +236,9 @@ def test_load_snapshot_failure_handling(uvm_plain):
     jailed_vmstate = vm.create_jailed_resource(snapshot_vmstate)
 
     # Load the snapshot
-    expected_msg = 'An error occured during bincode decoding: Io { inner: Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }'
-    with pytest.raises(RuntimeError, match=expected_msg):
+    with pytest.raises(
+        RuntimeError, match="An error occured during bincode decoding: UnexpectedEnd"
+    ):
         vm.api.snapshot_load.put(mem_file_path=jailed_mem, snapshot_path=jailed_vmstate)
 
     vm.mark_killed()

--- a/tests/integration_tests/functional/test_snapshot_not_losing_dirty_pages.py
+++ b/tests/integration_tests/functional/test_snapshot_not_losing_dirty_pages.py
@@ -37,6 +37,7 @@ def test_diff_snapshot_works_after_error(
     )
 
     vm_mem_size = 128
+    uvm.time_api_requests = False  # The log may be incomplete due to lack of space
     uvm.spawn()
     uvm.basic_config(mem_size_mib=vm_mem_size, track_dirty_pages=True)
     uvm.add_net_iface()
@@ -51,13 +52,8 @@ def test_diff_snapshot_works_after_error(
 
     subprocess.check_call(f"fallocate -l {target_size} {fill}", shell=True)
 
-    try:
+    with pytest.raises(RuntimeError, match="No space left on device"):
         uvm.snapshot_diff()
-    except RuntimeError:
-        msg = "No space left on device"
-        uvm.check_log_message(msg)
-    else:
-        assert False, "This should fail"
 
     fill.unlink()
 

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -110,6 +110,11 @@ def download_spectre_meltdown_checker(tmp_path_factory):
     global_props.buildkite_pr,
     reason="Test depends solely on factors external to GitHub repository",
 )
+# Temporary suppression for Ubuntu 6.14 kernel
+@pytest.mark.skipif(
+    "Ubuntu" in global_props.os and global_props.host_linux_version == "6.14",
+    reason="Ubuntu does not enable CONFIG_MITIGATION_GDS on 6.14 kernel",
+)
 def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
     """Test with the spectre / meltdown checker on host."""
     report = spectre_meltdown_checker.get_report_for_host()
@@ -120,6 +125,11 @@ def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
 @pytest.mark.skipif(
     global_props.buildkite_pr,
     reason="Test depends solely on factors external to GitHub repository",
+)
+# Temporary suppression for Ubuntu 6.14 kernel
+@pytest.mark.skipif(
+    "Ubuntu" in global_props.os and global_props.host_linux_version == "6.14",
+    reason="Ubuntu does not enable CONFIG_MITIGATION_GDS on 6.14 kernel",
 )
 def test_vulnerabilities_on_host():
     """Test vulnerability files on host."""


### PR DESCRIPTION
This is a squashed merge of upstream/main into feature/virtio-mem. No commits were changed.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
