### PR TITLE
fix(test/mem_hotplug): check RSS decreases also on 4k pages

### DIFF
--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -245,7 +245,7 @@ def check_hotunplug(uvm, requested_size_mib):
     print(f"RSS before: {rss_before}, after: {rss_after}")
 
     huge_pages = HugePagesConfig(uvm.api.machine_config.get().json()["huge_pages"])
-    if huge_pages == HugePagesConfig.HUGETLBFS_2MB and supports_hugetlbfs_discard():
+    if huge_pages == HugePagesConfig.NONE or supports_hugetlbfs_discard():
         assert rss_after < rss_before, "RSS didn't decrease"
 
 


### PR DESCRIPTION
## Changes
Assert RSS decreases on memory hotunplug.

## Reason


The current test assertion is only triggered on HugePages when discard is supported (>=6.1 in the supported kernels). The intention however was to check it also on 4kB pages, where the RSS should always decrease.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
