### PR TITLE
chore(pci): gracefully handle errors in the PCI restore code

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -26,7 +26,7 @@ use crate::cpu_config::templates::{GetCpuTemplate, GetCpuTemplateError, GuestCon
 use crate::device_manager;
 use crate::device_manager::pci_mngr::PciManagerError;
 use crate::device_manager::{
-    AttachDeviceError, DeviceManager, DeviceManagerCreateError, DevicePersistError,
+    AttachDeviceError, DeviceManager, DeviceManagerCreateError, DeviceManagerPersistError,
     DeviceRestoreArgs,
 };
 use crate::devices::virtio::balloon::Balloon;
@@ -424,7 +424,7 @@ pub enum BuildMicrovmFromSnapshotError {
     /// Failed to apply VMM secccomp filter: {0}
     SeccompFiltersInternal(#[from] crate::seccomp::InstallationError),
     /// Failed to restore devices: {0}
-    RestoreDevices(#[from] DevicePersistError),
+    RestoreDevices(#[from] DeviceManagerPersistError),
 }
 
 /// Builds and starts a microVM based on the provided MicrovmState.

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -31,11 +31,20 @@ use crate::devices::legacy::RTCDevice;
 use crate::devices::legacy::serial::SerialOut;
 use crate::devices::legacy::{IER_RDA_BIT, IER_RDA_OFFSET, SerialDevice};
 use crate::devices::pseudo::BootTimer;
+use crate::devices::virtio::ActivateError;
+use crate::devices::virtio::balloon::BalloonError;
+use crate::devices::virtio::block::BlockError;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
+use crate::devices::virtio::mem::persist::VirtioMemPersistError;
+use crate::devices::virtio::net::persist::NetPersistError;
+use crate::devices::virtio::pmem::persist::PmemPersistError;
+use crate::devices::virtio::rng::persist::EntropyPersistError;
 use crate::devices::virtio::transport::mmio::{IrqTrigger, MmioTransport};
+use crate::devices::virtio::vsock::{VsockError, VsockUnixBackendError};
 use crate::resources::VmResources;
 use crate::snapshot::Persist;
 use crate::utils::open_file_nonblock;
+use crate::vmm_config::mmds::MmdsConfigError;
 use crate::vstate::bus::BusError;
 use crate::vstate::memory::GuestMemoryMmap;
 use crate::{EmulateSerialInitError, EventManager, Vm};
@@ -406,14 +415,51 @@ pub struct DevicesState {
     pub pci_state: pci_mngr::PciDevicesState,
 }
 
+/// Errors for (de)serialization of the devices.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum DevicePersistError {
+    /// Balloon: {0}
+    Balloon(#[from] BalloonError),
+    /// Block: {0}
+    Block(#[from] BlockError),
+    /// MMIO Device manager: {0}
+    MmioDeviceManager(#[from] mmio::MmioError),
+    /// Mmio transport
+    MmioTransport,
+    /// PCI Device manager: {0}
+    PciDeviceManager(#[from] PciManagerError),
+    /// Bus error: {0}
+    Bus(#[from] BusError),
+    #[cfg(target_arch = "aarch64")]
+    /// Legacy: {0}
+    Legacy(#[from] std::io::Error),
+    /// Net: {0}
+    Net(#[from] NetPersistError),
+    /// Vsock: {0}
+    Vsock(#[from] VsockError),
+    /// VsockUnixBackend: {0}
+    VsockUnixBackend(#[from] VsockUnixBackendError),
+    /// MmdsConfig: {0}
+    MmdsConfig(#[from] MmdsConfigError),
+    /// Entropy: {0}
+    Entropy(#[from] EntropyPersistError),
+    /// Pmem: {0}
+    Pmem(#[from] PmemPersistError),
+    /// virtio-mem: {0}
+    VirtioMem(#[from] VirtioMemPersistError),
+    /// Could not activate device: {0}
+    DeviceActivation(#[from] ActivateError),
+}
+
+/// Errors for (de)serialization of the device manager.
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum DeviceManagerPersistError {
     /// Error restoring MMIO devices: {0}
-    MmioRestore(#[from] persist::DevicePersistError),
+    MmioRestore(DevicePersistError),
     /// Error restoring ACPI devices: {0}
     AcpiRestore(#[from] ACPIDeviceError),
     /// Error restoring PCI devices: {0}
-    PciRestore(#[from] PciManagerError),
+    PciRestore(DevicePersistError),
     /// Error resetting serial console: {0}
     SerialRestore(#[from] EmulateSerialInitError),
     /// Error inserting device in bus: {0}
@@ -445,7 +491,7 @@ impl std::fmt::Debug for DeviceRestoreArgs<'_> {
 impl<'a> Persist<'a> for DeviceManager {
     type State = DevicesState;
     type ConstructorArgs = DeviceRestoreArgs<'a>;
-    type Error = DevicePersistError;
+    type Error = DeviceManagerPersistError;
 
     fn save(&self) -> Self::State {
         DevicesState {
@@ -476,7 +522,8 @@ impl<'a> Persist<'a> for DeviceManager {
             vm_resources: constructor_args.vm_resources,
             instance_id: constructor_args.instance_id,
         };
-        let mmio_devices = MMIODeviceManager::restore(mmio_ctor_args, &state.mmio_state)?;
+        let mmio_devices = MMIODeviceManager::restore(mmio_ctor_args, &state.mmio_state)
+            .map_err(DeviceManagerPersistError::MmioRestore)?;
 
         // Restore ACPI devices
         let acpi_devices = ACPIDeviceManager::restore(constructor_args.vm, &state.acpi_state)?;
@@ -489,7 +536,8 @@ impl<'a> Persist<'a> for DeviceManager {
             instance_id: constructor_args.instance_id,
             event_manager: constructor_args.event_manager,
         };
-        let pci_devices = PciDevices::restore(pci_ctor_args, &state.pci_state)?;
+        let pci_devices = PciDevices::restore(pci_ctor_args, &state.pci_state)
+            .map_err(DeviceManagerPersistError::PciRestore)?;
 
         let device_manager = DeviceManager {
             mmio_devices,

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -11,6 +11,7 @@ use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 
 use super::persist::MmdsState;
+use crate::device_manager::DevicePersistError;
 use crate::devices::pci::PciSegment;
 use crate::devices::virtio::balloon::Balloon;
 use crate::devices::virtio::balloon::persist::{BalloonConstructorArgs, BalloonState};
@@ -36,7 +37,6 @@ use crate::pci::bus::PciRootError;
 use crate::resources::VmResources;
 use crate::snapshot::Persist;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
-use crate::vmm_config::mmds::MmdsConfigError;
 use crate::vstate::bus::BusError;
 use crate::vstate::interrupts::InterruptError;
 use crate::vstate::memory::GuestMemoryMmap;
@@ -64,8 +64,6 @@ pub enum PciManagerError {
     VirtioPciDevice(#[from] VirtioPciDeviceError),
     /// KVM error: {0}
     Kvm(#[from] vmm_sys_util::errno::Error),
-    /// MMDS error: {0}
-    Mmds(#[from] MmdsConfigError),
 }
 
 impl PciDevices {
@@ -278,7 +276,7 @@ impl<'a> Debug for PciDevicesConstructorArgs<'a> {
 impl<'a> Persist<'a> for PciDevices {
     type State = PciDevicesState;
     type ConstructorArgs = PciDevicesConstructorArgs<'a>;
-    type Error = PciManagerError;
+    type Error = DevicePersistError;
 
     fn save(&self) -> Self::State {
         let mut state = PciDevicesState::default();
@@ -438,61 +436,52 @@ impl<'a> Persist<'a> for PciDevices {
         pci_devices.attach_pci_segment(constructor_args.vm)?;
 
         if let Some(balloon_state) = &state.balloon_device {
-            let device = Arc::new(Mutex::new(
-                Balloon::restore(
-                    BalloonConstructorArgs { mem: mem.clone() },
-                    &balloon_state.device_state,
-                )
-                .unwrap(),
-            ));
+            let device = Arc::new(Mutex::new(Balloon::restore(
+                BalloonConstructorArgs { mem: mem.clone() },
+                &balloon_state.device_state,
+            )?));
 
             constructor_args
                 .vm_resources
                 .balloon
                 .set_device(device.clone());
 
-            pci_devices
-                .restore_pci_device(
-                    constructor_args.vm,
-                    device,
-                    &balloon_state.device_id,
-                    &balloon_state.transport_state,
-                    constructor_args.event_manager,
-                )
-                .unwrap()
+            pci_devices.restore_pci_device(
+                constructor_args.vm,
+                device,
+                &balloon_state.device_id,
+                &balloon_state.transport_state,
+                constructor_args.event_manager,
+            )?
         }
 
         for block_state in &state.block_devices {
-            let device = Arc::new(Mutex::new(
-                Block::restore(
-                    BlockConstructorArgs { mem: mem.clone() },
-                    &block_state.device_state,
-                )
-                .unwrap(),
-            ));
+            let device = Arc::new(Mutex::new(Block::restore(
+                BlockConstructorArgs { mem: mem.clone() },
+                &block_state.device_state,
+            )?));
 
             constructor_args
                 .vm_resources
                 .block
                 .add_virtio_device(device.clone());
 
-            pci_devices
-                .restore_pci_device(
-                    constructor_args.vm,
-                    device,
-                    &block_state.device_id,
-                    &block_state.transport_state,
-                    constructor_args.event_manager,
-                )
-                .unwrap()
+            pci_devices.restore_pci_device(
+                constructor_args.vm,
+                device,
+                &block_state.device_id,
+                &block_state.transport_state,
+                constructor_args.event_manager,
+            )?
         }
 
         // Initialize MMDS if MMDS state is included.
         if let Some(mmds) = &state.mmds {
-            constructor_args
-                .vm_resources
-                .set_mmds_basic_config(mmds.version, mmds.imds_compat, constructor_args.instance_id)
-                .unwrap();
+            constructor_args.vm_resources.set_mmds_basic_config(
+                mmds.version,
+                mmds.imds_compat,
+                constructor_args.instance_id,
+            )?;
         } else if state
             .net_devices
             .iter()
@@ -505,125 +494,108 @@ impl<'a> Persist<'a> for PciDevices {
         }
 
         for net_state in &state.net_devices {
-            let device = Arc::new(Mutex::new(
-                Net::restore(
-                    NetConstructorArgs {
-                        mem: mem.clone(),
-                        mmds: constructor_args
-                            .vm_resources
-                            .mmds
-                            .as_ref()
-                            // Clone the Arc reference.
-                            .cloned(),
-                    },
-                    &net_state.device_state,
-                )
-                .unwrap(),
-            ));
+            let device = Arc::new(Mutex::new(Net::restore(
+                NetConstructorArgs {
+                    mem: mem.clone(),
+                    mmds: constructor_args
+                        .vm_resources
+                        .mmds
+                        .as_ref()
+                        // Clone the Arc reference.
+                        .cloned(),
+                },
+                &net_state.device_state,
+            )?));
 
             constructor_args
                 .vm_resources
                 .net_builder
                 .add_device(device.clone());
 
-            pci_devices
-                .restore_pci_device(
-                    constructor_args.vm,
-                    device,
-                    &net_state.device_id,
-                    &net_state.transport_state,
-                    constructor_args.event_manager,
-                )
-                .unwrap()
+            pci_devices.restore_pci_device(
+                constructor_args.vm,
+                device,
+                &net_state.device_id,
+                &net_state.transport_state,
+                constructor_args.event_manager,
+            )?
         }
 
         if let Some(vsock_state) = &state.vsock_device {
             let ctor_args = VsockUdsConstructorArgs {
                 cid: vsock_state.device_state.frontend.cid,
             };
-            let backend =
-                VsockUnixBackend::restore(ctor_args, &vsock_state.device_state.backend).unwrap();
-            let device = Arc::new(Mutex::new(
-                Vsock::restore(
-                    VsockConstructorArgs {
-                        mem: mem.clone(),
-                        backend,
-                    },
-                    &vsock_state.device_state.frontend,
-                )
-                .unwrap(),
-            ));
+            let backend = VsockUnixBackend::restore(ctor_args, &vsock_state.device_state.backend)?;
+            let device = Arc::new(Mutex::new(Vsock::restore(
+                VsockConstructorArgs {
+                    mem: mem.clone(),
+                    backend,
+                },
+                &vsock_state.device_state.frontend,
+            )?));
 
             constructor_args
                 .vm_resources
                 .vsock
                 .set_device(device.clone());
 
-            pci_devices
-                .restore_pci_device(
-                    constructor_args.vm,
-                    device,
-                    &vsock_state.device_id,
-                    &vsock_state.transport_state,
-                    constructor_args.event_manager,
-                )
-                .unwrap()
+            pci_devices.restore_pci_device(
+                constructor_args.vm,
+                device,
+                &vsock_state.device_id,
+                &vsock_state.transport_state,
+                constructor_args.event_manager,
+            )?
         }
 
         if let Some(entropy_state) = &state.entropy_device {
             let ctor_args = EntropyConstructorArgs { mem: mem.clone() };
 
-            let device = Arc::new(Mutex::new(
-                Entropy::restore(ctor_args, &entropy_state.device_state).unwrap(),
-            ));
+            let device = Arc::new(Mutex::new(Entropy::restore(
+                ctor_args,
+                &entropy_state.device_state,
+            )?));
 
             constructor_args
                 .vm_resources
                 .entropy
                 .set_device(device.clone());
 
-            pci_devices
-                .restore_pci_device(
-                    constructor_args.vm,
-                    device,
-                    &entropy_state.device_id,
-                    &entropy_state.transport_state,
-                    constructor_args.event_manager,
-                )
-                .unwrap()
+            pci_devices.restore_pci_device(
+                constructor_args.vm,
+                device,
+                &entropy_state.device_id,
+                &entropy_state.transport_state,
+                constructor_args.event_manager,
+            )?
         }
 
         for pmem_state in &state.pmem_devices {
-            let device = Arc::new(Mutex::new(
-                Pmem::restore(
-                    PmemConstructorArgs {
-                        mem,
-                        vm: constructor_args.vm.as_ref(),
-                    },
-                    &pmem_state.device_state,
-                )
-                .unwrap(),
-            ));
+            let device = Arc::new(Mutex::new(Pmem::restore(
+                PmemConstructorArgs {
+                    mem,
+                    vm: constructor_args.vm.as_ref(),
+                },
+                &pmem_state.device_state,
+            )?));
 
             constructor_args
                 .vm_resources
                 .pmem
                 .add_device(device.clone());
 
-            pci_devices
-                .restore_pci_device(
-                    constructor_args.vm,
-                    device,
-                    &pmem_state.device_id,
-                    &pmem_state.transport_state,
-                    constructor_args.event_manager,
-                )
-                .unwrap()
+            pci_devices.restore_pci_device(
+                constructor_args.vm,
+                device,
+                &pmem_state.device_id,
+                &pmem_state.transport_state,
+                constructor_args.event_manager,
+            )?
         }
 
         if let Some(memory_device) = &state.memory_device {
             let ctor_args = VirtioMemConstructorArgs::new(Arc::clone(constructor_args.vm));
-            let device = VirtioMem::restore(ctor_args, &memory_device.device_state).unwrap();
+            let device = VirtioMem::restore(ctor_args, &memory_device.device_state)?;
 
             constructor_args.vm_resources.memory_hotplug = Some(MemoryHotplugConfig {
                 total_size_mib: device.total_size_mib(),
@@ -632,15 +604,13 @@ impl<'a> Persist<'a> for PciDevices {
             });
 
             let arcd_device = Arc::new(Mutex::new(device));
-            pci_devices
-                .restore_pci_device(
-                    constructor_args.vm,
-                    arcd_device,
-                    &memory_device.device_id,
-                    &memory_device.transport_state,
-                    constructor_args.event_manager,
-                )
-                .unwrap()
+            pci_devices.restore_pci_device(
+                constructor_args.vm,
+                arcd_device,
+                &memory_device.device_id,
+                &memory_device.transport_state,
+                constructor_args.event_manager,
+            )?
         }
 
         Ok(pci_devices)

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -14,82 +14,37 @@ use super::acpi::ACPIDeviceManager;
 use super::mmio::*;
 #[cfg(target_arch = "aarch64")]
 use crate::arch::DeviceType;
+use crate::device_manager::DevicePersistError;
 use crate::device_manager::acpi::ACPIDeviceError;
 use crate::devices::acpi::vmclock::{VmClock, VmClockState};
 use crate::devices::acpi::vmgenid::{VMGenIDState, VmGenId};
 #[cfg(target_arch = "aarch64")]
 use crate::devices::legacy::RTCDevice;
-use crate::devices::virtio::ActivateError;
+use crate::devices::virtio::balloon::Balloon;
 use crate::devices::virtio::balloon::persist::{BalloonConstructorArgs, BalloonState};
-use crate::devices::virtio::balloon::{Balloon, BalloonError};
-use crate::devices::virtio::block::BlockError;
 use crate::devices::virtio::block::device::Block;
 use crate::devices::virtio::block::persist::{BlockConstructorArgs, BlockState};
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::mem::VirtioMem;
-use crate::devices::virtio::mem::persist::{
-    VirtioMemConstructorArgs, VirtioMemPersistError, VirtioMemState,
-};
+use crate::devices::virtio::mem::persist::{VirtioMemConstructorArgs, VirtioMemState};
 use crate::devices::virtio::net::Net;
-use crate::devices::virtio::net::persist::{
-    NetConstructorArgs, NetPersistError as NetError, NetState,
-};
+use crate::devices::virtio::net::persist::{NetConstructorArgs, NetState};
 use crate::devices::virtio::persist::{MmioTransportConstructorArgs, MmioTransportState};
 use crate::devices::virtio::pmem::device::Pmem;
-use crate::devices::virtio::pmem::persist::{
-    PmemConstructorArgs, PmemPersistError as PmemError, PmemState,
-};
+use crate::devices::virtio::pmem::persist::{PmemConstructorArgs, PmemState};
 use crate::devices::virtio::rng::Entropy;
-use crate::devices::virtio::rng::persist::{
-    EntropyConstructorArgs, EntropyPersistError as EntropyError, EntropyState,
-};
+use crate::devices::virtio::rng::persist::{EntropyConstructorArgs, EntropyState};
 use crate::devices::virtio::transport::mmio::{IrqTrigger, MmioTransport};
 use crate::devices::virtio::vsock::persist::{
     VsockConstructorArgs, VsockState, VsockUdsConstructorArgs,
 };
-use crate::devices::virtio::vsock::{Vsock, VsockError, VsockUnixBackend, VsockUnixBackendError};
+use crate::devices::virtio::vsock::{Vsock, VsockUnixBackend};
 use crate::mmds::data_store::MmdsVersion;
 use crate::resources::VmResources;
 use crate::snapshot::Persist;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
-use crate::vmm_config::mmds::MmdsConfigError;
-use crate::vstate::bus::BusError;
 use crate::vstate::memory::GuestMemoryMmap;
 use crate::{EventManager, Vm};
-
-/// Errors for (de)serialization of the MMIO device manager.
-#[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub enum DevicePersistError {
-    /// Balloon: {0}
-    Balloon(#[from] BalloonError),
-    /// Block: {0}
-    Block(#[from] BlockError),
-    /// Device manager: {0}
-    DeviceManager(#[from] super::mmio::MmioError),
-    /// Mmio transport
-    MmioTransport,
-    /// Bus error: {0}
-    Bus(#[from] BusError),
-    #[cfg(target_arch = "aarch64")]
-    /// Legacy: {0}
-    Legacy(#[from] std::io::Error),
-    /// Net: {0}
-    Net(#[from] NetError),
-    /// Vsock: {0}
-    Vsock(#[from] VsockError),
-    /// VsockUnixBackend: {0}
-    VsockUnixBackend(#[from] VsockUnixBackendError),
-    /// MmdsConfig: {0}
-    MmdsConfig(#[from] MmdsConfigError),
-    /// Entropy: {0}
-    Entropy(#[from] EntropyError),
-    /// Pmem: {0}
-    Pmem(#[from] PmemError),
-    /// virtio-mem: {0}
-    VirtioMem(#[from] VirtioMemPersistError),
-    /// Could not activate device: {0}
-    DeviceActivation(#[from] ActivateError),
-}
 
 /// Holds the state of a MMIO VirtIO device
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Changes

All errors were previously unwrapped, differently from MMIO where they were handled. Refactor the code to handle the errors in the same way as MMIO.

## Reason

unify MMIO and PCI persist logic.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
