### PR TITLE
feat: Add Seqpacket support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ and this project adheres to
   rescan the PCI bus after hotplug and remove the device before unplug since no
   automatic notification mechanism is implemented yet. More information can be
   found in the [Device Hotplugging](docs/device-hotplug.md) documentation page.
+- [#5595](https://github.com/firecracker-microvm/firecracker/pull/5595): Added
+  `vsock_type` field to the vsock device API to denote the type of the
+  underlying socket. Can be `stream` or `seqpacket`
+- [#5595](https://github.com/firecracker-microvm/firecracker/pull/5595): Added
+  `conn_buffer_size` field to denote how many bytes we can internally buffer
+  during receiving large seqpacket packets from the host.
 - [#5323](https://github.com/firecracker-microvm/firecracker/pull/5323): Add
   support for Vsock Unix domain socket path overriding on snapshot restore. More
   information can be found in the

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -458,6 +458,32 @@
                 ]
             },
             {
+                "syscall": "socket",
+                "comment": "Called to open the vsock seqpacket UDS (SeqpacketConn::connect and SeqpacketListener::bind)",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "libc::AF_UNIX"
+                    },
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 524293,
+                        "comment": "libc::SOCK_SEQPACKET | libc::SOCK_CLOEXEC"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 0
+                    }
+                ]
+            },
+            {
                 "syscall": "sendto",
                 "comment": "Rust std uses it to write to unix socket"
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -458,6 +458,32 @@
                 ]
             },
             {
+                "syscall": "socket",
+                "comment": "Called to open the vsock seqpacket UDS (SeqpacketConn::connect and SeqpacketListener::bind)",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "libc::AF_UNIX"
+                    },
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 524293,
+                        "comment": "libc::SOCK_SEQPACKET | libc::SOCK_CLOEXEC"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 0
+                    }
+                ]
+            },
+            {
                 "syscall": "sendto",
                 "comment": "Rust std uses it to write to unix socket"
             },

