### PR TITLE
refactor(dev-mngr): store vm as Arc in MMIODevManagerConstructorArgs

### DIFF
--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -501,7 +501,7 @@ impl<'a> Persist<'a> for DeviceManager {
 
         // Restore PCI devices
         let pci_ctor_args = PciDevicesConstructorArgs {
-            vm: constructor_args.vm.clone(),
+            vm: constructor_args.vm,
             mem: constructor_args.mem,
             vm_resources: constructor_args.vm_resources,
             instance_id: constructor_args.instance_id,

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -243,7 +243,7 @@ pub struct PciDevicesState {
 }
 
 pub struct PciDevicesConstructorArgs<'a> {
-    pub vm: Arc<Vm>,
+    pub vm: &'a Arc<Vm>,
     pub mem: &'a GuestMemoryMmap,
     pub vm_resources: &'a mut VmResources,
     pub instance_id: &'a str,
@@ -405,7 +405,7 @@ impl<'a> Persist<'a> for PciDevices {
             return Ok(pci_devices);
         }
 
-        pci_devices.attach_pci_segment(&constructor_args.vm)?;
+        pci_devices.attach_pci_segment(constructor_args.vm)?;
 
         if let Some(balloon_state) = &state.balloon_device {
             let device = Arc::new(Mutex::new(
@@ -426,7 +426,7 @@ impl<'a> Persist<'a> for PciDevices {
 
             pci_devices
                 .restore_pci_device(
-                    &constructor_args.vm,
+                    constructor_args.vm,
                     device,
                     &balloon_state.device_id,
                     &balloon_state.transport_state,
@@ -451,7 +451,7 @@ impl<'a> Persist<'a> for PciDevices {
 
             pci_devices
                 .restore_pci_device(
-                    &constructor_args.vm,
+                    constructor_args.vm,
                     device,
                     &block_state.device_id,
                     &block_state.transport_state,
@@ -501,7 +501,7 @@ impl<'a> Persist<'a> for PciDevices {
 
             pci_devices
                 .restore_pci_device(
-                    &constructor_args.vm,
+                    constructor_args.vm,
                     device,
                     &net_state.device_id,
                     &net_state.transport_state,
@@ -534,7 +534,7 @@ impl<'a> Persist<'a> for PciDevices {
 
             pci_devices
                 .restore_pci_device(
-                    &constructor_args.vm,
+                    constructor_args.vm,
                     device,
                     &vsock_state.device_id,
                     &vsock_state.transport_state,
@@ -557,7 +557,7 @@ impl<'a> Persist<'a> for PciDevices {
 
             pci_devices
                 .restore_pci_device(
-                    &constructor_args.vm,
+                    constructor_args.vm,
                     device,
                     &entropy_state.device_id,
                     &entropy_state.transport_state,
@@ -664,7 +664,7 @@ mod tests {
                 .data;
         let vm_resources = &mut VmResources::default();
         let restore_args = PciDevicesConstructorArgs {
-            vm: vmm.vm.clone(),
+            vm: &vmm.vm,
             mem: vmm.vm.guest_memory(),
             vm_resources,
             instance_id: "microvm-id",

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -140,7 +140,7 @@ pub enum SharedDeviceType {
 
 pub struct MMIODevManagerConstructorArgs<'a> {
     pub mem: &'a GuestMemoryMmap,
-    pub vm: &'a Vm,
+    pub vm: &'a Arc<Vm>,
     pub event_manager: &'a mut EventManager,
     pub vm_resources: &'a mut VmResources,
     pub instance_id: &'a str,
@@ -364,11 +364,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                 }
                 if state.type_ == DeviceType::Rtc {
                     let rtc = Arc::new(Mutex::new(RTCDevice::new()));
-                    dev_manager.register_mmio_rtc(
-                        constructor_args.vm,
-                        rtc,
-                        Some(state.device_info),
-                    )?;
+                    dev_manager.register_mmio_rtc(vm, rtc, Some(state.device_info))?;
                 }
             }
         }


### PR DESCRIPTION
## Changes

Store the vm type as an Arc in the constructor args for the MMIO dev mgr restore, as it's done in the PCI one. Also use a reference to avoid extra clones.

## Reason

I will need to pass the `Arc<Vm>` to the virtio-mem device. It's already done like so in the PCI device manager, but not in MMIO.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
