### PR TITLE
docs: pmem.md: Replace invalid --flags option to mount with --options

### DIFF
--- a/docs/pmem.md
+++ b/docs/pmem.md
@@ -25,7 +25,7 @@ device and make VM boot from it.
 > there is no need to use guest page cache for its operations. This behaviour
 > can be configured by using `DAX` feature of the kernel.
 >
-> - To mount a device with `DAX` add `--flags=dax` to the `mount` command.
+> - To mount a device with `DAX` add `--options=dax` to the `mount` command.
 > - To configure a root device with `DAX` append `rootflags=dax` to the kernel
 >   arguments.
 >


### PR DESCRIPTION
The mount command has no --flags option, but it has an --options flag (see what I did there?) to specify mount options.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
