### PR TITLE
feat: switch to a per-device metrics model for vsock and rng devices

### DIFF
--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -27,6 +27,7 @@ use super::{
     VIRTIO_BALLOON_S_OOM_KILL, VIRTIO_BALLOON_S_SWAP_IN, VIRTIO_BALLOON_S_SWAP_OUT,
 };
 use crate::devices::virtio::balloon::BalloonError;
+use crate::devices::virtio::balloon::metrics::BalloonDeviceMetrics;
 use crate::devices::virtio::device::{ActiveState, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::queue::InvalidAvailIdx;
@@ -214,7 +215,7 @@ pub struct BalloonStats {
 }
 
 impl BalloonStats {
-    fn update_with_stat(&mut self, stat: &BalloonStat) {
+    fn update_with_stat(&mut self, stat: &BalloonStat, metrics: &Arc<BalloonDeviceMetrics>) {
         let val = Some(stat.val);
         match stat.tag {
             VIRTIO_BALLOON_S_SWAP_IN => self.swap_in = val,
@@ -234,7 +235,7 @@ impl BalloonStats {
             VIRTIO_BALLOON_S_ASYNC_RECLAIM => self.async_reclaim = val,
             VIRTIO_BALLOON_S_DIRECT_RECLAIM => self.direct_reclaim = val,
             tag => {
-                METRICS.stats_update_fails.inc();
+                metrics.stats_update_fails.inc();
                 debug!("balloon: unknown stats update tag: {tag}");
             }
         }
@@ -267,6 +268,8 @@ pub struct Balloon {
 
     // Holds state for free page hinting
     pub(crate) hinting_state: HintingState,
+    // Device metrics instance.
+    pub(crate) metrics: Arc<BalloonDeviceMetrics>,
 }
 
 impl Balloon {
@@ -311,6 +314,8 @@ impl Balloon {
             .collect::<Result<Vec<_>, _>>()?;
 
         let stats_timer = TimerFd::new();
+        let metrics = Arc::new(BalloonDeviceMetrics::default());
+        let _ = METRICS.write().unwrap().replace(metrics.clone());
 
         Ok(Balloon {
             avail_features,
@@ -330,6 +335,7 @@ impl Balloon {
             latest_stats: BalloonStats::default(),
             pfn_buffer: [0u32; MAX_PAGE_COMPACT_BUFFER],
             hinting_state: Default::default(),
+            metrics,
         })
     }
 
@@ -380,7 +386,7 @@ impl Balloon {
             .active_state()
             .ok_or(BalloonError::DeviceNotActive)?
             .mem;
-        METRICS.inflate_count.inc();
+        self.metrics.inflate_count.inc();
 
         let queue = &mut self.queues[INFLATE_INDEX];
         // The pfn buffer index used during descriptor processing.
@@ -467,7 +473,7 @@ impl Balloon {
     }
 
     pub(crate) fn process_deflate_queue(&mut self) -> Result<(), BalloonError> {
-        METRICS.deflate_count.inc();
+        self.metrics.deflate_count.inc();
 
         let queue = &mut self.queues[DEFLATE_INDEX];
         let mut needs_interrupt = false;
@@ -488,7 +494,7 @@ impl Balloon {
     pub(crate) fn process_stats_queue(&mut self) -> Result<(), BalloonError> {
         // This is safe since we checked in the event handler that the device is activated.
         let mem = &self.device_state.active_state().unwrap().mem;
-        METRICS.stats_updates_count.inc();
+        self.metrics.stats_updates_count.inc();
 
         while let Some(head) = self.queues[STATS_INDEX].pop()? {
             if let Some(prev_stats_desc) = self.stats_desc_index {
@@ -526,7 +532,7 @@ impl Balloon {
                 let stat = mem
                     .read_obj::<BalloonStat>(addr)
                     .map_err(|_| BalloonError::MalformedDescriptor)?;
-                self.latest_stats.update_with_stat(&stat);
+                self.latest_stats.update_with_stat(&stat, &self.metrics);
             }
 
             self.stats_desc_index = Some(head.index);
@@ -589,12 +595,12 @@ impl Balloon {
                     continue;
                 }
 
-                METRICS.free_page_hint_count.inc();
+                self.metrics.free_page_hint_count.inc();
                 if let Err(err) = mem.discard_range(desc.addr, desc.len as usize) {
-                    METRICS.free_page_hint_fails.inc();
+                    self.metrics.free_page_hint_fails.inc();
                     error!("balloon hinting: failed to remove range: {err:?}");
                 } else {
-                    METRICS.free_page_hint_freed.add(desc.len as u64);
+                    self.metrics.free_page_hint_freed.add(desc.len as u64);
                 }
             }
 
@@ -629,12 +635,12 @@ impl Balloon {
         while let Some(head) = queue.pop()? {
             let mut last_desc = Some(head);
             while let Some(desc) = last_desc {
-                METRICS.free_page_report_count.inc();
+                self.metrics.free_page_report_count.inc();
                 if let Err(err) = mem.discard_range(desc.addr, desc.len as usize) {
-                    METRICS.free_page_report_fails.inc();
+                    self.metrics.free_page_report_fails.inc();
                     error!("balloon: failed to remove range: {err:?}");
                 } else {
-                    METRICS.free_page_report_freed.add(desc.len as u64);
+                    self.metrics.free_page_report_freed.add(desc.len as u64);
                 }
                 last_desc = desc.next_descriptor();
             }
@@ -659,7 +665,7 @@ impl Balloon {
                     .unwrap_or_else(|_| panic!("balloon: invalid queue id: {qidx}")),
             ))
             .map_err(|err| {
-                METRICS.event_fails.inc();
+                self.metrics.event_fails.inc();
                 BalloonError::InterruptError(err)
             })
     }
@@ -963,7 +969,7 @@ impl VirtioDevice for Balloon {
 
         self.device_state = DeviceState::Activated(ActiveState { mem, interrupt });
         if self.activate_evt.write(1).is_err() {
-            METRICS.activate_fails.inc();
+            self.metrics.activate_fails.inc();
             self.device_state = DeviceState::Inactive;
             return Err(ActivateError::EventFd);
         }
@@ -1020,6 +1026,7 @@ pub(crate) mod tests {
 
     use super::super::BALLOON_CONFIG_SPACE_SIZE;
     use super::*;
+    use crate::align_up;
     use crate::arch::host_page_size;
     use crate::devices::virtio::balloon::report_balloon_event_fail;
     use crate::devices::virtio::balloon::test_utils::{
@@ -1032,7 +1039,6 @@ pub(crate) mod tests {
     use crate::devices::virtio::test_utils::{VirtQueue, default_interrupt, default_mem};
     use crate::test_utils::single_region_mem;
     use crate::vstate::memory::GuestAddress;
-    use crate::{align_up, check_metric_after_block};
 
     impl VirtioTestDevice for Balloon {
         fn set_queues(&mut self, queues: Vec<Queue>) {
@@ -1111,53 +1117,54 @@ pub(crate) mod tests {
             tag: VIRTIO_BALLOON_S_SWAP_IN,
             val: 1,
         };
+        let metrics = Arc::new(BalloonDeviceMetrics::default());
 
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.swap_in, Some(1));
         stat.tag = VIRTIO_BALLOON_S_SWAP_OUT;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.swap_out, Some(1));
         stat.tag = VIRTIO_BALLOON_S_MAJFLT;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.major_faults, Some(1));
         stat.tag = VIRTIO_BALLOON_S_MINFLT;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.minor_faults, Some(1));
         stat.tag = VIRTIO_BALLOON_S_MEMFREE;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.free_memory, Some(1));
         stat.tag = VIRTIO_BALLOON_S_MEMTOT;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.total_memory, Some(1));
         stat.tag = VIRTIO_BALLOON_S_AVAIL;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.available_memory, Some(1));
         stat.tag = VIRTIO_BALLOON_S_CACHES;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.disk_caches, Some(1));
         stat.tag = VIRTIO_BALLOON_S_HTLB_PGALLOC;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.hugetlb_allocations, Some(1));
         stat.tag = VIRTIO_BALLOON_S_HTLB_PGFAIL;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.hugetlb_failures, Some(1));
         stat.tag = VIRTIO_BALLOON_S_OOM_KILL;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.oom_kill, Some(1));
         stat.tag = VIRTIO_BALLOON_S_ALLOC_STALL;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.alloc_stall, Some(1));
         stat.tag = VIRTIO_BALLOON_S_ASYNC_SCAN;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.async_scan, Some(1));
         stat.tag = VIRTIO_BALLOON_S_DIRECT_SCAN;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.direct_scan, Some(1));
         stat.tag = VIRTIO_BALLOON_S_ASYNC_RECLAIM;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.async_reclaim, Some(1));
         stat.tag = VIRTIO_BALLOON_S_DIRECT_RECLAIM;
-        stats.update_with_stat(&stat);
+        stats.update_with_stat(&stat, &metrics);
         assert_eq!(stats.direct_reclaim, Some(1));
     }
 
@@ -1394,13 +1401,10 @@ pub(crate) mod tests {
                 VIRTQ_DESC_F_NEXT,
             );
 
-            check_metric_after_block!(
-                METRICS.event_fails,
-                1,
-                balloon
-                    .process_inflate_queue_event()
-                    .unwrap_or_else(report_balloon_event_fail)
-            );
+            balloon
+                .process_inflate_queue_event()
+                .unwrap_or_else(|e| report_balloon_event_fail(e, &balloon.metrics));
+            assert_eq!(balloon.metrics.event_fails.count(), 1);
             // Verify that nothing got processed.
             assert_eq!(infq.used.idx.get(), 0);
 
@@ -1421,11 +1425,8 @@ pub(crate) mod tests {
                 VIRTQ_DESC_F_NEXT,
             );
 
-            check_metric_after_block!(
-                METRICS.inflate_count,
-                1,
-                invoke_handler_for_queue_event(&mut balloon, INFLATE_INDEX)
-            );
+            invoke_handler_for_queue_event(&mut balloon, INFLATE_INDEX);
+            assert_eq!(balloon.metrics.inflate_count.count(), 1);
             check_request_completion(&infq, 0);
 
             // Check that the page was zeroed.
@@ -1456,13 +1457,10 @@ pub(crate) mod tests {
                 SIZE_OF_U32.try_into().unwrap(),
                 VIRTQ_DESC_F_NEXT,
             );
-            check_metric_after_block!(
-                METRICS.event_fails,
-                1,
-                balloon
-                    .process_deflate_queue_event()
-                    .unwrap_or_else(report_balloon_event_fail)
-            );
+            balloon
+                .process_deflate_queue_event()
+                .unwrap_or_else(|e| report_balloon_event_fail(e, &balloon.metrics));
+            assert_eq!(balloon.metrics.event_fails.count(), 1);
             // Verify that nothing got processed.
             assert_eq!(defq.used.idx.get(), 0);
         }
@@ -1476,11 +1474,8 @@ pub(crate) mod tests {
                 SIZE_OF_U32.try_into().unwrap(),
                 VIRTQ_DESC_F_NEXT,
             );
-            check_metric_after_block!(
-                METRICS.deflate_count,
-                1,
-                invoke_handler_for_queue_event(&mut balloon, DEFLATE_INDEX)
-            );
+            invoke_handler_for_queue_event(&mut balloon, DEFLATE_INDEX);
+            assert_eq!(balloon.metrics.deflate_count.count(), 1);
             check_request_completion(&defq, 1);
         }
     }
@@ -1507,13 +1502,10 @@ pub(crate) mod tests {
                 SIZE_OF_STAT.try_into().unwrap(),
                 VIRTQ_DESC_F_NEXT,
             );
-            check_metric_after_block!(
-                METRICS.event_fails,
-                1,
-                balloon
-                    .process_stats_queue_event()
-                    .unwrap_or_else(report_balloon_event_fail)
-            );
+            balloon
+                .process_stats_queue_event()
+                .unwrap_or_else(|e| report_balloon_event_fail(e, &balloon.metrics));
+            assert_eq!(balloon.metrics.event_fails.count(), 1);
             // Verify that nothing got processed.
             assert_eq!(statsq.used.idx.get(), 0);
         }
@@ -1545,12 +1537,11 @@ pub(crate) mod tests {
                 2 * u32::try_from(SIZE_OF_STAT).unwrap(),
                 VIRTQ_DESC_F_NEXT,
             );
-            check_metric_after_block!(METRICS.stats_updates_count, 1, {
-                // Trigger the queue event.
-                balloon.queue_events()[STATS_INDEX].write(1).unwrap();
-                balloon.process_stats_queue_event().unwrap();
-                // Don't check for completion yet.
-            });
+            // Trigger the queue event.
+            balloon.queue_events()[STATS_INDEX].write(1).unwrap();
+            balloon.process_stats_queue_event().unwrap();
+            assert_eq!(balloon.metrics.stats_updates_count.count(), 1);
+            // Don't check for completion yet.
 
             let stats = balloon.latest_stats().unwrap();
             let expected_stats = BalloonStats {
@@ -1564,16 +1555,20 @@ pub(crate) mod tests {
             // we could just process the timer event and it would not
             // return an error.
             std::thread::sleep(Duration::from_secs(1));
-            check_metric_after_block!(METRICS.event_fails, 0, {
-                // Trigger the timer event, which consumes the stats
-                // descriptor index and signals the used queue.
-                assert!(balloon.stats_desc_index.is_some());
-                balloon.process_stats_timer_event().unwrap();
-                assert!(balloon.stats_desc_index.is_none());
-                assert!(balloon.interrupt_trigger().has_pending_interrupt(
-                    VirtioInterruptType::Queue(STATS_INDEX.try_into().unwrap())
-                ));
-            });
+            // Trigger the timer event, which consumes the stats
+            // descriptor index and signals the used queue.
+            assert!(balloon.stats_desc_index.is_some());
+            balloon.process_stats_timer_event().unwrap();
+            assert!(balloon.stats_desc_index.is_none());
+
+            assert!(
+                balloon
+                    .interrupt_trigger()
+                    .has_pending_interrupt(VirtioInterruptType::Queue(
+                        STATS_INDEX.try_into().unwrap()
+                    ))
+            );
+            assert_eq!(balloon.metrics.event_fails.count(), 1);
         }
     }
 
@@ -1595,10 +1590,10 @@ pub(crate) mod tests {
         let safe_addr = align_up!(th.data_address(), page_size);
 
         th.add_scatter_gather(reporting_idx, &[(0, safe_addr, page_size_chain, 0)]);
-        check_metric_after_block!(
-            METRICS.free_page_report_freed,
-            page_size,
-            invoke_handler_for_queue_event(&mut th.device(), reporting_idx)
+        invoke_handler_for_queue_event(&mut th.device(), reporting_idx);
+        assert_eq!(
+            th.device().metrics.free_page_report_freed.count(),
+            page_size
         );
 
         // Test with multiple items
@@ -1611,20 +1606,17 @@ pub(crate) mod tests {
             ],
         );
 
-        check_metric_after_block!(
-            METRICS.free_page_report_freed,
-            page_size * 3,
-            invoke_handler_for_queue_event(&mut th.device(), reporting_idx)
+        invoke_handler_for_queue_event(&mut th.device(), reporting_idx);
+        assert_eq!(
+            th.device().metrics.free_page_report_freed.count(),
+            page_size * 4
         );
 
         // Test with unaligned length
         th.add_scatter_gather(reporting_idx, &[(1, safe_addr + 1, page_size_chain, 0)]);
 
-        check_metric_after_block!(
-            METRICS.free_page_report_fails,
-            1,
-            invoke_handler_for_queue_event(&mut th.device(), reporting_idx)
-        );
+        invoke_handler_for_queue_event(&mut th.device(), reporting_idx);
+        assert_eq!(th.device().metrics.free_page_report_fails.count(), 1);
     }
 
     struct HintingTestHelper<'a> {
@@ -1680,7 +1672,7 @@ pub(crate) mod tests {
                 .ack_interrupt(VirtioInterruptType::Config);
         }
 
-        fn send_stop(&mut self, cmd: Option<u32>) {
+        fn send_stop(&mut self, cmd: Option<u32>, expected: u64) {
             let cmd = cmd.unwrap_or(FREE_PAGE_HINT_STOP);
 
             self.mem
@@ -1698,10 +1690,10 @@ pub(crate) mod tests {
                     ),
                 ],
             );
-            check_metric_after_block!(
-                METRICS.free_page_hint_freed,
-                0,
-                self.th.device().process_free_page_hinting_queue()
+            self.th.device().process_free_page_hinting_queue().unwrap();
+            assert_eq!(
+                self.th.device().metrics.free_page_hint_freed.count(),
+                expected
             );
             self.th
                 .device()
@@ -1740,11 +1732,12 @@ pub(crate) mod tests {
                     )]
                 }
             };
+
             self.th.add_scatter_gather(self.hinting_idx, &payload);
-            check_metric_after_block!(
-                METRICS.free_page_hint_freed,
-                expected,
-                invoke_handler_for_queue_event(&mut self.th.device(), self.hinting_idx)
+            invoke_handler_for_queue_event(&mut self.th.device(), self.hinting_idx);
+            assert_eq!(
+                self.th.device().metrics.free_page_hint_freed.count(),
+                expected
             );
         }
     }
@@ -1802,12 +1795,12 @@ pub(crate) mod tests {
         // Trigger another hinting run this will bump the cmd id
         // so we should ignore any inflight requests
         ht.start_hinting(None);
-        ht.test_hinting(None, 0);
+        ht.test_hinting(None, ht.page_size);
 
         // Update to our new host cmd and check this now works
         host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
-        ht.test_hinting(Some(host_cmd), ht.page_size);
-        ht.test_hinting(None, ht.page_size);
+        ht.test_hinting(Some(host_cmd), ht.page_size * 2);
+        ht.test_hinting(None, ht.page_size * 3);
     }
 
     #[test]
