### PR TITLE
fix: correctly set device status to 0 on reset

### DIFF
--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -962,11 +962,12 @@ impl PciDevice for VirtioPciDevice {
                 }
                 None => {
                     error!("Attempt to reset device when not implemented in underlying device");
-                    self.common_config.driver_status = DEVICE_FAILED;
+                    // TODO: currently we don't support device resetting, but we still
+                    // follow the spec and set the status field to 0.
+                    self.common_config.driver_status = DEVICE_INIT;
                 }
             }
         }
-
         None
     }
 }


### PR DESCRIPTION
## Changes
Even though currently, no device supports resetting, once the guest attempts to reset the device we must set the status to 0 as specified in the 2.4.1 Device Requirements: Device Reset.

This does not change the current status of us not supporting device resetting.

## Reason
This is the issue we encountered during addition of virtio-pmem device where the guest kernel now resets devices on VM shutdown.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
