### PR TITLE
Do not look into full path for error metric

### DIFF
--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -479,7 +479,10 @@ def flush_fc_metrics_to_cw(fc_metrics, metrics):
     failure_metrics = {
         key: value
         for key, value in flattened_metrics.items()
-        if "err" in key or "fail" in key or "panic" in key or "num_faults" in key
+        if "err" in key.split(".")[-1]
+        or "fail" in key.split(".")[-1]
+        or "panic" in key.split(".")[-1]
+        or "num_faults" in key.split(".")[-1]
         if value
         if key not in ignored_failure_metrics
     }


### PR DESCRIPTION
In order to collect all error metrics we're checking for "err" in the key name, which causes performance tests to fail because we added metrics called "intERRupts".  Change the check to only look at the leafof the path, so that when we have a metric such as `fc_metrics.net_metrics.cfg_fails`, we'll only be looking into cfg_fails`.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
