### PR TITLE
block: add read-only VMDK disk image support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,25 +135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,10 +757,8 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "imago"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404f567d70cd6d288e43f95ea8f2d6e8fe6156dd07df7da955cb9b147c4ab2a5"
+source = "git+https://gitlab.com/hreitz/imago?rev=942edb4ff11bec23c6344e7317ee3fa17d15036d#942edb4ff11bec23c6344e7317ee3fa17d15036d"
 dependencies = [
- "bincode",
  "cfg-if",
  "libc",
  "maybe-async",
@@ -1656,12 +1635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "userfaultfd"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,12 +1699,6 @@ dependencies = [
  "vm-memory",
  "vmm-sys-util",
 ]
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vm-allocator"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +133,25 @@ name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bindgen"
@@ -258,6 +283,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -743,6 +774,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "imago"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404f567d70cd6d288e43f95ea8f2d6e8fe6156dd07df7da955cb9b147c4ab2a5"
+dependencies = [
+ "bincode",
+ "cfg-if",
+ "libc",
+ "maybe-async",
+ "miniz_oxide",
+ "nix 0.30.1",
+ "page_size",
+ "rustc_version",
+ "tracing",
+ "vm-memory",
+ "windows-sys",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1010,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1051,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1067,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -1513,6 +1595,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1656,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "userfaultfd"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,7 +1670,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
  "libc",
- "nix",
+ "nix 0.27.1",
  "thiserror 1.0.69",
  "userfaultfd-sys",
 ]
@@ -1609,6 +1728,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
 name = "vm-allocator"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,6 +1787,7 @@ dependencies = [
  "event-manager",
  "gdbstub",
  "gdbstub_arch",
+ "imago",
  "itertools 0.15.0",
  "kvm-bindings",
  "kvm-ioctls",

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -103,6 +103,10 @@
                 "comment": "Used by the block device"
             },
             {
+                "syscall": "preadv",
+                "comment": "Used by the imago VMDK disk image backend"
+            },
+            {
                 "syscall": "mremap",
                 "comment": "Used for re-allocating large memory regions, for example vectors"
             },

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -26,6 +26,10 @@
                 "syscall": "read"
             },
             {
+                "syscall": "readlinkat",
+                "comment": "Used to canonicalize VMDK descriptor paths on drive patch"
+            },
+            {
                 "syscall": "write"
             },
             {
@@ -95,6 +99,10 @@
                 "comment": "Used for drive patching & rescanning, for reading the local timezone from /etc/localtime"
             },
             {
+                "syscall": "fstatfs",
+                "comment": "Used by the imago VMDK disk image backend"
+            },
+            {
                 "syscall": "ftruncate",
                 "comment": "Used for snapshotting"
             },
@@ -103,7 +111,15 @@
                 "comment": "Used by the block device"
             },
             {
+                "syscall": "pread64",
+                "comment": "Used by the imago VMDK disk image backend"
+            },
+            {
                 "syscall": "preadv",
+                "comment": "Used by the imago VMDK disk image backend"
+            },
+            {
+                "syscall": "pwrite64",
                 "comment": "Used by the imago VMDK disk image backend"
             },
             {
@@ -164,6 +180,19 @@
                         "op": "eq",
                         "val": 1,
                         "comment": "FCNTL_FD_CLOEXEC"
+                    }
+                ]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "Used by the imago VMDK disk image backend",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "F_GETFL"
                     }
                 ]
             },

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -99,10 +99,6 @@
                 "comment": "Used for drive patching & rescanning, for reading the local timezone from /etc/localtime"
             },
             {
-                "syscall": "fstatfs",
-                "comment": "Used by the imago VMDK disk image backend"
-            },
-            {
                 "syscall": "ftruncate",
                 "comment": "Used for snapshotting"
             },
@@ -111,15 +107,7 @@
                 "comment": "Used by the block device"
             },
             {
-                "syscall": "pread64",
-                "comment": "Used by the imago VMDK disk image backend"
-            },
-            {
                 "syscall": "preadv",
-                "comment": "Used by the imago VMDK disk image backend"
-            },
-            {
-                "syscall": "pwrite64",
                 "comment": "Used by the imago VMDK disk image backend"
             },
             {
@@ -180,19 +168,6 @@
                         "op": "eq",
                         "val": 1,
                         "comment": "FCNTL_FD_CLOEXEC"
-                    }
-                ]
-            },
-            {
-                "syscall": "fcntl",
-                "comment": "Used by the imago VMDK disk image backend",
-                "args": [
-                    {
-                        "index": 1,
-                        "type": "dword",
-                        "op": "eq",
-                        "val": 3,
-                        "comment": "F_GETFL"
                     }
                 ]
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -29,6 +29,10 @@
                 "syscall": "read"
             },
             {
+                "syscall": "readlink",
+                "comment": "Used to canonicalize VMDK descriptor paths on drive patch"
+            },
+            {
                 "syscall": "write"
             },
             {
@@ -98,6 +102,10 @@
                 "comment": "Used for drive patching & rescanning, for reading the local timezone from /etc/localtime"
             },
             {
+                "syscall": "fstatfs",
+                "comment": "Used by the imago VMDK disk image backend"
+            },
+            {
                 "syscall": "ftruncate",
                 "comment": "Used for snapshotting"
             },
@@ -106,7 +114,15 @@
                 "comment": "Used by the block device"
             },
             {
+                "syscall": "pread64",
+                "comment": "Used by the imago VMDK disk image backend"
+            },
+            {
                 "syscall": "preadv",
+                "comment": "Used by the imago VMDK disk image backend"
+            },
+            {
+                "syscall": "pwrite64",
                 "comment": "Used by the imago VMDK disk image backend"
             },
             {
@@ -167,6 +183,19 @@
                         "op": "eq",
                         "val": 1,
                         "comment": "FCNTL_FD_CLOEXEC"
+                    }
+                ]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "Used by the imago VMDK disk image backend",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "F_GETFL"
                     }
                 ]
             },
@@ -832,9 +861,6 @@
                 "syscall": "open"
             },
             {
-                "syscall": "openat"
-            },
-            {
                 "syscall": "read"
             },
             {
@@ -1129,9 +1155,6 @@
             },
             {
                 "syscall": "open"
-            },
-            {
-                "syscall": "openat"
             },
             {
                 "syscall": "close"

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -102,10 +102,6 @@
                 "comment": "Used for drive patching & rescanning, for reading the local timezone from /etc/localtime"
             },
             {
-                "syscall": "fstatfs",
-                "comment": "Used by the imago VMDK disk image backend"
-            },
-            {
                 "syscall": "ftruncate",
                 "comment": "Used for snapshotting"
             },
