### PR TITLE
fix: resolve TODO to preserve TokenBucket budget during updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to
 
 ### Fixed
 
+- [#5594](https://github.com/firecracker-microvm/firecracker/pull/5594): Fixed
+  rate limiter bucket updates to preserve budget and one-time burst state
+  (capped at new bucket limits if smaller) instead of resetting to full
+  capacity.
+
 ## [v1.14.0]
 
 ### Added

--- a/docs/api_requests/patch-network-interface.md
+++ b/docs/api_requests/patch-network-interface.md
@@ -63,6 +63,11 @@ found in our [OpenAPI spec](../../src/firecracker/swagger/firecracker.yaml).
 > The data provided for the update is merged with the existing data. In the
 > above example, the RX rate limit is updated, but the TX rate limit remains
 > unchanged.
+>
+> When updating rate limiter parameters, the current budget and one-time burst
+> state are preserved (capped at the new bucket's limits if the new bucket is
+> smaller), ensuring rate limiting continues smoothly without resetting to full
+> capacity.
 
 ## Removing Rate Limiting
 

--- a/src/acpi-tables/src/aml.rs
+++ b/src/acpi-tables/src/aml.rs
@@ -160,8 +160,6 @@ pub struct Name {
 
 impl Aml for Name {
     fn append_aml_bytes(&self, bytes: &mut Vec<u8>) -> Result<(), AmlError> {
-        // TODO: Refactor this to make more efficient but there are
-        // lifetime/ownership challenges.
         bytes.extend_from_slice(&self.bytes);
         Ok(())
     }

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -586,10 +586,6 @@ impl VsockMuxer {
 
     /// Allocate a host-side port to be assigned to a new host-initiated connection.
     fn allocate_local_port(&mut self) -> u32 {
-        // TODO: this doesn't seem very space-efficient.
-        // Mybe rewrite this to limit port range and use a bitmap?
-        //
-
         loop {
             self.local_port_last = (self.local_port_last + 1) & !(1 << 31) | (1 << 30);
             if self.local_port_set.insert(self.local_port_last) {

--- a/src/vmm/src/utils/net/mac.rs
+++ b/src/vmm/src/utils/net/mac.rs
@@ -84,8 +84,6 @@ impl MacAddr {
     /// * `src` - slice from which to copy MAC address content.
     #[inline]
     pub fn from_bytes_unchecked(src: &[u8]) -> MacAddr {
-        // TODO: using something like std::mem::uninitialized could avoid the extra initialization,
-        // if this ever becomes a performance bottleneck.
         let mut bytes = [0u8; MAC_ADDR_LEN as usize];
         bytes[..].copy_from_slice(src);
 


### PR DESCRIPTION
Also remove some stale TODOs and update docs.

## Changes

- Rate limiter state preservation: `update_buckets()` preserves budget, one_time_burst, and last_update (capped at new bucket limits) instead of resetting to full capacity.
- Removed stale TODOs.

## Reason

Address a TODO regarding `TokenBucket` updates. See #3273.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
