### PR TITLE
test(perf/vsock): copy iperf binary only once

### DIFF
--- a/tests/integration_tests/performance/test_vsock.py
+++ b/tests/integration_tests/performance/test_vsock.py
@@ -41,6 +41,11 @@ class VsockIPerf3Test(IPerf3Test):
             iperf="/usr/local/bin/iperf3-vsock",
             payload_length=payload_length,
         )
+        # The rootfs does not have iperf3-vsock
+        iperf3_guest = "/tmp/iperf3-vsock"
+
+        self._microvm.ssh.scp_put(self._iperf, iperf3_guest)
+        self._guest_iperf = iperf3_guest
 
     def host_command(self, port_offset):
         return (
@@ -58,11 +63,6 @@ class VsockIPerf3Test(IPerf3Test):
                 make_host_port_path(VSOCK_UDS_PATH, self._base_port + client_idx),
             )
         )
-        # The rootfs does not have iperf3-vsock
-        iperf3_guest = "/tmp/iperf3-vsock"
-
-        self._microvm.ssh.scp_put(self._iperf, iperf3_guest)
-        self._guest_iperf = iperf3_guest
         return super().spawn_iperf3_client(client_idx, client_mode_flag)
 
     def guest_command(self, port_offset):


### PR DESCRIPTION
## Changes

Move the copy into the test construction to copy the binary only once.

## Reason

Currently we copy the iperf3-vsock binary into the guest in spawn_iperf3_client that is called by every client (we have 2).  If by the time the second binary is being copied that first one is already executing, we get the "Text file busy" error.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- ~~[ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.~~
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
