### PR TITLE
fix(a/b): ignore network latency on 5.10 host m8i instances

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -126,6 +126,15 @@ IGNORED = [
         "performance_test": "test_vsock_throughput",
         "mode": "g2h",
     },
+    # Network latencies on m8i.metal-{48,96}xl w/ 5.10 host
+    *[
+        {
+            "instance": instance,
+            "performance_test": "test_network_latency",
+            "host_kernel": "linux-5.10",
+        }
+        for instance in ["m8i.metal-48xl", "m8i.metal-96xl"]
+    ],
     # block latencies if guest uses async request submission
     {"fio_engine": "libaio", "metric": "clat_read"},
     {"fio_engine": "libaio", "metric": "clat_write"},


### PR DESCRIPTION
## Changes

Ignore Network latency A/B on m8i.metal instances with 5.10 host kernel

## Reason

This is known to be flaky, and given we do not officially support these instances on 5.10, we can ignore.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
