### PR TITLE
test(popular-containers): build AL image first

### DIFF
--- a/tools/test-popular-containers/build_rootfs.sh
+++ b/tools/test-popular-containers/build_rootfs.sh
@@ -73,9 +73,13 @@ passwd -d root
 EOF
 }
 
+# FIXME: The AL image build procedure is known for keeping changing the ext4 file
+# even after the systemd-nspawn command exits, for unknown reason, causing
+# the subsequent tar command to fail.  Placing it first as a mitigation gives it
+# more time to converge to a stable state.
+make_rootfs amazonlinux:2023
 make_rootfs alpine:latest
 make_rootfs ubuntu:22.04
 make_rootfs ubuntu:24.04
 make_rootfs ubuntu:25.04
 make_rootfs ubuntu:latest
-make_rootfs amazonlinux:2023


### PR DESCRIPTION
## Changes

Hoist building the AL image build on top to mitigate the issue.

## Reason

We observed intermittent issues where subsequent tar operation complained about the ext4 file being changed under the hood, presumably due to residual processes going on after systemd-nspawn exits:
```
tar: amazonlinux\:2023.ext4: file changed as we read it
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- ~~[ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.~~
- ~~[ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.~~
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- ~~[ ] I have mentioned all user-facing changes in `CHANGELOG.md`.~~
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- ~~[ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.~~
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
