### PR TITLE
fix(test/vulnerabilities): add exception for TSA before 6.1.153

### DIFF
--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -11,11 +11,13 @@ from pathlib import Path
 
 import pytest
 import requests
+from packaging import version
 
 from framework import utils
 from framework.ab_test import git_clone
 from framework.microvm import MicroVMFactory
 from framework.properties import global_props
+from framework.utils_cpuid import CpuVendor, get_cpu_vendor
 
 CHECKER_URL = "https://raw.githubusercontent.com/speed47/spectre-meltdown-checker/master/spectre-meltdown-checker.sh"
 CHECKER_FILENAME = "spectre-meltdown-checker.sh"
@@ -132,7 +134,31 @@ def get_vuln_files_exception_dict(template):
     """
     Returns a dictionary of expected values for vulnerability files requiring special treatment.
     """
+    host_kernel_version = version.parse(utils.get_kernel_version())
+    cpu_vendor = get_cpu_vendor()
     exception_dict = {}
+
+    # Exception for tsa
+    # =============================
+    #
+    # AMD guests on 6.1 hosts before 6.1.153
+    # --------------------------------------------
+    # On 6.1 kernels before 6.1.153 [1], KVM doesn't tell the guest that the microcode with the TSA
+    # mitigation has been applied by setting CPUID.(EAX=0x80000021,ECX=0):EAX[5 (CLEAR_VERW)].
+    # The guest applies the mitigation anyways, but flags it as possibly vulnerable as it cannot
+    # verify that the microcode update has been applied correctly.
+    # Note that this doesn't affect the T2A template (deprecated) as the presented CPU is older
+    # and not recognised as being affected by TSA.
+    # [1]: https://github.com/amazonlinux/linux/commit/8d1e0db16431610b5b35737d88595bdd7a08e271
+
+    if (
+        cpu_vendor == CpuVendor.AMD
+        and template == "None"
+        and host_kernel_version.major == 6
+        and host_kernel_version.minor == 1
+        and host_kernel_version.micro < 153
+    ):
+        exception_dict["tsa"] = "Vulnerable: Clear CPU buffers attempted, no microcode"
 
     # Exception for mmio_stale_data
     # =============================


### PR DESCRIPTION
## Changes

Add an exception for TSA for host kernels before 6.1.153


## Reason

Vulnerability checks are failing. 

TSA is marked as vulnerable as 6.1 kernels before 6.1.153 don't correctly pass through the CPUID bit to let the guest know that the microcode is applied (CLEAR_VERW).
We noticed only now as we just updated the guest kernels and they now contain the TSA mitigation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
