### PR TITLE
chore: update vm-memory to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.1.0"
 dependencies = [
  "displaydoc",
  "thiserror 2.0.17",
- "vm-memory",
+ "vm-memory 0.17.0",
  "zerocopy",
 ]
 
@@ -600,7 +600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -848,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3432d9f609fbede9f624d1dbefcce77985a9322de1d0e6d460ec05502b7fd0"
+checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
 dependencies = [
  "serde",
  "vmm-sys-util",
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e00243d27a20feb05cf001ae52ddc79831ac70c020f215ba1153ff9270b650a"
+checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
 dependencies = [
  "bitflags 2.9.4",
  "kvm-bindings",
@@ -894,16 +894,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
 name = "linux-loader"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870c3814345f050991f99869417779f6062542bcf4ed81db7a1b926ad1306638"
+checksum = "53802c0b111faf302a16fa20a2e3a33bd0eab408f60fc34cbfe052f6b153791e"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.17.0",
 ]
 
 [[package]]
@@ -1254,7 +1254,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1626,7 +1626,7 @@ dependencies = [
  "bitflags 2.9.4",
  "libc",
  "uuid",
- "vm-memory",
+ "vm-memory 0.16.2",
  "vmm-sys-util",
 ]
 
@@ -1665,10 +1665,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "vm-superio"
-version = "0.8.0"
+name = "vm-memory"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3428ee25acbfc75ed14600f2043876e0889cbd57c39dd441191417377cdceda0"
+checksum = "48f1f33aee6ae648087fbed47c2944e2796f7877d4717a59edc8d7cb62f71061"
+dependencies = [
+ "libc",
+ "thiserror 2.0.17",
+ "winapi",
+]
+
+[[package]]
+name = "vm-superio"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69c376a9b84afdf97bddd2628096cf3554208b2a676cf06b4532e0f433a54e02"
 
 [[package]]
 name = "vmm"
@@ -1714,7 +1725,7 @@ dependencies = [
  "vhost",
  "vm-allocator",
  "vm-fdt",
- "vm-memory",
+ "vm-memory 0.17.0",
  "vm-superio",
  "vmm-sys-util",
  "zerocopy",
@@ -1841,7 +1852,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src/acpi-tables/Cargo.toml
+++ b/src/acpi-tables/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 [dependencies]
 displaydoc = "0.2.5"
 thiserror = "2.0.17"
-vm-memory = { version = "0.16.2", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.17.0", features = ["backend-mmap", "backend-bitmap"] }
 zerocopy = { version = "0.8.27", features = ["derive"] }
 
 [lints]

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -33,10 +33,10 @@ displaydoc = "0.2.5"
 event-manager = "0.4.1"
 gdbstub = { version = "0.7.7", optional = true }
 gdbstub_arch = { version = "0.3.2", optional = true }
-kvm-bindings = { version = "0.13.0", features = ["fam-wrappers", "serde"] }
-kvm-ioctls = "0.23.0"
+kvm-bindings = { version = "0.14.0", features = ["fam-wrappers", "serde"] }
+kvm-ioctls = "0.24.0"
 libc = "0.2.176"
-linux-loader = "0.13.0"
+linux-loader = "0.13.1"
 log = { version = "0.4.28", features = ["std", "serde"] }
 log-instrument = { path = "../log-instrument", optional = true }
 memfd = "0.6.5"
@@ -53,11 +53,11 @@ utils = { path = "../utils" }
 uuid = "1.18.1"
 vhost = { version = "0.14.0", features = ["vhost-user-frontend"] }
 vm-allocator = { version = "0.1.3", features = ["serde"] }
-vm-memory = { version = "0.16.2", features = [
+vm-memory = { version = "0.17.0", features = [
   "backend-mmap",
   "backend-bitmap",
 ] }
-vm-superio = "0.8.0"
+vm-superio = "0.8.1"
 vmm-sys-util = { version = "0.14.0", features = ["with-serde"] }
 zerocopy = { version = "0.8.27" }
 

--- a/src/vmm/src/devices/virtio/vhost_user.rs
+++ b/src/vmm/src/devices/virtio/vhost_user.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use vhost::vhost_user::message::*;
 use vhost::vhost_user::{Frontend, VhostUserFrontend};
 use vhost::{Error as VhostError, VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
-use vm_memory::{Address, Error as MmapError, GuestMemory, GuestMemoryError, GuestMemoryRegion};
+use vm_memory::{Address, GuestMemory, GuestMemoryError, GuestMemoryRegion};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::devices::virtio::queue::Queue;
@@ -51,8 +51,8 @@ pub enum VhostUserError {
     VhostUserSetVringKick(VhostError),
     /// Set vring enable failed: {0}
     VhostUserSetVringEnable(VhostError),
-    /// Failed to read vhost eventfd: {0}
-    VhostUserMemoryRegion(MmapError),
+    /// Failed to read vhost eventfd: No memory region found
+    VhostUserNoMemoryRegion,
     /// Invalid used address
     UsedAddress(GuestMemoryError),
 }
@@ -371,9 +371,7 @@ impl<T: VhostUserHandleBackend> VhostUserHandleImpl<T> {
             let (mmap_handle, mmap_offset) = match region.file_offset() {
                 Some(_file_offset) => (_file_offset.file().as_raw_fd(), _file_offset.start()),
                 None => {
-                    return Err(VhostUserError::VhostUserMemoryRegion(
-                        MmapError::NoMemoryRegion,
-                    ));
+                    return Err(VhostUserError::VhostUserNoMemoryRegion);
                 }
             };
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -81,8 +81,8 @@ pub enum VmError {
     CreateVcpu(VcpuError),
     /// The number of configured slots is bigger than the maximum reported by KVM: {0}
     NotEnoughMemorySlots(u32),
-    /// Memory Error: {0}
-    VmMemory(#[from] vm_memory::Error),
+    /// Failed to add a memory region: {0}
+    InsertRegion(#[from] vm_memory::GuestRegionCollectionError),
     /// Error calling mincore: {0}
     Mincore(vmm_sys_util::errno::Error),
     /// ResourceAllocator error: {0}


### PR DESCRIPTION
## Changes

This commit updates VM memory and other rust-vmm dependencies:
 - kvm-bindings from 0.13.0 to 0.14.0
 - kvm-ioctls from 0.23.0 to 0.24.0
 - linux-loader from 0.13.0 to 0.13.1
 - vm-memory from 0.16.2 to 0.17.0
 - vm-superio from 0.8.0 to 0.8.1

## Reason

Update vm-memory 0.17.0 to unlock https://github.com/firecracker-microvm/firecracker/pull/5452

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