@@ -1820,9 +1813,9 @@ pub(crate) mod tests {
 
         // Simulate the driver finishing a run. Any reported values after
         // should be ignored
-        ht.send_stop(None);
+        ht.send_stop(None, 0);
         // Test we handle invalid cmd from driver
-        ht.send_stop(Some(FREE_PAGE_HINT_DONE));
+        ht.send_stop(Some(FREE_PAGE_HINT_DONE), 0);
         ht.test_hinting(None, 0);
 
         // As we had auto ack on finish the host cmd should be set to done
@@ -1845,9 +1838,9 @@ pub(crate) mod tests {
 
         let host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
         ht.test_hinting(Some(host_cmd), ht.page_size);
-        ht.test_hinting(None, ht.page_size);
+        ht.test_hinting(None, ht.page_size * 2);
 
-        ht.send_stop(None);
+        ht.send_stop(None, ht.page_size * 2);
         let new_host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
         assert_eq!(host_cmd, new_host_cmd);
     }
@@ -1862,18 +1855,15 @@ pub(crate) mod tests {
         let host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
 
         ht.test_hinting(Some(host_cmd), ht.page_size);
-        ht.test_hinting(None, ht.page_size);
+        ht.test_hinting(None, ht.page_size * 2);
 
         ht.th.add_scatter_gather(
             ht.hinting_idx,
             &[(0, ht.safe_addr + ht.page_size + 1, ht.page_size_chain, 0)],
         );
 
-        check_metric_after_block!(
-            METRICS.free_page_hint_fails,
-            1,
-            ht.th.device().process_free_page_hinting_queue().unwrap()
-        );
+        ht.th.device().process_free_page_hinting_queue().unwrap();
+        assert_eq!(ht.th.device().metrics.free_page_hint_fails.count(), 1);
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/balloon/event_handler.rs
+++ b/src/vmm/src/devices/virtio/balloon/event_handler.rs
@@ -118,22 +118,22 @@ impl MutEventSubscriber for Balloon {
                 Self::PROCESS_ACTIVATE => self.process_activate_event(ops),
                 Self::PROCESS_VIRTQ_INFLATE => self
                     .process_inflate_queue_event()
-                    .unwrap_or_else(report_balloon_event_fail),
+                    .unwrap_or_else(|e| report_balloon_event_fail(e, &self.metrics)),
                 Self::PROCESS_VIRTQ_DEFLATE => self
                     .process_deflate_queue_event()
-                    .unwrap_or_else(report_balloon_event_fail),
+                    .unwrap_or_else(|e| report_balloon_event_fail(e, &self.metrics)),
                 Self::PROCESS_VIRTQ_STATS => self
                     .process_stats_queue_event()
-                    .unwrap_or_else(report_balloon_event_fail),
+                    .unwrap_or_else(|e| report_balloon_event_fail(e, &self.metrics)),
                 Self::PROCESS_STATS_TIMER => self
                     .process_stats_timer_event()
-                    .unwrap_or_else(report_balloon_event_fail),
+                    .unwrap_or_else(|e| report_balloon_event_fail(e, &self.metrics)),
                 Self::PROCESS_VIRTQ_FREE_PAGE_HINTING => self
                     .process_free_page_hinting_queue_event()
-                    .unwrap_or_else(report_balloon_event_fail),
+                    .unwrap_or_else(|e| report_balloon_event_fail(e, &self.metrics)),
                 Self::PROCESS_VIRTQ_FREE_PAGE_REPORTING => self
                     .process_free_page_reporting_queue_event()
-                    .unwrap_or_else(report_balloon_event_fail),
+                    .unwrap_or_else(|e| report_balloon_event_fail(e, &self.metrics)),
                 _ => {
                     warn!("Balloon: Spurious event received: {:?}", source);
                 }

--- a/src/vmm/src/devices/virtio/balloon/metrics.rs
+++ b/src/vmm/src/devices/virtio/balloon/metrics.rs
@@ -35,22 +35,27 @@
 
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
+use std::sync::{Arc, RwLock};
 
 use crate::logger::SharedIncMetric;
 
 /// Stores aggregated balloon metrics
-pub(super) static METRICS: BalloonDeviceMetrics = BalloonDeviceMetrics::new();
+pub(super) static METRICS: RwLock<Option<Arc<BalloonDeviceMetrics>>> = RwLock::new(None);
 
 /// Called by METRICS.flush(), this function facilitates serialization of balloon device metrics.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let mut seq = serializer.serialize_map(Some(1))?;
-    seq.serialize_entry("balloon", &METRICS)?;
+    let dev_name = "balloon";
+    match METRICS.read().unwrap().as_ref() {
+        Some(metrics) => seq.serialize_entry(dev_name, &metrics)?,
+        None => seq.serialize_entry(dev_name, &BalloonDeviceMetrics::default())?,
+    }
     seq.end()
 }
 
 /// Balloon Device associated metrics.
-#[derive(Debug, Serialize)]
-pub(super) struct BalloonDeviceMetrics {
+#[derive(Default, Debug, Serialize)]
+pub struct BalloonDeviceMetrics {
     /// Number of times when activate failed on a balloon device.
     pub activate_fails: SharedIncMetric,
     /// Number of balloon device inflations.
@@ -76,25 +81,6 @@ pub(super) struct BalloonDeviceMetrics {
     /// Number of errors occurred while hinting
     pub free_page_hint_fails: SharedIncMetric,
 }
-impl BalloonDeviceMetrics {
-    /// Const default construction.
-    const fn new() -> Self {
-        Self {
-            activate_fails: SharedIncMetric::new(),
-            inflate_count: SharedIncMetric::new(),
-            stats_updates_count: SharedIncMetric::new(),
-            stats_update_fails: SharedIncMetric::new(),
-            deflate_count: SharedIncMetric::new(),
-            event_fails: SharedIncMetric::new(),
-            free_page_report_count: SharedIncMetric::new(),
-            free_page_report_freed: SharedIncMetric::new(),
-            free_page_report_fails: SharedIncMetric::new(),
-            free_page_hint_count: SharedIncMetric::new(),
-            free_page_hint_freed: SharedIncMetric::new(),
-            free_page_hint_fails: SharedIncMetric::new(),
-        }
-    }
-}
 
 #[cfg(test)]
 pub mod tests {
@@ -103,14 +89,13 @@ pub mod tests {
 
     #[test]
     fn test_balloon_dev_metrics() {
-        let balloon_metrics: BalloonDeviceMetrics = BalloonDeviceMetrics::new();
-        let balloon_metrics_local: String = serde_json::to_string(&balloon_metrics).unwrap();
-        // the 1st serialize flushes the metrics and resets values to 0 so that
-        // we can compare the values with local metrics.
-        serde_json::to_string(&METRICS).unwrap();
-        let balloon_metrics_global: String = serde_json::to_string(&METRICS).unwrap();
-        assert_eq!(balloon_metrics_local, balloon_metrics_global);
+        let balloon_metrics = BalloonDeviceMetrics::default();
         balloon_metrics.inflate_count.inc();
-        assert_eq!(balloon_metrics.inflate_count.count(), 1);
+
+        let serialized = serde_json::to_string(&balloon_metrics).unwrap();
+        let json_val: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let obj = json_val.as_object().unwrap();
+
+        assert_eq!(obj.get("inflate_count").and_then(|v| v.as_u64()), Some(1));
     }
 }

--- a/src/vmm/src/devices/virtio/balloon/mod.rs
+++ b/src/vmm/src/devices/virtio/balloon/mod.rs
@@ -12,7 +12,7 @@ mod util;
 
 pub use self::device::{Balloon, BalloonConfig, BalloonStats};
 use super::queue::{InvalidAvailIdx, QueueError};
-use crate::devices::virtio::balloon::metrics::METRICS;
+use crate::devices::virtio::balloon::metrics::BalloonDeviceMetrics;
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
 use crate::logger::{IncMetric, error};
 use crate::vstate::interrupts::InterruptError;
@@ -100,10 +100,24 @@ pub enum BalloonError {
     InvalidAvailIdx(#[from] InvalidAvailIdx),
 }
 
-pub(super) fn report_balloon_event_fail(err: BalloonError) {
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum RemoveRegionError {
+    /// Address translation error.
+    AddressTranslation,
+    /// Malformed guest address range.
+    MalformedRange,
+    /// Error calling madvise: {0}
+    MadviseFail(std::io::Error),
+    /// Error calling mmap: {0}
+    MmapFail(std::io::Error),
+    /// Region not found.
+    RegionNotFound,
+}
+
+pub(super) fn report_balloon_event_fail(err: BalloonError, metrics: &BalloonDeviceMetrics) {
     if let BalloonError::InvalidAvailIdx(err) = err {
         panic!("{}", err);
     }
     error!("{:?}", err);
-    METRICS.event_fails.inc();
+    metrics.event_fails.inc();
 }

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -22,9 +22,7 @@ use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use crate::devices::virtio::queue::Queue;
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::virtio::vhost_user::{VhostUserHandleBackend, VhostUserHandleImpl};
-use crate::devices::virtio::vhost_user_metrics::{
-    VhostUserDeviceMetrics, VhostUserMetricsPerDevice,
-};
+use crate::devices::virtio::vhost_user_metrics::{METRICS, VhostUserDeviceMetrics};
 use crate::logger::{IncMetric, StoreMetric, log_dev_preview_warning};
 use crate::utils::u64_to_usize;
 use crate::vmm_config::drive::BlockDeviceConfig;
@@ -216,9 +214,11 @@ impl<T: VhostUserHandleBackend> VhostUserBlockImpl<T> {
         let avail_features = acked_features;
         let acked_features = acked_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
         let read_only = acked_features & (1 << VIRTIO_BLK_F_RO) != 0;
-        let vhost_user_block_metrics_name = format!("block_{}", config.drive_id);
+        let id = format!("block_{}", config.drive_id);
 
-        let metrics = VhostUserMetricsPerDevice::alloc(vhost_user_block_metrics_name);
+        let metrics = Arc::new(VhostUserDeviceMetrics::default());
+        METRICS.write().unwrap().insert(id.clone(), metrics.clone());
+
         let delta_us = get_time_us(ClockType::Monotonic) - start_time;
         metrics.init_time_us.store(delta_us);
 

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -29,7 +29,7 @@ use super::{
 };
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::block::CacheType;
-use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, BlockMetricsPerDevice};
+use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, METRICS};
 use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::{
     VIRTIO_BLK_F_BLK_SIZE, VIRTIO_BLK_F_DISCARD, VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO,
@@ -485,6 +485,12 @@ impl VirtioBlock {
 
         let queues = BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect();
 
+        let metrics = Arc::new(BlockDeviceMetrics::default());
+        METRICS
+            .write()
+            .unwrap()
+            .insert(config.drive_id.clone(), metrics.clone());
+
         Ok(VirtioBlock {
             avail_features,
             acked_features: 0u64,
@@ -504,7 +510,7 @@ impl VirtioBlock {
             disk: disk_properties,
             rate_limiter,
             is_io_engine_throttled: false,
-            metrics: BlockMetricsPerDevice::alloc(config.drive_id),
+            metrics,
         })
     }
 
@@ -878,7 +884,6 @@ mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::check_metric_after_block;
     use crate::devices::virtio::block::virtio::IO_URING_NUM_ENTRIES;
     use crate::devices::virtio::block::virtio::test_utils::{
         RequestDescriptorChain, default_block, read_blk_req_descriptors, set_queue,
@@ -1385,11 +1390,8 @@ mod tests {
                 .flags
                 .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
 
-            check_metric_after_block!(
-                &block.metrics.read_count,
-                1,
-                simulate_queue_and_async_completion_events(&mut block, true)
-            );
+            simulate_queue_and_async_completion_events(&mut block, true);
+            assert_eq!(block.metrics.read_count.count(), 1);
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
@@ -1467,11 +1469,8 @@ mod tests {
                 vq.avail.idx.set(1);
                 vq.used.idx.set(0);
 
-                check_metric_after_block!(
-                    &block.metrics.invalid_reqs_count,
-                    1,
-                    simulate_queue_and_async_completion_events(&mut block, true)
-                );
+                simulate_queue_and_async_completion_events(&mut block, true);
+                assert_eq!(block.metrics.invalid_reqs_count.count(), 1);
 
                 let used_idx = vq.used.idx.get();
                 assert_eq!(used_idx, 1);
@@ -1495,11 +1494,8 @@ mod tests {
                 vq.dtable[1].len.set(512);
                 mem.write_slice(&rand_data[..512], data_addr).unwrap();
 
-                check_metric_after_block!(
-                    &block.metrics.write_count,
-                    1,
-                    simulate_queue_and_async_completion_events(&mut block, true)
-                );
+                simulate_queue_and_async_completion_events(&mut block, true);
+                assert_eq!(block.metrics.write_count.count(), 1);
 
                 assert_eq!(vq.used.idx.get(), 1);
                 assert_eq!(vq.used.ring[0].get().id, 0);
@@ -1546,11 +1542,8 @@ mod tests {
                 vq.dtable[1].len.set(512);
                 mem.write_slice(empty_data.as_slice(), data_addr).unwrap();
 
-                check_metric_after_block!(
-                    &block.metrics.read_count,
-                    1,
-                    simulate_queue_and_async_completion_events(&mut block, true)
-                );
+                simulate_queue_and_async_completion_events(&mut block, true);
+                assert_eq!(block.metrics.read_count.count(), 1);
 
                 assert_eq!(vq.used.idx.get(), 1);
                 assert_eq!(vq.used.ring[0].get().id, 0);
@@ -1713,11 +1706,8 @@ mod tests {
                     .flags
                     .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
 
-                check_metric_after_block!(
-                    &block.metrics.invalid_reqs_count,
-                    1,
-                    simulate_queue_and_async_completion_events(&mut block, true)
-                );
+                simulate_queue_and_async_completion_events(&mut block, true);
+                assert_eq!(block.metrics.invalid_reqs_count.count(), 1);
 
                 let used_idx = vq.used.idx.get();
                 assert_eq!(used_idx, 1);
@@ -2022,11 +2012,8 @@ mod tests {
             // Following write procedure should fail because of bandwidth rate limiting.
             {
                 // Trigger the attempt to write.
-                check_metric_after_block!(
-                    &block.metrics.rate_limiter_throttled_events,
-                    1,
-                    simulate_queue_event(&mut block, Some(false))
-                );
+                simulate_queue_event(&mut block, Some(false));
+                assert_eq!(block.metrics.rate_limiter_throttled_events.count(), 1);
 
                 // Assert that limiter is blocked.
                 assert!(block.rate_limiter.is_blocked());
@@ -2040,11 +2027,8 @@ mod tests {
 
             // Following write procedure should succeed because bandwidth should now be available.
             {
-                check_metric_after_block!(
-                    &block.metrics.rate_limiter_throttled_events,
-                    0,
-                    block.process_rate_limiter_event()
-                );
+                block.process_rate_limiter_event();
+                assert_eq!(block.metrics.rate_limiter_throttled_events.count(), 1);
                 // Validate the rate_limiter is no longer blocked.
                 assert!(!block.rate_limiter.is_blocked());
                 // Complete async IO ops if needed
@@ -2091,11 +2075,8 @@ mod tests {
             // Following write procedure should fail because of ops rate limiting.
             {
                 // Trigger the attempt to write.
-                check_metric_after_block!(
-                    &block.metrics.rate_limiter_throttled_events,
-                    1,
-                    simulate_queue_event(&mut block, Some(false))
-                );
+                simulate_queue_event(&mut block, Some(false));
+                assert_eq!(block.metrics.rate_limiter_throttled_events.count(), 1);
 
                 // Assert that limiter is blocked.
                 assert!(block.rate_limiter.is_blocked());
@@ -2106,11 +2087,8 @@ mod tests {
             // Do a second write that still fails but this time on the fast path.
             {
                 // Trigger the attempt to write.
-                check_metric_after_block!(
-                    &block.metrics.rate_limiter_throttled_events,
-                    1,
-                    simulate_queue_event(&mut block, Some(false))
-                );
+                simulate_queue_event(&mut block, Some(false));
+                assert_eq!(block.metrics.rate_limiter_throttled_events.count(), 2);
 
                 // Assert that limiter is blocked.
                 assert!(block.rate_limiter.is_blocked());
@@ -2124,11 +2102,8 @@ mod tests {
 
             // Following write procedure should succeed because ops budget should now be available.
             {
-                check_metric_after_block!(
-                    &block.metrics.rate_limiter_throttled_events,
-                    0,
-                    block.process_rate_limiter_event()
-                );
+                block.process_rate_limiter_event();
+                assert_eq!(block.metrics.rate_limiter_throttled_events.count(), 2);
                 // Validate the rate_limiter is no longer blocked.
                 assert!(!block.rate_limiter.is_blocked());
                 // Complete async IO ops if needed

--- a/src/vmm/src/devices/virtio/block/virtio/metrics.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/metrics.rs
@@ -86,50 +86,23 @@ use serde::{Serialize, Serializer};
 
 use crate::logger::{IncMetric, LatencyAggregateMetrics, SharedIncMetric};
 
-/// map of block drive id and metrics
-/// this should be protected by a lock before accessing.
-#[derive(Debug)]
-pub struct BlockMetricsPerDevice {
-    /// used to access per block device metrics
-    pub metrics: BTreeMap<String, Arc<BlockDeviceMetrics>>,
-}
-
-impl BlockMetricsPerDevice {
-    /// Allocate `BlockDeviceMetrics` for block device having
-    /// id `drive_id`. Also, allocate only if it doesn't
-    /// exist to avoid overwriting previously allocated data.
-    /// lock is always initialized so it is safe the unwrap
-    /// the lock without a check.
-    pub fn alloc(drive_id: String) -> Arc<BlockDeviceMetrics> {
-        Arc::clone(
-            METRICS
-                .write()
-                .unwrap()
-                .metrics
-                .entry(drive_id)
-                .or_insert_with(|| Arc::new(BlockDeviceMetrics::default())),
-        )
-    }
-}
-
 /// Pool of block-related metrics per device behind a lock to
 /// keep things thread safe. Since the lock is initialized here
 /// it is safe to unwrap it without any check.
-static METRICS: RwLock<BlockMetricsPerDevice> = RwLock::new(BlockMetricsPerDevice {
-    metrics: BTreeMap::new(),
-});
+pub(crate) static METRICS: RwLock<BTreeMap<String, Arc<BlockDeviceMetrics>>> =
+    RwLock::new(BTreeMap::new());
 
 /// This function facilitates aggregation and serialization of
 /// per block device metrics.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let block_metrics = METRICS.read().unwrap();
-    let metrics_len = block_metrics.metrics.len();
+    let metrics_len = block_metrics.len();
     // +1 to accommodate aggregate block metrics
     let mut seq = serializer.serialize_map(Some(1 + metrics_len))?;
 
     let mut block_aggregated: BlockDeviceMetrics = BlockDeviceMetrics::default();
 
-    for (name, metrics) in block_metrics.metrics.iter() {
+    for (name, metrics) in block_metrics.iter() {
         let devn = format!("block_{}", name);
         // serialization will flush the metrics so aggregate before it.
         let m: &BlockDeviceMetrics = metrics;
@@ -238,90 +211,16 @@ pub mod tests {
     use super::*;
 
     #[test]
-    fn test_max_block_dev_metrics() {
-        // Note: this test has nothing to do with
-        // block structure or IRQs, this is just to allocate
-        // metrics for max number of devices that system can have.
-        // We have 5-23 IRQ for block devices on x86_64 so, there
-        // are 19 block devices at max. And, even though we have more
-        // devices on aarch64 but we stick to 19 to keep test common.
-        const MAX_BLOCK_DEVICES: usize = 19;
+    fn test_block_device_metrics() {
+        let block_metrics = BlockDeviceMetrics::default();
+        block_metrics.activate_fails.inc();
+        block_metrics.read_bytes.add(1000);
 
-        // This is to make sure that RwLock for block::metrics::METRICS is good.
-        drop(METRICS.read().unwrap());
-        drop(METRICS.write().unwrap());
+        let serialized = serde_json::to_string(&block_metrics).unwrap();
+        let json_val: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let obj = json_val.as_object().unwrap();
 
-        // block::metrics::METRICS is in short RwLock on Vec of BlockDeviceMetrics.
-        // Normally, pointer to unique entries of block::metrics::METRICS are stored
-        // in Block device so that Block device can do self.metrics.* to
-        // update a metric. We try to do something similar here without
-        // using Block device by allocating max number of
-        // BlockDeviceMetrics in block::metrics::METRICS and store pointer to
-        // each entry in the local `metrics` vec.
-        // We then update 1 IncMetric and 2 SharedMetric for each metrics
-        // and validate if the metrics for per device was updated as
-        // expected.
-        let mut metrics: Vec<Arc<BlockDeviceMetrics>> = Vec::new();
-        for i in 0..MAX_BLOCK_DEVICES {
-            let devn: String = format!("drv{}", i);
-            metrics.push(BlockMetricsPerDevice::alloc(devn.clone()));
-            // update IncMetric
-            metrics[i].activate_fails.inc();
-            // update SharedMetric
-            metrics[i].read_bytes.add(10);
-            metrics[i].write_bytes.add(5);
-
-            if i == 0 {
-                // Unit tests run in parallel and we have
-                // `test_single_block_dev_metrics` that also increases
-                // the IncMetric count of drv0 by 1 (intentional to check
-                // thread safety) so we check if the count is >=1.
-                assert!(metrics[i].activate_fails.count() >= 1);
-
-                // For the same reason as above since we have
-                // another unit test running in parallel which updates
-                // drv0 metrics we check if count is >=10.
-                assert!(metrics[i].read_bytes.count() >= 10);
-            } else {
-                assert!(metrics[i].activate_fails.count() == 1);
-                assert!(metrics[i].read_bytes.count() == 10);
-            }
-            assert_eq!(metrics[i].write_bytes.count(), 5);
-        }
-    }
-
-    #[test]
-    fn test_single_block_dev_metrics() {
-        // Use drv0 so that we can check thread safety with the
-        // `test_max_block_dev_metrics` which also uses the same name.
-        let devn = "drv0";
-
-        // This is to make sure that RwLock for block::metrics::METRICS is good.
-        drop(METRICS.read().unwrap());
-        drop(METRICS.write().unwrap());
-
-        let test_metrics = BlockMetricsPerDevice::alloc(String::from(devn));
-        // Test to update IncMetrics
-        test_metrics.activate_fails.inc();
-        assert!(
-            test_metrics.activate_fails.count() > 0,
-            "{}",
-            test_metrics.activate_fails.count()
-        );
-
-        // We expect only 2 tests (this and test_max_block_dev_metrics)
-        // to update activate_fails count for drv0.
-        assert!(
-            test_metrics.activate_fails.count() <= 2,
-            "{}",
-            test_metrics.activate_fails.count()
-        );
-
-        // Test to update SharedMetrics
-        test_metrics.read_bytes.add(5);
-        // We expect only 2 tests (this and test_max_block_dev_metrics)
-        // to update read_bytes count for drv0 by 5.
-        assert!(test_metrics.read_bytes.count() >= 5);
-        assert!(test_metrics.read_bytes.count() <= 15);
+        assert_eq!(obj.get("activate_fails").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(obj.get("read_bytes").and_then(|v| v.as_u64()), Some(1000));
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -12,13 +12,15 @@ use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
 use crate::devices::virtio::block::virtio::device::FileEngineType;
 use crate::devices::virtio::block::virtio::device::VirtioBlkTopology;
-use crate::devices::virtio::block::virtio::metrics::BlockMetricsPerDevice;
+use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, METRICS};
 use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::VIRTIO_BLK_F_RO;
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::rate_limiter::RateLimiter;
 use crate::rate_limiter::persist::RateLimiterState;
 use crate::snapshot::Persist;
+
+use std::sync::Arc;
 
 /// Holds info about block's file engine type. Gets saved in snapshot.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -125,6 +127,13 @@ impl Persist<'_> for VirtioBlock {
             ..Default::default()
         };
 
+        let metrics = Arc::new(BlockDeviceMetrics::default());
+
+        METRICS
+            .write()
+            .unwrap()
+            .insert(state.id.clone(), metrics.clone());
+
         Ok(VirtioBlock {
             avail_features,
             acked_features,
@@ -144,7 +153,7 @@ impl Persist<'_> for VirtioBlock {
             disk: disk_properties,
             rate_limiter,
             is_io_engine_throttled: false,
-            metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
+            metrics,
         })
     }
 }

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -18,7 +18,7 @@ use crate::devices::virtio::generated::virtio_mem::{
     self, VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE, virtio_mem_config,
 };
 use crate::devices::virtio::mem::VIRTIO_MEM_DEV_ID;
-use crate::devices::virtio::mem::metrics::METRICS;
+use crate::devices::virtio::mem::metrics::{METRICS, VirtioMemDeviceMetrics};
 use crate::devices::virtio::mem::request::{BlockRangeState, Request, RequestedRange, Response};
 use crate::devices::virtio::queue::{
     DescriptorChain, FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue, QueueError,
@@ -92,6 +92,7 @@ pub struct VirtioMem {
     // Bitmap to track which blocks are plugged
     pub(crate) plugged_blocks: BitVec,
     vm: Arc<KvmVm>,
+    metrics: Arc<VirtioMemDeviceMetrics>,
 }
 
 /// Memory hotplug device status information.
@@ -125,6 +126,7 @@ impl VirtioMem {
             block_size: u32_mib_to_bytes(block_size_mib),
             ..Default::default()
         };
+
         let plugged_blocks = BitVec::repeat(
             false,
             u64_to_usize((total_size_mib / block_size_mib).into()),
@@ -151,6 +153,9 @@ impl VirtioMem {
             .map(|_| EventFd::new(libc::EFD_NONBLOCK))
             .collect::<Result<Vec<EventFd>, io::Error>>()?;
 
+        let metrics = Arc::new(VirtioMemDeviceMetrics::default());
+        let _ = METRICS.write().unwrap().replace(metrics.clone());
+
         Ok(Self {
             avail_features: (1 << VIRTIO_F_VERSION_1) | (1 << VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE),
             acked_features: 0u64,
@@ -162,6 +167,7 @@ impl VirtioMem {
             vm,
             slot_size,
             plugged_blocks,
+            metrics,
         })
     }
 
@@ -344,17 +350,18 @@ impl VirtioMem {
         resp_addr: GuestAddress,
         used_idx: u16,
     ) -> Result<(), VirtioMemError> {
-        METRICS.plug_count.inc();
-        let _metric = METRICS.plug_agg.record_latency_metrics();
+        let metrics = Arc::clone(&self.metrics);
+        metrics.plug_count.inc();
+        let _metric = metrics.plug_agg.record_latency_metrics();
 
         let response = match self.process_plug_request(range) {
             Err(err) => {
-                METRICS.plug_fails.inc();
+                self.metrics.plug_fails.inc();
                 error!("virtio-mem: Failed to plug range: {}", err);
                 Response::error()
             }
             Ok(_) => {
-                METRICS
+                self.metrics
                     .plug_bytes
                     .add(usize_to_u64(self.nb_blocks_to_len(range.nb_blocks)));
                 Response::ack()
@@ -379,16 +386,18 @@ impl VirtioMem {
         resp_addr: GuestAddress,
         used_idx: u16,
     ) -> Result<(), VirtioMemError> {
-        METRICS.unplug_count.inc();
-        let _metric = METRICS.unplug_agg.record_latency_metrics();
+        let metrics = Arc::clone(&self.metrics);
+        metrics.unplug_count.inc();
+        let _metric = metrics.unplug_agg.record_latency_metrics();
+
         let response = match self.process_unplug_request(range) {
             Err(err) => {
-                METRICS.unplug_fails.inc();
+                self.metrics.unplug_fails.inc();
                 error!("virtio-mem: Failed to unplug range: {}", err);
                 Response::error()
             }
             Ok(_) => {
-                METRICS
+                self.metrics
                     .unplug_bytes
                     .add(usize_to_u64(self.nb_blocks_to_len(range.nb_blocks)));
                 Response::ack()
@@ -402,15 +411,17 @@ impl VirtioMem {
         resp_addr: GuestAddress,
         used_idx: u16,
     ) -> Result<(), VirtioMemError> {
-        METRICS.unplug_all_count.inc();
-        let _metric = METRICS.unplug_all_agg.record_latency_metrics();
+        let metrics = Arc::clone(&self.metrics);
+        metrics.unplug_all_count.inc();
+        let _metric = metrics.unplug_all_agg.record_latency_metrics();
+
         let range = RequestedRange {
             addr: self.guest_address(),
             nb_blocks: self.plugged_blocks.len(),
         };
         let response = match self.update_range(&range, false) {
             Err(err) => {
-                METRICS.unplug_all_fails.inc();
+                self.metrics.unplug_all_fails.inc();
                 error!("virtio-mem: Failed to unplug all: {}", err);
                 Response::error()
             }
@@ -428,11 +439,13 @@ impl VirtioMem {
         resp_addr: GuestAddress,
         used_idx: u16,
     ) -> Result<(), VirtioMemError> {
-        METRICS.state_count.inc();
-        let _metric = METRICS.state_agg.record_latency_metrics();
+        let metrics = Arc::clone(&self.metrics);
+        metrics.state_count.inc();
+        let _metrics = metrics.state_agg.record_latency_metrics();
+
         let response = match self.validate_range(range) {
             Err(err) => {
-                METRICS.state_fails.inc();
+                self.metrics.state_fails.inc();
                 error!("virtio-mem: Failed to retrieve state of range: {}", err);
                 Response::error()
             }
@@ -465,15 +478,15 @@ impl VirtioMem {
     }
 
     pub(crate) fn process_mem_queue_event(&mut self) {
-        METRICS.queue_event_count.inc();
+        self.metrics.queue_event_count.inc();
         if let Err(err) = self.queue_events[MEM_QUEUE].read() {
-            METRICS.queue_event_fails.inc();
+            self.metrics.queue_event_fails.inc();
             error!("Failed to read mem queue event: {err}");
             return;
         }
 
         if let Err(err) = self.process_mem_queue() {
-            METRICS.queue_event_fails.inc();
+            self.metrics.queue_event_fails.inc();
             error!("virtio-mem: Failed to process queue: {err}");
         }
     }
@@ -590,7 +603,7 @@ impl VirtioMem {
                 self.apply_range_to_slot(slot_num, first_block, block_count, &req_blocks, plug)?;
         }
         if discard_failed {
-            METRICS.unplug_discard_fails.inc();
+            self.metrics.unplug_discard_fails.inc();
         }
         Ok(())
     }
@@ -714,7 +727,7 @@ impl VirtioDevice for VirtioMem {
             error!(
                 "virtio-mem: VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE feature not acknowledged by guest"
             );
-            METRICS.activate_fails.inc();
+            self.metrics.activate_fails.inc();
             return Err(ActivateError::RequiredFeatureNotAcked(
                 "VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE",
             ));
@@ -727,7 +740,7 @@ impl VirtioDevice for VirtioMem {
 
         self.device_state = DeviceState::Activated(ActiveState { mem, interrupt });
         if self.activate_event.write(1).is_err() {
-            METRICS.activate_fails.inc();
+            self.metrics.activate_fails.inc();
             self.device_state = DeviceState::Inactive;
             return Err(ActivateError::EventFd);
         }
@@ -955,14 +968,11 @@ mod tests {
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
-        let queue_event_count = METRICS.queue_event_count.count();
-        let queue_event_fails = METRICS.queue_event_fails.count();
-
         th.add_desc_chain(MEM_QUEUE, 0, &[(0, REQ_SIZE, 0)]);
         assert_eq!(th.emulate_for_msec(100).unwrap(), 1);
 
-        assert_eq!(METRICS.queue_event_count.count(), queue_event_count + 1);
-        assert_eq!(METRICS.queue_event_fails.count(), queue_event_fails + 1);
+        assert_eq!(th.device().metrics.queue_event_count.count(), 1);
+        assert_eq!(th.device().metrics.queue_event_fails.count(), 1);
     }
 
     #[test]
@@ -971,14 +981,11 @@ mod tests {
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
-        let queue_event_count = METRICS.queue_event_count.count();
-        let queue_event_fails = METRICS.queue_event_fails.count();
-
         th.add_desc_chain(MEM_QUEUE, 0, &[(0, 1, 0)]);
         assert_eq!(th.emulate_for_msec(100).unwrap(), 1);
 
-        assert_eq!(METRICS.queue_event_count.count(), queue_event_count + 1);
-        assert_eq!(METRICS.queue_event_fails.count(), queue_event_fails + 1);
+        assert_eq!(th.device().metrics.queue_event_count.count(), 1);
+        assert_eq!(th.device().metrics.queue_event_fails.count(), 1);
     }
 
     #[test]
@@ -987,14 +994,11 @@ mod tests {
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
-        let queue_event_count = METRICS.queue_event_count.count();
-        let queue_event_fails = METRICS.queue_event_fails.count();
-
         th.add_desc_chain(MEM_QUEUE, 0, &[(0, REQ_SIZE, VIRTQ_DESC_F_WRITE)]);
         assert_eq!(th.emulate_for_msec(100).unwrap(), 1);
 
-        assert_eq!(METRICS.queue_event_count.count(), queue_event_count + 1);
-        assert_eq!(METRICS.queue_event_fails.count(), queue_event_fails + 1);
+        assert_eq!(th.device().metrics.queue_event_count.count(), 1);
+        assert_eq!(th.device().metrics.queue_event_fails.count(), 1);
     }
 
     #[test]
@@ -1003,14 +1007,11 @@ mod tests {
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
-        let queue_event_count = METRICS.queue_event_count.count();
-        let queue_event_fails = METRICS.queue_event_fails.count();
-
         th.add_desc_chain(MEM_QUEUE, 0, &[(0, REQ_SIZE, 0), (1, RESP_SIZE, 0)]);
         assert_eq!(th.emulate_for_msec(100).unwrap(), 1);
 
-        assert_eq!(METRICS.queue_event_count.count(), queue_event_count + 1);
-        assert_eq!(METRICS.queue_event_fails.count(), queue_event_fails + 1);
+        assert_eq!(th.device().metrics.queue_event_count.count(), 1);
+        assert_eq!(th.device().metrics.queue_event_fails.count(), 1);
     }
 
     #[test]
@@ -1019,9 +1020,6 @@ mod tests {
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
-        let queue_event_count = METRICS.queue_event_count.count();
-        let queue_event_fails = METRICS.queue_event_fails.count();
-
         th.add_desc_chain(
             MEM_QUEUE,
             0,
@@ -1029,8 +1027,8 @@ mod tests {
         );
         assert_eq!(th.emulate_for_msec(100).unwrap(), 1);
 
-        assert_eq!(METRICS.queue_event_count.count(), queue_event_count + 1);
-        assert_eq!(METRICS.queue_event_fails.count(), queue_event_fails + 1);
+        assert_eq!(th.device().metrics.queue_event_count.count(), 1);
+        assert_eq!(th.device().metrics.queue_event_fails.count(), 1);
     }
 
     #[test]
@@ -1081,12 +1079,6 @@ mod tests {
         th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
-        let queue_event_count = METRICS.queue_event_count.count();
-        let queue_event_fails = METRICS.queue_event_fails.count();
-        let plug_count = METRICS.plug_count.count();
-        let plug_bytes = METRICS.plug_bytes.count();
-        let plug_fails = METRICS.plug_fails.count();
-
         let resp = emulate_request(
             &mut th,
             &guest_mem,
@@ -1095,11 +1087,11 @@ mod tests {
         assert!(resp.is_ack());
         assert_eq!(th.device().plugged_size_mib(), 2);
 
-        assert_eq!(METRICS.queue_event_count.count(), queue_event_count + 1);
-        assert_eq!(METRICS.queue_event_fails.count(), queue_event_fails);
-        assert_eq!(METRICS.plug_count.count(), plug_count + 1);
-        assert_eq!(METRICS.plug_bytes.count(), plug_bytes + (2 << 20));
-        assert_eq!(METRICS.plug_fails.count(), plug_fails);
+        assert_eq!(th.device().metrics.queue_event_count.count(), 1);
+        assert_eq!(th.device().metrics.queue_event_fails.count(), 0);
+        assert_eq!(th.device().metrics.plug_count.count(), 1);
+        assert_eq!(th.device().metrics.plug_bytes.count(), 2 << 20);
+        assert_eq!(th.device().metrics.plug_fails.count(), 0);
     }
 
     #[test]
@@ -1110,10 +1102,6 @@ mod tests {
         th.device().update_requested_size(2).unwrap();
         let addr = th.device().guest_address();
 
-        let plug_count = METRICS.plug_count.count();
-        let plug_bytes = METRICS.plug_bytes.count();
-        let plug_fails = METRICS.plug_fails.count();
-
         let resp = emulate_request(
             &mut th,
             &guest_mem,
@@ -1121,9 +1109,9 @@ mod tests {
         );
         assert!(resp.is_error());
 
-        assert_eq!(METRICS.plug_count.count(), plug_count + 1);
-        assert_eq!(METRICS.plug_bytes.count(), plug_bytes);
-        assert_eq!(METRICS.plug_fails.count(), plug_fails + 1);
+        assert_eq!(th.device().metrics.plug_count.count(), 1);
+        assert_eq!(th.device().metrics.plug_bytes.count(), 0);
+        assert_eq!(th.device().metrics.plug_fails.count(), 1);
     }
 
     #[test]
@@ -1159,10 +1147,6 @@ mod tests {
         th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
-        let unplug_count = METRICS.unplug_count.count();
-        let unplug_bytes = METRICS.unplug_bytes.count();
-        let unplug_fails = METRICS.unplug_fails.count();
-
         // First plug
         let resp = emulate_request(
             &mut th,
@@ -1181,9 +1165,9 @@ mod tests {
         assert!(resp.is_ack());
         assert_eq!(th.device().plugged_size_mib(), 0);
 
-        assert_eq!(METRICS.unplug_count.count(), unplug_count + 1);
-        assert_eq!(METRICS.unplug_bytes.count(), unplug_bytes + (2 << 20));
-        assert_eq!(METRICS.unplug_fails.count(), unplug_fails);
+        assert_eq!(th.device().metrics.unplug_count.count(), 1);
+        assert_eq!(th.device().metrics.unplug_bytes.count(), 2 << 20);
+        assert_eq!(th.device().metrics.unplug_fails.count(), 0);
     }
 
     #[test]
@@ -1194,10 +1178,6 @@ mod tests {
         th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
-        let unplug_count = METRICS.unplug_count.count();
-        let unplug_bytes = METRICS.unplug_bytes.count();
-        let unplug_fails = METRICS.unplug_fails.count();
-
         let resp = emulate_request(
             &mut th,
             &guest_mem,
@@ -1205,9 +1185,9 @@ mod tests {
         );
         assert!(resp.is_error());
 
-        assert_eq!(METRICS.unplug_count.count(), unplug_count + 1);
-        assert_eq!(METRICS.unplug_bytes.count(), unplug_bytes);
-        assert_eq!(METRICS.unplug_fails.count(), unplug_fails + 1);
+        assert_eq!(th.device().metrics.unplug_count.count(), 1);
+        assert_eq!(th.device().metrics.unplug_bytes.count(), 0);
+        assert_eq!(th.device().metrics.unplug_fails.count(), 1);
     }
 
     #[test]
@@ -1217,9 +1197,6 @@ mod tests {
         let mut th = test_helper(mem_dev, &guest_mem);
         th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
-
-        let unplug_all_count = METRICS.unplug_all_count.count();
-        let unplug_all_fails = METRICS.unplug_all_fails.count();
 
         // Plug some blocks
         let resp = emulate_request(
@@ -1235,8 +1212,8 @@ mod tests {
         assert!(resp.is_ack());
         assert_eq!(th.device().plugged_size_mib(), 0);
 
-        assert_eq!(METRICS.unplug_all_count.count(), unplug_all_count + 1);
-        assert_eq!(METRICS.unplug_all_fails.count(), unplug_all_fails);
+        assert_eq!(th.device().metrics.unplug_all_count.count(), 1);
+        assert_eq!(th.device().metrics.unplug_all_fails.count(), 0);
     }
 
     /// A plug spanning two slots where the second slot's KVM update fails must leave only the first
@@ -1286,11 +1263,14 @@ mod tests {
         assert!(resp.is_ack());
         assert_eq!(th.device().plugged_size_mib(), 0);
 
-        let unplug_all_fails = METRICS.unplug_all_fails.count();
+        let unplug_all_fails = th.device().metrics.unplug_all_fails.count();
         let resp = emulate_request(&mut th, &guest_mem, Request::UnplugAll);
         assert!(resp.is_ack());
         assert_eq!(th.device().plugged_size_mib(), 0);
-        assert_eq!(METRICS.unplug_all_fails.count(), unplug_all_fails);
+        assert_eq!(
+            th.device().metrics.unplug_all_fails.count(),
+            unplug_all_fails
+        );
     }
 
     #[test]
@@ -1301,9 +1281,6 @@ mod tests {
         th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
-        let state_count = METRICS.state_count.count();
-        let state_fails = METRICS.state_fails.count();
-
         let resp = emulate_request(
             &mut th,
             &guest_mem,
@@ -1311,8 +1288,8 @@ mod tests {
         );
         assert_eq!(resp, Response::ack_with_state(BlockRangeState::Unplugged));
 
-        assert_eq!(METRICS.state_count.count(), state_count + 1);
-        assert_eq!(METRICS.state_fails.count(), state_fails);
+        assert_eq!(th.device().metrics.state_count.count(), 1);
+        assert_eq!(th.device().metrics.state_fails.count(), 0);
     }
 
     #[test]
@@ -1373,9 +1350,6 @@ mod tests {
         th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address().unchecked_add(1);
 
-        let state_count = METRICS.state_count.count();
-        let state_fails = METRICS.state_fails.count();
-
         let resp = emulate_request(
             &mut th,
             &guest_mem,
@@ -1383,8 +1357,8 @@ mod tests {
         );
         assert!(resp.is_error());
 
-        assert_eq!(METRICS.state_count.count(), state_count + 1);
-        assert_eq!(METRICS.state_fails.count(), state_fails + 1);
+        assert_eq!(th.device().metrics.state_count.count(), 1);
+        assert_eq!(th.device().metrics.state_fails.count(), 1);
     }
 
     #[test]
@@ -1428,9 +1402,6 @@ mod tests {
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
-        let queue_event_count = METRICS.queue_event_count.count();
-        let queue_event_fails = METRICS.queue_event_fails.count();
-
         th.add_desc_chain(
             MEM_QUEUE,
             0,
@@ -1444,7 +1415,7 @@ mod tests {
             .unwrap();
         assert_eq!(th.emulate_for_msec(100).unwrap(), 1);
 
-        assert_eq!(METRICS.queue_event_count.count(), queue_event_count + 1);
-        assert_eq!(METRICS.queue_event_fails.count(), queue_event_fails + 1);
+        assert_eq!(th.device().metrics.queue_event_count.count(), 1);
+        assert_eq!(th.device().metrics.queue_event_fails.count(), 1);
     }
 }

--- a/src/vmm/src/devices/virtio/mem/metrics.rs
+++ b/src/vmm/src/devices/virtio/mem/metrics.rs
@@ -24,20 +24,25 @@
 
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
+use std::sync::{Arc, RwLock};
 
 use crate::logger::{LatencyAggregateMetrics, SharedIncMetric};
 
 /// Stores aggregated virtio-mem metrics
-pub(super) static METRICS: VirtioMemDeviceMetrics = VirtioMemDeviceMetrics::new();
+pub(super) static METRICS: RwLock<Option<Arc<VirtioMemDeviceMetrics>>> = RwLock::new(None);
 
 /// Called by METRICS.flush(), this function facilitates serialization of virtio-mem device metrics.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let mut seq = serializer.serialize_map(Some(1))?;
-    seq.serialize_entry("memory_hotplug", &METRICS)?;
+    let dev_name = "memory_hotplug";
+    match METRICS.read().unwrap().as_ref() {
+        Some(metrics) => seq.serialize_entry(dev_name, &metrics)?,
+        None => seq.serialize_entry(dev_name, &VirtioMemDeviceMetrics::default())?,
+    }
     seq.end()
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub(super) struct VirtioMemDeviceMetrics {
     /// Number of device activation failures
     pub activate_fails: SharedIncMetric,
@@ -77,32 +82,6 @@ pub(super) struct VirtioMemDeviceMetrics {
     pub state_fails: SharedIncMetric,
 }
 
-impl VirtioMemDeviceMetrics {
-    /// Const default construction.
-    const fn new() -> Self {
-        Self {
-            activate_fails: SharedIncMetric::new(),
-            queue_event_fails: SharedIncMetric::new(),
-            queue_event_count: SharedIncMetric::new(),
-            plug_agg: LatencyAggregateMetrics::new(),
-            plug_count: SharedIncMetric::new(),
-            plug_bytes: SharedIncMetric::new(),
-            plug_fails: SharedIncMetric::new(),
-            unplug_agg: LatencyAggregateMetrics::new(),
-            unplug_count: SharedIncMetric::new(),
-            unplug_bytes: SharedIncMetric::new(),
-            unplug_fails: SharedIncMetric::new(),
-            unplug_discard_fails: SharedIncMetric::new(),
-            unplug_all_agg: LatencyAggregateMetrics::new(),
-            unplug_all_count: SharedIncMetric::new(),
-            unplug_all_fails: SharedIncMetric::new(),
-            state_agg: LatencyAggregateMetrics::new(),
-            state_count: SharedIncMetric::new(),
-            state_fails: SharedIncMetric::new(),
-        }
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -110,9 +89,17 @@ pub mod tests {
 
     #[test]
     fn test_memory_hotplug_metrics() {
-        let mem_metrics: VirtioMemDeviceMetrics = VirtioMemDeviceMetrics::new();
+        let mem_metrics = VirtioMemDeviceMetrics::default();
         mem_metrics.queue_event_count.inc();
         assert_eq!(mem_metrics.queue_event_count.count(), 1);
-        let _ = serde_json::to_string(&mem_metrics).unwrap();
+
+        let serialized = serde_json::to_string(&mem_metrics).unwrap();
+        let json_val: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let obj = json_val.as_object().unwrap();
+
+        assert_eq!(
+            obj.get("queue_event_count").and_then(|v| v.as_u64()),
+            Some(1)
+        );
     }
 }

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -28,7 +28,7 @@ use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use crate::devices::virtio::iovec::{
     IoVecBuffer, IoVecBufferMut, IoVecError, ParsedDescriptorChain,
 };
-use crate::devices::virtio::net::metrics::{NetDeviceMetrics, NetMetricsPerDevice};
+use crate::devices::virtio::net::metrics::{METRICS as NETMETRICS, NetDeviceMetrics};
 use crate::devices::virtio::net::tap::Tap;
 use crate::devices::virtio::net::{
     MAX_BUFFER_SIZE, NET_QUEUE_SIZES, NetError, NetQueue, RX_INDEX, TX_INDEX, generated,
@@ -325,6 +325,11 @@ impl Net {
             queue_evts.push(EventFd::new(libc::EFD_NONBLOCK).map_err(NetError::EventFd)?);
             queues.push(Queue::new(size));
         }
+        let metrics = Arc::new(NetDeviceMetrics::default());
+        NETMETRICS
+            .write()
+            .unwrap()
+            .insert(id.clone(), metrics.clone());
 
         Ok(Net {
             id: id.clone(),
@@ -342,7 +347,7 @@ impl Net {
             device_state: DeviceState::Inactive,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(NetError::EventFd)?,
             mmds_ns: None,
-            metrics: NetMetricsPerDevice::alloc(id),
+            metrics,
             tx_buffer: Default::default(),
             rx_buffer: RxBuffers::new()?,
         })
@@ -1124,7 +1129,6 @@ pub mod tests {
     use vm_memory::{GuestAddress, GuestMemoryBackend};
 
     use super::*;
-    use crate::check_metric_after_block;
     use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
     use crate::devices::virtio::iovec::IoVecBuffer;
     use crate::devices::virtio::net::NET_QUEUE_SIZES;
@@ -1347,11 +1351,8 @@ pub mod tests {
 
         th.add_desc_chain(NetQueue::Rx, 0, &[(0, 4096, VIRTQ_DESC_F_WRITE)]);
         th.net().queue_evts[RX_INDEX].read().unwrap();
-        check_metric_after_block!(
-            th.net().metrics.event_fails,
-            1,
-            th.simulate_event(NetEvent::RxQueue)
-        );
+        th.simulate_event(NetEvent::RxQueue);
+        assert_eq!(th.net().metrics.event_fails.count(), 1);
 
         // Check that the used queue didn't advance.
         assert_eq!(th.rxq.used.idx.get(), 0);
@@ -1370,11 +1371,8 @@ pub mod tests {
             ],
         );
         let mut frame = inject_tap_tx_frame(&th.net(), 1000);
-        check_metric_after_block!(
-            th.net().metrics.rx_fails,
-            1,
-            th.event_manager.run_with_timeout(100).unwrap()
-        );
+        th.event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(th.net().metrics.rx_fails.count(), 1);
         th.rxq.check_used_elem(0, 0, 0);
         header_set_num_buffers(frame.as_mut_slice(), 1);
         th.check_rx_queue_resume(&frame);
@@ -1493,11 +1491,8 @@ pub mod tests {
 
         // Inject frame to tap and run epoll.
         let mut frame = inject_tap_tx_frame(&th.net(), 1000);
-        check_metric_after_block!(
-            th.net().metrics.rx_packets_count,
-            1,
-            th.event_manager.run_with_timeout(100).unwrap()
-        );
+        th.event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(th.net().metrics.rx_packets_count.count(), 1);
 
         // Check that the used queue has advanced.
         assert_eq!(th.rxq.used.idx.get(), 4);
@@ -1553,11 +1548,8 @@ pub mod tests {
         );
         // Inject frame to tap and run epoll.
         let mut frame = inject_tap_tx_frame(&th.net(), 1000);
-        check_metric_after_block!(
-            th.net().metrics.rx_packets_count,
-            1,
-            th.event_manager.run_with_timeout(100).unwrap()
-        );
+        th.event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(th.net().metrics.rx_packets_count.count(), 1);
 
         // Check that the frame wasn't deferred.
         assert!(th.net().rx_buffer.used_descriptors == 0);
@@ -1620,11 +1612,8 @@ pub mod tests {
         // Inject 2 frames to tap and run epoll.
         let mut frame_1 = inject_tap_tx_frame(&th.net(), 200);
         let mut frame_2 = inject_tap_tx_frame(&th.net(), 300);
-        check_metric_after_block!(
-            th.net().metrics.rx_packets_count,
-            2,
-            th.event_manager.run_with_timeout(100).unwrap()
-        );
+        th.event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(th.net().metrics.rx_packets_count.count(), 2);
 
         // Check that the frames weren't deferred.
         assert!(th.net().rx_buffer.used_bytes == 0);
@@ -1682,11 +1671,8 @@ pub mod tests {
         );
         // Inject frame to tap and run epoll.
         let mut frame = inject_tap_tx_frame(&th.net(), 1000);
-        check_metric_after_block!(
-            th.net().metrics.rx_packets_count,
-            1,
-            th.event_manager.run_with_timeout(100).unwrap()
-        );
+        th.event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(th.net().metrics.rx_packets_count.count(), 1);
 
         // Check that the frame wasn't deferred.
         assert!(th.net().rx_buffer.used_bytes == 0);
@@ -1735,11 +1721,8 @@ pub mod tests {
 
         th.add_desc_chain(NetQueue::Tx, 0, &[(0, 4096, 0)]);
         th.net().queue_evts[TX_INDEX].read().unwrap();
-        check_metric_after_block!(
-            th.net().metrics.event_fails,
-            1,
-            th.simulate_event(NetEvent::TxQueue)
-        );
+        th.simulate_event(NetEvent::TxQueue);
+        assert_eq!(th.net().metrics.event_fails.count(), 1);
 
         // Check that the used queue didn't advance.
         assert_eq!(th.txq.used.idx.get(), 0);
@@ -1780,11 +1763,8 @@ pub mod tests {
 
         // Send an invalid frame (too small, VNET header missing).
         th.add_desc_chain(NetQueue::Tx, 0, &[(0, 1, 0)]);
-        check_metric_after_block!(
-            th.net().metrics.tx_malformed_frames,
-            1,
-            th.event_manager.run_with_timeout(100)
-        );
+        th.event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(th.net().metrics.tx_malformed_frames.count(), 1);
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 1);
@@ -1811,11 +1791,8 @@ pub mod tests {
             0,
             &[(0, (MAX_BUFFER_SIZE + 1).try_into().unwrap(), 0)],
         );
-        check_metric_after_block!(
-            th.net().metrics.tx_malformed_frames,
-            1,
-            th.event_manager.run_with_timeout(100)
-        );
+        let _ = th.event_manager.run_with_timeout(100);
+        assert_eq!(th.net().metrics.tx_malformed_frames.count(), 1);
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 1);
@@ -1838,11 +1815,8 @@ pub mod tests {
 
         // Send an invalid frame (too small, VNET header missing).
         th.add_desc_chain(NetQueue::Tx, 0, &[(0, 0, 0)]);
-        check_metric_after_block!(
-            th.net().metrics.tx_malformed_frames,
-            1,
-            th.event_manager.run_with_timeout(100)
-        );
+        let _ = th.event_manager.run_with_timeout(100);
+        assert_eq!(th.net().metrics.tx_malformed_frames.count(), 1);
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 1);
@@ -1881,11 +1855,8 @@ pub mod tests {
 
         // One frame is valid, one will not be handled because it includes write-only memory
         // so that leaves us with 2 malformed (no vnet header) frames.
-        check_metric_after_block!(
-            th.net().metrics.tx_malformed_frames,
-            2,
-            th.event_manager.run_with_timeout(100)
-        );
+        let _ = th.event_manager.run_with_timeout(100);
+        assert_eq!(th.net().metrics.tx_malformed_frames.count(), 2);
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 4);
@@ -1916,11 +1887,8 @@ pub mod tests {
         th.add_desc_chain(NetQueue::Tx, 0, &desc_list);
         let frame = th.write_tx_frame(&desc_list, 1000);
 
-        check_metric_after_block!(
-            th.net().metrics.tx_packets_count,
-            1,
-            th.event_manager.run_with_timeout(100).unwrap()
-        );
+        th.event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(th.net().metrics.tx_packets_count.count(), 1);
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 1);
@@ -1949,11 +1917,8 @@ pub mod tests {
         th.add_desc_chain(NetQueue::Tx, 0, &desc_list);
         let _ = th.write_tx_frame(&desc_list, 1000);
 
-        check_metric_after_block!(
-            th.net().metrics.tap_write_fails,
-            1,
-            th.event_manager.run_with_timeout(100).unwrap()
-        );
+        th.event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(th.net().metrics.tap_write_fails.count(), 1);
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 1);
@@ -1984,11 +1949,8 @@ pub mod tests {
         th.add_desc_chain(NetQueue::Tx, 500, &desc_list);
         let frame_2 = th.write_tx_frame(&desc_list, 600);
 
-        check_metric_after_block!(
-            th.net().metrics.tx_packets_count,
-            2,
-            th.event_manager.run_with_timeout(100).unwrap()
-        );
+        th.event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(th.net().metrics.tx_packets_count.count(), 2);
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 2);
@@ -2075,29 +2037,23 @@ pub mod tests {
 
         // Call the code which sends the packet to the host or MMDS.
         // Validate the frame was consumed by MMDS and that the metrics reflect that.
-        check_metric_after_block!(
-            &METRICS.mmds.rx_accepted,
-            1,
-            assert!(
-                Net::write_to_mmds_or_tap(
-                    net.mmds_ns.as_mut(),
-                    &mut net.tx_rate_limiter,
-                    &mut headers,
-                    &buffer,
-                    &mut net.tap,
-                    Some(src_mac),
-                    &net.metrics,
-                )
-                .unwrap()
+        assert!(
+            Net::write_to_mmds_or_tap(
+                net.mmds_ns.as_mut(),
+                &mut net.tx_rate_limiter,
+                &mut headers,
+                &buffer,
+                &mut net.tap,
+                Some(src_mac),
+                &net.metrics,
             )
+            .unwrap()
         );
+        assert_eq!(METRICS.mmds.rx_accepted.count(), 1);
 
         // Validate that MMDS has a response and we can retrieve it.
-        check_metric_after_block!(
-            &METRICS.mmds.tx_frames,
-            1,
-            net.read_from_mmds_or_tap().unwrap()
-        );
+        net.read_from_mmds_or_tap().unwrap();
+        assert_eq!(METRICS.mmds.tx_frames.count(), 1);
     }
 
     #[test]
@@ -2115,34 +2071,29 @@ pub mod tests {
         let mut headers = vec![0; frame_hdr_len()];
 
         // Check that a legit MAC doesn't affect the spoofed MAC metric.
-        check_metric_after_block!(
-            net.metrics.tx_spoofed_mac_count,
-            0,
-            Net::write_to_mmds_or_tap(
-                net.mmds_ns.as_mut(),
-                &mut net.tx_rate_limiter,
-                &mut headers,
-                &buffer,
-                &mut net.tap,
-                Some(guest_mac),
-                &net.metrics,
-            )
+        let _ = Net::write_to_mmds_or_tap(
+            net.mmds_ns.as_mut(),
+            &mut net.tx_rate_limiter,
+            &mut headers,
+            &buffer,
+            &mut net.tap,
+            Some(guest_mac),
+            &net.metrics,
         );
+        assert_eq!(net.metrics.tx_spoofed_mac_count.count(), 0);
 
         // Check that a spoofed MAC increases our spoofed MAC metric.
-        check_metric_after_block!(
-            net.metrics.tx_spoofed_mac_count,
-            1,
-            Net::write_to_mmds_or_tap(
-                net.mmds_ns.as_mut(),
-                &mut net.tx_rate_limiter,
-                &mut headers,
-                &buffer,
-                &mut net.tap,
-                Some(not_guest_mac),
-                &net.metrics,
-            )
-        );
+        Net::write_to_mmds_or_tap(
+            net.mmds_ns.as_mut(),
+            &mut net.tx_rate_limiter,
+            &mut headers,
+            &buffer,
+            &mut net.tap,
+            Some(not_guest_mac),
+            &net.metrics,
+        )
+        .unwrap();
+        assert_eq!(net.metrics.tx_spoofed_mac_count.count(), 1);
     }
 
     #[test]
@@ -2153,19 +2104,13 @@ pub mod tests {
 
         // RX rate limiter events should error since the limiter is not blocked.
         // Validate that the event failed and failure was properly accounted for.
-        check_metric_after_block!(
-            th.net().metrics.event_fails,
-            1,
-            th.simulate_event(NetEvent::RxRateLimiter)
-        );
+        th.simulate_event(NetEvent::RxRateLimiter);
+        assert_eq!(th.net().metrics.event_fails.count(), 1);
 
         // TX rate limiter events should error since the limiter is not blocked.
         // Validate that the event failed and failure was properly accounted for.
-        check_metric_after_block!(
-            th.net().metrics.event_fails,
-            1,
-            th.simulate_event(NetEvent::TxRateLimiter)
-        );
+        th.simulate_event(NetEvent::TxRateLimiter);
+        assert_eq!(th.net().metrics.event_fails.count(), 2);
     }
 
     // Cannot easily test failures for:
@@ -2183,11 +2128,8 @@ pub mod tests {
         // The RX queue is empty and there is a deferred frame.
         th.net().rx_buffer.used_descriptors = 1;
         th.net().rx_buffer.used_bytes = 100;
-        check_metric_after_block!(
-            th.net().metrics.no_rx_avail_buffer,
-            1,
-            th.simulate_event(NetEvent::Tap)
-        );
+        th.simulate_event(NetEvent::Tap);
+        assert_eq!(th.net().metrics.no_rx_avail_buffer.count(), 1);
 
         // We need to set this here to false, otherwise the device will try to
         // handle a deferred frame, it will fail and will never try to read from
@@ -2200,11 +2142,8 @@ pub mod tests {
             0,
             &[(0, MAX_BUFFER_SIZE as u32, VIRTQ_DESC_F_WRITE)],
         );
-        check_metric_after_block!(
-            th.net().metrics.tap_read_fails,
-            1,
-            th.simulate_event(NetEvent::Tap)
-        );
+        th.simulate_event(NetEvent::Tap);
+        assert_eq!(th.net().metrics.tap_read_fails.count(), 1);
 
         // dropping th would double close the tap fd, so leak it
         std::mem::forget(th);
@@ -2218,11 +2157,8 @@ pub mod tests {
 
         th.net().rx_rate_limiter = RateLimiter::new(0, 0, 0, 0, 0, 0);
         // There is no actual event on the rate limiter's timerfd.
-        check_metric_after_block!(
-            th.net().metrics.event_fails,
-            1,
-            th.simulate_event(NetEvent::RxRateLimiter)
-        );
+        th.simulate_event(NetEvent::RxRateLimiter);
+        assert_eq!(th.net().metrics.event_fails.count(), 1);
     }
 
     #[test]
@@ -2234,11 +2170,8 @@ pub mod tests {
         th.net().tx_rate_limiter = RateLimiter::new(0, 0, 0, 0, 0, 0);
         th.simulate_event(NetEvent::TxRateLimiter);
         // There is no actual event on the rate limiter's timerfd.
-        check_metric_after_block!(
-            th.net().metrics.event_fails,
-            1,
-            th.simulate_event(NetEvent::TxRateLimiter)
-        );
+        th.simulate_event(NetEvent::TxRateLimiter);
+        assert_eq!(th.net().metrics.event_fails.count(), 2);
     }
 
     #[test]
@@ -2287,11 +2220,8 @@ pub mod tests {
             // following TX procedure should succeed because bandwidth should now be available
             {
                 // tx_count increments 1 from write_to_mmds_or_tap()
-                check_metric_after_block!(
-                    th.net().metrics.tx_count,
-                    1,
-                    th.simulate_event(NetEvent::TxRateLimiter)
-                );
+                th.simulate_event(NetEvent::TxRateLimiter);
+                assert_eq!(th.net().metrics.tx_count.count(), 1);
                 // This should be still blocked. We managed to send the first frame, but
                 // not enough budget for the second
                 assert!(th.net().tx_rate_limiter.is_blocked());
@@ -2304,11 +2234,8 @@ pub mod tests {
             // following TX procedure should succeed to handle the second frame as well
             {
                 // tx_count increments 1 from write_to_mmds_or_tap()
-                check_metric_after_block!(
-                    th.net().metrics.tx_count,
-                    1,
-                    th.simulate_event(NetEvent::TxRateLimiter)
-                );
+                th.simulate_event(NetEvent::TxRateLimiter);
+                assert_eq!(th.net().metrics.tx_count.count(), 2);
                 // validate the rate_limiter is no longer blocked
                 assert!(!th.net().tx_rate_limiter.is_blocked());
                 // make sure the data queue advance one more place
@@ -2372,11 +2299,8 @@ pub mod tests {
             // following RX procedure should succeed because bandwidth should now be available
             {
                 // no longer throttled
-                check_metric_after_block!(
-                    th.net().metrics.rx_rate_limiter_throttled,
-                    0,
-                    th.simulate_event(NetEvent::RxRateLimiter)
-                );
+                th.simulate_event(NetEvent::RxRateLimiter);
+                assert_eq!(th.net().metrics.rx_rate_limiter_throttled.count(), 2);
                 // validate the rate_limiter is no longer blocked
                 assert!(!th.net().rx_rate_limiter.is_blocked());
                 // make sure the virtio queue operation completed this time
@@ -2416,11 +2340,8 @@ pub mod tests {
             {
                 // trigger the TX handler
                 th.add_desc_chain(NetQueue::Tx, 0, &[(0, 4096, 0)]);
-                check_metric_after_block!(
-                    th.net().metrics.tx_rate_limiter_throttled,
-                    1,
-                    th.simulate_event(NetEvent::TxQueue)
-                );
+                th.simulate_event(NetEvent::TxQueue);
+                assert_eq!(th.net().metrics.tx_rate_limiter_throttled.count(), 1);
 
                 // assert that limiter is blocked
                 assert!(th.net().tx_rate_limiter.is_blocked());
@@ -2435,11 +2356,8 @@ pub mod tests {
             // following TX procedure should succeed because ops should now be available
             {
                 // no longer throttled
-                check_metric_after_block!(
-                    th.net().metrics.tx_rate_limiter_throttled,
-                    0,
-                    th.simulate_event(NetEvent::TxRateLimiter)
-                );
+                th.simulate_event(NetEvent::TxRateLimiter);
+                assert_eq!(th.net().metrics.tx_rate_limiter_throttled.count(), 1);
                 // validate the rate_limiter is no longer blocked
                 assert!(!th.net().tx_rate_limiter.is_blocked());
                 // make sure the data queue advanced
@@ -2470,11 +2388,8 @@ pub mod tests {
             // following RX procedure should fail because of ops rate limiting
             {
                 // trigger the RX handler
-                check_metric_after_block!(
-                    th.net().metrics.rx_rate_limiter_throttled,
-                    1,
-                    th.simulate_event(NetEvent::Tap)
-                );
+                th.simulate_event(NetEvent::Tap);
+                assert_eq!(th.net().metrics.rx_rate_limiter_throttled.count(), 1);
 
                 // assert that limiter is blocked
                 assert!(th.net().rx_rate_limiter.is_blocked());

--- a/src/vmm/src/devices/virtio/net/metrics.rs
+++ b/src/vmm/src/devices/virtio/net/metrics.rs
@@ -84,50 +84,23 @@ use serde::{Serialize, Serializer};
 
 use crate::logger::{IncMetric, LatencyAggregateMetrics, SharedIncMetric};
 
-/// map of network interface id and metrics
-/// this should be protected by a lock before accessing.
-#[derive(Debug)]
-pub struct NetMetricsPerDevice {
-    /// used to access per net device metrics
-    pub metrics: BTreeMap<String, Arc<NetDeviceMetrics>>,
-}
-
-impl NetMetricsPerDevice {
-    /// Allocate `NetDeviceMetrics` for net device having
-    /// id `iface_id`. Also, allocate only if it doesn't
-    /// exist to avoid overwriting previously allocated data.
-    /// lock is always initialized so it is safe the unwrap
-    /// the lock without a check.
-    pub fn alloc(iface_id: String) -> Arc<NetDeviceMetrics> {
-        Arc::clone(
-            METRICS
-                .write()
-                .unwrap()
-                .metrics
-                .entry(iface_id)
-                .or_insert_with(|| Arc::new(NetDeviceMetrics::default())),
-        )
-    }
-}
-
 /// Pool of Network-related metrics per device behind a lock to
 /// keep things thread safe. Since the lock is initialized here
 /// it is safe to unwrap it without any check.
-static METRICS: RwLock<NetMetricsPerDevice> = RwLock::new(NetMetricsPerDevice {
-    metrics: BTreeMap::new(),
-});
+pub(crate) static METRICS: RwLock<BTreeMap<String, Arc<NetDeviceMetrics>>> =
+    RwLock::new(BTreeMap::new());
 
 /// This function facilitates aggregation and serialization of
 /// per net device metrics.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let net_metrics = METRICS.read().unwrap();
-    let metrics_len = net_metrics.metrics.len();
-    // +1 to accommodate aggregate net metrics
+    let metrics_len = net_metrics.len();
+    // +1 to accomodate aggregate net metrics
     let mut seq = serializer.serialize_map(Some(1 + metrics_len))?;
 
     let mut net_aggregated: NetDeviceMetrics = NetDeviceMetrics::default();
 
-    for (name, metrics) in net_metrics.metrics.iter() {
+    for (name, metrics) in net_metrics.iter() {
         let devn = format!("net_{}", name);
         // serialization will flush the metrics so aggregate before it.
         let m: &NetDeviceMetrics = metrics;
@@ -260,171 +233,37 @@ pub mod tests {
     use super::*;
 
     #[test]
-    fn test_max_net_dev_metrics() {
-        // Note: this test has nothing to do with
-        // Net structure or IRQs, this is just to allocate
-        // metrics for max number of devices that system can have.
-        // we have 5-23 irq for net devices so max 19 net devices.
-        const MAX_NET_DEVICES: usize = 19;
+    fn test_net_metrics_aggregation() {
+        let metrics1 = NetDeviceMetrics::default();
+        metrics1.rx_bytes_count.add(1000);
+        metrics1.tx_bytes_count.add(1500);
 
-        drop(METRICS.read().unwrap());
-        drop(METRICS.write().unwrap());
+        let metrics2 = NetDeviceMetrics::default();
+        metrics2.rx_bytes_count.add(800);
+        metrics2.tx_bytes_count.add(200);
 
-        for i in 0..MAX_NET_DEVICES {
-            let devn: String = format!("eth{}", i);
-            NetMetricsPerDevice::alloc(devn.clone());
-            METRICS
-                .read()
-                .unwrap()
-                .metrics
-                .get(&devn)
-                .unwrap()
-                .activate_fails
-                .inc();
-            METRICS
-                .read()
-                .unwrap()
-                .metrics
-                .get(&devn)
-                .unwrap()
-                .rx_bytes_count
-                .add(10);
-            METRICS
-                .read()
-                .unwrap()
-                .metrics
-                .get(&devn)
-                .unwrap()
-                .tx_bytes_count
-                .add(5);
-        }
+        // Create an aggregated metrics instance
+        let mut aggregated = NetDeviceMetrics::default();
+        aggregated.aggregate(&metrics1);
+        aggregated.aggregate(&metrics2);
 
-        for i in 0..MAX_NET_DEVICES {
-            let devn: String = format!("eth{}", i);
-            assert!(
-                METRICS
-                    .read()
-                    .unwrap()
-                    .metrics
-                    .get(&devn)
-                    .unwrap()
-                    .activate_fails
-                    .count()
-                    >= 1
-            );
-            assert!(
-                METRICS
-                    .read()
-                    .unwrap()
-                    .metrics
-                    .get(&devn)
-                    .unwrap()
-                    .rx_bytes_count
-                    .count()
-                    >= 10
-            );
-            assert_eq!(
-                METRICS
-                    .read()
-                    .unwrap()
-                    .metrics
-                    .get(&devn)
-                    .unwrap()
-                    .tx_bytes_count
-                    .count(),
-                5
-            );
-        }
-    }
-    #[test]
-    fn test_signle_net_dev_metrics() {
-        // Use eth0 so that we can check thread safety with the
-        // `test_net_dev_metrics` which also uses the same name.
-        let devn = "eth0";
+        // Verify aggregated values
+        assert_eq!(aggregated.rx_bytes_count.count(), 1800);
+        assert_eq!(aggregated.tx_bytes_count.count(), 1700);
 
-        drop(METRICS.read().unwrap());
-        drop(METRICS.write().unwrap());
+        // Verify serialization of aggregated metrics
+        let serialized = serde_json::to_string(&aggregated).expect("Failed to serialize");
+        let json_value: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Failed to parse");
+        let obj = json_value.as_object().unwrap();
 
-        NetMetricsPerDevice::alloc(String::from(devn));
-        METRICS.read().unwrap().metrics.get(devn).unwrap();
-
-        METRICS
-            .read()
-            .unwrap()
-            .metrics
-            .get(devn)
-            .unwrap()
-            .activate_fails
-            .inc();
-        assert!(
-            METRICS
-                .read()
-                .unwrap()
-                .metrics
-                .get(devn)
-                .unwrap()
-                .activate_fails
-                .count()
-                > 0,
-            "{}",
-            METRICS
-                .read()
-                .unwrap()
-                .metrics
-                .get(devn)
-                .unwrap()
-                .activate_fails
-                .count()
+        assert_eq!(
+            obj.get("rx_bytes_count").and_then(|v| v.as_u64()),
+            Some(1800)
         );
-        // we expect only 2 tests (this and test_max_net_dev_metrics)
-        // to update activate_fails count for eth0.
-        assert!(
-            METRICS
-                .read()
-                .unwrap()
-                .metrics
-                .get(devn)
-                .unwrap()
-                .activate_fails
-                .count()
-                <= 2,
-            "{}",
-            METRICS
-                .read()
-                .unwrap()
-                .metrics
-                .get(devn)
-                .unwrap()
-                .activate_fails
-                .count()
-        );
-
-        METRICS
-            .read()
-            .unwrap()
-            .metrics
-            .get(devn)
-            .unwrap()
-            .activate_fails
-            .inc();
-        METRICS
-            .read()
-            .unwrap()
-            .metrics
-            .get(devn)
-            .unwrap()
-            .rx_bytes_count
-            .add(5);
-        assert!(
-            METRICS
-                .read()
-                .unwrap()
-                .metrics
-                .get(devn)
-                .unwrap()
-                .rx_bytes_count
-                .count()
-                >= 5
+        assert_eq!(
+            obj.get("tx_bytes_count").and_then(|v| v.as_u64()),
+            Some(1700)
         );
     }
 }

--- a/src/vmm/src/devices/virtio/net/test_utils.rs
+++ b/src/vmm/src/devices/virtio/net/test_utils.rs
@@ -293,7 +293,6 @@ pub mod test {
 
     use event_manager::{EventManager, SubscriberId, SubscriberOps};
 
-    use crate::check_metric_after_block;
     use crate::devices::virtio::device::VirtioDevice;
     use crate::devices::virtio::net::device::vnet_hdr_len;
     use crate::devices::virtio::net::generated::ETH_HLEN;
@@ -432,11 +431,8 @@ pub mod test {
 
             // Inject frame to tap and run epoll.
             let frame = inject_tap_tx_frame(&self.net(), frame_len);
-            check_metric_after_block!(
-                self.net().metrics.rx_packets_count,
-                0,
-                self.event_manager.run_with_timeout(100).unwrap()
-            );
+            self.event_manager.run_with_timeout(100).unwrap();
+            assert_eq!(self.net().metrics.rx_packets_count.count(), 0);
             // Check that the descriptor chain has been discarded.
             assert_eq!(
                 self.net().rx_buffer.used_descriptors,
@@ -466,11 +462,8 @@ pub mod test {
                 0,
                 &[(0, MAX_BUFFER_SIZE as u32, VIRTQ_DESC_F_WRITE)],
             );
-            check_metric_after_block!(
-                self.net().metrics.rx_packets_count,
-                1,
-                self.event_manager.run_with_timeout(100).unwrap()
-            );
+            self.event_manager.run_with_timeout(100).unwrap();
+            assert_eq!(self.net().metrics.rx_packets_count.count(), 1);
             // Check that the expected frame was sent to the Rx queue eventually.
             assert_eq!(self.rxq.used.idx.get(), used_idx + 1);
             assert!(

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -482,8 +482,11 @@ mod tests {
         temp_uds_path.remove().unwrap();
         let uds_path = String::from(temp_uds_path.as_path().to_str().unwrap());
         let backend = VsockUnixBackend::new(guest_cid, uds_path).unwrap();
-        let vsock = Vsock::new(guest_cid, backend).unwrap();
-        let vsock = Arc::new(Mutex::new(vsock));
+
+        let backend_metrics = backend.metrics.clone();
+        let vsock = Arc::new(Mutex::new(
+            Vsock::new(guest_cid, backend, backend_metrics).unwrap(),
+        ));
         let mmio_transport =
             MmioTransport::new(mem.clone(), interrupt.clone(), vsock.clone(), false);
 

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -16,7 +16,7 @@ use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::pmem::PMEM_QUEUE_SIZE;
-use crate::devices::virtio::pmem::metrics::{PmemMetrics, PmemMetricsPerDevice};
+use crate::devices::virtio::pmem::metrics::{METRICS, PmemMetrics};
 use crate::devices::virtio::queue::{DescriptorChain, InvalidAvailIdx, Queue, QueueError};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::logger::{IncMetric, error, info, warn};
@@ -330,6 +330,11 @@ impl Pmem {
             0
         };
         let kvm_mem_slot = KvmMemSlot::new(vm, cs.start, cs.size, mmap.mmap_ptr, flags)?;
+        let metrics = Arc::new(PmemMetrics::default());
+        METRICS
+            .write()
+            .unwrap()
+            .insert(config.id.clone(), metrics.clone());
 
         let rate_limiter = config
             .rate_limiter
@@ -344,7 +349,7 @@ impl Pmem {
             queues,
             queue_events: vec![EventFd::new(libc::EFD_NONBLOCK).map_err(PmemError::EventFd)?],
             guest_region,
-            metrics: PmemMetricsPerDevice::alloc(config.id.clone()),
+            metrics,
             rate_limiter,
             config,
             mmap,

--- a/src/vmm/src/devices/virtio/pmem/metrics.rs
+++ b/src/vmm/src/devices/virtio/pmem/metrics.rs
@@ -86,50 +86,23 @@ use serde::{Serialize, Serializer};
 
 use crate::logger::{IncMetric, SharedIncMetric};
 
-/// map of pmem drive id and metrics
-/// this should be protected by a lock before accessing.
-#[derive(Debug)]
-pub struct PmemMetricsPerDevice {
-    /// used to access per pmem device metrics
-    pub metrics: BTreeMap<String, Arc<PmemMetrics>>,
-}
-
-impl PmemMetricsPerDevice {
-    /// Allocate `PmemDeviceMetrics` for pmem device having
-    /// id `drive_id`. Also, allocate only if it doesn't
-    /// exist to avoid overwriting previously allocated data.
-    /// lock is always initialized so it is safe the unwrap
-    /// the lock without a check.
-    pub fn alloc(drive_id: String) -> Arc<PmemMetrics> {
-        Arc::clone(
-            METRICS
-                .write()
-                .unwrap()
-                .metrics
-                .entry(drive_id)
-                .or_insert_with(|| Arc::new(PmemMetrics::default())),
-        )
-    }
-}
-
 /// Pool of pmem-related metrics per device behind a lock to
 /// keep things thread safe. Since the lock is initialized here
 /// it is safe to unwrap it without any check.
-static METRICS: RwLock<PmemMetricsPerDevice> = RwLock::new(PmemMetricsPerDevice {
-    metrics: BTreeMap::new(),
-});
+pub(crate) static METRICS: RwLock<BTreeMap<String, Arc<PmemMetrics>>> =
+    RwLock::new(BTreeMap::new());
 
 /// This function facilitates aggregation and serialization of
 /// per pmem device metrics.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let pmem_metrics = METRICS.read().unwrap();
-    let metrics_len = pmem_metrics.metrics.len();
+    let metrics_len = pmem_metrics.len();
     // +1 to accommodate aggregate pmem metrics
     let mut seq = serializer.serialize_map(Some(1 + metrics_len))?;
 
     let mut pmem_aggregated: PmemMetrics = PmemMetrics::default();
 
-    for (name, metrics) in pmem_metrics.metrics.iter() {
+    for (name, metrics) in pmem_metrics.iter() {
         let devn = format!("pmem_{}", name);
         // serialization will flush the metrics so aggregate before it.
         let m: &PmemMetrics = metrics;
@@ -188,65 +161,37 @@ pub mod tests {
     use super::*;
 
     #[test]
-    fn test_max_pmem_dev_metrics() {
-        // Note: this test has nothing to do with
-        // pmem structure or IRQs, this is just to allocate
-        // metrics for max number of devices that system can have.
-        // We have 5-23 IRQ for pmem devices on x86_64 so, there
-        // are 19 pmem devices at max. And, even though we have more
-        // devices on aarch64 but we stick to 19 to keep test common.
-        const MAX_PMEM_DEVICES: usize = 19;
+    fn test_pmem_metrics_aggregation() {
+        let metrics1 = PmemMetrics::default();
+        metrics1.queue_event_count.add(1000);
+        metrics1.rate_limiter_event_count.add(1500);
 
-        // This is to make sure that RwLock for pmem::metrics::METRICS is good.
-        drop(METRICS.read().unwrap());
-        drop(METRICS.write().unwrap());
+        let metrics2 = PmemMetrics::default();
+        metrics2.queue_event_count.add(800);
+        metrics2.rate_limiter_event_count.add(200);
 
-        // pmem::metrics::METRICS is in short RwLock on Vec of PmemDeviceMetrics.
-        // Normally, pointer to unique entries of pmem::metrics::METRICS are stored
-        // in Pmem device so that Pmem device can do self.metrics.* to
-        // update a metric. We try to do something similar here without
-        // using Pmem device by allocating max number of
-        // PmemDeviceMetrics in pmem::metrics::METRICS and store pointer to
-        // each entry in the local `metrics` vec.
-        // We then update 1 IncMetric and 2 SharedMetric for each metrics
-        // and validate if the metrics for per device was updated as
-        // expected.
-        let mut metrics: Vec<Arc<PmemMetrics>> = Vec::new();
-        for i in 0..MAX_PMEM_DEVICES {
-            let pmem_name: String = format!("pmem{}", i);
-            metrics.push(PmemMetricsPerDevice::alloc(pmem_name.clone()));
-            // update IncMetric
-            metrics[i].activate_fails.inc();
+        // Create an aggregated metrics instance
+        let mut aggregated = PmemMetrics::default();
+        aggregated.aggregate(&metrics1);
+        aggregated.aggregate(&metrics2);
 
-            if i == 0 {
-                // Unit tests run in parallel and we have
-                // `test_single_pmem_dev_metrics` that also increases
-                // the IncMetric count of drv0 by 1 (intentional to check
-                // thread safety) so we check if the count is >=1.
-                assert!(metrics[i].activate_fails.count() >= 1);
-            } else {
-                assert!(metrics[i].activate_fails.count() == 1);
-            }
-        }
-    }
+        // Verify aggregated values
+        assert_eq!(aggregated.queue_event_count.count(), 1800);
+        assert_eq!(aggregated.rate_limiter_event_count.count(), 1700);
 
-    #[test]
-    fn test_single_pmem_dev_metrics() {
-        let test_metrics = PmemMetricsPerDevice::alloc(String::from("pmem0"));
-        // Test to update IncMetrics
-        test_metrics.activate_fails.inc();
-        assert!(
-            test_metrics.activate_fails.count() > 0,
-            "{}",
-            test_metrics.activate_fails.count()
+        // Verify serialization of aggregated metrics
+        let serialized = serde_json::to_string(&aggregated).expect("Failed to serialize");
+        let json_value: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Failed to parse");
+        let obj = json_value.as_object().unwrap();
+
+        assert_eq!(
+            obj.get("queue_event_count").and_then(|v| v.as_u64()),
+            Some(1800)
         );
-
-        // We expect only 2 tests (this and test_max_pmem_dev_metrics)
-        // to update activate_fails count for pmem0.
-        assert!(
-            test_metrics.activate_fails.count() <= 2,
-            "{}",
-            test_metrics.activate_fails.count()
+        assert_eq!(
+            obj.get("rate_limiter_event_count").and_then(|v| v.as_u64()),
+            Some(1700)
         );
     }
 }

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -18,6 +18,7 @@ use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::iov_deque::IovDequeError;
 use crate::devices::virtio::iovec::IoVecBufferMut;
 use crate::devices::virtio::queue::{FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue};
+use crate::devices::virtio::rng::metrics::EntropyDeviceMetrics;
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, debug, error};
@@ -62,6 +63,7 @@ pub struct Entropy {
     pub(crate) rate_limiter: RateLimiter,
 
     buffer: IoVecBufferMut,
+    metrics: Arc<EntropyDeviceMetrics>,
 }
 
 impl Entropy {
@@ -78,6 +80,8 @@ impl Entropy {
         let queue_events = (0..RNG_NUM_QUEUES)
             .map(|_| EventFd::new(libc::EFD_NONBLOCK))
             .collect::<Result<Vec<EventFd>, io::Error>>()?;
+        let metrics = Arc::new(EntropyDeviceMetrics::default());
+        let _ = METRICS.write().unwrap().replace(metrics.clone());
 
         Ok(Self {
             avail_features: 1 << VIRTIO_F_VERSION_1,
@@ -88,6 +92,7 @@ impl Entropy {
             queue_events,
             rate_limiter,
             buffer: IoVecBufferMut::new()?,
+            metrics,
         })
     }
 
@@ -128,7 +133,7 @@ impl Entropy {
 
         let mut rand_bytes = vec![0; len as usize];
         rand::fill(&mut rand_bytes).inspect_err(|_| {
-            METRICS.host_rng_fails.inc();
+            self.metrics.host_rng_fails.inc();
         })?;
 
         // It is ok to unwrap here. We are writing `len` bytes at offset 0.
@@ -142,7 +147,7 @@ impl Entropy {
             // This is safe since we checked in the event handler that the device is activated.
             let mem = &self.device_state.active_state().unwrap().mem;
             let index = desc.index;
-            METRICS.entropy_event_count.inc();
+            self.metrics.entropy_event_count.inc();
 
             // SAFETY: This descriptor chain points to a single `DescriptorChain` memory buffer,
             // no other `IoVecBufferMut` object points to the same `DescriptorChain` at the same
@@ -159,20 +164,20 @@ impl Entropy {
                     // to handle once we do have budget.
                     if !self.rate_limit_request(u64::from(self.buffer.len())) {
                         debug!("entropy: throttling entropy queue");
-                        METRICS.entropy_rate_limiter_throttled.inc();
+                        self.metrics.entropy_rate_limiter_throttled.inc();
                         self.queues[RNG_QUEUE].undo_pop();
                         break;
                     }
 
                     self.handle_one().unwrap_or_else(|err| {
                         error!("entropy: {err}");
-                        METRICS.entropy_event_fails.inc();
+                        self.metrics.entropy_event_fails.inc();
                         0
                     })
                 }
                 Err(err) => {
                     error!("entropy: Could not parse descriptor chain: {err}");
-                    METRICS.entropy_event_fails.inc();
+                    self.metrics.entropy_event_fails.inc();
                     0
                 }
             };
@@ -180,12 +185,12 @@ impl Entropy {
             match self.queues[RNG_QUEUE].add_used(index, bytes) {
                 Ok(_) => {
                     used_any = true;
-                    METRICS.entropy_bytes.add(bytes.into());
+                    self.metrics.entropy_bytes.add(bytes.into());
                 }
                 Err(err) => {
                     error!("entropy: Could not add used descriptor to queue: {err}");
                     Self::rate_limit_replenish_request(&mut self.rate_limiter, bytes.into());
-                    METRICS.entropy_event_fails.inc();
+                    self.metrics.entropy_event_fails.inc();
                     // If we are not able to add a buffer to the used queue, something
                     // is probably seriously wrong, so just stop processing additional
                     // buffers
@@ -198,7 +203,7 @@ impl Entropy {
         if used_any {
             self.signal_used_queue().unwrap_or_else(|err| {
                 error!("entropy: {err:?}");
-                METRICS.entropy_event_fails.inc()
+                self.metrics.entropy_event_fails.inc()
             });
         }
 
@@ -208,17 +213,17 @@ impl Entropy {
     pub(crate) fn process_entropy_queue_event(&mut self) {
         if let Err(err) = self.queue_events[RNG_QUEUE].read() {
             error!("Failed to read entropy queue event: {err}");
-            METRICS.entropy_event_fails.inc();
+            self.metrics.entropy_event_fails.inc();
         } else if !self.rate_limiter.is_blocked() {
             // We are not throttled, handle the entropy queue
             self.process_entropy_queue().unwrap()
         } else {
-            METRICS.rate_limiter_event_count.inc();
+            self.metrics.rate_limiter_event_count.inc();
         }
     }
 
     pub(crate) fn process_rate_limiter_event(&mut self) {
-        METRICS.rate_limiter_event_count.inc();
+        self.metrics.rate_limiter_event_count.inc();
         match self.rate_limiter.event_handler() {
             Ok(_) => {
                 // There might be enough budget now to process entropy requests.
@@ -226,7 +231,7 @@ impl Entropy {
             }
             Err(err) => {
                 error!("entropy: Failed to handle rate-limiter event: {err:?}");
-                METRICS.entropy_event_fails.inc();
+                self.metrics.entropy_event_fails.inc();
             }
         }
     }
@@ -322,7 +327,7 @@ impl VirtioDevice for Entropy {
         }
 
         self.activate_event.write(1).map_err(|_| {
-            METRICS.activate_fails.inc();
+            self.metrics.activate_fails.inc();
             ActivateError::EventFd
         })?;
         self.device_state = DeviceState::Activated(ActiveState { mem, interrupt });
@@ -335,7 +340,6 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::check_metric_after_block;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
     use crate::devices::virtio::queue::VIRTQ_DESC_F_WRITE;
     use crate::devices::virtio::test_utils::test::{
@@ -450,29 +454,21 @@ mod tests {
         // Add a read-only descriptor (this should fail)
         th.add_desc_chain(RNG_QUEUE, 0, &[(0, 64, 0)]);
 
-        let entropy_event_fails = METRICS.entropy_event_fails.count();
-        let entropy_event_count = METRICS.entropy_event_count.count();
-        let entropy_bytes = METRICS.entropy_bytes.count();
-        let host_rng_fails = METRICS.host_rng_fails.count();
         assert_eq!(th.emulate_for_msec(100).unwrap(), 1);
-        assert_eq!(METRICS.entropy_event_fails.count(), entropy_event_fails + 1);
-        assert_eq!(METRICS.entropy_event_count.count(), entropy_event_count + 1);
-        assert_eq!(METRICS.entropy_bytes.count(), entropy_bytes);
-        assert_eq!(METRICS.host_rng_fails.count(), host_rng_fails);
+        assert_eq!(th.device().metrics.entropy_event_fails.count(), 1);
+        assert_eq!(th.device().metrics.entropy_event_count.count(), 1);
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 0);
+        assert_eq!(th.device().metrics.host_rng_fails.count(), 0);
 
         // Add two good descriptors
         th.add_desc_chain(RNG_QUEUE, 0, &[(1, 10, VIRTQ_DESC_F_WRITE)]);
         th.add_desc_chain(RNG_QUEUE, 100, &[(2, 20, VIRTQ_DESC_F_WRITE)]);
 
-        let entropy_event_fails = METRICS.entropy_event_fails.count();
-        let entropy_event_count = METRICS.entropy_event_count.count();
-        let entropy_bytes = METRICS.entropy_bytes.count();
-        let host_rng_fails = METRICS.host_rng_fails.count();
         assert_eq!(th.emulate_for_msec(100).unwrap(), 1);
-        assert_eq!(METRICS.entropy_event_fails.count(), entropy_event_fails);
-        assert_eq!(METRICS.entropy_event_count.count(), entropy_event_count + 2);
-        assert_eq!(METRICS.entropy_bytes.count(), entropy_bytes + 30);
-        assert_eq!(METRICS.host_rng_fails.count(), host_rng_fails);
+        assert_eq!(th.device().metrics.entropy_event_fails.count(), 1);
+        assert_eq!(th.device().metrics.entropy_event_count.count(), 3);
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 30);
+        assert_eq!(th.device().metrics.host_rng_fails.count(), 0);
 
         th.add_desc_chain(
             RNG_QUEUE,
@@ -484,15 +480,11 @@ mod tests {
             ],
         );
 
-        let entropy_event_fails = METRICS.entropy_event_fails.count();
-        let entropy_event_count = METRICS.entropy_event_count.count();
-        let entropy_bytes = METRICS.entropy_bytes.count();
-        let host_rng_fails = METRICS.host_rng_fails.count();
         assert_eq!(th.emulate_for_msec(100).unwrap(), 1);
-        assert_eq!(METRICS.entropy_event_fails.count(), entropy_event_fails);
-        assert_eq!(METRICS.entropy_event_count.count(), entropy_event_count + 1);
-        assert_eq!(METRICS.entropy_bytes.count(), entropy_bytes + 512);
-        assert_eq!(METRICS.host_rng_fails.count(), host_rng_fails);
+        assert_eq!(th.device().metrics.entropy_event_fails.count(), 1);
+        assert_eq!(th.device().metrics.entropy_event_count.count(), 4);
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 542);
+        assert_eq!(th.device().metrics.host_rng_fails.count(), 0);
     }
 
     #[test]
@@ -503,11 +495,8 @@ mod tests {
         th.activate_device(&mem);
         let mut dev = th.device();
 
-        check_metric_after_block!(
-            &METRICS.entropy_event_fails,
-            1,
-            dev.process_rate_limiter_event()
-        );
+        dev.process_rate_limiter_event();
+        assert_eq!(dev.metrics.entropy_event_fails.count(), 1);
     }
 
     #[test]
@@ -522,11 +511,8 @@ mod tests {
         // We are asking for 4000 bytes which should be available, so the
         // buffer should be processed normally
         th.add_desc_chain(RNG_QUEUE, 0, &[(0, 4000, VIRTQ_DESC_F_WRITE)]);
-        check_metric_after_block!(
-            METRICS.entropy_bytes,
-            4000,
-            th.device().process_entropy_queue()
-        );
+        th.device().process_entropy_queue().unwrap();
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 4000);
         assert!(!th.device().rate_limiter.is_blocked());
 
         // Completely replenish the rate limiter
@@ -538,22 +524,20 @@ mod tests {
         // so the next one should be throttled.
         th.add_desc_chain(RNG_QUEUE, 0, &[(0, 4000, VIRTQ_DESC_F_WRITE)]);
         th.add_desc_chain(RNG_QUEUE, 1, &[(1, 1000, VIRTQ_DESC_F_WRITE)]);
-        check_metric_after_block!(
-            METRICS.entropy_bytes,
-            4000,
-            th.device().process_entropy_queue()
-        );
-        check_metric_after_block!(
-            METRICS.entropy_rate_limiter_throttled,
-            1,
-            th.device().process_entropy_queue()
+        th.device().process_entropy_queue().unwrap();
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 8000);
+        th.device().process_entropy_queue().unwrap();
+        assert_eq!(
+            th.device().metrics.entropy_rate_limiter_throttled.count(),
+            2
         );
         assert!(th.device().rate_limiter().is_blocked());
 
         // 250 msec should give enough time for replenishing 1000 bytes worth of tokens.
         // Give it an extra 100 ms just to be sure the timer event reaches us from the kernel.
         std::thread::sleep(Duration::from_millis(350));
-        check_metric_after_block!(METRICS.entropy_bytes, 1000, th.emulate_for_msec(100));
+        th.emulate_for_msec(100).unwrap();
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 9000);
         assert!(!th.device().rate_limiter().is_blocked());
     }
 
@@ -570,42 +554,35 @@ mod tests {
         // We don't have a bandwidth limit and we can do 10 requests per sec
         // so this should succeed.
         th.add_desc_chain(RNG_QUEUE, 0, &[(0, 4000, VIRTQ_DESC_F_WRITE)]);
-        check_metric_after_block!(
-            METRICS.entropy_bytes,
-            4000,
-            th.device().process_entropy_queue()
-        );
+        th.device().process_entropy_queue().unwrap();
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 4000);
         assert!(!th.device().rate_limiter.is_blocked());
 
         // Sleep for 1 second to completely replenish the rate limiter
         std::thread::sleep(Duration::from_millis(1000));
 
         // First one should succeed
-        let entropy_bytes = METRICS.entropy_bytes.count();
         th.add_desc_chain(RNG_QUEUE, 0, &[(0, 64, VIRTQ_DESC_F_WRITE)]);
-        check_metric_after_block!(METRICS.entropy_bytes, 64, th.emulate_for_msec(100));
-        assert_eq!(METRICS.entropy_bytes.count(), entropy_bytes + 64);
+        th.emulate_for_msec(100).unwrap();
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 4064);
         // The rate limiter is not blocked yet.
         assert!(!th.device().rate_limiter().is_blocked());
         // But immediately asking another operation should block it because we have 1 op every 100
         // msec.
         th.add_desc_chain(RNG_QUEUE, 0, &[(0, 64, VIRTQ_DESC_F_WRITE)]);
-        check_metric_after_block!(
-            METRICS.entropy_rate_limiter_throttled,
-            1,
-            th.emulate_for_msec(50)
+        th.emulate_for_msec(50).unwrap();
+        assert_eq!(
+            th.device().metrics.entropy_rate_limiter_throttled.count(),
+            1
         );
         // Entropy bytes count should not have increased.
-        assert_eq!(METRICS.entropy_bytes.count(), entropy_bytes + 64);
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 4064);
         // After 100 msec (plus 50 msec for ensuring the event reaches us from the kernel), the
         // timer of the rate limiter should fire saying that there's now more tokens available
-        check_metric_after_block!(
-            METRICS.rate_limiter_event_count,
-            1,
-            th.emulate_for_msec(150)
-        );
+        th.emulate_for_msec(150).unwrap();
+        assert_eq!(th.device().metrics.rate_limiter_event_count.count(), 1);
         // The rate limiter event should have processed the pending buffer as well
-        assert_eq!(METRICS.entropy_bytes.count(), entropy_bytes + 128);
+        assert_eq!(th.device().metrics.entropy_bytes.count(), 4128);
     }
 
     /// Verify that handle_one() caps the host allocation to MAX_ENTROPY_BYTES

--- a/src/vmm/src/devices/virtio/rng/metrics.rs
+++ b/src/vmm/src/devices/virtio/rng/metrics.rs
@@ -37,19 +37,25 @@ use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 
 use crate::logger::SharedIncMetric;
+use std::sync::{Arc, RwLock};
 
-/// Stores aggregated entropy metrics
-pub(super) static METRICS: EntropyDeviceMetrics = EntropyDeviceMetrics::new();
-
-/// Called by METRICS.flush(), this function facilitates serialization of entropy device metrics.
+/// This function facilitates aggregation and serialization of rng metrics.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let mut seq = serializer.serialize_map(Some(1))?;
-    seq.serialize_entry("entropy", &METRICS)?;
+    let dev_name = "entropy";
+    match METRICS.read().unwrap().as_ref() {
+        Some(metrics) => seq.serialize_entry(dev_name, &metrics)?,
+        None => seq.serialize_entry(dev_name, &EntropyDeviceMetrics::default())?,
+    }
+
     seq.end()
 }
 
-#[derive(Debug, Serialize)]
-pub(super) struct EntropyDeviceMetrics {
+/// Stores aggregated rng metrics
+pub(crate) static METRICS: RwLock<Option<Arc<EntropyDeviceMetrics>>> = RwLock::new(None);
+
+#[derive(Debug, Serialize, Default)]
+pub struct EntropyDeviceMetrics {
     /// Number of device activation failures
     pub activate_fails: SharedIncMetric,
     /// Number of entropy queue event handling failures
@@ -65,20 +71,6 @@ pub(super) struct EntropyDeviceMetrics {
     /// Number of events associated with the rate limiter
     pub rate_limiter_event_count: SharedIncMetric,
 }
-impl EntropyDeviceMetrics {
-    /// Const default construction.
-    const fn new() -> Self {
-        Self {
-            activate_fails: SharedIncMetric::new(),
-            entropy_event_fails: SharedIncMetric::new(),
-            entropy_event_count: SharedIncMetric::new(),
-            entropy_bytes: SharedIncMetric::new(),
-            host_rng_fails: SharedIncMetric::new(),
-            entropy_rate_limiter_throttled: SharedIncMetric::new(),
-            rate_limiter_event_count: SharedIncMetric::new(),
-        }
-    }
-}
 
 #[cfg(test)]
 pub mod tests {
@@ -86,15 +78,23 @@ pub mod tests {
     use crate::logger::IncMetric;
 
     #[test]
-    fn test_entropy_dev_metrics() {
-        let entropy_metrics: EntropyDeviceMetrics = EntropyDeviceMetrics::new();
-        let entropy_metrics_local: String = serde_json::to_string(&entropy_metrics).unwrap();
-        // the 1st serialize flushes the metrics and resets values to 0 so that
-        // we can compare the values with local metrics.
-        serde_json::to_string(&METRICS).unwrap();
-        let entropy_metrics_global: String = serde_json::to_string(&METRICS).unwrap();
-        assert_eq!(entropy_metrics_local, entropy_metrics_global);
-        entropy_metrics.entropy_event_count.inc();
-        assert_eq!(entropy_metrics.entropy_event_count.count(), 1);
+    fn test_rng_dev_metrics() {
+        let metrics_instance = EntropyDeviceMetrics::default();
+        metrics_instance.activate_fails.inc();
+        metrics_instance.entropy_bytes.add(10);
+        metrics_instance.host_rng_fails.add(5);
+
+        assert!(metrics_instance.activate_fails.count() >= 1);
+        assert!(metrics_instance.entropy_bytes.count() >= 10);
+        assert_eq!(metrics_instance.host_rng_fails.count(), 5);
+
+        let serialized = serde_json::to_string(&metrics_instance).unwrap();
+        let json_value: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Failed to parse");
+        let obj = json_value.as_object().unwrap();
+
+        assert_eq!(obj.get("activate_fails").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(obj.get("entropy_bytes").and_then(|v| v.as_u64()), Some(10));
+        assert_eq!(obj.get("host_rng_fails").and_then(|v| v.as_u64()), Some(5));
     }
 }

--- a/src/vmm/src/devices/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/test_utils.rs
@@ -17,15 +17,6 @@ use crate::test_utils::single_region_mem;
 use crate::utils::u64_to_usize;
 use crate::vstate::memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
 
-#[macro_export]
-macro_rules! check_metric_after_block {
-    ($metric:expr, $delta:expr, $block:expr) => {{
-        let before = $metric.count();
-        let _ = $block;
-        assert_eq!($metric.count() - before, $delta, "unexpected metric value");
-    }};
-}
-
 /// Creates a [`GuestMemoryMmap`] with a single region  of size 65536 (= 0x10000 hex) starting at
 /// guest physical address 0
 pub fn default_mem() -> GuestMemoryMmap {

--- a/src/vmm/src/devices/virtio/vhost_user_metrics.rs
+++ b/src/vmm/src/devices/virtio/vhost_user_metrics.rs
@@ -81,46 +81,19 @@ use serde::{Serialize, Serializer};
 
 use crate::logger::{SharedIncMetric, SharedStoreMetric};
 
-/// map of vhost_user drive id and metrics
-/// this should be protected by a lock before accessing.
-#[allow(missing_debug_implementations)]
-pub struct VhostUserMetricsPerDevice {
-    /// used to access per vhost_user device metrics
-    pub metrics: BTreeMap<String, Arc<VhostUserDeviceMetrics>>,
-}
-
-impl VhostUserMetricsPerDevice {
-    /// Allocate `VhostUserDeviceMetrics` for vhost_user device having
-    /// id `drive_id`. Also, allocate only if it doesn't
-    /// exist to avoid overwriting previously allocated data.
-    /// lock is always initialized so it is safe the unwrap
-    /// the lock without a check.
-    pub fn alloc(drive_id: String) -> Arc<VhostUserDeviceMetrics> {
-        Arc::clone(
-            METRICS
-                .write()
-                .unwrap()
-                .metrics
-                .entry(drive_id)
-                .or_insert_with(|| Arc::new(VhostUserDeviceMetrics::default())),
-        )
-    }
-}
-
 /// Pool of vhost_user-related metrics per device behind a lock to
 /// keep things thread safe. Since the lock is initialized here
 /// it is safe to unwrap it without any check.
-static METRICS: RwLock<VhostUserMetricsPerDevice> = RwLock::new(VhostUserMetricsPerDevice {
-    metrics: BTreeMap::new(),
-});
+pub(crate) static METRICS: RwLock<BTreeMap<String, Arc<VhostUserDeviceMetrics>>> =
+    RwLock::new(BTreeMap::new());
 
 /// This function facilitates serialization of vhost_user device metrics.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let vhost_user_metrics = METRICS.read().unwrap();
-    let metrics_len = vhost_user_metrics.metrics.len();
+    let metrics_len = vhost_user_metrics.len();
     let mut seq = serializer.serialize_map(Some(metrics_len))?;
 
-    for (name, metrics) in vhost_user_metrics.metrics.iter() {
+    for (name, metrics) in vhost_user_metrics.iter() {
         let devn = format!("vhost_user_{}", name);
         seq.serialize_entry(&devn, metrics)?;
     }
@@ -144,26 +117,16 @@ pub struct VhostUserDeviceMetrics {
 
 #[cfg(test)]
 pub mod tests {
+    use crate::logger::{IncMetric, StoreMetric};
     use utils::time::{ClockType, get_time_us};
 
     use super::*;
-    use crate::logger::{IncMetric, StoreMetric};
 
-    // vhost-user metrics has both SharedIncMetrics and SharedStoreMetrics
-    // In this test we try to test one field for each type by creating a
-    // dummy vhost_user_block metric named `vhost_user_block_drvN`.
-    // There is no specific reason to storing the measured time taken vs a
-    // random number in `init_time_us`.
-    // We add an additional test to confirm that `vhost_user_metrics::METRICS`
-    // actually has an entry for `vhost_user_block_drvN` and compare it.
-    // We chose serde_json to compare because that seemed easiest to compare
-    // the entire struct format and serialization of VhostUserDeviceMetrics.
     #[test]
     fn test_vhost_user_basic_metrics() {
-        let vhost_user_dev_name: String = String::from("vhost_user_block_drvN");
         let start_time = get_time_us(ClockType::Monotonic);
-        let vhost_user_metrics: Arc<VhostUserDeviceMetrics> =
-            VhostUserMetricsPerDevice::alloc(vhost_user_dev_name.clone());
+        let vhost_user_metrics = VhostUserDeviceMetrics::default();
+
         let delta_us = get_time_us(ClockType::Monotonic) - start_time;
         vhost_user_metrics.activate_fails.inc();
         assert_eq!(vhost_user_metrics.activate_fails.count(), 1);
@@ -171,19 +134,18 @@ pub mod tests {
         vhost_user_metrics.init_time_us.store(delta_us);
         assert_eq!(vhost_user_metrics.init_time_us.fetch(), delta_us);
 
-        // fill another local variable with the same data and use it to compare with the METRICS
-        // entry
+        // create an empty instance to assert json structure
         let vhost_user_metrics_backup: VhostUserDeviceMetrics = VhostUserDeviceMetrics::default();
-        vhost_user_metrics_backup.activate_fails.inc();
-        vhost_user_metrics_backup.init_time_us.store(delta_us);
 
-        // serializing METRICS also flushes the SharedIncMetric data so we have to use _backup
-        // variable for comparison.
-        let vhost_user_metrics_global: String =
-            serde_json::to_string(&METRICS.read().unwrap().metrics.get(&vhost_user_dev_name))
-                .unwrap();
-        let vhost_user_metrics_local: String =
-            serde_json::to_string(&vhost_user_metrics_backup).unwrap();
-        assert_eq!(vhost_user_metrics_local, vhost_user_metrics_global);
+        let vu_metrics_1 = serde_json::to_string(&vhost_user_metrics).unwrap();
+        let json_val1: serde_json::Value = serde_json::from_str(&vu_metrics_1).unwrap();
+        let obj1 = json_val1.as_object().unwrap();
+
+        let vu_metrics_2 = serde_json::to_string(&vhost_user_metrics_backup).unwrap();
+        let json_val2: serde_json::Value = serde_json::from_str(&vu_metrics_2).unwrap();
+        let obj2 = json_val2.as_object().unwrap();
+
+        assert!(obj1.len() == obj2.len());
+        assert!(obj1.keys().all(|key| obj2.contains_key(key)));
     }
 }

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -80,6 +80,7 @@ use std::fmt::Debug;
 use std::io::{ErrorKind, Write};
 use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use vm_memory::GuestMemoryError;
@@ -90,7 +91,7 @@ use super::super::defs::uapi;
 use super::super::{VsockChannel, VsockEpollListener, VsockError};
 use super::txbuf::TxBuf;
 use super::{ConnState, PendingRx, PendingRxSet, VsockCsmError, defs};
-use crate::devices::virtio::vsock::metrics::METRICS;
+use crate::devices::virtio::vsock::metrics::VsockDeviceMetrics;
 use crate::devices::virtio::vsock::packet::{VsockPacketHeader, VsockPacketRx, VsockPacketTx};
 use crate::logger::{IncMetric, debug, error, info, warn};
 use crate::utils::wrap_usize_to_u32;
@@ -138,6 +139,8 @@ pub struct VsockConnection<S: VsockConnectionBackend> {
     /// Instant when this connection should be scheduled for immediate termination, due to some
     /// timeout condition having been fulfilled.
     expiry: Option<Instant>,
+    /// Metrics per device counter
+    metrics: Arc<VsockDeviceMetrics>,
 }
 
 impl<S> VsockChannel for VsockConnection<S>
@@ -163,7 +166,7 @@ where
         // Perform some generic initialization that is the same for any packet operation (e.g.
         // source, destination, credit, etc).
         self.init_pkt_hdr(&mut pkt.hdr);
-        METRICS.rx_packets_count.inc();
+        self.metrics.rx_packets_count.inc();
 
         // If forceful termination is pending, there's no point in checking for anything else.
         // It's dead, Jim.
@@ -238,7 +241,7 @@ where
                         // Safe to unwrap because read_cnt is no more than max_len, which is bounded
                         // by self.peer_avail_credit(), a u32 internally.
                         pkt.hdr.set_op(uapi::VSOCK_OP_RW).set_len(read_cnt);
-                        METRICS.rx_bytes_count.add(read_cnt as u64);
+                        self.metrics.rx_bytes_count.add(read_cnt as u64);
                         // There may be more data to read, so keep `Rw` pending to stay
                         // scheduled for another read.
                         self.pending_rx.insert(PendingRx::Rw);
@@ -255,7 +258,7 @@ where
                 Err(err) => {
                     // We are not expecting any other errors when reading from the underlying
                     // stream. If any show up, we'll immediately kill this connection.
-                    METRICS.rx_read_fails.inc();
+                    self.metrics.rx_read_fails.inc();
                     error!(
                         "vsock: error reading from backing stream: lp={}, pp={}, err={:?}",
                         self.local_port, self.peer_port, err
@@ -293,7 +296,7 @@ where
         // Update the peer credit information.
         self.peer_buf_alloc = pkt.hdr.buf_alloc();
         self.peer_fwd_cnt = Wrapping(pkt.hdr.fwd_cnt());
-        METRICS.tx_packets_count.inc();
+        self.metrics.tx_packets_count.inc();
 
         match self.state {
             // Most frequent case: this is an established connection that needs to forward some
@@ -458,7 +461,7 @@ where
             // Data can be written to the host stream. Time to flush out the TX buffer.
             //
             if self.tx_buf.is_empty() {
-                METRICS.conn_event_fails.inc();
+                self.metrics.conn_event_fails.inc();
                 info!("vsock: connection received unexpected EPOLLOUT event");
                 return;
             }
@@ -466,7 +469,7 @@ where
                 .tx_buf
                 .flush_to(&mut self.stream)
                 .unwrap_or_else(|err| {
-                    METRICS.tx_flush_fails.inc();
+                    self.metrics.tx_flush_fails.inc();
                     warn!(
                         "vsock: error flushing TX buf for (lp={}, pp={}): {:?}",
                         self.local_port, self.peer_port, err
@@ -483,7 +486,7 @@ where
                     0
                 });
             self.fwd_cnt += wrap_usize_to_u32(flushed);
-            METRICS.tx_bytes_count.add(flushed as u64);
+            self.metrics.tx_bytes_count.add(flushed as u64);
 
             // If this connection was shutting down, but is waiting to drain the TX buffer
             // before forceful termination, the wait might be over.
@@ -510,6 +513,7 @@ where
         local_port: u32,
         peer_port: u32,
         peer_buf_alloc: u32,
+        metrics: Arc<VsockDeviceMetrics>,
     ) -> Self {
         Self {
             local_cid,
@@ -526,6 +530,7 @@ where
             last_fwd_cnt_to_peer: Wrapping(0),
             pending_rx: PendingRxSet::from(PendingRx::Response),
             expiry: None,
+            metrics,
         }
     }
 
@@ -536,6 +541,7 @@ where
         peer_cid: u64,
         local_port: u32,
         peer_port: u32,
+        metrics: Arc<VsockDeviceMetrics>,
     ) -> Self {
         Self {
             local_cid,
@@ -552,6 +558,7 @@ where
             last_fwd_cnt_to_peer: Wrapping(0),
             pending_rx: PendingRxSet::from(PendingRx::Request),
             expiry: None,
+            metrics,
         }
     }
 
@@ -631,14 +638,14 @@ where
             Err(err) => {
                 // We don't know how to handle any other write error, so we'll send it up
                 // the call chain.
-                METRICS.tx_write_fails.inc();
+                self.metrics.tx_write_fails.inc();
                 return Err(err);
             }
         };
         // Move the "forwarded bytes" counter ahead by how much we were able to send out.
         // Safe to unwrap because the maximum value is pkt.len(), which is a u32.
         self.fwd_cnt += written;
-        METRICS.tx_bytes_count.add(written as u64);
+        self.metrics.tx_bytes_count.add(written as u64);
 
         // If we couldn't write the whole slice, we'll need to push the remaining data to our
         // buffer.
@@ -861,6 +868,9 @@ mod tests {
 
         fn new(conn_state: ConnState) -> Self {
             let vsock_test_ctx = TestContext::new();
+            // Extract the metrics instance from the test backend to supply to connection
+            // builders
+            let metrics = vsock_test_ctx.device.backend.metrics.clone();
             let mut handler_ctx = vsock_test_ctx.create_event_handler_context();
             let stream = TestStream::new();
             let mut rx_pkt = VsockPacketRx::new().unwrap();
@@ -885,9 +895,15 @@ mod tests {
                     LOCAL_PORT,
                     PEER_PORT,
                     PEER_BUF_ALLOC,
+                    metrics.clone(),
                 ),
                 ConnState::LocalInit => VsockConnection::<TestStream>::new_local_init(
-                    stream, LOCAL_CID, PEER_CID, LOCAL_PORT, PEER_PORT,
+                    stream,
+                    LOCAL_CID,
+                    PEER_CID,
+                    LOCAL_PORT,
+                    PEER_PORT,
+                    metrics.clone(),
                 ),
                 ConnState::Established => {
                     let mut conn = VsockConnection::<TestStream>::new_peer_init(
@@ -897,6 +913,7 @@ mod tests {
                         LOCAL_PORT,
                         PEER_PORT,
                         PEER_BUF_ALLOC,
+                        metrics.clone(),
                     );
                     assert!(conn.has_pending_rx());
                     conn.recv_pkt(&mut rx_pkt).unwrap();

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -36,7 +36,7 @@ use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use crate::devices::virtio::queue::{InvalidAvailIdx, Queue as VirtQueue};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::virtio::vsock::VsockError;
-use crate::devices::virtio::vsock::metrics::METRICS;
+use crate::devices::virtio::vsock::metrics::VsockDeviceMetrics;
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, info, warn};
 use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap};
@@ -79,6 +79,7 @@ pub struct Vsock<B> {
 
     /// Gates RX delivery while a TRANSPORT_RESET is awaiting guest ack.
     pub(crate) pending_event_ack: bool,
+    pub(crate) metrics: Arc<VsockDeviceMetrics>,
 }
 
 impl<B> Vsock<B>
@@ -91,6 +92,7 @@ where
         cid: u64,
         backend: B,
         queues: Vec<VirtQueue>,
+        metrics: Arc<VsockDeviceMetrics>,
     ) -> Result<Vsock<B>, VsockError> {
         let mut queue_events = Vec::new();
         for _ in 0..queues.len() {
@@ -109,16 +111,21 @@ where
             rx_packet: VsockPacketRx::new()?,
             tx_packet: VsockPacketTx::default(),
             pending_event_ack: false,
+            metrics,
         })
     }
 
     /// Create a new virtio-vsock device with the given VM CID and vsock backend.
-    pub fn new(cid: u64, backend: B) -> Result<Vsock<B>, VsockError> {
+    pub fn new(
+        cid: u64,
+        backend: B,
+        metrics: Arc<VsockDeviceMetrics>,
+    ) -> Result<Vsock<B>, VsockError> {
         let queues: Vec<VirtQueue> = defs::VSOCK_QUEUE_SIZES
             .iter()
             .map(|&max_size| VirtQueue::new(max_size))
             .collect();
-        Self::with_queues(cid, backend, queues)
+        Self::with_queues(cid, backend, queues, metrics)
     }
 
     /// Retrieve the cid associated with this vsock device.
@@ -253,12 +260,13 @@ where
     // connections and the guest_cid configuration field is fetched again. Existing listen sockets
     // remain but their CID is updated to reflect the current guest_cid.
     pub fn send_transport_reset_event(&mut self) -> Result<(), DeviceError> {
+        let metrics = Arc::clone(&self.metrics);
         // This is safe since we checked in the caller function that the device is activated.
         let mem = &self.device_state.active_state().unwrap().mem;
 
         let queue = &mut self.queues[EVQ_INDEX];
         let head = queue.pop()?.ok_or_else(|| {
-            METRICS.ev_queue_event_fails.inc();
+            metrics.ev_queue_event_fails.inc();
             DeviceError::VsockError(VsockError::EmptyQueue)
         })?;
 
@@ -343,7 +351,7 @@ where
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {
-        METRICS.cfg_fails.inc();
+        self.metrics.cfg_fails.inc();
         warn!(
             "vsock: guest driver attempted to write device config (offset={:#x}, len={:#x})",
             offset,
@@ -364,7 +372,7 @@ where
         }
 
         if self.queues.len() != defs::VSOCK_NUM_QUEUES {
-            METRICS.activate_fails.inc();
+            self.metrics.activate_fails.inc();
             return Err(ActivateError::QueueMismatch {
                 expected: defs::VSOCK_NUM_QUEUES,
                 got: self.queues.len(),
@@ -377,13 +385,14 @@ where
             }
         }
 
+        let metrics = Arc::clone(&self.metrics);
         self.backend.activate().map_err(|err| {
-            METRICS.activate_fails.inc();
+            metrics.activate_fails.inc();
             ActivateError::VsockBackend(err)
         })?;
 
         if self.activate_evt.write(1).is_err() {
-            METRICS.activate_fails.inc();
+            self.metrics.activate_fails.inc();
             return Err(ActivateError::EventFd);
         }
 

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -33,7 +33,6 @@ use super::VsockBackend;
 use super::device::{EVQ_INDEX, RXQ_INDEX, TXQ_INDEX, Vsock};
 use crate::devices::virtio::device::VirtioDevice;
 use crate::devices::virtio::queue::InvalidAvailIdx;
-use crate::devices::virtio::vsock::metrics::METRICS;
 use crate::logger::{IncMetric, error, warn};
 
 impl<B> Vsock<B>
@@ -50,18 +49,18 @@ where
         let mut used_queues = Vec::new();
         if evset != EventSet::IN {
             warn!("vsock: rxq unexpected event {:?}", evset);
-            METRICS.rx_queue_event_fails.inc();
+            self.metrics.rx_queue_event_fails.inc();
             return used_queues;
         }
 
         if let Err(err) = self.queue_events[RXQ_INDEX].read() {
             error!("Failed to get vsock rx queue event: {:?}", err);
-            METRICS.rx_queue_event_fails.inc();
+            self.metrics.rx_queue_event_fails.inc();
         } else if self.backend.has_pending_rx() {
             if self.process_rx().unwrap() {
                 used_queues.push(RXQ_INDEX.try_into().unwrap());
             }
-            METRICS.rx_queue_event_count.inc();
+            self.metrics.rx_queue_event_count.inc();
         }
         used_queues
     }
@@ -70,18 +69,18 @@ where
         let mut used_queues = Vec::new();
         if evset != EventSet::IN {
             warn!("vsock: txq unexpected event {:?}", evset);
-            METRICS.tx_queue_event_fails.inc();
+            self.metrics.tx_queue_event_fails.inc();
             return used_queues;
         }
 
         if let Err(err) = self.queue_events[TXQ_INDEX].read() {
             error!("Failed to get vsock tx queue event: {:?}", err);
-            METRICS.tx_queue_event_fails.inc();
+            self.metrics.tx_queue_event_fails.inc();
         } else {
             if self.process_tx().unwrap() {
                 used_queues.push(TXQ_INDEX.try_into().unwrap());
             }
-            METRICS.tx_queue_event_count.inc();
+            self.metrics.tx_queue_event_count.inc();
             // The backend may have queued up responses to the packets we sent during
             // TX queue processing. If that happened, we need to fetch those responses
             // and place them into RX buffers.
@@ -96,13 +95,13 @@ where
         let mut used_queues = Vec::new();
         if evset != EventSet::IN {
             warn!("vsock: evq unexpected event {:?}", evset);
-            METRICS.ev_queue_event_fails.inc();
+            self.metrics.ev_queue_event_fails.inc();
             return used_queues;
         }
 
         if let Err(err) = self.queue_events[EVQ_INDEX].read() {
             error!("Failed to consume vsock evq event: {:?}", err);
-            METRICS.ev_queue_event_fails.inc();
+            self.metrics.ev_queue_event_fails.inc();
         }
 
         // Guest's evq kick = TRANSPORT_RESET ack. Clear the gate and drain any RX the
@@ -311,9 +310,8 @@ mod tests {
             let mut ctx = test_ctx.create_event_handler_context();
             ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
 
-            let metric_before = METRICS.tx_queue_event_fails.count();
             ctx.device.handle_txq_event(EventSet::IN);
-            assert_eq!(metric_before + 1, METRICS.tx_queue_event_fails.count());
+            assert_eq!(ctx.device.metrics.tx_queue_event_fails.count(), 1);
         }
     }
 
@@ -374,9 +372,8 @@ mod tests {
             let mut ctx = test_ctx.create_event_handler_context();
             ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
             ctx.device.backend.set_pending_rx(false);
-            let metric_before = METRICS.rx_queue_event_fails.count();
             ctx.device.handle_rxq_event(EventSet::IN);
-            assert_eq!(metric_before + 1, METRICS.rx_queue_event_fails.count());
+            assert_eq!(ctx.device.metrics.rx_queue_event_fails.count(), 1);
         }
     }
 
@@ -387,9 +384,8 @@ mod tests {
             let test_ctx = TestContext::new();
             let mut ctx = test_ctx.create_event_handler_context();
             ctx.device.backend.set_pending_rx(false);
-            let metric_before = METRICS.ev_queue_event_fails.count();
             ctx.device.handle_evq_event(EventSet::IN);
-            assert_eq!(metric_before + 1, METRICS.ev_queue_event_fails.count());
+            assert_eq!(ctx.device.metrics.ev_queue_event_fails.count(), 1);
         }
     }
 
@@ -513,10 +509,9 @@ mod tests {
         ctx.device.pending_event_ack = true;
         ctx.device.backend.set_pending_rx(false);
 
-        let metric_before = METRICS.ev_queue_event_fails.count();
         let used = ctx.device.handle_evq_event(EventSet::IN);
 
-        assert_eq!(metric_before + 1, METRICS.ev_queue_event_fails.count());
+        assert_eq!(ctx.device.metrics.ev_queue_event_fails.count(), 1);
         assert!(used.is_empty());
         assert!(
             !ctx.device.pending_event_ack,

--- a/src/vmm/src/devices/virtio/vsock/metrics.rs
+++ b/src/vmm/src/devices/virtio/vsock/metrics.rs
@@ -36,24 +36,29 @@
 //! * Shared Incremental Metrics (SharedIncMetrics) - dedicated for the metrics which need a counter
 //!   (i.e the number of times an API request failed). These metrics are reset upon flush.
 
+use std::sync::{Arc, RwLock};
+
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 
 use crate::logger::SharedIncMetric;
 
-/// Stores aggregate metrics of all Vsock connections/actions
-pub(super) static METRICS: VsockDeviceMetrics = VsockDeviceMetrics::new();
-
 /// Called by METRICS.flush(), this function facilitates serialization of vsock device metrics.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let mut seq = serializer.serialize_map(Some(1))?;
-    seq.serialize_entry("vsock", &METRICS)?;
+    match METRICS.read().unwrap().as_ref() {
+        Some(metrics) => seq.serialize_entry("vsock", metrics.as_ref())?,
+        None => seq.serialize_entry("vsock", &VsockDeviceMetrics::default())?,
+    }
     seq.end()
 }
 
+/// Metrics of the (single) vsock device, shared by the device, its muxer and all connections.
+pub(super) static METRICS: RwLock<Option<Arc<VsockDeviceMetrics>>> = RwLock::new(None);
+
 /// Vsock-related metrics.
-#[derive(Debug, Serialize)]
-pub(super) struct VsockDeviceMetrics {
+#[derive(Debug, Serialize, Default)]
+pub struct VsockDeviceMetrics {
     /// Number of times when activate failed on a vsock device.
     pub activate_fails: SharedIncMetric,
     /// Number of times when interacting with the space config of a vsock device failed.
@@ -96,50 +101,130 @@ pub(super) struct VsockDeviceMetrics {
     pub rx_read_fails: SharedIncMetric,
 }
 
-impl VsockDeviceMetrics {
-    // We need this because vsock::metrics::METRICS does not accept
-    // VsockDeviceMetrics::default()
-    const fn new() -> Self {
-        Self {
-            activate_fails: SharedIncMetric::new(),
-            cfg_fails: SharedIncMetric::new(),
-            rx_queue_event_fails: SharedIncMetric::new(),
-            tx_queue_event_fails: SharedIncMetric::new(),
-            ev_queue_event_fails: SharedIncMetric::new(),
-            muxer_event_fails: SharedIncMetric::new(),
-            conn_event_fails: SharedIncMetric::new(),
-            rx_queue_event_count: SharedIncMetric::new(),
-            tx_queue_event_count: SharedIncMetric::new(),
-            rx_bytes_count: SharedIncMetric::new(),
-            tx_bytes_count: SharedIncMetric::new(),
-            rx_packets_count: SharedIncMetric::new(),
-            tx_packets_count: SharedIncMetric::new(),
-            conns_added: SharedIncMetric::new(),
-            conns_killed: SharedIncMetric::new(),
-            conns_removed: SharedIncMetric::new(),
-            killq_resync: SharedIncMetric::new(),
-            tx_flush_fails: SharedIncMetric::new(),
-            tx_write_fails: SharedIncMetric::new(),
-            rx_read_fails: SharedIncMetric::new(),
-        }
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
     use crate::logger::IncMetric;
 
     #[test]
-    fn test_vsock_dev_metrics() {
-        let vsock_metrics: VsockDeviceMetrics = VsockDeviceMetrics::new();
-        let vsock_metrics_local: String = serde_json::to_string(&vsock_metrics).unwrap();
-        // the 1st serialize flushes the metrics and resets values to 0 so that
-        // we can compare the values with local metrics.
-        serde_json::to_string(&METRICS).unwrap();
-        let vsock_metrics_global: String = serde_json::to_string(&METRICS).unwrap();
-        assert_eq!(vsock_metrics_local, vsock_metrics_global);
-        vsock_metrics.conns_added.inc();
-        assert_eq!(vsock_metrics.conns_added.count(), 1);
+    fn test_vsock_default() {
+        let metrics = VsockDeviceMetrics::default();
+
+        // Increment a field (e.g. activate_fails) to ensure it's being tracked.
+        metrics.activate_fails.inc();
+
+        let count = metrics.activate_fails.count();
+        assert!(
+            count > 0,
+            "Expected activate_fails count > 0 but got {}",
+            count
+        );
+
+        // Add more metric changes and assert correctness.
+        metrics.activate_fails.inc();
+        metrics.rx_bytes_count.add(5);
+
+        let rx_count = metrics.rx_bytes_count.count();
+        assert!(
+            rx_count >= 5,
+            "Expected rx_bytes_count >= 5 but got {}",
+            rx_count
+        );
+    }
+
+    #[test]
+    fn test_vsock_metrics_serialization() {
+        // Create a fresh metrics instance
+        let metrics = VsockDeviceMetrics::default();
+
+        // Set specific values for each metric
+        metrics.activate_fails.add(1);
+        metrics.cfg_fails.add(2);
+        metrics.rx_queue_event_fails.add(3);
+        metrics.tx_queue_event_fails.add(4);
+        metrics.ev_queue_event_fails.add(5);
+        metrics.muxer_event_fails.add(6);
+        metrics.conn_event_fails.add(7);
+        metrics.rx_queue_event_count.add(100);
+        metrics.tx_queue_event_count.add(200);
+        metrics.rx_bytes_count.add(1024);
+        metrics.tx_bytes_count.add(2048);
+        metrics.rx_packets_count.add(10);
+        metrics.tx_packets_count.add(20);
+        metrics.conns_added.add(5);
+        metrics.conns_killed.add(2);
+        metrics.conns_removed.add(3);
+        metrics.killq_resync.add(1);
+        metrics.tx_flush_fails.add(8);
+        metrics.tx_write_fails.add(9);
+        metrics.rx_read_fails.add(10);
+
+        let serialized = serde_json::to_string(&metrics).expect("Failed to serialize metrics");
+
+        let json_value: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Failed to parse JSON");
+
+        assert!(
+            json_value.is_object(),
+            "Serialized metrics should be a JSON object"
+        );
+
+        let obj = json_value.as_object().unwrap();
+
+        assert_eq!(obj.get("activate_fails").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(obj.get("cfg_fails").and_then(|v| v.as_u64()), Some(2));
+        assert_eq!(
+            obj.get("rx_queue_event_fails").and_then(|v| v.as_u64()),
+            Some(3)
+        );
+        assert_eq!(
+            obj.get("tx_queue_event_fails").and_then(|v| v.as_u64()),
+            Some(4)
+        );
+        assert_eq!(
+            obj.get("ev_queue_event_fails").and_then(|v| v.as_u64()),
+            Some(5)
+        );
+        assert_eq!(
+            obj.get("muxer_event_fails").and_then(|v| v.as_u64()),
+            Some(6)
+        );
+        assert_eq!(
+            obj.get("conn_event_fails").and_then(|v| v.as_u64()),
+            Some(7)
+        );
+        assert_eq!(
+            obj.get("rx_queue_event_count").and_then(|v| v.as_u64()),
+            Some(100)
+        );
+        assert_eq!(
+            obj.get("tx_queue_event_count").and_then(|v| v.as_u64()),
+            Some(200)
+        );
+        assert_eq!(
+            obj.get("rx_bytes_count").and_then(|v| v.as_u64()),
+            Some(1024)
+        );
+        assert_eq!(
+            obj.get("tx_bytes_count").and_then(|v| v.as_u64()),
+            Some(2048)
+        );
+        assert_eq!(
+            obj.get("rx_packets_count").and_then(|v| v.as_u64()),
+            Some(10)
+        );
+        assert_eq!(
+            obj.get("tx_packets_count").and_then(|v| v.as_u64()),
+            Some(20)
+        );
+        assert_eq!(obj.get("conns_added").and_then(|v| v.as_u64()), Some(5));
+        assert_eq!(obj.get("conns_killed").and_then(|v| v.as_u64()), Some(2));
+        assert_eq!(obj.get("conns_removed").and_then(|v| v.as_u64()), Some(3));
+        assert_eq!(obj.get("killq_resync").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(obj.get("tx_flush_fails").and_then(|v| v.as_u64()), Some(8));
+        assert_eq!(obj.get("tx_write_fails").and_then(|v| v.as_u64()), Some(9));
+        assert_eq!(obj.get("rx_read_fails").and_then(|v| v.as_u64()), Some(10));
+
+        assert_eq!(obj.len(), 20, "Expected exactly 20 metric fields");
     }
 }

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -4,6 +4,7 @@
 //! Defines state and support structures for persisting Vsock devices and backends.
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +12,7 @@ use super::*;
 use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
+use crate::devices::virtio::vsock::metrics::{METRICS, VsockDeviceMetrics};
 use crate::snapshot::Persist;
 use crate::vstate::memory::GuestMemoryMmap;
 
@@ -113,7 +115,14 @@ where
                 FIRECRACKER_MAX_QUEUE_SIZE,
             )
             .map_err(VsockError::VirtioState)?;
-        let mut vsock = Self::with_queues(state.cid, constructor_args.backend, queues)?;
+        // If we are here then the muxer must have been initiated, so it has already published
+        // the device's metrics instance. Share it with the restored vsock struct.
+        let metrics = METRICS
+            .read()
+            .unwrap()
+            .clone()
+            .unwrap_or_else(|| Arc::new(VsockDeviceMetrics::default()));
+        let mut vsock = Self::with_queues(state.cid, constructor_args.backend, queues, metrics)?;
 
         vsock.acked_features = state.virtio_state.acked_features;
         vsock.avail_features = state.virtio_state.avail_features;

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -16,6 +16,7 @@ use crate::devices::virtio::queue::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
 use crate::devices::virtio::test_utils::{VirtQueue as GuestQ, default_interrupt};
 use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::devices::virtio::vsock::device::{RXQ_INDEX, TXQ_INDEX};
+use crate::devices::virtio::vsock::metrics::VsockDeviceMetrics;
 use crate::devices::virtio::vsock::packet::VSOCK_PKT_HDR_SIZE;
 use crate::devices::virtio::vsock::{
     Vsock, VsockBackend, VsockChannel, VsockEpollListener, VsockError,
@@ -31,6 +32,7 @@ pub struct TestBackend {
     pub rx_ok_cnt: usize,
     pub tx_ok_cnt: usize,
     pub evset: Option<EventSet>,
+    pub metrics: Arc<VsockDeviceMetrics>,
 }
 
 impl TestBackend {
@@ -42,6 +44,7 @@ impl TestBackend {
             rx_ok_cnt: 0,
             tx_ok_cnt: 0,
             evset: None,
+            metrics: Arc::new(VsockDeviceMetrics::default()),
         }
     }
 
@@ -124,7 +127,10 @@ impl TestContext {
         const CID: u64 = 52;
         const MEM_SIZE: usize = 1024 * 1024 * 128;
         let mem = single_region_mem(MEM_SIZE);
-        let mut device = Vsock::new(CID, TestBackend::new()).unwrap();
+        let backend = TestBackend::new();
+        let metrics = backend.metrics.clone();
+        let mut device = Vsock::new(CID, backend, metrics).unwrap();
+
         for q in device.queues_mut() {
             q.ready = true;
             q.size = q.max_size;
@@ -171,11 +177,13 @@ impl TestContext {
         // the memory is write-only.
 
         let queues = vec![rxvq, txvq, evvq];
+        let backend = TestBackend::new();
+        let metrics = backend.metrics.clone();
         EventHandlerContext {
             guest_rxvq,
             guest_txvq,
             guest_evvq,
-            device: Vsock::with_queues(self.cid, TestBackend::new(), queues).unwrap(),
+            device: Vsock::with_queues(self.cid, backend, queues, metrics).unwrap(),
         }
     }
 }

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -35,6 +35,7 @@ use std::fmt::Debug;
 use std::io::Read;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::Arc;
 
 use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 
@@ -44,7 +45,7 @@ use super::super::{VsockBackend, VsockChannel, VsockEpollListener, VsockError};
 use super::muxer_killq::MuxerKillQ;
 use super::muxer_rxq::MuxerRxQ;
 use super::{MuxerConnection, VsockUnixBackendError, defs};
-use crate::devices::virtio::vsock::metrics::METRICS;
+use crate::devices::virtio::vsock::metrics::{METRICS, VsockDeviceMetrics};
 use crate::devices::virtio::vsock::packet::{VsockPacketRx, VsockPacketTx};
 use crate::logger::{IncMetric, debug, error, info, warn};
 
@@ -106,7 +107,6 @@ pub struct VsockMuxer {
     /// ports to host-initiated connections.
     local_port_set: HashSet<u32>,
     /// The last used host-side port.
-    ///
     /// Local ports are allocated in a round-robin fashion within the range [1 << 30, 1 << 31).
     /// There should be no inherent technical requirement for this specific range. But the range
     /// provides 1 billion available ports, making port collisions unlikely. In addition, the
@@ -114,6 +114,8 @@ pub struct VsockMuxer {
     /// This appears to have been a design decision dating back to the initial introduction of the
     /// vsock implementation.
     pub(crate) local_port_last: u32,
+    /// Device metrics instance
+    pub(crate) metrics: Arc<VsockDeviceMetrics>,
 }
 
 impl VsockChannel for VsockMuxer {
@@ -295,7 +297,7 @@ impl VsockEpollListener for VsockMuxer {
             }
             Err(err) => {
                 warn!("vsock: failed to consume muxer epoll event: {}", err);
-                METRICS.muxer_event_fails.inc();
+                self.metrics.muxer_event_fails.inc();
             }
         }
     }
@@ -336,6 +338,11 @@ impl VsockMuxer {
             .and_then(|sock| sock.set_nonblocking(true).map(|_| sock))
             .map_err(VsockUnixBackendError::UnixBind)?;
 
+        // The muxer creates the metrics instance for the vsock device and publishes it
+        // globally, so that the logger can serialize it on flush.
+        let metrics = Arc::new(VsockDeviceMetrics::default());
+        let _ = METRICS.write().unwrap().replace(metrics.clone());
+
         let muxer = Self {
             cid,
             host_sock,
@@ -347,6 +354,7 @@ impl VsockMuxer {
             killq: MuxerKillQ::new(),
             local_port_last: (1u32 << 30) - 1,
             local_port_set: HashSet::with_capacity(defs::MAX_CONNECTIONS),
+            metrics: metrics.clone(),
         };
 
         Ok(muxer)
@@ -426,6 +434,7 @@ impl VsockMuxer {
                                     self.cid,
                                     local_port,
                                     peer_port,
+                                    self.metrics.clone(),
                                 ),
                             )
                         })
@@ -440,7 +449,7 @@ impl VsockMuxer {
                     "vsock: unexpected event: fd={:?}, evset={:?}",
                     fd, event_set
                 );
-                METRICS.muxer_event_fails.inc();
+                self.metrics.muxer_event_fails.inc();
             }
         }
     }
@@ -530,7 +539,7 @@ impl VsockMuxer {
                 self.rxq.push(MuxerRx::ConnRx(key));
             }
             self.conn_map.insert(key, conn);
-            METRICS.conns_added.inc();
+            self.metrics.conns_added.inc();
         })
     }
 
@@ -538,7 +547,7 @@ impl VsockMuxer {
     fn remove_connection(&mut self, key: ConnMapKey) {
         if let Some(conn) = self.conn_map.remove(&key) {
             self.remove_listener(conn.as_raw_fd());
-            METRICS.conns_removed.inc();
+            self.metrics.conns_removed.inc();
         }
         self.free_local_port(key.local_port);
     }
@@ -548,7 +557,7 @@ impl VsockMuxer {
     /// it an RST packet.
     fn kill_connection(&mut self, key: ConnMapKey) {
         let mut had_rx = false;
-        METRICS.conns_killed.inc();
+        self.metrics.conns_killed.inc();
 
         self.conn_map.entry(key).and_modify(|conn| {
             had_rx = conn.has_pending_rx();
@@ -653,6 +662,7 @@ impl VsockMuxer {
                         pkt.hdr.dst_port(),
                         pkt.hdr.src_port(),
                         pkt.hdr.buf_alloc(),
+                        self.metrics.clone(),
                     ),
                 )
             })
@@ -741,7 +751,7 @@ impl VsockMuxer {
                                 "vsock: error updating epoll listener for (lp={}, pp={}): {:?}",
                                 key.local_port, key.peer_port, err
                             );
-                            METRICS.muxer_event_fails.inc();
+                            self.metrics.muxer_event_fails.inc();
                         });
                 }
             } else {
@@ -760,7 +770,7 @@ impl VsockMuxer {
                         "vsock: error updating epoll listener for (lp={}, pp={}): {:?}",
                         key.local_port, key.peer_port, err
                     );
-                    METRICS.muxer_event_fails.inc();
+                    self.metrics.muxer_event_fails.inc();
                 });
             }
         }
@@ -784,7 +794,7 @@ impl VsockMuxer {
 
         if self.killq.is_empty() && !self.killq.is_synced() {
             self.killq = MuxerKillQ::from_conn_map(&self.conn_map);
-            METRICS.killq_resync.inc();
+            self.metrics.killq_resync.inc();
             // If we've just re-created the kill queue, we can sweep it again; maybe there's
             // more to kill.
             self.sweep_killq();
@@ -1039,13 +1049,13 @@ mod tests {
 
         assert_eq!(conn.get_polled_evset(), EventSet::IN);
 
-        assert_eq!(METRICS.conn_event_fails.count(), 0);
+        assert_eq!(ctx.muxer.metrics.conn_event_fails.count(), 0);
 
         let conn_eventfd = conn.as_raw_fd();
 
         ctx.muxer.handle_event(conn_eventfd, EventSet::OUT);
 
-        assert_eq!(METRICS.conn_event_fails.count(), 1);
+        assert_eq!(ctx.muxer.metrics.conn_event_fails.count(), 1);
     }
 
     #[test]
@@ -1460,12 +1470,6 @@ mod tests {
         let peer_port_last = peer_port_first + defs::MUXER_KILLQ_SIZE;
         let mut listener = ctx.create_local_listener(local_port);
 
-        // Save metrics relevant for this test.
-        let conns_added = METRICS.conns_added.count();
-        let conns_killed = METRICS.conns_killed.count();
-        let conns_removed = METRICS.conns_removed.count();
-        let killq_resync = METRICS.killq_resync.count();
-
         for peer_port in peer_port_first..=peer_port_last {
             ctx.init_tx_pkt(local_port, peer_port, uapi::VSOCK_OP_REQUEST);
             ctx.send();
@@ -1505,19 +1509,16 @@ mod tests {
         // Check that MUXER_KILLQ_SIZE + 2 connections were added
         // We count +2, because there are two extra connections being
         // done outside of the loop.
-        assert_eq!(
-            METRICS.conns_added.count(),
-            conns_added + u64::from(defs::MUXER_KILLQ_SIZE) + 2
-        );
+        assert_eq!(ctx.muxer.metrics.conns_added.count(), 130);
         // Check that MUXER_KILLQ_SIZE connections were killed
         assert_eq!(
-            METRICS.conns_killed.count(),
-            conns_killed + u64::from(defs::MUXER_KILLQ_SIZE)
+            ctx.muxer.metrics.conns_killed.count(),
+            u64::from(defs::MUXER_KILLQ_SIZE)
         );
         // No connections should be removed at this point.
-        assert_eq!(METRICS.conns_removed.count(), conns_removed);
+        assert_eq!(ctx.muxer.metrics.conns_removed.count(), 0);
 
-        assert_eq!(METRICS.killq_resync.count(), killq_resync + 1);
+        assert_eq!(ctx.muxer.metrics.killq_resync.count(), 1);
         // After sweeping the kill queue, it should now be synced (assuming the RX queue is larger
         // than the kill queue, since an RST packet will be queued for each killed connection).
         assert!(ctx.muxer.killq.is_synced());
@@ -1532,8 +1533,8 @@ mod tests {
 
         // The connections should have been removed here.
         assert_eq!(
-            METRICS.conns_removed.count(),
-            conns_removed + u64::from(defs::MUXER_KILLQ_SIZE)
+            ctx.muxer.metrics.conns_removed.count(),
+            u64::from(defs::MUXER_KILLQ_SIZE)
         );
 
         // There should be one more packet in the RX queue: the connection response our request
@@ -1606,35 +1607,27 @@ mod tests {
 
     #[test]
     fn test_vsock_basic_metrics() {
-        // Save the metrics values that we need tested.
-        let mut tx_packets_count = METRICS.tx_packets_count.count();
-        let mut rx_packets_count = METRICS.rx_packets_count.count();
+        let mut ctx = MuxerTestContext::new("vsock_basic_metrics");
 
-        let tx_bytes_count = METRICS.tx_bytes_count.count();
-        let rx_bytes_count = METRICS.rx_bytes_count.count();
-
-        let conns_added = METRICS.conns_added.count();
-        let conns_removed = METRICS.conns_removed.count();
+        // Capture the current count of removed connection so we can check if it increased
+        // at the end of the test.
+        let conns_removed = ctx.muxer.metrics.conns_removed.count();
 
         // Create a basic connection.
-        let mut ctx = MuxerTestContext::new("vsock_basic_metrics");
         let peer_port = 1025;
         let (mut stream, local_port) = ctx.local_connect(peer_port);
 
         // Once the handshake is done, we check that the TX bytes count has
         // not been increased.
-        assert_eq!(METRICS.tx_bytes_count.count(), tx_bytes_count);
+        assert_eq!(ctx.muxer.metrics.tx_bytes_count.count(), 0);
 
         // Check that one packet was sent through the handshake.
-        assert_eq!(METRICS.tx_packets_count.count(), tx_packets_count + 1);
-        tx_packets_count = METRICS.tx_packets_count.count();
+        assert_eq!(ctx.muxer.metrics.tx_packets_count.count(), 1);
 
         // Check that one packet was received through the handshake.
-        assert_eq!(METRICS.rx_packets_count.count(), rx_packets_count + 1);
-        rx_packets_count = METRICS.rx_packets_count.count();
+        assert_eq!(ctx.muxer.metrics.rx_packets_count.count(), 1);
 
-        // Check that a new connection was added.
-        assert_eq!(METRICS.conns_added.count(), conns_added + 1);
+        assert_eq!(ctx.muxer.metrics.conns_added.count(), 1);
 
         // Send some data from guest to host.
         let data = [1, 2, 3, 4];
@@ -1642,13 +1635,10 @@ mod tests {
         ctx.send();
 
         // Check that tx_bytes was incremented.
-        assert_eq!(
-            METRICS.tx_bytes_count.count(),
-            tx_bytes_count + data.len() as u64
-        );
+        assert_eq!(ctx.muxer.metrics.tx_bytes_count.count(), data.len() as u64);
 
         // Check that one packet was accounted for.
-        assert_eq!(METRICS.tx_packets_count.count(), tx_packets_count + 1);
+        assert_eq!(ctx.muxer.metrics.tx_packets_count.count(), 2);
 
         // Send some data from the host to the guest.
         let data = [1, 2, 3, 4, 5, 6];
@@ -1657,19 +1647,16 @@ mod tests {
         ctx.recv();
 
         // Check that a packet was received.
-        assert_eq!(METRICS.rx_packets_count.count(), rx_packets_count + 1);
+        assert_eq!(ctx.muxer.metrics.rx_packets_count.count(), 2);
 
         // Check that the 6 bytes have been received.
-        assert_eq!(
-            METRICS.rx_bytes_count.count(),
-            rx_bytes_count + data.len() as u64
-        );
+        assert_eq!(ctx.muxer.metrics.rx_bytes_count.count(), data.len() as u64);
 
         // Send a connection reset.
         ctx.init_tx_pkt(local_port, peer_port, uapi::VSOCK_OP_RST);
         ctx.send();
 
-        // Check that the connection was removed.
-        assert_eq!(METRICS.conns_removed.count(), conns_removed + 1);
+        // Check that the connection was removed due to sending a rst packet.
+        assert_eq!(ctx.muxer.metrics.conns_removed.count(), conns_removed + 1);
     }
 }

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -587,7 +587,6 @@ impl MsixCap {
 mod tests {
     use super::*;
     use crate::builder::tests::default_vmm;
-    use crate::check_metric_after_block;
     use crate::logger::{IncMetric, METRICS};
     use crate::vstate::vm::KvmVm;
     use std::sync::atomic::Ordering;
@@ -771,54 +770,58 @@ mod tests {
     fn test_access_table() {
         let mut config = MsixConfig::new(msix_vector_group(2), PciSBDF::from(0x42));
         // enabled and not masked
-        check_metric_after_block!(
-            METRICS.interrupts.config_updates,
-            1,
-            config.set_msg_ctl(0x8000)
+        let mut config_update_count = METRICS.interrupts.config_updates.count();
+        config.set_msg_ctl(0x8000);
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count + 2
         );
         let mut buffer = [0u8; 8];
+        config_update_count += 2;
 
         // Write first vector's address with a single 8-byte write
         // It's still masked so shouldn't be updated
-        check_metric_after_block!(
-            METRICS.interrupts.config_updates,
-            0,
-            config.write_table(0, &u64::to_le_bytes(0x0000_1312_0000_1110))
+        config.write_table(0, &u64::to_le_bytes(0x0000_1312_0000_1110));
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count
         );
 
         // Same for control and message data
         // Now, we enabled it, so we should see an update
-        check_metric_after_block!(
-            METRICS.interrupts.config_updates,
-            1,
-            config.write_table(8, &u64::to_le_bytes(0x0_0000_0020))
+        config.write_table(8, &u64::to_le_bytes(0x0_0000_0020));
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count + 1
         );
+        config_update_count += 1;
 
         // Write second vector's fields with 4-byte writes
         // low 32 bits of the address (still masked)
-        check_metric_after_block!(
-            METRICS.interrupts.config_updates,
-            0,
-            config.write_table(16, &u32::to_le_bytes(0x4241))
+        config.write_table(16, &u32::to_le_bytes(0x4241));
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count
         );
         // high 32 bits of the address (still masked)
-        check_metric_after_block!(
-            METRICS.interrupts.config_updates,
-            0,
-            config.write_table(20, &u32::to_le_bytes(0x4443))
+        config.write_table(20, &u32::to_le_bytes(0x4443));
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count
         );
         // message data (still masked)
-        check_metric_after_block!(
-            METRICS.interrupts.config_updates,
-            0,
-            config.write_table(24, &u32::to_le_bytes(0x21))
+        config.write_table(24, &u32::to_le_bytes(0x21));
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count
         );
         // vector control (now unmasked)
-        check_metric_after_block!(
-            METRICS.interrupts.config_updates,
-            1,
-            config.write_table(28, &u32::to_le_bytes(0x0))
+        config.write_table(28, &u32::to_le_bytes(0x0));
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count + 1
         );
+        config_update_count += 1;
 
         assert_eq!(config.table_entries[0].msg_addr_hi, 0x1312);
         assert_eq!(config.table_entries[0].msg_addr_lo, 0x1110);
@@ -865,22 +868,30 @@ mod tests {
         assert_eq!(0x0_0000_0020, u64::from_le_bytes(buffer));
 
         // If we mask the interrupts we shouldn't see any update
-        check_metric_after_block!(METRICS.interrupts.config_updates, 0, {
-            config.write_table(12, &u32::to_le_bytes(0x1));
-            config.write_table(28, &u32::to_le_bytes(0x1));
-        });
+        config.write_table(12, &u32::to_le_bytes(0x1));
+        config.write_table(28, &u32::to_le_bytes(0x1));
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count
+        );
 
         // Un-masking them should update them
-        check_metric_after_block!(METRICS.interrupts.config_updates, 2, {
-            config.write_table(12, &u32::to_le_bytes(0x0));
-            config.write_table(28, &u32::to_le_bytes(0x0));
-        });
+        config.write_table(12, &u32::to_le_bytes(0x0));
+        config.write_table(28, &u32::to_le_bytes(0x0));
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count + 2
+        );
+
+        config_update_count += 2;
 
         // Setting up the same config should have no effect
-        check_metric_after_block!(METRICS.interrupts.config_updates, 0, {
-            config.write_table(12, &u32::to_le_bytes(0x0));
-            config.write_table(28, &u32::to_le_bytes(0x0));
-        });
+        config.write_table(12, &u32::to_le_bytes(0x0));
+        config.write_table(28, &u32::to_le_bytes(0x0));
+        assert_eq!(
+            METRICS.interrupts.config_updates.count(),
+            config_update_count
+        );
     }
 
     #[test]
@@ -975,28 +986,32 @@ mod tests {
         assert_eq!(config.get_pba_bit(1), 1);
         // Enable MSI-X vector and unmask interrupts
         // Individual vectors are still masked, so no change
-        check_metric_after_block!(METRICS.interrupts.triggers, 0, config.set_msg_ctl(0x8000));
+
+        let mut triggers_cnt = METRICS.interrupts.triggers.count();
+        config.set_msg_ctl(0x8000);
+        assert_eq!(METRICS.interrupts.triggers.count(), triggers_cnt);
 
         // Enable all vectors
         // Vector one had a pending bit, so we must have triggered an interrupt for it
         // and cleared the pending bit
-        check_metric_after_block!(METRICS.interrupts.triggers, 1, {
-            config.write_table(8, &u64::to_le_bytes(0x0_0000_0020));
-            config.write_table(24, &u64::to_le_bytes(0x0_0000_0020));
-        });
+        config.write_table(8, &u64::to_le_bytes(0x0_0000_0020));
+        config.write_table(24, &u64::to_le_bytes(0x0_0000_0020));
+        triggers_cnt += 1;
+        assert_eq!(METRICS.interrupts.triggers.count(), triggers_cnt);
         assert_eq!(config.get_pba_bit(1), 0);
 
         // Check that interrupt is sent as well for enabled vectors once we unmask from
         // Message Control
 
         // Mask vectors and set pending bit for vector 0
-        check_metric_after_block!(METRICS.interrupts.triggers, 0, {
-            config.set_msg_ctl(0xc000);
-            config.set_pba_bit(0, false);
-        });
+        config.set_msg_ctl(0xc000);
+        config.set_pba_bit(0, false);
+        assert_eq!(METRICS.interrupts.triggers.count(), triggers_cnt);
 
         // Unmask them
-        check_metric_after_block!(METRICS.interrupts.triggers, 1, config.set_msg_ctl(0x8000));
+        config.set_msg_ctl(0x8000);
+        triggers_cnt += 1;
+        assert_eq!(METRICS.interrupts.triggers.count(), triggers_cnt);
         assert_eq!(config.get_pba_bit(0), 0);
     }
 }

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -110,8 +110,10 @@ impl VsockBuilder {
         cfg: VsockDeviceConfig,
     ) -> Result<Vsock<VsockUnixBackend>, VsockConfigError> {
         let backend = VsockUnixBackend::new(u64::from(cfg.guest_cid), cfg.uds_path)?;
+        let metrics = backend.metrics.clone();
 
-        Vsock::new(u64::from(cfg.guest_cid), backend).map_err(VsockConfigError::CreateVsockDevice)
+        Vsock::new(u64::from(cfg.guest_cid), backend, metrics)
+            .map_err(VsockConfigError::CreateVsockDevice)
     }
 
     /// Returns the structure used to configure the vsock device.
@@ -180,12 +182,11 @@ pub(crate) mod tests {
         let mut vsock_builder = VsockBuilder::new();
         let mut tmp_sock_file = TempFile::new().unwrap();
         tmp_sock_file.remove().unwrap();
-        let vsock = Vsock::new(
-            0,
+        let backend =
             VsockUnixBackend::new(1, tmp_sock_file.as_path().to_str().unwrap().to_string())
-                .unwrap(),
-        )
-        .unwrap();
+                .unwrap();
+        let metrics = backend.metrics.clone();
+        let vsock = Vsock::new(0, backend, metrics).unwrap();
 
         vsock_builder.set_device(Arc::new(Mutex::new(vsock)));
         assert!(vsock_builder.inner.is_some());


### PR DESCRIPTION
## Changes

Building on the original [PR](https://github.com/firecracker-microvm/firecracker/pull/5196) and addressing the reviewer comments.
With the following remarks:

- Vsock device metrics are keyed in the btreemap by the guest CID which is hardcoded for test instance to be 52. if the desire is to run the tests in a given file, it may be needed to not hardcode it
- Entropy device metrics use a random generated UUID as the key of the map, because entropy devices don't have a unique identifier in the system that distinguishes them from one another (if one exists, let me know about it)
 
## Reason

Closes https://github.com/firecracker-microvm/firecracker/issues/4709

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
