### PR TITLE
fix: resolve TODO to use stateless structs for public VMM code

### DIFF
--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -161,7 +161,7 @@ fn run(cli: Cli) -> Result<(), HelperError> {
                 let (vmm, vm_resources) = utils::build_microvm_from_config(config, template)?;
 
                 let cpu_template = vm_resources
-                    .machine_config
+                    .machine_spec
                     .cpu_template
                     .get_cpu_template()?
                     .into_owned();

--- a/src/cpu-template-helper/src/utils/mod.rs
+++ b/src/cpu-template-helper/src/utils/mod.rs
@@ -165,7 +165,7 @@ pub fn add_suffix(path: &Path, suffix: &str) -> PathBuf {
 pub mod tests {
     use std::fmt::Display;
 
-    use vmm::resources::VmmConfig;
+    use vmm::resources::VmmSpec;
 
     use super::*;
 
@@ -217,8 +217,8 @@ pub mod tests {
             assert!(kernel.as_file().metadata().unwrap().len() > 0);
             // Ensure the rootfs exists and it is empty.
             assert_eq!(rootfs.as_file().metadata().unwrap().len(), 0);
-            // Ensure the generated config is valid as `VmmConfig`.
-            serde_json::from_str::<VmmConfig>(&config).unwrap();
+            // Ensure the generated config is valid as `VmmSpec`.
+            serde_json::from_str::<VmmSpec>(&config).unwrap();
         }
         // Ensure the temporary mock resources are deleted.
         assert!(!kernel_path.exists());

--- a/src/firecracker/src/api_server/request/boot_source.rs
+++ b/src/firecracker/src/api_server/request/boot_source.rs
@@ -3,18 +3,19 @@
 
 use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
-use vmm::vmm_config::boot_source::BootSourceConfig;
+use vmm::vmm_config::boot_source::BootSourceSpec;
 
 use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 
 pub(crate) fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, RequestError> {
     METRICS.put_api_requests.boot_source_count.inc();
-    Ok(ParsedRequest::new_sync(VmmAction::ConfigureBootSource(
-        serde_json::from_slice::<BootSourceConfig>(body.raw()).inspect_err(|_| {
+    Ok(ParsedRequest::new_stateless(
+        VmmAction::ConfigureBootSource,
+        serde_json::from_slice::<BootSourceSpec>(body.raw()).inspect_err(|_| {
             METRICS.put_api_requests.boot_source_fails.inc();
         })?,
-    )))
+    ))
 }
 
 #[cfg(test)]
@@ -30,7 +31,7 @@ mod tests {
             "initrd_path": "/bar/foo",
             "boot_args": "foobar"
         }"#;
-        let same_body = BootSourceConfig {
+        let same_body = BootSourceSpec {
             kernel_image_path: String::from("/foo/bar"),
             initrd_path: Some(String::from("/bar/foo")),
             boot_args: Some(String::from("foobar")),

--- a/src/firecracker/src/api_server/request/cpu_configuration.rs
+++ b/src/firecracker/src/api_server/request/cpu_configuration.rs
@@ -12,12 +12,13 @@ pub(crate) fn parse_put_cpu_config(body: &Body) -> Result<ParsedRequest, Request
     METRICS.put_api_requests.cpu_cfg_count.inc();
 
     // Convert the API request into a a deserialized/binary format
-    Ok(ParsedRequest::new_sync(VmmAction::PutCpuConfiguration(
+    Ok(ParsedRequest::new_stateless(
+        VmmAction::PutCpuConfiguration,
         CustomCpuTemplate::try_from(body.raw()).map_err(|err| {
             METRICS.put_api_requests.cpu_cfg_fails.inc();
             RequestError::SerdeJson(err)
         })?,
-    )))
+    ))
 }
 
 #[cfg(test)]

--- a/src/firecracker/src/api_server/request/entropy.rs
+++ b/src/firecracker/src/api_server/request/entropy.rs
@@ -2,14 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use vmm::rpc_interface::VmmAction;
-use vmm::vmm_config::entropy::EntropyDeviceConfig;
+use vmm::vmm_config::entropy::EntropyDeviceSpec;
 
 use super::super::parsed_request::{ParsedRequest, RequestError};
 use super::Body;
 
 pub(crate) fn parse_put_entropy(body: &Body) -> Result<ParsedRequest, RequestError> {
-    let cfg = serde_json::from_slice::<EntropyDeviceConfig>(body.raw())?;
-    Ok(ParsedRequest::new_sync(VmmAction::SetEntropyDevice(cfg)))
+    let spec = serde_json::from_slice::<EntropyDeviceSpec>(body.raw())?;
+    Ok(ParsedRequest::new_stateless(
+        VmmAction::SetEntropyDevice,
+        spec,
+    ))
 }
 
 #[cfg(test)]

--- a/src/firecracker/src/api_server/request/logger.rs
+++ b/src/firecracker/src/api_server/request/logger.rs
@@ -13,7 +13,10 @@ pub(crate) fn parse_put_logger(body: &Body) -> Result<ParsedRequest, RequestErro
     let config = res.inspect_err(|_| {
         METRICS.put_api_requests.logger_fails.inc();
     })?;
-    Ok(ParsedRequest::new_sync(VmmAction::ConfigureLogger(config)))
+    Ok(ParsedRequest::new_stateless(
+        VmmAction::ConfigureLogger,
+        config,
+    ))
 }
 
 #[cfg(test)]

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -30,7 +30,7 @@ use vmm::seccomp::BpfThreadMap;
 use vmm::signal_handler::register_signal_handlers;
 use vmm::snapshot::{SnapshotError, get_format_version};
 use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
-use vmm::vmm_config::metrics::{MetricsConfig, MetricsConfigError, init_metrics};
+use vmm::vmm_config::metrics::{MetricsSpec, MetricsSpecError, init_metrics};
 use vmm::{EventManager, FcExitCode, HTTP_MAX_PAYLOAD_SIZE};
 use vmm_sys_util::terminal::Terminal;
 
@@ -58,7 +58,7 @@ enum MainError {
     /// Could not initialize logger: {0}
     LoggerInitialization(vmm::logger::LoggerUpdateError),
     /// Could not initialize metrics: {0}
-    MetricsInitialization(MetricsConfigError),
+    MetricsInitialization(MetricsSpecError),
     /// Seccomp error: {0}
     SeccompFilter(FilterError),
     /// Failed to resize fd table: {0}
@@ -350,10 +350,10 @@ fn main_exec() -> Result<(), MainError> {
     };
 
     if let Some(metrics_path) = arguments.single_value("metrics-path") {
-        let metrics_config = MetricsConfig {
+        let metrics_spec = MetricsSpec {
             metrics_path: PathBuf::from(metrics_path),
         };
-        init_metrics(metrics_config).map_err(MainError::MetricsInitialization)?;
+        init_metrics(metrics_spec).map_err(MainError::MetricsInitialization)?;
     }
 
     let mut seccomp_filters: BpfThreadMap = SeccompConfig::from_args(

--- a/src/vmm/benches/memory_access.rs
+++ b/src/vmm/benches/memory_access.rs
@@ -5,7 +5,7 @@
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use vmm::resources::VmResources;
-use vmm::vmm_config::machine_config::{HugePageConfig, MachineConfig};
+use vmm::vmm_config::machine_config::{HugePageConfig, MachineSpec};
 
 fn bench_single_page_fault(c: &mut Criterion, configuration: VmResources) {
     c.bench_function("page_fault", |b| {
@@ -34,7 +34,7 @@ pub fn bench_4k_page_fault(c: &mut Criterion) {
     bench_single_page_fault(
         c,
         VmResources {
-            machine_config: MachineConfig {
+            machine_spec: MachineSpec {
                 vcpu_count: 1,
                 mem_size_mib: 2,
                 ..Default::default()
@@ -48,7 +48,7 @@ pub fn bench_2m_page_fault(c: &mut Criterion) {
     bench_single_page_fault(
         c,
         VmResources {
-            machine_config: MachineConfig {
+            machine_spec: MachineSpec {
                 vcpu_count: 1,
                 mem_size_mib: 2,
                 huge_pages: HugePageConfig::Hugetlbfs2M,

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -29,7 +29,7 @@ use crate::cpu_config::aarch64::{CpuConfiguration, CpuConfigurationError};
 use crate::cpu_config::templates::CustomCpuTemplate;
 use crate::initrd::InitrdConfig;
 use crate::utils::{align_up, u64_to_usize, usize_to_u64};
-use crate::vmm_config::machine_config::MachineConfig;
+use crate::vmm_config::machine_config::MachineSpec;
 use crate::vstate::memory::{
     Address, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestRegionType,
 };
@@ -90,7 +90,7 @@ pub fn configure_system_for_boot(
     vm: &Vm,
     device_manager: &mut DeviceManager,
     vcpus: &mut [Vcpu],
-    machine_config: &MachineConfig,
+    machine_spec: &MachineSpec,
     cpu_template: &CustomCpuTemplate,
     entry_point: EntryPoint,
     initrd: &Option<InitrdConfig>,
@@ -103,8 +103,8 @@ pub fn configure_system_for_boot(
     let cpu_config = CpuConfiguration::apply_template(cpu_config, cpu_template);
 
     let vcpu_config = VcpuConfig {
-        vcpu_count: machine_config.vcpu_count,
-        smt: machine_config.smt,
+        vcpu_count: machine_spec.vcpu_count,
+        smt: machine_spec.smt,
         cpu_config,
     };
 

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -58,7 +58,7 @@ use crate::cpu_config::x86_64::CpuConfiguration;
 use crate::device_manager::DeviceManager;
 use crate::initrd::InitrdConfig;
 use crate::utils::{align_down, u64_to_usize, usize_to_u64};
-use crate::vmm_config::machine_config::MachineConfig;
+use crate::vmm_config::machine_config::MachineSpec;
 use crate::vstate::memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionType,
 };
@@ -178,7 +178,7 @@ pub fn configure_system_for_boot(
     vm: &Vm,
     device_manager: &mut DeviceManager,
     vcpus: &mut [Vcpu],
-    machine_config: &MachineConfig,
+    machine_spec: &MachineSpec,
     cpu_template: &CustomCpuTemplate,
     entry_point: EntryPoint,
     initrd: &Option<InitrdConfig>,
@@ -190,8 +190,8 @@ pub fn configure_system_for_boot(
     let cpu_config = CpuConfiguration::apply_template(cpu_config, cpu_template)?;
 
     let vcpu_config = VcpuConfig {
-        vcpu_count: machine_config.vcpu_count,
-        smt: machine_config.smt,
+        vcpu_count: machine_spec.vcpu_count,
+        smt: machine_spec.smt,
         cpu_config,
     };
 

--- a/src/vmm/src/cpu_config/templates.rs
+++ b/src/vmm/src/cpu_config/templates.rs
@@ -72,7 +72,7 @@ impl From<&Option<CpuTemplateType>> for StaticCpuTemplate {
     }
 }
 
-// This conversion is used when converting `&VmConfig` to `MachineConfig` to
+// This conversion is used when converting `&VmConfig` to `MachineSpec` to
 // respond `GET /machine-config` and `GET /vm`.
 impl From<&CpuTemplateType> for StaticCpuTemplate {
     fn from(value: &CpuTemplateType) -> Self {

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -19,7 +19,7 @@ use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::impl_device_type;
 use crate::rate_limiter::BucketUpdate;
 use crate::snapshot::Persist;
-use crate::vmm_config::drive::BlockDeviceConfig;
+use crate::vmm_config::drive::BlockDeviceSpec;
 use crate::vstate::memory::GuestMemoryMmap;
 
 // Clippy thinks that values of the enum are too different in size.
@@ -31,12 +31,12 @@ pub enum Block {
 }
 
 impl Block {
-    pub fn new(config: BlockDeviceConfig) -> Result<Block, BlockError> {
-        if let Ok(config) = VirtioBlockConfig::try_from(&config) {
+    pub fn new(spec: BlockDeviceSpec) -> Result<Block, BlockError> {
+        if let Ok(config) = VirtioBlockConfig::try_from(&spec) {
             Ok(Self::Virtio(
                 VirtioBlock::new(config).map_err(BlockError::VirtioBackend)?,
             ))
-        } else if let Ok(config) = VhostUserBlockConfig::try_from(&config) {
+        } else if let Ok(config) = VhostUserBlockConfig::try_from(&spec) {
             Ok(Self::VhostUser(
                 VhostUserBlock::new(config).map_err(BlockError::VhostUserBackend)?,
             ))
@@ -45,7 +45,7 @@ impl Block {
         }
     }
 
-    pub fn config(&self) -> BlockDeviceConfig {
+    pub fn config(&self) -> BlockDeviceSpec {
         match self {
             Self::Virtio(b) => b.config().into(),
             Self::VhostUser(b) => b.config().into(),

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -30,7 +30,7 @@ use crate::devices::virtio::vhost_user_metrics::{
 use crate::impl_device_type;
 use crate::logger::{IncMetric, StoreMetric, log_dev_preview_warning};
 use crate::utils::u64_to_usize;
-use crate::vmm_config::drive::BlockDeviceConfig;
+use crate::vmm_config::drive::BlockDeviceSpec;
 use crate::vstate::memory::GuestMemoryMmap;
 
 /// Block device config space size in bytes.
@@ -65,10 +65,10 @@ pub struct VhostUserBlockConfig {
     pub socket: String,
 }
 
-impl TryFrom<&BlockDeviceConfig> for VhostUserBlockConfig {
+impl TryFrom<&BlockDeviceSpec> for VhostUserBlockConfig {
     type Error = VhostUserBlockError;
 
-    fn try_from(value: &BlockDeviceConfig) -> Result<Self, Self::Error> {
+    fn try_from(value: &BlockDeviceSpec) -> Result<Self, Self::Error> {
         if value.socket.is_some()
             && value.is_read_only.is_none()
             && value.path_on_host.is_none()
@@ -89,7 +89,7 @@ impl TryFrom<&BlockDeviceConfig> for VhostUserBlockConfig {
     }
 }
 
-impl From<VhostUserBlockConfig> for BlockDeviceConfig {
+impl From<VhostUserBlockConfig> for BlockDeviceSpec {
     fn from(value: VhostUserBlockConfig) -> Self {
         Self {
             drive_id: value.drive_id,
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn test_from_config() {
-        let block_config = BlockDeviceConfig {
+        let block_spec = BlockDeviceSpec {
             drive_id: "".to_string(),
             partuuid: None,
             is_root_device: false,
@@ -408,9 +408,9 @@ mod tests {
 
             socket: Some("sock".to_string()),
         };
-        VhostUserBlockConfig::try_from(&block_config).unwrap();
+        VhostUserBlockConfig::try_from(&block_spec).unwrap();
 
-        let block_config = BlockDeviceConfig {
+        let block_spec = BlockDeviceSpec {
             drive_id: "".to_string(),
             partuuid: None,
             is_root_device: false,
@@ -423,9 +423,9 @@ mod tests {
 
             socket: None,
         };
-        VhostUserBlockConfig::try_from(&block_config).unwrap_err();
+        VhostUserBlockConfig::try_from(&block_spec).unwrap_err();
 
-        let block_config = BlockDeviceConfig {
+        let block_spec = BlockDeviceSpec {
             drive_id: "".to_string(),
             partuuid: None,
             is_root_device: false,
@@ -438,7 +438,7 @@ mod tests {
 
             socket: Some("sock".to_string()),
         };
-        VhostUserBlockConfig::try_from(&block_config).unwrap_err();
+        VhostUserBlockConfig::try_from(&block_spec).unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -23,7 +23,7 @@ use crate::devices::virtio::test_utils::{VirtQueue, VirtqDesc};
 #[cfg(test)]
 use crate::devices::virtio::transport::VirtioInterruptType;
 use crate::rate_limiter::RateLimiter;
-use crate::vmm_config::{RateLimiterConfig, TokenBucketConfig};
+use crate::vmm_config::{RateLimiterSpec, TokenBucketSpec};
 use crate::vstate::memory::{Bytes, GuestAddress};
 
 /// Create a default Block instance to be used in tests.
@@ -45,13 +45,13 @@ pub fn default_block_with_path(path: String, file_engine_type: FileEngineType) -
         is_read_only: false,
         cache_type: CacheType::Unsafe,
         // Rate limiting is enabled but with a high operation rate (10 million ops/s).
-        rate_limiter: Some(RateLimiterConfig {
-            bandwidth: Some(TokenBucketConfig {
+        rate_limiter: Some(RateLimiterSpec {
+            bandwidth: Some(TokenBucketSpec {
                 size: 0,
                 one_time_burst: Some(0),
                 refill_time: 0,
             }),
-            ops: Some(TokenBucketConfig {
+            ops: Some(TokenBucketSpec {
                 size: 100_000,
                 one_time_burst: Some(0),
                 refill_time: 10,

--- a/src/vmm/src/initrd.rs
+++ b/src/vmm/src/initrd.rs
@@ -38,10 +38,10 @@ pub struct InitrdConfig {
 impl InitrdConfig {
     /// Load initrd into guest memory based on the boot config.
     pub fn from_config(
-        boot_cfg: &BootConfig,
+        boot_spec: &BootConfig,
         vm_memory: &GuestMemoryMmap,
     ) -> Result<Option<Self>, InitrdError> {
-        Ok(match &boot_cfg.initrd_file {
+        Ok(match &boot_spec.initrd_file {
             Some(f) => {
                 let f = f.try_clone().map_err(InitrdError::CloneFd)?;
                 Some(Self::from_file(vm_memory, f)?)

--- a/src/vmm/src/test_utils/mock_resources/mod.rs
+++ b/src/vmm/src/test_utils/mock_resources/mod.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 
 use crate::cpu_config::templates::CustomCpuTemplate;
 use crate::resources::VmResources;
-use crate::vmm_config::boot_source::BootSourceConfig;
-use crate::vmm_config::machine_config::{MachineConfig, MachineConfigUpdate};
+use crate::vmm_config::boot_source::BootSourceSpec;
+use crate::vmm_config::machine_config::{MachineSpec, MachineSpecUpdate};
 
 pub const DEFAULT_BOOT_ARGS: &str = "reboot=k panic=1 pci=off";
 #[cfg(target_arch = "x86_64")]
@@ -37,11 +37,11 @@ macro_rules! generate_from {
 }
 
 #[derive(Debug)]
-pub struct MockBootSourceConfig(BootSourceConfig);
+pub struct MockBootSourceConfig(BootSourceSpec);
 
 impl MockBootSourceConfig {
     pub fn new() -> MockBootSourceConfig {
-        MockBootSourceConfig(BootSourceConfig {
+        MockBootSourceConfig(BootSourceSpec {
             kernel_image_path: kernel_image_path(None),
             initrd_path: None,
             boot_args: None,
@@ -74,24 +74,24 @@ impl MockVmResources {
         MockVmResources::default()
     }
 
-    pub fn with_boot_source(mut self, boot_source_cfg: BootSourceConfig) -> Self {
-        self.0.build_boot_source(boot_source_cfg).unwrap();
+    pub fn with_boot_source(mut self, boot_source_spec: BootSourceSpec) -> Self {
+        self.0.build_boot_source(boot_source_spec).unwrap();
         self
     }
 
-    pub fn with_vm_config(mut self, vm_config: MachineConfig) -> Self {
-        let machine_config = MachineConfigUpdate::from(vm_config);
-        self.0.update_machine_config(&machine_config).unwrap();
+    pub fn with_vm_config(mut self, vm_spec: MachineSpec) -> Self {
+        let machine_spec_update = MachineSpecUpdate::from(vm_spec);
+        self.0.update_machine_spec(&machine_spec_update).unwrap();
         self
     }
 
     pub fn set_cpu_template(&mut self, cpu_template: CustomCpuTemplate) {
-        self.0.machine_config.set_custom_cpu_template(cpu_template);
+        self.0.machine_spec.set_custom_cpu_template(cpu_template);
     }
 }
 
 #[derive(Debug, Default)]
-pub struct MockVmConfig(MachineConfig);
+pub struct MockVmConfig(MachineSpec);
 
 impl MockVmConfig {
     pub fn new() -> MockVmConfig {
@@ -104,6 +104,6 @@ impl MockVmConfig {
     }
 }
 
-generate_from!(MockBootSourceConfig, BootSourceConfig);
+generate_from!(MockBootSourceConfig, BootSourceSpec);
 generate_from!(MockVmResources, VmResources);
-generate_from!(MockVmConfig, MachineConfig);
+generate_from!(MockVmConfig, MachineSpec);

--- a/src/vmm/src/vmm_config/entropy.rs
+++ b/src/vmm/src/vmm_config/entropy.rs
@@ -6,22 +6,22 @@ use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 
-use super::RateLimiterConfig;
+use super::RateLimiterSpec;
 use crate::devices::virtio::rng::{Entropy, EntropyError};
 
 /// This struct represents the strongly typed equivalent of the json body from entropy device
 /// related requests.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct EntropyDeviceConfig {
+pub struct EntropyDeviceSpec {
     /// Configuration for RateLimiter of Entropy device
-    pub rate_limiter: Option<RateLimiterConfig>,
+    pub rate_limiter: Option<RateLimiterSpec>,
 }
 
-impl From<&Entropy> for EntropyDeviceConfig {
+impl From<&Entropy> for EntropyDeviceSpec {
     fn from(dev: &Entropy) -> Self {
-        let rate_limiter: RateLimiterConfig = dev.rate_limiter().into();
-        EntropyDeviceConfig {
+        let rate_limiter: RateLimiterSpec = dev.rate_limiter().into();
+        EntropyDeviceSpec {
             rate_limiter: rate_limiter.into_option(),
         }
     }
@@ -50,11 +50,11 @@ impl EntropyDeviceBuilder {
     /// Build an entropy device and return a (counted) reference to it protected by a mutex
     pub fn build(
         &mut self,
-        config: EntropyDeviceConfig,
+        spec: EntropyDeviceSpec,
     ) -> Result<Arc<Mutex<Entropy>>, EntropyDeviceError> {
-        let rate_limiter = config
+        let rate_limiter = spec
             .rate_limiter
-            .map(RateLimiterConfig::try_into)
+            .map(RateLimiterSpec::try_into)
             .transpose()?;
         let dev = Arc::new(Mutex::new(Entropy::new(rate_limiter.unwrap_or_default())?));
         self.0 = Some(dev.clone());
@@ -63,8 +63,8 @@ impl EntropyDeviceBuilder {
     }
 
     /// Insert a new entropy device from a configuration object
-    pub fn insert(&mut self, config: EntropyDeviceConfig) -> Result<(), EntropyDeviceError> {
-        let _ = self.build(config)?;
+    pub fn insert(&mut self, spec: EntropyDeviceSpec) -> Result<(), EntropyDeviceError> {
+        let _ = self.build(spec)?;
         Ok(())
     }
 
@@ -74,10 +74,10 @@ impl EntropyDeviceBuilder {
     }
 
     /// Get the configuration of the entropy device (if any)
-    pub fn config(&self) -> Option<EntropyDeviceConfig> {
+    pub fn config(&self) -> Option<EntropyDeviceSpec> {
         self.0
             .as_ref()
-            .map(|dev| EntropyDeviceConfig::from(dev.lock().unwrap().deref()))
+            .map(|dev| EntropyDeviceSpec::from(dev.lock().unwrap().deref()))
     }
 
     /// Set the entropy device from an already created object
@@ -93,13 +93,13 @@ mod tests {
 
     #[test]
     fn test_entropy_device_create() {
-        let config = EntropyDeviceConfig::default();
+        let spec = EntropyDeviceSpec::default();
         let mut builder = EntropyDeviceBuilder::new();
         assert!(builder.get().is_none());
 
-        builder.insert(config.clone()).unwrap();
+        builder.insert(spec.clone()).unwrap();
         assert!(builder.get().is_some());
-        assert_eq!(builder.config().unwrap(), config);
+        assert_eq!(builder.config().unwrap(), spec);
     }
 
     #[test]

--- a/src/vmm/src/vmm_config/metrics.rs
+++ b/src/vmm/src/vmm_config/metrics.rs
@@ -11,27 +11,27 @@ use crate::utils::open_file_write_nonblock;
 
 /// Strongly typed structure used to describe the metrics system.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct MetricsConfig {
+pub struct MetricsSpec {
     /// Named pipe or file used as output for metrics.
     pub metrics_path: PathBuf,
 }
 
-/// Errors associated with actions on the `MetricsConfig`.
+/// Errors associated with actions on the `MetricsSpec`.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub enum MetricsConfigError {
+pub enum MetricsSpecError {
     /// Cannot initialize the metrics system due to bad user input: {0}
     InitializationFailure(String),
 }
 
-/// Configures the metrics as described in `metrics_cfg`.
-pub fn init_metrics(metrics_cfg: MetricsConfig) -> Result<(), MetricsConfigError> {
+/// Configures the metrics as described in `metrics_spec`.
+pub fn init_metrics(metrics_spec: MetricsSpec) -> Result<(), MetricsSpecError> {
     let writer = FcLineWriter::new(
-        open_file_write_nonblock(&metrics_cfg.metrics_path)
-            .map_err(|err| MetricsConfigError::InitializationFailure(err.to_string()))?,
+        open_file_write_nonblock(&metrics_spec.metrics_path)
+            .map_err(|err| MetricsSpecError::InitializationFailure(err.to_string()))?,
     );
     METRICS
         .init(writer)
-        .map_err(|err| MetricsConfigError::InitializationFailure(err.to_string()))
+        .map_err(|err| MetricsSpecError::InitializationFailure(err.to_string()))
 }
 
 #[cfg(test)]
@@ -44,7 +44,7 @@ mod tests {
     fn test_init_metrics() {
         // Initializing metrics with valid pipe is ok.
         let metrics_file = TempFile::new().unwrap();
-        let desc = MetricsConfig {
+        let desc = MetricsSpec {
             metrics_path: metrics_file.as_path().to_path_buf(),
         };
 

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -7,24 +7,24 @@ use serde::{Deserialize, Serialize};
 use crate::mmds::data_store;
 use crate::mmds::data_store::MmdsVersion;
 
-/// Keeps the MMDS configuration.
+/// Keeps the MMDS specification.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct MmdsConfig {
+pub struct MmdsSpec {
     /// MMDS version.
     #[serde(default)]
     pub version: MmdsVersion,
     /// Network interfaces that allow forwarding packets to MMDS.
     pub network_interfaces: Vec<String>,
-    /// MMDS IPv4 configured address.
+    /// MMDS IPv4 specified address.
     pub ipv4_address: Option<Ipv4Addr>,
     /// Compatibility with EC2 IMDS.
     #[serde(default)]
     pub imds_compat: bool,
 }
 
-impl MmdsConfig {
-    /// Returns the MMDS version configured.
+impl MmdsSpec {
+    /// Returns the MMDS version specified.
     pub fn version(&self) -> MmdsVersion {
         self.version
     }
@@ -34,22 +34,22 @@ impl MmdsConfig {
         self.network_interfaces.clone()
     }
 
-    /// Returns the MMDS IPv4 address if one was configured.
+    /// Returns the MMDS IPv4 address if one was specified.
     /// Otherwise returns None.
     pub fn ipv4_addr(&self) -> Option<Ipv4Addr> {
         self.ipv4_address
     }
 }
 
-/// MMDS configuration related errors.
+/// MMDS specification related errors.
 #[rustfmt::skip]
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub enum MmdsConfigError {
+pub enum MmdsSpecError {
     /// The list of network interface IDs that allow forwarding MMDS requests is empty.
     EmptyNetworkIfaceList,
     /// The MMDS IPv4 address is not link local.
     InvalidIpv4Addr,
-    /// The list of network interface IDs provided contains at least one ID that does not correspond to any existing network interface.
+    /// The list of network interface IDs specified contains at least one ID that does not correspond to any existing network interface.
     InvalidNetworkInterfaceId,
     /// Failed to initialize MMDS data store: {0}
     InitMmdsDatastore(#[from] data_store::MmdsDatastoreError),

--- a/src/vmm/src/vmm_config/serial.rs
+++ b/src/vmm/src/vmm_config/serial.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 /// The body of a PUT /serial request.
 #[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct SerialConfig {
+pub struct SerialSpec {
     /// Named pipe or file used as output for guest serial console.
     pub serial_out_path: Option<PathBuf>,
 }

--- a/src/vmm/src/vmm_config/snapshot.rs
+++ b/src/vmm/src/vmm_config/snapshot.rs
@@ -58,12 +58,12 @@ pub struct NetworkOverride {
 }
 
 /// Stores the configuration that will be used for loading a snapshot.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct LoadSnapshotParams {
     /// Path to the file that contains the microVM state to be loaded.
     pub snapshot_path: PathBuf,
     /// Specifies guest memory backend configuration.
-    pub mem_backend: MemBackendConfig,
+    pub mem_backend: MemBackendSpec,
     /// Whether KVM dirty page tracking should be enabled, to space optimization
     /// of differential snapshots.
     pub track_dirty_pages: bool,
@@ -77,7 +77,7 @@ pub struct LoadSnapshotParams {
 /// Stores the configuration for loading a snapshot that is provided by the user.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct LoadSnapshotConfig {
+pub struct LoadSnapshotSpec {
     /// Path to the file that contains the microVM state to be loaded.
     pub snapshot_path: PathBuf,
     /// Path to the file that contains the guest memory to be loaded. To be used only if
@@ -87,7 +87,7 @@ pub struct LoadSnapshotConfig {
     /// Guest memory backend configuration. Is not to be used in conjunction with `mem_file_path`.
     /// None value is allowed only if `mem_file_path` is present.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mem_backend: Option<MemBackendConfig>,
+    pub mem_backend: Option<MemBackendSpec>,
     /// Whether or not to enable KVM dirty page tracking.
     #[serde(default)]
     #[deprecated]
@@ -106,7 +106,7 @@ pub struct LoadSnapshotConfig {
 /// Stores the configuration used for managing snapshot memory.
 #[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct MemBackendConfig {
+pub struct MemBackendSpec {
     /// Path to the backend used to handle the guest memory.
     pub backend_path: PathBuf,
     /// Specifies the guest memory backend type.


### PR DESCRIPTION
use VmmActions with (entrypoint, args) tuples and `spec` struct suffix.

## Changes

- Renamed public VMM inputs from *Config/cfg to *Spec/spec. Using “spec” suffix makes the contract explicit.
- VMM entry points take static specs as arguments.

## Reason

Address a TODO regarding public-facing VMM structs. See #3273.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
