### PR TITLE
fix(test): skip test_cpu_topology test on Ubuntu

### DIFF
--- a/tests/integration_tests/functional/test_topology.py
+++ b/tests/integration_tests/functional/test_topology.py
@@ -6,9 +6,11 @@ import platform
 import subprocess
 
 import pytest
+from packaging import version
 
 import framework.utils_cpuid as utils
 from framework.properties import global_props
+from framework.utils import get_kernel_version
 
 TOPOLOGY_STR = {1: "0", 2: "0,1", 16: "0-15"}
 PLATFORM = platform.machine()
@@ -198,6 +200,12 @@ def test_cpu_topology(uvm_plain_any, num_vcpus, htt):
     """
     if htt and PLATFORM == "aarch64":
         pytest.skip("SMT is configurable only on x86.")
+
+    # TODO:Remove (or adapt) this once we unify the way we expose the CPU cache hierarchy on
+    # Aarch64 systems.
+    if version.parse(get_kernel_version()) >= version.parse("6.14"):
+        pytest.skip("Starting on 6.14 KVM exposes a different CPU cache hierarchy")
+
     vm = uvm_plain_any
     vm.spawn()
     vm.basic_config(vcpu_count=num_vcpus, smt=htt)


### PR DESCRIPTION
On Aarch64 systems we do not normalize vCPUs, we let KVM configure them. This means that the CPU cache hierarchy exposed to the guest depends entirely on what the KVM decides it to be.

We observed that when we're running tests on Ubuntu hosts with a 6.14 kernel the cache hierarchy is different than the one we expect on AL hosts.

Until we decide how to deal with CPU hierarchy in a controlled way (or not) skip the test on Ubuntu systems.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
