### PR TITLE
chore(acpi): Rename post_restore() to do_post_restore()

### DIFF
--- a/src/vmm/src/device_manager/acpi.rs
+++ b/src/vmm/src/device_manager/acpi.rs
@@ -68,16 +68,19 @@ impl ACPIDeviceManager {
         Ok(())
     }
 
-    pub fn post_restore_vmgenid(&self) -> Result<(), ACPIDeviceError> {
-        self.vmgenid().post_restore()?;
+    pub fn do_post_restore_vmgenid(&self) -> Result<(), ACPIDeviceError> {
+        self.vmgenid().do_post_restore()?;
         Ok(())
     }
 
-    pub fn post_restore_vmclock(&mut self, mem: &GuestMemoryMmap) -> Result<(), ACPIDeviceError> {
+    pub fn do_post_restore_vmclock(
+        &mut self,
+        mem: &GuestMemoryMmap,
+    ) -> Result<(), ACPIDeviceError> {
         self.vmclock
             .as_mut()
             .expect("Missing VMClock device")
-            .post_restore(mem)?;
+            .do_post_restore(mem)?;
         Ok(())
     }
 }

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -191,10 +191,10 @@ impl<'a> Persist<'a> for ACPIDeviceManager {
         );
 
         acpi_devices.activate_vmgenid(vm)?;
-        acpi_devices.post_restore_vmgenid()?;
+        acpi_devices.do_post_restore_vmgenid()?;
 
         acpi_devices.activate_vmclock(vm)?;
-        acpi_devices.post_restore_vmclock(vm.guest_memory())?;
+        acpi_devices.do_post_restore_vmclock(vm.guest_memory())?;
 
         Ok(acpi_devices)
     }

--- a/src/vmm/src/devices/acpi/vmclock.rs
+++ b/src/vmm/src/devices/acpi/vmclock.rs
@@ -118,7 +118,7 @@ impl VmClock {
     }
 
     /// Bump the VM generation counter and notify guest after snapshot restore
-    pub fn post_restore(&mut self, mem: &GuestMemoryMmap) -> Result<(), VmClockError> {
+    pub fn do_post_restore(&mut self, mem: &GuestMemoryMmap) -> Result<(), VmClockError> {
         write_vmclock_field!(self, mem, seq_count, self.inner.seq_count | 1);
 
         // This fence ensures guest sees all previous writes. It is matched to a
@@ -276,7 +276,7 @@ mod tests {
 
         let state = vmclock.save();
         let mut vmclock_new = VmClock::restore((), &state).unwrap();
-        vmclock_new.post_restore(&mem);
+        vmclock_new.do_post_restore(&mem);
 
         let guest_data_new: vmclock_abi = mem.read_obj(VMCLOCK_TEST_GUEST_ADDR).unwrap();
         assert_ne!(guest_data_new, vmclock.inner);

--- a/src/vmm/src/devices/acpi/vmgenid.rs
+++ b/src/vmm/src/devices/acpi/vmgenid.rs
@@ -101,7 +101,7 @@ impl VmGenId {
     ///
     /// This will only have effect if we have updated the generation ID in guest memory, i.e. when
     /// re-creating the device after snapshot resumption.
-    pub fn post_restore(&self) -> Result<(), VmGenIdError> {
+    pub fn do_post_restore(&self) -> Result<(), VmGenIdError> {
         self.interrupt_evt
             .trigger()
             .map_err(VmGenIdError::NotifyGuest)?;


### PR DESCRIPTION
## Reason

This renaming does make it clearer that we're mutating something. See https://github.com/firecracker-microvm/firecracker/pull/5710#discussion_r2852029691

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [na] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [na] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [na] If a specific issue led to this PR, this PR closes the issue.
- [na] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [na] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
