### PR TITLE
fix(changelog): move serial to v1.14 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ and this project adheres to
 
 ### Added
 
+- [#5350](https://github.com/firecracker-microvm/firecracker/pull/5350): Added a
+  `/serial` endpoint, which allows setting `serial_out_path` to the path of a
+  pre-created file into which Firecracker should redirect output from the
+  guest's serial console. Not configuring it means Firecracker will continue to
+  print serial output to stdout. Similarly to the logger, this configuration is
+  not persisted across snapshots.
 - [#5463](https://github.com/firecracker-microvm/firecracker/pull/5463): Added
   support for `virtio-pmem` devices. See [documentation](docs/pmem.md) for more
   information.
@@ -124,12 +130,6 @@ and this project adheres to
   requests to `/mmds/config` to enforce MMDS to always respond plain text
   contents in the IMDS format regardless of the `Accept` header in requests.
   Users need to regenerate snapshots.
-- [#5350](https://github.com/firecracker-microvm/firecracker/pull/5350): Added a
-  `/serial` endpoint, which allows setting `serial_out_path` to the path of a
-  pre-created file into which Firecracker should redirect output from the
-  guest's serial console. Not configuring it means Firecracker will continue to
-  print serial output to stdout. Similarly to the logger, this configuration is
-  not persisted across snapshots.
 - [#5364](https://github.com/firecracker-microvm/firecracker/pull/5364): Added
   PCI support in Firecracker. PCI support is optional. Users can enable it
   passing the `--enable-pci` flag when launching the Firecracker process. When


### PR DESCRIPTION
## Changes

CHANGELOG: move serial to v1.14 release notes

## Reason

There was an issue with automatic rebase that made it go into 1.13 instead of 1.14.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
