### PR TITLE
buildkite: increase timeout for population latency tests

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -49,6 +49,7 @@ perf_test = {
         "label": "📸 Memory Population Latency",
         "tests": "integration_tests/performance/test_snapshot.py::test_population_latency",
         "devtool_opts": "-c 1-12 -m 0",
+        "timeout_in_minutes": 90,
     },
     "vsock-throughput": {
         "label": "🧦 Vsock Throughput",


### PR DESCRIPTION
## Changes

Increase timeout for population latency tests.

## Reason

We are seeing the execution time exceed the default 60 minutes Buidlkite timeout sometimes.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- ~~[ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.~~
- ~~[ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.~~
- ~~[ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.~~
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
