### PR TITLE
fix: return error on missing ITS with gicv3

### DIFF
--- a/src/vmm/src/arch/aarch64/gic/gicv3/regs/mod.rs
+++ b/src/vmm/src/arch/aarch64/gic/gicv3/regs/mod.rs
@@ -57,9 +57,11 @@ pub fn restore_state(
         icc_regs::set_icc_regs(gic_device, *mpidr, &vcpu_state.icc)?;
     }
 
-    // Safe to unwrap here, as we know we support an ITS device, so `its_state.is_some()` is always
-    // `true`.
-    state.its_state.as_ref().unwrap().restore(its_device)
+    state
+        .its_state
+        .as_ref()
+        .ok_or(GicError::MissingItsState)?
+        .restore(its_device)
 }
 
 #[cfg(test)]

--- a/src/vmm/src/arch/aarch64/gic/mod.rs
+++ b/src/vmm/src/arch/aarch64/gic/mod.rs
@@ -58,6 +58,8 @@ pub enum GicError {
     InconsistentVcpuCount,
     /// The VgicSysRegsState is invalid.
     InvalidVgicSysRegState,
+    /// ITS state is missing.
+    MissingItsState,
 }
 
 /// List of implemented GICs.


### PR DESCRIPTION
## Changes

Return `Err(MissingItsState)` when restoring a giv3 snapshot that doesn't contain the ITS state, instead of unwrapping an panicking.

## Reason

The fuzzer found a crash when Gicv3 is used but `its_state` is `None`. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
