### PR TITLE
fix(tests): disable C6 and C6P C-states on Intel Granite Rapids

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -758,6 +758,30 @@ apply_performance_tweaks() {
     echo 100 |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct &> /dev/null
   fi
 
+  # If CPU is Intel Granite Rapids (Xeon 6, FMS 06-AD-XX), disable C6 and C6P states.
+  # We've observed significant volatility in our performance tests on Intel Granite Rapids CPUs
+  # (Xeon 6, FMS 06-AD-XX), specifically in many of our latency metrics. After spending time investigating
+  # this, it seems like cross-CPU communication becomes prohibitively slow with the deepest C-states
+  # enabled. Since GNR chips have higher core density (96 per socket vs. SPR's 48 per socket), we believe
+  # that the tail latency of transitioning out of the deepest C-states explains the volatility.
+
+  # Disabling these deep states appear to stabilise the performance, so for consistency in our CI, we will disable them.
+
+  # NB: The performance volatility only appears to affect Granite Rapids instances with low load
+  # (e.g., our performance integration tests). The assumption is that when the load is high, cores
+  # are unlikely to enter deeper C-states, so inter-CPU communication does not encounter the overhead
+  # of transitioning out of deeper C-states.
+  model=$(awk '/^model\s+:/ {print $3; exit}' /proc/cpuinfo)
+  family=$(awk '/^cpu family\s+:/ {print $4; exit}' /proc/cpuinfo)
+  if [[ "$family" -eq 6 && "$model" -eq 173 ]]; then
+    say "Intel Granite Rapids CPU detected. Disabling C6 and C6P C-states"
+    for state in /sys/devices/system/cpu/cpu[0-9]*/cpuidle/state*/; do
+      if [[ -f "$state/name" && $(cat "$state/name") == C6* ]]; then
+        echo 1 | sudo tee "$state/disable" &> /dev/null
+      fi
+    done
+  fi
+
   # The governor is a linux component that can adjust CPU frequency. "performance" tells it to always run CPUs at
   # their maximum safe frequency. It seems to be the default for Amazon Linux, but it doesn't hurt to make this explicit.
   # See also https://wiki.archlinux.org/title/CPU_frequency_scaling
@@ -772,6 +796,17 @@ unapply_performance_tweaks() {
     # restore p-state limits
     echo $MIN_PERF_PCT |sudo tee /sys/devices/system/cpu/intel_pstate/min_perf_pct &> /dev/null
     echo $MAX_PERF_PCT |sudo tee /sys/devices/system/cpu/intel_pstate/max_perf_pct &> /dev/null
+  fi
+
+  # reenable Granite Rapids C-states
+  model=$(awk '/^model\s+:/ {print $3; exit}' /proc/cpuinfo)
+  family=$(awk '/^cpu family\s+:/ {print $4; exit}' /proc/cpuinfo)
+  if [[ "$family" -eq 6 && "$model" -eq 173 ]]; then
+    for state in /sys/devices/system/cpu/cpu[0-9]*/cpuidle/state*/; do
+      if [[ -f "$state/name" && $(cat "$state/name") == C6* ]]; then
+        echo 0 | sudo tee "$state/disable" &> /dev/null
+      fi
+    done
   fi
 
   # We do not reset the governor, as keeping track of each CPUs configured governor is not trivial here. On our CI


### PR DESCRIPTION
We've observed significant volatility in our performance tests on Intel Granite Rapids CPUs (Xeon 6, FMS 06-AD-XX), specifically in many of our latency metrics. After spending time investigating this, it seems like cross-CPU communication becomes prohibitively slow with the deepest C-states enabled. Since GNR chips have higher core density (96 per socket vs. SPR's 48 per socket), we believe that the tail latency of transitioning out of the deepest C-states explains the volatility.

Disabling these deep states appear to stabilise the performance, so for consistency in our CI, we will disable them.

NB: The performance volatility only appears to affect Granite Rapids instances with low load (e.g., our performance integration tests). We ran a high-load benchmark, and the performance difference was minimal with the deep C-states enabled vs. disabled. The assumption is that when the load is high, it is unlikely that cores will enter the deep C-states, hence the we do not encounter the extra latency incurred during C-state transitioning.

Related to #5518.
 
## Changes

Update devtool performance tweaks

## Reason

Performance test stability

## Testing

Tested both on Granite Rapids and Sapphire Rapids CPUs. W/ Granite Rapids, C6 and C6P are disabled during test runtime, and re-enabled afterwards. On Sapphire Rapids, C-states remain unaffected (expected behaviour).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
