### PR TITLE
fix(test framework): fix local path to artifacts

### DIFF
--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -43,4 +43,4 @@ if not ARTIFACT_DIR.exists():
         .read_text(encoding="utf-8")
         .strip()
     )
-    ARTIFACT_DIR = LOCAL_BUILD_PATH / current_artifacts_dir
+    ARTIFACT_DIR = FC_WORKSPACE_DIR / current_artifacts_dir


### PR DESCRIPTION
## Changes
When python tests like `test-popular-containers` is run, it will use local path to artifacts which is determined by reading `build/current_artifacts` file. This file will contain path in form `build/artifacts/...`. The problem was that the `LOCAL_BUILD_PATH` also containers `/build` in the path, so when both are concatenated, it results in the invalid path. Fix this by using `FC_WORKSPACE_DIR` directly.

## Reason
Fixes popular container tests

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
