### PR TITLE
secret-hiding: Add apply_kernel_patches.sh

### DIFF
--- a/resources/hiding_ci/apply_kernel_patches.sh
+++ b/resources/hiding_ci/apply_kernel_patches.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu -o pipefail
+
+apply_patch_file() {
+  echo "Applying patch:" $(basename $1)
+
+  git am < $1
+}
+
+apply_patch_or_series() {
+  case "$1" in
+  *.patch) apply_patch_file $1 ;;
+  *) echo "Skipping non-patch file" $1 ;;
+  esac
+}
+
+apply_all_patches() {
+  if [ ! -d "$1" ]; then
+    echo "Not a directory: $1"
+    return
+  fi
+
+  echo "Applying all patches in $1"
+
+  for f in $1/*; do
+    if [ -d $f ]; then
+      apply_all_patches $f
+    else
+      apply_patch_or_series $f
+    fi
+  done
+}
+
+SCRIPT_DIR="$(dirname "$0")"
+KERNEL_COMMIT_HASH=$(cat "$SCRIPT_DIR"/kernel_commit_hash)
+KERNEL_PATCHES_DIR="$SCRIPT_DIR"/linux_patches
+
+HEAD_HASH="$(git rev-parse HEAD)"
+if [ $? != 0 ]; then
+  echo "Failed to get git revision, are you in a kernel tree?"
+  exit $?
+fi
+if [ "$HEAD_HASH" != "$KERNEL_COMMIT_HASH" ]; then
+  echo "Cowardly refusing to apply patches unless you check out $KERNEL_COMMIT_HASH"
+  exit 1
+fi
+
+# Apply our patches on top
+apply_all_patches $KERNEL_PATCHES_DIR


### PR DESCRIPTION
For kernel development, it's handy to have a Git tree with all these patches applied. However since the existing source of truth is these patch files, instead of directly providing such a tree, it's simpler to just provide a script that generates one.

The user needs to run it from a kernel tree checked out at a specific revision, but they don't need to know that, they can just run it and it will tell them.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
   
  ( Don't have Docker, doesn't seem relevant to this PR)
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks
  ( Don't have Docker, doesn't seem relevant to this PR)
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
