### PR TITLE
Backport GNR template change to v1.15

### DIFF
--- a/tests/data/custom_cpu_templates/GNR_TO_T2_5.10.json
+++ b/tests/data/custom_cpu_templates/GNR_TO_T2_5.10.json
@@ -54,17 +54,6 @@
       ]
     },
     {
-      "leaf": "0x7",
-      "subleaf": "0x2",
-      "flags": 1,
-      "modifiers": [
-        {
-          "register": "edx",
-          "bitmap": "0bxxxxxxxxxxxxxxxxxxxxxxxxxxxx0xxx"
-        }
-      ]
-    },
-    {
       "leaf": "0xd",
       "subleaf": "0x0",
       "flags": 1,


### PR DESCRIPTION
Subleaf 07H.02H contains some extended feature information on granite rapids CPUs. Our template accidentally tried to mask this out despite it not being passed through by KVM on 5.10 hosts. This led to fatal errors when trying to spawn a VM using this template.

To fix, just remove subleaf 07H.02H from the GNR_TO_T2_5.10 template. This will not affect the security posture of this instance combination, it will just fix the error when applying the template

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
