### PR TITLE
Add dma-coherent property to virtio_node in the AArch64 device tree

### DIFF
--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -376,6 +376,9 @@ fn create_psci_node(fdt: &mut FdtWriter) -> Result<(), FdtError> {
 
 fn create_virtio_node(fdt: &mut FdtWriter, dev_info: &MMIODeviceInfo) -> Result<(), FdtError> {
     let virtio_mmio = fdt.begin_node(&format!("virtio_mmio@{:x}", dev_info.addr))?;
+    // Adding the dma-coherent property ensures that the guest driver allocates the virtio 
+    // queue with the Write-Back attribute, maintaining cache coherency with Firecracker's
+    // accesses to the virtio queue. 
     fdt.property_null("dma-coherent")?;
     fdt.property_string("compatible", "virtio,mmio")?;
     fdt.property_array_u64("reg", &[dev_info.addr, dev_info.len])?;


### PR DESCRIPTION
## Changes
Add `dma-coherent` property to `virtio_node` in the AArch64 device tree. Resolves https://github.com/firecracker-microvm/firecracker/issues/5536.

## Reason
When the virtio_node lacks the dma-coherent property, running a Firecracker virtual machine on Arm platforms earlier than Armv8.3 results in cache incoherency between Firecracker and the guest driver when accessing the virtio queue.
Armv8.3 introduces the Force Write-Back (FWB) mechanism. Allowing the hypervisor (running at EL2) to fully override the guest (running at EL1) in determining memory attributes. Therefore, when running Firecracker on platforms implementing Armv8.3 or newer, both the Firecracker device model and the guest driver end up accessing the virtio queue with Write-Back caching, avoiding the cache-incoherence problem.
On platforms without the FWB (Force Write-Back) mechanism, when running Firecracker, the guest driver allocates the virtio queue with the non-cacheable attribute, while the Firecracker emulated device accesses the virtio queue using Write-Back. As a result, the Firecracker vm cannot boot correctly.
After adding the `dma-coherent` property, the guest driver allocates the virtio queue with the Write-Back attribute. Consequently, both Firecracker and the guest driver access the virtio queue using Write-Back caching, preventing the mentioned issue.
LKVM and QEMU have already added this property.
LKVM adds the dma-coherent property to virtio_node: https://github.com/kvmtool/kvmtool/blob/b48735e5d562eaffb96cf98a91da212176f1534c/virtio/mmio.c#L135
QEMU adds the dma-coherent property to virtio_node: https://github.com/qemu/qemu/blob/9ef49528b5286f078061b52ac41e0ca19fa10e36/hw/arm/virt.c#L1238

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
