### PR TITLE
chore: update Amazon Linux vmclock patches

### DIFF
--- a/resources/patches/vmclock/5.10/0001-ptp-vmclock-add-vm-generation-counter.patch
+++ b/resources/patches/vmclock/5.10/0001-ptp-vmclock-add-vm-generation-counter.patch
@@ -1,7 +1,7 @@
-From a46562c571c6d50e7afc3994b33d0ffb61ff7409 Mon Sep 17 00:00:00 2001
+From f2309165752b4af1fb2245fb434f4b0938aecd06 Mon Sep 17 00:00:00 2001
 From: Babis Chalios <bchalios@amazon.es>
-Date: Tue, 2 Dec 2025 20:11:32 +0000
-Subject: [PATCH 1/4] ptp: vmclock: add vm generation counter
+Date: Wed, 21 Jan 2026 14:33:38 +0000
+Subject: [PATCH 1/7] ptp: vmclock: add vm generation counter
 
 Similar to live migration, loading a VM from some saved state (aka
 snapshot) is also an event that calls for clock adjustments in the
@@ -18,31 +18,151 @@ presence of this bit in vmclock_abi flags field before using this flag.
 
 Signed-off-by: Babis Chalios <bchalios@amazon.es>
 Reviewed-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
 ---
- include/uapi/linux/vmclock-abi.h | 15 +++++++++++++++
- 1 file changed, 15 insertions(+)
+ include/uapi/linux/vmclock-abi.h | 93 ++++++++++++++++++--------------
+ 1 file changed, 54 insertions(+), 39 deletions(-)
 
 diff --git a/include/uapi/linux/vmclock-abi.h b/include/uapi/linux/vmclock-abi.h
-index d7ca44313bf8..75deb6ae2b27 100644
+index d7ca44313bf8..62b8f2091ca5 100644
 --- a/include/uapi/linux/vmclock-abi.h
 +++ b/include/uapi/linux/vmclock-abi.h
