### PR TITLE
Simplify PCI code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,6 @@ dependencies = [
  "serde",
  "serde_test",
  "thiserror 2.0.16",
- "vm-allocator",
  "vm-device",
  "vm-memory",
  "vmm-sys-util",

--- a/src/pci/Cargo.toml
+++ b/src/pci/Cargo.toml
@@ -18,7 +18,6 @@ libc = "0.2.175"
 log = "0.4.28"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.16"
-vm-allocator = "0.1.3"
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.16.1", features = [
   "backend-mmap",

--- a/src/pci/src/configuration.rs
+++ b/src/pci/src/configuration.rs
@@ -32,7 +32,7 @@ const CAPABILITY_MAX_OFFSET: usize = 192;
 pub const PCI_CONFIGURATION_ID: &str = "pci_configuration";
 
 /// Represents the types of PCI headers allowed in the configuration registers.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum PciHeaderType {
     Device,
     Bridge,
@@ -483,17 +483,11 @@ impl PciConfiguration {
                     | (u32::from(pi) << 8)
                     | u32::from(revision_id);
                 writable_bits[3] = 0x0000_00ff; // Cacheline size (r/w)
-                match header_type {
-                    PciHeaderType::Device => {
-                        registers[3] = 0x0000_0000; // Header type 0 (device)
-                        writable_bits[15] = 0x0000_00ff; // IRQ line (r/w)
-                    }
-                    PciHeaderType::Bridge => {
-                        registers[3] = 0x0001_0000; // Header type 1 (bridge)
-                        writable_bits[9] = 0xfff0_fff0; // Memory base and limit
-                        writable_bits[15] = 0xffff_00ff; // Bridge control (r/w), IRQ line (r/w)
-                    }
-                };
+
+                // We only every create device types. No bridges used at the moment
+                assert_eq!(header_type, PciHeaderType::Device);
+                registers[3] = 0x0000_0000; // Header type 0 (device)
+                writable_bits[15] = 0x0000_00ff; // IRQ line (r/w)
                 registers[11] = (u32::from(subsystem_id) << 16) | u32::from(subsystem_vendor_id);
 
                 (

--- a/src/pci/src/device.rs
+++ b/src/pci/src/device.rs
@@ -8,8 +8,6 @@
 use std::sync::{Arc, Barrier};
 use std::{io, result};
 
-use vm_allocator::AddressAllocator;
-
 use crate::configuration::{self, PciBarRegionType};
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -23,7 +21,6 @@ pub enum Error {
     /// Expected resource not found.
     MissingResource,
 }
-pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BarReprogrammingParams {
@@ -34,25 +31,6 @@ pub struct BarReprogrammingParams {
 }
 
 pub trait PciDevice: Send {
-    /// Allocates the needed PCI BARs space using the `allocate` function which takes a size and
-    /// returns an address. Returns a Vec of (GuestAddress, GuestUsize) tuples.
-    fn allocate_bars(
-        &mut self,
-        _mmio32_allocator: &mut AddressAllocator,
-        _mmio64_allocator: &mut AddressAllocator,
-    ) -> Result<()> {
-        Ok(())
-    }
-
-    /// Frees the PCI BARs previously allocated with a call to allocate_bars().
-    fn free_bars(
-        &mut self,
-        _mmio32_allocator: &mut AddressAllocator,
-        _mmio64_allocator: &mut AddressAllocator,
-    ) -> Result<()> {
-        Ok(())
-    }
-
     /// Sets a register in the configuration space.
     /// * `reg_idx` - The index of the config register to modify.
     /// * `offset` - Offset into the register.

--- a/src/pci/src/device.rs
+++ b/src/pci/src/device.rs
@@ -8,16 +8,10 @@
 use std::sync::{Arc, Barrier};
 use std::{io, result};
 
-use crate::configuration::{self, PciBarRegionType};
-
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum Error {
-    /// Setup of the device capabilities failed: {0}.
-    CapabilitiesSetup(configuration::Error),
     /// Allocating space for an IO BAR failed, size={0}.
     IoAllocationFailed(u64),
-    /// Registering an IO BAR at address {0} failed: {1}
-    IoRegistrationFailed(u64, configuration::Error),
     /// Expected resource not found.
     MissingResource,
 }
@@ -27,7 +21,6 @@ pub struct BarReprogrammingParams {
     pub old_base: u64,
     pub new_base: u64,
     pub len: u64,
-    pub region_type: PciBarRegionType,
 }
 
 pub trait PciDevice: Send {
@@ -78,6 +71,5 @@ pub trait DeviceRelocation: Send + Sync {
         new_base: u64,
         len: u64,
         pci_dev: &mut dyn PciDevice,
-        region_type: PciBarRegionType,
     ) -> result::Result<(), io::Error>;
 }

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use event_manager::{MutEventSubscriber, SubscriberOps};
 use log::{debug, error, warn};
-use pci::{PciBarRegionType, PciDevice, PciDeviceError, PciRootError};
+use pci::{PciBarRegionType, PciDeviceError, PciRootError};
 use serde::{Deserialize, Serialize};
 use vm_device::BusError;
 
@@ -130,10 +130,7 @@ impl PciDevices {
         let mut resource_allocator_lock = vm.resource_allocator();
         let resource_allocator = resource_allocator_lock.deref_mut();
 
-        virtio_device.allocate_bars(
-            &mut resource_allocator.mmio32_memory,
-            &mut resource_allocator.mmio64_memory,
-        )?;
+        virtio_device.allocate_bars(&mut resource_allocator.mmio64_memory)?;
 
         let virtio_device = Arc::new(Mutex::new(virtio_device));
         pci_segment

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use event_manager::{MutEventSubscriber, SubscriberOps};
 use log::{debug, error, warn};
-use pci::{PciBarRegionType, PciDeviceError, PciRootError};
+use pci::{PciDeviceError, PciRootError};
 use serde::{Deserialize, Serialize};
 use vm_device::BusError;
 
@@ -25,7 +25,7 @@ use crate::devices::virtio::net::persist::{NetConstructorArgs, NetState};
 use crate::devices::virtio::rng::Entropy;
 use crate::devices::virtio::rng::persist::{EntropyConstructorArgs, EntropyState};
 use crate::devices::virtio::transport::pci::device::{
-    VirtioPciDevice, VirtioPciDeviceError, VirtioPciDeviceState,
+    CAPABILITY_BAR_SIZE, VirtioPciDevice, VirtioPciDeviceError, VirtioPciDeviceState,
 };
 use crate::devices::virtio::vsock::persist::{
     VsockConstructorArgs, VsockState, VsockUdsConstructorArgs,
@@ -89,13 +89,16 @@ impl PciDevices {
         virtio_device: &Arc<Mutex<VirtioPciDevice>>,
     ) -> Result<(), PciManagerError> {
         let virtio_device_locked = virtio_device.lock().expect("Poisoned lock");
-        let bar = &virtio_device_locked.bar_region;
-        assert_eq!(bar.region_type, PciBarRegionType::Memory64BitRegion);
 
-        debug!("Inserting MMIO BAR region: {:#x}:{:#x}", bar.addr, bar.size);
-        vm.common
-            .mmio_bus
-            .insert(virtio_device.clone(), bar.addr, bar.size)?;
+        debug!(
+            "Inserting MMIO BAR region: {:#x}:{:#x}",
+            virtio_device_locked.bar_address, CAPABILITY_BAR_SIZE
+        );
+        vm.common.mmio_bus.insert(
+            virtio_device.clone(),
+            virtio_device_locked.bar_address,
+            CAPABILITY_BAR_SIZE,
+        )?;
 
         Ok(())
     }

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -938,8 +938,6 @@ impl PciDevice for VirtioPciDevice {
                     let _ = interrupt.trigger(VirtioInterruptType::Config);
                 }
             }
-        } else {
-            debug!("Device doesn't need activation");
         }
 
         // Device has been reset by the driver

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -669,7 +669,6 @@ impl DeviceRelocation for Vm {
         _new_base: u64,
         _len: u64,
         _pci_dev: &mut dyn pci::PciDevice,
-        _region_type: pci::PciBarRegionType,
     ) -> Result<(), std::io::Error> {
         error!("pci: device relocation not supported");
         Err(std::io::Error::from(std::io::ErrorKind::Unsupported))


### PR DESCRIPTION
This is the first in a series of PRs that are meant to simplify our PCI codebase

## Changes

Mainly two changes:

* Move (de)allocation of the BAR outside the `PciDevice` trait
* Encode in the PCI handling logic the fact that we only ever create 64-bit BAR regions with fixed size (for VirtIO) devices

## Reason

A lot of the PCI code we pulled from Cloud Hypervisor is built in the form of a library trying to be generic and support various functionalities of the PCI specification.a

In our case, we only support certain functionality. For example, we only have two types of PCI devices, VirtIO devices and the Root Port. Only VirtIO devices use BAR regions (64 bits). We don't use 32-bit, I/O or ROM BARs.

We'd like to move towards a PCI implementation which is tailored to our use-case instead of a generic library implementation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
