### PR TITLE
fix(test): do not override Firecracker binary

### DIFF
--- a/tests/integration_tests/build/test_seccomp_no_redundant_rules.py
+++ b/tests/integration_tests/build/test_seccomp_no_redundant_rules.py
@@ -13,6 +13,9 @@ from framework.static_analysis import (
     load_seccomp_rules,
 )
 
+# Make sure we don't override the Firecracker binary used from other tests
+TMP_BUILD_DIR = "../redundant_seccomp_rules_build"
+
 
 def test_redundant_seccomp_rules():
     """Test that fails if static analysis determines redundant seccomp rules"""
@@ -24,11 +27,11 @@ def test_redundant_seccomp_rules():
     target = f"{arch}-unknown-linux-musl"
 
     utils.check_output(
-        f'RUSTFLAGS="-C relocation-model=static -C link-args=-no-pie" cargo +{nightly_toolchain} -Zbuild-std=panic_abort,std build --release --target {target} -p firecracker'
+        f'CARGO_TARGET_DIR={TMP_BUILD_DIR} RUSTFLAGS="-C relocation-model=static -C link-args=-no-pie" cargo +{nightly_toolchain} -Zbuild-std=panic_abort,std build --release --target {target} -p firecracker'
     )
 
     found_syscalls = find_syscalls_in_binary(
-        Path(f"../build/cargo_target/{target}/release/firecracker")
+        Path(f"{TMP_BUILD_DIR}/{target}/release/firecracker")
     )
 
     seccomp_rules = load_seccomp_rules(Path(f"../resources/seccomp/{target}.json"))


### PR DESCRIPTION
## Changes

Build the binary used by `test_redundant_seccomp_rules` test in an alternative build directory.

## Reason

`test_redundant_seccomp_rules` builds the Firecracker binary using the nightly toolchain (we need this to be able to run its static analysis). This replaces the binary used by all subsequent tests and it causes them to fail since nightly might introduce a system call that is not allowed by our seccomp rules.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