@@ -114,15 +110,7 @@
                 "comment": "Used by the block device"
             },
             {
-                "syscall": "pread64",
-                "comment": "Used by the imago VMDK disk image backend"
-            },
-            {
                 "syscall": "preadv",
-                "comment": "Used by the imago VMDK disk image backend"
-            },
-            {
-                "syscall": "pwrite64",
                 "comment": "Used by the imago VMDK disk image backend"
             },
             {
@@ -183,19 +171,6 @@
                         "op": "eq",
                         "val": 1,
                         "comment": "FCNTL_FD_CLOEXEC"
-                    }
-                ]
-            },
-            {
-                "syscall": "fcntl",
-                "comment": "Used by the imago VMDK disk image backend",
-                "args": [
-                    {
-                        "index": 1,
-                        "type": "dword",
-                        "op": "eq",
-                        "val": 3,
-                        "comment": "F_GETFL"
                     }
                 ]
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -23,6 +23,9 @@
                 "syscall": "open"
             },
             {
+                "syscall": "openat"
+            },
+            {
                 "syscall": "read"
             },
             {
@@ -101,6 +104,10 @@
             {
                 "syscall": "lseek",
                 "comment": "Used by the block device"
+            },
+            {
+                "syscall": "preadv",
+                "comment": "Used by the imago VMDK disk image backend"
             },
             {
                 "syscall": "mremap",
@@ -825,6 +832,9 @@
                 "syscall": "open"
             },
             {
+                "syscall": "openat"
+            },
+            {
                 "syscall": "read"
             },
             {
@@ -1119,6 +1129,9 @@
             },
             {
                 "syscall": "open"
+            },
+            {
+                "syscall": "openat"
             },
             {
                 "syscall": "close"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -26,13 +26,17 @@ bitvec = { version = "1.0.1", features = ["atomic", "serde"] }
 byteorder = "1.5.0"
 crc64 = "2.0.0"
 derive_more = { version = "2.1.1", default-features = false, features = [
-  "from",
-  "display",
+    "from",
+    "display",
 ] }
 displaydoc = "0.2.6"
 event-manager = "0.4.2"
 gdbstub = { version = "0.7.10", optional = true }
 gdbstub_arch = { version = "0.3.3", optional = true }
+imago = { version = "0.2.4", default-features = false, features = [
+    "sync",
+    "vm-memory",
+] }
 kvm-bindings = { version = "0.14.0", features = ["fam-wrappers", "serde"] }
 kvm-ioctls = "0.25.0"
 libc = "0.2.186"
@@ -52,8 +56,8 @@ uuid = "1.23.2"
 vhost = { version = "0.17.0", features = ["vhost-user-frontend"] }
 vm-allocator = { version = "0.1.4", features = ["serde"] }
 vm-memory = { version = "0.18.0", features = [
-  "backend-mmap",
-  "backend-bitmap",
+    "backend-mmap",
+    "backend-bitmap",
 ] }
 vm-superio = "0.8.1"
 vmm-sys-util = { version = "0.15.0", features = ["with-serde"] }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -33,7 +33,9 @@ displaydoc = "0.2.6"
 event-manager = "0.4.2"
 gdbstub = { version = "0.7.10", optional = true }
 gdbstub_arch = { version = "0.3.3", optional = true }
-imago = { version = "0.2.4", default-features = false, features = [
+# Pin past 0.2.4: skip alignment probes on buffered/read-only files
+# (https://gitlab.com/hreitz/imago/-/merge_requests/61).
+imago = { git = "https://gitlab.com/hreitz/imago", rev = "942edb4ff11bec23c6344e7317ee3fa17d15036d", default-features = false, features = [
     "sync",
     "vm-memory",
 ] }

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 use std::os::fd::AsRawFd;
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::FileTypeExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use block_io::FileEngine;
@@ -94,20 +94,69 @@ impl DiskProperties {
         Ok(disk_size)
     }
 
+    fn from_disk_image(
+        disk_image_path: &str,
+        mut disk_image: File,
+        is_disk_read_only: bool,
+        file_engine_type: FileEngineType,
+    ) -> Result<(FileEngine, u64), VirtioBlockError> {
+        let format = block_io::detect_disk_format(&mut disk_image)
+            .map_err(|e| VirtioBlockError::BackingFile(e, disk_image_path.to_string()))?;
+
+        match format {
+            block_io::DiskImageFormat::Vmdk => {
+                if !is_disk_read_only {
+                    return Err(VirtioBlockError::FileEngine(block_io::BlockIoError::Vmdk(
+                        block_io::VmdkIoError::RequiresReadOnly,
+                    )));
+                }
+                if file_engine_type == FileEngineType::Async {
+                    return Err(VirtioBlockError::FileEngine(block_io::BlockIoError::Vmdk(
+                        block_io::VmdkIoError::AsyncNotSupported,
+                    )));
+                }
+
+                let vmdk_engine = block_io::VmdkFileEngine::from_path(Path::new(disk_image_path))
+                    .map_err(|e| {
+                    VirtioBlockError::FileEngine(block_io::BlockIoError::Vmdk(e))
+                })?;
+                let disk_size = vmdk_engine.disk_size();
+                Ok((FileEngine::Vmdk(vmdk_engine), disk_size))
+            }
+            block_io::DiskImageFormat::Raw => {
+                let disk_size = Self::file_size(disk_image_path, &mut disk_image)?;
+                let engine = FileEngine::from_file(disk_image, file_engine_type)
+                    .map_err(VirtioBlockError::FileEngine)?;
+                Ok((engine, disk_size))
+            }
+        }
+    }
+
+    fn file_engine_type(&self) -> FileEngineType {
+        match self.file_engine {
+            FileEngine::Async(_) => FileEngineType::Async,
+            FileEngine::Sync(_) | FileEngine::Vmdk(_) => FileEngineType::Sync,
+        }
+    }
+
     /// Create a new file for the block device using a FileEngine
     pub fn new(
         disk_image_path: String,
         is_disk_read_only: bool,
         file_engine_type: FileEngineType,
     ) -> Result<Self, VirtioBlockError> {
-        let mut disk_image = Self::open_file(&disk_image_path, is_disk_read_only)?;
-        let disk_size = Self::file_size(&disk_image_path, &mut disk_image)?;
+        let disk_image = Self::open_file(&disk_image_path, is_disk_read_only)?;
         let image_id = Self::build_disk_image_id(&disk_image);
+        let (file_engine, disk_size) = Self::from_disk_image(
+            &disk_image_path,
+            disk_image,
+            is_disk_read_only,
+            file_engine_type,
+        )?;
 
         Ok(Self {
             file_path: disk_image_path,
-            file_engine: FileEngine::from_file(disk_image, file_engine_type)
-                .map_err(VirtioBlockError::FileEngine)?,
+            file_engine,
             nsectors: disk_size >> SECTOR_SHIFT,
             image_id,
         })
@@ -120,12 +169,35 @@ impl DiskProperties {
         is_disk_read_only: bool,
     ) -> Result<(), VirtioBlockError> {
         let mut disk_image = Self::open_file(&disk_image_path, is_disk_read_only)?;
-        let disk_size = Self::file_size(&disk_image_path, &mut disk_image)?;
-
         self.image_id = Self::build_disk_image_id(&disk_image);
-        self.file_engine
-            .update_file_path(disk_image)
-            .map_err(VirtioBlockError::FileEngine)?;
+
+        let format = block_io::detect_disk_format(&mut disk_image)
+            .map_err(|e| VirtioBlockError::BackingFile(e, disk_image_path.clone()))?;
+
+        let can_reuse_engine = format == block_io::DiskImageFormat::Raw
+            && !matches!(self.file_engine, FileEngine::Vmdk(_));
+
+        let disk_size = if can_reuse_engine {
+            let disk_size = Self::file_size(&disk_image_path, &mut disk_image)?;
+            match &mut self.file_engine {
+                FileEngine::Async(engine) => engine
+                    .update_file(disk_image)
+                    .map_err(|e| VirtioBlockError::FileEngine(block_io::BlockIoError::Async(e)))?,
+                FileEngine::Sync(engine) => engine.update_file(disk_image),
+                FileEngine::Vmdk(_) => unreachable!("checked by can_reuse_engine above"),
+            }
+            disk_size
+        } else {
+            let (file_engine, disk_size) = Self::from_disk_image(
+                &disk_image_path,
+                disk_image,
+                is_disk_read_only,
+                self.file_engine_type(),
+            )?;
+            self.file_engine = file_engine;
+            disk_size
+        };
+
         self.nsectors = disk_size >> SECTOR_SHIFT;
         self.file_path = disk_image_path;
 
@@ -410,7 +482,7 @@ macro_rules! unwrap_async_file_engine_or_return {
     ($file_engine: expr) => {
         match $file_engine {
             FileEngine::Async(engine) => engine,
-            FileEngine::Sync(_) => {
+            FileEngine::Sync(_) | FileEngine::Vmdk(_) => {
                 error!("The block device doesn't use an async IO engine");
                 return;
             }
@@ -463,7 +535,10 @@ impl VirtioBlock {
             ..Default::default()
         };
 
-        if config.blk_size.is_none() && config.topology.is_none() {
+        if config.blk_size.is_none()
+            && config.topology.is_none()
+            && !matches!(disk_properties.file_engine, FileEngine::Vmdk(_))
+        {
             if let Some((blk_size, topology)) = query_blk_attrs(disk_properties.file_engine.file())
                 .and_then(calculate_blk_size_and_topology)
             {
@@ -733,6 +808,7 @@ impl VirtioBlock {
         match self.disk.file_engine {
             FileEngine::Sync(_) => FileEngineType::Sync,
             FileEngine::Async(_) => FileEngineType::Async,
+            FileEngine::Vmdk(_) => FileEngineType::Sync,
         }
     }
 

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -956,6 +956,7 @@ mod tests {
     use super::*;
     use crate::check_metric_after_block;
     use crate::devices::virtio::block::virtio::IO_URING_NUM_ENTRIES;
+    use crate::devices::virtio::block::virtio::io::format::vmdk::tests::create_test_vmdk;
     use crate::devices::virtio::block::virtio::test_utils::{
         RequestDescriptorChain, default_block, read_blk_req_descriptors, set_queue,
         set_rate_limiter, simulate_async_completion_event,
@@ -1071,6 +1072,38 @@ mod tests {
                 res
             );
         }
+    }
+
+    #[test]
+    fn test_vmdk_disk_properties() {
+        let (_dir, descriptor) = create_test_vmdk("extent");
+        let path = descriptor.to_string_lossy().into_owned();
+
+        assert!(matches!(
+            DiskProperties::new(path.clone(), false, FileEngineType::Sync),
+            Err(VirtioBlockError::FileEngine(block_io::BlockIoError::Vmdk(
+                block_io::VmdkIoError::RequiresReadOnly
+            )))
+        ));
+        assert!(matches!(
+            DiskProperties::new(path.clone(), true, FileEngineType::Async),
+            Err(VirtioBlockError::FileEngine(block_io::BlockIoError::Vmdk(
+                block_io::VmdkIoError::AsyncNotSupported
+            )))
+        ));
+
+        let mut disk = DiskProperties::new(path.clone(), true, FileEngineType::Sync).unwrap();
+        assert!(matches!(disk.file_engine, FileEngine::Vmdk(_)));
+        assert_eq!(disk.nsectors, 2048);
+
+        let raw = TempFile::new().unwrap();
+        raw.as_file().set_len(4096).unwrap();
+        disk.update(raw.as_path().to_string_lossy().into_owned(), true)
+            .unwrap();
+        assert!(matches!(disk.file_engine, FileEngine::Sync(_)));
+
+        disk.update(path, true).unwrap();
+        assert!(matches!(disk.file_engine, FileEngine::Vmdk(_)));
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/block/virtio/io/format/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/format/mod.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Tencent. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod vmdk;
+
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom};
+
+pub use self::vmdk::{VmdkFileEngine, VmdkIoError};
+
+/// VMDK4 sparse file magic: 'KDMV' in little-endian.
+const VMDK4_MAGIC: u32 = 0x564d_444b;
+
+/// The detected disk image format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiskImageFormat {
+    /// Raw disk image (no format header detected).
+    Raw,
+    /// VMDK disk image.
+    Vmdk,
+}
+
+/// Detects the format of a disk image by reading its first bytes.
+pub fn detect_disk_format(file: &mut File) -> io::Result<DiskImageFormat> {
+    let mut header = [0u8; 512];
+    file.seek(SeekFrom::Start(0))?;
+    let bytes_read = file.read(&mut header)?;
+    if bytes_read < 4 {
+        return Ok(DiskImageFormat::Raw);
+    }
+
+    let magic = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+    if magic == VMDK4_MAGIC {
+        return Ok(DiskImageFormat::Vmdk);
+    }
+
+    if let Ok(text) = std::str::from_utf8(&header[..bytes_read])
+        && (text.contains("# Disk DescriptorFile")
+            || (text.contains("version") && text.contains("createType")))
+    {
+        return Ok(DiskImageFormat::Vmdk);
+    }
+
+    Ok(DiskImageFormat::Raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    #[test]
+    fn test_detect_raw_format() {
+        let empty = TempFile::new().unwrap();
+        let mut file = File::open(empty.as_path()).unwrap();
+        assert_eq!(detect_disk_format(&mut file).unwrap(), DiskImageFormat::Raw);
+
+        let non_empty = TempFile::new().unwrap();
+        non_empty.as_file().set_len(4096).unwrap();
+        let mut file = File::open(non_empty.as_path()).unwrap();
+        assert_eq!(detect_disk_format(&mut file).unwrap(), DiskImageFormat::Raw);
+    }
+
+    #[test]
+    fn test_detect_vmdk_text_format() {
+        let descriptor = TempFile::new().unwrap();
+        descriptor
+            .as_file()
+            .write_all(b"# Disk DescriptorFile\nversion=1\n")
+            .unwrap();
+        let mut file = File::open(descriptor.as_path()).unwrap();
+        assert_eq!(
+            detect_disk_format(&mut file).unwrap(),
+            DiskImageFormat::Vmdk
+        );
+
+        let createtype = TempFile::new().unwrap();
+        createtype
+            .as_file()
+            .write_all(b"version=1\ncreateType=\"monolithicFlat\"\n")
+            .unwrap();
+        let mut file = File::open(createtype.as_path()).unwrap();
+        assert_eq!(
+            detect_disk_format(&mut file).unwrap(),
+            DiskImageFormat::Vmdk
+        );
+    }
+
+    #[test]
+    fn test_detect_vmdk_sparse_magic() {
+        let f = TempFile::new().unwrap();
+        let magic_bytes: [u8; 4] = VMDK4_MAGIC.to_le_bytes();
+        f.as_file().write_all(&magic_bytes).unwrap();
+        f.as_file().set_len(4096).unwrap();
+
+        let mut file = File::open(f.as_path()).unwrap();
+        assert_eq!(
+            detect_disk_format(&mut file).unwrap(),
+            DiskImageFormat::Vmdk
+        );
+    }
+}

--- a/src/vmm/src/devices/virtio/block/virtio/io/format/vmdk.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/format/vmdk.rs
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 Tencent. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::CString;
+use std::fs;
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Component, Path, PathBuf};
+
+use imago::FormatDriverBuilder;
+use imago::file::File as ImagoFile;
+use imago::format::access::FormatAccess;
+use imago::format::gate::ImplicitOpenGate;
+use imago::io_buffers::IoVectorMut;
+use imago::vmdk::Vmdk;
+use imago::{Storage, StorageOpenOptions};
+use vm_memory::{GuestMemoryBackend, GuestMemoryError};
+
+use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
+
+/// Errors specific to the VMDK IO engine.
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum VmdkIoError {
+    /// Failed to open VMDK image: {0}
+    Open(io::Error),
+    /// VMDK backend does not support the async file engine.
+    AsyncNotSupported,
+    /// VMDK read error: {0}
+    Read(io::Error),
+    /// VMDK write not supported (read-only image)
+    WriteNotSupported,
+    /// VMDK backend requires is_read_only=true.
+    RequiresReadOnly,
+    /// Guest memory error: {0}
+    GuestMemory(GuestMemoryError),
+    /// VMDK flush error: {0}
+    Flush(io::Error),
+}
+
+#[derive(Debug)]
+pub struct VmdkFileEngine {
+    access: FormatAccess<ImagoFile>,
+}
+
+#[derive(Debug)]
+struct VmdkImplicitOpenGate {
+    descriptor_path: PathBuf,
+    descriptor_dir: fs::File,
+}
+
+impl VmdkImplicitOpenGate {
+    fn new(path: &Path) -> io::Result<Self> {
+        let descriptor_path = fs::canonicalize(path)?;
+        let descriptor_dir_path = descriptor_path
+            .parent()
+            .ok_or_else(|| io::Error::other("VMDK descriptor has no parent directory"))?;
+        let descriptor_dir = fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW)
+            .open(descriptor_dir_path)?;
+
+        Ok(Self {
+            descriptor_path,
+            descriptor_dir,
+        })
+    }
+
+    fn open_extent(&self, path: &Path) -> io::Result<ImagoFile> {
+        // VMDK descriptors are untrusted input.  Extents are read-only, direct children of the
+        // descriptor directory, and are opened relative to its held directory FD to prevent path
+        // traversal, symlink traversal, and check-then-open races.
+        let relative = path
+            .strip_prefix(
+                self.descriptor_path
+                    .parent()
+                    .expect("canonical descriptor path has a parent"),
+            )
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "VMDK extent is outside the descriptor directory",
+                )
+            })?;
+        let mut components = relative.components();
+        let Some(Component::Normal(filename)) = components.next() else {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "VMDK extent must be a direct child of the descriptor directory",
+            ));
+        };
+        if components.next().is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "VMDK extent must be a direct child of the descriptor directory",
+            ));
+        }
+        let filename = CString::new(filename.as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "VMDK extent filename contains a null byte",
+            )
+        })?;
+        // SAFETY: descriptor_dir is an open directory FD and filename is a NUL-terminated component.
+        let fd = unsafe {
+            libc::openat(
+                self.descriptor_dir.as_raw_fd(),
+                filename.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: fd was returned by openat and ownership is transferred to std::fs::File.
+        ImagoFile::try_from(unsafe { fs::File::from_raw_fd(fd) })
+    }
+}
+
+impl ImplicitOpenGate<ImagoFile> for VmdkImplicitOpenGate {
+    fn open_format<F: FormatDriverBuilder<ImagoFile>>(
+        &mut self,
+        _builder: F,
+    ) -> io::Result<FormatAccess<ImagoFile>> {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Opening implicit VMDK format dependencies is denied",
+        ))
+    }
+
+    fn open_storage(&mut self, options: StorageOpenOptions) -> io::Result<ImagoFile> {
+        if options.get_writable() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "Opening writable VMDK dependencies is denied",
+            ));
+        }
+
+        let path = options.get_filename().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "VMDK dependency is missing its filename",
+            )
+        })?;
+        if path == self.descriptor_path {
+            return ImagoFile::open(options);
+        }
+
+        self.open_extent(path)
+    }
+}
+
+impl VmdkFileEngine {
+    pub fn from_path(path: &Path) -> Result<Self, VmdkIoError> {
+        let gate = VmdkImplicitOpenGate::new(path).map_err(VmdkIoError::Open)?;
+        let vmdk = Vmdk::<ImagoFile>::builder_path(&gate.descriptor_path)
+            .write(false)
+            .open(gate)
+            .map_err(VmdkIoError::Open)?;
+
+        Ok(Self {
+            access: FormatAccess::new(vmdk),
+        })
+    }
+
+    pub fn disk_size(&self) -> u64 {
+        self.access.size()
+    }
+
+    pub fn read(
+        &self,
+        offset: u64,
+        mem: &GuestMemoryMmap,
+        addr: GuestAddress,
+        count: u32,
+    ) -> Result<u32, VmdkIoError> {
+        let slice = mem
+            .get_slice(addr, count as usize)
+            .map_err(VmdkIoError::GuestMemory)?;
+        let slices = [slice];
+        let (bufv, _guard) = IoVectorMut::from_volatile_slice(&slices);
+        self.access.readv(bufv, offset).map_err(VmdkIoError::Read)?;
+
+        Ok(count)
+    }
+
+    pub fn write(
+        &self,
+        _offset: u64,
+        _mem: &GuestMemoryMmap,
+        _addr: GuestAddress,
+        _count: u32,
+    ) -> Result<u32, VmdkIoError> {
+        Err(VmdkIoError::WriteNotSupported)
+    }
+
+    pub fn flush(&self) -> Result<(), VmdkIoError> {
+        self.access.flush().map_err(VmdkIoError::Flush)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::Write;
+    use std::os::unix::fs::symlink;
+    use std::path::PathBuf;
+
+    use vmm_sys_util::tempdir::TempDir;
+
+    use super::*;
+
+    fn create_test_vmdk(extent: &str) -> (TempDir, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let extent_file = dir.as_path().join("extent");
+        let extent_size: u64 = 1024 * 1024;
+        let mut file = fs::File::create(&extent_file).unwrap();
+        file.set_len(extent_size).unwrap();
+
+        let test_data = b"Hello VMDK from Firecracker!";
+        file.write_all(test_data).unwrap();
+        let extent_sectors = extent_size / 512;
+
+        let descriptor_file = dir.as_path().join("descriptor.vmdk");
+        let descriptor_content = format!(
+            r#"# Disk DescriptorFile
+version=1
+CID=fffffffe
+parentCID=ffffffff
+createType="monolithicFlat"
+
+# Extent description
+RW {extent_sectors} FLAT "{extent}" 0
+
+# The Disk Data Base
+#DDB
+"#
+        );
+        fs::write(&descriptor_file, descriptor_content).unwrap();
+
+        (dir, descriptor_file)
+    }
+
+    #[test]
+    fn test_vmdk_engine_open_and_read() {
+        let (_dir, descriptor) = create_test_vmdk("extent");
+        let engine = VmdkFileEngine::from_path(&descriptor).unwrap();
+
+        assert_eq!(engine.disk_size(), 1024 * 1024);
+
+        let mut buf = vec![0u8; 512];
+        engine.access.read(&mut buf[..], 0).unwrap();
+        assert_eq!(&buf[..28], b"Hello VMDK from Firecracker!");
+    }
+
+    #[test]
+    fn test_vmdk_engine_rejects_unsafe_extents() {
+        for extent in ["../secret", "/etc/passwd", "sub/extent"] {
+            let (_dir, descriptor) = create_test_vmdk(extent);
+            VmdkFileEngine::from_path(&descriptor).unwrap_err();
+        }
+
+        let (dir, descriptor) = create_test_vmdk("symlink");
+        symlink(dir.as_path().join("extent"), dir.as_path().join("symlink")).unwrap();
+        VmdkFileEngine::from_path(&descriptor).unwrap_err();
+    }
+
+    #[test]
+    fn test_vmdk_gate_rejects_writable_extent() {
+        let (dir, descriptor) = create_test_vmdk("extent");
+        let mut gate = VmdkImplicitOpenGate::new(&descriptor).unwrap();
+        let options = StorageOpenOptions::new()
+            .filename(dir.as_path().join("extent"))
+            .write(true);
+
+        gate.open_storage(options).unwrap_err();
+    }
+}

--- a/src/vmm/src/devices/virtio/block/virtio/io/format/vmdk.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/format/vmdk.rs
@@ -209,7 +209,7 @@ impl VmdkFileEngine {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::fs;
     use std::io::Write;
     use std::os::unix::fs::symlink;
@@ -218,8 +218,10 @@ mod tests {
     use vmm_sys_util::tempdir::TempDir;
 
     use super::*;
+    use crate::devices::virtio::test_utils::default_mem;
+    use crate::vstate::memory::Bytes;
 
-    fn create_test_vmdk(extent: &str) -> (TempDir, PathBuf) {
+    pub(crate) fn create_test_vmdk(extent: &str) -> (TempDir, PathBuf) {
         let dir = TempDir::new().unwrap();
         let extent_file = dir.as_path().join("extent");
         let extent_size: u64 = 1024 * 1024;
@@ -257,9 +259,16 @@ RW {extent_sectors} FLAT "{extent}" 0
 
         assert_eq!(engine.disk_size(), 1024 * 1024);
 
+        let mem = default_mem();
+        engine.read(0, &mem, GuestAddress(0), 512).unwrap();
         let mut buf = vec![0u8; 512];
-        engine.access.read(&mut buf[..], 0).unwrap();
+        mem.read_slice(&mut buf, GuestAddress(0)).unwrap();
         assert_eq!(&buf[..28], b"Hello VMDK from Firecracker!");
+        assert!(matches!(
+            engine.write(0, &mem, GuestAddress(0), 512),
+            Err(VmdkIoError::WriteNotSupported)
+        ));
+        engine.flush().unwrap();
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/block/virtio/io/format/vmdk.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/format/vmdk.rs
@@ -115,7 +115,14 @@ impl VmdkImplicitOpenGate {
         }
 
         // SAFETY: fd was returned by openat and ownership is transferred to std::fs::File.
-        ImagoFile::try_from(unsafe { fs::File::from_raw_fd(fd) })
+        // from_open_file (not TryFrom) skips fcntl(F_GETFL) / alignment probes.
+        ImagoFile::from_open_file(
+            unsafe { fs::File::from_raw_fd(fd) },
+            StorageOpenOptions::new()
+                .filename(path)
+                .write(false)
+                .direct(false),
+        )
     }
 }
 

--- a/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
@@ -244,6 +244,7 @@ pub mod tests {
 
     use super::*;
     use crate::devices::virtio::block::virtio::device::FileEngineType;
+    use crate::devices::virtio::block::virtio::io::format::vmdk::tests::create_test_vmdk;
     use crate::utils::u64_to_usize;
     use crate::vmm_config::machine_config::HugePageConfig;
     use crate::vstate::memory;
@@ -451,5 +452,51 @@ pub mod tests {
 
         engine.drain(true).unwrap();
         engine.drain_and_flush(true).unwrap();
+    }
+
+    #[test]
+    fn test_vmdk() {
+        let (_dir, descriptor) = create_test_vmdk("extent");
+        let mut engine = FileEngine::Vmdk(VmdkFileEngine::from_path(&descriptor).unwrap());
+        let mem = create_mem();
+
+        assert_sync_execution!(
+            engine.read(0, &mem, GuestAddress(0), 512, PendingRequest::default()),
+            512
+        );
+        assert!(matches!(
+            engine
+                .read(
+                    0,
+                    &mem,
+                    GuestAddress(MEM_LEN as u64),
+                    512,
+                    PendingRequest::default()
+                )
+                .unwrap_err()
+                .error,
+            BlockIoError::Vmdk(VmdkIoError::GuestMemory(_))
+        ));
+        assert!(matches!(
+            engine
+                .write(0, &mem, GuestAddress(0), 512, PendingRequest::default())
+                .unwrap_err()
+                .error,
+            BlockIoError::Vmdk(VmdkIoError::WriteNotSupported)
+        ));
+        assert_sync_execution!(engine.flush(PendingRequest::default()), 0);
+        assert!(matches!(
+            engine
+                .discard((0, 512), PendingRequest::default())
+                .unwrap_err()
+                .error,
+            BlockIoError::Vmdk(VmdkIoError::WriteNotSupported)
+        ));
+        engine.drain(true).unwrap();
+        engine.drain_and_flush(true).unwrap();
+        assert!(matches!(
+            engine.update_file_path(File::open(descriptor).unwrap()),
+            Err(BlockIoError::Vmdk(VmdkIoError::WriteNotSupported))
+        ));
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod async_io;
+pub mod format;
 pub mod sync_io;
 
 use std::fmt::Debug;
 use std::fs::File;
 
 pub use self::async_io::{AsyncFileEngine, AsyncIoError};
+pub use self::format::{DiskImageFormat, VmdkFileEngine, VmdkIoError, detect_disk_format};
 pub use self::sync_io::{SyncFileEngine, SyncIoError};
 use crate::devices::virtio::block::virtio::PendingRequest;
 use crate::devices::virtio::block::virtio::device::FileEngineType;
@@ -31,6 +33,8 @@ pub enum BlockIoError {
     Sync(SyncIoError),
     /// Async error: {0}
     Async(AsyncIoError),
+    /// VMDK error: {0}
+    Vmdk(VmdkIoError),
 }
 
 impl BlockIoError {
@@ -54,6 +58,7 @@ pub enum FileEngine {
     #[allow(unused)]
     Async(AsyncFileEngine),
     Sync(SyncFileEngine),
+    Vmdk(VmdkFileEngine),
 }
 
 impl FileEngine {
@@ -70,6 +75,9 @@ impl FileEngine {
         match self {
             FileEngine::Async(engine) => engine.update_file(file).map_err(BlockIoError::Async)?,
             FileEngine::Sync(engine) => engine.update_file(file),
+            FileEngine::Vmdk(_) => {
+                return Err(BlockIoError::Vmdk(VmdkIoError::WriteNotSupported));
+            }
         };
 
         Ok(())
@@ -79,6 +87,9 @@ impl FileEngine {
         match self {
             FileEngine::Async(engine) => engine.file(),
             FileEngine::Sync(engine) => engine.file(),
+            FileEngine::Vmdk(_) => {
+                panic!("file() is not supported for VMDK engine")
+            }
         }
     }
 
@@ -103,6 +114,13 @@ impl FileEngine {
                 Err(err) => Err(RequestError {
                     req,
                     error: BlockIoError::Sync(err),
+                }),
+            },
+            FileEngine::Vmdk(engine) => match engine.read(offset, mem, addr, count) {
+                Ok(count) => Ok(FileEngineOk::Executed(RequestOk { req, count })),
+                Err(err) => Err(RequestError {
+                    req,
+                    error: BlockIoError::Vmdk(err),
                 }),
             },
         }
@@ -131,6 +149,13 @@ impl FileEngine {
                     error: BlockIoError::Sync(err),
                 }),
             },
+            FileEngine::Vmdk(engine) => match engine.write(offset, mem, addr, count) {
+                Ok(count) => Ok(FileEngineOk::Executed(RequestOk { req, count })),
+                Err(err) => Err(RequestError {
+                    req,
+                    error: BlockIoError::Vmdk(err),
+                }),
+            },
         }
     }
 
@@ -151,6 +176,13 @@ impl FileEngine {
                 Err(err) => Err(RequestError {
                     req,
                     error: BlockIoError::Sync(err),
+                }),
+            },
+            FileEngine::Vmdk(engine) => match engine.flush() {
+                Ok(_) => Ok(FileEngineOk::Executed(RequestOk { req, count: 0 })),
+                Err(err) => Err(RequestError {
+                    req,
+                    error: BlockIoError::Vmdk(err),
                 }),
             },
         }
@@ -176,6 +208,10 @@ impl FileEngine {
                     error: BlockIoError::Sync(err),
                 }),
             },
