### PR TITLE
feat(cargo-audit): install fresh cargo-audit on test run

### DIFF
--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -35,6 +35,6 @@ def test_cargo_audit():
         )
 
     git_ab_test_host_command_if_pr(
-        "cargo audit --deny warnings -q --json",
+        "cargo install --locked cargo-audit && cargo audit --deny warnings -q --json",
         comparator=set_did_not_grow_comparator(set_of_vulnerabilities),
     )

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -123,7 +123,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-too
     && rustup target add x86_64-unknown-linux-musl \
     && rustup target add aarch64-unknown-linux-musl \
     && rustup component add llvm-tools-preview clippy rustfmt \
-    && cargo install --locked cargo-audit grcov cargo-sort cargo-afl \
+    && cargo install --locked grcov cargo-sort cargo-afl \
     && cargo install --locked cargo-deny --version 0.17.0 \
     && cargo install --locked kani-verifier --version 0.64.0 && cargo kani setup \
     \


### PR DESCRIPTION
## Changes
In order to prevent future `cargo-audit` failures of reading new new security database disclosures, remove `cargo-audit` from dev container and always try to install `cargo-audit` from source instaed. This makes CI always use new version of the binary while for normal development, local version will be used (so no `--force` flag).

## Reason
Keep `cargo-audit` up to date to prevent future false positive CI breakages.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
