### PR TITLE
fix(pytest): fail if no disks or kernels are found

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -484,6 +484,8 @@ def results_dir(request, pytestconfig):
 def guest_kernel_fxt(request, record_property):
     """Return all supported guest kernels."""
     kernel = request.param
+    if kernel is None:
+        pytest.fail(f"No kernel artifacts found in {ARTIFACT_DIR}")
     # vmlinux-5.10.167 -> linux-5.10
     prop = kernel.stem[2:]
     record_property("guest_kernel", prop)
@@ -513,13 +515,23 @@ guest_kernel_linux_6_1 = pytest.fixture(
 @pytest.fixture
 def rootfs():
     """Return an Ubuntu 24.04 read-only rootfs"""
-    return disks("ubuntu-24.04.squashfs")[0]
+    disk_list = disks("ubuntu-24.04.squashfs")
+    if not disk_list:
+        pytest.fail(
+            f"No disk artifacts found matching 'ubuntu-24.04.squashfs' in {ARTIFACT_DIR}"
+        )
+    return disk_list[0]
 
 
 @pytest.fixture
 def rootfs_rw():
     """Return an Ubuntu 24.04 ext4 rootfs"""
-    return disks("ubuntu-24.04.ext4")[0]
+    disk_list = disks("ubuntu-24.04.ext4")
+    if not disk_list:
+        pytest.fail(
+            f"No disk artifacts found matching 'ubuntu-24.04.ext4' in {ARTIFACT_DIR}"
+        )
+    return disk_list[0]
 
 
 @pytest.fixture

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -45,9 +45,8 @@ def disks(glob) -> list:
     return sorted(ARTIFACT_DIR.glob(glob))
 
 
-def kernel_params(
-    glob="vmlinux-*", select=kernels, artifact_dir=ARTIFACT_DIR
-) -> Iterator:
-    """Return supported kernels"""
-    for kernel in select(glob, artifact_dir):
-        yield pytest.param(kernel, id=kernel.name)
+def kernel_params(glob="vmlinux-*", select=kernels, artifact_dir=ARTIFACT_DIR) -> list:
+    """Return supported kernels or a single None if no kernels are found"""
+    return [
+        pytest.param(kernel, id=kernel.name) for kernel in select(glob, artifact_dir)
+    ] or [pytest.param(None, id="no-kernel-found")]


### PR DESCRIPTION
## Changes

This change ensures that the disks and kernels fixtures are not empty.

## Reason

Currently the absence of CI artifacts leads to the CI run passing after skipping all tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
