### PR TITLE
chore(patches): minor updates to the direct map removal

### DIFF
--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0022-set_memory-add-folio_-zap-restore-_direct_map-helper.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0022-set_memory-add-folio_-zap-restore-_direct_map-helper.patch
@@ -1,4 +1,4 @@
-From 11fa4031094890e536874ef874a52386aec89293 Mon Sep 17 00:00:00 2001
+From a8501e271439fe4ccb492e2c0e3d13d2a10e0b14 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 12 Jan 2026 14:24:52 +0000
 Subject: [PATCH 22/50] set_memory: add folio_{zap,restore}_direct_map helpers
@@ -6,30 +6,32 @@ Subject: [PATCH 22/50] set_memory: add folio_{zap,restore}_direct_map helpers
 From: Nikita Kalyazin <kalyazin@amazon.com>
 
 These allow guest_memfd to remove its memory from the direct map.
-Only implement them for x86 and arm64 as guest_memfd is only supported
-on those architectures.
-Only flush TLB in folio_zap_direct_map() on x86 as
-set_direct_map_valid_noflush on arm64 performs the flush internally
-despite of its name.
-Only export to KVM module on x86 as arm64 does not support building KVM
-as a module.
+Only implement them for architectures that have direct map.
+In folio_zap_direct_map(), flush TLB on architectures where
+set_direct_map_valid_noflush() does not flush it internally.
+
+The new helpers need to be accessible to KVM on architectures that
+support guest_memfd (x86 and arm64).  Since arm64 does not support
+building KVM as a module, only export them on x86.
 
 Direct map removal gives guest_memfd the same protection that
-memfd_secret enjoys, such as hardening against Spectre-like attacks
+memfd_secret does, such as hardening against Spectre-like attacks
 through in-kernel gadgets.
 
-Based-on-patch-by: Patrick Roy <patrick.roy@linux.dev>
 Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
 ---
  arch/arm64/include/asm/set_memory.h     |  2 ++
  arch/arm64/mm/pageattr.c                | 12 ++++++++++++
  arch/loongarch/include/asm/set_memory.h |  2 ++
+ arch/loongarch/mm/pageattr.c            | 16 ++++++++++++++++
  arch/riscv/include/asm/set_memory.h     |  2 ++
+ arch/riscv/mm/pageattr.c                | 16 ++++++++++++++++
  arch/s390/include/asm/set_memory.h      |  2 ++
+ arch/s390/mm/pageattr.c                 | 18 ++++++++++++++++++
  arch/x86/include/asm/set_memory.h       |  2 ++
  arch/x86/mm/pat/set_memory.c            | 20 ++++++++++++++++++++
  include/linux/set_memory.h              | 10 ++++++++++
- 8 files changed, 52 insertions(+)
+ 11 files changed, 102 insertions(+)
 
 diff --git a/arch/arm64/include/asm/set_memory.h b/arch/arm64/include/asm/set_memory.h
 index 90f61b17275e..d949f1deb701 100644
@@ -79,6 +81,30 @@ index 55dfaefd02c8..9bc80ac420a9 100644
 +int folio_restore_direct_map(struct folio *folio);
  
  #endif /* _ASM_LOONGARCH_SET_MEMORY_H */
+diff --git a/arch/loongarch/mm/pageattr.c b/arch/loongarch/mm/pageattr.c
+index f5e910b68229..14bd322dd112 100644
+--- a/arch/loongarch/mm/pageattr.c
++++ b/arch/loongarch/mm/pageattr.c
+@@ -236,3 +236,19 @@ int set_direct_map_valid_noflush(struct page *page, unsigned nr, bool valid)
+ 
+ 	return __set_memory(addr, 1, set, clear);
+ }
++
++int folio_zap_direct_map(struct folio *folio)
++{
++	int ret;
++
++	ret = set_direct_map_valid_noflush(folio_page(folio, 0),
++					   folio_nr_pages(folio), false);
++
++	return ret;
++}
++
++int folio_restore_direct_map(struct folio *folio)
++{
++	return set_direct_map_valid_noflush(folio_page(folio, 0),
++					    folio_nr_pages(folio), true);
++}
 diff --git a/arch/riscv/include/asm/set_memory.h b/arch/riscv/include/asm/set_memory.h
 index 87389e93325a..16557b70c830 100644
 --- a/arch/riscv/include/asm/set_memory.h
