### PR TITLE
fix: section for v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.14.0]
+## [1.14.0]
 
 ### Added
 


### PR DESCRIPTION
CHANGELOG expects versions in format X.Y.Z. The section for 1.14.0 was headed as `v1.14.0`. This breaks the release-tag.sh script.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
