### PR TITLE
Gracefully clean-up potentially dead microVMs

### DIFF
--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -228,6 +228,9 @@ def test_deflate_on_oom(uvm_plain_any, deflate_on_oom):
             assert balloon_size_after < balloon_size_before, "Balloon did not deflate"
         else:
             assert balloon_size_after >= balloon_size_before, "Balloon deflated"
+            # Kill it here, letting the infrastructure know that the process might
+            # be dead already.
+            test_microvm.kill(might_be_dead=True)
 
 
 # pylint: disable=C0103


### PR DESCRIPTION
## Changes

Teach MicroVM.kill() that there might be cases where the microVM process has already died and let it finish its cleanup gracefully.

## Reason

We have some tests that stress the microVM in a way that _might_ cause it to die. We do check whether that's the case, however this is inherently racy, i.e. the microVM might die on us after the check but before the fixture logic tries to recycle it. Such a test is test_balloon.py::test_deflate_oom.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
