### PR TITLE
tools: try modprobe kvm if not loaded

### DIFF
--- a/tools/functions
+++ b/tools/functions
@@ -130,10 +130,39 @@ function validate_version {
 # Firecracker functions #
 #########################
 
-# Check if /dev/kvm exists. Exit if it doesn't.
-# Upon returning from this call, the caller can be certain /dev/kvm is
-# available.
+# Attempt to load the appropriate KVM module for the current platform.
+# Returns 0 on success, non-zero on failure.
+#
+load_kvm() {
+    local arch
+    arch=$(uname -m)
+
+    case "$arch" in
+        x86_64|i*86)
+            if grep -q "vmx" /proc/cpuinfo; then
+                modprobe kvm_intel || return 1
+            elif grep -q "svm" /proc/cpuinfo; then
+                modprobe kvm_amd || return 1
+            else
+                return 1
+            fi
+            ;;
+        aarch64|arm*)
+            modprobe kvm || return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    # Check /dev/kvm now exists
+    [[ -c /dev/kvm ]]
+}
+
+# Check if /dev/kvm exists. Attempt to load the module if it doesn't.
+# Exit if KVM is unavailable. Upon returning from this call, the caller
+# can be certain /dev/kvm is available.
 #
 ensure_kvm() {
-    [[ -c /dev/kvm ]] || die "/dev/kvm not found. Aborting."
+    [[ -c /dev/kvm ]] || load_kvm || die "/dev/kvm not found. Aborting."
 }


### PR DESCRIPTION

## Changes

When running the check to ensure KVM, if not present rather than failing try and modprobe KVM before bailing out.

## Reason

Some tests are failing with error `[Firecracker devtool] /dev/kvm not found. Aborting.` To attempt remediate this, try to modprobe KVM before we fail

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