+            FileEngine::Vmdk(_) => Err(RequestError {
+                req,
+                error: BlockIoError::Vmdk(VmdkIoError::WriteNotSupported),
+            }),
         }
     }
 
@@ -183,6 +219,7 @@ impl FileEngine {
         match self {
             FileEngine::Async(engine) => engine.drain(discard).map_err(BlockIoError::Async),
             FileEngine::Sync(_engine) => Ok(()),
+            FileEngine::Vmdk(_engine) => Ok(()),
         }
     }
 
@@ -192,6 +229,7 @@ impl FileEngine {
                 engine.drain_and_flush(discard).map_err(BlockIoError::Async)
             }
             FileEngine::Sync(engine) => engine.flush().map_err(BlockIoError::Sync),
+            FileEngine::Vmdk(engine) => engine.flush().map_err(BlockIoError::Vmdk),
         }
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use vmm_sys_util::eventfd::EventFd;
 
 use super::device::DiskProperties;
+use super::io::FileEngine;
 use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
 use crate::devices::virtio::block::virtio::device::FileEngineType;
@@ -50,6 +51,25 @@ impl From<FileEngineTypeState> for FileEngineType {
     }
 }
 
+/// Holds the disk image format saved in the snapshot.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DiskImageFormatState {
+    /// Raw disk image.
+    #[default]
+    Raw,
+    /// VMDK disk image.
+    Vmdk,
+}
+
+impl From<&FileEngine> for DiskImageFormatState {
+    fn from(file_engine: &FileEngine) -> Self {
+        match file_engine {
+            FileEngine::Sync(_) | FileEngine::Async(_) => DiskImageFormatState::Raw,
+            FileEngine::Vmdk(_) => DiskImageFormatState::Vmdk,
+        }
+    }
+}
+
 /// Holds info about the block device. Gets saved in snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VirtioBlockState {