@@ -92,6 +118,33 @@ index 87389e93325a..16557b70c830 100644
  bool kernel_page_present(struct page *page);
  
  #endif /* __ASSEMBLER__ */
+diff --git a/arch/riscv/mm/pageattr.c b/arch/riscv/mm/pageattr.c
+index 3f76db3d2769..2c218868114b 100644
+--- a/arch/riscv/mm/pageattr.c
++++ b/arch/riscv/mm/pageattr.c
+@@ -401,6 +401,22 @@ int set_direct_map_valid_noflush(struct page *page, unsigned nr, bool valid)
+ 	return __set_memory((unsigned long)page_address(page), nr, set, clear);
+ }
+ 
++int folio_zap_direct_map(struct folio *folio)
++{
++	int ret;
++
++	ret = set_direct_map_valid_noflush(folio_page(folio, 0),
++					   folio_nr_pages(folio), false);
++
++	return ret;
++}
++
++int folio_restore_direct_map(struct folio *folio)
++{
++	return set_direct_map_valid_noflush(folio_page(folio, 0),
++					    folio_nr_pages(folio), true);
++}
++
+ #ifdef CONFIG_DEBUG_PAGEALLOC
+ static int debug_pagealloc_set_page(pte_t *pte, unsigned long addr, void *data)
+ {
 diff --git a/arch/s390/include/asm/set_memory.h b/arch/s390/include/asm/set_memory.h
 index 94092f4ae764..fc73652e5715 100644
 --- a/arch/s390/include/asm/set_memory.h
@@ -105,6 +158,35 @@ index 94092f4ae764..fc73652e5715 100644
  bool kernel_page_present(struct page *page);
  
  #endif
+diff --git a/arch/s390/mm/pageattr.c b/arch/s390/mm/pageattr.c
+index 348e759840e7..96ce1851411e 100644
+--- a/arch/s390/mm/pageattr.c
++++ b/arch/s390/mm/pageattr.c
+@@ -414,6 +414,24 @@ int set_direct_map_valid_noflush(struct page *page, unsigned nr, bool valid)
+ 	return __set_memory((unsigned long)page_to_virt(page), nr, flags);
+ }
+ 
++int folio_zap_direct_map(struct folio *folio)
++{
++	unsigned long addr = (unsigned long)folio_address(folio);
++	int ret;
++
++	ret = set_direct_map_valid_noflush(folio_page(folio, 0),
++					   folio_nr_pages(folio), false);
++	flush_tlb_kernel_range(addr, addr + folio_size(folio));
++
++	return ret;
++}
++
++int folio_restore_direct_map(struct folio *folio)
++{
++	return set_direct_map_valid_noflush(folio_page(folio, 0),
++					    folio_nr_pages(folio), true);
++}
++
+ bool kernel_page_present(struct page *page)
+ {
+ 	unsigned long addr;
 diff --git a/arch/x86/include/asm/set_memory.h b/arch/x86/include/asm/set_memory.h
 index 61f56cdaccb5..7208af609121 100644
 --- a/arch/x86/include/asm/set_memory.h
@@ -150,14 +232,13 @@ index 970981893c9b..6bf3f2390ffd 100644
  void __kernel_map_pages(struct page *page, int numpages, int enable)
  {
 diff --git a/include/linux/set_memory.h b/include/linux/set_memory.h
-index 3030d9245f5a..066a5568c194 100644
+index 3030d9245f5a..8d1c8a7f7d79 100644
 --- a/include/linux/set_memory.h
 +++ b/include/linux/set_memory.h
-@@ -44,6 +44,16 @@ static inline bool kernel_page_present(struct page *page)
- {
- 	return true;
+@@ -40,6 +40,16 @@ static inline int set_direct_map_valid_noflush(struct page *page,
+ 	return 0;
  }
-+
+ 
 +static inline int folio_zap_direct_map(struct folio *folio)
 +{
 +	return 0;
@@ -167,9 +248,10 @@ index 3030d9245f5a..066a5568c194 100644
 +{
 +	return 0;
 +}
- #else /* CONFIG_ARCH_HAS_SET_DIRECT_MAP */
- /*
-  * Some architectures, e.g. ARM64 can disable direct map modifications at
++
+ static inline bool kernel_page_present(struct page *page)
+ {
+ 	return true;
 -- 
 2.50.1
 

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0023-mm-gup-drop-secretmem-optimization-from-gup_fast_fol.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0023-mm-gup-drop-secretmem-optimization-from-gup_fast_fol.patch
@@ -1,10 +1,8 @@
-From 8f26ca2eb25f4b2611fa9835f6799a6555a7cf66 Mon Sep 17 00:00:00 2001
-From: Nikita Kalyazin <kalyazin@amazon.com>
+From 6f45086530993630cf7c136425e287b1663b6cc6 Mon Sep 17 00:00:00 2001
+From: Patrick Roy <patrick.roy@linux.dev>
 Date: Mon, 12 Jan 2026 15:22:56 +0000
 Subject: [PATCH 23/50] mm/gup: drop secretmem optimization from
  gup_fast_folio_allowed
-
-From: Nikita Kalyazin <kalyazin@amazon.com>
 
 This drops an optimization in gup_fast_folio_allowed() where
 secretmem_mapping() was only called if CONFIG_SECRETMEM=y. secretmem is
@@ -18,7 +16,7 @@ mappings that match this description are secretmem mappings
 (memfd_secret()).  Later, some guest_memfd configurations will also fall
 into this category.
 
-Based-on-patch-by: Patrick Roy <patrick.roy@linux.dev>
+Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
 Acked-by: Vlastimil Babka <vbabka@suse.cz>
 Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
 ---

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0024-mm-introduce-AS_NO_DIRECT_MAP.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0024-mm-introduce-AS_NO_DIRECT_MAP.patch
@@ -1,9 +1,7 @@
-From 7d4a20beafd780537b730263c30f5bdeaebab747 Mon Sep 17 00:00:00 2001
-From: Nikita Kalyazin <kalyazin@amazon.com>
+From 5dbca69a2c0a711d91a4473e25c74d66205850bd Mon Sep 17 00:00:00 2001
+From: Patrick Roy <patrick.roy@linux.dev>
 Date: Mon, 12 Jan 2026 15:29:36 +0000
 Subject: [PATCH 24/50] mm: introduce AS_NO_DIRECT_MAP
-
-From: Patrick Roy <patrick.roy@linux.dev>
 
 Add AS_NO_DIRECT_MAP for mappings where direct map entries of folios are
 set to not present. Currently, mappings that match this description are
@@ -24,9 +22,9 @@ can be mapped to userspace should also be GUP-able, and generally not
 have restrictions on who can access it).
 
 Acked-by: Mike Rapoport (Microsoft) <rppt@kernel.org>
-Acked-by: David Hildenbrand (Red Hat)" <david@kernel.org>
-Acked-by: Vlastimil Babka <vbabka@suse.cz>
+Acked-by: David Hildenbrand (Red Hat) <david@kernel.org>
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
+Acked-by: Vlastimil Babka <vbabka@suse.cz>
 Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
 ---
  include/linux/pagemap.h   | 16 ++++++++++++++++

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0025-KVM-guest_memfd-Add-stub-for-kvm_arch_gmem_invalidat.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0025-KVM-guest_memfd-Add-stub-for-kvm_arch_gmem_invalidat.patch
@@ -1,4 +1,4 @@
-From 1867ec7f5af8e591fbd6730d37d31b497cd4ca48 Mon Sep 17 00:00:00 2001
+From fe4036b78292891978bd9aa35c4e541cdc1c8b05 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:33 +0100
 Subject: [PATCH 25/50] KVM: guest_memfd: Add stub for kvm_arch_gmem_invalidate
@@ -9,9 +9,9 @@ kvm_gmem_free_folio without ifdef-ery, which allows more cleanly using
 guest_memfd's free_folio callback for non-arch-invalidation related
 code.
 
-Acked-by: David Hildenbrand (Red Hat)" <david@kernel.org
-Acked-by: Vlastimil Babka <vbabka@suse.cz>
+Acked-by: David Hildenbrand (Red Hat) <david@kernel.org>
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
+Acked-by: Vlastimil Babka <vbabka@suse.cz>
 Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
 ---
  include/linux/kvm_host.h | 2 ++

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0026-KVM-x86-define-kvm_arch_gmem_supports_no_direct_map.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0026-KVM-x86-define-kvm_arch_gmem_supports_no_direct_map.patch
@@ -1,7 +1,7 @@
-From f3889de4e235f3dea6eaf7756c8c97e9f9eb2e57 Mon Sep 17 00:00:00 2001
+From ec8d20a66b850917cdbbd1f36c436b44c4e8cf49 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:34 +0100
-Subject: [PATCH 27/50] KVM: x86: define kvm_arch_gmem_supports_no_direct_map()
+Subject: [PATCH 26/50] KVM: x86: define kvm_arch_gmem_supports_no_direct_map()
 
 x86 supports GUEST_MEMFD_FLAG_NO_DIRECT_MAP whenever direct map
 modifications are possible (which is always the case).

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0027-KVM-arm64-define-kvm_arch_gmem_supports_no_direct_ma.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0027-KVM-arm64-define-kvm_arch_gmem_supports_no_direct_ma.patch
@@ -1,7 +1,7 @@
-From 15d79d1d3cdfc8cebe1438174d610ade4b144b64 Mon Sep 17 00:00:00 2001
+From 1a1d10d194a6222ea67bc61b3961882b20388d2d Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:34 +0100
-Subject: [PATCH 28/50] KVM: arm64: define
+Subject: [PATCH 27/50] KVM: arm64: define
  kvm_arch_gmem_supports_no_direct_map()
 
 Support for GUEST_MEMFD_FLAG_NO_DIRECT_MAP on arm64 depends on 1) direct
@@ -12,9 +12,8 @@ map manipulations at 4k granularity being possible, and 2) FEAT_S2FWB.
 break-before-make semantics, breaking huge mappings into 4k mappings in
 the direct map is not possible (BBM would require temporary invalidation
 of the entire huge mapping, even if only a 4k subrange should be zapped,
-which will probably crash the kernel). However, current defconfigs
-select for example CONFIG_RO_DATA_FULL_DEFAULT_ENABLED, which forces a 4k
-direct map.
+which will probably crash the kernel). However, the current default for
+rodata_full is true, which forces a 4k direct map.
 
 2) is required to allow KVM to elide cache coherency operations when
 installing stage 2 page tables, which require the direct map to be

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0028-KVM-guest_memfd-Add-flag-to-remove-from-direct-map.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0028-KVM-guest_memfd-Add-flag-to-remove-from-direct-map.patch
@@ -1,7 +1,7 @@
-From a407e4b01512cc377029129410987fe4ce5172de Mon Sep 17 00:00:00 2001
+From c1e3788bca173bc91aee1ab1f94aaca96d46ec01 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:33 +0100
-Subject: [PATCH 26/50] KVM: guest_memfd: Add flag to remove from direct map
+Subject: [PATCH 28/50] KVM: guest_memfd: Add flag to remove from direct map
 
 Add GUEST_MEMFD_FLAG_NO_DIRECT_MAP flag for KVM_CREATE_GUEST_MEMFD()
 ioctl. When set, guest_memfd folios will be removed from the direct map
@@ -119,7 +119,7 @@ index 52f6000ab020..13ee57c09669 100644
  struct kvm_create_guest_memfd {
  	__u64 size;
 diff --git a/virt/kvm/guest_memfd.c b/virt/kvm/guest_memfd.c
-index 658b611760ff..d9cec048bbe8 100644
+index 658b611760ff..fc59fe94f045 100644
 --- a/virt/kvm/guest_memfd.c
 +++ b/virt/kvm/guest_memfd.c
 @@ -7,6 +7,9 @@
@@ -168,7 +168,7 @@ index 658b611760ff..d9cec048bbe8 100644
 +	 * Thus folio_restore_direct_map() here only updates prot bits.
 +	 */
 +	if (kvm_gmem_folio_no_direct_map(folio)) {
-+		WARN_ON(folio_restore_direct_map(folio));
++		WARN_ON_ONCE(folio_restore_direct_map(folio));
 +		folio->private = (void *)((u64)folio->private & ~KVM_GMEM_FOLIO_NO_DIRECT_MAP);
 +	}
 +}


### PR DESCRIPTION
## Changes

Minor updates to the direct map removal. No functional changes in x86 or ARM intended.

## Reason

This is to keep it in line with the published v9.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
