### PR TITLE
fix: Call KVM_KVMCLOCK_CTRL not only after pause but also before snapshot resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to
   bug causing a read/write from an iovec to be duplicated when receiving an
   error on an iovec other than the first. This caused a data corruption issue in
   the vsock device starting from guest kernel 6.17.
+- [#5494](https://github.com/firecracker-microvm/firecracker/pull/5494): Fixed a
+  watchdog soft lockup bug on microVMs restored from snapshots by calling
+  KVM_KVMCLOCK_CTRL ioctl before resuming.
 
 ## [1.13.0]
 


### PR DESCRIPTION
Fixes #5322.

## Changes

- Call KVM_KVMCLOCK_CTRL not only after pause but also before snapshot resume

## Reason

KVM_KVMCLOCK_CTRL ioctl sets `pvclock_set_guest_stopped_request` flag of `kvm_vcpu_arch` [1]. On the next guest time update, if the flag is set, KVM ORs in `PVCLOCK_GUEST_STOPPED` and `kvm_setup_guest_pvclock()` pushes the `hv_clock` into the guest's pvclock page [2]. If the `hv_clock` has not been written to the guest's pvclock page when taking a snapshot, it is not saved in the snapshot memory (i.e. `PVCLOCK_GUEST_STOPPED` isn't set in resumed VMs). So we should call KVM_KVMCLOCK_CTRL ioctl before resuming a VM rather than after pausing a VM. That covers both the pause-and-resume case and the restore-and-resume case.

[1]: https://elixir.bootlin.com/linux/v6.16.3/source/arch/x86/kvm/x86.c#L5734
[2]: https://elixir.bootlin.com/linux/v6.16.3/source/arch/x86/kvm/x86.c#L3286-L3295

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- ~~[ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.~~
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- ~~[ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].~~
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- ~~[ ] I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