@@ -64,6 +84,8 @@ pub struct VirtioBlockState {
     blk_size: u32,
     topology: VirtioBlkTopology,
     discard_sector_alignment: u32,
+    #[serde(default)]
+    disk_image_format: DiskImageFormatState,
 }
 
 impl Persist<'_> for VirtioBlock {
@@ -85,6 +107,7 @@ impl Persist<'_> for VirtioBlock {
             blk_size: self.config_space.blk_size,
             topology: self.config_space.topology,
             discard_sector_alignment: self.config_space.discard_sector_alignment,
+            disk_image_format: DiskImageFormatState::from(&self.disk.file_engine),
         }
     }
 

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -122,7 +122,7 @@ pub fn simulate_queue_and_async_completion_events(b: &mut VirtioBlock, expected_
             simulate_queue_event(b, None);
             simulate_async_completion_event(b, expected_irq);
         }
-        FileEngine::Sync(_) => {
+        FileEngine::Sync(_) | FileEngine::Vmdk(_) => {
             simulate_queue_event(b, Some(expected_irq));
         }
     }

--- a/tests/host_tools/drive.py
+++ b/tests/host_tools/drive.py
@@ -62,3 +62,81 @@ class FilesystemFile:
                 os.remove(self.path)
             except OSError:
                 pass
