### PR TITLE
FAQ.md: Re-write reboot/poweroff section

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -180,21 +180,28 @@ on event file descriptors to drive device emulation.
 
 ### How can I gracefully reboot the guest? How can I gracefully poweroff the guest?
 
-Firecracker does not virtualize guest power management, therefore operations
-like gracefully rebooting or powering off the guest are supported in
-unconventional ways.
+Regardless of architecture, Firecracker does not currently support guest reboot.
 
-Running the `poweroff` or `halt` commands inside a Linux guest will bring it
-down but Firecracker process remains unaware of the guest shutdown so it lives
-on.
+On **ARM**, issuing either `poweroff` or `reboot` inside a Linux guest results
+in a graceful system shutdown and the termination of the Firecracker process.
+This works because KVM emulates the PSCI interface for power management and
+notifies Firecracker when the guest tries to change the power state of the
+virtual machine.
 
-Running the `reboot` command in a Linux guest will gracefully bring down the
-guest system and also bring a graceful end to the Firecracker process.
+On **x86**, Firecracker does not virtualize power management (e.g. there is no
+ACPI PM support). Consequently:
 
-On `x86_64` systems, issuing a `SendCtrlAltDel` action command through the
-Firecracker API will generate a `Ctrl + Alt + Del` keyboard event in the guest
-which triggers a behavior identical to running the `reboot` command. This is,
-however, not supported on `aarch64` systems.
+- `poweroff`: This will shut down the guest OS, but because the guest has no way
+  of requesting a power-off, the Firecracker process will remain alive.
+- `reboot`: Running reboot will successfully terminate the Firecracker process
+  if the guest is booted with `reboot=k` in the kernel command line. This option
+  instructs Linux to reset the CPU(s) via the i8042 (keyboard controller) reset
+  line when rebooting. Firecracker, which emulates the i8042 controller,
+  intercepts the reset command and terminates the process.
+- API Command: Issuing a `SendCtrlAltDel` action via the Firecracker API injects
+  a `Ctrl+Alt+Del` keyboard sequence into the guest. Depending on the guest
+  configuration (see ctrl-alt-del.target on systemd systems), this typically
+  triggers the same reboot behavior described above.
 
 ### How can I create my own rootfs or kernel images?
 


### PR DESCRIPTION
The documentation is incomplete or partially incorrect. Particularly, it
does not explain that `poweroff` works as expected and kills the process
on ARM. Improve the documentation by explaining what works and what
doesn't work for each architecture and why.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
