### PR TITLE
Fix `test_failing_filter` intermittent issue

### DIFF
--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -6,8 +6,6 @@ import platform
 import time
 from pathlib import Path
 
-import requests
-
 from framework import utils
 
 
@@ -76,9 +74,10 @@ def test_failing_filter(uvm_plain, seccompiler):
     test_microvm.basic_config(vcpu_count=1)
 
     # Try to start the VM with error checking off, because it will fail.
+    # pylint: disable=bare-except
     try:
         test_microvm.start()
-    except requests.exceptions.ConnectionError:
+    except:
         pass
 
     # Give time for the process to get killed


### PR DESCRIPTION
## Changes

Change `test_failing_filter` to catch all types of exceptions when trying to start a microVM.

## Reason

We intermittently get failures in this test while destroying the microVM object given to us by the fixture. That code checks that the microVM was not killed due to a signal and in this case, it clearly has (that's the intention of the test). The test itself is marking the microVM as killed so the cleanup logic should never reach that check.

The only way that kill() fails in this case is when test_microvm.mark_killed() (the last command in this test) is never called, meaning that the test errors out before that. I believe that the only point in the code that can cause the test to exit earlier is this:

```python
try:
    test_microvm.start()
except requests.exceptions.ConnectionError:
    pass
```

We are expecting test_microvm.start() to fail due to seccomp violations, however we are only catching the ConnectionError exception. If any other exception is raised the test will fail pre-maturely without setting test_microvm.mark_killed(). In fact, looking at the backtrace from intermittent errors it looks like the code
is actually raising a ConnectionResetError.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