+
+
+class VmdkFile:
+    """Build a read-only ``monolithicFlat`` VMDK image (descriptor + FLAT extent).
+
+    Firecracker only supports read-only VMDK images backed by a single flat
+    extent (``monolithicFlat``). This helper writes a plain-text VMDK descriptor
+    alongside a flat extent file that is filled with a recognizable byte pattern,
+    so the image can be attached as a read-only ``virtio`` block device and the
+    data can be verified from inside the guest.
+
+    The descriptor and the extent are placed in the same directory; the extent is
+    referenced from the descriptor by its base name only, which is what lets
+    Firecracker open it once both files are jailed into the microVM root.
+    """
+
+    def __init__(
+        self, path=None, size=16, pattern=b"FIRECRACKER VMDK INTEGRATION TEST"
+    ):
+        """Create a ``size`` MiB VMDK with ``pattern`` repeated to fill the extent.
+
+        :param path: path of the descriptor file; if ``None`` a temp file is used.
+        :param size: size of the image, in MiB.
+        :param pattern: byte pattern used to fill the flat extent.
+        """
+        if path is None:
+            path = os.path.join(tempfile.mkdtemp(prefix="vmdk"), "disk.vmdk")
+        self.path = path
+        self.size = size
+        self.pattern = pattern
+        self._build()
+
+    @property
+    def descriptor_path(self):
+        """Path of the VMDK descriptor file (passed to Firecracker)."""
+        return self.path
+
+    @property
+    def extent_path(self):
+        """Path of the flat extent file backing the descriptor."""
+        stem, _ = os.path.splitext(self.path)
+        return stem + "-flat.vmdk"
+
+    def _build(self):
+        """Write the descriptor and the flat extent with the byte pattern."""
+        total_bytes = self.size * 1024 * 1024
+        sectors = total_bytes // 512
+
+        # Fill the flat extent with the repeated pattern so that reading the
+        # device back yields deterministic, verifiable data.
+        repeated = (self.pattern * (total_bytes // len(self.pattern) + 1))[:total_bytes]
+        with open(self.extent_path, "wb") as extent:
+            extent.write(repeated)
+
+        extent_name = os.path.basename(self.extent_path)
+        descriptor = (
+            "# Disk DescriptorFile\n"
+            "version=1\n"
+            "CID=ffffffff\n"
+            "parentCID=ffffffff\n"
+            'createType="monolithicFlat"\n'
+            "\n"
+            "# Extent description\n"
+            f'RW {sectors} FLAT "{extent_name}" 0\n'
+            "\n"
+            "# The disk Data Base\n"
+            "#DDB\n"
+        )
+        with open(self.path, "w", encoding="utf-8") as desc:
+            desc.write(descriptor)
+
+    def __del__(self):
+        """Remove the descriptor and the flat extent."""
+        for pth in (self.path, self.extent_path):
+            try:
+                os.remove(pth)
+            except OSError:
+                pass

--- a/tests/integration_tests/functional/test_vmdk.py
+++ b/tests/integration_tests/functional/test_vmdk.py
@@ -1,0 +1,89 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for read-only VMDK disk image support."""
+
+import hashlib
+import os
+
+import pytest
+
+import host_tools.drive as drive_tools
+
+MB = 1024 * 1024
+
+
+def _check_vmdk_data(ssh, dev_path, extent_path):
+    """Verify the guest reads back exactly the data written to the flat extent.
+
+    Mirrors the read-back / ``cmp`` step used by other block integration tests:
+    the full device is checksummed from inside the guest and compared against the
+    checksum of the flat extent written on the host.
+    """
+    _, stdout, stderr = ssh.run("md5sum {}".format(dev_path))
+    assert stderr == "", stderr
+    guest_md5 = stdout.split()[0]
+
+    with open(extent_path, "rb") as extent:
+        host_md5 = hashlib.md5(extent.read()).hexdigest()
+    assert guest_md5 == host_md5
+
+
+def _check_vmdk_size(ssh, dev_path, size_bytes):
+    """Verify the virtio-block device reports the flat extent's size in bytes."""
+    _, stdout, stderr = ssh.run("blockdev --getsize64 {}".format(dev_path))
+    assert stderr == "", stderr
+    assert int(stdout.strip()) == size_bytes
+
+
+def test_vmdk_readonly_read(uvm):
+    """Boot with a read-only VMDK data disk and verify the end-to-end read path.
+
+    The VMDK is mounted as a read-only virtio-block drive. The data read back
+    from the guest must match the flat extent written on the host, and the
+    device must report the expected size. A guest-side write must be rejected,
+    guarding the read-only contract.
+    """
+    test_microvm = uvm
+    test_microvm.spawn()
+    test_microvm.basic_config()
+    test_microvm.add_net_iface()
+
+    vmdk = drive_tools.VmdkFile(
+        os.path.join(test_microvm.fsfiles, "vmdk.vmdk"), size=16
+    )
+    # Both the descriptor and the flat extent must be reachable inside the
+    # jail, otherwise the VMDK backend cannot open the extent.
+    test_microvm.create_jailed_resource(vmdk.extent_path)
+    test_microvm.add_drive("vmdk", vmdk.descriptor_path, is_read_only=True)
+
+    test_microvm.start()
+
+    _check_vmdk_data(test_microvm.ssh, "/dev/vdb", vmdk.extent_path)
+    _check_vmdk_size(test_microvm.ssh, "/dev/vdb", vmdk.size * MB)
+
+    # Writes to a read-only disk must fail from the guest. When the virtio-blk
+    # device negotiates VIRTIO_BLK_F_RO, the Linux block layer rejects writes
+    # before they ever reach Firecracker, surfacing as EPERM
+    # ("Operation not permitted") rather than an I/O error from the device.
+    _, _, stderr = test_microvm.ssh.run("dd if=/dev/zero of=/dev/vdb bs=512 count=1")
+    assert "Operation not permitted" in stderr
+
+
+def test_vmdk_requires_read_only(uvm):
+    """A VMDK drive must be attached with ``is_read_only=true``."""
+    test_microvm = uvm
+    test_microvm.spawn()
+    test_microvm.basic_config()
+
+    vmdk = drive_tools.VmdkFile(
+        os.path.join(test_microvm.fsfiles, "vmdk.vmdk"), size=16
+    )
+    jail_path = test_microvm.create_jailed_resource(vmdk.descriptor_path)
+    with pytest.raises(RuntimeError, match="VMDK backend requires is_read_only=true."):
+        test_microvm.api.drive.put(
+            drive_id="vmdk",
+            path_on_host=jail_path,
+            is_read_only=False,
+            is_root_device=False,
+            io_engine="Sync",
+        )

--- a/tests/integration_tests/style/test_licenses.py
+++ b/tests/integration_tests/style/test_licenses.py
@@ -31,6 +31,8 @@ RIVOS_COPYRIGHT = "Copyright © 2023 Rivos, Inc."
 RIVOS_LICENSE = "SPDX-License-Identifier: Apache-2.0"
 ORACLE_COPYRIGHT = "Copyright © 2020, Oracle and/or its affiliates."
 ORACLE_LICENSE = "SPDX-License-Identifier: Apache-2.0"
+TENCENT_COPYRIGHT = "Copyright (c) 2026 Tencent. All Rights Reserved."
+TENCENT_LICENSE = "SPDX-License-Identifier: Apache-2.0"
 
 EXCLUDE = ["build", ".kernel", ".git"]
 
@@ -98,6 +100,11 @@ def _validate_license(filename):
             file, ORACLE_LICENSE
         )
 
+        has_tencent_copyright = (
+            TENCENT_COPYRIGHT in copyright_info
+            and _look_for_license(file, TENCENT_LICENSE)
+        )
+
         return (
             has_amazon_copyright
             or has_chromium_copyright
@@ -106,6 +113,7 @@ def _validate_license(filename):
             or has_intel_copyright
             or has_rivos_copyright
             or has_oracle_copyright
+            or has_tencent_copyright
         )
 
 


### PR DESCRIPTION
This change adds read-only VMDK support to the virtio-block path, and the primary motivation is the EROFS fsmerge scenario described in [containerd/nerdbox#30](https://github.com/containerd/nerdbox/issues/30). In that workflow, multiple layer blobs are referenced through one VMDK descriptor, so the guest can consume them as one logical block device instead of attaching many devices.

Why this is needed:
The main driver is the EROFS fsmerge workflow (see [containerd/nerdbox#30](https://github.com/containerd/nerdbox/issues/30)). In that setup, many layer blobs are referenced by a small metadata image. For VM-based runtimes, attaching one block device per layer does not scale well.

What is included in this patch:
This patch adds read-only VMDK support so those layers can be presented as one logical disk through a standard descriptor format. That removes the need to pass a large number of block devices or add an extra image conversion step before boot.

How this solves the problem:
- when a disk is opened, Firecracker detects VMDK and selects the VMDK engine;
- read requests are served through the VMDK backend and mapped into guest memory;
- write requests fail with a clear unsupported error, preserving read-only semantics;
- raw image behavior remains unchanged.

<img width="3182" height="1752" alt="image" src="https://github.com/user-attachments/assets/374dabef-8cc7-4cd0-8c92-8e33aa4161be" />


## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
