### PR TITLE
docs: Clarify jailer's behavior when --parent-cgroup provided but --cgroup not provided

### DIFF
--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -123,8 +123,7 @@ After starting, the Jailer goes through the following operations:
   identified location (referred to as `<cgroup_base>`), the jailer creates the
   `<cgroup_base>/<parent_cgroup>/<id>` subfolder, and writes the current pid to
   `<cgroup_base>/<parent_cgroup>/<id>/tasks`. Also, the value passed for each
-  `<cgroup_file>` is written to the file. If `--node` is used the corresponding
-  values are written to the appropriate `cpuset.mems` and `cpuset.cpus` files.
+  `<cgroup_file>` is written to the file.
 - Call `unshare()` into a new mount namespace, use `pivot_root()` to switch the
   old system root mount point with a new one base in `chroot_dir`, switch the
   current working directory to the new root, unmount the old root mount point,

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -33,9 +33,7 @@ jailer --id <id> \
   alphanumeric characters and hyphens. The maximum length is currently 64
   characters.
 - `--exec-file` specifies the path to the Firecracker binary that will be
-  exec-ed by the jailer. The filename must include the string `firecracker`.
-  This is enforced because the interaction with the jailer is Firecracker
-  specific.
+  exec-ed by the jailer.
 - `--uid` and `--gid` specify the uid and gid the jailer switches to as it execs
   the target binary.
 - `--cgroup-version` is used to select which type of cgroup hierarchy to use for

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -18,9 +18,9 @@ jailer --id <id> \
        --exec-file <exec_file> \
        --uid <uid> \
        --gid <gid> \
-       [--parent-cgroup <parent_cgroup>] \
        [--cgroup-version <cgroup_version>] \
        [--cgroup <cgroup>] \
+       [--parent-cgroup <parent_cgroup>] \
        [--chroot-base-dir <chroot_base>] \
        [--netns <netns>] \
        [--resource-limit <resource=value>] \
@@ -38,19 +38,6 @@ jailer --id <id> \
   specific.
 - `--uid` and `--gid` specify the uid and gid the jailer switches to as it execs
   the target binary.
-- `--parent-cgroup` is used to allow the placement of microvm cgroups in custom
-  nested hierarchies. By specifying this parameter, the jailer will create a new
-  cgroup named `<id>` for the microvm in the `<cgroup_base>/<parent_cgroup>`
-  subfolder. `<cgroup_base>` is the cgroup controller root for `cgroup v1` (e.g.
-  `/sys/fs/cgroup/cpu`) or the unified controller hierarchy for `cgroup v2`
-  (e.g. `/sys/fs/cgroup/unified`). `<parent_cgroup>` is a relative path within
-  that hierarchy. For example, if `--parent-cgroup all_uvms/external_uvms` is
-  specified, the jailer will write all cgroup parameters specified through
-  `--cgroup` in `/sys/fs/cgroup/<controller_name>/all_uvms/external_uvms/<id>`.
-  By default, the parent cgroup is the filename of `<exec_file>`, which will be
-  henceforth referred to as `<exec_file_name>`. If there are no `--cgroup`
-  parameters specified and `--group-version=2` was passed, then the jailer will
-  move the process to the specified cgroup.
 - `--cgroup-version` is used to select which type of cgroup hierarchy to use for
   the creation of cgroups. The default value is "1" which means that cgroups
   specified with `--cgroup` will be created within a v1 hierarchy. Supported
@@ -64,6 +51,19 @@ jailer --id <id> \
   Firecracker process cgroups before the VM starts running, with no need to
   create the entire cgroup hierarchy manually (which requires privileged
   permissions).
+- `--parent-cgroup` is used to allow the placement of microvm cgroups in custom
+  nested hierarchies. By specifying this parameter, the jailer will create a new
+  cgroup named `<id>` for the microvm in the `<cgroup_base>/<parent_cgroup>`
+  subfolder. `<cgroup_base>` is the cgroup controller root for `cgroup v1` (e.g.
+  `/sys/fs/cgroup/cpu`) or the unified controller hierarchy for `cgroup v2`
+  (e.g. `/sys/fs/cgroup/unified`). `<parent_cgroup>` is a relative path within
+  that hierarchy. For example, if `--parent-cgroup all_uvms/external_uvms` is
+  specified, the jailer will write all cgroup parameters specified through
+  `--cgroup` in `/sys/fs/cgroup/<controller_name>/all_uvms/external_uvms/<id>`.
+  By default, the parent cgroup is the filename of `<exec_file>`, which will be
+  henceforth referred to as `<exec_file_name>`. If there are no `--cgroup`
+  parameters specified and `--group-version=2` was passed, then the jailer will
+  move the process to the specified cgroup.
 - `--chroot-base-dir` specifies the base folder where chroot jails are built.
   The default is `/srv/jailer`.
 - `--netns` specifies the path to a network namespace handle. If present, the

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -17,15 +17,15 @@ The jailer is invoked in this manner:
 jailer --id <id> \
        --exec-file <exec_file> \
        --uid <uid> \
