### PR TITLE
fix(ab_test): ignore api_time and fc_time metrics for memory hotplug

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -128,6 +128,15 @@ IGNORED = [
     # block throughput on m8g
     {"fio_engine": "libaio", "vcpus": "2", "instance": "m8g.metal-24xl"},
     {"fio_engine": "libaio", "vcpus": "2", "instance": "m8g.metal-48xl"},
+    # memory hotplug metrics: ignore api_time and fc_time metrics, keeping only total_time.
+    *[
+        {
+            "performance_test": "test_memory_hotplug_latency",
+            "metric": f"{prefix}_{metric}",
+        }
+        for prefix in ["hotplug", "hotunplug", "hotplug_2nd"]
+        for metric in ["api_time", "fc_time"]
+    ],
 ]
 
 


### PR DESCRIPTION


## Changes

Ignore `api_time` and `fc_time` metrics from the memory hotplug latency test.

## Reason

These metrics are a subset of the customer-visible total_time and are flaky in our CI. Keep only total_time in the A/B.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
