### PR TITLE
test: rename host metrics to use linux next

### DIFF
--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -520,7 +520,7 @@ def test_memory_hotplug_latency(
                 {
                     "instance": global_props.instance,
                     "cpu_model": global_props.cpu_model,
-                    "host_kernel": f"linux-{global_props.host_linux_version}",
+                    "host_kernel": f"linux-{global_props.host_linux_version_metrics}",
                     "performance_test": "test_memory_hotplug_latency",
                     "hotplug_size": str(hotplug_size),
                     "huge_pages": huge_pages,

--- a/tests/integration_tests/performance/test_jailer.py
+++ b/tests/integration_tests/performance/test_jailer.py
@@ -52,7 +52,7 @@ def test_jailer_startup(
         {
             "instance": global_props.instance,
             "cpu_model": global_props.cpu_model,
-            "host_kernel": f"linux-{global_props.host_linux_version}",
+            "host_kernel": f"linux-{global_props.host_linux_version_metrics}",
             "performance_test": "test_jailer_startup",
             "parallel": str(parallel),
             "mounts": str(mounts),


### PR DESCRIPTION
## Changes

Rename host metrics to use linux next.

## Reason

Rename metrics published by memory hotplug and jailer tests so they are visible on the dashboard.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