-       --gid <gid>
-       [--parent-cgroup <relative_path>]
-       [--cgroup-version <cgroup-version>]
-       [--cgroup <cgroup>]
-       [--chroot-base-dir <chroot_base>]
-       [--netns <netns>]
-       [--resource-limit <resource=value>]
-       [--daemonize]
-       [--new-pid-ns]
+       --gid <gid> \
+       [--parent-cgroup <relative_path>] \
+       [--cgroup-version <cgroup-version>] \
+       [--cgroup <cgroup>] \
+       [--chroot-base-dir <chroot_base>] \
+       [--netns <netns>] \
+       [--resource-limit <resource=value>] \
+       [--daemonize] \
+       [--new-pid-ns] \
        [--...extra arguments for Firecracker]
 ```
 

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -19,7 +19,7 @@ jailer --id <id> \
        --uid <uid> \
        --gid <gid> \
        [--parent-cgroup <relative_path>] \
-       [--cgroup-version <cgroup-version>] \
+       [--cgroup-version <cgroup_version>] \
        [--cgroup <cgroup>] \
        [--chroot-base-dir <chroot_base>] \
        [--netns <netns>] \

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -40,8 +40,8 @@ jailer --id <id> \
   nested hierarchies. By specifying this parameter, the jailer will create a new
   cgroup named `id` for the microvm in the `<cgroup_base>/<parent_cgroup>`
   subfolder. `cgroup_base` is the cgroup controller root for `cgroup v1` (e.g.
-  `/sys/fs/cgroup/cpu`) or the unified controller hierarchy for `cgroup v2` (
-  e.g. `/sys/fs/cgroup/unified`. `<parent_cgroup>` is a relative path within
+  `/sys/fs/cgroup/cpu`) or the unified controller hierarchy for `cgroup v2`
+  (e.g. `/sys/fs/cgroup/unified`). `<parent_cgroup>` is a relative path within
   that hierarchy. For example, if `--parent-cgroup all_uvms/external_uvms` is
   specified, the jailer will write all cgroup parameters specified through
   `--cgroup` in `/sys/fs/cgroup/<controller_name>/all_uvms/external_uvms/<id>`.

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -218,7 +218,7 @@ impl Env {
             let cg_parent_procs = cg_parent.join("cgroup.procs");
             if cg_parent.exists() {
                 fs::write(cg_parent_procs, std::process::id().to_string())
-                    .map_err(|_| JailerError::CgroupWrite(io::Error::last_os_error()))?;
+                    .map_err(|_| JailerError::CgroupMove(cg_parent, io::Error::last_os_error()))?;
             }
         }
 

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -43,8 +43,11 @@ pub enum JailerError {
     CgroupInvalidVersion(String),
     #[error("Parent cgroup path is invalid. Path should not be absolute or contain '..' or '.'")]
     CgroupInvalidParentPath(),
-    #[error("Failed to write to cgroups file: {0}")]
-    CgroupWrite(io::Error),
+    #[error(
+        "Failed to move process to cgroup ({0}): {1}.\nHint: If you intended to create a child \
+         cgroup under {0}, pass any --cgroup parameters."
+    )]
+    CgroupMove(PathBuf, io::Error),
     #[error("Failed to change owner for {0}: {1}")]
     ChangeFileOwner(PathBuf, io::Error),
     #[error("Failed to chdir into chroot directory: {0}")]


### PR DESCRIPTION
## Changes

- Tiny cleanups of jailer doc
- Clarify the jailer's behavior when --parent-cgroup provided but --cgroup not provided
- Add integration tests for all the cases when --parent-cgroup provided but --cgroup not provided.

## Reason

The behavior of `--parent-cgroup` parameter on cgroup v2 is a bit complicated:
- If any --cgroup parameters passed, jailer creates a new cgroup under the specified cgroup
- If no --cgroup parameters not passed,
    - If the specified cgroup exists, jailer moves the process to the cgroup instead of creating a new cgroup under it.
    - If the specified cgroup does not exist, jailer doesn't do anything and proceeds without error.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
