### PR TITLE
test: fix failing CPU features test

### DIFF
--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -289,9 +289,8 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
                 # MSR address 0x33 (MSR_MEMORY_CTRL in Intel SDM, MSR_TEST_CTRL in Linux kernel).
                 expected_host_minus_guest |= {"split_lock_detect"}
 
-            elif CPU_MODEL == CpuModel.INTEL_GRANITE_RAPIDS:
-                # VMScape mitigation. Granite Rapids CPUs are not affected, and therefore do not need
-                # this feature.
+            # FIX: VMScape mitigation has not yet been backported to 5.10.
+            elif host_version < (6, 1) and CPU_MODEL == CpuModel.INTEL_GRANITE_RAPIDS:
                 expected_host_minus_guest -= {
                     "ibpb_exit_to_user",
                 }


### PR DESCRIPTION
## Changes

^^^

## Reason

Due to Granite Rapids not fully being supported on older kernels, CPU feature support is a bit patchy at the moment. VMscape mitigation is available on 6.1 but not 5.10. This is a temporary fix to make our tests pass, but we will want the vmscape mitigation on 5.10 as well

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
