### PR TITLE
[1.14] Revert "test(cargo audit): temporarily ignore bincode advisory"

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,7 @@
 [advisories]
-ignore = [
-        # The `paste` dependency is transitively included via `gdbstub`.
-        # While the crate is archived/unmaintained, the author considers it feature-complete
-        # and functionally stable. gdbstub will be update once they migrate
-        # to an alternative solution.
-        # See https://github.com/daniel5151/gdbstub/issues/168
-        "RUSTSEC-2024-0436",
-        # Temporary exclusion of the bincode crate advisory
-        # while we are working on migration to a substitution.
-        "RUSTSEC-2025-0141",
-]
+# The `paste` dependency is transitively included via `gdbstub`.
+# While the crate is archived/unmaintained, the author considers it feature-complete
+# and functionally stable. gdbstub will be update once they migrate 
+# to an alternative solution.
+# See https://github.com/daniel5151/gdbstub/issues/168
+ignore = ["RUSTSEC-2024-0436"]


### PR DESCRIPTION
Backport from https://github.com/firecracker-microvm/firecracker/pull/5682 .

## Changes

This reverts commit a4cfb3ef654a055211048e1458b86c05d3894578.

## Reason

We migrated from bincode to bitcode and the advisory is no longer relevant.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
