### PR TITLE
Fix typo in swagger

### DIFF
--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1146,7 +1146,7 @@ definitions:
         format: "169.254.([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-4]).([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"
         default: "169.254.169.254"
         description: A valid IPv4 link-local address.
-      imds_comat:
+      imds_compat:
         type: boolean
         description:
           MMDS operates compatibly with EC2 IMDS (i.e. reponds "text/plain"

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -596,7 +596,7 @@ paths:
       parameters:
         - name: body
           in: body
-          description: The configuration used for creating a snaphot.
+          description: The configuration used for creating a snapshot.
           required: true
           schema:
             $ref: "#/definitions/SnapshotCreateParams"
@@ -623,7 +623,7 @@ paths:
       parameters:
         - name: body
           in: body
-          description: The configuration used for loading a snaphot.
+          description: The configuration used for loading a snapshot.
           required: true
           schema:
             $ref: "#/definitions/SnapshotLoadParams"
@@ -1149,7 +1149,7 @@ definitions:
       imds_compat:
         type: boolean
         description:
-          MMDS operates compatibly with EC2 IMDS (i.e. reponds "text/plain"
+          MMDS operates compatibly with EC2 IMDS (i.e. responds "text/plain"
           content regardless of Accept header in requests).
         default: false
 


### PR DESCRIPTION
## Changes

Fix a few typos in swagger
 - `imds_compat` parameter of `mmds` endpoint
 - `snapshot` spelled as `snaphot` in some descriptions
 - `responds` spelled as `reponds` in a description

## Reason

Fixes #5417.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