-@@ -119,6 +119,12 @@ struct vmclock_abi {
+@@ -67,22 +67,22 @@
+ struct vmclock_abi {
+ 	/* CONSTANT FIELDS */
+ 	uint32_t magic;
+-#define VMCLOCK_MAGIC	0x4b4c4356 /* "VCLK" */
+-	uint32_t size;		/* Size of region containing this structure */
+-	uint16_t version;	/* 1 */
++#define VMCLOCK_MAGIC 0x4b4c4356 /* "VCLK" */
++	uint32_t size; /* Size of region containing this structure */
++	uint16_t version; /* 1 */
+ 	uint8_t counter_id; /* Matches VIRTIO_RTC_COUNTER_xxx except INVALID */
+-#define VMCLOCK_COUNTER_ARM_VCNT	0
+-#define VMCLOCK_COUNTER_X86_TSC		1
+-#define VMCLOCK_COUNTER_INVALID		0xff
++#define VMCLOCK_COUNTER_ARM_VCNT 0
++#define VMCLOCK_COUNTER_X86_TSC 1
++#define VMCLOCK_COUNTER_INVALID 0xff
+ 	uint8_t time_type; /* Matches VIRTIO_RTC_TYPE_xxx */
+-#define VMCLOCK_TIME_UTC			0	/* Since 1970-01-01 00:00:00z */
+-#define VMCLOCK_TIME_TAI			1	/* Since 1970-01-01 00:00:00z */
+-#define VMCLOCK_TIME_MONOTONIC			2	/* Since undefined epoch */
+-#define VMCLOCK_TIME_INVALID_SMEARED		3	/* Not supported */
+-#define VMCLOCK_TIME_INVALID_MAYBE_SMEARED	4	/* Not supported */
++#define VMCLOCK_TIME_UTC 0 /* Since 1970-01-01 00:00:00z */
++#define VMCLOCK_TIME_TAI 1 /* Since 1970-01-01 00:00:00z */
++#define VMCLOCK_TIME_MONOTONIC 2 /* Since undefined epoch */
++#define VMCLOCK_TIME_INVALID_SMEARED 3 /* Not supported */
++#define VMCLOCK_TIME_INVALID_MAYBE_SMEARED 4 /* Not supported */
+ 
+ 	/* NON-CONSTANT FIELDS PROTECTED BY SEQCOUNT LOCK */
+-	uint32_t seq_count;	/* Low bit means an update is in progress */
++	uint32_t seq_count; /* Low bit means an update is in progress */
+ 	/*
+ 	 * This field changes to another non-repeating value when the CPU
+ 	 * counter is disrupted, for example on live migration. This lets
+@@ -92,19 +92,19 @@ struct vmclock_abi {
+ 	uint64_t disruption_marker;
+ 	uint64_t flags;
+ 	/* Indicates that the tai_offset_sec field is valid */
+-#define VMCLOCK_FLAG_TAI_OFFSET_VALID		(1 << 0)
++#define VMCLOCK_FLAG_TAI_OFFSET_VALID (1 << 0)
+ 	/*
+ 	 * Optionally used to notify guests of pending maintenance events.
+ 	 * A guest which provides latency-sensitive services may wish to
+ 	 * remove itself from service if an event is coming up. Two flags
+ 	 * indicate the approximate imminence of the event.
+ 	 */
+-#define VMCLOCK_FLAG_DISRUPTION_SOON		(1 << 1) /* About a day */
+-#define VMCLOCK_FLAG_DISRUPTION_IMMINENT	(1 << 2) /* About an hour */
+-#define VMCLOCK_FLAG_PERIOD_ESTERROR_VALID	(1 << 3)
+-#define VMCLOCK_FLAG_PERIOD_MAXERROR_VALID	(1 << 4)
+-#define VMCLOCK_FLAG_TIME_ESTERROR_VALID	(1 << 5)
+-#define VMCLOCK_FLAG_TIME_MAXERROR_VALID	(1 << 6)
++#define VMCLOCK_FLAG_DISRUPTION_SOON (1 << 1) /* About a day */
++#define VMCLOCK_FLAG_DISRUPTION_IMMINENT (1 << 2) /* About an hour */
++#define VMCLOCK_FLAG_PERIOD_ESTERROR_VALID (1 << 3)
++#define VMCLOCK_FLAG_PERIOD_MAXERROR_VALID (1 << 4)
++#define VMCLOCK_FLAG_TIME_ESTERROR_VALID (1 << 5)
++#define VMCLOCK_FLAG_TIME_MAXERROR_VALID (1 << 6)
+ 	/*
+ 	 * If the MONOTONIC flag is set then (other than leap seconds) it is
+ 	 * guaranteed that the time calculated according this structure at
+@@ -118,15 +118,21 @@ struct vmclock_abi {
+ 	 * a counter reading taken immediately before *clearing* the low
  	 * bit again after the update, using the about-to-be-valid fields.
  	 */
- #define VMCLOCK_FLAG_TIME_MONOTONIC		(1 << 7)
+-#define VMCLOCK_FLAG_TIME_MONOTONIC		(1 << 7)
++#define VMCLOCK_FLAG_TIME_MONOTONIC (1 << 7)
 +	/*
 +	 * If the VM_GEN_COUNTER_PRESENT flag is set, the hypervisor will
 +	 * bump the vm_generation_counter field every time the guest is
 +	 * loaded from some save state (restored from a snapshot).
 +	 */
-+#define VMCLOCK_FLAG_VM_GEN_COUNTER_PRESENT     (1 << 8)
++#define VMCLOCK_FLAG_VM_GEN_COUNTER_PRESENT (1 << 8)
  
  	uint8_t pad[2];
  	uint8_t clock_status;
-@@ -183,6 +189,15 @@ struct vmclock_abi {
- 	uint64_t time_frac_sec;		/* (seconds >> 64) */
- 	uint64_t time_esterror_picosec;	/* (± picoseconds) */
- 	uint64_t time_maxerror_picosec;	/* (± picoseconds) */
+-#define VMCLOCK_STATUS_UNKNOWN		0
+-#define VMCLOCK_STATUS_INITIALIZING	1
+-#define VMCLOCK_STATUS_SYNCHRONIZED	2
+-#define VMCLOCK_STATUS_FREERUNNING	3
+-#define VMCLOCK_STATUS_UNRELIABLE	4
++#define VMCLOCK_STATUS_UNKNOWN 0
++#define VMCLOCK_STATUS_INITIALIZING 1
++#define VMCLOCK_STATUS_SYNCHRONIZED 2
++#define VMCLOCK_STATUS_FREERUNNING 3
++#define VMCLOCK_STATUS_UNRELIABLE 4
+ 
+ 	/*
+ 	 * The time exposed through this device is never smeared. This field
+@@ -138,9 +144,9 @@ struct vmclock_abi {
+ 	 * in the nearby environment.
+ 	 */
+ 	uint8_t leap_second_smearing_hint; /* Matches VIRTIO_RTC_SUBTYPE_xxx */
+-#define VMCLOCK_SMEARING_STRICT		0
+-#define VMCLOCK_SMEARING_NOON_LINEAR	1
+-#define VMCLOCK_SMEARING_UTC_SLS	2
++#define VMCLOCK_SMEARING_STRICT 0
++#define VMCLOCK_SMEARING_NOON_LINEAR 1
++#define VMCLOCK_SMEARING_UTC_SLS 2
+ 	int16_t tai_offset_sec;
+ 	uint8_t leap_indicator;
+ 	/*
+@@ -154,13 +160,13 @@ struct vmclock_abi {
+ 	 * leap second when such smearing may need to continue being applied.
+ 	 * It is hoped that these will be incorporated into virtio-rtc too.
+ 	 */
+-#define VMCLOCK_LEAP_NONE	0	/* No known nearby leap second */
+-#define VMCLOCK_LEAP_PRE_POS	1	/* Positive leap second at EOM */
+-#define VMCLOCK_LEAP_PRE_NEG	2	/* Negative leap second at EOM */
+-#define VMCLOCK_LEAP_POS	3	/* Set during 23:59:60 second */
+-#define VMCLOCK_LEAP_NEG	4	/* Not used in VMCLOCK */
+-#define VMCLOCK_LEAP_POST_POS	5
+-#define VMCLOCK_LEAP_POST_NEG	6
++#define VMCLOCK_LEAP_NONE 0 /* No known nearby leap second */
++#define VMCLOCK_LEAP_PRE_POS 1 /* Positive leap second at EOM */
++#define VMCLOCK_LEAP_PRE_NEG 2 /* Negative leap second at EOM */
++#define VMCLOCK_LEAP_POS 3 /* Set during 23:59:60 second */
++#define VMCLOCK_LEAP_NEG 4 /* Not used in VMCLOCK */
++#define VMCLOCK_LEAP_POST_POS 5
++#define VMCLOCK_LEAP_POST_NEG 6
+ 
+ 	/* Bit shift for counter_period_frac_sec and its error rate */
+ 	uint8_t counter_period_shift;
+@@ -179,10 +185,19 @@ struct vmclock_abi {
+ 	/*
+ 	 * Time according to time_type field above.
+ 	 */
+-	uint64_t time_sec;		/* Seconds since time_type epoch */
+-	uint64_t time_frac_sec;		/* (seconds >> 64) */
+-	uint64_t time_esterror_picosec;	/* (± picoseconds) */
+-	uint64_t time_maxerror_picosec;	/* (± picoseconds) */
++	uint64_t time_sec; /* Seconds since time_type epoch */
++	uint64_t time_frac_sec; /* (seconds >> 64) */
++	uint64_t time_esterror_picosec; /* (± picoseconds) */
++	uint64_t time_maxerror_picosec; /* (± picoseconds) */
 +
 +	/*
 +	 * This field changes to another non-repeating value when the guest
@@ -56,5 +176,5 @@ index d7ca44313bf8..75deb6ae2b27 100644
  
  #endif /*  __VMCLOCK_ABI_H__ */
 -- 
-2.34.1
+2.52.0
 

--- a/resources/patches/vmclock/5.10/0002-ptp-vmclock-support-device-notifications.patch
+++ b/resources/patches/vmclock/5.10/0002-ptp-vmclock-support-device-notifications.patch
@@ -1,7 +1,7 @@
-From d0a6bf47dd6cd2a9ed17dbdc32dd34a6ba0f5b5f Mon Sep 17 00:00:00 2001
+From b1a7ba47d96753695d9101dde049bc0808f76167 Mon Sep 17 00:00:00 2001
 From: Babis Chalios <bchalios@amazon.es>
-Date: Tue, 2 Dec 2025 20:11:44 +0000
-Subject: [PATCH 2/4] ptp: vmclock: support device notifications
+Date: Wed, 21 Jan 2026 14:33:39 +0000
+Subject: [PATCH 2/7] ptp: vmclock: support device notifications
 
 Add optional support for device notifications in VMClock. When
 supported, the hypervisor will send a device notification every time it
@@ -22,13 +22,15 @@ the flag is not present the driver won't setup the ACPI notification
 handler and poll() will always immediately return POLLHUP.
 
 Signed-off-by: Babis Chalios <bchalios@amazon.es>
+Reviewed-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
 ---
- drivers/ptp/ptp_vmclock.c        | 130 ++++++++++++++++++++++++++++---
- include/uapi/linux/vmclock-abi.h |   5 ++
- 2 files changed, 126 insertions(+), 9 deletions(-)
+ drivers/ptp/ptp_vmclock.c        | 200 ++++++++++++++++++++++++++-----
+ include/uapi/linux/vmclock-abi.h |   5 +
+ 2 files changed, 172 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
-index 1ce69eada4b2..4673915c43e7 100644
+index 1ce69eada4b2..87435b65ea7b 100644
 --- a/drivers/ptp/ptp_vmclock.c
 +++ b/drivers/ptp/ptp_vmclock.c
 @@ -5,6 +5,9 @@
@@ -49,15 +51,18 @@ index 1ce69eada4b2..4673915c43e7 100644
  	struct ptp_clock_info ptp_clock_info;
  	struct ptp_clock *ptp_clock;
  	enum clocksource_ids cs_id, sys_cs_id;
-@@ -311,10 +315,15 @@ static const struct ptp_clock_info ptp_vmclock_info = {
- 	.getcrosststamp = ptp_vmclock_getcrosststamp,
- };
+@@ -46,6 +50,9 @@ struct vmclock_state {
  
-+struct vmclock_file_state {
-+	struct vmclock_state *st;
-+	atomic_t seq;
-+};
+ #define VMCLOCK_MAX_WAIT ms_to_ktime(100)
+ 
++/* Require at least the flags field to be present. All else can be optional */
++#define VMCLOCK_MIN_SIZE offsetof(struct vmclock_abi, pad)
 +
+ /*
+  * Multiply a 64-bit count by a 64-bit tick 'period' in units of seconds >> 64
+  * and add the fractional second part of the reference time.
+@@ -313,8 +320,8 @@ static const struct ptp_clock_info ptp_vmclock_info = {
+ 
  static int vmclock_miscdev_mmap(struct file *fp, struct vm_area_struct *vma)
  {
 -	struct vmclock_state *st = container_of(fp->private_data,
@@ -67,23 +72,38 @@ index 1ce69eada4b2..4673915c43e7 100644
  
  	if ((vma->vm_flags & (VM_READ|VM_WRITE)) != VM_READ)
  		return -EROFS;
-@@ -333,11 +342,12 @@ static int vmclock_miscdev_mmap(struct file *fp, struct vm_area_struct *vma)
+@@ -322,22 +329,22 @@ static int vmclock_miscdev_mmap(struct file *fp, struct vm_area_struct *vma)
+ 	if (vma->vm_end - vma->vm_start != PAGE_SIZE || vma->vm_pgoff)
+ 		return -EINVAL;
+ 
+-        if (io_remap_pfn_range(vma, vma->vm_start,
+-			       st->res.start >> PAGE_SHIFT, PAGE_SIZE,
+-                               vma->vm_page_prot))
+-                return -EAGAIN;
++  if (io_remap_pfn_range(vma, vma->vm_start,
++             st->res.start >> PAGE_SHIFT, PAGE_SIZE,
++             vma->vm_page_prot))
++		return -EAGAIN;
+ 
+-        return 0;
++  return 0;
+ }
+ 
  static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
  				    size_t count, loff_t *ppos)
  {
 -	struct vmclock_state *st = container_of(fp->private_data,
 -						struct vmclock_state, miscdev);
+ 	ktime_t deadline = ktime_add(ktime_get(), VMCLOCK_MAX_WAIT);
 +	struct vmclock_file_state *fst = fp->private_data;
 +	struct vmclock_state *st = fst->st;
-+
- 	ktime_t deadline = ktime_add(ktime_get(), VMCLOCK_MAX_WAIT);
++	uint32_t seq, old_seq;
  	size_t max_count;
 -	int32_t seq;
-+	int32_t seq, old_seq;
  
  	if (*ppos >= PAGE_SIZE)
  		return 0;
-@@ -346,6 +356,7 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
+@@ -346,6 +353,7 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
  	if (count > max_count)
  		count = max_count;
  
@@ -91,13 +111,13 @@ index 1ce69eada4b2..4673915c43e7 100644
  	while (1) {
  		seq = st->clk->seq_count & ~1ULL;
  		virt_rmb();
-@@ -354,8 +365,16 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
+@@ -354,8 +362,16 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
  			return -EFAULT;
  
  		virt_rmb();
 -		if (seq == st->clk->seq_count)
 -			break;
-+		if (seq == st->clk->seq_count) {
++		if (seq == le32_to_cpu(st->clk->seq_count)) {
 +			/*
 +			 * Either we updated fst->seq to seq (the latest version we observed)
 +			 * or someone else did (old_seq == seq), so we can break.
@@ -110,41 +130,53 @@ index 1ce69eada4b2..4673915c43e7 100644
  
  		if (ktime_after(ktime_get(), deadline))
  			return -ETIMEDOUT;
-@@ -365,9 +384,57 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
+@@ -365,32 +381,67 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
  	return count;
  }
  
+-static const struct file_operations vmclock_miscdev_fops = {
+-        .mmap = vmclock_miscdev_mmap,
+-        .read = vmclock_miscdev_read,
+-};
 +static __poll_t vmclock_miscdev_poll(struct file *fp, poll_table *wait)
 +{
 +	struct vmclock_file_state *fst = fp->private_data;
 +	struct vmclock_state *st = fst->st;
 +	uint32_t seq;
-+
+ 
+-/* module operations */
 +	/*
 +	 * Hypervisor will not send us any notifications, so fail immediately
 +	 * to avoid having caller sleeping for ever.
 +	 */
-+	if (!(st->clk->flags & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
++	if (!(le64_to_cpu(st->clk->flags) & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
 +		return POLLHUP;
 +
 +	poll_wait(fp, &st->disrupt_wait, wait);
 +
-+	seq = st->clk->seq_count;
++	seq = le32_to_cpu(st->clk->seq_count);
 +	if (atomic_read(&fst->seq) != seq)
 +		return POLLIN | POLLRDNORM;
 +
 +	return 0;
 +}
-+
+ 
+-static int vmclock_remove(struct platform_device *pdev)
 +static int vmclock_miscdev_open(struct inode *inode, struct file *fp)
-+{
+ {
+-	struct device *dev = &pdev->dev;
+-	struct vmclock_state *st = dev_get_drvdata(dev);
 +	struct vmclock_state *st = container_of(fp->private_data,
 +						struct vmclock_state, miscdev);
 +	struct vmclock_file_state *fst = kzalloc(sizeof(*fst), GFP_KERNEL);
-+
+ 
+-	if (st->ptp_clock)
+-		ptp_clock_unregister(st->ptp_clock);
 +	if (!fst)
 +		return -ENOMEM;
-+
+ 
+-	if (st->miscdev.minor != MISC_DYNAMIC_MINOR)
+-		misc_deregister(&st->miscdev);
 +	fst->st = st;
 +	atomic_set(&fst->seq, 0);
 +
@@ -152,25 +184,43 @@ index 1ce69eada4b2..4673915c43e7 100644
 +
 +	return 0;
 +}
-+
+ 
 +static int vmclock_miscdev_release(struct inode *inode, struct file *fp)
 +{
 +	kfree(fp->private_data);
-+	return 0;
-+}
-+
- static const struct file_operations vmclock_miscdev_fops = {
--        .mmap = vmclock_miscdev_mmap,
--        .read = vmclock_miscdev_read,
+ 	return 0;
+ }
+ 
++static const struct file_operations vmclock_miscdev_fops = {
++	.owner = THIS_MODULE,
 +	.open = vmclock_miscdev_open,
 +	.release = vmclock_miscdev_release,
 +	.mmap = vmclock_miscdev_mmap,
 +	.read = vmclock_miscdev_read,
 +	.poll = vmclock_miscdev_poll,
- };
++};
++
++/* module operations */
++
+ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data)
+ {
+ 	struct vmclock_state *st = data;
+ 	struct resource_win win;
+-	struct resource *res = &(win.res);
++	struct resource *res = &win.res;
  
- /* module operations */
-@@ -413,6 +480,44 @@ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data
+ 	if (ares->type == ACPI_RESOURCE_TYPE_END_TAG)
+ 		return AE_OK;
+@@ -399,7 +450,7 @@ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data
+ 	if (resource_type(&st->res) == IORESOURCE_MEM)
+ 		return AE_ERROR;
+ 
+-        if (acpi_dev_resource_memory(ares, res) ||
++  if (acpi_dev_resource_memory(ares, res) ||
+ 	    acpi_dev_resource_address_space(ares, &win)) {
+ 
+ 		if (resource_type(res) != IORESOURCE_MEM ||
+@@ -413,6 +464,44 @@ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data
  	return AE_ERROR;
  }
  
@@ -198,7 +248,7 @@ index 1ce69eada4b2..4673915c43e7 100644
 +		return -ENODEV;
 +
 +	/* The device does not support notifications. Nothing else to do */
-+	if (!(st->clk->flags & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
++	if (!(le64_to_cpu(st->clk->flags) & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
 +		return 0;
 +
 +	status = acpi_install_notify_handler(adev->handle, ACPI_DEVICE_NOTIFY,
@@ -215,43 +265,130 @@ index 1ce69eada4b2..4673915c43e7 100644
  static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
  {
  	struct acpi_device *adev = ACPI_COMPANION(dev);
-@@ -495,6 +600,11 @@ static int vmclock_probe(struct platform_device *pdev)
+@@ -436,6 +525,30 @@ static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
+ 	return 0;
+ }
+ 
++static void vmclock_remove(void *data)
++{
++	struct device *dev = data;
++	struct vmclock_state *st = dev->driver_data;
++
++	if (!st) {
++		dev_err(dev, "vmclock_remove() called with NULL driver_data");
++		return;
++	}
++
++	if (has_acpi_companion(dev))
++		acpi_remove_notify_handler(ACPI_COMPANION(dev)->handle,
++					   ACPI_DEVICE_NOTIFY,
++					   vmclock_acpi_notification_handler);
++
++	if (st->ptp_clock)
++		ptp_clock_unregister(st->ptp_clock);
++
++	if (st->miscdev.minor != MISC_DYNAMIC_MINOR)
++		misc_deregister(&st->miscdev);
++
++	dev->driver_data = NULL;
++}
++
+ static void vmclock_put_idx(void *data)
+ {
+ 	struct vmclock_state *st = data;
+@@ -449,7 +562,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ 	struct vmclock_state *st;
+ 	int ret;
+ 
+-	st = devm_kzalloc(dev, sizeof (*st), GFP_KERNEL);
++	st = devm_kzalloc(dev, sizeof(*st), GFP_KERNEL);
+ 	if (!st)
+ 		return -ENOMEM;
+ 
+@@ -463,6 +576,11 @@ static int vmclock_probe(struct platform_device *pdev)
  		goto out;
  	}
  
++	if (resource_size(&st->res) < VMCLOCK_MIN_SIZE) {
++		dev_info(dev, "Region too small (0x%llx)\n",
++			 resource_size(&st->res));
++		return -EINVAL;
++	}
+ 	st->clk = devm_memremap(dev, st->res.start, resource_size(&st->res),
+ 				MEMREMAP_WB | MEMREMAP_DEC);
+ 	if (IS_ERR(st->clk)) {
+@@ -473,7 +591,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	if (st->clk->magic != VMCLOCK_MAGIC ||
+-	    st->clk->size < sizeof(*st->clk) ||
++	    st->clk->size > resource_size(&st->res) ||
+ 	    st->clk->version != 1) {
+ 		dev_info(dev, "vmclock magic fields invalid\n");
+ 		ret = -EINVAL;
+@@ -485,7 +603,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ 		goto out;
+ 
+ 	st->index = ret;
+-        ret = devm_add_action_or_reset(&pdev->dev, vmclock_put_idx, st);
++  ret = devm_add_action_or_reset(&pdev->dev, vmclock_put_idx, st);
+ 	if (ret)
+ 		goto out;
+ 
+@@ -495,9 +613,26 @@ static int vmclock_probe(struct platform_device *pdev)
+ 		goto out;
+ 	}
+ 
+-	/* If the structure is big enough, it can be mapped to userspace */
+-	if (st->clk->size >= PAGE_SIZE) {
+-		st->miscdev.minor = MISC_DYNAMIC_MINOR;
++	st->miscdev.minor = MISC_DYNAMIC_MINOR;
++
 +	init_waitqueue_head(&st->disrupt_wait);
++	dev->driver_data = st;
++
++	ret = devm_add_action_or_reset(&pdev->dev, vmclock_remove, dev);
++	if (ret)
++		return ret;
++
 +	ret = vmclock_setup_notification(dev, st);
 +	if (ret)
 +		return ret;
 +
- 	/* If the structure is big enough, it can be mapped to userspace */
- 	if (st->clk->size >= PAGE_SIZE) {
- 		st->miscdev.minor = MISC_DYNAMIC_MINOR;
-@@ -544,6 +654,8 @@ static int vmclock_probe(struct platform_device *pdev)
- 		goto out;
- 	}
++	/*
++	 * If the structure is big enough, it can be mapped to userspace.
++	 * Theoretically a guest OS even using larger pages could still
++	 * use 4KiB PTEs to map smaller MMIO regions like this, but let's
++	 * cross that bridge if/when we come to it.
++	 */
++	if (le32_to_cpu(st->clk->size) >= PAGE_SIZE) {
+ 		st->miscdev.fops = &vmclock_miscdev_fops;
+ 		st->miscdev.name = st->name;
  
-+	dev->driver_data = st;
-+
- 	dev_info(dev, "%s: registered %s%s%s\n", st->name,
- 		 st->miscdev.minor ? "miscdev" : "",
- 		 (st->miscdev.minor && st->ptp_clock) ? ", " : "",
+@@ -563,7 +698,6 @@ MODULE_DEVICE_TABLE(acpi, vmclock_acpi_ids);
+ 
+ static struct platform_driver vmclock_platform_driver = {
+ 	.probe		= vmclock_probe,
+-	.remove		= vmclock_remove,
+ 	.driver	= {
+ 		.name	= "vmclock",
+ 		.acpi_match_table = vmclock_acpi_ids,
 diff --git a/include/uapi/linux/vmclock-abi.h b/include/uapi/linux/vmclock-abi.h
-index 75deb6ae2b27..4b7cd2b8532c 100644
+index 62b8f2091ca5..412784fd5969 100644
 --- a/include/uapi/linux/vmclock-abi.h
 +++ b/include/uapi/linux/vmclock-abi.h
 @@ -125,6 +125,11 @@ struct vmclock_abi {
  	 * loaded from some save state (restored from a snapshot).
  	 */
- #define VMCLOCK_FLAG_VM_GEN_COUNTER_PRESENT     (1 << 8)
+ #define VMCLOCK_FLAG_VM_GEN_COUNTER_PRESENT (1 << 8)
 +	/*
 +	 * If the NOTIFICATION_PRESENT flag is set, the hypervisor will send
 +	 * a notification every time it updates seq_count to a new even number.
 +	 */
-+#define VMCLOCK_FLAG_NOTIFICATION_PRESENT       (1 << 9)
++#define VMCLOCK_FLAG_NOTIFICATION_PRESENT (1 << 9)
  
  	uint8_t pad[2];
  	uint8_t clock_status;
 -- 
-2.34.1
+2.52.0
 

--- a/resources/patches/vmclock/5.10/0003-dt-bindings-ptp-Add-amazon-vmclock.patch
+++ b/resources/patches/vmclock/5.10/0003-dt-bindings-ptp-Add-amazon-vmclock.patch
@@ -1,7 +1,7 @@
-From d594b01069fb6fabb068379b59bd26e59dbd6661 Mon Sep 17 00:00:00 2001
+From daf492c70d7e7a2a09d76481fd7ecbc5e99fb58f Mon Sep 17 00:00:00 2001
 From: David Woodhouse <dwmw@amazon.co.uk>
-Date: Tue, 2 Dec 2025 20:11:55 +0000
-Subject: [PATCH 3/4] dt-bindings: ptp: Add amazon,vmclock
+Date: Wed, 21 Jan 2026 14:33:40 +0000
+Subject: [PATCH 3/7] dt-bindings: ptp: Add amazon,vmclock
 
 The vmclock device provides a PTP clock source and precise timekeeping
 across live migration and snapshot/restore operations.
@@ -9,7 +9,7 @@ across live migration and snapshot/restore operations.
 The binding has a required memory region containing the vmclock_abi
 structure and an optional interrupt for clock disruption notifications.
 
-The full specification is at https://david.woodhou.se/VMClock.pdf
+The full spec is at https://uapi-group.org/specifications/specs/vmclock/
 
 Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
 Signed-off-by: Babis Chalios <bchalios@amazon.es>
@@ -21,7 +21,7 @@ Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
 
 diff --git a/Documentation/devicetree/bindings/ptp/amazon,vmclock.yaml b/Documentation/devicetree/bindings/ptp/amazon,vmclock.yaml
 new file mode 100644
-index 000000000000..b98fee20ce5f
+index 000000000000..357790df876f
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/ptp/amazon,vmclock.yaml
 @@ -0,0 +1,46 @@
@@ -39,8 +39,8 @@ index 000000000000..b98fee20ce5f
 +description:
 +  The vmclock device provides a precise clock source and allows for
 +  accurate timekeeping across live migration and snapshot/restore
-+  operations. The full specification of the shared data structure
-+  is available at https://david.woodhou.se/VMClock.pdf
++  operations. The full specification of the shared data structure is
++  available at https://uapi-group.org/specifications/specs/vmclock/
 +
 +properties:
 +  compatible:
@@ -72,5 +72,5 @@ index 000000000000..b98fee20ce5f
 +      interrupts = <GIC_SPI 36 IRQ_TYPE_EDGE_RISING>;
 +    };
 -- 
-2.34.1
+2.52.0
 

--- a/resources/patches/vmclock/5.10/0004-ptp-ptp_vmclock-Add-device-tree-support.patch
+++ b/resources/patches/vmclock/5.10/0004-ptp-ptp_vmclock-Add-device-tree-support.patch
@@ -1,36 +1,26 @@
-From a70db7595dac8a3b84d14a8dc62b4067cc152055 Mon Sep 17 00:00:00 2001
+From 30468d547a380aa6db4d9e2ba8ab735daeab0694 Mon Sep 17 00:00:00 2001
 From: David Woodhouse <dwmw@amazon.co.uk>
-Date: Tue, 2 Dec 2025 20:12:07 +0000
-Subject: [PATCH 4/4] ptp: ptp_vmclock: Add device tree support
+Date: Wed, 21 Jan 2026 14:33:41 +0000
+Subject: [PATCH 4/7] ptp: ptp_vmclock: Add device tree support
 
 Add device tree support to the ptp_vmclock driver, allowing it to probe
 via device tree in addition to ACPI.
 
 Handle optional interrupt for clock disruption notifications, mirroring
-the ACPI notification behavior.
+the ACPI notification behaviour.
+
+Although the interrupt is marked as 'optional' in the DT bindings, if
+the device *advertises* the VMCLOCK_FLAG_NOTIFICATION_ABSENT then it
+*should* have an interrupt. The driver will refuse to initialize if not.
 
 Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
 Signed-off-by: Babis Chalios <bchalios@amazon.es>
 ---
- drivers/ptp/Kconfig       |  2 +-
- drivers/ptp/ptp_vmclock.c | 83 ++++++++++++++++++++++++++++++++++++---
- 2 files changed, 78 insertions(+), 7 deletions(-)
+ drivers/ptp/ptp_vmclock.c | 67 +++++++++++++++++++++++++++++++++++----
+ 1 file changed, 61 insertions(+), 6 deletions(-)
 
-diff --git a/drivers/ptp/Kconfig b/drivers/ptp/Kconfig
-index 44bc88a0a772..8c1aad77d708 100644
---- a/drivers/ptp/Kconfig
-+++ b/drivers/ptp/Kconfig
-@@ -121,7 +121,7 @@ config PTP_1588_CLOCK_KVM
- config PTP_1588_CLOCK_VMCLOCK
-        tristate "Virtual machine PTP clock"
-        depends on X86_TSC || ARM_ARCH_TIMER
--       depends on PTP_1588_CLOCK && ACPI && ARCH_SUPPORTS_INT128
-+       depends on PTP_1588_CLOCK && ARCH_SUPPORTS_INT128
-        default y
-        help
-          This driver adds support for using a virtual precision clock
 diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
-index 4673915c43e7..4b8c7fa4ea91 100644
+index 87435b65ea7b..662fbe93534c 100644
 --- a/drivers/ptp/ptp_vmclock.c
 +++ b/drivers/ptp/ptp_vmclock.c
 @@ -14,10 +14,13 @@
@@ -47,15 +37,7 @@ index 4673915c43e7..4b8c7fa4ea91 100644
  #include <linux/platform_device.h>
  #include <linux/slab.h>
  #include <linux/vmclock-abi.h>
-@@ -453,6 +456,7 @@ static int vmclock_remove(struct platform_device *pdev)
- 	return 0;
- }
- 
-+#ifdef CONFIG_ACPI
- static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data)
- {
- 	struct vmclock_state *st = data;
-@@ -490,7 +494,7 @@ vmclock_acpi_notification_handler(acpi_handle __always_unused handle,
+@@ -474,7 +477,7 @@ vmclock_acpi_notification_handler(acpi_handle __always_unused handle,
  	wake_up_interruptible(&st->disrupt_wait);
  }
  
@@ -64,38 +46,24 @@ index 4673915c43e7..4b8c7fa4ea91 100644
  {
  	struct acpi_device *adev = ACPI_COMPANION(dev);
  	acpi_status status;
-@@ -503,10 +507,6 @@ static int vmclock_setup_notification(struct device *dev, struct vmclock_state *
+@@ -487,10 +490,6 @@ static int vmclock_setup_notification(struct device *dev, struct vmclock_state *
  	if (!adev)
  		return -ENODEV;
  
 -	/* The device does not support notifications. Nothing else to do */
--	if (!(st->clk->flags & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
+-	if (!(le64_to_cpu(st->clk->flags) & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
 -		return 0;
 -
  	status = acpi_install_notify_handler(adev->handle, ACPI_DEVICE_NOTIFY,
  					     vmclock_acpi_notification_handler,
  					     dev);
-@@ -540,6 +540,70 @@ static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
- 
+@@ -525,6 +524,55 @@ static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
  	return 0;
  }
-+#else
-+static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
+ 
++static irqreturn_t vmclock_of_irq_handler(int __always_unused irq, void *_st)
 +{
-+	return -EINVAL;
-+}
-+
-+static int vmclock_setup_acpi_notification(struct device *dev)
-+{
-+	return -EINVAL;
-+}
-+
-+#endif
-+
-+static irqreturn_t vmclock_of_irq_handler(int __always_unused irq, void *dev)
-+{
-+	struct device *device = dev;
-+	struct vmclock_state *st = device->driver_data;
++	struct vmclock_state *st = _st;
 +
 +	wake_up_interruptible(&st->disrupt_wait);
 +	return IRQ_HANDLED;
@@ -125,7 +93,7 @@ index 4673915c43e7..4b8c7fa4ea91 100644
 +		return irq;
 +
 +	return devm_request_irq(dev, irq, vmclock_of_irq_handler, IRQF_SHARED,
-+				"vmclock", dev);
++				"vmclock", dev->driver_data);
 +}
 +
 +static int vmclock_setup_notification(struct device *dev,
@@ -140,13 +108,12 @@ index 4673915c43e7..4b8c7fa4ea91 100644
 +	} else {
 +		return vmclock_setup_of_notification(dev);
 +	}
-+
 +}
 +
- 
- static void vmclock_put_idx(void *data)
+ static void vmclock_remove(void *data)
  {
-@@ -561,7 +625,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ 	struct device *dev = data;
+@@ -569,7 +617,7 @@ static int vmclock_probe(struct platform_device *pdev)
  	if (has_acpi_companion(dev))
  		ret = vmclock_probe_acpi(dev, st);
  	else
@@ -155,7 +122,7 @@ index 4673915c43e7..4b8c7fa4ea91 100644
  
  	if (ret) {
  		dev_info(dev, "Failed to obtain physical address: %d\n", ret);
-@@ -673,12 +737,19 @@ static const struct acpi_device_id vmclock_acpi_ids[] = {
+@@ -696,11 +744,18 @@ static const struct acpi_device_id vmclock_acpi_ids[] = {
  };
  MODULE_DEVICE_TABLE(acpi, vmclock_acpi_ids);
  
@@ -167,7 +134,6 @@ index 4673915c43e7..4b8c7fa4ea91 100644
 +
  static struct platform_driver vmclock_platform_driver = {
  	.probe		= vmclock_probe,
- 	.remove		= vmclock_remove,
  	.driver	= {
  		.name	= "vmclock",
  		.acpi_match_table = vmclock_acpi_ids,
@@ -176,5 +142,5 @@ index 4673915c43e7..4b8c7fa4ea91 100644
  };
  
 -- 
-2.34.1
+2.52.0
 

--- a/resources/patches/vmclock/5.10/0005-ptp-ptp_vmclock-add-VMCLOCK-to-ACPI-device-match.patch
+++ b/resources/patches/vmclock/5.10/0005-ptp-ptp_vmclock-add-VMCLOCK-to-ACPI-device-match.patch
@@ -1,0 +1,34 @@
+From d291cf42344f2f48557e545648bc26eea9b1828f Mon Sep 17 00:00:00 2001
+From: David Woodhouse <dwmw@amazon.co.uk>
+Date: Wed, 21 Jan 2026 14:33:42 +0000
+Subject: [PATCH 5/7] ptp: ptp_vmclock: add 'VMCLOCK' to ACPI device match
+
+As we finalised the spec, we spotted that vmgenid actually says that the
+_HID is supposed to be hypervisor-specific. Although in the 13 years
+since the original vmgenid doc was published, nobody seems to have cared
+about using _HID to distinguish between implementations on different
+hypervisors, and we only ever use the _CID.
+
+For consistency, match the _CID of "VMCLOCK" too.
+
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: Babis Chalios <bchalios@amazon.es>
+---
+ drivers/ptp/ptp_vmclock.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
+index 662fbe93534c..dbe549cc4b04 100644
+--- a/drivers/ptp/ptp_vmclock.c
++++ b/drivers/ptp/ptp_vmclock.c
+@@ -739,6 +739,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ }
+ 
+ static const struct acpi_device_id vmclock_acpi_ids[] = {
++	{ "AMZNC10C", 0 },
+ 	{ "VMCLOCK", 0 },
+ 	{}
+ };
+-- 
+2.52.0
+

--- a/resources/patches/vmclock/5.10/0006-ptp-ptp_vmclock-remove-dependency-on-CONFIG_ACPI.patch
+++ b/resources/patches/vmclock/5.10/0006-ptp-ptp_vmclock-remove-dependency-on-CONFIG_ACPI.patch
@@ -1,0 +1,116 @@
+From 1cb36e019ef80058db243c7a02696e17429bd0b1 Mon Sep 17 00:00:00 2001
+From: David Woodhouse <dwmw@amazon.co.uk>
+Date: Wed, 21 Jan 2026 14:33:43 +0000
+Subject: [PATCH 6/7] ptp: ptp_vmclock: remove dependency on CONFIG_ACPI
+
+Now that we added device tree support we can remove dependency on
+CONFIG_ACPI.
+
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: Babis Chalios <bchalios@amazon.es>
+---
+ drivers/ptp/Kconfig       | 26 +++++++++++++++-----------
+ drivers/ptp/ptp_vmclock.c | 14 ++++++++++----
+ 2 files changed, 25 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/ptp/Kconfig b/drivers/ptp/Kconfig
+index ebadd82c7a7d..e020045bac13 100644
+--- a/drivers/ptp/Kconfig
++++ b/drivers/ptp/Kconfig
+@@ -132,17 +132,21 @@ config PTP_1588_CLOCK_KVM
+ 	  will be called ptp_kvm.
+ 
+ config PTP_1588_CLOCK_VMCLOCK
+-       tristate "Virtual machine PTP clock"
+-       depends on X86_TSC || ARM_ARCH_TIMER
+-       depends on PTP_1588_CLOCK && ACPI && ARCH_SUPPORTS_INT128
+-       default y
+-       help
+-         This driver adds support for using a virtual precision clock
+-         advertised by the hypervisor. This clock is only useful in virtual
+-         machines where such a device is present.
+-
+-         To compile this driver as a module, choose M here: the module
+-         will be called ptp_vmclock.
++	tristate "Virtual machine PTP clock"
++	depends on X86_TSC || ARM_ARCH_TIMER
++	depends on PTP_1588_CLOCK && ARCH_SUPPORTS_INT128
++	default PTP_1588_CLOCK_KVM
++	help
++	  This driver adds support for using a virtual precision clock
++	  advertised by the hypervisor. This clock is only useful in virtual
++	  machines where such a device is present.
++
++	  Unlike the KVM virtual PTP clock, the VMCLOCK device offers support
++	  for reliable timekeeping even across live migration. So this driver
++	  is enabled by default whenever the KVM PTP clock is.
++
++		To compile this driver as a module, choose M here: the module
++		will be called ptp_vmclock.
+ 
+ config PTP_1588_CLOCK_IDT82P33
+ 	tristate "IDT 82P33xxx PTP clock"
+diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
+index dbe549cc4b04..2114d5fd760e 100644
+--- a/drivers/ptp/ptp_vmclock.c
++++ b/drivers/ptp/ptp_vmclock.c
+@@ -440,6 +440,7 @@ static const struct file_operations vmclock_miscdev_fops = {
+ 
+ /* module operations */
+ 
++#if IS_ENABLED(CONFIG_ACPI)
+ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data)
+ {
+ 	struct vmclock_state *st = data;
+@@ -523,6 +524,7 @@ static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
+ 
+ 	return 0;
+ }
++#endif /* CONFIG_ACPI */
+ 
+ static irqreturn_t vmclock_of_irq_handler(int __always_unused irq, void *_st)
+ {
+@@ -566,11 +568,11 @@ static int vmclock_setup_notification(struct device *dev,
+ 	if (!(le64_to_cpu(st->clk->flags) & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
+ 		return 0;
+ 
+-	if (has_acpi_companion(dev)) {
++#if IS_ENABLED(CONFIG_ACPI)
++	if (has_acpi_companion(dev))
+ 		return vmclock_setup_acpi_notification(dev);
+-	} else {
+-		return vmclock_setup_of_notification(dev);
+-	}
++#endif
++	return vmclock_setup_of_notification(dev);
+ }
+ 
+ static void vmclock_remove(void *data)
+@@ -583,10 +585,12 @@ static void vmclock_remove(void *data)
+ 		return;
+ 	}
+ 
++#if IS_ENABLED(CONFIG_ACPI)
+ 	if (has_acpi_companion(dev))
+ 		acpi_remove_notify_handler(ACPI_COMPANION(dev)->handle,
+ 					   ACPI_DEVICE_NOTIFY,
+ 					   vmclock_acpi_notification_handler);
++#endif
+ 
+ 	if (st->ptp_clock)
+ 		ptp_clock_unregister(st->ptp_clock);
+@@ -614,9 +618,11 @@ static int vmclock_probe(struct platform_device *pdev)
+ 	if (!st)
+ 		return -ENOMEM;
+ 
++#if IS_ENABLED(CONFIG_ACPI)
+ 	if (has_acpi_companion(dev))
+ 		ret = vmclock_probe_acpi(dev, st);
+ 	else
++#endif
+ 		ret = vmclock_probe_dt(dev, st);
+ 
+ 	if (ret) {
+-- 
+2.52.0
+

--- a/resources/patches/vmclock/5.10/0007-ptp-ptp_vmclock-return-TAI-not-UTC.patch
+++ b/resources/patches/vmclock/5.10/0007-ptp-ptp_vmclock-return-TAI-not-UTC.patch
@@ -1,0 +1,55 @@
+From 726b41d6531d0e77fc20f6d7ea4b3178ade41e80 Mon Sep 17 00:00:00 2001
+From: David Woodhouse <dwmw@amazon.co.uk>
+Date: Wed, 21 Jan 2026 14:33:44 +0000
+Subject: [PATCH 7/7] ptp: ptp_vmclock: return TAI not UTC
+
+To output UTC would involve complex calculations about whether the time
+elapsed since the reference time has crossed the end of the month when
+a leap second takes effect. I've prototyped that, but it made me sad.
+
+Much better to report TAI, which is what PHCs should do anyway.
+And much much simpler.
+
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: Babis Chalios <bchalios@amazon.es>
+---
+ drivers/ptp/ptp_vmclock.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
+index 2114d5fd760e..e0da9c5f5d00 100644
+--- a/drivers/ptp/ptp_vmclock.c
++++ b/drivers/ptp/ptp_vmclock.c
+@@ -80,13 +80,13 @@ static inline uint64_t mul_u64_u64_shr_add_u64(uint64_t *res_hi, uint64_t delta,
+ 
+ static inline bool tai_adjust(struct vmclock_abi *clk, uint64_t *sec)
+ {
+-	if (likely(clk->time_type == VMCLOCK_TIME_UTC))
++	if (clk->time_type == VMCLOCK_TIME_TAI)
+ 		return true;
+ 
+-	if (clk->time_type == VMCLOCK_TIME_TAI &&
+-	    (clk->flags & VMCLOCK_FLAG_TAI_OFFSET_VALID)) {
++	if (clk->time_type == VMCLOCK_TIME_UTC &&
++	    (le64_to_cpu(clk->flags) & VMCLOCK_FLAG_TAI_OFFSET_VALID)) {
+ 		if (sec)
+-			*sec += clk->tai_offset_sec;
++			*sec -= (int16_t)le16_to_cpu(clk->tai_offset_sec);
+ 		return true;
+ 	}
+ 	return false;
+@@ -321,6 +321,11 @@ static const struct ptp_clock_info ptp_vmclock_info = {
+ 	.getcrosststamp = ptp_vmclock_getcrosststamp,
+ };
+ 
++struct vmclock_file_state {
++	struct vmclock_state *st;
++	atomic_t seq;
++};
++
+ static int vmclock_miscdev_mmap(struct file *fp, struct vm_area_struct *vma)
+ {
+ 	struct vmclock_file_state *fst = fp->private_data;
+-- 
+2.52.0
+

--- a/resources/patches/vmclock/6.1/0001-ptp-vmclock-add-vm-generation-counter.patch
+++ b/resources/patches/vmclock/6.1/0001-ptp-vmclock-add-vm-generation-counter.patch
@@ -1,7 +1,7 @@
-From a46562c571c6d50e7afc3994b33d0ffb61ff7409 Mon Sep 17 00:00:00 2001
+From f2309165752b4af1fb2245fb434f4b0938aecd06 Mon Sep 17 00:00:00 2001
 From: Babis Chalios <bchalios@amazon.es>
-Date: Tue, 2 Dec 2025 20:11:32 +0000
-Subject: [PATCH 1/4] ptp: vmclock: add vm generation counter
+Date: Wed, 21 Jan 2026 14:33:38 +0000
+Subject: [PATCH 1/7] ptp: vmclock: add vm generation counter
 
 Similar to live migration, loading a VM from some saved state (aka
 snapshot) is also an event that calls for clock adjustments in the
@@ -18,31 +18,151 @@ presence of this bit in vmclock_abi flags field before using this flag.
 
 Signed-off-by: Babis Chalios <bchalios@amazon.es>
 Reviewed-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
 ---
- include/uapi/linux/vmclock-abi.h | 15 +++++++++++++++
- 1 file changed, 15 insertions(+)
+ include/uapi/linux/vmclock-abi.h | 93 ++++++++++++++++++--------------
+ 1 file changed, 54 insertions(+), 39 deletions(-)
 
 diff --git a/include/uapi/linux/vmclock-abi.h b/include/uapi/linux/vmclock-abi.h
-index d7ca44313bf8..75deb6ae2b27 100644
+index d7ca44313bf8..62b8f2091ca5 100644
 --- a/include/uapi/linux/vmclock-abi.h
 +++ b/include/uapi/linux/vmclock-abi.h
-@@ -119,6 +119,12 @@ struct vmclock_abi {
+@@ -67,22 +67,22 @@
+ struct vmclock_abi {
+ 	/* CONSTANT FIELDS */
+ 	uint32_t magic;
+-#define VMCLOCK_MAGIC	0x4b4c4356 /* "VCLK" */
+-	uint32_t size;		/* Size of region containing this structure */
+-	uint16_t version;	/* 1 */
++#define VMCLOCK_MAGIC 0x4b4c4356 /* "VCLK" */
++	uint32_t size; /* Size of region containing this structure */
++	uint16_t version; /* 1 */
+ 	uint8_t counter_id; /* Matches VIRTIO_RTC_COUNTER_xxx except INVALID */
+-#define VMCLOCK_COUNTER_ARM_VCNT	0
+-#define VMCLOCK_COUNTER_X86_TSC		1
+-#define VMCLOCK_COUNTER_INVALID		0xff
++#define VMCLOCK_COUNTER_ARM_VCNT 0
++#define VMCLOCK_COUNTER_X86_TSC 1
++#define VMCLOCK_COUNTER_INVALID 0xff
+ 	uint8_t time_type; /* Matches VIRTIO_RTC_TYPE_xxx */
+-#define VMCLOCK_TIME_UTC			0	/* Since 1970-01-01 00:00:00z */
+-#define VMCLOCK_TIME_TAI			1	/* Since 1970-01-01 00:00:00z */
+-#define VMCLOCK_TIME_MONOTONIC			2	/* Since undefined epoch */
+-#define VMCLOCK_TIME_INVALID_SMEARED		3	/* Not supported */
+-#define VMCLOCK_TIME_INVALID_MAYBE_SMEARED	4	/* Not supported */
++#define VMCLOCK_TIME_UTC 0 /* Since 1970-01-01 00:00:00z */
++#define VMCLOCK_TIME_TAI 1 /* Since 1970-01-01 00:00:00z */
++#define VMCLOCK_TIME_MONOTONIC 2 /* Since undefined epoch */
++#define VMCLOCK_TIME_INVALID_SMEARED 3 /* Not supported */
++#define VMCLOCK_TIME_INVALID_MAYBE_SMEARED 4 /* Not supported */
+ 
+ 	/* NON-CONSTANT FIELDS PROTECTED BY SEQCOUNT LOCK */
+-	uint32_t seq_count;	/* Low bit means an update is in progress */
++	uint32_t seq_count; /* Low bit means an update is in progress */
+ 	/*
+ 	 * This field changes to another non-repeating value when the CPU
+ 	 * counter is disrupted, for example on live migration. This lets
+@@ -92,19 +92,19 @@ struct vmclock_abi {
+ 	uint64_t disruption_marker;
+ 	uint64_t flags;
+ 	/* Indicates that the tai_offset_sec field is valid */
+-#define VMCLOCK_FLAG_TAI_OFFSET_VALID		(1 << 0)
++#define VMCLOCK_FLAG_TAI_OFFSET_VALID (1 << 0)
+ 	/*
+ 	 * Optionally used to notify guests of pending maintenance events.
+ 	 * A guest which provides latency-sensitive services may wish to
+ 	 * remove itself from service if an event is coming up. Two flags
+ 	 * indicate the approximate imminence of the event.
+ 	 */
+-#define VMCLOCK_FLAG_DISRUPTION_SOON		(1 << 1) /* About a day */
+-#define VMCLOCK_FLAG_DISRUPTION_IMMINENT	(1 << 2) /* About an hour */
+-#define VMCLOCK_FLAG_PERIOD_ESTERROR_VALID	(1 << 3)
+-#define VMCLOCK_FLAG_PERIOD_MAXERROR_VALID	(1 << 4)
+-#define VMCLOCK_FLAG_TIME_ESTERROR_VALID	(1 << 5)
+-#define VMCLOCK_FLAG_TIME_MAXERROR_VALID	(1 << 6)
++#define VMCLOCK_FLAG_DISRUPTION_SOON (1 << 1) /* About a day */
++#define VMCLOCK_FLAG_DISRUPTION_IMMINENT (1 << 2) /* About an hour */
++#define VMCLOCK_FLAG_PERIOD_ESTERROR_VALID (1 << 3)
++#define VMCLOCK_FLAG_PERIOD_MAXERROR_VALID (1 << 4)
++#define VMCLOCK_FLAG_TIME_ESTERROR_VALID (1 << 5)
++#define VMCLOCK_FLAG_TIME_MAXERROR_VALID (1 << 6)
+ 	/*
+ 	 * If the MONOTONIC flag is set then (other than leap seconds) it is
+ 	 * guaranteed that the time calculated according this structure at
+@@ -118,15 +118,21 @@ struct vmclock_abi {
+ 	 * a counter reading taken immediately before *clearing* the low
  	 * bit again after the update, using the about-to-be-valid fields.
  	 */
- #define VMCLOCK_FLAG_TIME_MONOTONIC		(1 << 7)
+-#define VMCLOCK_FLAG_TIME_MONOTONIC		(1 << 7)
++#define VMCLOCK_FLAG_TIME_MONOTONIC (1 << 7)
 +	/*
 +	 * If the VM_GEN_COUNTER_PRESENT flag is set, the hypervisor will
 +	 * bump the vm_generation_counter field every time the guest is
 +	 * loaded from some save state (restored from a snapshot).
 +	 */
-+#define VMCLOCK_FLAG_VM_GEN_COUNTER_PRESENT     (1 << 8)
++#define VMCLOCK_FLAG_VM_GEN_COUNTER_PRESENT (1 << 8)
  
  	uint8_t pad[2];
  	uint8_t clock_status;
-@@ -183,6 +189,15 @@ struct vmclock_abi {
- 	uint64_t time_frac_sec;		/* (seconds >> 64) */
- 	uint64_t time_esterror_picosec;	/* (± picoseconds) */
- 	uint64_t time_maxerror_picosec;	/* (± picoseconds) */
+-#define VMCLOCK_STATUS_UNKNOWN		0
+-#define VMCLOCK_STATUS_INITIALIZING	1
+-#define VMCLOCK_STATUS_SYNCHRONIZED	2
+-#define VMCLOCK_STATUS_FREERUNNING	3
+-#define VMCLOCK_STATUS_UNRELIABLE	4
++#define VMCLOCK_STATUS_UNKNOWN 0
++#define VMCLOCK_STATUS_INITIALIZING 1
++#define VMCLOCK_STATUS_SYNCHRONIZED 2
++#define VMCLOCK_STATUS_FREERUNNING 3
++#define VMCLOCK_STATUS_UNRELIABLE 4
+ 
+ 	/*
+ 	 * The time exposed through this device is never smeared. This field
+@@ -138,9 +144,9 @@ struct vmclock_abi {
+ 	 * in the nearby environment.
+ 	 */
+ 	uint8_t leap_second_smearing_hint; /* Matches VIRTIO_RTC_SUBTYPE_xxx */
+-#define VMCLOCK_SMEARING_STRICT		0
+-#define VMCLOCK_SMEARING_NOON_LINEAR	1
+-#define VMCLOCK_SMEARING_UTC_SLS	2
++#define VMCLOCK_SMEARING_STRICT 0
++#define VMCLOCK_SMEARING_NOON_LINEAR 1
++#define VMCLOCK_SMEARING_UTC_SLS 2
+ 	int16_t tai_offset_sec;
+ 	uint8_t leap_indicator;
+ 	/*
+@@ -154,13 +160,13 @@ struct vmclock_abi {
+ 	 * leap second when such smearing may need to continue being applied.
+ 	 * It is hoped that these will be incorporated into virtio-rtc too.
+ 	 */
+-#define VMCLOCK_LEAP_NONE	0	/* No known nearby leap second */
+-#define VMCLOCK_LEAP_PRE_POS	1	/* Positive leap second at EOM */
+-#define VMCLOCK_LEAP_PRE_NEG	2	/* Negative leap second at EOM */
+-#define VMCLOCK_LEAP_POS	3	/* Set during 23:59:60 second */
+-#define VMCLOCK_LEAP_NEG	4	/* Not used in VMCLOCK */
+-#define VMCLOCK_LEAP_POST_POS	5
+-#define VMCLOCK_LEAP_POST_NEG	6
++#define VMCLOCK_LEAP_NONE 0 /* No known nearby leap second */
++#define VMCLOCK_LEAP_PRE_POS 1 /* Positive leap second at EOM */
++#define VMCLOCK_LEAP_PRE_NEG 2 /* Negative leap second at EOM */
++#define VMCLOCK_LEAP_POS 3 /* Set during 23:59:60 second */
++#define VMCLOCK_LEAP_NEG 4 /* Not used in VMCLOCK */
++#define VMCLOCK_LEAP_POST_POS 5
++#define VMCLOCK_LEAP_POST_NEG 6
+ 
+ 	/* Bit shift for counter_period_frac_sec and its error rate */
+ 	uint8_t counter_period_shift;
+@@ -179,10 +185,19 @@ struct vmclock_abi {
+ 	/*
+ 	 * Time according to time_type field above.
+ 	 */
+-	uint64_t time_sec;		/* Seconds since time_type epoch */
+-	uint64_t time_frac_sec;		/* (seconds >> 64) */
+-	uint64_t time_esterror_picosec;	/* (± picoseconds) */
+-	uint64_t time_maxerror_picosec;	/* (± picoseconds) */
++	uint64_t time_sec; /* Seconds since time_type epoch */
++	uint64_t time_frac_sec; /* (seconds >> 64) */
++	uint64_t time_esterror_picosec; /* (± picoseconds) */
++	uint64_t time_maxerror_picosec; /* (± picoseconds) */
 +
 +	/*
 +	 * This field changes to another non-repeating value when the guest
@@ -56,5 +176,5 @@ index d7ca44313bf8..75deb6ae2b27 100644
  
  #endif /*  __VMCLOCK_ABI_H__ */
 -- 
-2.34.1
+2.52.0
 

--- a/resources/patches/vmclock/6.1/0002-ptp-vmclock-support-device-notifications.patch
+++ b/resources/patches/vmclock/6.1/0002-ptp-vmclock-support-device-notifications.patch
@@ -1,7 +1,7 @@
-From d0a6bf47dd6cd2a9ed17dbdc32dd34a6ba0f5b5f Mon Sep 17 00:00:00 2001
+From b1a7ba47d96753695d9101dde049bc0808f76167 Mon Sep 17 00:00:00 2001
 From: Babis Chalios <bchalios@amazon.es>
-Date: Tue, 2 Dec 2025 20:11:44 +0000
-Subject: [PATCH 2/4] ptp: vmclock: support device notifications
+Date: Wed, 21 Jan 2026 14:33:39 +0000
+Subject: [PATCH 2/7] ptp: vmclock: support device notifications
 
 Add optional support for device notifications in VMClock. When
 supported, the hypervisor will send a device notification every time it
@@ -22,13 +22,15 @@ the flag is not present the driver won't setup the ACPI notification
 handler and poll() will always immediately return POLLHUP.
 
 Signed-off-by: Babis Chalios <bchalios@amazon.es>
+Reviewed-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
 ---
- drivers/ptp/ptp_vmclock.c        | 130 ++++++++++++++++++++++++++++---
- include/uapi/linux/vmclock-abi.h |   5 ++
- 2 files changed, 126 insertions(+), 9 deletions(-)
+ drivers/ptp/ptp_vmclock.c        | 200 ++++++++++++++++++++++++++-----
+ include/uapi/linux/vmclock-abi.h |   5 +
+ 2 files changed, 172 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
-index 1ce69eada4b2..4673915c43e7 100644
+index 1ce69eada4b2..87435b65ea7b 100644
 --- a/drivers/ptp/ptp_vmclock.c
 +++ b/drivers/ptp/ptp_vmclock.c
 @@ -5,6 +5,9 @@
@@ -49,15 +51,18 @@ index 1ce69eada4b2..4673915c43e7 100644
  	struct ptp_clock_info ptp_clock_info;
  	struct ptp_clock *ptp_clock;
  	enum clocksource_ids cs_id, sys_cs_id;
-@@ -311,10 +315,15 @@ static const struct ptp_clock_info ptp_vmclock_info = {
- 	.getcrosststamp = ptp_vmclock_getcrosststamp,
- };
+@@ -46,6 +50,9 @@ struct vmclock_state {
  
-+struct vmclock_file_state {
-+	struct vmclock_state *st;
-+	atomic_t seq;
-+};
+ #define VMCLOCK_MAX_WAIT ms_to_ktime(100)
+ 
++/* Require at least the flags field to be present. All else can be optional */
++#define VMCLOCK_MIN_SIZE offsetof(struct vmclock_abi, pad)
 +
+ /*
+  * Multiply a 64-bit count by a 64-bit tick 'period' in units of seconds >> 64
+  * and add the fractional second part of the reference time.
+@@ -313,8 +320,8 @@ static const struct ptp_clock_info ptp_vmclock_info = {
+ 
  static int vmclock_miscdev_mmap(struct file *fp, struct vm_area_struct *vma)
  {
 -	struct vmclock_state *st = container_of(fp->private_data,
@@ -67,23 +72,38 @@ index 1ce69eada4b2..4673915c43e7 100644
  
  	if ((vma->vm_flags & (VM_READ|VM_WRITE)) != VM_READ)
  		return -EROFS;
-@@ -333,11 +342,12 @@ static int vmclock_miscdev_mmap(struct file *fp, struct vm_area_struct *vma)
+@@ -322,22 +329,22 @@ static int vmclock_miscdev_mmap(struct file *fp, struct vm_area_struct *vma)
+ 	if (vma->vm_end - vma->vm_start != PAGE_SIZE || vma->vm_pgoff)
+ 		return -EINVAL;
+ 
+-        if (io_remap_pfn_range(vma, vma->vm_start,
+-			       st->res.start >> PAGE_SHIFT, PAGE_SIZE,
+-                               vma->vm_page_prot))
+-                return -EAGAIN;
++  if (io_remap_pfn_range(vma, vma->vm_start,
++             st->res.start >> PAGE_SHIFT, PAGE_SIZE,
++             vma->vm_page_prot))
++		return -EAGAIN;
+ 
+-        return 0;
++  return 0;
+ }
+ 
  static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
  				    size_t count, loff_t *ppos)
  {
 -	struct vmclock_state *st = container_of(fp->private_data,
 -						struct vmclock_state, miscdev);
+ 	ktime_t deadline = ktime_add(ktime_get(), VMCLOCK_MAX_WAIT);
 +	struct vmclock_file_state *fst = fp->private_data;
 +	struct vmclock_state *st = fst->st;
-+
- 	ktime_t deadline = ktime_add(ktime_get(), VMCLOCK_MAX_WAIT);
++	uint32_t seq, old_seq;
  	size_t max_count;
 -	int32_t seq;
-+	int32_t seq, old_seq;
  
  	if (*ppos >= PAGE_SIZE)
  		return 0;
-@@ -346,6 +356,7 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
+@@ -346,6 +353,7 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
  	if (count > max_count)
  		count = max_count;
  
@@ -91,13 +111,13 @@ index 1ce69eada4b2..4673915c43e7 100644
  	while (1) {
  		seq = st->clk->seq_count & ~1ULL;
  		virt_rmb();
-@@ -354,8 +365,16 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
+@@ -354,8 +362,16 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
  			return -EFAULT;
  
  		virt_rmb();
 -		if (seq == st->clk->seq_count)
 -			break;
-+		if (seq == st->clk->seq_count) {
++		if (seq == le32_to_cpu(st->clk->seq_count)) {
 +			/*
 +			 * Either we updated fst->seq to seq (the latest version we observed)
 +			 * or someone else did (old_seq == seq), so we can break.
@@ -110,41 +130,53 @@ index 1ce69eada4b2..4673915c43e7 100644
  
  		if (ktime_after(ktime_get(), deadline))
  			return -ETIMEDOUT;
-@@ -365,9 +384,57 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
+@@ -365,32 +381,67 @@ static ssize_t vmclock_miscdev_read(struct file *fp, char __user *buf,
  	return count;
  }
  
+-static const struct file_operations vmclock_miscdev_fops = {
+-        .mmap = vmclock_miscdev_mmap,
+-        .read = vmclock_miscdev_read,
+-};
 +static __poll_t vmclock_miscdev_poll(struct file *fp, poll_table *wait)
 +{
 +	struct vmclock_file_state *fst = fp->private_data;
 +	struct vmclock_state *st = fst->st;
 +	uint32_t seq;
-+
+ 
+-/* module operations */
 +	/*
 +	 * Hypervisor will not send us any notifications, so fail immediately
 +	 * to avoid having caller sleeping for ever.
 +	 */
-+	if (!(st->clk->flags & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
++	if (!(le64_to_cpu(st->clk->flags) & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
 +		return POLLHUP;
 +
 +	poll_wait(fp, &st->disrupt_wait, wait);
 +
-+	seq = st->clk->seq_count;
++	seq = le32_to_cpu(st->clk->seq_count);
 +	if (atomic_read(&fst->seq) != seq)
 +		return POLLIN | POLLRDNORM;
 +
 +	return 0;
 +}
-+
+ 
+-static int vmclock_remove(struct platform_device *pdev)
 +static int vmclock_miscdev_open(struct inode *inode, struct file *fp)
-+{
+ {
+-	struct device *dev = &pdev->dev;
+-	struct vmclock_state *st = dev_get_drvdata(dev);
 +	struct vmclock_state *st = container_of(fp->private_data,
 +						struct vmclock_state, miscdev);
 +	struct vmclock_file_state *fst = kzalloc(sizeof(*fst), GFP_KERNEL);
-+
+ 
+-	if (st->ptp_clock)
+-		ptp_clock_unregister(st->ptp_clock);
 +	if (!fst)
 +		return -ENOMEM;
-+
+ 
+-	if (st->miscdev.minor != MISC_DYNAMIC_MINOR)
+-		misc_deregister(&st->miscdev);
 +	fst->st = st;
 +	atomic_set(&fst->seq, 0);
 +
@@ -152,25 +184,43 @@ index 1ce69eada4b2..4673915c43e7 100644
 +
 +	return 0;
 +}
-+
+ 
 +static int vmclock_miscdev_release(struct inode *inode, struct file *fp)
 +{
 +	kfree(fp->private_data);
-+	return 0;
-+}
-+
- static const struct file_operations vmclock_miscdev_fops = {
--        .mmap = vmclock_miscdev_mmap,
--        .read = vmclock_miscdev_read,
+ 	return 0;
+ }
+ 
++static const struct file_operations vmclock_miscdev_fops = {
++	.owner = THIS_MODULE,
 +	.open = vmclock_miscdev_open,
 +	.release = vmclock_miscdev_release,
 +	.mmap = vmclock_miscdev_mmap,
 +	.read = vmclock_miscdev_read,
 +	.poll = vmclock_miscdev_poll,
- };
++};
++
++/* module operations */
++
+ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data)
+ {
+ 	struct vmclock_state *st = data;
+ 	struct resource_win win;
+-	struct resource *res = &(win.res);
++	struct resource *res = &win.res;
  
- /* module operations */
-@@ -413,6 +480,44 @@ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data
+ 	if (ares->type == ACPI_RESOURCE_TYPE_END_TAG)
+ 		return AE_OK;
+@@ -399,7 +450,7 @@ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data
+ 	if (resource_type(&st->res) == IORESOURCE_MEM)
+ 		return AE_ERROR;
+ 
+-        if (acpi_dev_resource_memory(ares, res) ||
++  if (acpi_dev_resource_memory(ares, res) ||
+ 	    acpi_dev_resource_address_space(ares, &win)) {
+ 
+ 		if (resource_type(res) != IORESOURCE_MEM ||
+@@ -413,6 +464,44 @@ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data
  	return AE_ERROR;
  }
  
@@ -198,7 +248,7 @@ index 1ce69eada4b2..4673915c43e7 100644
 +		return -ENODEV;
 +
 +	/* The device does not support notifications. Nothing else to do */
-+	if (!(st->clk->flags & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
++	if (!(le64_to_cpu(st->clk->flags) & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
 +		return 0;
 +
 +	status = acpi_install_notify_handler(adev->handle, ACPI_DEVICE_NOTIFY,
@@ -215,43 +265,130 @@ index 1ce69eada4b2..4673915c43e7 100644
  static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
  {
  	struct acpi_device *adev = ACPI_COMPANION(dev);
-@@ -495,6 +600,11 @@ static int vmclock_probe(struct platform_device *pdev)
+@@ -436,6 +525,30 @@ static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
+ 	return 0;
+ }
+ 
++static void vmclock_remove(void *data)
++{
++	struct device *dev = data;
++	struct vmclock_state *st = dev->driver_data;
++
++	if (!st) {
++		dev_err(dev, "vmclock_remove() called with NULL driver_data");
++		return;
++	}
++
++	if (has_acpi_companion(dev))
++		acpi_remove_notify_handler(ACPI_COMPANION(dev)->handle,
++					   ACPI_DEVICE_NOTIFY,
++					   vmclock_acpi_notification_handler);
++
++	if (st->ptp_clock)
++		ptp_clock_unregister(st->ptp_clock);
++
++	if (st->miscdev.minor != MISC_DYNAMIC_MINOR)
++		misc_deregister(&st->miscdev);
++
++	dev->driver_data = NULL;
++}
++
+ static void vmclock_put_idx(void *data)
+ {
+ 	struct vmclock_state *st = data;
+@@ -449,7 +562,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ 	struct vmclock_state *st;
+ 	int ret;
+ 
+-	st = devm_kzalloc(dev, sizeof (*st), GFP_KERNEL);
++	st = devm_kzalloc(dev, sizeof(*st), GFP_KERNEL);
+ 	if (!st)
+ 		return -ENOMEM;
+ 
+@@ -463,6 +576,11 @@ static int vmclock_probe(struct platform_device *pdev)
  		goto out;
  	}
  
++	if (resource_size(&st->res) < VMCLOCK_MIN_SIZE) {
++		dev_info(dev, "Region too small (0x%llx)\n",
++			 resource_size(&st->res));
++		return -EINVAL;
++	}
+ 	st->clk = devm_memremap(dev, st->res.start, resource_size(&st->res),
+ 				MEMREMAP_WB | MEMREMAP_DEC);
+ 	if (IS_ERR(st->clk)) {
+@@ -473,7 +591,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	if (st->clk->magic != VMCLOCK_MAGIC ||
+-	    st->clk->size < sizeof(*st->clk) ||
++	    st->clk->size > resource_size(&st->res) ||
+ 	    st->clk->version != 1) {
+ 		dev_info(dev, "vmclock magic fields invalid\n");
+ 		ret = -EINVAL;
+@@ -485,7 +603,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ 		goto out;
+ 
+ 	st->index = ret;
+-        ret = devm_add_action_or_reset(&pdev->dev, vmclock_put_idx, st);
++  ret = devm_add_action_or_reset(&pdev->dev, vmclock_put_idx, st);
+ 	if (ret)
+ 		goto out;
+ 
+@@ -495,9 +613,26 @@ static int vmclock_probe(struct platform_device *pdev)
+ 		goto out;
+ 	}
+ 
+-	/* If the structure is big enough, it can be mapped to userspace */
+-	if (st->clk->size >= PAGE_SIZE) {
+-		st->miscdev.minor = MISC_DYNAMIC_MINOR;
++	st->miscdev.minor = MISC_DYNAMIC_MINOR;
++
 +	init_waitqueue_head(&st->disrupt_wait);
++	dev->driver_data = st;
++
++	ret = devm_add_action_or_reset(&pdev->dev, vmclock_remove, dev);
++	if (ret)
++		return ret;
++
 +	ret = vmclock_setup_notification(dev, st);
 +	if (ret)
 +		return ret;
 +
- 	/* If the structure is big enough, it can be mapped to userspace */
- 	if (st->clk->size >= PAGE_SIZE) {
- 		st->miscdev.minor = MISC_DYNAMIC_MINOR;
-@@ -544,6 +654,8 @@ static int vmclock_probe(struct platform_device *pdev)
- 		goto out;
- 	}
++	/*
++	 * If the structure is big enough, it can be mapped to userspace.
++	 * Theoretically a guest OS even using larger pages could still
++	 * use 4KiB PTEs to map smaller MMIO regions like this, but let's
++	 * cross that bridge if/when we come to it.
++	 */
++	if (le32_to_cpu(st->clk->size) >= PAGE_SIZE) {
+ 		st->miscdev.fops = &vmclock_miscdev_fops;
+ 		st->miscdev.name = st->name;
  
-+	dev->driver_data = st;
-+
- 	dev_info(dev, "%s: registered %s%s%s\n", st->name,
- 		 st->miscdev.minor ? "miscdev" : "",
- 		 (st->miscdev.minor && st->ptp_clock) ? ", " : "",
+@@ -563,7 +698,6 @@ MODULE_DEVICE_TABLE(acpi, vmclock_acpi_ids);
+ 
+ static struct platform_driver vmclock_platform_driver = {
+ 	.probe		= vmclock_probe,
+-	.remove		= vmclock_remove,
+ 	.driver	= {
+ 		.name	= "vmclock",
+ 		.acpi_match_table = vmclock_acpi_ids,
 diff --git a/include/uapi/linux/vmclock-abi.h b/include/uapi/linux/vmclock-abi.h
-index 75deb6ae2b27..4b7cd2b8532c 100644
+index 62b8f2091ca5..412784fd5969 100644
 --- a/include/uapi/linux/vmclock-abi.h
 +++ b/include/uapi/linux/vmclock-abi.h
 @@ -125,6 +125,11 @@ struct vmclock_abi {
  	 * loaded from some save state (restored from a snapshot).
  	 */
- #define VMCLOCK_FLAG_VM_GEN_COUNTER_PRESENT     (1 << 8)
+ #define VMCLOCK_FLAG_VM_GEN_COUNTER_PRESENT (1 << 8)
 +	/*
 +	 * If the NOTIFICATION_PRESENT flag is set, the hypervisor will send
 +	 * a notification every time it updates seq_count to a new even number.
 +	 */
-+#define VMCLOCK_FLAG_NOTIFICATION_PRESENT       (1 << 9)
++#define VMCLOCK_FLAG_NOTIFICATION_PRESENT (1 << 9)
  
  	uint8_t pad[2];
  	uint8_t clock_status;
 -- 
-2.34.1
+2.52.0
 

--- a/resources/patches/vmclock/6.1/0003-dt-bindings-ptp-Add-amazon-vmclock.patch
+++ b/resources/patches/vmclock/6.1/0003-dt-bindings-ptp-Add-amazon-vmclock.patch
@@ -1,7 +1,7 @@
-From d594b01069fb6fabb068379b59bd26e59dbd6661 Mon Sep 17 00:00:00 2001
+From daf492c70d7e7a2a09d76481fd7ecbc5e99fb58f Mon Sep 17 00:00:00 2001
 From: David Woodhouse <dwmw@amazon.co.uk>
-Date: Tue, 2 Dec 2025 20:11:55 +0000
-Subject: [PATCH 3/4] dt-bindings: ptp: Add amazon,vmclock
+Date: Wed, 21 Jan 2026 14:33:40 +0000
+Subject: [PATCH 3/7] dt-bindings: ptp: Add amazon,vmclock
 
 The vmclock device provides a PTP clock source and precise timekeeping
 across live migration and snapshot/restore operations.
@@ -9,7 +9,7 @@ across live migration and snapshot/restore operations.
 The binding has a required memory region containing the vmclock_abi
 structure and an optional interrupt for clock disruption notifications.
 
-The full specification is at https://david.woodhou.se/VMClock.pdf
+The full spec is at https://uapi-group.org/specifications/specs/vmclock/
 
 Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
 Signed-off-by: Babis Chalios <bchalios@amazon.es>
@@ -21,7 +21,7 @@ Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@oss.qualcomm.com>
 
 diff --git a/Documentation/devicetree/bindings/ptp/amazon,vmclock.yaml b/Documentation/devicetree/bindings/ptp/amazon,vmclock.yaml
 new file mode 100644
-index 000000000000..b98fee20ce5f
+index 000000000000..357790df876f
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/ptp/amazon,vmclock.yaml
 @@ -0,0 +1,46 @@
@@ -39,8 +39,8 @@ index 000000000000..b98fee20ce5f
 +description:
 +  The vmclock device provides a precise clock source and allows for
 +  accurate timekeeping across live migration and snapshot/restore
-+  operations. The full specification of the shared data structure
-+  is available at https://david.woodhou.se/VMClock.pdf
++  operations. The full specification of the shared data structure is
++  available at https://uapi-group.org/specifications/specs/vmclock/
 +
 +properties:
 +  compatible:
@@ -72,5 +72,5 @@ index 000000000000..b98fee20ce5f
 +      interrupts = <GIC_SPI 36 IRQ_TYPE_EDGE_RISING>;
 +    };
 -- 
-2.34.1
+2.52.0
 

--- a/resources/patches/vmclock/6.1/0004-ptp-ptp_vmclock-Add-device-tree-support.patch
+++ b/resources/patches/vmclock/6.1/0004-ptp-ptp_vmclock-Add-device-tree-support.patch
@@ -1,36 +1,26 @@
-From a70db7595dac8a3b84d14a8dc62b4067cc152055 Mon Sep 17 00:00:00 2001
+From 30468d547a380aa6db4d9e2ba8ab735daeab0694 Mon Sep 17 00:00:00 2001
 From: David Woodhouse <dwmw@amazon.co.uk>
-Date: Tue, 2 Dec 2025 20:12:07 +0000
-Subject: [PATCH 4/4] ptp: ptp_vmclock: Add device tree support
+Date: Wed, 21 Jan 2026 14:33:41 +0000
+Subject: [PATCH 4/7] ptp: ptp_vmclock: Add device tree support
 
 Add device tree support to the ptp_vmclock driver, allowing it to probe
 via device tree in addition to ACPI.
 
 Handle optional interrupt for clock disruption notifications, mirroring
-the ACPI notification behavior.
+the ACPI notification behaviour.
+
+Although the interrupt is marked as 'optional' in the DT bindings, if
+the device *advertises* the VMCLOCK_FLAG_NOTIFICATION_ABSENT then it
+*should* have an interrupt. The driver will refuse to initialize if not.
 
 Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
 Signed-off-by: Babis Chalios <bchalios@amazon.es>
 ---
- drivers/ptp/Kconfig       |  2 +-
- drivers/ptp/ptp_vmclock.c | 83 ++++++++++++++++++++++++++++++++++++---
- 2 files changed, 78 insertions(+), 7 deletions(-)
+ drivers/ptp/ptp_vmclock.c | 67 +++++++++++++++++++++++++++++++++++----
+ 1 file changed, 61 insertions(+), 6 deletions(-)
 
-diff --git a/drivers/ptp/Kconfig b/drivers/ptp/Kconfig
-index 44bc88a0a772..8c1aad77d708 100644
---- a/drivers/ptp/Kconfig
-+++ b/drivers/ptp/Kconfig
-@@ -121,7 +121,7 @@ config PTP_1588_CLOCK_KVM
- config PTP_1588_CLOCK_VMCLOCK
-        tristate "Virtual machine PTP clock"
-        depends on X86_TSC || ARM_ARCH_TIMER
--       depends on PTP_1588_CLOCK && ACPI && ARCH_SUPPORTS_INT128
-+       depends on PTP_1588_CLOCK && ARCH_SUPPORTS_INT128
-        default y
-        help
-          This driver adds support for using a virtual precision clock
 diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
-index 4673915c43e7..4b8c7fa4ea91 100644
+index 87435b65ea7b..662fbe93534c 100644
 --- a/drivers/ptp/ptp_vmclock.c
 +++ b/drivers/ptp/ptp_vmclock.c
 @@ -14,10 +14,13 @@
@@ -47,15 +37,7 @@ index 4673915c43e7..4b8c7fa4ea91 100644
  #include <linux/platform_device.h>
  #include <linux/slab.h>
  #include <linux/vmclock-abi.h>
-@@ -453,6 +456,7 @@ static int vmclock_remove(struct platform_device *pdev)
- 	return 0;
- }
- 
-+#ifdef CONFIG_ACPI
- static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data)
- {
- 	struct vmclock_state *st = data;
-@@ -490,7 +494,7 @@ vmclock_acpi_notification_handler(acpi_handle __always_unused handle,
+@@ -474,7 +477,7 @@ vmclock_acpi_notification_handler(acpi_handle __always_unused handle,
  	wake_up_interruptible(&st->disrupt_wait);
  }
  
@@ -64,38 +46,24 @@ index 4673915c43e7..4b8c7fa4ea91 100644
  {
  	struct acpi_device *adev = ACPI_COMPANION(dev);
  	acpi_status status;
-@@ -503,10 +507,6 @@ static int vmclock_setup_notification(struct device *dev, struct vmclock_state *
+@@ -487,10 +490,6 @@ static int vmclock_setup_notification(struct device *dev, struct vmclock_state *
  	if (!adev)
  		return -ENODEV;
  
 -	/* The device does not support notifications. Nothing else to do */
--	if (!(st->clk->flags & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
+-	if (!(le64_to_cpu(st->clk->flags) & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
 -		return 0;
 -
  	status = acpi_install_notify_handler(adev->handle, ACPI_DEVICE_NOTIFY,
  					     vmclock_acpi_notification_handler,
  					     dev);
-@@ -540,6 +540,70 @@ static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
- 
+@@ -525,6 +524,55 @@ static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
  	return 0;
  }
-+#else
-+static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
+ 
++static irqreturn_t vmclock_of_irq_handler(int __always_unused irq, void *_st)
 +{
-+	return -EINVAL;
-+}
-+
-+static int vmclock_setup_acpi_notification(struct device *dev)
-+{
-+	return -EINVAL;
-+}
-+
-+#endif
-+
-+static irqreturn_t vmclock_of_irq_handler(int __always_unused irq, void *dev)
-+{
-+	struct device *device = dev;
-+	struct vmclock_state *st = device->driver_data;
++	struct vmclock_state *st = _st;
 +
 +	wake_up_interruptible(&st->disrupt_wait);
 +	return IRQ_HANDLED;
@@ -125,7 +93,7 @@ index 4673915c43e7..4b8c7fa4ea91 100644
 +		return irq;
 +
 +	return devm_request_irq(dev, irq, vmclock_of_irq_handler, IRQF_SHARED,
-+				"vmclock", dev);
++				"vmclock", dev->driver_data);
 +}
 +
 +static int vmclock_setup_notification(struct device *dev,
@@ -140,13 +108,12 @@ index 4673915c43e7..4b8c7fa4ea91 100644
 +	} else {
 +		return vmclock_setup_of_notification(dev);
 +	}
-+
 +}
 +
- 
- static void vmclock_put_idx(void *data)
+ static void vmclock_remove(void *data)
  {
-@@ -561,7 +625,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ 	struct device *dev = data;
+@@ -569,7 +617,7 @@ static int vmclock_probe(struct platform_device *pdev)
  	if (has_acpi_companion(dev))
  		ret = vmclock_probe_acpi(dev, st);
  	else
@@ -155,7 +122,7 @@ index 4673915c43e7..4b8c7fa4ea91 100644
  
  	if (ret) {
  		dev_info(dev, "Failed to obtain physical address: %d\n", ret);
-@@ -673,12 +737,19 @@ static const struct acpi_device_id vmclock_acpi_ids[] = {
+@@ -696,11 +744,18 @@ static const struct acpi_device_id vmclock_acpi_ids[] = {
  };
  MODULE_DEVICE_TABLE(acpi, vmclock_acpi_ids);
  
@@ -167,7 +134,6 @@ index 4673915c43e7..4b8c7fa4ea91 100644
 +
  static struct platform_driver vmclock_platform_driver = {
  	.probe		= vmclock_probe,
- 	.remove		= vmclock_remove,
  	.driver	= {
  		.name	= "vmclock",
  		.acpi_match_table = vmclock_acpi_ids,
@@ -176,5 +142,5 @@ index 4673915c43e7..4b8c7fa4ea91 100644
  };
  
 -- 
-2.34.1
+2.52.0
 

--- a/resources/patches/vmclock/6.1/0005-ptp-ptp_vmclock-add-VMCLOCK-to-ACPI-device-match.patch
+++ b/resources/patches/vmclock/6.1/0005-ptp-ptp_vmclock-add-VMCLOCK-to-ACPI-device-match.patch
@@ -1,0 +1,34 @@
+From d291cf42344f2f48557e545648bc26eea9b1828f Mon Sep 17 00:00:00 2001
+From: David Woodhouse <dwmw@amazon.co.uk>
+Date: Wed, 21 Jan 2026 14:33:42 +0000
+Subject: [PATCH 5/7] ptp: ptp_vmclock: add 'VMCLOCK' to ACPI device match
+
+As we finalised the spec, we spotted that vmgenid actually says that the
+_HID is supposed to be hypervisor-specific. Although in the 13 years
+since the original vmgenid doc was published, nobody seems to have cared
+about using _HID to distinguish between implementations on different
+hypervisors, and we only ever use the _CID.
+
+For consistency, match the _CID of "VMCLOCK" too.
+
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: Babis Chalios <bchalios@amazon.es>
+---
+ drivers/ptp/ptp_vmclock.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
+index 662fbe93534c..dbe549cc4b04 100644
+--- a/drivers/ptp/ptp_vmclock.c
++++ b/drivers/ptp/ptp_vmclock.c
+@@ -739,6 +739,7 @@ static int vmclock_probe(struct platform_device *pdev)
+ }
+ 
+ static const struct acpi_device_id vmclock_acpi_ids[] = {
++	{ "AMZNC10C", 0 },
+ 	{ "VMCLOCK", 0 },
+ 	{}
+ };
+-- 
+2.52.0
+

--- a/resources/patches/vmclock/6.1/0006-ptp-ptp_vmclock-remove-dependency-on-CONFIG_ACPI.patch
+++ b/resources/patches/vmclock/6.1/0006-ptp-ptp_vmclock-remove-dependency-on-CONFIG_ACPI.patch
@@ -1,0 +1,116 @@
+From 1cb36e019ef80058db243c7a02696e17429bd0b1 Mon Sep 17 00:00:00 2001
+From: David Woodhouse <dwmw@amazon.co.uk>
+Date: Wed, 21 Jan 2026 14:33:43 +0000
+Subject: [PATCH 6/7] ptp: ptp_vmclock: remove dependency on CONFIG_ACPI
+
+Now that we added device tree support we can remove dependency on
+CONFIG_ACPI.
+
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: Babis Chalios <bchalios@amazon.es>
+---
+ drivers/ptp/Kconfig       | 26 +++++++++++++++-----------
+ drivers/ptp/ptp_vmclock.c | 14 ++++++++++----
+ 2 files changed, 25 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/ptp/Kconfig b/drivers/ptp/Kconfig
+index ebadd82c7a7d..e020045bac13 100644
+--- a/drivers/ptp/Kconfig
++++ b/drivers/ptp/Kconfig
+@@ -132,17 +132,21 @@ config PTP_1588_CLOCK_KVM
+ 	  will be called ptp_kvm.
+ 
+ config PTP_1588_CLOCK_VMCLOCK
+-       tristate "Virtual machine PTP clock"
+-       depends on X86_TSC || ARM_ARCH_TIMER
+-       depends on PTP_1588_CLOCK && ACPI && ARCH_SUPPORTS_INT128
+-       default y
+-       help
+-         This driver adds support for using a virtual precision clock
+-         advertised by the hypervisor. This clock is only useful in virtual
+-         machines where such a device is present.
+-
+-         To compile this driver as a module, choose M here: the module
+-         will be called ptp_vmclock.
++	tristate "Virtual machine PTP clock"
++	depends on X86_TSC || ARM_ARCH_TIMER
++	depends on PTP_1588_CLOCK && ARCH_SUPPORTS_INT128
++	default PTP_1588_CLOCK_KVM
++	help
++	  This driver adds support for using a virtual precision clock
++	  advertised by the hypervisor. This clock is only useful in virtual
++	  machines where such a device is present.
++
++	  Unlike the KVM virtual PTP clock, the VMCLOCK device offers support
++	  for reliable timekeeping even across live migration. So this driver
++	  is enabled by default whenever the KVM PTP clock is.
++
++		To compile this driver as a module, choose M here: the module
++		will be called ptp_vmclock.
+ 
+ config PTP_1588_CLOCK_IDT82P33
+ 	tristate "IDT 82P33xxx PTP clock"
+diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
+index dbe549cc4b04..2114d5fd760e 100644
+--- a/drivers/ptp/ptp_vmclock.c
++++ b/drivers/ptp/ptp_vmclock.c
+@@ -440,6 +440,7 @@ static const struct file_operations vmclock_miscdev_fops = {
+ 
+ /* module operations */
+ 
++#if IS_ENABLED(CONFIG_ACPI)
+ static acpi_status vmclock_acpi_resources(struct acpi_resource *ares, void *data)
+ {
+ 	struct vmclock_state *st = data;
+@@ -523,6 +524,7 @@ static int vmclock_probe_acpi(struct device *dev, struct vmclock_state *st)
+ 
+ 	return 0;
+ }
++#endif /* CONFIG_ACPI */
+ 
+ static irqreturn_t vmclock_of_irq_handler(int __always_unused irq, void *_st)
+ {
+@@ -566,11 +568,11 @@ static int vmclock_setup_notification(struct device *dev,
+ 	if (!(le64_to_cpu(st->clk->flags) & VMCLOCK_FLAG_NOTIFICATION_PRESENT))
+ 		return 0;
+ 
+-	if (has_acpi_companion(dev)) {
++#if IS_ENABLED(CONFIG_ACPI)
++	if (has_acpi_companion(dev))
+ 		return vmclock_setup_acpi_notification(dev);
+-	} else {
+-		return vmclock_setup_of_notification(dev);
+-	}
++#endif
++	return vmclock_setup_of_notification(dev);
+ }
+ 
+ static void vmclock_remove(void *data)
+@@ -583,10 +585,12 @@ static void vmclock_remove(void *data)
+ 		return;
+ 	}
+ 
++#if IS_ENABLED(CONFIG_ACPI)
+ 	if (has_acpi_companion(dev))
+ 		acpi_remove_notify_handler(ACPI_COMPANION(dev)->handle,
+ 					   ACPI_DEVICE_NOTIFY,
+ 					   vmclock_acpi_notification_handler);
++#endif
+ 
+ 	if (st->ptp_clock)
+ 		ptp_clock_unregister(st->ptp_clock);
+@@ -614,9 +618,11 @@ static int vmclock_probe(struct platform_device *pdev)
+ 	if (!st)
+ 		return -ENOMEM;
+ 
++#if IS_ENABLED(CONFIG_ACPI)
+ 	if (has_acpi_companion(dev))
+ 		ret = vmclock_probe_acpi(dev, st);
+ 	else
++#endif
+ 		ret = vmclock_probe_dt(dev, st);
+ 
+ 	if (ret) {
+-- 
+2.52.0
+

--- a/resources/patches/vmclock/6.1/0007-ptp-ptp_vmclock-return-TAI-not-UTC.patch
+++ b/resources/patches/vmclock/6.1/0007-ptp-ptp_vmclock-return-TAI-not-UTC.patch
@@ -1,0 +1,55 @@
+From 726b41d6531d0e77fc20f6d7ea4b3178ade41e80 Mon Sep 17 00:00:00 2001
+From: David Woodhouse <dwmw@amazon.co.uk>
+Date: Wed, 21 Jan 2026 14:33:44 +0000
+Subject: [PATCH 7/7] ptp: ptp_vmclock: return TAI not UTC
+
+To output UTC would involve complex calculations about whether the time
+elapsed since the reference time has crossed the end of the month when
+a leap second takes effect. I've prototyped that, but it made me sad.
+
+Much better to report TAI, which is what PHCs should do anyway.
+And much much simpler.
+
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: Babis Chalios <bchalios@amazon.es>
+---
+ drivers/ptp/ptp_vmclock.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/ptp/ptp_vmclock.c b/drivers/ptp/ptp_vmclock.c
+index 2114d5fd760e..e0da9c5f5d00 100644
+--- a/drivers/ptp/ptp_vmclock.c
++++ b/drivers/ptp/ptp_vmclock.c
+@@ -80,13 +80,13 @@ static inline uint64_t mul_u64_u64_shr_add_u64(uint64_t *res_hi, uint64_t delta,
+ 
+ static inline bool tai_adjust(struct vmclock_abi *clk, uint64_t *sec)
+ {
+-	if (likely(clk->time_type == VMCLOCK_TIME_UTC))
++	if (clk->time_type == VMCLOCK_TIME_TAI)
+ 		return true;
+ 
+-	if (clk->time_type == VMCLOCK_TIME_TAI &&
+-	    (clk->flags & VMCLOCK_FLAG_TAI_OFFSET_VALID)) {
++	if (clk->time_type == VMCLOCK_TIME_UTC &&
++	    (le64_to_cpu(clk->flags) & VMCLOCK_FLAG_TAI_OFFSET_VALID)) {
+ 		if (sec)
+-			*sec += clk->tai_offset_sec;
++			*sec -= (int16_t)le16_to_cpu(clk->tai_offset_sec);
+ 		return true;
+ 	}
+ 	return false;
+@@ -321,6 +321,11 @@ static const struct ptp_clock_info ptp_vmclock_info = {
+ 	.getcrosststamp = ptp_vmclock_getcrosststamp,
+ };
+ 
++struct vmclock_file_state {
++	struct vmclock_state *st;
++	atomic_t seq;
++};
++
+ static int vmclock_miscdev_mmap(struct file *fp, struct vm_area_struct *vma)
+ {
+ 	struct vmclock_file_state *fst = fp->private_data;
+-- 
+2.52.0
+


### PR DESCRIPTION
Update VMClock Linux patches we use for building our CI kernels, so that they match latest discussions in the mailing list: https://lore.kernel.org/lkml/f663dbfff1568d8924a2a3b8fbd6532b97f54b68.camel@infradead.org/.

The diff includes:
* Addressing various comments during the discussion in the mailing list.
* Including a few more changes we brought in the patchset.

For posterity, the commit that add VMClock support to Amazon Linux linux (hash: 3e14f63) is different than the one that adds the device to mainline (hash: 2050327). I initially tried to revert 3e14f63 and cherry-pick the mainline commit and all subsequent VMClock-related commits but couldn't. The reason is that mainline includes changes in the PTP subsystem that are not present in the Amazon Linux 5.10 and 6.1 trees. Hence, what I did was backporting the patchset directly to the Amazon Linux trees.

I have tested this locally by using `./tools/devtool build_ci_artifacts kernels`, copying the built kernels in the CI artifacts and running the VMClock functional tests. Everything works fine for me. The only glitch I've seen is that some tests some times fail because Firecracker hits the 5MBs memory overhead threshold, on my machine. Since, I'm not touching Firecracker code here, I don't think this is a problem with the current PR, rather something weird on the machine I'm testing.

Regardless that, I'm opening this PR as draft since someone (cc @zulinx86) needs to recreate CI artifacts and point the PR to them. Once we've tested with the provisional artifacts and everything works fine, we can make them default and run tests again.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
