### PR TITLE
[SH] chore(linux_patches): revert the srcu optimisation

### DIFF
--- a/resources/hiding_ci/linux_patches/90-temp/0001-Revert-KVM-Avoid-synchronize_srcu-in-kvm_io_bus_regi.patch
+++ b/resources/hiding_ci/linux_patches/90-temp/0001-Revert-KVM-Avoid-synchronize_srcu-in-kvm_io_bus_regi.patch
@@ -1,0 +1,68 @@
+From 505a15593e6d4101fb42a800992d79abd0664816 Mon Sep 17 00:00:00 2001
+From: Nikita Kalyazin <kalyazin@amazon.com>
+Date: Mon, 9 Feb 2026 16:35:56 +0000
+Subject: [PATCH] Revert "KVM: Avoid synchronize_srcu() in
+ kvm_io_bus_register_dev()"
+
+This reverts commit 7d9a0273c45962e9a6bc06f3b87eef7c431c1853.
+
+The commit introduced a KVM_CREATE_VCPU regression where the first call
+was taking ~20 ms.
+
+Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+---
+ include/linux/kvm_host.h |  1 -
+ virt/kvm/kvm_main.c      | 11 ++---------
+ 2 files changed, 2 insertions(+), 10 deletions(-)
+
+diff --git a/include/linux/kvm_host.h b/include/linux/kvm_host.h
+index 4e8b94243ac4..5f0fa6908ee3 100644
+--- a/include/linux/kvm_host.h
++++ b/include/linux/kvm_host.h
+@@ -208,7 +208,6 @@ struct kvm_io_range {
+ struct kvm_io_bus {
+ 	int dev_count;
+ 	int ioeventfd_count;
+-	struct rcu_head rcu;
+ 	struct kvm_io_range range[];
+ };
+ 
+diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
+index a634e8f59ccc..3190b4fdf2e4 100644
+--- a/virt/kvm/kvm_main.c
++++ b/virt/kvm/kvm_main.c
+@@ -1323,7 +1323,6 @@ static void kvm_destroy_vm(struct kvm *kvm)
+ 		kvm_free_memslots(kvm, &kvm->__memslots[i][1]);
+ 	}
+ 	cleanup_srcu_struct(&kvm->irq_srcu);
+-	srcu_barrier(&kvm->srcu);
+ 	cleanup_srcu_struct(&kvm->srcu);
+ #ifdef CONFIG_KVM_GENERIC_MEMORY_ATTRIBUTES
+ 	xa_destroy(&kvm->mem_attr_array);
+@@ -5982,13 +5981,6 @@ int kvm_io_bus_read(struct kvm_vcpu *vcpu, enum kvm_bus bus_idx, gpa_t addr,
+ }
+ EXPORT_SYMBOL_FOR_KVM_INTERNAL(kvm_io_bus_read);
+ 
+-static void __free_bus(struct rcu_head *rcu)
+-{
+-	struct kvm_io_bus *bus = container_of(rcu, struct kvm_io_bus, rcu);
+-
+-	kfree(bus);
+-}
+-
+ int kvm_io_bus_register_dev(struct kvm *kvm, enum kvm_bus bus_idx, gpa_t addr,
+ 			    int len, struct kvm_io_device *dev)
+ {
+@@ -6027,7 +6019,8 @@ int kvm_io_bus_register_dev(struct kvm *kvm, enum kvm_bus bus_idx, gpa_t addr,
+ 	memcpy(new_bus->range + i + 1, bus->range + i,
+ 		(bus->dev_count - i) * sizeof(struct kvm_io_range));
+ 	rcu_assign_pointer(kvm->buses[bus_idx], new_bus);
+-	call_srcu(&kvm->srcu, &bus->rcu, __free_bus);
++	synchronize_srcu_expedited(&kvm->srcu);
++	kfree(bus);
+ 
+ 	return 0;
+ }
+-- 
+2.50.1
+


### PR DESCRIPTION
We observed that it introduced a regression to the first call to KVM_CREATE_VCPU of ~20 ms in both booted and restored VMs.

We are reverting the patch until we find a solution upstream.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