--- a/src/firecracker/src/api_server/parsed_request.rs
+++ b/src/firecracker/src/api_server/parsed_request.rs
@@ -958,7 +958,7 @@ pub mod tests {
     fn test_try_from_put_vsock() {
         let (mut sender, receiver) = UnixStream::pair().unwrap();
         let mut connection = HttpConnection::new(receiver);
-        let body = "{ \"vsock_id\": \"string\", \"guest_cid\": 0, \"uds_path\": \"string\" }";
+        let body = "{ \"vsock_id\": \"string\", \"guest_cid\": 0, \"uds_path\": \"string\", \"vsock_type\": \"stream\" }";
         sender
             .write_all(http_request("PUT", "/vsock", Some(body)).as_bytes())
             .unwrap();

--- a/src/firecracker/src/api_server/request/vsock.rs
+++ b/src/firecracker/src/api_server/request/vsock.rs
@@ -41,7 +41,8 @@ mod tests {
     fn test_parse_put_vsock_request() {
         let body = r#"{
             "guest_cid": 42,
-            "uds_path": "vsock.sock"
+            "uds_path": "vsock.sock",
+            "vsock_type": "stream"
         }"#;
         parse_put_vsock(&Body::new(body)).unwrap();
 
@@ -57,7 +58,8 @@ mod tests {
         let body = r#"{
             "vsock_id": "foo",
             "guest_cid": 42,
-            "uds_path": "vsock.sock"
+            "uds_path": "vsock.sock",
+            "vsock_type": "stream"
         }"#;
         depr_action_from_req(
             parse_put_vsock(&Body::new(body)).unwrap(),
@@ -66,7 +68,8 @@ mod tests {
 
         let body = r#"{
             "guest_cid": 42,
-            "uds_path": "vsock.sock"
+            "uds_path": "vsock.sock",
+            "vsock_type": "stream"
         }"#;
         let (_, mut parsing_info) = parse_put_vsock(&Body::new(body)).unwrap().into_parts();
         assert!(parsing_info.take_deprecation_message().is_none());

--- a/src/firecracker/src/api_server/request/vsock.rs
+++ b/src/firecracker/src/api_server/request/vsock.rs
@@ -34,6 +34,8 @@ pub(crate) fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, RequestError
 
 #[cfg(test)]
 mod tests {
+    use vmm::vmm_config::vsock::VsockType;
+
     use super::*;
     use crate::api_server::parsed_request::tests::depr_action_from_req;
 
@@ -41,8 +43,7 @@ mod tests {
     fn test_parse_put_vsock_request() {
         let body = r#"{
             "guest_cid": 42,
-            "uds_path": "vsock.sock",
-            "vsock_type": "stream"
+            "uds_path": "vsock.sock"
         }"#;
         parse_put_vsock(&Body::new(body)).unwrap();
 
@@ -58,8 +59,7 @@ mod tests {
         let body = r#"{
             "vsock_id": "foo",
             "guest_cid": 42,
-            "uds_path": "vsock.sock",
-            "vsock_type": "stream"
+            "uds_path": "vsock.sock"
         }"#;
         depr_action_from_req(
             parse_put_vsock(&Body::new(body)).unwrap(),
@@ -68,10 +68,19 @@ mod tests {
 
         let body = r#"{
             "guest_cid": 42,
-            "uds_path": "vsock.sock",
-            "vsock_type": "stream"
+            "uds_path": "vsock.sock"
         }"#;
         let (_, mut parsing_info) = parse_put_vsock(&Body::new(body)).unwrap().into_parts();
         assert!(parsing_info.take_deprecation_message().is_none());
+    }
+
+    #[test]
+    fn test_default_vsock_type_serialization() {
+        let body = r#"{
+            "guest_cid": 42,
+            "uds_path": "vsock.sock"
+        }"#;
+        let vsock_cfg = serde_json::from_slice::<VsockDeviceConfig>(Body::new(body).raw()).unwrap();
+        assert!(vsock_cfg.vsock_type == VsockType::Stream);
     }
 }

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1891,6 +1891,15 @@ definitions:
           - stream
           - seqpacket
         default: stream
+      conn_buffer_size:
+        type: integer
+        minimum: 4096
+        maximum: 262144
+        description:
+          The amount in bytes that can be buffered in firecracker if the data in the tx/rx queue is
+          too much to fit in a single descriptor. This parameter is ignored for stream sockets 
+          because connection buffering is a seqpacket only concept. The minimum is 4096 (one 
+          virtqueue descriptor) and the maximum is 256KB (kernel limit)
       vsock_id:
         type: string
         description:

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1884,6 +1884,13 @@ definitions:
       uds_path:
         type: string
         description: Path to UNIX domain socket, used to proxy vsock connections.
+      vsock_type:
+        description: Enumeration indicating the type of the underlying socket (stream or seqpacket)
+        type: string
+        enum:
+          - stream
+          - seqpacket
+        default: stream
       vsock_id:
         type: string
         description:

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -975,7 +975,7 @@ pub(crate) mod tests {
         vsock_config: VsockDeviceConfig,
     ) {
         let vsock_dev_id = VSOCK_DEV_ID.to_owned();
-        let vsock = VsockBuilder::create_unixsock_vsock(vsock_config).unwrap();
+        let vsock = VsockBuilder::create_unixsock_vsock(&vsock_config).unwrap();
         let vsock = Arc::new(Mutex::new(vsock));
 
         attach_unixsock_vsock_device(

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -692,7 +692,7 @@ mod tests {
     use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
     use crate::vmm_config::net::NetworkInterfaceConfig;
     use crate::vmm_config::pmem::PmemConfig;
-    use crate::vmm_config::vsock::VsockDeviceConfig;
+    use crate::vmm_config::vsock::{VsockDeviceConfig, VsockType};
     use crate::vstate::resources::ResourceAllocator;
 
     #[test]
@@ -753,6 +753,7 @@ mod tests {
                 vsock_id: Some(vsock_dev_id.to_string()),
                 guest_cid: 3,
                 uds_path: tmp_sock_file.as_path().to_str().unwrap().to_string(),
+                vsock_type: VsockType::Stream,
             };
             insert_vsock_device(&mut vmm, &mut cmdline, &mut event_manager, vsock_config);
             // Add an entropy device.
@@ -874,7 +875,8 @@ mod tests {
   ],
   "vsock": {{
     "guest_cid": 3,
-    "uds_path": "{}"
+    "uds_path": "{}",
+    "vsock_type": "stream"
   }},
   "entropy": {{
     "rate_limiter": null

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -754,6 +754,7 @@ mod tests {
                 guest_cid: 3,
                 uds_path: tmp_sock_file.as_path().to_str().unwrap().to_string(),
                 vsock_type: VsockType::Stream,
+                conn_buffer_size: None,
             };
             insert_vsock_device(&mut vmm, &mut cmdline, &mut event_manager, vsock_config);
             // Add an entropy device.

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -755,6 +755,7 @@ mod tests {
                 guest_cid: 3,
                 uds_path: tmp_sock_file.as_path().to_str().unwrap().to_string(),
                 vsock_type: VsockType::Stream,
+                conn_buffer_size: None,
             };
             insert_vsock_device(&mut vmm, &mut cmdline, &mut event_manager, vsock_config);
             // Add an entropy device.

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -654,7 +654,7 @@ mod tests {
     use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
     use crate::vmm_config::net::NetworkInterfaceConfig;
     use crate::vmm_config::pmem::PmemConfig;
-    use crate::vmm_config::vsock::VsockDeviceConfig;
+    use crate::vmm_config::vsock::{VsockDeviceConfig, VsockType};
 
     impl<T> PartialEq for VirtioDeviceState<T> {
         fn eq(&self, other: &VirtioDeviceState<T>) -> bool {
@@ -754,6 +754,7 @@ mod tests {
                 vsock_id: Some(vsock_dev_id.to_string()),
                 guest_cid: 3,
                 uds_path: tmp_sock_file.as_path().to_str().unwrap().to_string(),
+                vsock_type: VsockType::Stream,
             };
             insert_vsock_device(&mut vmm, &mut cmdline, &mut event_manager, vsock_config);
             // Add an entropy device.
@@ -866,7 +867,8 @@ mod tests {
   ],
   "vsock": {{
     "guest_cid": 3,
-    "uds_path": "{}"
+    "uds_path": "{}",
+    "vsock_type": "stream"
   }},
   "entropy": {{
     "rate_limiter": null

--- a/src/vmm/src/devices/virtio/generated/virtio_config.rs
+++ b/src/vmm/src/devices/virtio/generated/virtio_config.rs
@@ -16,6 +16,7 @@
     clippy::redundant_static_lifetimes
 )]
 
+pub const VIRTIO_VSOCK_F_SEQPACKET: u32 = 1;
 pub const VIRTIO_F_NOTIFY_ON_EMPTY: u32 = 24;
 pub const VIRTIO_F_ANY_LAYOUT: u32 = 27;
 pub const VIRTIO_F_VERSION_1: u32 = 32;

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -268,6 +268,8 @@ mod tests {
     use crate::devices::virtio::test_utils::default_mem;
     use crate::devices::virtio::transport::mmio::tests::DummyDevice;
     use crate::devices::virtio::vsock::{Vsock, VsockUnixBackend};
+    use crate::snapshot::Snapshot;
+    use crate::vmm_config::vsock::VsockType;
 
     const DEFAULT_QUEUE_MAX_SIZE: u16 = 256;
     impl Default for QueueState {
@@ -481,7 +483,7 @@ mod tests {
         // Remove the file so the path can be used by the socket.
         temp_uds_path.remove().unwrap();
         let uds_path = String::from(temp_uds_path.as_path().to_str().unwrap());
-        let backend = VsockUnixBackend::new(guest_cid, uds_path).unwrap();
+        let backend = VsockUnixBackend::new(guest_cid, uds_path, VsockType::Stream).unwrap();
         let vsock = Vsock::new(guest_cid, backend).unwrap();
         let vsock = Arc::new(Mutex::new(vsock));
         let mmio_transport =

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -483,7 +483,7 @@ mod tests {
         // Remove the file so the path can be used by the socket.
         temp_uds_path.remove().unwrap();
         let uds_path = String::from(temp_uds_path.as_path().to_str().unwrap());
-        let backend = VsockUnixBackend::new(guest_cid, uds_path, VsockType::Stream).unwrap();
+        let backend = VsockUnixBackend::new(guest_cid, uds_path, VsockType::Stream, None).unwrap();
         let device = Vsock::new(guest_cid, backend, &VsockType::Stream).unwrap();
         let vsock = Arc::new(Mutex::new(device));
         let mmio_transport =

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -484,8 +484,8 @@ mod tests {
         temp_uds_path.remove().unwrap();
         let uds_path = String::from(temp_uds_path.as_path().to_str().unwrap());
         let backend = VsockUnixBackend::new(guest_cid, uds_path, VsockType::Stream).unwrap();
-        let vsock = Vsock::new(guest_cid, backend).unwrap();
-        let vsock = Arc::new(Mutex::new(vsock));
+        let device = Vsock::new(guest_cid, backend, &VsockType::Stream).unwrap();
+        let vsock = Arc::new(Mutex::new(device));
         let mmio_transport =
             MmioTransport::new(mem.clone(), interrupt.clone(), vsock.clone(), false);
 

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -94,6 +94,7 @@ use crate::devices::virtio::vsock::metrics::METRICS;
 use crate::devices::virtio::vsock::packet::{VsockPacketHeader, VsockPacketRx, VsockPacketTx};
 use crate::logger::{IncMetric, debug, error, info, warn};
 use crate::utils::wrap_usize_to_u32;
+use crate::vmm_config::vsock::VsockType;
 
 /// Trait that vsock connection backends need to implement.
 ///
@@ -138,6 +139,8 @@ pub struct VsockConnection<S: VsockConnectionBackend> {
     /// Instant when this connection should be scheduled for immediate termination, due to some
     /// timeout condition having been fulfilled.
     expiry: Option<Instant>,
+    /// The type of the underlying socket connection
+    vsock_type: VsockType,
 }
 
 impl<S> VsockChannel for VsockConnection<S>
@@ -510,6 +513,7 @@ where
         local_port: u32,
         peer_port: u32,
         peer_buf_alloc: u32,
+        vsock_type: VsockType,
     ) -> Self {
         Self {
             local_cid,
@@ -526,6 +530,7 @@ where
             last_fwd_cnt_to_peer: Wrapping(0),
             pending_rx: PendingRxSet::from(PendingRx::Response),
             expiry: None,
+            vsock_type,
         }
     }
 
@@ -536,6 +541,7 @@ where
         peer_cid: u64,
         local_port: u32,
         peer_port: u32,
+        vsock_type: VsockType,
     ) -> Self {
         Self {
             local_cid,
@@ -552,6 +558,7 @@ where
             last_fwd_cnt_to_peer: Wrapping(0),
             pending_rx: PendingRxSet::from(PendingRx::Request),
             expiry: None,
+            vsock_type,
         }
     }
 
@@ -672,9 +679,12 @@ where
             .set_dst_cid(self.peer_cid)
             .set_src_port(self.local_port)
             .set_dst_port(self.peer_port)
-            .set_type(uapi::VSOCK_TYPE_STREAM)
             .set_buf_alloc(defs::CONN_TX_BUF_SIZE)
             .set_fwd_cnt(self.fwd_cnt.0);
+        match self.vsock_type {
+            VsockType::Seqpacket => hdr.set_type(uapi::VSOCK_TYPE_SEQPACKET),
+            VsockType::Stream => hdr.set_type(uapi::VSOCK_TYPE_STREAM),
+        };
     }
 }
 
@@ -883,9 +893,15 @@ mod tests {
                     LOCAL_PORT,
                     PEER_PORT,
                     PEER_BUF_ALLOC,
+                    VsockType::Stream,
                 ),
                 ConnState::LocalInit => VsockConnection::<TestStream>::new_local_init(
-                    stream, LOCAL_CID, PEER_CID, LOCAL_PORT, PEER_PORT,
+                    stream,
+                    LOCAL_CID,
+                    PEER_CID,
+                    LOCAL_PORT,
+                    PEER_PORT,
+                    VsockType::Stream,
                 ),
                 ConnState::Established => {
                     let mut conn = VsockConnection::<TestStream>::new_peer_init(
@@ -895,6 +911,7 @@ mod tests {
                         LOCAL_PORT,
                         PEER_PORT,
                         PEER_BUF_ALLOC,
+                        VsockType::Stream,
                     );
                     assert!(conn.has_pending_rx());
                     conn.recv_pkt(&mut rx_pkt).unwrap();

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -77,21 +77,25 @@ use std::fmt::Debug;
 //          2. The receiver can be proactive, and send VSOCK_OP_CREDIT_UPDATE packet, whenever
 //             it thinks its peer's information is out of date.
 //          Our implementation uses the proactive approach.
-use std::io::{ErrorKind, Write};
+use std::io::{Cursor, Error, ErrorKind, Read, Write};
 use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
-use vm_memory::GuestMemoryError;
 use vm_memory::io::{ReadVolatile, WriteVolatile};
+use vm_memory::{GuestMemoryError, VolatileMemory, VolatileSlice};
 use vmm_sys_util::epoll::EventSet;
 
 use super::super::defs::uapi;
 use super::super::{VsockChannel, VsockEpollListener, VsockError};
 use super::txbuf::TxBuf;
 use super::{ConnState, PendingRx, PendingRxSet, VsockCsmError, defs};
+use crate::devices::virtio::vsock::VsockUnixBackendError;
 use crate::devices::virtio::vsock::metrics::METRICS;
-use crate::devices::virtio::vsock::packet::{VsockPacketHeader, VsockPacketRx, VsockPacketTx};
+use crate::devices::virtio::vsock::packet::{
+    VIRTIO_VSOCK_SEQ_EOM, VIRTIO_VSOCK_SEQ_EOR, VsockPacketHeader, VsockPacketRx, VsockPacketTx,
+};
+use crate::devices::virtio::vsock::unix::{IncomingLength, ReadResult};
 use crate::logger::{IncMetric, debug, error, info, warn};
 use crate::utils::wrap_usize_to_u32;
 use crate::vmm_config::vsock::VsockType;
@@ -101,7 +105,9 @@ use crate::vmm_config::vsock::VsockType;
 /// Used as an alias for `ReadVolatile + Write + WriteVolatile + AsRawFd`
 /// (sadly, trait aliases are not supported,
 /// <https://github.com/rust-lang/rfcs/pull/1733#issuecomment-243840014>).
-pub trait VsockConnectionBackend: ReadVolatile + Write + WriteVolatile + AsRawFd {}
+pub trait VsockConnectionBackend: Read + ReadVolatile + Write + WriteVolatile + AsRawFd {}
+
+const DEFAULT_CONN_BUFFER_SIZE: usize = (64 * 1024);
 
 /// A self-managing connection object, that handles communication between a guest-side AF_VSOCK
 /// socket and a host-side `ReadVolatile + Write + WriteVolatile + AsRawFd` stream.
@@ -141,6 +147,106 @@ pub struct VsockConnection<S: VsockConnectionBackend> {
     expiry: Option<Instant>,
     /// The type of the underlying socket connection
     vsock_type: VsockType,
+    /// Intermediate buffer for bytes received from the AF_UNIX
+    connection_buffer: Option<Cursor<Vec<u8>>>,
+    /// The amount of bytes we wrote into the intermediate connection buffer
+    conn_buf_size: usize,
+}
+
+impl<S: VsockConnectionBackend + Debug> VsockConnection<S> {
+    fn recv_into(
+        &mut self,
+        pkt: &mut VsockPacketRx,
+        max_len: u32,
+    ) -> Result<ReadResult, VsockError> {
+        match self.vsock_type {
+            VsockType::Stream => {
+                let stream_bytes_read = pkt.read_at_offset_from(&mut self.stream, 0, max_len)?;
+                Ok(ReadResult::new(stream_bytes_read, false))
+            }
+            VsockType::Seqpacket => {
+                if self.connection_buffer.is_none() {
+                    // check how many bytes are in this incoming message
+                    let incoming_msg_size = self.stream.incoming_len().map_err(|e| {
+                        VsockError::VsockUdsBackend(VsockUnixBackendError::UnixRead(e))
+                    })?;
+                    // if its bigger than what we can receive, return an error
+                    if incoming_msg_size > self.conn_buf_size {
+                        return Err(VsockError::MessageTooLong(
+                            self.conn_buf_size,
+                            incoming_msg_size,
+                        ));
+                    }
+                    return self.handle_new_packet(
+                        pkt,
+                        max_len,
+                        u32::try_from(incoming_msg_size).unwrap(),
+                    );
+                }
+
+                self.handle_connection_buffer_has_data(pkt, max_len)
+            }
+        }
+    }
+
+    fn handle_new_packet(
+        &mut self,
+        pkt: &mut VsockPacketRx,
+        max_len: u32,
+        incoming_msg_len: u32,
+    ) -> Result<ReadResult, VsockError> {
+        // the incoming message is small enough to fit in the current packet's buffer
+        if incoming_msg_len <= pkt.buf_size() {
+            let b = pkt.read_at_offset_from(&mut self.stream, 0, max_len)?;
+            // packet is small enough to fit into a single descriptor, set EOM/EOR directly.
+            pkt.hdr
+                .set_flag(VIRTIO_VSOCK_SEQ_EOM)
+                .set_flag(VIRTIO_VSOCK_SEQ_EOR);
+            return Ok(ReadResult::new(b, false));
+        }
+
+        // Message is big for a single packet's buffer. Create an intermediary vector
+        // and receive into it.
+        let mut backing_vector = vec![0u8; incoming_msg_len as usize];
+        self.stream
+            .read(&mut backing_vector)
+            .map_err(|e| VsockError::VsockUdsBackend(VsockUnixBackendError::UnixRead(e)))?;
+
+        let mut cursor = Cursor::new(backing_vector);
+        let b = pkt.read_at_offset_from(&mut cursor, 0, max_len)?;
+        self.connection_buffer = Some(cursor);
+
+        Ok(ReadResult::new(b, true))
+    }
+
+    fn handle_connection_buffer_has_data(
+        &mut self,
+        pkt: &mut VsockPacketRx,
+        max_len: u32,
+    ) -> Result<ReadResult, VsockError> {
+        let Some(ref mut conn_buf) = self.connection_buffer else {
+            return Err(VsockError::PktBufMissing);
+        };
+
+        let conn_buffer_rem = u32::try_from(conn_buf.get_ref().len() as u64 - conn_buf.position())
+            .unwrap_or(u32::MAX);
+
+        let b = pkt.read_at_offset_from(conn_buf, 0, max_len.min(conn_buffer_rem))?;
+
+        // set MSG_EOM/EOR if we finished the buffer and mark should
+        // retrigger as false. or mark should retrigger to true to
+        // make another read happen
+        let done = conn_buf.position() >= conn_buf.get_ref().len() as u64;
+        if done {
+            self.connection_buffer = None;
+            pkt.hdr
+                .set_flag(VIRTIO_VSOCK_SEQ_EOM)
+                .set_flag(VIRTIO_VSOCK_SEQ_EOR);
+            Ok(ReadResult::new(b, false))
+        } else {
+            Ok(ReadResult::new(b, true))
+        }
+    }
 }
 
 impl<S> VsockChannel for VsockConnection<S>
@@ -162,7 +268,7 @@ where
     /// - `Err(VsockError::NoData)`: there was no data available with which to fill in the packet;
     /// - `Err(VsockError::PktBufMissing)`: the packet would've been filled in with data, but it is
     ///   missing the data buffer.
-    fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<(), VsockError> {
+    fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<ReadResult, VsockError> {
         // Perform some generic initialization that is the same for any packet operation (e.g.
         // source, destination, credit, etc).
         self.init_pkt_hdr(&mut pkt.hdr);
@@ -172,7 +278,7 @@ where
         // It's dead, Jim.
         if self.pending_rx.remove(PendingRx::Rst) {
             pkt.hdr.set_op(uapi::VSOCK_OP_RST);
-            return Ok(());
+            return Ok(ReadResult::default());
         }
 
         // Next up: if we're due a connection confirmation, that's all we need to know to fill
@@ -180,7 +286,7 @@ where
         if self.pending_rx.remove(PendingRx::Response) {
             self.state = ConnState::Established;
             pkt.hdr.set_op(uapi::VSOCK_OP_RESPONSE);
-            return Ok(());
+            return Ok(ReadResult::default());
         }
 
         // Same thing goes for locally-initiated connections that need to yield a connection
@@ -189,7 +295,7 @@ where
             self.expiry =
                 Some(Instant::now() + Duration::from_millis(defs::CONN_REQUEST_TIMEOUT_MS));
             pkt.hdr.set_op(uapi::VSOCK_OP_REQUEST);
-            return Ok(());
+            return Ok(ReadResult::default());
         }
 
         if self.pending_rx.remove(PendingRx::Rw) {
@@ -204,7 +310,7 @@ where
                     // Any other connection state is invalid at this point, and we need to kill it
                     // with fire.
                     pkt.hdr.set_op(uapi::VSOCK_OP_RST);
-                    return Ok(());
+                    return Ok(ReadResult::default());
                 }
             }
 
@@ -213,17 +319,17 @@ where
             if self.need_credit_update_from_peer() {
                 self.last_fwd_cnt_to_peer = self.fwd_cnt;
                 pkt.hdr.set_op(uapi::VSOCK_OP_CREDIT_REQUEST);
-                return Ok(());
+                return Ok(ReadResult::default());
             }
 
             // The maximum amount of data we can read in is limited by both the RX buffer size and
             // the peer available buffer space.
             let max_len = std::cmp::min(pkt.buf_size(), self.peer_avail_credit());
 
-            // Read data from the stream straight to the RX buffer, for maximum throughput.
-            match pkt.read_at_offset_from(&mut self.stream, 0, max_len) {
-                Ok(read_cnt) => {
-                    if read_cnt == 0 {
+            let recv_res = self.recv_into(pkt, max_len);
+            match recv_res {
+                Ok(res) => {
+                    if res.bytes_read == 0 {
                         // A 0-length read means the host stream was closed down. In that case,
                         // we'll ask our peer to shut down the connection. We can neither send nor
                         // receive any more data.
@@ -240,15 +346,22 @@ where
                         // length of the read data.
                         // Safe to unwrap because read_cnt is no more than max_len, which is bounded
                         // by self.peer_avail_credit(), a u32 internally.
-                        pkt.hdr.set_op(uapi::VSOCK_OP_RW).set_len(read_cnt);
-                        METRICS.rx_bytes_count.add(read_cnt as u64);
+                        pkt.hdr.set_op(uapi::VSOCK_OP_RW).set_len(res.bytes_read);
+                        METRICS.rx_bytes_count.add(res.bytes_read as u64);
                         // There may be more data to read, so keep `Rw` pending to stay
                         // scheduled for another read.
                         self.pending_rx.insert(PendingRx::Rw);
                     }
                     self.rx_cnt += Wrapping(pkt.hdr.len());
                     self.last_fwd_cnt_to_peer = self.fwd_cnt;
-                    return Ok(());
+
+                    // the read was buffered into an intermediate vector and this
+                    // means there is still data to process but no fd event will
+                    // kick off. manually push a a PendingRx queue entry
+                    if res.should_retrigger {
+                        self.pending_rx.insert(PendingRx::Rw);
+                    }
+                    return Ok(res);
                 }
                 Err(VsockError::GuestMemoryMmap(GuestMemoryError::IOError(err)))
                     if err.kind() == ErrorKind::WouldBlock =>
@@ -265,7 +378,7 @@ where
                     );
                     pkt.hdr.set_op(uapi::VSOCK_OP_RST);
                     self.last_fwd_cnt_to_peer = self.fwd_cnt;
-                    return Ok(());
+                    return Ok(ReadResult::default());
                 }
             };
         }
@@ -276,7 +389,7 @@ where
         if self.pending_rx.remove(PendingRx::CreditUpdate) && !self.has_pending_rx() {
             pkt.hdr.set_op(uapi::VSOCK_OP_CREDIT_UPDATE);
             self.last_fwd_cnt_to_peer = self.fwd_cnt;
-            return Ok(());
+            return Ok(ReadResult::default());
         }
 
         // We've already checked for all conditions that would have produced a packet, so
@@ -506,6 +619,7 @@ where
     S: VsockConnectionBackend + Debug,
 {
     /// Create a new guest-initiated connection object.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_peer_init(
         stream: S,
         local_cid: u64,
@@ -514,7 +628,12 @@ where
         peer_port: u32,
         peer_buf_alloc: u32,
         vsock_type: VsockType,
+        conn_buffer_size: Option<usize>,
     ) -> Self {
+        let buf_size = match vsock_type {
+            VsockType::Seqpacket => conn_buffer_size.unwrap_or(DEFAULT_CONN_BUFFER_SIZE),
+            VsockType::Stream => 0,
+        };
         Self {
             local_cid,
             peer_cid,
@@ -531,6 +650,8 @@ where
             pending_rx: PendingRxSet::from(PendingRx::Response),
             expiry: None,
             vsock_type,
+            connection_buffer: None,
+            conn_buf_size: buf_size,
         }
     }
 
@@ -542,7 +663,12 @@ where
         local_port: u32,
         peer_port: u32,
         vsock_type: VsockType,
+        conn_buffer_size: Option<usize>,
     ) -> Self {
+        let buf_size = match vsock_type {
+            VsockType::Seqpacket => conn_buffer_size.unwrap_or(DEFAULT_CONN_BUFFER_SIZE),
+            VsockType::Stream => 0,
+        };
         Self {
             local_cid,
             peer_cid,
@@ -559,6 +685,8 @@ where
             pending_rx: PendingRxSet::from(PendingRx::Request),
             expiry: None,
             vsock_type,
+            connection_buffer: None,
+            conn_buf_size: buf_size,
         }
     }
 
@@ -690,7 +818,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Error as IoError, ErrorKind, Write};
+    use std::io::{Error as IoError, ErrorKind, Read, Write};
     use std::os::unix::io::RawFd;
     use std::time::{Duration, Instant};
 
@@ -777,6 +905,25 @@ mod tests {
                     IoError::new(ErrorKind::WouldBlock, "EAGAIN"),
                 )),
             }
+        }
+    }
+
+    impl Read for TestStream {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            // SAFETY: `buf` is a valid writable buffer for the duration of
+            // the call.
+            let ret = unsafe {
+                libc::recv(
+                    self.fd.as_raw_fd(),
+                    buf.as_mut_ptr().cast::<libc::c_void>(),
+                    buf.len(),
+                    0,
+                )
+            };
+            if ret < 0 {
+                return Err(IoError::last_os_error());
+            }
+            Ok(ret.cast_unsigned())
         }
     }
 
@@ -894,6 +1041,7 @@ mod tests {
                     PEER_PORT,
                     PEER_BUF_ALLOC,
                     VsockType::Stream,
+                    None,
                 ),
                 ConnState::LocalInit => VsockConnection::<TestStream>::new_local_init(
                     stream,
@@ -902,6 +1050,7 @@ mod tests {
                     LOCAL_PORT,
                     PEER_PORT,
                     VsockType::Stream,
+                    None,
                 ),
                 ConnState::Established => {
                     let mut conn = VsockConnection::<TestStream>::new_peer_init(
@@ -912,6 +1061,7 @@ mod tests {
                         PEER_PORT,
                         PEER_BUF_ALLOC,
                         VsockType::Stream,
+                        None,
                     );
                     assert!(conn.has_pending_rx());
                     conn.recv_pkt(&mut rx_pkt).unwrap();
@@ -1373,6 +1523,297 @@ mod tests {
             ctx.notify_epollout();
             assert_eq!(ctx.conn.state, ConnState::Killed);
         }
+    }
+
+    // A real AF_UNIX SOCK_SEQPACKET socket pair used for seqpacket tests.
+    // The local fd is the connection's read end; the remote fd is the test's write end.
+    #[derive(Debug)]
+    struct SeqpacketTestStream {
+        local_fd: RawFd,
+        remote_fd: RawFd,
+    }
+
+    impl SeqpacketTestStream {
+        fn new() -> Self {
+            let mut fds = [0i32; 2];
+            // SAFETY: valid AF_UNIX socketpair call; fds is a valid 2-element array.
+            let ret = unsafe {
+                libc::socketpair(
+                    libc::AF_UNIX,
+                    libc::SOCK_SEQPACKET | libc::SOCK_NONBLOCK,
+                    0,
+                    fds.as_mut_ptr(),
+                )
+            };
+            assert_eq!(ret, 0, "socketpair failed: {}", IoError::last_os_error());
+            Self {
+                local_fd: fds[0],
+                remote_fd: fds[1],
+            }
+        }
+
+        // Write one seqpacket message into the remote end.
+        fn push_message(&self, data: &[u8]) {
+            // SAFETY: `remote_fd` is valid; `data` is a valid slice for the duration of the call.
+            let ret = unsafe {
+                libc::write(
+                    self.remote_fd,
+                    data.as_ptr().cast::<libc::c_void>(),
+                    data.len(),
+                )
+            };
+            assert_eq!(ret.cast_unsigned(), data.len(), "push_message write failed");
+        }
+    }
+
+    impl Drop for SeqpacketTestStream {
+        fn drop(&mut self) {
+            // SAFETY: Both fds are valid and owned by this struct; closing them on drop.
+            unsafe {
+                libc::close(self.local_fd);
+                libc::close(self.remote_fd);
+            }
+        }
+    }
+
+    impl AsRawFd for SeqpacketTestStream {
+        fn as_raw_fd(&self) -> RawFd {
+            self.local_fd
+        }
+    }
+
+    impl ReadVolatile for SeqpacketTestStream {
+        fn read_volatile<B: BitmapSlice>(
+            &mut self,
+            buf: &mut VolatileSlice<B>,
+        ) -> Result<usize, VolatileMemoryError> {
+            let mut tmp = vec![0u8; buf.len()];
+            // SAFETY: `local_fd` is valid; `tmp` is a valid writable buffer for the duration of
+            // the call.
+            let ret = unsafe {
+                libc::recv(
+                    self.local_fd,
+                    tmp.as_mut_ptr().cast::<libc::c_void>(),
+                    tmp.len(),
+                    0,
+                )
+            };
+            if ret < 0 {
+                return Err(VolatileMemoryError::IOError(IoError::last_os_error()));
+            }
+            let n = ret.cast_unsigned();
+            buf.copy_from(&tmp[..n]);
+            Ok(n)
+        }
+    }
+
+    impl Read for SeqpacketTestStream {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            // SAFETY: `buf` is a valid writable buffer for the duration of
+            // the call.
+            let ret = unsafe {
+                libc::recv(
+                    self.local_fd,
+                    buf.as_mut_ptr().cast::<libc::c_void>(),
+                    buf.len(),
+                    0,
+                )
+            };
+            if ret < 0 {
+                return Err(IoError::last_os_error());
+            }
+            Ok(ret.cast_unsigned())
+        }
+    }
+
+    impl Write for SeqpacketTestStream {
+        fn write(&mut self, data: &[u8]) -> Result<usize, IoError> {
+            // SAFETY: `local_fd` is valid; `data` is a valid readable slice for the duration of
+            // the call.
+            let ret = unsafe {
+                libc::write(
+                    self.local_fd,
+                    data.as_ptr().cast::<libc::c_void>(),
+                    data.len(),
+                )
+            };
+            if ret < 0 {
+                Err(IoError::last_os_error())
+            } else {
+                Ok(ret.cast_unsigned())
+            }
+        }
+
+        fn flush(&mut self) -> Result<(), IoError> {
+            Ok(())
+        }
+    }
+
+    impl WriteVolatile for SeqpacketTestStream {
+        fn write_volatile<B: BitmapSlice>(
+            &mut self,
+            buf: &VolatileSlice<B>,
+        ) -> Result<usize, VolatileMemoryError> {
+            let mut tmp = vec![0u8; buf.len()];
+            buf.copy_to(&mut tmp);
+            // SAFETY: `local_fd` is valid; `tmp` is a valid readable buffer for the duration of
+            // the call.
+            let ret = unsafe {
+                libc::write(
+                    self.local_fd,
+                    tmp.as_ptr().cast::<libc::c_void>(),
+                    tmp.len(),
+                )
+            };
+            if ret < 0 {
+                Err(VolatileMemoryError::IOError(IoError::last_os_error()))
+            } else {
+                Ok(ret.cast_unsigned())
+            }
+        }
+    }
+
+    impl VsockConnectionBackend for SeqpacketTestStream {}
+
+    // EOM bit as defined in packet.rs
+    const VIRTIO_VSOCK_SEQ_EOM: u32 = 1 << 0;
+
+    // Creates an established seqpacket connection backed by `stream`.
+    // `conn_buffer_size` sets the intermediate buffer used for large messages.
+    // Returns (connection, rx_pkt); the caller must keep _ctx alive for the duration.
+    fn make_established_seqpacket(
+        stream: SeqpacketTestStream,
+        conn_buffer_size: Option<usize>,
+    ) -> (
+        VsockConnection<SeqpacketTestStream>,
+        VsockPacketRx,
+        TestContext,
+    ) {
+        let vsock_test_ctx = TestContext::new();
+        let mut handler_ctx = vsock_test_ctx.create_event_handler_context();
+        let mut rx_pkt = VsockPacketRx::new().unwrap();
+        rx_pkt
+            .parse(
+                &vsock_test_ctx.mem,
+                handler_ctx.device.queues[RXQ_INDEX].pop().unwrap().unwrap(),
+            )
+            .unwrap();
+
+        let mut conn = VsockConnection::<SeqpacketTestStream>::new_peer_init(
+            stream,
+            LOCAL_CID,
+            PEER_CID,
+            LOCAL_PORT,
+            PEER_PORT,
+            PEER_BUF_ALLOC,
+            VsockType::Seqpacket,
+            conn_buffer_size,
+        );
+        // Drain the initial RESPONSE to reach Established state.
+        assert!(conn.has_pending_rx());
+        conn.recv_pkt(&mut rx_pkt).unwrap();
+        assert_eq!(rx_pkt.hdr.op(), uapi::VSOCK_OP_RESPONSE);
+        assert_eq!(conn.state, ConnState::Established);
+
+        (conn, rx_pkt, vsock_test_ctx)
+    }
+
+    // Seqpacket: a small message (fits in one RX descriptor) is delivered in a single recv_pkt
+    // call with EOM set and should_retrigger=false.
+    #[test]
+    fn test_seqpacket_recv_small_message() {
+        let stream = SeqpacketTestStream::new();
+        stream.push_message(b"hello");
+        let (mut conn, mut rx_pkt, _ctx) = make_established_seqpacket(stream, None);
+
+        conn.notify(EventSet::IN);
+        assert!(conn.has_pending_rx());
+
+        let res = conn.recv_pkt(&mut rx_pkt).unwrap();
+
+        assert_eq!(rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(rx_pkt.hdr.len(), 5);
+        assert_eq!(res.bytes_read, 5);
+        assert!(!res.should_retrigger);
+        // EOM flag must be set: this is the end of the seqpacket message.
+        assert_ne!(rx_pkt.hdr.flags() & VIRTIO_VSOCK_SEQ_EOM, 0);
+        // No further pending RX after a complete small message.
+        assert!(!conn.has_pending_rx());
+    }
+
+    // Seqpacket: a message larger than the RX descriptor buffer (4096 bytes) is split across
+    // two recv_pkt calls. The first call sets should_retrigger=true and leaves EOM clear;
+    // the second call delivers the remainder with EOM set.
+    #[test]
+    fn test_seqpacket_recv_large_message() {
+        const BUF_SIZE: usize = 4096; // matches the test descriptor size
+        const MSG_LEN: usize = BUF_SIZE + 512;
+
+        let stream = SeqpacketTestStream::new();
+        stream.push_message(&vec![0xABu8; MSG_LEN]);
+        let (mut conn, mut rx_pkt, _ctx) = make_established_seqpacket(stream, None);
+
+        conn.notify(EventSet::IN);
+        assert!(conn.has_pending_rx());
+
+        // First call: fills the descriptor (4096 bytes), does not set EOM.
+        let res1 = conn.recv_pkt(&mut rx_pkt).unwrap();
+        assert_eq!(rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(res1.bytes_read, u32::try_from(BUF_SIZE).unwrap());
+        assert!(res1.should_retrigger);
+        assert_eq!(rx_pkt.hdr.flags() & VIRTIO_VSOCK_SEQ_EOM, 0);
+        // Connection must still have pending RX for the remainder.
+        assert!(conn.has_pending_rx());
+
+        // Second call: delivers the remaining 512 bytes with EOM set.
+        let res2 = conn.recv_pkt(&mut rx_pkt).unwrap();
+        assert_eq!(rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(res2.bytes_read, 512);
+        assert!(!res2.should_retrigger);
+        assert_ne!(rx_pkt.hdr.flags() & VIRTIO_VSOCK_SEQ_EOM, 0);
+        assert!(!conn.has_pending_rx());
+    }
+
+    // Seqpacket: a message that exactly fills the RX descriptor is handled in one call,
+    // as a "small" packet (not buffered), with EOM set.
+    #[test]
+    fn test_seqpacket_recv_exact_buf_size_message() {
+        const BUF_SIZE: usize = 4096;
+
+        let stream = SeqpacketTestStream::new();
+        stream.push_message(&vec![0x42u8; BUF_SIZE]);
+        let (mut conn, mut rx_pkt, _ctx) = make_established_seqpacket(stream, None);
+
+        conn.notify(EventSet::IN);
+
+        let res = conn.recv_pkt(&mut rx_pkt).unwrap();
+
+        assert_eq!(rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(res.bytes_read, u32::try_from(BUF_SIZE).unwrap());
+        assert!(!res.should_retrigger);
+        assert_ne!(rx_pkt.hdr.flags() & VIRTIO_VSOCK_SEQ_EOM, 0);
+        assert!(!conn.has_pending_rx());
+    }
+
+    // Seqpacket: a message too large to fit in the intermediate connection buffer returns
+    // a MessageTooLong error and kills the connection (RST).
+    #[test]
+    fn test_seqpacket_recv_message_too_long() {
+        // Use a tiny intermediate buffer so a message slightly larger than the RX descriptor
+        // (4097 bytes > 4096 buf_size) exceeds it.
+        const SMALL_BUF: usize = 128;
+        const MSG_LEN: usize = 4097; // > buf_size (4096) so large-packet path is taken
+
+        let stream = SeqpacketTestStream::new();
+        stream.push_message(&vec![0u8; MSG_LEN]);
+        let (mut conn, mut rx_pkt, _ctx) = make_established_seqpacket(stream, Some(SMALL_BUF));
+
+        conn.notify(EventSet::IN);
+
+        // recv_pkt should not propagate the error; instead it emits an RST packet.
+        let res = conn.recv_pkt(&mut rx_pkt).unwrap();
+        assert_eq!(rx_pkt.hdr.op(), uapi::VSOCK_OP_RST);
+        assert_eq!(res.bytes_read, 0);
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -32,7 +32,9 @@ use super::packet::{VSOCK_PKT_HDR_SIZE, VsockPacketRx, VsockPacketTx};
 use super::{VsockBackend, defs};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
-use crate::devices::virtio::generated::virtio_config::{VIRTIO_F_IN_ORDER, VIRTIO_F_VERSION_1};
+use crate::devices::virtio::generated::virtio_config::{
+    VIRTIO_F_IN_ORDER, VIRTIO_F_VERSION_1, VIRTIO_VSOCK_F_SEQPACKET,
+};
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use crate::devices::virtio::queue::{InvalidAvailIdx, Queue as VirtQueue};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
@@ -41,6 +43,7 @@ use crate::devices::virtio::vsock::metrics::METRICS;
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, info, warn};
 use crate::utils::byte_order;
+use crate::vmm_config::vsock::VsockType;
 use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap};
 
 pub(crate) const RXQ_INDEX: usize = 0;
@@ -92,19 +95,25 @@ where
     pub fn with_queues(
         cid: u64,
         backend: B,
+        vsock_type: &VsockType,
         queues: Vec<VirtQueue>,
     ) -> Result<Vsock<B>, VsockError> {
         let mut queue_events = Vec::new();
         for _ in 0..queues.len() {
             queue_events.push(EventFd::new(libc::EFD_NONBLOCK).map_err(VsockError::EventFd)?);
         }
+        // Start with the basic features and if the type is seqpacket add the seqpacket bit.
+        let mut features = AVAIL_FEATURES;
+        if let VsockType::Seqpacket = vsock_type {
+            features |= 1u64 << VIRTIO_VSOCK_F_SEQPACKET;
+        };
 
         Ok(Vsock {
             cid,
             queues,
             queue_events,
             backend,
-            avail_features: AVAIL_FEATURES,
+            avail_features: features,
             acked_features: 0,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VsockError::EventFd)?,
             device_state: DeviceState::Inactive,
@@ -115,12 +124,12 @@ where
     }
 
     /// Create a new virtio-vsock device with the given VM CID and vsock backend.
-    pub fn new(cid: u64, backend: B) -> Result<Vsock<B>, VsockError> {
+    pub fn new(cid: u64, backend: B, vsock_type: &VsockType) -> Result<Vsock<B>, VsockError> {
         let queues: Vec<VirtQueue> = defs::VSOCK_QUEUE_SIZES
             .iter()
             .map(|&max_size| VirtQueue::new(max_size))
             .collect();
-        Self::with_queues(cid, backend, queues)
+        Self::with_queues(cid, backend, vsock_type, queues)
     }
 
     /// Retrieve the cid associated with this vsock device.
@@ -169,26 +178,13 @@ where
 
         let queue = &mut self.queues[RXQ_INDEX];
         let mut have_used = false;
+        let mut should_retrigger = false;
 
         while let Some(head) = queue.pop_or_enable_notification()? {
             let index = head.index;
             let used_len = match self.rx_packet.parse(mem, head) {
                 Ok(()) => match self.backend.recv_pkt(&mut self.rx_packet) {
-                    Ok(()) => match self.rx_packet.commit_hdr() {
-                        // This addition cannot overflow, because packet length
-                        // is previously validated against `MAX_PKT_BUF_SIZE`
-                        // bound as part of `commit_hdr()`.
-                        Ok(()) => VSOCK_PKT_HDR_SIZE + self.rx_packet.hdr.len(),
-                        Err(err) => {
-                            warn!(
-                                "vsock: Error writing packet header to guest memory: \
-                                 {:?}.Discarding the package.",
-                                err
-                            );
-                            0
-                        }
-                    },
-                    Err(VsockError::NoData) => {
+                   Err(VsockError::NoData) => {
                         // No more data to deliver. Return the unused buffer to the queue.
                         queue.undo_pop();
                         break;
@@ -198,20 +194,35 @@ where
                         queue.undo_pop();
                         break;
                     }
+                    Ok(read_res) => {
+                        should_retrigger = read_res.should_retrigger;
+                        self.rx_packet
+                            .commit_hdr()
+                            .map(|_| VSOCK_PKT_HDR_SIZE + read_res.bytes_read)
+                            .unwrap_or_else(|err| {
+                                warn!("vsock: Error writing packet header: {:?}. Discarding.", err);
+                                0
+                        })
+                    }
                 },
                 Err(err) => {
                     warn!("vsock: RX queue error: {:?}. Discarding the package.", err);
                     0
                 }
             };
-
             have_used = true;
             queue.add_used(index, used_len).unwrap_or_else(|err| {
                 error!("Failed to add available descriptor {}: {}", index, err)
             });
-        }
-        queue.advance_used_ring_idx();
 
+            // we received more than the rx packet size
+            // trigger another loop iteration to consume from the temp buffer
+            if should_retrigger {
+                continue;
+            }
+        }
+
+        queue.advance_used_ring_idx();
         Ok(have_used && queue.prepare_kick())
     }
 
@@ -363,6 +374,15 @@ where
         for q in self.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;
+        }
+        // The guest should ack the seqpacket feature if we requested seqpacket
+        // sockets. Raise an error if it didn't happen.
+        if let VsockType::Seqpacket = self.backend().save()
+            && self.acked_features & (1 << VIRTIO_VSOCK_F_SEQPACKET) == 0
+        {
+            return Err(ActivateError::RequiredFeatureNotAcked(
+                "VIRTIO_VSOCK_F_SEQPACKET not acked by the guest kernel",
+            ));
         }
 
         if self.queues.len() != defs::VSOCK_NUM_QUEUES {

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -32,6 +32,7 @@ pub use self::unix::{VsockUnixBackend, VsockUnixBackendError};
 use super::iov_deque::IovDequeError;
 use crate::devices::virtio::iovec::IoVecError;
 use crate::devices::virtio::persist::PersistError as VirtioStateError;
+use crate::vmm_config::vsock::VsockType;
 
 mod defs {
     use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
@@ -84,8 +85,10 @@ mod defs {
         /// Vsock packet type.
         /// Defined in `/include/uapi/linux/virtio_vsock.h`.
         ///
-        /// Stream / connection-oriented packet (the only currently valid type).
+        /// Stream / connection-oriented packet.
         pub const VSOCK_TYPE_STREAM: u16 = 1;
+        /// Seqpacket based connection
+        pub const VSOCK_TYPE_SEQPACKET: u16 = 2;
 
         pub const VSOCK_HOST_CID: u64 = 2;
     }

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -22,7 +22,7 @@ mod unix;
 
 use std::os::unix::io::AsRawFd;
 
-use vm_memory::GuestMemoryError;
+use vm_memory::{GuestMemoryError, VolatileMemoryError};
 use vmm_sys_util::epoll::EventSet;
 
 pub use self::defs::VSOCK_DEV_ID;
@@ -132,6 +132,8 @@ pub enum VsockError {
     IovDeque(IovDequeError),
     /// Tried to push to full IovDeque.
     IovDequeOverflow,
+    /// Message too big for the intermediate connection buffer. buffer length {0}, incoming size {1}
+    MessageTooLong(usize, usize),
 }
 
 impl From<IoVecError> for VsockError {

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -32,6 +32,7 @@ pub use self::unix::{VsockUnixBackend, VsockUnixBackendError};
 use super::iov_deque::IovDequeError;
 use crate::devices::virtio::iovec::IoVecError;
 use crate::devices::virtio::persist::PersistError as VirtioStateError;
+use crate::devices::virtio::vsock::unix::ReadResult;
 use crate::vmm_config::vsock::VsockType;
 
 mod defs {
@@ -174,7 +175,7 @@ pub trait Save {
 ///       - `send_pkt(&pkt)` will fetch data from `pkt`, and place it into the channel.
 pub trait VsockChannel {
     /// Read/receive an incoming packet from the channel.
-    fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<(), VsockError>;
+    fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<ReadResult, VsockError>;
 
     /// Write/send a packet through the channel.
     ///

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -158,6 +158,11 @@ pub trait VsockEpollListener: AsRawFd {
     fn notify(&mut self, evset: EventSet);
 }
 
+/// An object that can inform its callers on its underlying vsock protocol.
+pub trait Save {
+    fn save(&self) -> &VsockType;
+}
+
 /// Any channel that handles vsock packet traffic: sending and receiving packets. Since we're
 /// implementing the device model here, our responsibility is to always process the sending of
 /// packets (i.e. the TX queue). So, any locally generated data, addressed to the driver (e.g.
@@ -186,7 +191,7 @@ pub trait VsockChannel {
 /// The vsock backend, which is basically an epoll-event-driven vsock channel.
 /// Currently, the only implementation we have is `crate::devices::virtio::unix::muxer::VsockMuxer`,
 /// which translates guest-side vsock connections to host-side Unix domain socket connections.
-pub trait VsockBackend: VsockChannel + VsockEpollListener + Send {
+pub trait VsockBackend: VsockChannel + VsockEpollListener + Send + Save {
     /// Activate the backend, adding its listeners to the poll set.
     fn activate(&mut self) -> Result<(), VsockError>;
 

--- a/src/vmm/src/devices/virtio/vsock/packet.rs
+++ b/src/vmm/src/devices/virtio/vsock/packet.rs
@@ -78,6 +78,9 @@ pub struct VsockPacketHeader {
     fwd_cnt: u32,
 }
 
+pub const VIRTIO_VSOCK_SEQ_EOM: u32 = 1 << 0;
+pub const VIRTIO_VSOCK_SEQ_EOR: u32 = 1 << 1;
+
 impl VsockPacketHeader {
     pub fn src_cid(&self) -> u64 {
         u64::from_le(self.src_cid)

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -6,6 +6,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use crate::vmm_config::vsock::deserialize_conn_buffer_size;
 use serde::{Deserialize, Serialize};
 
 use super::*;
@@ -41,7 +42,12 @@ pub struct VsockBackendState {
     pub uds_path: String,
     /// The last used host-side port.
     pub local_port_last: u32,
+    #[serde(default)]
     pub vsock_type: VsockType,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(deserialize_with = "deserialize_conn_buffer_size")]
+    pub conn_buffer_size: Option<usize>,
 }
 
 /// A helper structure that holds the constructor arguments for VsockUnixBackend
@@ -70,6 +76,7 @@ impl Persist<'_> for VsockUnixBackend {
             uds_path: self.host_sock_path.clone(),
             local_port_last: self.local_port_last,
             vsock_type: self.vsock_type.clone(),
+            conn_buffer_size: self.conn_buffer_size,
         }
     }
 
@@ -81,6 +88,7 @@ impl Persist<'_> for VsockUnixBackend {
             constructor_args.cid,
             state.uds_path.clone(),
             state.vsock_type.clone(),
+            state.conn_buffer_size,
         )?;
         backend.local_port_last = state.local_port_last;
         Ok(backend)
@@ -116,7 +124,9 @@ where
                 FIRECRACKER_MAX_QUEUE_SIZE,
             )
             .map_err(VsockError::VirtioState)?;
-        let mut vsock = Self::with_queues(state.cid, constructor_args.backend, queues)?;
+        let backend_type = constructor_args.backend.save().clone();
+        let mut vsock =
+            Self::with_queues(state.cid, constructor_args.backend, &backend_type, queues)?;
 
         vsock.acked_features = state.virtio_state.acked_features;
         vsock.avail_features = state.virtio_state.avail_features;
@@ -146,6 +156,7 @@ pub(crate) mod tests {
                 uds_path: "test".to_owned(),
                 local_port_last: 0xdeadbeef,
                 vsock_type: VsockType::Stream,
+                conn_buffer_size: None,
             }
         }
 

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -14,6 +14,7 @@ use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
 use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::snapshot::Persist;
+use crate::vmm_config::vsock::VsockType;
 use crate::vstate::memory::GuestMemoryMmap;
 
 /// The Vsock serializable state.
@@ -40,6 +41,7 @@ pub struct VsockBackendState {
     pub uds_path: String,
     /// The last used host-side port.
     pub local_port_last: u32,
+    pub vsock_type: VsockType,
 }
 
 /// A helper structure that holds the constructor arguments for VsockUnixBackend
@@ -67,6 +69,7 @@ impl Persist<'_> for VsockUnixBackend {
         VsockBackendState {
             uds_path: self.host_sock_path.clone(),
             local_port_last: self.local_port_last,
+            vsock_type: self.vsock_type.clone(),
         }
     }
 
@@ -74,7 +77,11 @@ impl Persist<'_> for VsockUnixBackend {
         constructor_args: Self::ConstructorArgs,
         state: &Self::State,
     ) -> Result<Self, Self::Error> {
-        let mut backend = Self::new(constructor_args.cid, state.uds_path.clone())?;
+        let mut backend = Self::new(
+            constructor_args.cid,
+            state.uds_path.clone(),
+            state.vsock_type.clone(),
+        )?;
         backend.local_port_last = state.local_port_last;
         Ok(backend)
     }
@@ -138,6 +145,7 @@ pub(crate) mod tests {
             VsockBackendState {
                 uds_path: "test".to_owned(),
                 local_port_last: 0xdeadbeef,
+                vsock_type: VsockType::Stream,
             }
         }
 

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -122,6 +122,7 @@ where
 pub(crate) mod tests {
     use super::device::AVAIL_FEATURES;
     use super::*;
+    use crate::Persist;
     use crate::devices::virtio::device::VirtioDevice;
     use crate::devices::virtio::test_utils::default_interrupt;
     use crate::devices::virtio::vsock::defs::uapi;
@@ -162,7 +163,7 @@ pub(crate) mod tests {
         // Test serialization
         // Save backend and device state separately.
         let state = VsockState {
-            backend: ctx.device.backend().save(),
+            backend: Persist::save(ctx.device.backend()),
             frontend: ctx.device.save(),
         };
 

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -18,9 +18,10 @@ use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::devices::virtio::vsock::device::{EVQ_INDEX, RXQ_INDEX, TXQ_INDEX};
 use crate::devices::virtio::vsock::packet::VSOCK_PKT_HDR_SIZE;
 use crate::devices::virtio::vsock::{
-    Vsock, VsockBackend, VsockChannel, VsockEpollListener, VsockError,
+    Save, Vsock, VsockBackend, VsockChannel, VsockEpollListener, VsockError,
 };
 use crate::test_utils::single_region_mem;
+use crate::vmm_config::vsock::VsockType;
 use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
 
 #[derive(Debug)]
@@ -102,12 +103,19 @@ impl VsockEpollListener for TestBackend {
         self.evset = Some(evset);
     }
 }
+
 impl VsockBackend for TestBackend {
     fn activate(&mut self) -> Result<(), VsockError> {
         Ok(())
     }
 
     fn reset(&mut self) {}
+}
+
+impl Save for TestBackend {
+    fn save(&self) -> &VsockType {
+        &VsockType::Stream
+    }
 }
 
 #[derive(Debug)]

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -17,6 +17,7 @@ use crate::devices::virtio::test_utils::{VirtQueue as GuestQ, default_interrupt}
 use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::devices::virtio::vsock::device::{EVQ_INDEX, RXQ_INDEX, TXQ_INDEX};
 use crate::devices::virtio::vsock::packet::VSOCK_PKT_HDR_SIZE;
+use crate::devices::virtio::vsock::unix::ReadResult;
 use crate::devices::virtio::vsock::{
     Save, Vsock, VsockBackend, VsockChannel, VsockEpollListener, VsockError,
 };
@@ -61,7 +62,7 @@ impl Default for TestBackend {
 }
 
 impl VsockChannel for TestBackend {
-    fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<(), VsockError> {
+    fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<ReadResult, VsockError> {
         let cool_buf = [0xDu8, 0xE, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF];
         match self.rx_err.take() {
             None => {
@@ -74,7 +75,7 @@ impl VsockChannel for TestBackend {
                         .unwrap();
                 }
                 self.rx_ok_cnt += 1;
-                Ok(())
+                Ok(ReadResult::new(buf_size, false))
             }
             Some(err) => Err(err),
         }

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -132,7 +132,7 @@ impl TestContext {
         const CID: u64 = 52;
         const MEM_SIZE: usize = 1024 * 1024 * 128;
         let mem = single_region_mem(MEM_SIZE);
-        let mut device = Vsock::new(CID, TestBackend::new()).unwrap();
+        let mut device = Vsock::new(CID, TestBackend::new(), &VsockType::default()).unwrap();
         for q in device.queues_mut() {
             q.ready = true;
             q.size = q.max_size;
@@ -183,7 +183,8 @@ impl TestContext {
             guest_rxvq,
             guest_txvq,
             guest_evvq,
-            device: Vsock::with_queues(self.cid, TestBackend::new(), queues).unwrap(),
+            device: Vsock::with_queues(self.cid, TestBackend::new(), &VsockType::default(), queues)
+                .unwrap(),
         }
     }
 }

--- a/src/vmm/src/devices/virtio/vsock/unix/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/mod.rs
@@ -159,5 +159,47 @@ impl AsRawFd for ListenerSocket {
         }
     }
 }
+pub trait IncomingLength {
+    fn incoming_len(&mut self) -> Result<usize, io::Error>;
+}
+
+impl<B: VsockConnectionBackend> IncomingLength for B {
+    fn incoming_len(&mut self) -> Result<usize, io::Error> {
+        let fd = self.as_raw_fd();
+        // the maximum message size 256 bytes anyways
+        let mut peek_buf = [0u8; 1];
+        // SAFETY: `fd` is a valid file descriptor for the duration of this call, and `peek_buf`
+        // is a valid single-byte buffer. MSG_PEEK | MSG_TRUNC returns the message size without
+        // consuming it.
+        let msg_size = unsafe {
+            libc::recv(
+                fd,
+                peek_buf.as_mut_ptr().cast(),
+                1,
+                libc::MSG_PEEK | libc::MSG_TRUNC,
+            )
+        };
+        if msg_size < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(msg_size.cast_unsigned())
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct ReadResult {
+    pub bytes_read: u32,
+    pub should_retrigger: bool,
+}
+
+impl ReadResult {
+    pub fn new(bytes_read: u32, should_retrigger: bool) -> Self {
+        ReadResult {
+            bytes_read,
+            should_retrigger,
+        }
+    }
+}
 
 impl VsockConnectionBackend for ConnBackend {}

--- a/src/vmm/src/devices/virtio/vsock/unix/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/mod.rs
@@ -12,14 +12,14 @@ mod muxer_killq;
 mod muxer_rxq;
 mod seqpacket;
 use std::io::{self, Read, Write};
-use std::os::fd::AsRawFd;
-use std::os::unix::net::UnixStream;
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
 
 pub use muxer::VsockMuxer as VsockUnixBackend;
 use vm_memory::io::{ReadVolatile, WriteVolatile};
 
 use crate::devices::virtio::vsock::csm::VsockConnectionBackend;
-use crate::devices::virtio::vsock::unix::seqpacket::SeqpacketConn;
+use crate::devices::virtio::vsock::unix::seqpacket::{SeqpacketConn, SeqpacketListener};
 use crate::vmm_config::vsock::VsockType;
 
 mod defs {
@@ -129,6 +129,34 @@ impl Write for ConnBackend {
     }
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum ListenerSocket {
+    Stream(UnixListener),
+    Seqpacket(SeqpacketListener),
+}
+
+impl ListenerSocket {
+    fn accept(&self) -> Result<ConnBackend, io::Error> {
+        match self {
+            Self::Stream(sock) => {
+                let (conn, _) = sock.accept()?;
+                conn.set_nonblocking(true)?;
+                Ok(ConnBackend::Stream(conn))
+            }
+            Self::Seqpacket(sock) => sock.accept(),
+        }
+    }
+}
+
+impl AsRawFd for ListenerSocket {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            Self::Stream(sock) => sock.as_raw_fd(),
+            Self::Seqpacket(sock) => sock.as_raw_fd(),
+        }
     }
 }
 

--- a/src/vmm/src/devices/virtio/vsock/unix/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/mod.rs
@@ -10,10 +10,17 @@
 mod muxer;
 mod muxer_killq;
 mod muxer_rxq;
+mod seqpacket;
+use std::io::{self, Read, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
 
 pub use muxer::VsockMuxer as VsockUnixBackend;
+use vm_memory::io::{ReadVolatile, WriteVolatile};
 
 use crate::devices::virtio::vsock::csm::VsockConnectionBackend;
+use crate::devices::virtio::vsock::unix::seqpacket::SeqpacketConn;
+use crate::vmm_config::vsock::VsockType;
 
 mod defs {
     /// Maximum number of established connections that we can handle.
@@ -47,6 +54,82 @@ pub enum VsockUnixBackendError {
     TooManyConnections,
 }
 
-type MuxerConnection = super::csm::VsockConnection<std::os::unix::net::UnixStream>;
+#[derive(Debug)]
+pub enum ConnBackend {
+    Stream(UnixStream),
+    Seqpacket(SeqpacketConn),
+}
 
-impl VsockConnectionBackend for std::os::unix::net::UnixStream {}
+impl ConnBackend {
+    fn connect(conn_type: &VsockType, port_path: String) -> Result<Self, VsockUnixBackendError> {
+        match conn_type {
+            VsockType::Seqpacket => {
+                let conn = SeqpacketConn::connect(port_path)
+                    .map_err(VsockUnixBackendError::UnixConnect)?;
+                Ok(ConnBackend::Seqpacket(conn))
+            }
+            VsockType::Stream => {
+                let conn = UnixStream::connect(port_path)
+                    .and_then(|stream| stream.set_nonblocking(true).map(|_| stream))
+                    .map_err(VsockUnixBackendError::UnixConnect)?;
+                Ok(ConnBackend::Stream(conn))
+            }
+        }
+    }
+}
+
+impl Read for ConnBackend {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            ConnBackend::Stream(inner) => inner.read(buf),
+            ConnBackend::Seqpacket(inner) => inner.read(buf),
+        }
+    }
+}
+
+impl AsRawFd for ConnBackend {
+    fn as_raw_fd(&self) -> i32 {
+        match self {
+            ConnBackend::Stream(inner) => inner.as_raw_fd(),
+            ConnBackend::Seqpacket(inner) => inner.as_raw_fd(),
+        }
+    }
+}
+
+impl ReadVolatile for ConnBackend {
+    fn read_volatile<B: vm_memory::bitmap::BitmapSlice>(
+        &mut self,
+        buf: &mut vm_memory::VolatileSlice<B>,
+    ) -> Result<usize, vm_memory::VolatileMemoryError> {
+        match self {
+            ConnBackend::Stream(inner) => inner.read_volatile(buf),
+            ConnBackend::Seqpacket(inner) => inner.read_volatile(buf),
+        }
+    }
+}
+
+impl WriteVolatile for ConnBackend {
+    fn write_volatile<B: vm_memory::bitmap::BitmapSlice>(
+        &mut self,
+        buf: &vm_memory::VolatileSlice<B>,
+    ) -> Result<usize, vm_memory::VolatileMemoryError> {
+        match self {
+            ConnBackend::Stream(inner) => inner.write_volatile(buf),
+            ConnBackend::Seqpacket(inner) => inner.write_volatile(buf),
+        }
+    }
+}
+
+impl Write for ConnBackend {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            ConnBackend::Stream(inner) => inner.write(buf),
+            ConnBackend::Seqpacket(inner) => inner.write(buf),
+        }
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl VsockConnectionBackend for ConnBackend {}

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -32,8 +32,9 @@
 ///  mapping `RawFd`s to `EpollListener`s.
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
-use std::io::Read;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::io::{self, Read};
+use std::os::fd::FromRawFd;
+use std::os::unix::io::{AsRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 
 use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
@@ -43,10 +44,17 @@ use super::super::defs::uapi;
 use super::super::{VsockBackend, VsockChannel, VsockEpollListener, VsockError};
 use super::muxer_killq::MuxerKillQ;
 use super::muxer_rxq::MuxerRxQ;
-use super::{MuxerConnection, VsockUnixBackendError, defs};
+use super::{VsockUnixBackendError, defs};
+use crate::devices::virtio::vsock::Save;
+use crate::devices::virtio::vsock::csm::VsockConnection;
+use crate::devices::virtio::vsock::defs::uapi::{VSOCK_TYPE_SEQPACKET, VSOCK_TYPE_STREAM};
 use crate::devices::virtio::vsock::metrics::METRICS;
 use crate::devices::virtio::vsock::packet::{VsockPacketRx, VsockPacketTx};
+use crate::devices::virtio::vsock::unix::ConnBackend;
+use crate::devices::virtio::vsock::unix::ListenerSocket;
+use crate::devices::virtio::vsock::unix::seqpacket::{SeqpacketConn, SeqpacketListener};
 use crate::logger::{IncMetric, debug, error, info, warn};
+use crate::vmm_config::vsock::VsockType;
 
 /// A unique identifier of a `MuxerConnection` object. Connections are stored in a hash map,
 /// keyed by a `ConnMapKey` object.
@@ -76,7 +84,7 @@ enum EpollListener {
     HostSock,
     /// A listener interested in reading host `connect <port>` commands from a freshly
     /// connected host socket.
-    LocalStream(UnixStream),
+    LocalStream(ConnBackend),
 }
 
 /// The vsock connection multiplexer.
@@ -85,7 +93,9 @@ pub struct VsockMuxer {
     /// Guest CID.
     cid: u64,
     /// A hash map used to store the active connections.
-    conn_map: HashMap<ConnMapKey, MuxerConnection>,
+    conn_map: HashMap<ConnMapKey, VsockConnection<ConnBackend>>,
+    /// the underlying host socket file descriptor type wrapper
+    host_sock: ListenerSocket,
     /// A hash map used to store epoll event listeners / handlers.
     listener_map: HashMap<RawFd, EpollListener>,
     /// The RX queue. Items in this queue are consumed by `VsockMuxer::recv_pkt()`, and
@@ -95,8 +105,6 @@ pub struct VsockMuxer {
     rxq: MuxerRxQ,
     /// A queue used for terminating connections that are taking too long to shut down.
     killq: MuxerKillQ,
-    /// The Unix socket, through which host-initiated connections are accepted.
-    host_sock: UnixListener,
     /// The file system path of the host-side Unix socket. This is used to figure out the path
     /// to Unix sockets listening on specific ports. I.e. `"<this path>_<port number>"`.
     pub(crate) host_sock_path: String,
@@ -106,7 +114,6 @@ pub struct VsockMuxer {
     /// ports to host-initiated connections.
     local_port_set: HashSet<u32>,
     /// The last used host-side port.
-    ///
     /// Local ports are allocated in a round-robin fashion within the range [1 << 30, 1 << 31).
     /// There should be no inherent technical requirement for this specific range. But the range
     /// provides 1 billion available ports, making port collisions unlikely. In addition, the
@@ -114,6 +121,8 @@ pub struct VsockMuxer {
     /// This appears to have been a design decision dating back to the initial introduction of the
     /// vsock implementation.
     pub(crate) local_port_last: u32,
+    /// The type of the socket (stream or seqpacket)
+    pub(crate) vsock_type: VsockType,
 }
 
 impl VsockChannel for VsockMuxer {
@@ -145,10 +154,13 @@ impl VsockChannel for VsockMuxer {
                         .set_src_port(local_port)
                         .set_dst_port(peer_port)
                         .set_len(0)
-                        .set_type(uapi::VSOCK_TYPE_STREAM)
                         .set_flags(0)
                         .set_buf_alloc(0)
                         .set_fwd_cnt(0);
+                    match self.vsock_type {
+                        VsockType::Seqpacket => pkt.hdr.set_type(VSOCK_TYPE_SEQPACKET),
+                        VsockType::Stream => pkt.hdr.set_type(VSOCK_TYPE_STREAM),
+                    };
                     self.rxq.pop().unwrap();
                     return Ok(());
                 }
@@ -207,9 +219,11 @@ impl VsockChannel for VsockMuxer {
             pkt.hdr
         );
 
-        // If this packet has an unsupported type (!=stream), we must send back an RST.
+        // If this packet has an unsupported type (!=stream or seqpacket), we must send back an RST.
         //
-        if pkt.hdr.type_() != uapi::VSOCK_TYPE_STREAM {
+        if pkt.hdr.type_() != uapi::VSOCK_TYPE_STREAM
+            && pkt.hdr.type_() != uapi::VSOCK_TYPE_SEQPACKET
+        {
             self.enq_rst(pkt.hdr.dst_port(), pkt.hdr.src_port());
             return;
         }
@@ -327,14 +341,35 @@ impl VsockBackend for VsockMuxer {
     }
 }
 
+impl Save for VsockMuxer {
+    fn save(&self) -> &VsockType {
+        &self.vsock_type
+    }
+}
+
 impl VsockMuxer {
     /// Muxer constructor.
-    pub fn new(cid: u64, host_sock_path: String) -> Result<Self, VsockUnixBackendError> {
+    pub fn new(
+        cid: u64,
+        host_sock_path: String,
+        vsock_type: VsockType,
+    ) -> Result<Self, VsockUnixBackendError> {
         // Open/bind on the host Unix socket, so we can accept host-initiated
         // connections.
-        let host_sock = UnixListener::bind(&host_sock_path)
-            .and_then(|sock| sock.set_nonblocking(true).map(|_| sock))
-            .map_err(VsockUnixBackendError::UnixBind)?;
+        let host_sock = match vsock_type {
+            VsockType::Seqpacket => {
+                // we don't need to set non blocking here because by default we pass the flags for a non blocking socket
+                let sock = SeqpacketListener::bind(&host_sock_path)
+                    .map_err(VsockUnixBackendError::UnixBind)?;
+                ListenerSocket::Seqpacket(sock)
+            }
+            VsockType::Stream => {
+                let sock = UnixListener::bind(&host_sock_path)
+                    .and_then(|sock| sock.set_nonblocking(true).map(|_| sock))
+                    .map_err(VsockUnixBackendError::UnixBind)?;
+                ListenerSocket::Stream(sock)
+            }
+        };
 
         let muxer = Self {
             cid,
@@ -347,6 +382,7 @@ impl VsockMuxer {
             killq: MuxerKillQ::new(),
             local_port_last: (1u32 << 30) - 1,
             local_port_set: HashSet::with_capacity(defs::MAX_CONNECTIONS),
+            vsock_type,
         };
 
         Ok(muxer)
@@ -355,6 +391,11 @@ impl VsockMuxer {
     /// Return the file system path of the host-side Unix socket.
     pub fn host_sock_path(&self) -> &str {
         &self.host_sock_path
+    }
+
+    /// Return the type of the underlying socket. (stream or seqpacket)
+    pub fn vsock_type(&self) -> &VsockType {
+        &self.vsock_type
     }
 
     /// Handle/dispatch an epoll event to its listener.
@@ -390,12 +431,6 @@ impl VsockMuxer {
                 self.host_sock
                     .accept()
                     .map_err(VsockUnixBackendError::UnixAccept)
-                    .and_then(|(stream, _)| {
-                        stream
-                            .set_nonblocking(true)
-                            .map(|_| stream)
-                            .map_err(VsockUnixBackendError::UnixAccept)
-                    })
                     .and_then(|stream| {
                         // Before forwarding this connection to a listening AF_VSOCK socket on
                         // the guest side, we need to know the destination port. We'll read
@@ -412,7 +447,7 @@ impl VsockMuxer {
             // "connect" command that we're expecting.
             Some(EpollListener::LocalStream(_)) => {
                 if let Some(EpollListener::LocalStream(mut stream)) = self.remove_listener(fd) {
-                    Self::read_local_stream_port(&mut stream)
+                    Self::read_local_stream_port(&mut stream, &self.vsock_type)
                         .map(|peer_port| (self.allocate_local_port(), peer_port))
                         .and_then(|(local_port, peer_port)| {
                             self.add_connection(
@@ -420,18 +455,19 @@ impl VsockMuxer {
                                     local_port,
                                     peer_port,
                                 },
-                                MuxerConnection::new_local_init(
+                                VsockConnection::new_local_init(
                                     stream,
                                     uapi::VSOCK_HOST_CID,
                                     self.cid,
                                     local_port,
                                     peer_port,
+                                    self.vsock_type.clone(),
                                 ),
                             )
                         })
                         .unwrap_or_else(|err| {
                             info!("vsock: error adding local-init connection: {:?}", err);
-                        })
+                        });
                 }
             }
 
@@ -446,28 +482,43 @@ impl VsockMuxer {
     }
 
     /// Parse a host "connect" command, and extract the destination vsock port.
-    fn read_local_stream_port(stream: &mut UnixStream) -> Result<u32, VsockUnixBackendError> {
+    fn read_local_stream_port(
+        stream: &mut dyn Read,
+        vsock_type: &VsockType,
+    ) -> Result<u32, VsockUnixBackendError> {
         let mut buf = [0u8; 32];
 
-        // This is the minimum number of bytes that we should be able to read, when parsing a
-        // valid connection request. I.e. `b"connect 0\n".len()`.
-        const MIN_READ_LEN: usize = 10;
+        let blen = match vsock_type {
+            VsockType::Seqpacket => {
+                // Seqpacket delivers the entire message atomically, so a single read gets it
+                // all. Using read_exact would silently truncate messages longer than
+                // MIN_READ_LEN bytes (e.g. "connect 525\n"), discarding the remainder.
+                stream
+                    .read(&mut buf)
+                    .map_err(VsockUnixBackendError::UnixRead)?
+            }
+            VsockType::Stream => {
+                // This is the minimum number of bytes that we should be able to read, when
+                // parsing a valid connection request. I.e. `b"connect 0\n".len()`.
+                const MIN_READ_LEN: usize = 10;
 
-        // Bring in the minimum number of bytes that we should be able to read.
-        stream
-            .read_exact(&mut buf[..MIN_READ_LEN])
-            .map_err(VsockUnixBackendError::UnixRead)?;
+                // Bring in the minimum number of bytes that we should be able to read.
+                stream
+                    .read_exact(&mut buf[..MIN_READ_LEN])
+                    .map_err(VsockUnixBackendError::UnixRead)?;
 
-        // Now, finish reading the destination port number, by bringing in one byte at a time,
-        // until we reach an EOL terminator (or our buffer space runs out).  Yeah, not
-        // particularly proud of this approach, but it will have to do for now.
-        let mut blen = MIN_READ_LEN;
-        while buf[blen - 1] != b'\n' && blen < buf.len() {
-            stream
-                .read_exact(&mut buf[blen..=blen])
-                .map_err(VsockUnixBackendError::UnixRead)?;
-            blen += 1;
-        }
+                // Now, finish reading the destination port number, by bringing in one byte at
+                // a time, until we reach an EOL terminator (or our buffer space runs out).
+                let mut blen = MIN_READ_LEN;
+                while buf[blen - 1] != b'\n' && blen < buf.len() {
+                    stream
+                        .read_exact(&mut buf[blen..=blen])
+                        .map_err(VsockUnixBackendError::UnixRead)?;
+                    blen += 1;
+                }
+                blen
+            }
+        };
 
         let mut word_iter = std::str::from_utf8(&buf[..blen])
             .map_err(|_| VsockUnixBackendError::InvalidPortRequest)?
@@ -499,7 +550,7 @@ impl VsockMuxer {
     fn add_connection(
         &mut self,
         key: ConnMapKey,
-        conn: MuxerConnection,
+        conn: VsockConnection<ConnBackend>,
     ) -> Result<(), VsockUnixBackendError> {
         // We might need to make room for this new connection, so let's sweep the kill queue
         // first.  It's fine to do this here because:
@@ -636,27 +687,29 @@ impl VsockMuxer {
     /// RST packet will be scheduled for delivery to the guest.
     fn handle_peer_request_pkt(&mut self, pkt: &VsockPacketTx) {
         let port_path = format!("{}_{}", self.host_sock_path, pkt.hdr.dst_port());
+        let backend = match ConnBackend::connect(&self.vsock_type, port_path) {
+            Ok(b) => b,
+            Err(_) => {
+                self.enq_rst(pkt.hdr.dst_port(), pkt.hdr.src_port());
+                return;
+            }
+        };
 
-        UnixStream::connect(port_path)
-            .and_then(|stream| stream.set_nonblocking(true).map(|_| stream))
-            .map_err(VsockUnixBackendError::UnixConnect)
-            .and_then(|stream| {
-                self.add_connection(
-                    ConnMapKey {
-                        local_port: pkt.hdr.dst_port(),
-                        peer_port: pkt.hdr.src_port(),
-                    },
-                    MuxerConnection::new_peer_init(
-                        stream,
-                        uapi::VSOCK_HOST_CID,
-                        self.cid,
-                        pkt.hdr.dst_port(),
-                        pkt.hdr.src_port(),
-                        pkt.hdr.buf_alloc(),
-                    ),
-                )
-            })
-            .unwrap_or_else(|_| self.enq_rst(pkt.hdr.dst_port(), pkt.hdr.src_port()));
+        self.add_connection(
+            ConnMapKey {
+                local_port: pkt.hdr.dst_port(),
+                peer_port: pkt.hdr.src_port(),
+            },
+            VsockConnection::<ConnBackend>::new_peer_init(
+                backend,
+                uapi::VSOCK_HOST_CID,
+                self.cid,
+                pkt.hdr.dst_port(),
+                pkt.hdr.src_port(),
+                pkt.hdr.buf_alloc(),
+                self.vsock_type.clone(),
+            ),
+        );
     }
 
     /// Perform an action that might mutate a connection's state.
@@ -668,7 +721,7 @@ impl VsockMuxer {
     /// - kill the connection if an unrecoverable error occurs.
     fn apply_conn_mutation<F>(&mut self, key: ConnMapKey, mut_fn: F)
     where
-        F: FnOnce(&mut MuxerConnection),
+        F: FnOnce(&mut VsockConnection<ConnBackend>),
     {
         if let Some(conn) = self.conn_map.get_mut(&key) {
             let had_rx = conn.has_pending_rx();
@@ -873,7 +926,7 @@ mod tests {
                 )
                 .unwrap();
 
-            let mut muxer = VsockMuxer::new(PEER_CID, get_file(name)).unwrap();
+            let mut muxer = VsockMuxer::new(PEER_CID, get_file(name), VsockType::Stream).unwrap();
             muxer.activate().unwrap();
             Self {
                 _vsock_test_ctx: vsock_test_ctx,

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -50,9 +50,9 @@ use crate::devices::virtio::vsock::csm::VsockConnection;
 use crate::devices::virtio::vsock::defs::uapi::{VSOCK_TYPE_SEQPACKET, VSOCK_TYPE_STREAM};
 use crate::devices::virtio::vsock::metrics::METRICS;
 use crate::devices::virtio::vsock::packet::{VsockPacketRx, VsockPacketTx};
-use crate::devices::virtio::vsock::unix::ConnBackend;
 use crate::devices::virtio::vsock::unix::ListenerSocket;
 use crate::devices::virtio::vsock::unix::seqpacket::{SeqpacketConn, SeqpacketListener};
+use crate::devices::virtio::vsock::unix::{ConnBackend, ReadResult};
 use crate::logger::{IncMetric, debug, error, info, warn};
 use crate::vmm_config::vsock::VsockType;
 
@@ -123,6 +123,8 @@ pub struct VsockMuxer {
     pub(crate) local_port_last: u32,
     /// The type of the socket (stream or seqpacket)
     pub(crate) vsock_type: VsockType,
+    /// Length of the intermediate connection buffer
+    pub(crate) conn_buffer_size: Option<usize>,
 }
 
 impl VsockChannel for VsockMuxer {
@@ -131,7 +133,7 @@ impl VsockChannel for VsockMuxer {
     /// Retuns:
     /// - `Ok(())`: `pkt` has been successfully filled in; or
     /// - `Err(VsockError::NoData)`: there was no available data with which to fill in the packet.
-    fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<(), VsockError> {
+    fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<ReadResult, VsockError> {
         // We'll look for instructions on how to build the RX packet in the RX queue. If the
         // queue is empty, that doesn't necessarily mean we don't have any pending RX, since
         // the queue might be out-of-sync. If that's the case, we'll attempt to sync it first,
@@ -162,7 +164,7 @@ impl VsockChannel for VsockMuxer {
                         VsockType::Stream => pkt.hdr.set_type(VSOCK_TYPE_STREAM),
                     };
                     self.rxq.pop().unwrap();
-                    return Ok(());
+                    return Ok(ReadResult::default());
                 }
 
                 // We'll defer building the packet to this connection, since it has something
@@ -193,7 +195,18 @@ impl VsockChannel for VsockMuxer {
                 }
 
                 debug!("vsock muxer: RX pkt: {:?}", pkt.hdr);
-                return Ok(());
+                match res {
+                    Ok(read_res) => {
+                        // the read was buffered into an intermediate vector and this
+                        // means there is still data to process but no fd event will
+                        // kick off. manually push a a PendingRx queue entry
+                        if read_res.should_retrigger {
+                            self.rxq.push(rx);
+                        }
+                        return Ok(read_res);
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         }
 
@@ -353,6 +366,7 @@ impl VsockMuxer {
         cid: u64,
         host_sock_path: String,
         vsock_type: VsockType,
+        conn_buffer_size: Option<usize>,
     ) -> Result<Self, VsockUnixBackendError> {
         // Open/bind on the host Unix socket, so we can accept host-initiated
         // connections.
@@ -383,6 +397,7 @@ impl VsockMuxer {
             local_port_last: (1u32 << 30) - 1,
             local_port_set: HashSet::with_capacity(defs::MAX_CONNECTIONS),
             vsock_type,
+            conn_buffer_size,
         };
 
         Ok(muxer)
@@ -462,6 +477,7 @@ impl VsockMuxer {
                                     local_port,
                                     peer_port,
                                     self.vsock_type.clone(),
+                                    self.conn_buffer_size,
                                 ),
                             )
                         })
@@ -708,6 +724,7 @@ impl VsockMuxer {
                 pkt.hdr.src_port(),
                 pkt.hdr.buf_alloc(),
                 self.vsock_type.clone(),
+                None,
             ),
         );
     }
@@ -926,7 +943,7 @@ mod tests {
                 )
                 .unwrap();
 
-            let mut muxer = VsockMuxer::new(PEER_CID, get_file(name), VsockType::Stream).unwrap();
+            let mut muxer = VsockMuxer::new(PEER_CID, get_file(name), VsockType::Stream, None).unwrap();
             muxer.activate().unwrap();
             Self {
                 _vsock_test_ctx: vsock_test_ctx,

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer_killq.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer_killq.rs
@@ -27,8 +27,10 @@
 use std::collections::{HashMap, VecDeque};
 use std::time::Instant;
 
+use super::defs;
 use super::muxer::ConnMapKey;
-use super::{MuxerConnection, defs};
+use crate::devices::virtio::vsock::csm::VsockConnection;
+use crate::devices::virtio::vsock::unix::ConnBackend;
 
 /// A kill queue item, holding the connection key and the scheduled time for termination.
 #[derive(Debug, Clone, Copy)]
@@ -66,7 +68,7 @@ impl MuxerKillQ {
     /// set to expire at some point in the future.
     /// Note: if more than `Self::SIZE` connections are found, the queue will be created in an
     ///       out-of-sync state, and will be discarded after it is emptied.
-    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
+    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, VsockConnection<ConnBackend>>) -> Self {
         let mut q_buf: Vec<MuxerKillQItem> = Vec::with_capacity(Self::SIZE);
         let mut synced = true;
         for (key, conn) in conn_map.iter() {

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer_rxq.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer_rxq.rs
@@ -18,8 +18,10 @@
 use std::collections::{HashMap, VecDeque};
 
 use super::super::VsockChannel;
+use super::defs;
 use super::muxer::{ConnMapKey, MuxerRx};
-use super::{MuxerConnection, defs};
+use crate::devices::virtio::vsock::csm::VsockConnection;
+use crate::devices::virtio::vsock::unix::ConnBackend;
 
 /// The muxer RX queue.
 #[derive(Debug)]
@@ -45,7 +47,7 @@ impl MuxerRxQ {
     /// Note: the resulting queue may still be desynchronized, if there are too many connections
     ///       that have pending RX data. In that case, the muxer will first drain this queue, and
     ///       then try again to build a synchronized one.
-    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
+    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, VsockConnection<ConnBackend>>) -> Self {
         let mut q = VecDeque::new();
         let mut synced = true;
 

--- a/src/vmm/src/devices/virtio/vsock/unix/seqpacket.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/seqpacket.rs
@@ -1,0 +1,255 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::cast_possible_truncation)]
+
+use std::io;
+use std::io::{Error, ErrorKind, Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+
+use std::fmt::Debug;
+use vm_memory::{ReadVolatile, VolatileMemoryError, WriteVolatile};
+
+use crate::devices::virtio::vsock::unix::ConnBackend;
+
+#[derive(Debug)]
+pub struct SeqpacketConn(std::os::fd::OwnedFd);
+
+impl SeqpacketConn {
+    pub fn connect(path: String) -> Result<Self, io::Error> {
+        let (addr, addr_len) = build_addr(&path.to_string())?;
+
+        // SAFETY: Valid flags and socket type.
+        let fd = unsafe {
+            libc::socket(
+                libc::AF_UNIX,
+                libc::SOCK_SEQPACKET | libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK,
+                0,
+            )
+        };
+        if fd == -1 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: We just checked that the file descriptor is valid.
+        let ownedfd = unsafe { OwnedFd::from_raw_fd(fd) };
+
+        // SAFETY: Valid file descriptor and errors checked.
+        unsafe {
+            if libc::connect(
+                fd,
+                (&addr as *const libc::sockaddr_un).cast::<libc::sockaddr>(),
+                addr_len,
+            ) == -1
+            {
+                return Err(io::Error::last_os_error());
+            }
+        };
+
+        Ok(SeqpacketConn(ownedfd))
+    }
+}
+
+impl AsRawFd for SeqpacketConn {
+    fn as_raw_fd(&self) -> i32 {
+        self.0.as_raw_fd()
+    }
+}
+
+impl Read for SeqpacketConn {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let ptr = buf.as_mut_ptr().cast::<libc::c_void>();
+        // SAFETY: The file descriptor is valid and open. The buffer pointer is valid for writing
+        // `buf.len()` bytes.
+        let received = unsafe { libc::recv(self.0.as_raw_fd(), ptr, buf.len(), libc::MSG_TRUNC) };
+        if received < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(received.try_into().unwrap())
+    }
+}
+
+impl Write for SeqpacketConn {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let ptr = buf.as_ptr().cast::<libc::c_void>();
+        let flags = libc::MSG_NOSIGNAL;
+        // SAFETY: The file descriptor is valid and open. The buffer pointer is valid for reading
+        // `buf.len()` bytes.
+        let sent = unsafe { libc::send(self.0.as_raw_fd(), ptr, buf.len(), flags) };
+        if sent < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(sent.try_into().unwrap())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl ReadVolatile for SeqpacketConn {
+    fn read_volatile<B: vm_memory::bitmap::BitmapSlice>(
+        &mut self,
+        buf: &mut vm_memory::VolatileSlice<B>,
+    ) -> Result<usize, vm_memory::VolatileMemoryError> {
+        let fd = self.0.as_raw_fd();
+        let guard = buf.ptr_guard_mut();
+
+        let dst = guard.as_ptr().cast::<libc::c_void>();
+
+        // SAFETY: Rust's I/O safety invariants ensure that BorrowedFd contains a valid file
+        // descriptor`. The memory pointed to by `dst` is valid for writes of length
+        // `buf.len() by the invariants upheld by the constructor of `VolatileSlice`.
+        let bytes_read = unsafe { libc::recv(fd, dst, buf.len(), libc::MSG_TRUNC) };
+
+        if bytes_read < 0 {
+            // We don't know if a partial read might have happened, so mark everything as dirty
+            buf.bitmap().mark_dirty(0, buf.len());
+            Err(VolatileMemoryError::IOError(std::io::Error::last_os_error()))
+        } else {
+            let bytes_read = bytes_read.try_into().unwrap();
+            buf.bitmap().mark_dirty(0, bytes_read);
+            Ok(bytes_read)
+        }
+    }
+}
+
+impl WriteVolatile for SeqpacketConn {
+    fn write_volatile<B: vm_memory::bitmap::BitmapSlice>(
+        &mut self,
+        buf: &vm_memory::VolatileSlice<B>,
+    ) -> Result<usize, vm_memory::VolatileMemoryError> {
+        let fd = self.0.as_raw_fd();
+        let guard = buf.ptr_guard();
+
+        let src = guard.as_ptr().cast::<libc::c_void>();
+
+        // SAFETY: Rust's I/O safety invariants ensure that BorrowedFd contains a valid file
+        // descriptor`. The memory pointed to by `src` is valid for reads of length
+        // `buf.len() by the invariants upheld by the constructor of `VolatileSlice`.
+        let bytes_written = unsafe { libc::send(fd, src, buf.len(), libc::MSG_NOSIGNAL) };
+
+        if bytes_written < 0 {
+            Err(VolatileMemoryError::IOError(std::io::Error::last_os_error()))
+        } else {
+            Ok(bytes_written.try_into().unwrap())
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SeqpacketListener(OwnedFd);
+
+impl SeqpacketListener {
+    pub fn bind(path: &str) -> Result<Self, io::Error> {
+        // SAFETY: Valid socket() parameters, error checked
+        let fd = unsafe {
+            libc::socket(
+                libc::AF_UNIX,
+                libc::SOCK_SEQPACKET | libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK,
+                0,
+            )
+        };
+
+        if fd == -1 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: Transferring unique ownership of valid fd to OwnedFd
+        let ownedfd = unsafe { OwnedFd::from_raw_fd(fd) };
+
+        let (addr, addr_len) = build_addr(path)?;
+
+        // SAFETY: Valid fd and addr pointer, closes fd on error
+        unsafe {
+            if libc::bind(
+                fd,
+                (&addr as *const libc::sockaddr_un).cast::<libc::sockaddr>(),
+                addr_len,
+            ) == -1
+            {
+                return Err(io::Error::last_os_error());
+            }
+        };
+
+        // SAFETY: Valid bound socket, closes fd on error
+        unsafe {
+            if libc::listen(fd, libc::SOMAXCONN) == -1 {
+                let err = io::Error::last_os_error();
+                return Err(err);
+            }
+        };
+
+        Ok(SeqpacketListener(ownedfd))
+    }
+
+    pub fn accept(&self) -> Result<ConnBackend, io::Error> {
+        let flags = libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK;
+        let mut addr: libc::sockaddr_un = uninitialized_address();
+        let mut addr_len: libc::socklen_t = std::mem::size_of_val(&addr) as libc::socklen_t;
+
+        addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+        // SAFETY: Valid fd, errors checked.
+        let fd = unsafe {
+            libc::accept4(
+                self.0.as_raw_fd(),
+                (&mut addr as *mut libc::sockaddr_un).cast::<libc::sockaddr>(),
+                &mut addr_len,
+                flags,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: We just checked if its a valid fd.
+        let ownedfd = unsafe { OwnedFd::from_raw_fd(fd) };
+
+        // Set non-blocking via FIONBIO ioctl (already allowed by seccomp filter)
+        let mut nonblocking: libc::c_int = 1;
+        // SAFETY: `fd` is valid (checked above); `nonblocking` is a valid int pointer.
+        let ret = unsafe { libc::ioctl(fd, libc::FIONBIO, &mut nonblocking) };
+        if ret < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(ConnBackend::Seqpacket(SeqpacketConn(ownedfd)))
+    }
+}
+
+impl AsRawFd for SeqpacketListener {
+    fn as_raw_fd(&self) -> i32 {
+        self.0.as_raw_fd()
+    }
+}
+
+fn build_addr(path: &str) -> Result<(libc::sockaddr_un, u32), io::Error> {
+    let mut addr: libc::sockaddr_un = uninitialized_address();
+    addr.sun_family = libc::AF_UNIX as _;
+    let max_addr = std::mem::size_of_val(&addr.sun_path);
+    if path.len() >= std::mem::size_of_val(&addr.sun_path) {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "the path has length higher than maximum allowed: {}, got: {}",
+                path.len(),
+                max_addr
+            ),
+        ));
+    };
+
+    // SAFETY: Bounded copy, non-overlapping pointers
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            path.as_ptr().cast::<libc::c_char>(),
+            addr.sun_path.as_mut_ptr(),
+            path.len(),
+        );
+    };
+    Ok((addr, std::mem::size_of::<libc::sockaddr_un>() as u32))
+}
+
+fn uninitialized_address() -> libc::sockaddr_un {
+    // SAFETY: sockaddr_un has no invalid bit patterns
+    unsafe { std::mem::zeroed() }
+}

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -377,7 +377,7 @@ impl VmResources {
 
     /// Sets a vsock device to be attached when the VM starts.
     pub fn set_vsock_device(&mut self, config: VsockDeviceConfig) -> Result<(), VsockConfigError> {
-        self.vsock.insert(config)
+        self.vsock.insert(&config)
     }
 
     /// Builds an entropy device to be attached when the VM starts.

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1300,6 +1300,7 @@ mod tests {
                 guest_cid: 0,
                 uds_path: String::new(),
                 vsock_type: VsockType::Stream,
+                conn_buffer_size: None,
             },
         )));
         check_unsupported(runtime_request(VmmAction::SetBalloonDevice(
@@ -1311,6 +1312,7 @@ mod tests {
                 guest_cid: 0,
                 uds_path: String::new(),
                 vsock_type: VsockType::Stream,
+                conn_buffer_size: None,
             },
         )));
         check_unsupported(runtime_request(VmmAction::SetMmdsConfiguration(

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1038,6 +1038,7 @@ mod tests {
     use crate::mmds::data_store::MmdsVersion;
     use crate::seccomp::BpfThreadMap;
     use crate::vmm_config::snapshot::{MemBackendConfig, MemBackendType};
+    use crate::vmm_config::vsock::VsockType;
 
     fn default_preboot<'a>(
         vm_resources: &'a mut VmResources,
@@ -1298,6 +1299,7 @@ mod tests {
                 vsock_id: Some(String::new()),
                 guest_cid: 0,
                 uds_path: String::new(),
+                vsock_type: VsockType::Stream,
             },
         )));
         check_unsupported(runtime_request(VmmAction::SetBalloonDevice(
@@ -1308,6 +1310,7 @@ mod tests {
                 vsock_id: Some(String::new()),
                 guest_cid: 0,
                 uds_path: String::new(),
+                vsock_type: VsockType::Stream,
             },
         )));
         check_unsupported(runtime_request(VmmAction::SetMmdsConfiguration(

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -19,6 +19,18 @@ pub enum VsockConfigError {
     CreateVsockDevice(VsockError),
 }
 
+/// from vsock related requests.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VsockType {
+    /// A stream type socket. No message boundary preservation.
+    #[default]
+    Stream,
+    /// A seqpacket type socket. Message boundaries are denoted
+    /// by a MSG_EOM flag in the vsock header.
+    Seqpacket,
+}
+
 /// This struct represents the strongly typed equivalent of the json body
 /// from vsock related requests.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -32,12 +44,16 @@ pub struct VsockDeviceConfig {
     pub guest_cid: u32,
     /// Path to local unix socket.
     pub uds_path: String,
+    #[serde(default)]
+    /// the type of the underlying socket
+    pub vsock_type: VsockType,
 }
 
 #[derive(Debug)]
 struct VsockAndUnixPath {
     vsock: MutexVsockUnix,
     uds_path: String,
+    vsock_type: VsockType,
 }
 
 impl From<&VsockAndUnixPath> for VsockDeviceConfig {
@@ -47,6 +63,7 @@ impl From<&VsockAndUnixPath> for VsockDeviceConfig {
             vsock_id: None,
             guest_cid: u32::try_from(vsock_lock.cid()).unwrap(),
             uds_path: vsock.uds_path.clone(),
+            vsock_type: vsock.vsock_type.clone(),
         }
     }
 }
@@ -57,6 +74,7 @@ impl From<&Vsock<VsockUnixBackend>> for VsockDeviceConfig {
             vsock_id: None, // deprecated
             guest_cid: u32::try_from(vsock.cid()).unwrap(),
             uds_path: vsock.backend().host_sock_path().to_owned(),
+            vsock_type: vsock.backend().vsock_type.clone(),
         }
     }
 }
@@ -75,20 +93,17 @@ impl VsockBuilder {
 
     /// Inserts an existing vsock device.
     pub fn set_device(&mut self, device: Arc<Mutex<Vsock<VsockUnixBackend>>>) {
+        let device_inner = device.lock().expect("Poisoned lock");
         self.inner = Some(VsockAndUnixPath {
-            uds_path: device
-                .lock()
-                .expect("Poisoned lock")
-                .backend()
-                .host_sock_path()
-                .to_owned(),
+            uds_path: device_inner.backend().host_sock_path().to_owned(),
             vsock: device.clone(),
+            vsock_type: device_inner.backend().vsock_type().clone(),
         });
     }
 
     /// Inserts a Unix backend Vsock in the store.
     /// If an entry already exists, it will overwrite it.
-    pub fn insert(&mut self, cfg: VsockDeviceConfig) -> Result<(), VsockConfigError> {
+    pub fn insert(&mut self, cfg: &VsockDeviceConfig) -> Result<(), VsockConfigError> {
         // Make sure to drop the old one and remove the socket before creating a new one.
         if let Some(existing) = self.inner.take() {
             std::fs::remove_file(existing.uds_path).map_err(VsockUnixBackendError::UnixBind)?;
@@ -96,6 +111,7 @@ impl VsockBuilder {
         self.inner = Some(VsockAndUnixPath {
             uds_path: cfg.uds_path.clone(),
             vsock: Arc::new(Mutex::new(Self::create_unixsock_vsock(cfg)?)),
+            vsock_type: cfg.vsock_type.clone(),
         });
         Ok(())
     }
@@ -107,9 +123,13 @@ impl VsockBuilder {
 
     /// Creates a Vsock device from a VsockDeviceConfig.
     pub fn create_unixsock_vsock(
-        cfg: VsockDeviceConfig,
+        cfg: &VsockDeviceConfig,
     ) -> Result<Vsock<VsockUnixBackend>, VsockConfigError> {
-        let backend = VsockUnixBackend::new(u64::from(cfg.guest_cid), cfg.uds_path)?;
+        let backend = VsockUnixBackend::new(
+            u64::from(cfg.guest_cid),
+            cfg.uds_path.clone(),
+            cfg.vsock_type.clone(),
+        )?;
 
         Vsock::new(u64::from(cfg.guest_cid), backend).map_err(VsockConfigError::CreateVsockDevice)
     }
@@ -133,6 +153,7 @@ pub(crate) mod tests {
             vsock_id: None,
             guest_cid: 3,
             uds_path: tmp_sock_file.as_path().to_str().unwrap().to_string(),
+            vsock_type: VsockType::default(),
         }
     }
 
@@ -141,7 +162,7 @@ pub(crate) mod tests {
         let mut tmp_sock_file = TempFile::new().unwrap();
         tmp_sock_file.remove().unwrap();
         let vsock_config = default_config(&tmp_sock_file);
-        VsockBuilder::create_unixsock_vsock(vsock_config).unwrap();
+        VsockBuilder::create_unixsock_vsock(&vsock_config).unwrap();
     }
 
     #[test]
@@ -151,13 +172,13 @@ pub(crate) mod tests {
         tmp_sock_file.remove().unwrap();
         let mut vsock_config = default_config(&tmp_sock_file);
 
-        store.insert(vsock_config.clone()).unwrap();
+        store.insert(&vsock_config.clone()).unwrap();
         let vsock = store.get().unwrap();
         assert_eq!(vsock.lock().unwrap().id(), VSOCK_DEV_ID);
 
         let new_cid = vsock_config.guest_cid + 1;
         vsock_config.guest_cid = new_cid;
-        store.insert(vsock_config).unwrap();
+        store.insert(&vsock_config).unwrap();
         let vsock = store.get().unwrap();
         assert_eq!(vsock.lock().unwrap().cid(), u64::from(new_cid));
     }
@@ -168,7 +189,7 @@ pub(crate) mod tests {
         let mut tmp_sock_file = TempFile::new().unwrap();
         tmp_sock_file.remove().unwrap();
         let vsock_config = default_config(&tmp_sock_file);
-        vsock_builder.insert(vsock_config.clone()).unwrap();
+        vsock_builder.insert(&vsock_config.clone()).unwrap();
 
         let config = vsock_builder.config();
         assert!(config.is_some());
@@ -182,8 +203,12 @@ pub(crate) mod tests {
         tmp_sock_file.remove().unwrap();
         let vsock = Vsock::new(
             0,
-            VsockUnixBackend::new(1, tmp_sock_file.as_path().to_str().unwrap().to_string())
-                .unwrap(),
+            VsockUnixBackend::new(
+                1,
+                tmp_sock_file.as_path().to_str().unwrap().to_string(),
+                VsockType::default(),
+            )
+            .unwrap(),
         )
         .unwrap();
 

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -131,7 +131,8 @@ impl VsockBuilder {
             cfg.vsock_type.clone(),
         )?;
 
-        Vsock::new(u64::from(cfg.guest_cid), backend).map_err(VsockConfigError::CreateVsockDevice)
+        Vsock::new(u64::from(cfg.guest_cid), backend, &cfg.vsock_type)
+            .map_err(VsockConfigError::CreateVsockDevice)
     }
 
     /// Returns the structure used to configure the vsock device.
@@ -201,14 +202,16 @@ pub(crate) mod tests {
         let mut vsock_builder = VsockBuilder::new();
         let mut tmp_sock_file = TempFile::new().unwrap();
         tmp_sock_file.remove().unwrap();
+        let vsock_type = VsockType::default();
         let vsock = Vsock::new(
             0,
             VsockUnixBackend::new(
                 1,
                 tmp_sock_file.as_path().to_str().unwrap().to_string(),
-                VsockType::default(),
+                vsock_type.clone(),
             )
             .unwrap(),
+            &vsock_type,
         )
         .unwrap();
 

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -4,9 +4,13 @@
 use std::convert::TryFrom;
 use std::sync::{Arc, Mutex};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::devices::virtio::vsock::{Vsock, VsockError, VsockUnixBackend, VsockUnixBackendError};
+
+// A connection buffer needs to be equivalent to atleast 1 page of memory
+const MIN_CONN_BUF: usize = 4 * 1024;
+const MAX_CONN_BUF: usize = 256 * 1024;
 
 type MutexVsockUnix = Arc<Mutex<Vsock<VsockUnixBackend>>>;
 
@@ -31,6 +35,23 @@ pub enum VsockType {
     Seqpacket,
 }
 
+/// This function imposes limits on the conn_buffer_size during serialization for how
+/// big or small it can be and rejects invalid values by returning an error.
+pub fn deserialize_conn_buffer_size<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let v = Option::<usize>::deserialize(deserializer)?;
+    if let Some(n) = v
+        && !(MIN_CONN_BUF..=MAX_CONN_BUF).contains(&n)
+    {
+        return Err(serde::de::Error::custom(format!(
+            "conn_buffer_size is invalid (max {}), (min {})",
+            MAX_CONN_BUF, MIN_CONN_BUF
+        )));
+    }
+    Ok(v)
+}
 /// This struct represents the strongly typed equivalent of the json body
 /// from vsock related requests.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -47,6 +68,11 @@ pub struct VsockDeviceConfig {
     #[serde(default)]
     /// the type of the underlying socket
     pub vsock_type: VsockType,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(deserialize_with = "deserialize_conn_buffer_size")]
+    /// the size of the intermediate connection buffer
+    pub conn_buffer_size: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -54,6 +80,7 @@ struct VsockAndUnixPath {
     vsock: MutexVsockUnix,
     uds_path: String,
     vsock_type: VsockType,
+    conn_buffer_size: Option<usize>,
 }
 
 impl From<&VsockAndUnixPath> for VsockDeviceConfig {
@@ -64,6 +91,7 @@ impl From<&VsockAndUnixPath> for VsockDeviceConfig {
             guest_cid: u32::try_from(vsock_lock.cid()).unwrap(),
             uds_path: vsock.uds_path.clone(),
             vsock_type: vsock.vsock_type.clone(),
+            conn_buffer_size: vsock.conn_buffer_size,
         }
     }
 }
@@ -75,6 +103,7 @@ impl From<&Vsock<VsockUnixBackend>> for VsockDeviceConfig {
             guest_cid: u32::try_from(vsock.cid()).unwrap(),
             uds_path: vsock.backend().host_sock_path().to_owned(),
             vsock_type: vsock.backend().vsock_type.clone(),
+            conn_buffer_size: vsock.backend().conn_buffer_size,
         }
     }
 }
@@ -98,6 +127,7 @@ impl VsockBuilder {
             uds_path: device_inner.backend().host_sock_path().to_owned(),
             vsock: device.clone(),
             vsock_type: device_inner.backend().vsock_type().clone(),
+            conn_buffer_size: device_inner.backend().conn_buffer_size,
         });
     }
 
@@ -112,6 +142,7 @@ impl VsockBuilder {
             uds_path: cfg.uds_path.clone(),
             vsock: Arc::new(Mutex::new(Self::create_unixsock_vsock(cfg)?)),
             vsock_type: cfg.vsock_type.clone(),
+            conn_buffer_size: cfg.conn_buffer_size,
         });
         Ok(())
     }
@@ -129,6 +160,7 @@ impl VsockBuilder {
             u64::from(cfg.guest_cid),
             cfg.uds_path.clone(),
             cfg.vsock_type.clone(),
+            cfg.conn_buffer_size,
         )?;
 
         Vsock::new(u64::from(cfg.guest_cid), backend, &cfg.vsock_type)
@@ -155,6 +187,7 @@ pub(crate) mod tests {
             guest_cid: 3,
             uds_path: tmp_sock_file.as_path().to_str().unwrap().to_string(),
             vsock_type: VsockType::default(),
+            conn_buffer_size: None,
         }
     }
 
@@ -209,6 +242,7 @@ pub(crate) mod tests {
                 1,
                 tmp_sock_file.as_path().to_str().unwrap().to_string(),
                 vsock_type.clone(),
+                None,
             )
             .unwrap(),
             &vsock_type,

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -454,6 +454,7 @@ fn test_preboot_load_snap_disallowed_after_boot_resources() {
         guest_cid: 0,
         uds_path: String::new(),
         vsock_type: VsockType::Stream,
+        conn_buffer_size: None,
     });
     verify_load_snap_disallowed_after_boot_resources(req, "SetVsockDevice");
 

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -30,7 +30,7 @@ use vmm::vmm_config::net::NetworkInterfaceConfig;
 use vmm::vmm_config::snapshot::{
     CreateSnapshotParams, LoadSnapshotParams, MemBackendConfig, MemBackendType, SnapshotType,
 };
-use vmm::vmm_config::vsock::VsockDeviceConfig;
+use vmm::vmm_config::vsock::{VsockDeviceConfig, VsockType};
 use vmm::{DumpCpuConfigError, EventManager, FcExitCode, Vmm};
 use vmm_sys_util::tempfile::TempFile;
 
@@ -453,6 +453,7 @@ fn test_preboot_load_snap_disallowed_after_boot_resources() {
         vsock_id: Some(String::new()),
         guest_cid: 0,
         uds_path: String::new(),
+        vsock_type: VsockType::Stream,
     });
     verify_load_snap_disallowed_after_boot_resources(req, "SetVsockDevice");
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,6 +280,18 @@ def bin_sysgenid_path(test_fc_session_root_path):
 
 
 @pytest.fixture(scope="session")
+def bin_vsock_seqpacket_listener_path(test_fc_session_root_path):
+    """Build a simple vsock seqpacket server application."""
+    vsock_seq_srv_bin_path = os.path.join(test_fc_session_root_path, "vsock_seq_server")
+    build_tools.gcc_compile(
+        "host_tools/vsock_seq_server.c",
+        vsock_seq_srv_bin_path,
+        extra_flags="-lpthread -O3",
+    )
+    yield vsock_seq_srv_bin_path
+
+
+@pytest.fixture(scope="session")
 def bin_vmclock_path(test_fc_session_root_path):
     """Build a simple util for test VMclock device"""
     vmclock_helper_bin_path = os.path.join(test_fc_session_root_path, "vmclock")

--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -74,7 +74,6 @@ class HostEchoWorker(Thread):
                 buf = blob_file.read(BUF_SIZE)
                 if not buf:
                     break
-
                 sent = self.sock.send(buf)
                 while sent < len(buf):
                     sent += self.sock.send(buf[sent:])
@@ -152,7 +151,21 @@ def start_guest_echo_server(vm):
     return os.path.join(vm.jailer.chroot_path(), VSOCK_UDS_PATH)
 
 
-def check_host_connections(uds_path, blob_path, blob_hash):
+def start_seqpacket_echo_server(vm):
+    """Start a vsock seqpacket echo server in the microVM.
+
+    Returns a UDS path to connect to the server.
+    """
+    cmd = f"nohup /tmp/vsock_seq_server serve {ECHO_SERVER_PORT} af_vsock >/dev/null 2>&1 &"
+    vm.ssh.check_output(cmd)
+
+    # Give the server time to initialise
+    time.sleep(1)
+
+    return os.path.join(vm.jailer.chroot_path(), VSOCK_UDS_PATH)
+
+
+def check_host_connections(uds_path, blob_path, blob_hash, vsock_type=SOCK_STREAM):
     """Test host-initiated connections.
 
     This will spawn `TEST_CONNECTION_COUNT` `HostEchoWorker` threads.
@@ -163,7 +176,7 @@ def check_host_connections(uds_path, blob_path, blob_hash):
 
     with ExitStack() as stack:
         workers = [
-            stack.enter_context(HostEchoWorker(uds_path, blob_path))
+            stack.enter_context(HostEchoWorker(uds_path, blob_path, vsock_type))
             for _ in range(TEST_CONNECTION_COUNT)
         ]
         for wrk in workers:
@@ -229,6 +242,76 @@ def host_echo_server(vm, server_port_path):
         assert rc == 143
 
 
+def check_guest_connections_seqpacket(
+    vm, server_port_path, server_bin_path, blob_path, blob_hash
+):
+    """Test guest-initiated connections.
+
+    This will start an echo server on the host (in its own thread), then
+    start `TEST_CONNECTION_COUNT` workers inside the guest VM, all
+    communicating with the echo server.
+    """
+    port = server_port_path.split("_")[-1]
+    if Path(server_port_path).exists():
+        Path(
+            server_port_path
+        ).unlink()  # the vsock server program doesn't have reuseaddr
+
+    echo_server = Popen([server_bin_path, "serve", port, "af_unix", server_port_path])
+
+    try:
+        # Give the server program bit of time to create the socket
+        for attempt in Retrying(
+            wait=wait_fixed(0.2),
+            stop=stop_after_attempt(3),
+            reraise=True,
+        ):
+            with attempt:
+                assert Path(server_port_path).exists()
+
+        # Link the listening Unix socket into the VM's jail, so that
+        # Firecracker can connect to it.
+        vm.create_jailed_resource(server_port_path)
+
+        # Increase maximum process count for the ssh service.
+        # Avoids: "bash: fork: retry: Resource temporarily unavailable"
+        # Needed to execute the bash script that tests for concurrent
+        # vsock guest initiated connections.
+        vm.ssh.check_output(
+            "echo 1024 > /sys/fs/cgroup/system.slice/ssh.service/pids.max"
+        )
+
+        # Build the guest worker sub-command.
+        # `vsock_helper` will read the blob file from STDIN and send the echo
+        # server response to STDOUT. This response is then hashed, and the
+        # hash is compared against `blob_hash` (computed on the host). This
+        # comparison sets the exit status of the worker command.
+        worker_cmd = "hash=$("
+        worker_cmd += "cat {}".format(blob_path)
+        worker_cmd += " | /tmp/vsock_helper echo 2 {} seqpacket".format(
+            ECHO_SERVER_PORT
+        )
+        worker_cmd += " | md5sum | cut -f1 -d\\ "
+        worker_cmd += ")"
+        worker_cmd += ' && [[ "$hash" = "{}" ]]'.format(blob_hash)
+
+        # Run `TEST_CONNECTION_COUNT` concurrent workers, using the above
+        # worker sub-command.
+        # If any worker fails, this command will fail. If all worker sub-commands
+        # succeed, this will also succeed.
+        cmd = 'workers="";'
+        cmd += "for i in $(seq 1 {}); do".format(TEST_CONNECTION_COUNT)
+        cmd += "  ({})& ".format(worker_cmd)
+        cmd += '  workers="$workers $!";'
+        cmd += "done;"
+        cmd += "for w in $workers; do wait $w || (wait; exit 1); done"
+
+        vm.ssh.check_output(cmd)
+    finally:
+        echo_server.terminate()
+        echo_server.wait()
+
+
 def check_guest_connections(vm, server_port_path, blob_path, blob_hash):
     """Test guest-initiated connections.
 
@@ -245,7 +328,7 @@ def check_guest_connections(vm, server_port_path, blob_path, blob_hash):
         # comparison sets the exit status of the worker command.
         worker_cmd = "hash=$("
         worker_cmd += "cat {}".format(blob_path)
-        worker_cmd += " | /tmp/vsock_helper echo 2 {}".format(ECHO_SERVER_PORT)
+        worker_cmd += " | /tmp/vsock_helper echo 2 {} stream".format(ECHO_SERVER_PORT)
         worker_cmd += " | md5sum | cut -f1 -d\\ "
         worker_cmd += ")"
         worker_cmd += ' && [[ "$hash" = "{}" ]]'.format(blob_hash)
@@ -294,14 +377,19 @@ def vsock_connect_to_guest(uds_path, port):
     return sock
 
 
-def _copy_vsock_data_to_guest(ssh_connection, blob_path, vm_blob_path, vsock_helper):
+def _copy_vsock_data_to_guest(
+    ssh_connection, blob_path, vm_blob_path, vsock_helper=None, vsock_seq_server=None
+):
     # Copy the data file and a vsock helper to the guest.
 
     cmd = "mkdir -p /tmp/vsock"
     ecode, _, _ = ssh_connection.run(cmd)
     assert ecode == 0, "Failed to set up tmpfs drive on the guest."
+    if vsock_helper:
+        ssh_connection.scp_put(vsock_helper, "/tmp/vsock_helper")
+    if vsock_seq_server:
+        ssh_connection.scp_put(vsock_seq_server, "/tmp/vsock_seq_server")
 
-    ssh_connection.scp_put(vsock_helper, "/tmp/vsock_helper")
     ssh_connection.scp_put(blob_path, vm_blob_path)
 
 

--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -32,14 +32,15 @@ class HostEchoWorker(Thread):
     contents of `blob_path`.
     """
 
-    def __init__(self, uds_path, blob_path):
+    def __init__(self, uds_path, blob_path, vsock_type=SOCK_STREAM):
         """."""
         super().__init__()
         self.uds_path = uds_path
         self.blob_path = blob_path
         self.hash = None
+        self.vsock_type = vsock_type
         self.error = None
-        self.sock = vsock_connect_to_guest(self.uds_path, ECHO_SERVER_PORT)
+        self.sock = vsock_connect_to_guest(self.uds_path, ECHO_SERVER_PORT, self.vsock_type)
 
     def run(self):
         """Thread code payload.
@@ -352,7 +353,7 @@ def make_host_port_path(uds_path, port):
     return "{}_{}".format(uds_path, port)
 
 
-def vsock_connect_to_guest(uds_path, port):
+def vsock_connect_to_guest(uds_path, port, vsock_type=SOCK_STREAM):
     """Return a Unix socket, connected to the guest vsock port `port`.
 
     The returned socket is a regular `socket.socket`, so callers can
@@ -361,10 +362,9 @@ def vsock_connect_to_guest(uds_path, port):
     the CONNECT/ACK handshake the socket is closed before raising, so
     the caller never receives a half-open descriptor.
     """
-    sock = socket(AF_UNIX, SOCK_STREAM)
+    sock = socket(AF_UNIX, vsock_type)
     try:
         sock.connect(uds_path)
-
         buf = bytearray("CONNECT {}\n".format(port).encode("utf-8"))
         sock.send(buf)
 

--- a/tests/host_tools/vsock_helper.c
+++ b/tests/host_tools/vsock_helper.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <signal.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <time.h>
@@ -24,14 +25,17 @@
 #define BUF_SIZE (16 * 1024)
 #define SERVER_ACCEPT_BACKLOG 128
 
+volatile int connection_socket;
 
 int print_usage() {
     fprintf(stderr, "Usage: ./vsock-helper <command> <args>\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Commands:\n");
-    fprintf(stderr, "  echo <cid> <port>\n");
-    fprintf(stderr, "      Connect to echo server at CID:port. Pipe STDIN to server,\n");
-    fprintf(stderr, "      server response to STDOUT.\n");
+    fprintf(stderr, "  echo <cid> <port> [stream|seqpacket]\n");
+    fprintf(stderr, "      connect to an echo server, listening on CID:port.\n");
+    fprintf(stderr, "      STDIN will be piped through to the echo server, and\n");
+    fprintf(stderr, "      data coming from the server will pe sent to STDOUT.\n");
+    fprintf(stderr, "      stream|seqpacket  socket type (default: stream)\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "  ping <cid> <port> <count>\n");
     fprintf(stderr, "      Send <count> ping messages to echo server at CID:port.\n");
@@ -64,9 +68,9 @@ int xfer(int src_fd, int dst_fd) {
 }
 
 
-int run_echo(uint32_t cid, uint32_t port) {
+int run_echo(uint32_t cid, uint32_t port, int sock_type) {
 
-    int sock = socket(AF_VSOCK, SOCK_STREAM, 0);
+    int sock = socket(AF_VSOCK, sock_type, 0);
     if (sock < 0) {
         perror("socket()");
         return -1;
@@ -82,6 +86,8 @@ int run_echo(uint32_t cid, uint32_t port) {
         return -1;
     }
 
+    connection_socket = sock;
+
     for (;;) {
         int ping_cnt = xfer(STDIN_FILENO, sock);
         if (!ping_cnt) break;
@@ -96,6 +102,10 @@ int run_echo(uint32_t cid, uint32_t port) {
     }
 
     return close(sock);
+}
+
+void stop_server_loop(int sig) {
+    close(connection_socket);
 }
 
 
@@ -270,13 +280,15 @@ int run_ping_uds(const char *uds_path, uint32_t port, int count) {
 
 
 int main(int argc, char **argv) {
+    signal(SIGTERM, stop_server_loop);
+    signal(SIGINT, stop_server_loop);
 
     if (argc < 2) {
         return print_usage();
     }
 
     if (strcmp(argv[1], "echo") == 0) {
-        if (argc != 4) {
+        if (argc < 4 || argc > 5) {
             return print_usage();
         }
         uint32_t cid = atoi(argv[2]);
@@ -284,7 +296,19 @@ int main(int argc, char **argv) {
         if (!cid || !port) {
             return print_usage();
         }
-        return run_echo(cid, port);
+
+        int sock_type = SOCK_STREAM;
+        if (argc == 5) {
+            if (strcmp(argv[4], "seqpacket") == 0) {
+                sock_type = SOCK_SEQPACKET;
+            } else if (strcmp(argv[4], "stream") == 0) {
+                sock_type = SOCK_STREAM;
+            } else {
+                return print_usage();
+            }
+        }
+
+        return run_echo(cid, port, sock_type);
     }
 
     if (strcmp(argv[1], "ping") == 0) {

--- a/tests/host_tools/vsock_seq_server.c
+++ b/tests/host_tools/vsock_seq_server.c
@@ -1,0 +1,196 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <linux/vm_sockets.h>
+#include <sys/types.h>
+#include <sys/select.h>
+#include <sys/wait.h>
+#include <pthread.h>
+#include <signal.h>
+
+#define BUF_SIZE 16384
+
+volatile sig_atomic_t running = 1;
+volatile int listener_sockfd;
+
+void log_info(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    fprintf(stdout, "[INFO]  ");
+    vfprintf(stdout, fmt, args);
+    fprintf(stdout, "\n");
+    va_end(args);
+    fflush(stdout);
+}
+
+void log_error(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    fprintf(stderr, "[ERROR] ");
+    vfprintf(stderr, fmt, args);
+    fprintf(stderr, "\n");
+    va_end(args);
+}
+
+int print_usage() {
+    fprintf(stderr, "Usage: ./vsock_seq_server serve <port> [af_vsock|af_unix] [path]\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "  serve          start a SEQPACKET echo server on :port.\n");
+    fprintf(stderr, "                 Data received from the client is echoed back.\n");
+    fprintf(stderr, "  af_vsock|af_unix  socket family to use (default: af_vsock)\n");
+    fprintf(stderr, "  path           socket path for af_unix (optional; omit for no address)\n");
+    fprintf(stderr, "\n");
+    return -1;
+}
+
+void *handle_conn(void *connfd_ptr) {
+    int connfd = *(int *)(connfd_ptr);
+    free(connfd_ptr);
+    char buf[BUF_SIZE];
+    ssize_t n;
+
+    // echo back whatever you received into the connection again
+    while ((n = recv(connfd, buf, sizeof(buf), 0)) > 0) {
+        log_info("received %zd bytes", n);
+
+        if (send(connfd, buf, n, 0) < 0) {
+            log_error("send: %s", strerror(errno));
+            break;
+        }
+    }
+
+    if (n == 0) {
+        log_info("connection closed by peer");
+    }
+    else if (n < 0) {
+        log_error("recv: %s (errno=%d)", strerror(errno), errno);
+    }
+
+    close(connfd);
+    return NULL;
+}
+
+int run_seq_server(int port, int family, const char *path)
+{
+    int sockfd, connfd;
+
+    sockfd = socket(family, SOCK_SEQPACKET, 0);
+    if (sockfd < 0) {
+        log_error("socket: %s", strerror(errno));
+        exit(1);
+    }
+
+    listener_sockfd = sockfd;
+
+    if (family == AF_VSOCK) {
+        struct sockaddr_vm addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.svm_family = AF_VSOCK;
+        addr.svm_port = port;
+        addr.svm_cid = VMADDR_CID_ANY;
+
+        if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+            log_error("bind: %s", strerror(errno));
+            close(sockfd);
+            exit(1);
+        }
+    } else if (family == AF_UNIX && path != NULL) {
+        struct sockaddr_un addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sun_family = AF_UNIX;
+        strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+
+        if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+            log_error("bind: %s", strerror(errno));
+            close(sockfd);
+            exit(1);
+        }
+    }
+
+    if (listen(sockfd, 5) < 0) {
+        log_error("listen: %s", strerror(errno));
+        close(sockfd);
+        exit(1);
+    }
+
+    log_info("SEQPACKET server listening on port %d (family=%s%s%s)",
+             port,
+             family == AF_VSOCK ? "af_vsock" : "af_unix",
+             path ? " path=" : "",
+             path ? path : "");
+
+    while (running) {
+        connfd = accept(sockfd, NULL, NULL);
+        if (connfd < 0) {
+            if (errno == EINTR) break;  // accept interrupted by signal
+            log_error("accept: %s", strerror(errno));
+            exit(1);
+        }
+
+        log_info("connection accepted (fd=%d)", connfd);
+
+        int *connfd_ptr = malloc(sizeof(int));
+        *connfd_ptr = connfd;
+
+        pthread_t tid;
+        pthread_create(&tid, NULL, handle_conn, connfd_ptr);
+        pthread_detach(tid);
+    };
+
+    close(sockfd);
+    return 0;
+}
+
+void stop_server_loop(int sig) {
+    running = 0;
+    close(listener_sockfd);
+}
+
+int main(int argc, char **argv) {
+    signal(SIGTERM, stop_server_loop);
+    signal(SIGINT, stop_server_loop);
+
+    if (argc < 2) {
+        return print_usage();
+    }
+
+    if (strcmp(argv[1], "serve") == 0) {
+        if (argc < 3) {
+            return print_usage();
+        }
+
+        int port = atoi(argv[2]);
+        if (!port) {
+            return print_usage();
+        }
+
+        int family = AF_VSOCK;
+        const char *path = NULL;
+
+        if (argc >= 4) {
+            if (strcmp(argv[3], "af_unix") == 0) {
+                family = AF_UNIX;
+            } else if (strcmp(argv[3], "af_vsock") == 0) {
+                family = AF_VSOCK;
+            } else {
+                return print_usage();
+            }
+        }
+
+        if (argc >= 5) {
+            path = argv[4];
+        }
+
+        return run_seq_server(port, family, path);
+    }
+
+    return print_usage();
+}

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -988,8 +988,16 @@ def test_api_vsock(uvm_configured):
     # Create a vsock device.
     vm.api.vsock.put(guest_cid=15, uds_path="vsock.sock")
 
-    # Updating an existing vsock is currently fine.
-    vm.api.vsock.put(guest_cid=166, uds_path="vsock.sock")
+    # Updating an existing vsock is currently fine. Even changing its type.
+    vm.api.vsock.put(
+        guest_cid=166,
+        uds_path="vsock.sock",
+        vsock_type="seqpacket",
+        conn_buffer_size=4096,
+    )
+
+    # Revert it back to stream.
+    vm.api.vsock.put(guest_cid=166, uds_path="vsock.sock", vsock_type="stream")
 
     # Check PUT request. Although vsock_id is deprecated, it must still work.
     response = vm.api.vsock.put(vsock_id="vsock1", guest_cid=15, uds_path="vsock.sock")
@@ -1006,6 +1014,10 @@ def test_api_vsock(uvm_configured):
     # Updating an existing vsock should not be fine at this point.
     with pytest.raises(RuntimeError):
         vm.api.vsock.put(guest_cid=17, uds_path="vsock.sock")
+
+    # Changing the type of a vsock device should error at this point.
+    with pytest.raises(RuntimeError):
+        vm.api.vsock.put(guest_cid=17, uds_path="vsock.sock", vsock_type="seqpacket")
 
 
 @pin_guest_kernel(GUEST_KERNEL_DEFAULT)

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -986,7 +986,7 @@ def test_api_vsock(uvm_configured):
     """
     vm = uvm_configured
     # Create a vsock device.
-    vm.api.vsock.put(guest_cid=15, uds_path="vsock.sock")
+    vm.api.vsock.put(guest_cid=15, uds_path="vsock.sock", vsock_type="stream")
 
     # Updating an existing vsock is currently fine. Even changing its type.
     vm.api.vsock.put(
@@ -1000,12 +1000,16 @@ def test_api_vsock(uvm_configured):
     vm.api.vsock.put(guest_cid=166, uds_path="vsock.sock", vsock_type="stream")
 
     # Check PUT request. Although vsock_id is deprecated, it must still work.
-    response = vm.api.vsock.put(vsock_id="vsock1", guest_cid=15, uds_path="vsock.sock")
+    response = vm.api.vsock.put(
+        vsock_id="vsock1", guest_cid=15, uds_path="vsock.sock", vsock_type="stream"
+    )
     assert response.headers["deprecation"]
 
     # Updating an existing vsock is currently fine even with deprecated
     # `vsock_id`.
-    response = vm.api.vsock.put(vsock_id="vsock1", guest_cid=166, uds_path="vsock.sock")
+    response = vm.api.vsock.put(
+        vsock_id="vsock1", guest_cid=166, uds_path="vsock.sock", vsock_type="stream"
+    )
     assert response.headers["deprecation"]
 
     # No other vsock action is allowed after booting the VM.
@@ -1013,7 +1017,7 @@ def test_api_vsock(uvm_configured):
 
     # Updating an existing vsock should not be fine at this point.
     with pytest.raises(RuntimeError):
-        vm.api.vsock.put(guest_cid=17, uds_path="vsock.sock")
+        vm.api.vsock.put(guest_cid=17, uds_path="vsock.sock", vsock_type="stream")
 
     # Changing the type of a vsock device should error at this point.
     with pytest.raises(RuntimeError):
@@ -1366,8 +1370,12 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_configure
     }
 
     # Add a vsock device.
-    uvm_configured.api.vsock.put(guest_cid=15, uds_path="vsock.sock")
-    setup_cfg["vsock"] = {"guest_cid": 15, "uds_path": "vsock.sock"}
+    uvm_configured.api.vsock.put(guest_cid=15, uds_path="vsock.sock", vsock_type="stream")
+    setup_cfg["vsock"] = {
+        "guest_cid": 15,
+        "uds_path": "vsock.sock",
+        "vsock_type": "stream",
+    }
 
     setup_cfg["memory-hotplug"] = {
         "total_size_mib": 1024,
@@ -1506,9 +1514,14 @@ def test_get_full_config(uvm):
     }
 
     # Add a vsock device.
-    response = test_microvm.api.vsock.put(guest_cid=15, uds_path="vsock.sock")
-    expected_cfg["vsock"] = {"guest_cid": 15, "uds_path": "vsock.sock"}
-
+    response = test_microvm.api.vsock.put(
+        guest_cid=15, uds_path="vsock.sock", vsock_type="stream"
+    )
+    expected_cfg["vsock"] = {
+        "guest_cid": 15,
+        "uds_path": "vsock.sock",
+        "vsock_type": "stream",
+    }
     # Add hot-pluggable memory.
     expected_cfg["memory-hotplug"] = {
         "total_size_mib": 1024,
@@ -1649,7 +1662,7 @@ def test_negative_snapshot_load_api(microvm_factory):
         )
 
     # API request without `mem_backend` or `mem_file_path` should fail.
-    err_msg = "missing field: either `mem_backend` or " "`mem_file_path` is required"
+    err_msg = "missing field: either `mem_backend` or `mem_file_path` is required"
     with pytest.raises(RuntimeError, match=err_msg):
         vm.api.snapshot_load.put(snapshot_path="foo")
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -152,7 +152,9 @@ def test_cycled_snapshot_restore(
     )
     vm.set_cpu_template(cpu_template)
     vm.add_net_iface()
-    vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path=VSOCK_UDS_PATH)
+    vm.api.vsock.put(
+        vsock_id="vsock0", guest_cid=3, uds_path=VSOCK_UDS_PATH, vsock_type="stream"
+    )
     vm.start()
 
     vm_blob_path = "/tmp/vsock/test.blob"

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -620,7 +620,8 @@ def test_snapshot_rename_vsock(
     """
 
     vm = uvm_configured
-    vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path="/v.sock1")
+    vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path="/v.sock1", vsock_type="stream")
+
     vm.add_net_iface()
     vm.start()
 

--- a/tests/integration_tests/functional/test_snapshot_phase1.py
+++ b/tests/integration_tests/functional/test_snapshot_phase1.py
@@ -54,7 +54,9 @@ def test_snapshot_phase1(
     for i in range(4):
         vm.add_net_iface()
     # Add a vsock device
-    vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path="/v.sock")
+    vm.api.vsock.put(
+        vsock_id="vsock0", guest_cid=3, uds_path="/v.sock", vsock_type="stream"
+    )
     # Add MMDS
     configure_mmds(vm, ["eth3"], version="V2")
     # Add a memory balloon.

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -93,7 +93,7 @@ def test_vsock(vsock_uvm_any, bin_vsock_path, test_fc_session_root_path):
     validate_fc_metrics(metrics)
 
 
-def negative_test_host_connections(vm, blob_path, blob_hash):
+def negative_test_host_connections(vm, blob_path, blob_hash, vsock_type):
     """Negative test for host-initiated connections.
 
     This will start a daemonized echo server on the guest VM, and then spawn
@@ -105,7 +105,7 @@ def negative_test_host_connections(vm, blob_path, blob_hash):
 
     with ExitStack() as stack:
         workers = [
-            stack.enter_context(HostEchoWorker(uds_path, blob_path))
+            stack.enter_context(HostEchoWorker(uds_path, blob_path, vsock_type))
             for _ in range(NEGATIVE_TEST_CONNECTION_COUNT)
         ]
         for wrk in workers:
@@ -145,6 +145,7 @@ def test_vsock_epipe(vsock_uvm_any, bin_vsock_path, test_fc_session_root_path):
     Vsock negative test to validate SIGPIPE/EPIPE handling.
     """
     vm = vsock_uvm_any
+    vm.start()
 
     # Generate the random data blob file, 20MB
     blob_path, blob_hash = make_blob(test_fc_session_root_path, 20 * 2**20)
@@ -156,7 +157,7 @@ def test_vsock_epipe(vsock_uvm_any, bin_vsock_path, test_fc_session_root_path):
 
     # Negative test for host-initiated connections that
     # are closed with in flight data.
-    negative_test_host_connections(vm, blob_path, blob_hash)
+    negative_test_host_connections(vm, blob_path, blob_hash, SOCK_STREAM)
     metrics = vm.flush_metrics()
     validate_fc_metrics(metrics)
 

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -13,6 +13,7 @@ In order to test the vsock device connection state machine, these tests will:
   guest-initiated connections.
 """
 
+import os
 import os.path
 import socket
 import subprocess
@@ -21,7 +22,9 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
 from pathlib import Path
+from socket import SOCK_SEQPACKET, SOCK_STREAM
 from socket import timeout as SocketTimeout
+from threading import Thread
 
 import pytest
 from tenacity import Retrying, stop_after_delay, wait_fixed
@@ -36,14 +39,17 @@ from framework.utils_vsock import (
     VSOCK_UDS_PATH,
     HostEchoWorker,
     _copy_vsock_data_to_guest,
+    _vsock_connect_to_guest,
     boot_vsock_vm,
     check_guest_connections,
+    check_guest_connections_seqpacket,
     check_host_connections,
     check_vsock_device,
     host_echo_server,
     make_blob,
     make_host_port_path,
     start_guest_echo_server,
+    start_seqpacket_echo_server,
     vsock_connect_to_guest,
 )
 from host_tools.fcmetrics import validate_fc_metrics
@@ -318,6 +324,123 @@ def test_vsock_transport_reset_g2h(vsock_uvm, microvm_factory):
 
             # Terminate VM.
             new_vm.kill()
+
+
+def test_vsock_seqpacket_h2g(
+    uvm_plain_6_1, bin_vsock_seqpacket_listener_path, test_fc_session_root_path
+):
+    """Test host-to-guest vsock seqpacket connections."""
+    vm = uvm_plain_6_1
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+    vm.api.vsock.put(
+        vsock_id="vsock0",
+        guest_cid=3,
+        uds_path=f"/{VSOCK_UDS_PATH}",
+        vsock_type="seqpacket",
+        conn_buffer_size=16 * 1024,
+    )
+    vm.start()
+
+    blob_path, blob_hash = make_blob(test_fc_session_root_path, 16 * 1024)
+    vm_blob_path = "/tmp/vsock/test.blob"
+
+    _copy_vsock_data_to_guest(
+        vm.ssh,
+        blob_path,
+        vm_blob_path,
+        vsock_seq_server=bin_vsock_seqpacket_listener_path,
+    )
+    path = start_seqpacket_echo_server(vm)
+
+    check_host_connections(path, blob_path, blob_hash, SOCK_SEQPACKET)
+    metrics = vm.flush_metrics()
+    validate_fc_metrics(metrics)
+
+
+def test_vsock_seqpacket_g2h(
+    uvm_plain_6_1,
+    bin_vsock_seqpacket_listener_path,
+    bin_vsock_path,
+    test_fc_session_root_path,
+):
+    """Test guest-to-host vsock seqpacket connections."""
+    vm = uvm_plain_6_1
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+    vm.api.vsock.put(
+        vsock_id="vsock0",
+        guest_cid=3,
+        uds_path=f"/{VSOCK_UDS_PATH}",
+        vsock_type="seqpacket",
+        conn_buffer_size=16 * 1024,
+    )
+    vm.start()
+
+    blob_path, blob_hash = make_blob(test_fc_session_root_path, 16 * 1024)
+    vm_blob_path = "/tmp/vsock/test.blob"
+
+    _copy_vsock_data_to_guest(vm.ssh, blob_path, vm_blob_path, bin_vsock_path)
+
+    path = os.path.join(vm.path, make_host_port_path(VSOCK_UDS_PATH, ECHO_SERVER_PORT))
+    check_guest_connections_seqpacket(
+        vm, path, bin_vsock_seqpacket_listener_path, vm_blob_path, blob_hash
+    )
+
+    metrics = vm.flush_metrics()
+    validate_fc_metrics(metrics)
+
+
+def test_vsock_seqpacket_h2g_overflow(
+    uvm_plain_6_1, bin_vsock_seqpacket_listener_path, test_fc_session_root_path
+):
+    """Test that sending a message larger than conn_buffer_size errors."""
+    conn_buffer_size = 16 * 1024
+
+    vm = uvm_plain_6_1
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+    vm.api.vsock.put(
+        vsock_id="vsock0",
+        guest_cid=3,
+        uds_path=f"/{VSOCK_UDS_PATH}",
+        vsock_type="seqpacket",
+        conn_buffer_size=conn_buffer_size,
+    )
+    vm.start()
+
+    blob_path, _ = make_blob(test_fc_session_root_path, 1024)
+    vm_blob_path = "/tmp/vsock/test.blob"
+    _copy_vsock_data_to_guest(
+        vm.ssh,
+        blob_path,
+        vm_blob_path,
+        vsock_seq_server=bin_vsock_seqpacket_listener_path,
+    )
+    path = start_seqpacket_echo_server(vm)
+
+    worker_error = None
+
+    def worker():
+        nonlocal worker_error
+        try:
+            sock = _vsock_connect_to_guest(path, ECHO_SERVER_PORT, SOCK_SEQPACKET)
+            oversized_msg = os.urandom(conn_buffer_size + 1)
+            sock.send(oversized_msg)
+            sock.recv(conn_buffer_size + 1)
+        except OSError as err:
+            worker_error = err
+
+    t = Thread(target=worker)
+    t.start()
+    t.join()
+
+    assert (
+        worker_error is not None
+    ), "Expected an error when sending message larger than conn_buffer_size"
 
 
 def test_vsock_after_override(

--- a/tests/integration_tests/performance/test_snapshot.py
+++ b/tests/integration_tests/performance/test_snapshot.py
@@ -77,7 +77,9 @@ class SnapshotRestoreTest:
             vm.api.balloon.put(
                 amount_mib=0, deflate_on_oom=True, stats_polling_interval_s=1
             )
-            vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path="/v.sock")
+            vm.api.vsock.put(
+                vsock_id="vsock0", guest_cid=3, uds_path="/v.sock", vsock_type="stream"
+            )
 
         vm.start()
 

--- a/tests/integration_tests/performance/test_vsock.py
+++ b/tests/integration_tests/performance/test_vsock.py
@@ -136,7 +136,12 @@ def test_vsock_throughput(
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=mem_size_mib)
     vm.add_net_iface()
     # Create a vsock device
-    vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path="/" + VSOCK_UDS_PATH)
+    vm.api.vsock.put(
+        vsock_id="vsock0",
+        guest_cid=3,
+        uds_path="/" + VSOCK_UDS_PATH,
+        vsock_type="stream",
+    )
     vm.start()
 
     metrics.set_dimensions(


### PR DESCRIPTION
## Changes

There's currently no support for seqpacket based vsock connections in firecracker.
This PR adds it by creating an enum `ConnBackend` that implements `VsockConnectionBackend` and make its variants a unix stream or a seqpacket connection. The actual connection is handled by a module for seqpacket based connection that leverages libc calls.
It adds `vsock_type` as an api parameter to the vsock type.

## Reason

Fixes: https://github.com/firecracker-microvm/firecracker/issues/4822

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
