### PR TITLE
fix: Free page hinting kick on restore

### DIFF
--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -946,12 +946,6 @@ impl VirtioDevice for Balloon {
             self.update_timer_state();
         }
 
-        // On activate ensure hint cmd is reset to FREE_PAGE_HINT_DONE
-        if self.is_activated() && self.free_page_hinting() {
-            self.update_free_page_hint_cmd(FREE_PAGE_HINT_DONE)
-                .map_err(|_| ActivateError::EventFd)?;
-        }
-
         Ok(())
     }
 
@@ -965,6 +959,10 @@ impl VirtioDevice for Balloon {
         // Stats queue doesn't need kicking as it is notified via a `timer_fd`.
         if self.is_activated() {
             info!("kick balloon {}.", self.id());
+            if self.free_page_hinting() {
+                // On restore we reset back to DONE to ensure everythign is freed
+                self.update_free_page_hint_cmd(FREE_PAGE_HINT_DONE);
+            }
             self.process_virtio_queues();
         }
     }


### PR DESCRIPTION

## Changes

Move the reset of the hinting command id from activate to kick so it's only reset on resume

## Reason

Remove the uneeded interrupt on a booted instance

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
