### PR TITLE
fix(build): use cmake to build aws-lc-sys

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,4 +11,8 @@ git-fetch-with-cli = true
 AWS_LC_SYS_NO_JITTER_ENTROPY = "1"
 # disable AVX512 as it adds 600k of binary size
 # this was only used for MMDS token generation
+# Note: due to a bug in aws-lc [1] the AWS_LC_SYS_CFLAGS only work with
+# the cmake compiler.
+# [1]: https://github.com/aws/aws-lc-rs/issues/965
+AWS_LC_SYS_CMAKE_BUILDER = "1"
 AWS_LC_SYS_CFLAGS = "-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX"


### PR DESCRIPTION
## Changes

This patch reverts to the cmake builder while the cc builder is fixed.

## Reason

aws-lc-rs has a bug (https://github.com/aws/aws-lc-rs/issues/965) due to which the AWS_LC_SYS_CFLAGS env var is ignored in the default "ccBuilder".
When we removed "bindgen" feature (https://github.com/firecracker-microvm/firecracker/pull/5544), we were switched back from the cmakeBuilder to the default ccBuilder, thus the optimization to not compile AVX512 code was getting ignored and our binary size increased by 600kB.

Fixes: https://github.com/firecracker-microvm/firecracker/pull/5544

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
