### PR TITLE
fix: resolve TODO to stop failed virtio devices

### DIFF
--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -545,6 +545,10 @@ pub(crate) mod tests {
         fn is_activated(&self) -> bool {
             false
         }
+
+        fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+            None
+        }
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -949,6 +949,16 @@ impl VirtioDevice for Balloon {
         self.device_state.is_activated()
     }
 
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        let interrupt = self.device_state.active_state()?.interrupt.clone();
+        let mut queue_evts = Vec::with_capacity(self.queue_evts.len());
+        for evt in &self.queue_evts {
+            queue_evts.push(evt.try_clone().ok()?)
+        }
+        self.device_state = DeviceState::Inactive;
+        Some((interrupt, queue_evts))
+    }
+
     fn kick(&mut self) {
         // If device is activated, kick the balloon queue(s) to make up for any
         // pending or in-flight epoll events we may have not captured in snapshot.

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -209,6 +209,13 @@ impl VirtioDevice for Block {
         }
     }
 
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        match self {
+            Self::Virtio(b) => b.reset(),
+            Self::VhostUser(b) => b.reset(),
+        }
+    }
+
     fn kick(&mut self) {
         // If device is activated, kick the block queue(s) to make up for any
         // pending or in-flight epoll events we may have not captured in

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -373,6 +373,16 @@ impl<T: VhostUserHandleBackend + Send + 'static> VirtioDevice for VhostUserBlock
     fn is_activated(&self) -> bool {
         self.device_state.is_activated()
     }
+
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        let interrupt = self.device_state.active_state()?.interrupt.clone();
+        let mut queue_evts = Vec::with_capacity(self.queue_evts.len());
+        for evt in &self.queue_evts {
+            queue_evts.push(evt.try_clone().ok()?)
+        }
+        self.device_state = DeviceState::Inactive;
+        Some((interrupt, queue_evts))
+    }
 }
 
 #[cfg(test)]

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -671,6 +671,16 @@ impl VirtioDevice for VirtioBlock {
     fn is_activated(&self) -> bool {
         self.device_state.is_activated()
     }
+
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        let interrupt = self.device_state.active_state()?.interrupt.clone();
+        let mut queue_evts = Vec::with_capacity(self.queue_evts.len());
+        for evt in &self.queue_evts {
+            queue_evts.push(evt.try_clone().ok()?)
+        }
+        self.device_state = DeviceState::Inactive;
+        Some((interrupt, queue_evts))
+    }
 }
 
 impl Drop for VirtioBlock {

--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -155,9 +155,7 @@ pub trait VirtioDevice: AsAny + Send {
 
     /// Optionally deactivates this device and returns ownership of the guest memory map, interrupt
     /// event, and queue events.
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
-        None
-    }
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)>;
 
     /// Mark pages used by queues as dirty.
     fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
@@ -252,6 +250,10 @@ pub(crate) mod tests {
         }
 
         fn is_activated(&self) -> bool {
+            todo!()
+        }
+
+        fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
             todo!()
         }
     }

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -658,6 +658,16 @@ impl VirtioDevice for VirtioMem {
         self.device_state.is_activated()
     }
 
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        let interrupt = self.device_state.active_state()?.interrupt.clone();
+        let mut queue_evts = Vec::with_capacity(self.queue_events.len());
+        for evt in &self.queue_events {
+            queue_evts.push(evt.try_clone().ok()?)
+        }
+        self.device_state = DeviceState::Inactive;
+        Some((interrupt, queue_evts))
+    }
+
     fn activate(
         &mut self,
         mem: GuestMemoryMmap,

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -1039,6 +1039,16 @@ impl VirtioDevice for Net {
         self.device_state.is_activated()
     }
 
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        let interrupt = self.device_state.active_state()?.interrupt.clone();
+        let mut queue_evts = Vec::with_capacity(self.queue_evts.len());
+        for evt in &self.queue_evts {
+            queue_evts.push(evt.try_clone().ok()?)
+        }
+        self.device_state = DeviceState::Inactive;
+        Some((interrupt, queue_evts))
+    }
+
     fn kick(&mut self) {
         // If device is activated, kick the net queue(s) to make up for any
         // pending or in-flight epoll events we may have not captured in snapshot.

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -399,6 +399,16 @@ impl VirtioDevice for Pmem {
         self.device_state.is_activated()
     }
 
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        let interrupt = self.device_state.active_state()?.interrupt.clone();
+        let mut queue_evts = Vec::with_capacity(self.queue_events.len());
+        for evt in &self.queue_events {
+            queue_evts.push(evt.try_clone().ok()?)
+        }
+        self.device_state = DeviceState::Inactive;
+        Some((interrupt, queue_evts))
+    }
+
     fn kick(&mut self) {
         if self.is_activated() {
             info!("kick pmem {}.", self.config.id);

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -296,6 +296,16 @@ impl VirtioDevice for Entropy {
         self.device_state.is_activated()
     }
 
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        let interrupt = self.device_state.active_state()?.interrupt.clone();
+        let mut queue_evts = Vec::with_capacity(self.queue_events.len());
+        for evt in &self.queue_events {
+            queue_evts.push(evt.try_clone().ok()?)
+        }
+        self.device_state = DeviceState::Inactive;
+        Some((interrupt, queue_evts))
+    }
+
     fn activate(
         &mut self,
         mem: GuestMemoryMmap,

--- a/src/vmm/src/devices/virtio/transport/mod.rs
+++ b/src/vmm/src/devices/virtio/transport/mod.rs
@@ -40,9 +40,7 @@ pub trait VirtioInterrupt: std::fmt::Debug + Send + Sync {
     }
 
     /// Get the `EventFd` (if any) that backs the underlying interrupt.
-    fn notifier(&self, _interrupt_type: VirtioInterruptType) -> Option<&EventFd> {
-        None
-    }
+    fn notifier(&self, interrupt_type: VirtioInterruptType) -> Option<&EventFd>;
 
     /// Get the current device interrupt status.
     fn status(&self) -> Arc<AtomicU32>;

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -379,6 +379,16 @@ where
         self.device_state.is_activated()
     }
 
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        let interrupt = self.device_state.active_state()?.interrupt.clone();
+        let mut queue_evts = Vec::with_capacity(self.queue_events.len());
+        for evt in &self.queue_events {
+            queue_evts.push(evt.try_clone().ok()?)
+        }
+        self.device_state = DeviceState::Inactive;
+        Some((interrupt, queue_evts))
+    }
+
     fn kick(&mut self) {
         // Vsock has complicated protocol that isn't resilient to any packet loss,
         // so for Vsock we don't support connection persistence through snapshot.


### PR DESCRIPTION
Implemented VirtioDevice reset methods to run on failure.

## Changes

Address a TODO regarding notifying backend driver to stop device on failure. See #3273.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
