### PR TITLE
[v1.12] chore: Add ibpb_exit_to_user as host only feature

### DIFF
--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -49,6 +49,7 @@ INTEL_HOST_ONLY_FEATS = {
     "hwp_act_window",
     "hwp_epp",
     "hwp_pkg_req",
+    "ibpb_exit_to_user",
     "ida",
     "intel_ppin",
     "intel_pt",
@@ -94,6 +95,7 @@ AMD_MILAN_HOST_ONLY_FEATS = {
     "extd_apicid",
     "flushbyasid",
     "hw_pstate",
+    "ibpb_exit_to_user",
     "ibs",
     "irperf",
     "lbrv",
@@ -211,7 +213,14 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
             assert guest_feats - host_feats == expected_guest_minus_host
 
         case CpuModel.INTEL_ICELAKE:
-            host_guest_diff_5_10 = INTEL_HOST_ONLY_FEATS - {"cdp_l3"} | {
+            expected_host_minus_guest = INTEL_HOST_ONLY_FEATS
+
+            # As long as BHB clearing software mitigation is enabled, Intel Ice Lake is not
+            # vulnerable to VMScape and "IBPB before exit to userspace" is not needed.
+            # https://docs.kernel.org/admin-guide/hw-vuln/vmscape.html#affected-processors
+            expected_host_minus_guest -= {"ibpb_exit_to_user"}
+
+            host_guest_diff_5_10 = expected_host_minus_guest - {"cdp_l3"} | {
                 "pconfig",
                 "tme",
                 "split_lock_detect",


### PR DESCRIPTION

## Changes

Backport commit 8221464e80782e999aa980f34ced324e22336b74 from main.

chore: Add ibpb_exit_to_user as host only feature

## Reason

New Amazon Linux host kernels enable mitigation against VMScape that is IBPB before exit to userspace. However, our guest kernels still haven't had the patches yet. Note that Intel Ice Lake is not affected by VMScape as long as BHB clearing sequence is used to mitigate BHI.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
