### PR TITLE
fix(x86_64): serialize full KVM custom MSR range for snapshot

### DIFF
--- a/src/vmm/src/arch/x86_64/msr.rs
+++ b/src/vmm/src/arch/x86_64/msr.rs
@@ -50,13 +50,8 @@ const APIC_BASE_MSR: u32 = 0x800;
 const APIC_MSR_INDEXES: u32 = 0x400;
 
 /// Custom MSRs fall in the range 0x4b564d00-0x4b564dff
-const MSR_KVM_WALL_CLOCK_NEW: u32 = 0x4b56_4d00;
-const MSR_KVM_SYSTEM_TIME_NEW: u32 = 0x4b56_4d01;
-const MSR_KVM_ASYNC_PF_EN: u32 = 0x4b56_4d02;
-const MSR_KVM_STEAL_TIME: u32 = 0x4b56_4d03;
-const MSR_KVM_PV_EOI_EN: u32 = 0x4b56_4d04;
-const MSR_KVM_POLL_CONTROL: u32 = 0x4b56_4d05;
-const MSR_KVM_ASYNC_PF_INT: u32 = 0x4b56_4d06;
+const MSR_KVM_RANGE_START: u32 = 0x4b56_4d00;
+const MSR_KVM_RANGE_END: u32 = 0x4b56_4dff;
 
 /// Taken from arch/x86/include/asm/msr-index.h
 /// Spectre mitigations control MSR
@@ -218,11 +213,6 @@ static SERIALIZABLE_MSR_RANGES: &[MsrRange] = &[
     MSR_RANGE!(MSR_TURBO_ACTIVATION_RATIO),
     MSR_RANGE!(MSR_IA32_TSC_DEADLINE),
     MSR_RANGE!(APIC_BASE_MSR, APIC_MSR_INDEXES),
-    MSR_RANGE!(MSR_KVM_WALL_CLOCK_NEW),
-    MSR_RANGE!(MSR_KVM_SYSTEM_TIME_NEW),
-    MSR_RANGE!(MSR_KVM_ASYNC_PF_EN),
-    MSR_RANGE!(MSR_KVM_STEAL_TIME),
-    MSR_RANGE!(MSR_KVM_PV_EOI_EN),
     MSR_RANGE!(MSR_EFER),
     MSR_RANGE!(MSR_STAR),
     MSR_RANGE!(MSR_LSTAR),
@@ -234,9 +224,11 @@ static SERIALIZABLE_MSR_RANGES: &[MsrRange] = &[
     MSR_RANGE!(MSR_TSC_AUX),
     MSR_RANGE!(MSR_MISC_FEATURES_ENABLES),
     MSR_RANGE!(MSR_K7_HWCR),
-    MSR_RANGE!(MSR_KVM_POLL_CONTROL),
-    MSR_RANGE!(MSR_KVM_ASYNC_PF_INT),
     MSR_RANGE!(MSR_IA32_TSX_CTRL),
+    MSR_RANGE!(
+        MSR_KVM_RANGE_START,
+        MSR_KVM_RANGE_END - MSR_KVM_RANGE_START + 1
+    ),
 ];
 
 /// Specifies whether a particular MSR should be included in vcpu serialization.


### PR DESCRIPTION

## Changes

Replace the individual MSR entries with a single range covering the full KVM custom MSR space so that all KVM-defined MSRs are included during snapshot serialization.

## Reason

KVM reserves the range 0x4b564d00-0x4b564dff for custom MSRs. The current snapshot implementation only serializes a small subset of these MSRs, which risks missing newly introduced KVM features. Some MSRs are already absent from the list (e.g. MSR_KVM_ASYNC_PF_INT and MSR_KVM_ASYNC_PF_ACK).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
