### PR TITLE
test(devtool): Enable AVIC on AMD

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -139,6 +139,9 @@ CTR_CI_ARTIFACTS_PATH="${CTR_FC_ROOT_DIR}/resources/$(uname -m)"
 
 DEFAULT_ARTIFACTS_S3_BUCKET=s3://spec.ccfc.min/firecracker-ci
 
+# Lockfile used while modifying KVM modules
+KVM_MODULE_LOCKFILE="/tmp/.kvm_module.lock"
+
 # Query default S3 bucket with artifacts and return the most recient path
 get_newest_s3_artifacts() {
   local bucket="spec.ccfc.min"
@@ -705,18 +708,21 @@ apply_linux_61_tweaks() {
         echo -e "CPU not vulnerable to iTLB multihit, using kvm.nx_huge_pages=never mitigation"
         # we need a lock so another process is not running the same thing and to
         # avoid race conditions.
-        lockfile="/tmp/.linux61_tweaks.lock"
         set -C # noclobber
         while true; do
-            if echo "$$" > "$lockfile"; then
+            if echo "$$" > "$KVM_MODULE_LOCKFILE"; then
                 echo "Successfully acquired lock"
                 if ! grep -q "never" $NX_HUGEPAGES; then
                     echo "Reloading KVM modules with nx_huge_pages=never"
                     sudo modprobe -r $KVM_VENDOR_MOD kvm
                     sudo modprobe kvm nx_huge_pages=never
-                    sudo modprobe $KVM_VENDOR_MOD
+                    if [[ $KVM_VENDOR_MOD == "kvm_amd" ]]; then
+                        sudo modprobe kvm_amd avic=1
+                    else
+                        sudo modprobe $KVM_VENDOR_MOD
+                    fi
                 fi
-                rm "$lockfile"
+                rm "$KVM_MODULE_LOCKFILE"
                 break
             else
                 sleep 5s
@@ -735,6 +741,38 @@ apply_linux_61_tweaks() {
     fi
 }
 
+apply_amd_avic_tweaks() {
+    if ! grep -q "svm" /proc/cpuinfo; then
+        return
+    fi
+
+    AVIC_PARAM=/sys/module/kvm_amd/parameters/avic
+    if [[ ! -f $AVIC_PARAM ]]; then
+        return
+    fi
+
+    if grep -q "Y\|1" $AVIC_PARAM; then
+        echo "AVIC already enabled"
+        return
+    fi
+
+    set -C # noclobber
+    while true; do
+        if echo "$$" > "$KVM_MODULE_LOCKFILE"; then
+            echo "Successfully acquired lock"
+            if ! grep -q "Y\|1" $AVIC_PARAM; then
+                echo "Reloading kvm_amd with avic=1"
+                sudo modprobe -r kvm_amd
+                sudo modprobe kvm_amd avic=1
+            fi
+            rm "$KVM_MODULE_LOCKFILE"
+            break
+        else
+            sleep 5s
+        fi
+    done
+    tail -v $AVIC_PARAM
+}
 
 # Modifies the processors CPU governor and P-state configuration (x86_64 only) for consistent performance. This means
 # - Disable turbo boost (Intel only) by writing 1 to /sys/devices/system/cpu/intel_pstate/no_turbo
@@ -890,6 +928,7 @@ cmd_test() {
     fi
 
     apply_linux_61_tweaks
+    apply_amd_avic_tweaks
 
     # If we got to here, we've got all we need to continue.
     say "Kernel version: $(uname -r)"

--- a/tools/functions
+++ b/tools/functions
@@ -142,7 +142,7 @@ load_kvm() {
             if grep -q "vmx" /proc/cpuinfo; then
                 modprobe kvm_intel || return 1
             elif grep -q "svm" /proc/cpuinfo; then
-                modprobe kvm_amd || return 1
+                modprobe kvm_amd avic=1 || return 1
             else
                 return 1
             fi


### PR DESCRIPTION
## Changes

Enable AMD AVIC feature in the kvm_amd module, previously this was not always enabled.
Enabling AVIC can reduce the number of VM-Exits we encounter so should help with performance on these instances.

## Reason

Give us a more realistic view of AMD performance in our metrics which the AVIC enabled.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
