### PR TITLE
feat: add config option to enable transparent huge pages

### DIFF
--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -69,6 +69,8 @@ specification:
 |                           | show_level         |    O     |       O        |      O       |        O         |     O      |      O       |     O      |      O      |
 |                           | show_log_origin    |    O     |       O        |      O       |        O         |     O      |      O       |     O      |      O      |
 | `MachineConfiguration`    | cpu_template       |    O     |       O        |      O       |        O         |     O      |      O       |     O      |      O      |
+|                           | huge_pages         |    O     |       O        |      O       |        O         |     O      |      O       |     O      |      O      |
+|                           | enable_thp         |    O     |       O        |      O       |        O         |     O      |      O       |     O      |      O      |
 |                           | smt                |    O     |       O        |      O       |        O         |     O      |      O       |     O      |      O      |
 |                           | mem_size_mib       |    O     |       O        |      O       |        O         |     O      |      O       |     O      |      O      |
 |                           | track_dirty_pages  |    O     |       O        |      O       |        O         |     O      |      O       |     O      |      O      |

--- a/src/firecracker/src/api_server/request/machine_configuration.rs
+++ b/src/firecracker/src/api_server/request/machine_configuration.rs
@@ -123,6 +123,7 @@ mod tests {
                 cpu_template: None,
                 track_dirty_pages: Some(false),
                 huge_pages: Some(expected),
+                enable_thp: Some(false),
                 #[cfg(feature = "gdb")]
                 gdb_socket_path: None,
             };
@@ -144,6 +145,7 @@ mod tests {
             cpu_template: Some(StaticCpuTemplate::None),
             track_dirty_pages: Some(false),
             huge_pages: Some(HugePageConfig::None),
+            enable_thp: Some(false),
             #[cfg(feature = "gdb")]
             gdb_socket_path: None,
         };
@@ -165,6 +167,7 @@ mod tests {
             cpu_template: None,
             track_dirty_pages: Some(true),
             huge_pages: Some(HugePageConfig::None),
+            enable_thp: Some(false),
             #[cfg(feature = "gdb")]
             gdb_socket_path: None,
         };
@@ -190,6 +193,7 @@ mod tests {
                 cpu_template: Some(StaticCpuTemplate::T2),
                 track_dirty_pages: Some(true),
                 huge_pages: Some(HugePageConfig::None),
+                enable_thp: Some(false),
                 #[cfg(feature = "gdb")]
                 gdb_socket_path: None,
             };
@@ -217,6 +221,7 @@ mod tests {
             cpu_template: None,
             track_dirty_pages: Some(true),
             huge_pages: Some(HugePageConfig::None),
+            enable_thp: Some(false),
             #[cfg(feature = "gdb")]
             gdb_socket_path: None,
         };

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1140,6 +1140,13 @@ definitions:
           - None
           - 2M
         description: Which huge pages configuration (if any) should be used to back guest memory.
+      enable_thp:
+        type: boolean
+        description: >-
+          Enable transparent huge pages via madvise(MADV_HUGEPAGE) for guest memory.
+          Effective only for anonymous memory (non-memfd) and when not using explicit hugetlbfs pages.
+          If guest memory is memfd-backed (e.g., due to vhost-user-blk), setting this will cause an error.
+        default: false
 
   MemoryBackend:
     type: object

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -356,6 +356,7 @@ pub fn restore_from_snapshot(
             cpu_template: Some(microvm_state.vm_info.cpu_template),
             track_dirty_pages: Some(track_dirty_pages),
             huge_pages: Some(microvm_state.vm_info.huge_pages),
+            enable_thp: Some(false),
             #[cfg(feature = "gdb")]
             gdb_socket_path: None,
         })

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -115,6 +115,11 @@ pub struct MachineConfig {
     /// Configures what page size Firecracker should use to back guest memory.
     #[serde(default)]
     pub huge_pages: HugePageConfig,
+    /// Enables or disables transparent huge pages (THP) on guest memory via madvise.
+    /// Only effective when guest memory is backed by anonymous memory (non-memfd) and
+    /// not using explicit hugetlbfs pages.
+    #[serde(default)]
+    pub enable_thp: bool,
     /// GDB socket address.
     #[cfg(feature = "gdb")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -157,6 +162,7 @@ impl Default for MachineConfig {
             cpu_template: None,
             track_dirty_pages: false,
             huge_pages: HugePageConfig::None,
+            enable_thp: false,
             #[cfg(feature = "gdb")]
             gdb_socket_path: None,
         }
@@ -190,6 +196,9 @@ pub struct MachineConfigUpdate {
     /// Configures what page size Firecracker should use to back guest memory.
     #[serde(default)]
     pub huge_pages: Option<HugePageConfig>,
+    /// Enables or disables transparent huge pages (THP) on guest memory via madvise.
+    #[serde(default)]
+    pub enable_thp: Option<bool>,
     /// GDB socket address.
     #[cfg(feature = "gdb")]
     #[serde(default)]
@@ -214,6 +223,7 @@ impl From<MachineConfig> for MachineConfigUpdate {
             cpu_template: cfg.static_template(),
             track_dirty_pages: Some(cfg.track_dirty_pages),
             huge_pages: Some(cfg.huge_pages),
+            enable_thp: Some(cfg.enable_thp),
             #[cfg(feature = "gdb")]
             gdb_socket_path: cfg.gdb_socket_path,
         }
@@ -281,6 +291,7 @@ impl MachineConfig {
             cpu_template,
             track_dirty_pages: update.track_dirty_pages.unwrap_or(self.track_dirty_pages),
             huge_pages: page_config,
+            enable_thp: update.enable_thp.unwrap_or(self.enable_thp),
             #[cfg(feature = "gdb")]
             gdb_socket_path: update.gdb_socket_path.clone(),
         })

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -53,6 +53,10 @@ pub enum MemoryError {
     OffsetTooLarge,
     /// Cannot retrieve snapshot file metadata: {0}
     FileMetadata(std::io::Error),
+    /// Cannot apply madvise: {0}
+    Madvise(std::io::Error),
+    /// Transparent huge pages are unsupported for memfd-backed guest memory
+    ThpUnsupportedMemfd,
 }
 
 /// Type of the guest region

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -798,6 +798,7 @@ class Microvm:
         rootfs_io_engine=None,
         cpu_template: Optional[str] = None,
         enable_entropy_device=False,
+        enable_thp: Optional[bool] = None,
     ):
         """Shortcut for quickly configuring a microVM.
 
@@ -821,6 +822,7 @@ class Microvm:
             mem_size_mib=mem_size_mib,
             track_dirty_pages=track_dirty_pages,
             huge_pages=huge_pages,
+            enable_thp=enable_thp,
         )
         self.vcpus_count = vcpu_count
         self.mem_size_bytes = mem_size_mib * 2**20


### PR DESCRIPTION
## Changes

Add a new machine-config field, `enable_thp`, that controls whether transparent huge pages (THP) is enabled for the microVM.

## Reason

Currently, even for a VM that is not restored from a snapshot and not using any vhost-user devices, Firecracker does not attempt to enable transparent huge pages for it. This makes it necessary to reserve hugetlb pages on hypervisor host machines, making things hard on hosts that run mixed workloads.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
