### PR TITLE
[SH] test(memory_overhead): update x86 mmio gap start

### DIFF
--- a/tests/integration_tests/performance/test_memory_overhead.py
+++ b/tests/integration_tests/performance/test_memory_overhead.py
@@ -20,8 +20,8 @@ from pathlib import Path
 import psutil
 import pytest
 
-# If guest memory is >3328MB, it is split in a 2nd region
-X86_MEMORY_GAP_START = 3328 * 2**20
+# If guest memory is >3072MB, it is split in a 2nd region
+X86_MEMORY_GAP_START = 3072 * 2**20
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Cherry-pick from https://github.com/firecracker-microvm/firecracker/pull/5563 .

## Changes

test(memory_overhead): update x86 mmio gap start

## Reason

In the following commit we resized the 32b MMIO region to 1GiB, but it was not reflected in the test:

```
commit 7c623e89b4da8941ea8e8e37ca24676d90d3df67
Author: Babis Chalios <bchalios@amazon.es>
Date:   Mon May 5 17:52:08 2025 +0200

    arch: define 64-bit capable MMIO memory regions
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
