### PR TITLE
PCI: prepare for VFIO

### DIFF
--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -93,11 +93,12 @@ impl PciDevices {
 
         debug!(
             "Inserting MMIO BAR region: {:#x}:{:#x}",
-            virtio_device_locked.bar_address, CAPABILITY_BAR_SIZE
+            virtio_device_locked.config_bar_addr(),
+            CAPABILITY_BAR_SIZE
         );
         vm.common.mmio_bus.insert(
             virtio_device.clone(),
-            virtio_device_locked.bar_address,
+            virtio_device_locked.config_bar_addr(),
             CAPABILITY_BAR_SIZE,
         )?;
 

--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -71,7 +71,7 @@ impl std::fmt::Debug for PciSegment {
 impl PciSegment {
     fn build(id: u16, vm: &Arc<Vm>, pci_irq_slots: &[u8; 32]) -> Result<PciSegment, BusError> {
         let pci_root = PciRoot::new(None);
-        let pci_bus = Arc::new(Mutex::new(PciBus::new(pci_root, vm.clone())));
+        let pci_bus = Arc::new(Mutex::new(PciBus::new(pci_root)));
 
         let pci_config_mmio = Arc::new(Mutex::new(PciConfigMmio::new(Arc::clone(&pci_bus))));
         let mmio_config_address = PCI_MMCONFIG_START + PCI_MMIO_CONFIG_SIZE_PER_SEGMENT * id as u64;

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -21,6 +21,7 @@ use vm_allocator::{AddressAllocator, AllocPolicy, RangeInclusive};
 use vm_memory::{Address, ByteValued, GuestAddress, Le32};
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
+use zerocopy::IntoBytes;
 
 use crate::Vm;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
@@ -33,7 +34,8 @@ use crate::devices::virtio::transport::pci::device_status::*;
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::logger::{debug, error, warn};
 use crate::pci::configuration::{
-    PciCapability, PciConfiguration, PciConfigurationError, PciConfigurationState,
+    BAR0_REG, BarPrefetchable, Bars, NUM_BAR_REGS, PciCapability, PciConfiguration,
+    PciConfigurationError, PciConfigurationState,
 };
 use crate::pci::msix::{MsixCap, MsixConfig, MsixConfigState};
 use crate::pci::{
@@ -230,7 +232,7 @@ pub struct VirtioPciDeviceState {
     pub pci_configuration_state: PciConfigurationState,
     pub pci_dev_state: VirtioPciCommonConfigState,
     pub msix_state: MsixConfigState,
-    pub bar_address: u64,
+    pub bars: Bars,
 }
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -254,6 +256,8 @@ pub struct VirtioPciDevice {
 
     // PCI configuration registers.
     configuration: PciConfiguration,
+    // BARs region from configuration space handled separately
+    bars: Bars,
 
     // virtio PCI common configuration
     common_config: VirtioPciCommonConfig,
@@ -275,9 +279,6 @@ pub struct VirtioPciDevice {
     // needed when the guest tries to early access the virtio configuration of
     // a device.
     cap_pci_cfg_info: VirtioPciCfgCapInfo,
-
-    // Allocated address for the BAR
-    pub bar_address: u64,
 }
 
 impl Debug for VirtioPciDevice {
@@ -340,13 +341,13 @@ impl VirtioPciDevice {
             )
             .unwrap()
             .start();
-
-        self.configuration
-            .add_pci_bar(VIRTIO_BAR_INDEX, virtio_pci_bar_addr, CAPABILITY_BAR_SIZE);
-
-        // Once the BARs are allocated, the capabilities can be added to the PCI configuration.
+        self.bars.set_bar_64(
+            VIRTIO_BAR_INDEX,
+            virtio_pci_bar_addr,
+            CAPABILITY_BAR_SIZE,
+            BarPrefetchable::No,
+        );
         self.add_pci_capabilities();
-        self.bar_address = virtio_pci_bar_addr;
     }
 
     /// Constructs a new PCI transport for the given virtio device.
@@ -392,7 +393,7 @@ impl VirtioPciDevice {
             virtio_interrupt: Some(interrupt),
             memory,
             cap_pci_cfg_info: VirtioPciCfgCapInfo::default(),
-            bar_address: 0,
+            bars: Bars::default(),
         };
 
         Ok(virtio_pci_device)
@@ -438,7 +439,7 @@ impl VirtioPciDevice {
             virtio_interrupt: Some(interrupt),
             memory: vm.guest_memory().clone(),
             cap_pci_cfg_info,
-            bar_address: state.bar_address,
+            bars: state.bars,
         };
 
         if state.device_activated {
@@ -466,7 +467,7 @@ impl VirtioPciDevice {
     }
 
     pub fn config_bar_addr(&self) -> u64 {
-        self.configuration.get_bar_addr(VIRTIO_BAR_INDEX)
+        self.bars.get_bar_addr_64(VIRTIO_BAR_INDEX)
     }
 
     fn add_pci_capabilities(&mut self) {
@@ -622,7 +623,7 @@ impl VirtioPciDevice {
                 .lock()
                 .expect("Poisoned lock")
                 .state(),
-            bar_address: self.bar_address,
+            bars: self.bars,
         }
     }
 }
@@ -726,43 +727,62 @@ impl PciDevice for VirtioPciDevice {
         offset: u8,
         data: &[u8],
     ) -> Option<Arc<Barrier>> {
-        // Handle the special case where the capability VIRTIO_PCI_CAP_PCI_CFG
-        // is accessed. This capability has a special meaning as it allows the
-        // guest to access other capabilities without mapping the PCI BAR.
-        let base = reg_idx as usize * 4;
-        if base + offset as usize >= self.cap_pci_cfg_info.offset as usize
-            && base + offset as usize + data.len()
-                <= self.cap_pci_cfg_info.offset as usize + self.cap_pci_cfg_info.cap.bytes().len()
-        {
-            let offset = base + offset as usize - self.cap_pci_cfg_info.offset as usize;
-            self.write_cap_pci_cfg(offset, data)
-        } else {
-            self.configuration
-                .write_config_register(reg_idx, offset, data);
+        if u16::from(BAR0_REG) <= reg_idx && reg_idx < u16::from(BAR0_REG + NUM_BAR_REGS) {
+            // reg_idx is in [BAR0_REG, BAR0_REG+NUM_BAR_REGS), so the difference is 0..5.
+            #[allow(clippy::cast_possible_truncation)]
+            let bar_idx = (reg_idx - u16::from(BAR0_REG)) as u8;
+            self.bars.write(bar_idx, offset, data);
             None
+        } else {
+            // Handle the special case where the capability VIRTIO_PCI_CAP_PCI_CFG
+            // is accessed. This capability has a special meaning as it allows the
+            // guest to access other capabilities without mapping the PCI BAR.
+            let base = reg_idx as usize * 4;
+            if base + offset as usize >= self.cap_pci_cfg_info.offset as usize
+                && base + offset as usize + data.len()
+                    <= self.cap_pci_cfg_info.offset as usize
+                        + self.cap_pci_cfg_info.cap.bytes().len()
+            {
+                let offset = base + offset as usize - self.cap_pci_cfg_info.offset as usize;
+                self.write_cap_pci_cfg(offset, data)
+            } else {
+                self.configuration
+                    .write_config_register(reg_idx, offset, data);
+                None
+            }
         }
     }
 
     fn read_config_register(&mut self, reg_idx: u16) -> u32 {
-        // Handle the special case where the capability VIRTIO_PCI_CAP_PCI_CFG
-        // is accessed. This capability has a special meaning as it allows the
-        // guest to access other capabilities without mapping the PCI BAR.
-        let base = reg_idx as usize * 4;
-        if base >= self.cap_pci_cfg_info.offset as usize
-            && base + 4
-                <= self.cap_pci_cfg_info.offset as usize + self.cap_pci_cfg_info.cap.bytes().len()
-        {
-            let offset = base - self.cap_pci_cfg_info.offset as usize;
-            let mut data = [0u8; 4];
-            let len = u32::from(self.cap_pci_cfg_info.cap.cap.length) as usize;
-            if len <= 4 {
-                self.read_cap_pci_cfg(offset, &mut data[..len]);
-                u32::from_le_bytes(data)
-            } else {
-                0
-            }
+        if u16::from(BAR0_REG) <= reg_idx && reg_idx < u16::from(BAR0_REG + NUM_BAR_REGS) {
+            // reg_idx is in [BAR0_REG, BAR0_REG+NUM_BAR_REGS), so the difference is 0..5.
+            #[allow(clippy::cast_possible_truncation)]
+            let bar_idx = (reg_idx - u16::from(BAR0_REG)) as u8;
+            let mut value: u32 = 0;
+            self.bars.read(bar_idx, 0, value.as_mut_bytes());
+            value
         } else {
-            self.configuration.read_reg(reg_idx)
+            // Handle the special case where the capability VIRTIO_PCI_CAP_PCI_CFG
+            // is accessed. This capability has a special meaning as it allows the
+            // guest to access other capabilities without mapping the PCI BAR.
+            let base = reg_idx as usize * 4;
+            if base >= self.cap_pci_cfg_info.offset as usize
+                && base + 4
+                    <= self.cap_pci_cfg_info.offset as usize
+                        + self.cap_pci_cfg_info.cap.bytes().len()
+            {
+                let offset = base - self.cap_pci_cfg_info.offset as usize;
+                let mut data = [0u8; 4];
+                let len = u32::from(self.cap_pci_cfg_info.cap.cap.length) as usize;
+                if len <= 4 {
+                    self.read_cap_pci_cfg(offset, &mut data[..len]);
+                    u32::from_le_bytes(data)
+                } else {
+                    0
+                }
+            } else {
+                self.configuration.read_reg(reg_idx)
+            }
         }
     }
 
@@ -771,16 +791,10 @@ impl PciDevice for VirtioPciDevice {
         reg_idx: u16,
         data: &[u8],
     ) -> Option<BarReprogrammingParams> {
-        self.configuration.detect_bar_reprogramming(reg_idx, data)
+        None
     }
 
     fn move_bar(&mut self, old_base: u64, new_base: u64) -> Result<(), DeviceRelocationError> {
-        // We only update our idea of the bar in order to support free_bars() above.
-        // The majority of the reallocation is done inside DeviceManager.
-        if self.bar_address == old_base {
-            self.bar_address = new_base;
-        }
-
         Ok(())
     }
 

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -189,6 +189,17 @@ struct VirtioPciCfgCapInfo {
     cap: VirtioPciCfgCap,
 }
 
+impl VirtioPciCfgCapInfo {
+    fn in_range(&self, reg_idx: u16, offset: u8, data_len: usize) -> bool {
+        let base = reg_idx * 4;
+        let cap_start = self.offset;
+        let cap_end = self.offset as usize + self.cap.bytes().len();
+        let start = base + u16::from(offset);
+        let end = (base + u16::from(offset)) as usize + data_len;
+        cap_start <= start && end <= cap_end
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 #[repr(u8)]
 pub enum PciVirtioSubclass {
@@ -734,67 +745,62 @@ impl PciDevice for VirtioPciDevice {
         offset: u8,
         data: &[u8],
     ) -> Option<Arc<Barrier>> {
-        if BAR0_REG_IDX <= reg_idx && reg_idx < BAR0_REG_IDX + u16::from(NUM_BAR_REGS) {
+        let in_bars = BAR0_REG_IDX <= reg_idx && reg_idx < BAR0_REG_IDX + u16::from(NUM_BAR_REGS);
+        let in_msix_cap_header = reg_idx * 4 == self.msix_config_cap_offset;
+        let in_pci_cfg = self.cap_pci_cfg_info.in_range(reg_idx, offset, data.len());
+        if in_bars {
             // reg_idx is in [BAR0_REG_IDX, BAR0_REG_IDX+NUM_BAR_REGS), so the difference is 0..5.
             #[allow(clippy::cast_possible_truncation)]
             let bar_idx = (reg_idx - BAR0_REG_IDX) as u8;
             self.bars.write(bar_idx, offset, data);
             None
+        } else if in_msix_cap_header {
+            // For the MsixCap structure, we need to capture writes to the second 2 bytes
+            // of the capability header where Function Mask and MSI-X Enable bits are present.
+            // Everything else can be served from `self.configuration`.
+            self.msix_config
+                .lock()
+                .unwrap()
+                .write_msg_ctl_register(offset, data);
+            self.configuration
+                .write_config_register(reg_idx, offset, data);
+            None
+        } else if in_pci_cfg {
+            let offset = (reg_idx * 4 + u16::from(offset) - self.cap_pci_cfg_info.offset) as usize;
+            self.write_cap_pci_cfg(offset, data)
         } else {
-            // Handle access to the header of the MsixCapability. The rest of the
-            // capability is handled by the PciConfiguration.
-            let base = reg_idx * 4;
-            if base == self.msix_config_cap_offset {
-                self.msix_config
-                    .lock()
-                    .unwrap()
-                    .write_msg_ctl_register(offset, data);
-            }
-            if base + u16::from(offset) >= self.cap_pci_cfg_info.offset
-                && (base + u16::from(offset)) as usize + data.len()
-                    <= self.cap_pci_cfg_info.offset as usize
-                        + self.cap_pci_cfg_info.cap.bytes().len()
-            {
-                let offset = (base + u16::from(offset) - self.cap_pci_cfg_info.offset) as usize;
-                self.write_cap_pci_cfg(offset, data)
-            } else {
-                self.configuration
-                    .write_config_register(reg_idx, offset, data);
-                None
-            }
+            self.configuration
+                .write_config_register(reg_idx, offset, data);
+            None
         }
     }
 
     fn read_config_register(&mut self, reg_idx: u16) -> u32 {
-        if BAR0_REG_IDX <= reg_idx && reg_idx < BAR0_REG_IDX + u16::from(NUM_BAR_REGS) {
+        let in_bars = BAR0_REG_IDX <= reg_idx && reg_idx < BAR0_REG_IDX + u16::from(NUM_BAR_REGS);
+        let in_pci_cfg = self.cap_pci_cfg_info.in_range(reg_idx, 0, 4);
+
+        if in_bars {
             // reg_idx is in [BAR0_REG_IDX, BAR0_REG_IDX+NUM_BAR_REGS), so the difference is 0..5.
             #[allow(clippy::cast_possible_truncation)]
             let bar_idx = (reg_idx - BAR0_REG_IDX) as u8;
             let mut value: u32 = 0;
             self.bars.read(bar_idx, 0, value.as_mut_bytes());
             value
-        } else {
+        } else if in_pci_cfg {
             // Handle the special case where the capability VIRTIO_PCI_CAP_PCI_CFG
             // is accessed. This capability has a special meaning as it allows the
             // guest to access other capabilities without mapping the PCI BAR.
-            let base = reg_idx as usize * 4;
-            if base >= self.cap_pci_cfg_info.offset as usize
-                && base + 4
-                    <= self.cap_pci_cfg_info.offset as usize
-                        + self.cap_pci_cfg_info.cap.bytes().len()
-            {
-                let offset = base - self.cap_pci_cfg_info.offset as usize;
-                let mut data = [0u8; 4];
-                let len = u32::from(self.cap_pci_cfg_info.cap.cap.length) as usize;
-                if len <= 4 {
-                    self.read_cap_pci_cfg(offset, &mut data[..len]);
-                    u32::from_le_bytes(data)
-                } else {
-                    0
-                }
+            let offset = (reg_idx * 4 - self.cap_pci_cfg_info.offset) as usize;
+            let mut data = [0u8; 4];
+            let len = u32::from(self.cap_pci_cfg_info.cap.cap.length) as usize;
+            if len <= 4 {
+                self.read_cap_pci_cfg(offset, &mut data[..len]);
+                u32::from_le_bytes(data)
             } else {
-                self.configuration.read_reg(reg_idx)
+                0
             }
+        } else {
+            self.configuration.read_reg(reg_idx)
         }
     }
 

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -233,6 +233,7 @@ pub struct VirtioPciDeviceState {
     pub pci_dev_state: VirtioPciCommonConfigState,
     pub msix_state: MsixConfigState,
     pub bars: Bars,
+    pub msix_config_cap_offset: u16,
 }
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -279,6 +280,8 @@ pub struct VirtioPciDevice {
     // needed when the guest tries to early access the virtio configuration of
     // a device.
     cap_pci_cfg_info: VirtioPciCfgCapInfo,
+    msix_config_cap_offset: u16,
+    msix_config: Arc<Mutex<MsixConfig>>,
 }
 
 impl Debug for VirtioPciDevice {
@@ -318,7 +321,6 @@ impl VirtioPciDevice {
             subclass,
             VIRTIO_PCI_VENDOR_ID,
             pci_device_id,
-            Some(msix_config.clone()),
         )
     }
 
@@ -394,6 +396,8 @@ impl VirtioPciDevice {
             memory,
             cap_pci_cfg_info: VirtioPciCfgCapInfo::default(),
             bars: Bars::default(),
+            msix_config,
+            msix_config_cap_offset: 0,
         };
 
         Ok(virtio_pci_device)
@@ -409,10 +413,7 @@ impl VirtioPciDevice {
         let vectors = msix_config.vectors.clone();
         let msix_config = Arc::new(Mutex::new(msix_config));
 
-        let pci_config = PciConfiguration::type0_from_state(
-            state.pci_configuration_state,
-            Some(msix_config.clone()),
-        )?;
+        let pci_config = PciConfiguration::type0_from_state(state.pci_configuration_state)?;
         let virtio_common_config = VirtioPciCommonConfig::new(state.pci_dev_state);
         let cap_pci_cfg_info = VirtioPciCfgCapInfo {
             offset: state.cap_pci_cfg_offset,
@@ -440,6 +441,8 @@ impl VirtioPciDevice {
             memory: vm.guest_memory().clone(),
             cap_pci_cfg_info,
             bars: state.bars,
+            msix_config,
+            msix_config_cap_offset: state.msix_config_cap_offset,
         };
 
         if state.device_activated {
@@ -521,7 +524,10 @@ impl VirtioPciDevice {
                 VIRTIO_BAR_INDEX,
                 MSIX_PBA_BAR_OFFSET,
             );
-            self.configuration.add_capability(&msix_cap);
+            // The whole Configuration region is 4K, so u16 can address it all
+            #[allow(clippy::cast_possible_truncation)]
+            let offset = self.configuration.add_capability(&msix_cap) as u16;
+            self.msix_config_cap_offset = offset;
         }
     }
 
@@ -624,6 +630,7 @@ impl VirtioPciDevice {
                 .expect("Poisoned lock")
                 .state(),
             bars: self.bars,
+            msix_config_cap_offset: self.msix_config_cap_offset,
         }
     }
 }
@@ -734,16 +741,21 @@ impl PciDevice for VirtioPciDevice {
             self.bars.write(bar_idx, offset, data);
             None
         } else {
-            // Handle the special case where the capability VIRTIO_PCI_CAP_PCI_CFG
-            // is accessed. This capability has a special meaning as it allows the
-            // guest to access other capabilities without mapping the PCI BAR.
-            let base = reg_idx as usize * 4;
-            if base + offset as usize >= self.cap_pci_cfg_info.offset as usize
-                && base + offset as usize + data.len()
+            // Handle access to the header of the MsixCapability. The rest of the
+            // capability is handled by the PciConfiguration.
+            let base = reg_idx * 4;
+            if base == self.msix_config_cap_offset {
+                self.msix_config
+                    .lock()
+                    .unwrap()
+                    .write_msg_ctl_register(offset, data);
+            }
+            if base + u16::from(offset) >= self.cap_pci_cfg_info.offset
+                && (base + u16::from(offset)) as usize + data.len()
                     <= self.cap_pci_cfg_info.offset as usize
                         + self.cap_pci_cfg_info.cap.bytes().len()
             {
-                let offset = base + offset as usize - self.cap_pci_cfg_info.offset as usize;
+                let offset = (base + u16::from(offset) - self.cap_pci_cfg_info.offset) as usize;
                 self.write_cap_pci_cfg(offset, data)
             } else {
                 self.configuration

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -215,8 +215,6 @@ const MSIX_PBA_BAR_OFFSET: u32 = 0x48000;
 const MSIX_PBA_SIZE: u32 = 0x800;
 /// The BAR size must be a power of 2.
 pub const CAPABILITY_BAR_SIZE: u64 = 0x80000;
-const VIRTIO_COMMON_BAR_INDEX: u8 = 0;
-const VIRTIO_SHM_BAR_INDEX: usize = 2;
 
 const NOTIFY_OFF_MULTIPLIER: u32 = 4; // A dword per notification address.
 
@@ -343,11 +341,8 @@ impl VirtioPciDevice {
             .unwrap()
             .start();
 
-        self.configuration.add_pci_bar(
-            VIRTIO_COMMON_BAR_INDEX,
-            virtio_pci_bar_addr,
-            CAPABILITY_BAR_SIZE,
-        );
+        self.configuration
+            .add_pci_bar(VIRTIO_BAR_INDEX, virtio_pci_bar_addr, CAPABILITY_BAR_SIZE);
 
         // Once the BARs are allocated, the capabilities can be added to the PCI configuration.
         self.add_pci_capabilities();

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -39,8 +39,8 @@ use crate::pci::configuration::{
 };
 use crate::pci::msix::{MsixCap, MsixConfig, MsixConfigState};
 use crate::pci::{
-    BarReprogrammingParams, DeviceRelocationError, PciCapabilityId, PciClassCode, PciDevice,
-    PciMassStorageSubclass, PciNetworkControllerSubclass, PciSBDF,
+    BarReprogrammingParams, PciCapabilityId, PciClassCode, PciDevice, PciMassStorageSubclass,
+    PciNetworkControllerSubclass, PciSBDF,
 };
 use crate::snapshot::Persist;
 use crate::vstate::bus::BusDevice;
@@ -249,8 +249,6 @@ pub struct VirtioPciDeviceState {
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum VirtioPciDeviceError {
-    /// Failed creating VirtioPciDevice: {0}
-    CreateVirtioPciDevice(#[from] DeviceRelocationError),
     /// Error creating MSI configuration: {0}
     Msi(#[from] InterruptError),
     /// Invalid PCI configuration state: {0}
@@ -802,18 +800,6 @@ impl PciDevice for VirtioPciDevice {
         } else {
             self.configuration.read_reg(reg_idx)
         }
-    }
-
-    fn detect_bar_reprogramming(
-        &mut self,
-        reg_idx: u16,
-        data: &[u8],
-    ) -> Option<BarReprogrammingParams> {
-        None
-    }
-
-    fn move_bar(&mut self, old_base: u64, new_base: u64) -> Result<(), DeviceRelocationError> {
-        Ok(())
     }
 
     fn read_bar(&mut self, _base: u64, offset: u64, data: &mut [u8]) {

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -34,7 +34,7 @@ use crate::devices::virtio::transport::pci::device_status::*;
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::logger::{debug, error, warn};
 use crate::pci::configuration::{
-    BAR0_REG, BarPrefetchable, Bars, NUM_BAR_REGS, PciCapability, PciConfiguration,
+    BAR0_REG_IDX, BarPrefetchable, Bars, NUM_BAR_REGS, PciCapability, PciConfiguration,
     PciConfigurationError, PciConfigurationState,
 };
 use crate::pci::msix::{MsixCap, MsixConfig, MsixConfigState};
@@ -734,10 +734,10 @@ impl PciDevice for VirtioPciDevice {
         offset: u8,
         data: &[u8],
     ) -> Option<Arc<Barrier>> {
-        if u16::from(BAR0_REG) <= reg_idx && reg_idx < u16::from(BAR0_REG + NUM_BAR_REGS) {
-            // reg_idx is in [BAR0_REG, BAR0_REG+NUM_BAR_REGS), so the difference is 0..5.
+        if BAR0_REG_IDX <= reg_idx && reg_idx < BAR0_REG_IDX + u16::from(NUM_BAR_REGS) {
+            // reg_idx is in [BAR0_REG_IDX, BAR0_REG_IDX+NUM_BAR_REGS), so the difference is 0..5.
             #[allow(clippy::cast_possible_truncation)]
-            let bar_idx = (reg_idx - u16::from(BAR0_REG)) as u8;
+            let bar_idx = (reg_idx - BAR0_REG_IDX) as u8;
             self.bars.write(bar_idx, offset, data);
             None
         } else {
@@ -766,10 +766,10 @@ impl PciDevice for VirtioPciDevice {
     }
 
     fn read_config_register(&mut self, reg_idx: u16) -> u32 {
-        if u16::from(BAR0_REG) <= reg_idx && reg_idx < u16::from(BAR0_REG + NUM_BAR_REGS) {
-            // reg_idx is in [BAR0_REG, BAR0_REG+NUM_BAR_REGS), so the difference is 0..5.
+        if BAR0_REG_IDX <= reg_idx && reg_idx < BAR0_REG_IDX + u16::from(NUM_BAR_REGS) {
+            // reg_idx is in [BAR0_REG_IDX, BAR0_REG_IDX+NUM_BAR_REGS), so the difference is 0..5.
             #[allow(clippy::cast_possible_truncation)]
-            let bar_idx = (reg_idx - u16::from(BAR0_REG)) as u8;
+            let bar_idx = (reg_idx - BAR0_REG_IDX) as u8;
             let mut value: u32 = 0;
             self.bars.read(bar_idx, 0, value.as_mut_bytes());
             value

--- a/src/vmm/src/pci/bus.rs
+++ b/src/vmm/src/pci/bus.rs
@@ -51,7 +51,6 @@ impl PciRoot {
                     PciBridgeSubclass::HostBridge as u8,
                     0,
                     0,
-                    None,
                 ),
             }
         }
@@ -518,7 +517,6 @@ mod tests {
                 PciMassStorageSubclass::SerialScsiController as u8,
                 0x13,
                 0x12,
-                None,
             );
             PciDevMock(config)
         }

--- a/src/vmm/src/pci/bus.rs
+++ b/src/vmm/src/pci/bus.rs
@@ -492,12 +492,6 @@ mod tests {
         reloc_cnt: AtomicUsize,
     }
 
-    impl RelocationMock {
-        fn cnt(&self) -> usize {
-            self.reloc_cnt.load(std::sync::atomic::Ordering::SeqCst)
-        }
-    }
-
     impl DeviceRelocation for RelocationMock {
         fn move_bar(
             &self,
@@ -516,7 +510,7 @@ mod tests {
 
     impl PciDevMock {
         fn new() -> Self {
-            let mut config = PciConfiguration::new_type0(
+            let config = PciConfiguration::new_type0(
                 0x42,
                 0x0,
                 0x0,
@@ -526,9 +520,6 @@ mod tests {
                 0x12,
                 None,
             );
-
-            config.add_pci_bar(0, 0x1000, 0x1000);
-
             PciDevMock(config)
         }
     }
@@ -550,10 +541,10 @@ mod tests {
 
         fn detect_bar_reprogramming(
             &mut self,
-            reg_idx: u16,
-            data: &[u8],
+            _reg_idx: u16,
+            _data: &[u8],
         ) -> Option<BarReprogrammingParams> {
-            self.0.detect_bar_reprogramming(reg_idx, data)
+            None
         }
     }
 
@@ -935,57 +926,5 @@ mod tests {
         write_mmio_config(&mut mmio_config, 0, 0, 0, 15, 0, &[0x42]);
         read_mmio_config(&mut mmio_config, 0, 0, 0, 15, 0, &mut buffer);
         assert_eq!(buffer[0], 0x42);
-    }
-
-    #[test]
-    fn test_bar_reprogramming() {
-        let (mut mmio_config, _, mock) = initialize_bus();
-        let mut buffer = [0u8; 4];
-        assert_eq!(mock.cnt(), 0);
-
-        read_mmio_config(&mut mmio_config, 0, 1, 0, 0x4, 0, &mut buffer);
-        let old_addr = u32::from_le_bytes(buffer) & 0xffff_fff0;
-        assert_eq!(old_addr, 0x1000);
-
-        // Writing the lower 32bits first should not trigger any reprogramming
-        write_mmio_config(
-            &mut mmio_config,
-            0,
-            1,
-            0,
-            0x4,
-            0,
-            &u32::to_le_bytes(0x1312_0000),
-        );
-
-        read_mmio_config(&mut mmio_config, 0, 1, 0, 0x4, 0, &mut buffer);
-        let new_addr = u32::from_le_bytes(buffer) & 0xffff_fff0;
-        assert_eq!(new_addr, 0x1312_0000);
-        assert_eq!(mock.cnt(), 0);
-
-        // Writing the upper 32bits first should now trigger the reprogramming logic
-        write_mmio_config(&mut mmio_config, 0, 1, 0, 0x5, 0, &u32::to_le_bytes(0x1110));
-        read_mmio_config(&mut mmio_config, 0, 1, 0, 0x5, 0, &mut buffer);
-        let new_addr = u32::from_le_bytes(buffer);
-        assert_eq!(new_addr, 0x1110);
-        assert_eq!(mock.cnt(), 1);
-
-        // BAR2 should not be used, so reading its address should return all 0s
-        read_mmio_config(&mut mmio_config, 0, 1, 0, 0x6, 0, &mut buffer);
-        assert_eq!(buffer, [0x0, 0x0, 0x0, 0x0]);
-
-        // and reprogramming shouldn't have any effect
-        write_mmio_config(
-            &mut mmio_config,
-            0,
-            1,
-            0,
-            0x5,
-            0,
-            &u32::to_le_bytes(0x1312_1110),
-        );
-
-        read_mmio_config(&mut mmio_config, 0, 1, 0, 0x6, 0, &mut buffer);
-        assert_eq!(buffer, [0x0, 0x0, 0x0, 0x0]);
     }
 }

--- a/src/vmm/src/pci/bus.rs
+++ b/src/vmm/src/pci/bus.rs
@@ -7,14 +7,12 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::ops::DerefMut;
 use std::sync::{Arc, Barrier, Mutex};
 
 use byteorder::{ByteOrder, LittleEndian};
 
-use crate::logger::error;
 use crate::pci::configuration::PciConfiguration;
-use crate::pci::{DeviceRelocation, PciBridgeSubclass, PciClassCode, PciDevice};
+use crate::pci::{PciBridgeSubclass, PciClassCode, PciDevice};
 use crate::utils::u64_to_usize;
 use crate::vstate::bus::BusDevice;
 
@@ -80,7 +78,6 @@ pub struct PciBus {
     /// Devices attached to this bus.
     /// Device 0 is host bridge.
     pub devices: HashMap<u8, Arc<Mutex<dyn PciDevice>>>,
-    vm: Arc<dyn DeviceRelocation>,
     device_ids: Vec<bool>,
 }
 
@@ -94,7 +91,7 @@ impl Debug for PciBus {
 
 impl PciBus {
     /// Create a new PCI bus
-    pub fn new(pci_root: PciRoot, vm: Arc<dyn DeviceRelocation>) -> Self {
+    pub fn new(pci_root: PciRoot) -> Self {
         let mut devices: HashMap<u8, Arc<Mutex<dyn PciDevice>>> = HashMap::new();
         let mut device_ids: Vec<bool> = vec![false; NUM_DEVICE_IDS];
 
@@ -103,7 +100,6 @@ impl PciBus {
 
         PciBus {
             devices,
-            vm,
             device_ids,
         }
     }
@@ -219,22 +215,6 @@ impl PciConfigIo {
         let pci_bus = self.pci_bus.as_ref().lock().unwrap();
         if let Some(d) = pci_bus.devices.get(&device) {
             let mut device = d.lock().unwrap();
-
-            // Find out if one of the device's BAR is being reprogrammed, and
-            // reprogram it if needed.
-            if let Some(params) = device.detect_bar_reprogramming(register, data)
-                && let Err(e) = pci_bus.vm.move_bar(
-                    params.old_base,
-                    params.new_base,
-                    params.len,
-                    device.deref_mut(),
-                )
-            {
-                error!(
-                    "Failed moving device BAR: {}: 0x{:x}->0x{:x}(0x{:x})",
-                    e, params.old_base, params.new_base, params.len
-                );
-            }
 
             // offset is validated to be < 4 at the top of this function.
             #[allow(clippy::cast_possible_truncation)]
@@ -360,22 +340,6 @@ impl PciConfigMmio {
         if let Some(d) = pci_bus.devices.get(&device) {
             let mut device = d.lock().unwrap();
 
-            // Find out if one of the device's BAR is being reprogrammed, and
-            // reprogram it if needed.
-            if let Some(params) = device.detect_bar_reprogramming(register, data)
-                && let Err(e) = pci_bus.vm.move_bar(
-                    params.old_base,
-                    params.new_base,
-                    params.len,
-                    device.deref_mut(),
-                )
-            {
-                error!(
-                    "Failed moving device BAR: {}: 0x{:x}->0x{:x}(0x{:x})",
-                    e, params.old_base, params.new_base, params.len
-                );
-            }
-
             // offset is validated to be < 4 at the top of this function.
             #[allow(clippy::cast_possible_truncation)]
             let offset = offset as u8;
@@ -474,36 +438,13 @@ fn parse_io_config_address(config_address: u32) -> (u8, u8, u8, u16) {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::AtomicUsize;
     use std::sync::{Arc, Mutex};
 
     use super::{PciBus, PciConfigIo, PciConfigMmio, PciRoot};
     use crate::pci::bus::{DEVICE_ID_INTEL_VIRT_PCIE_HOST, VENDOR_ID_INTEL};
     use crate::pci::configuration::PciConfiguration;
-    use crate::pci::{
-        BarReprogrammingParams, DeviceRelocation, DeviceRelocationError, PciClassCode, PciDevice,
-        PciMassStorageSubclass,
-    };
+    use crate::pci::{PciClassCode, PciDevice, PciMassStorageSubclass};
     use crate::vstate::bus::BusDevice;
-
-    #[derive(Debug, Default)]
-    struct RelocationMock {
-        reloc_cnt: AtomicUsize,
-    }
-
-    impl DeviceRelocation for RelocationMock {
-        fn move_bar(
-            &self,
-            _old_base: u64,
-            _new_base: u64,
-            _len: u64,
-            _pci_dev: &mut dyn PciDevice,
-        ) -> Result<(), DeviceRelocationError> {
-            self.reloc_cnt
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(())
-        }
-    }
 
     struct PciDevMock(PciConfiguration);
 
@@ -536,21 +477,12 @@ mod tests {
         fn read_config_register(&mut self, reg_idx: u16) -> u32 {
             self.0.read_reg(reg_idx)
         }
-
-        fn detect_bar_reprogramming(
-            &mut self,
-            _reg_idx: u16,
-            _data: &[u8],
-        ) -> Option<BarReprogrammingParams> {
-            None
-        }
     }
 
     #[test]
     fn test_writing_io_config_address() {
-        let mock = Arc::new(RelocationMock::default());
         let root = PciRoot::new(None);
-        let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(root, mock))));
+        let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(root))));
 
         assert_eq!(bus.config_address, 0);
         // Writing more than 32 bits will should fail
@@ -590,9 +522,8 @@ mod tests {
 
     #[test]
     fn test_reading_io_config_address() {
-        let mock = Arc::new(RelocationMock::default());
         let root = PciRoot::new(None);
-        let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(root, mock))));
+        let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(root))));
 
         let mut buffer = [0u8; 4];
 
@@ -637,19 +568,18 @@ mod tests {
         assert_eq!(buffer, [0x45, 0x44, 0x43, 0x42]);
     }
 
-    fn initialize_bus() -> (PciConfigMmio, PciConfigIo, Arc<RelocationMock>) {
-        let mock = Arc::new(RelocationMock::default());
+    fn initialize_bus() -> (PciConfigMmio, PciConfigIo) {
         let root = PciRoot::new(None);
-        let mut bus = PciBus::new(root, mock.clone());
+        let mut bus = PciBus::new(root);
         bus.add_device(1, Arc::new(Mutex::new(PciDevMock::new())));
 
         let bus = Arc::new(Mutex::new(bus));
-        (PciConfigMmio::new(bus.clone()), PciConfigIo::new(bus), mock)
+        (PciConfigMmio::new(bus.clone()), PciConfigIo::new(bus))
     }
 
     #[test]
     fn test_invalid_register_boundary_reads() {
-        let (mut mmio_config, mut io_config, _) = initialize_bus();
+        let (mut mmio_config, mut io_config) = initialize_bus();
 
         // Read crossing register boundaries
         let mut buffer = [0u8; 4];
@@ -784,7 +714,7 @@ mod tests {
 
     #[test]
     fn test_mmio_invalid_bus_number() {
-        let (mut mmio_config, _, _) = initialize_bus();
+        let (mut mmio_config, _) = initialize_bus();
         let mut buffer = [0u8; 4];
 
         // Asking for Bus 1 should return all 1s
@@ -809,7 +739,7 @@ mod tests {
 
     #[test]
     fn test_io_invalid_bus_number() {
-        let (_, mut pio_config, _) = initialize_bus();
+        let (_, mut pio_config) = initialize_bus();
         let mut buffer = [0u8; 4];
 
         // Asking for Bus 1 should return all 1s
@@ -827,7 +757,7 @@ mod tests {
 
     #[test]
     fn test_mmio_invalid_function() {
-        let (mut mmio_config, _, _) = initialize_bus();
+        let (mut mmio_config, _) = initialize_bus();
         let mut buffer = [0u8; 4];
 
         // Asking for Bus 1 should return all 1s
@@ -852,7 +782,7 @@ mod tests {
 
     #[test]
     fn test_io_invalid_function() {
-        let (_, mut pio_config, _) = initialize_bus();
+        let (_, mut pio_config) = initialize_bus();
         let mut buffer = [0u8; 4];
 
         // Asking for Bus 1 should return all 1s
@@ -870,7 +800,7 @@ mod tests {
 
     #[test]
     fn test_io_disabled_reads() {
-        let (_, mut pio_config, _) = initialize_bus();
+        let (_, mut pio_config) = initialize_bus();
         let mut buffer = [0u8; 4];
 
         // Trying to read without enabling should return all 1s
@@ -888,7 +818,7 @@ mod tests {
 
     #[test]
     fn test_io_disabled_writes() {
-        let (_, mut pio_config, _) = initialize_bus();
+        let (_, mut pio_config) = initialize_bus();
 
         // Try to write the IRQ line used for the root port.
         let mut buffer = [0u8; 4];
@@ -916,7 +846,7 @@ mod tests {
 
     #[test]
     fn test_mmio_writes() {
-        let (mut mmio_config, _, _) = initialize_bus();
+        let (mut mmio_config, _) = initialize_bus();
         let mut buffer = [0u8; 4];
 
         read_mmio_config(&mut mmio_config, 0, 0, 0, 15, 0, &mut buffer);

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -34,16 +34,19 @@ const NUM_CONFIGURATION_REGISTERS: usize = 1024;
 
 const STATUS_REG: usize = 1;
 const STATUS_REG_CAPABILITIES_USED_MASK: u32 = 0x0010_0000;
-const BAR0_REG: u16 = 4;
 const ROM_BAR_REG: u16 = 12;
 const BAR_MEM_ADDR_MASK: u32 = 0xffff_fff0;
 const ROM_BAR_ADDR_MASK: u32 = 0xffff_f800;
 const MSI_CAPABILITY_REGISTER_MASK: u32 = 0x0071_0000;
 const MSIX_CAPABILITY_REGISTER_MASK: u32 = 0xc000_0000;
-const NUM_BAR_REGS: usize = 6;
 const CAPABILITY_LIST_HEAD_OFFSET: u8 = 0x34;
 const FIRST_CAPABILITY_OFFSET: u8 = 0x40;
 const CAPABILITY_MAX_OFFSET: u16 = 192;
+
+/// First register in the BARs region
+pub const BAR0_REG: u8 = 4;
+/// Number of BAR registers
+pub const NUM_BAR_REGS: u8 = 6;
 
 /// Type representing information about single BAR register
 ///  31                                                 4  3    2  1  0
@@ -88,17 +91,16 @@ pub enum BarPrefetchable {
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub struct Bars {
     /// BARs
-    pub bars: [Bar; NUM_BAR_REGS],
+    pub bars: [Bar; NUM_BAR_REGS as usize],
 }
 impl Bars {
     /// Set 2 consecutive BAR slots as a single 64bit bar
-    #[allow(clippy::cast_possible_truncation)]
     pub fn set_bar_64(&mut self, bar_idx: u8, addr: u64, size: u64, prefetchable: BarPrefetchable) {
         assert_ne!(size, 0);
         assert!(size.is_power_of_two());
         assert!(addr & 0b1111 == 0);
         addr.checked_add(size - 1).unwrap();
-        assert!(usize::from(bar_idx) < NUM_BAR_REGS - 1);
+        assert!(bar_idx < NUM_BAR_REGS - 1);
 
         // Unused BARs will have address and size of 0
         assert_eq!(self.bars[bar_idx as usize].encoded_addr, 0);
@@ -118,18 +120,16 @@ impl Bars {
         self.bars[(bar_idx + 1) as usize].encoded_size = size_hi;
     }
     /// Get the address of the 64bit bar
-    #[allow(clippy::cast_possible_truncation)]
     pub fn get_bar_addr_64(&self, bar_idx: u8) -> u64 {
-        assert!((bar_idx as usize) < NUM_BAR_REGS - 1);
+        assert!(bar_idx < NUM_BAR_REGS - 1);
         let addr_hi = self.bars[(bar_idx + 1) as usize].encoded_addr;
         let addr_lo = self.bars[bar_idx as usize].encoded_addr & !0b1111;
         (addr_hi as u64) << 32 | (addr_lo as u64)
     }
     /// Writes into a given BAR register at the given offset
-    #[allow(clippy::cast_possible_truncation)]
     pub fn write(&mut self, bar_idx: u8, offset: u8, data: &[u8]) {
         // There are only 6 registers each 4 bytes long
-        assert!((bar_idx as usize) < NUM_BAR_REGS);
+        assert!(bar_idx < NUM_BAR_REGS);
         assert!(offset as usize + data.len() <= 4);
         if let Ok(value) = u32::read_from_bytes(data)
             && value == 0xffff_ffff
@@ -145,10 +145,9 @@ impl Bars {
         }
     }
     /// Reads from a given BAR register at the given offset
-    #[allow(clippy::cast_possible_truncation)]
     pub fn read(&mut self, bar_idx: u8, offset: u8, data: &mut [u8]) {
         // There are only 6 registers each 4 bytes long
-        assert!((bar_idx as usize) < NUM_BAR_REGS);
+        assert!(bar_idx < NUM_BAR_REGS);
         assert!(offset as usize + data.len() <= 4);
         let bar = &mut self.bars[bar_idx as usize];
         let bytes = if bar.about_to_be_read {
@@ -216,7 +215,7 @@ pub struct PciConfigurationState {
 pub struct PciConfiguration {
     registers: [u32; NUM_CONFIGURATION_REGISTERS],
     writable_bits: [u32; NUM_CONFIGURATION_REGISTERS], // writable bits for each register.
-    bars: [PciBar; NUM_BAR_REGS],
+    bars: [PciBar; NUM_BAR_REGS as usize],
     // Contains the byte offset and size of the last capability.
     last_capability: Option<(u8, u8)>,
     msix_cap_reg_idx: Option<u16>,
@@ -252,7 +251,7 @@ impl PciConfiguration {
         PciConfiguration {
             registers,
             writable_bits,
-            bars: [PciBar::default(); NUM_BAR_REGS],
+            bars: [PciBar::default(); NUM_BAR_REGS as usize],
             last_capability: None,
             msix_cap_reg_idx: None,
             msix_config,
@@ -312,11 +311,11 @@ impl PciConfiguration {
     pub fn write_reg(&mut self, reg_idx: u16, value: u32) {
         let mut mask = self.writable_bits[reg_idx as usize];
 
-        if (BAR0_REG as usize..BAR0_REG as usize + NUM_BAR_REGS).contains(&(reg_idx as usize)) {
+        if (u16::from(BAR0_REG)..u16::from(BAR0_REG + NUM_BAR_REGS)).contains(&reg_idx) {
             // Handle very specific case where the BAR is being written with
             // all 1's to retrieve the BAR size during next BAR reading.
             if value == 0xffff_ffff {
-                mask &= self.bars[(reg_idx - BAR0_REG) as usize].size;
+                mask &= self.bars[(reg_idx - u16::from(BAR0_REG)) as usize].size;
             }
         } else if reg_idx == ROM_BAR_REG {
             // Handle very specific case where the BAR is being written with
@@ -386,7 +385,7 @@ impl PciConfiguration {
     /// Enforces a few constraints (i.e, region size must be power of two, register not already
     /// used).
     pub fn add_pci_bar(&mut self, bar_idx: u8, addr: u64, size: u64) {
-        let reg_idx = (BAR0_REG + u16::from(bar_idx)) as usize;
+        let reg_idx = (BAR0_REG + bar_idx) as usize;
 
         // These are a few constraints that are imposed due to the fact
         // that only VirtIO devices are actually allocating a BAR. Moreover, this is
@@ -434,9 +433,9 @@ impl PciConfiguration {
     ///
     /// This assumes that `bar_idx` is a valid BAR register.
     pub fn get_bar_addr(&self, bar_idx: u8) -> u64 {
-        assert!((bar_idx as usize) < NUM_BAR_REGS);
+        assert!(bar_idx < NUM_BAR_REGS);
 
-        let reg_idx = (BAR0_REG + u16::from(bar_idx)) as usize;
+        let reg_idx = (BAR0_REG + bar_idx) as usize;
 
         (u64::from(self.bars[bar_idx as usize].addr & self.writable_bits[reg_idx]))
             | (u64::from(self.bars[bar_idx as usize + 1].addr) << 32)
@@ -551,7 +550,7 @@ impl PciConfiguration {
         let value = LittleEndian::read_u32(data);
 
         let mask = self.writable_bits[reg_idx as usize];
-        if !(BAR0_REG as usize..BAR0_REG as usize + NUM_BAR_REGS).contains(&(reg_idx as usize)) {
+        if !(u16::from(BAR0_REG)..u16::from(BAR0_REG + NUM_BAR_REGS)).contains(&reg_idx) {
             return None;
         }
 
@@ -560,7 +559,7 @@ impl PciConfiguration {
             return None;
         }
 
-        let bar_idx = (reg_idx - BAR0_REG) as usize;
+        let bar_idx = (reg_idx - u16::from(BAR0_REG)) as usize;
 
         // Do not reprogram BARs we are not using
         if !self.bars[bar_idx].used {
@@ -920,9 +919,9 @@ mod tests {
         pci_config.add_pci_bar(0, 0x1_0000_0000, 0x1000);
 
         assert_eq!(pci_config.get_bar_addr(0), 0x1_0000_0000);
-        assert_eq!(pci_config.read_reg(BAR0_REG) & 0xffff_fff0, 0x0);
+        assert_eq!(pci_config.read_reg(u16::from(BAR0_REG)) & 0xffff_fff0, 0x0);
         assert!(pci_config.bars[0].used);
-        assert_eq!(pci_config.read_reg(BAR0_REG + 1), 1);
+        assert_eq!(pci_config.read_reg(u16::from(BAR0_REG) + 1), 1);
         assert!(pci_config.bars[0].used);
     }
 
@@ -979,37 +978,37 @@ mod tests {
         // Trying to reprogram with something less than 4 bytes (length of the address) should fail
         assert!(
             pci_config
-                .detect_bar_reprogramming(BAR0_REG, &[0x13])
+                .detect_bar_reprogramming(u16::from(BAR0_REG), &[0x13])
                 .is_none()
         );
         assert!(
             pci_config
-                .detect_bar_reprogramming(BAR0_REG, &[0x13, 0x12])
+                .detect_bar_reprogramming(u16::from(BAR0_REG), &[0x13, 0x12])
                 .is_none()
         );
         assert!(
             pci_config
-                .detect_bar_reprogramming(BAR0_REG, &[0x13, 0x12])
+                .detect_bar_reprogramming(u16::from(BAR0_REG), &[0x13, 0x12])
                 .is_none()
         );
         assert!(
             pci_config
-                .detect_bar_reprogramming(BAR0_REG, &[0x13, 0x12, 0x16])
+                .detect_bar_reprogramming(u16::from(BAR0_REG), &[0x13, 0x12, 0x16])
                 .is_none()
         );
 
         // Writing all 1s is a special case where we're actually asking for the size of the BAR
         assert!(
             pci_config
-                .detect_bar_reprogramming(BAR0_REG, &u32::to_le_bytes(0xffff_ffff))
+                .detect_bar_reprogramming(u16::from(BAR0_REG), &u32::to_le_bytes(0xffff_ffff))
                 .is_none()
         );
 
         // Trying to reprogram a BAR that hasn't be initialized does nothing
-        for reg_idx in BAR0_REG..BAR0_REG + NUM_BAR_REGS as u16 {
+        for reg_idx in BAR0_REG..BAR0_REG + NUM_BAR_REGS {
             assert!(
                 pci_config
-                    .detect_bar_reprogramming(reg_idx, &u32::to_le_bytes(0x1312_4243))
+                    .detect_bar_reprogramming(u16::from(reg_idx), &u32::to_le_bytes(0x1312_4243))
                     .is_none()
             );
         }
@@ -1020,43 +1019,43 @@ mod tests {
         // First we write the lower 32 bits and this shouldn't cause any reprogramming
         assert!(
             pci_config
-                .detect_bar_reprogramming(BAR0_REG, &u32::to_le_bytes(0x4200_0000))
+                .detect_bar_reprogramming(u16::from(BAR0_REG), &u32::to_le_bytes(0x4200_0000))
                 .is_none()
         );
-        pci_config.write_config_register(BAR0_REG, 0, &u32::to_le_bytes(0x4200_0000));
+        pci_config.write_config_register(u16::from(BAR0_REG), 0, &u32::to_le_bytes(0x4200_0000));
 
         // Writing the upper 32 bits should trigger the reprogramming
         assert_eq!(
-            pci_config.detect_bar_reprogramming(BAR0_REG + 1, &u32::to_le_bytes(0x84)),
+            pci_config.detect_bar_reprogramming(u16::from(BAR0_REG) + 1, &u32::to_le_bytes(0x84)),
             Some(BarReprogrammingParams {
                 old_base: 0x13_1200_0000,
                 new_base: 0x84_4200_0000,
                 len: 0x8000,
             })
         );
-        pci_config.write_config_register(BAR0_REG + 1, 0, &u32::to_le_bytes(0x84));
+        pci_config.write_config_register(u16::from(BAR0_REG) + 1, 0, &u32::to_le_bytes(0x84));
 
         // Trying to reprogram the upper bits directly (without first touching the lower bits)
         // should trigger a reprogramming
         assert_eq!(
-            pci_config.detect_bar_reprogramming(BAR0_REG + 1, &u32::to_le_bytes(0x1312)),
+            pci_config.detect_bar_reprogramming(u16::from(BAR0_REG) + 1, &u32::to_le_bytes(0x1312)),
             Some(BarReprogrammingParams {
                 old_base: 0x84_4200_0000,
                 new_base: 0x1312_4200_0000,
                 len: 0x8000,
             })
         );
-        pci_config.write_config_register(BAR0_REG + 1, 0, &u32::to_le_bytes(0x1312));
+        pci_config.write_config_register(u16::from(BAR0_REG) + 1, 0, &u32::to_le_bytes(0x1312));
 
         // Attempting to reprogram the BAR with the same address should not have any effect
         assert!(
             pci_config
-                .detect_bar_reprogramming(BAR0_REG, &u32::to_le_bytes(0x4200_0000))
+                .detect_bar_reprogramming(u16::from(BAR0_REG), &u32::to_le_bytes(0x4200_0000))
                 .is_none()
         );
         assert!(
             pci_config
-                .detect_bar_reprogramming(BAR0_REG + 1, &u32::to_le_bytes(0x1312))
+                .detect_bar_reprogramming(u16::from(BAR0_REG) + 1, &u32::to_le_bytes(0x1312))
                 .is_none()
         );
     }
@@ -1086,14 +1085,14 @@ mod tests {
     #[should_panic]
     fn test_bars_bad_bar_index() {
         let mut bars = Bars::default();
-        bars.set_bar_64(NUM_BAR_REGS as u8, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.set_bar_64(NUM_BAR_REGS, 0x1000, 0x1000, BarPrefetchable::No);
     }
 
     #[test]
     #[should_panic]
     fn test_bars_bad_64bit_bar_index() {
         let mut bars = Bars::default();
-        bars.set_bar_64(NUM_BAR_REGS as u8 - 1, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.set_bar_64(NUM_BAR_REGS - 1, 0x1000, 0x1000, BarPrefetchable::No);
     }
 
     #[test]

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
+use zerocopy::{FromBytes, IntoBytes};
 
 use super::BarReprogrammingParams;
 use super::msix::MsixConfig;
@@ -44,6 +45,126 @@ const CAPABILITY_LIST_HEAD_OFFSET: u8 = 0x34;
 const FIRST_CAPABILITY_OFFSET: u8 = 0x40;
 const CAPABILITY_MAX_OFFSET: u16 = 192;
 
+/// Type representing information about single BAR register
+///  31                                                 4  3    2  1  0
+/// +---------------------------------------------------+----+---+----+
+/// |                                                   |    |    |   |
+/// |          Base Address (28 bits)                   |Pref|Type| 0 |
+/// |                                                   |    |    |   |
+/// +---------------------------------------------------+----+---+----+
+///  \___________________________________________________/ \__/ \_/ \_/
+///               Base Address                            Pre- Type Memory
+///               (16-byte aligned minimum)               fetch     Space
+///                                                       able      Indicator
+///
+///   Bit  0   : Memory Space Indicator (hardwired to 0)
+///   Bits 2:1 : Type  - 00 = 32-bit address space
+///                      10 = 64-bit address space
+///                      (01, 11 = reserved)
+///   Bit  3   : Prefetchable - 0 = non-prefetchable
+///                             1 = prefetchable
+///   Bits 31:4: Base Address (read/write, writable bits depend on size)
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+pub struct Bar {
+    /// Encoded address value of the register (lower bits might carry information)
+    pub encoded_addr: u32,
+    /// Encoded size value of the register (according to PCI rules of size encoding).
+    pub encoded_size: u32,
+    /// Indicator if the register was prepared to be read as the `size` instead of `addr`
+    pub about_to_be_read: bool,
+}
+
+/// Specifies if the BAR is prefetchable
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum BarPrefetchable {
+    /// No
+    No = 0,
+    /// Yes
+    Yes = 1,
+}
+
+/// Type to handle basic interactions with BARs region
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+pub struct Bars {
+    /// BARs
+    pub bars: [Bar; NUM_BAR_REGS],
+}
+impl Bars {
+    /// Set 2 consecutive BAR slots as a single 64bit bar
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn set_bar_64(&mut self, bar_idx: u8, addr: u64, size: u64, prefetchable: BarPrefetchable) {
+        assert_ne!(size, 0);
+        assert!(size.is_power_of_two());
+        assert!(addr & 0b1111 == 0);
+        addr.checked_add(size - 1).unwrap();
+        assert!(usize::from(bar_idx) < NUM_BAR_REGS - 1);
+
+        // Unused BARs will have address and size of 0
+        assert_eq!(self.bars[bar_idx as usize].encoded_addr, 0);
+        assert_eq!(self.bars[bar_idx as usize].encoded_size, 0);
+        assert_eq!(self.bars[bar_idx as usize + 1].encoded_addr, 0);
+        assert_eq!(self.bars[bar_idx as usize + 1].encoded_size, 0);
+
+        let (size_hi, size_lo) = encode_64_bits_bar_size(size);
+        let addr_lo = (addr & 0xfffffff0) as u32;
+        let addr_hi = (addr >> 32) as u32;
+        let prefetchable = (prefetchable as u32) << 3;
+        let is_64_bit = 0b100;
+
+        self.bars[bar_idx as usize].encoded_addr = addr_lo | prefetchable | is_64_bit;
+        self.bars[bar_idx as usize].encoded_size = size_lo;
+        self.bars[(bar_idx + 1) as usize].encoded_addr = addr_hi;
+        self.bars[(bar_idx + 1) as usize].encoded_size = size_hi;
+    }
+    /// Get the address of the 64bit bar
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn get_bar_addr_64(&self, bar_idx: u8) -> u64 {
+        assert!((bar_idx as usize) < NUM_BAR_REGS - 1);
+        let addr_hi = self.bars[(bar_idx + 1) as usize].encoded_addr;
+        let addr_lo = self.bars[bar_idx as usize].encoded_addr & !0b1111;
+        (addr_hi as u64) << 32 | (addr_lo as u64)
+    }
+    /// Writes into a given BAR register at the given offset
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn write(&mut self, bar_idx: u8, offset: u8, data: &[u8]) {
+        // There are only 6 registers each 4 bytes long
+        assert!((bar_idx as usize) < NUM_BAR_REGS);
+        assert!(offset as usize + data.len() <= 4);
+        if let Ok(value) = u32::read_from_bytes(data)
+            && value == 0xffff_ffff
+        {
+            self.bars[bar_idx as usize].about_to_be_read = true;
+        } else {
+            self.bars[bar_idx as usize].about_to_be_read = false;
+            // There is no BAR relocation support as of right now.
+            // PCI specification does not provide a way for a device to
+            // tell the driver that it does not support BAR relocation, but
+            // linux kernel does check this at:
+            // https://elixir.bootlin.com/linux/v6.19.8/source/drivers/pci/setup-res.c#L107
+        }
+    }
+    /// Reads from a given BAR register at the given offset
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn read(&mut self, bar_idx: u8, offset: u8, data: &mut [u8]) {
+        // There are only 6 registers each 4 bytes long
+        assert!((bar_idx as usize) < NUM_BAR_REGS);
+        assert!(offset as usize + data.len() <= 4);
+        let bar = &mut self.bars[bar_idx as usize];
+        let bytes = if bar.about_to_be_read {
+            // This technically allows for an inconsistent behaviour where the guest would read
+            // only a part of the `size` of the BAR on the first read, but will get `addr` bytes
+            // on following reads. Any sane driver will read the whole register, so this should
+            // not be an issue. This will be fixed once we support BAR relocation/resizing.
+            bar.about_to_be_read = false;
+            bar.encoded_size.as_bytes()
+        } else {
+            bar.encoded_addr.as_bytes()
+        };
+        data.copy_from_slice(&bytes[offset as usize..][..data.len()]);
+    }
+}
+
 /// A PCI capability list. Devices can optionally specify capabilities in their configuration space.
 pub trait PciCapability {
     /// Bytes of the PCI capability
@@ -62,7 +183,7 @@ fn encode_64_bits_bar_size(bar_size: u64) -> (u32, u32) {
     (result_hi, result_lo)
 }
 
-// This decoes the BAR size from the value stored in the BAR registers.
+// Decode the BAR size from the value stored in the BAR registers.
 fn decode_64_bits_bar_size(bar_size_hi: u32, bar_size_lo: u32) -> u64 {
     let bar_size: u64 = ((bar_size_hi as u64) << 32) | (bar_size_lo as u64);
     let size = !bar_size + 1;
@@ -952,5 +1073,69 @@ mod tests {
         // Reading the size of the BAR should always return 0 as well
         pci_config.write_reg(ROM_BAR_REG, 0xffff_ffff);
         assert_eq!(pci_config.read_reg(ROM_BAR_REG), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_size_no_power_of_two() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1001, BarPrefetchable::No);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_bad_bar_index() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(NUM_BAR_REGS as u8, 0x1000, 0x1000, BarPrefetchable::No);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_bad_64bit_bar_index() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(NUM_BAR_REGS as u8 - 1, 0x1000, 0x1000, BarPrefetchable::No);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_bar_size_overflows() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, u64::MAX, 0x2, BarPrefetchable::No);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_lower_bar_free_upper_used() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(1, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_lower_bar_used() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_upper_bar_used() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.set_bar_64(1, 0x1000, 0x1000, BarPrefetchable::No);
+    }
+
+    #[test]
+    fn test_bars_add_pci_bar() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1_0000_0000, 0x1000, BarPrefetchable::No);
+        assert_eq!(bars.get_bar_addr_64(0), 0x1_0000_0000);
+        let mut v: u32 = 0;
+        bars.read(0, 0, v.as_mut_bytes());
+        assert_eq!(v & 0xffff_fff0, 0x0);
+        bars.read(1, 0, v.as_mut_bytes());
+        assert_eq!(v, 1);
     }
 }

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -39,7 +39,7 @@ const FIRST_CAPABILITY_OFFSET: u8 = 0x40;
 const CAPABILITY_MAX_OFFSET: u16 = 192;
 
 /// First register in the BARs region
-pub const BAR0_REG: u8 = 4;
+pub const BAR0_REG_IDX: u16 = 4;
 /// Number of BAR registers
 pub const NUM_BAR_REGS: u8 = 6;
 

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -11,9 +11,8 @@ use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
 use zerocopy::{FromBytes, IntoBytes};
 
-use super::BarReprogrammingParams;
 use super::msix::MsixConfig;
-use crate::logger::{info, warn};
+use crate::logger::warn;
 use crate::pci::{PciCapabilityId, PciClassCode};
 
 /// Errors from restoring PCI configuration state.
@@ -35,7 +34,6 @@ const NUM_CONFIGURATION_REGISTERS: usize = 1024;
 const STATUS_REG: usize = 1;
 const STATUS_REG_CAPABILITIES_USED_MASK: u32 = 0x0010_0000;
 const ROM_BAR_REG: u16 = 12;
-const BAR_MEM_ADDR_MASK: u32 = 0xffff_fff0;
 const ROM_BAR_ADDR_MASK: u32 = 0xffff_f800;
 const MSI_CAPABILITY_REGISTER_MASK: u32 = 0x0071_0000;
 const MSIX_CAPABILITY_REGISTER_MASK: u32 = 0xc000_0000;
@@ -182,27 +180,11 @@ fn encode_64_bits_bar_size(bar_size: u64) -> (u32, u32) {
     (result_hi, result_lo)
 }
 
-// Decode the BAR size from the value stored in the BAR registers.
-fn decode_64_bits_bar_size(bar_size_hi: u32, bar_size_lo: u32) -> u64 {
-    let bar_size: u64 = ((bar_size_hi as u64) << 32) | (bar_size_lo as u64);
-    let size = !bar_size + 1;
-    assert_ne!(size, 0);
-    size
-}
-
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
-struct PciBar {
-    addr: u32,
-    size: u32,
-    used: bool,
-}
-
 /// PCI configuration space state for (de)serialization
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PciConfigurationState {
     registers: Vec<u32>,
     writable_bits: Vec<u32>,
-    bars: Vec<PciBar>,
     last_capability: Option<(u8, u8)>,
     msix_cap_reg_idx: Option<u16>,
 }
@@ -215,7 +197,6 @@ pub struct PciConfigurationState {
 pub struct PciConfiguration {
     registers: [u32; NUM_CONFIGURATION_REGISTERS],
     writable_bits: [u32; NUM_CONFIGURATION_REGISTERS], // writable bits for each register.
-    bars: [PciBar; NUM_BAR_REGS as usize],
     // Contains the byte offset and size of the last capability.
     last_capability: Option<(u8, u8)>,
     msix_cap_reg_idx: Option<u16>,
@@ -251,7 +232,6 @@ impl PciConfiguration {
         PciConfiguration {
             registers,
             writable_bits,
-            bars: [PciBar::default(); NUM_BAR_REGS as usize],
             last_capability: None,
             msix_cap_reg_idx: None,
             msix_config,
@@ -275,16 +255,9 @@ impl PciConfiguration {
             .try_into()
             .map_err(|_| PciConfigurationError::InvalidWritableBitsLength(wb_len))?;
 
-        let bar_len = state.bars.len();
-        let bars = state
-            .bars
-            .try_into()
-            .map_err(|_| PciConfigurationError::InvalidBarsLength(bar_len))?;
-
         Ok(PciConfiguration {
             registers,
             writable_bits,
-            bars,
             last_capability: state.last_capability,
             msix_cap_reg_idx: state.msix_cap_reg_idx,
             msix_config,
@@ -296,7 +269,6 @@ impl PciConfiguration {
         PciConfigurationState {
             registers: self.registers.to_vec(),
             writable_bits: self.writable_bits.to_vec(),
-            bars: self.bars.to_vec(),
             last_capability: self.last_capability,
             msix_cap_reg_idx: self.msix_cap_reg_idx,
         }
@@ -311,13 +283,7 @@ impl PciConfiguration {
     pub fn write_reg(&mut self, reg_idx: u16, value: u32) {
         let mut mask = self.writable_bits[reg_idx as usize];
 
-        if (u16::from(BAR0_REG)..u16::from(BAR0_REG + NUM_BAR_REGS)).contains(&reg_idx) {
-            // Handle very specific case where the BAR is being written with
-            // all 1's to retrieve the BAR size during next BAR reading.
-            if value == 0xffff_ffff {
-                mask &= self.bars[(reg_idx - u16::from(BAR0_REG)) as usize].size;
-            }
-        } else if reg_idx == ROM_BAR_REG {
+        if reg_idx == ROM_BAR_REG {
             // Handle very specific case where the BAR is being written with
             // all 1's on bits 31-11 to retrieve the BAR size during next BAR
             // reading.
@@ -377,68 +343,6 @@ impl PciConfiguration {
         } else {
             warn!("bad PCI config write offset {}", offset);
         }
-    }
-
-    /// Add the [addr, addr + size) BAR region.
-    ///
-    /// Configures the specified BAR to report this region and size to the guest kernel.
-    /// Enforces a few constraints (i.e, region size must be power of two, register not already
-    /// used).
-    pub fn add_pci_bar(&mut self, bar_idx: u8, addr: u64, size: u64) {
-        let reg_idx = (BAR0_REG + bar_idx) as usize;
-
-        // These are a few constraints that are imposed due to the fact
-        // that only VirtIO devices are actually allocating a BAR. Moreover, this is
-        // a single 64-bit BAR. Not conforming to these requirements is an internal
-        // Firecracker bug.
-
-        // We are only using BAR 0
-        assert_eq!(bar_idx, 0);
-        // We shouldn't be trying to use the same BAR twice
-        assert!(!self.bars[0].used);
-        assert!(!self.bars[1].used);
-        // We can't have a size of 0
-        assert_ne!(size, 0);
-        // BAR size needs to be a power of two
-        assert!(size.is_power_of_two());
-        // We should not be overflowing the address space
-        addr.checked_add(size - 1).unwrap();
-
-        // Encode the BAR size as expected by the software running in
-        // the guest.
-        let (bar_size_hi, bar_size_lo) = encode_64_bits_bar_size(size);
-
-        self.registers[reg_idx + 1] = (addr >> 32) as u32;
-        self.writable_bits[reg_idx + 1] = 0xffff_ffff;
-        self.bars[bar_idx as usize + 1].addr = self.registers[reg_idx + 1];
-        self.bars[bar_idx as usize].size = bar_size_lo;
-        self.bars[bar_idx as usize + 1].size = bar_size_hi;
-        self.bars[bar_idx as usize + 1].used = true;
-
-        // Addresses of memory BARs are 16-byte aligned so the lower 4 bits are always 0. Within
-        // the register we use this 4 bits to encode extra information about the BAR. The meaning
-        // of these bits is:
-        //
-        // |    Bit 3     | Bits 2-1 |  Bit 0   |
-        // | Prefetchable |   type   | Always 0 |
-        //
-        // Non-prefetchable, 64 bits BAR region
-        self.registers[reg_idx] = (((addr & 0xffff_ffff) as u32) & BAR_MEM_ADDR_MASK) | 4u32;
-        self.writable_bits[reg_idx] = BAR_MEM_ADDR_MASK;
-        self.bars[bar_idx as usize].addr = self.registers[reg_idx];
-        self.bars[bar_idx as usize].used = true;
-    }
-
-    /// Returns the address of the given BAR region.
-    ///
-    /// This assumes that `bar_idx` is a valid BAR register.
-    pub fn get_bar_addr(&self, bar_idx: u8) -> u64 {
-        assert!(bar_idx < NUM_BAR_REGS);
-
-        let reg_idx = (BAR0_REG + bar_idx) as usize;
-
-        (u64::from(self.bars[bar_idx as usize].addr & self.writable_bits[reg_idx]))
-            | (u64::from(self.bars[bar_idx as usize + 1].addr) << 32)
     }
 
     /// Adds the capability `cap_data` to the list of capabilities.
@@ -535,74 +439,6 @@ impl PciConfiguration {
             4 => self.write_reg(reg_idx, LittleEndian::read_u32(data)),
             _ => (),
         }
-    }
-
-    /// Detect whether the guest wants to reprogram the address of a BAR
-    pub fn detect_bar_reprogramming(
-        &mut self,
-        reg_idx: u16,
-        data: &[u8],
-    ) -> Option<BarReprogrammingParams> {
-        if data.len() != 4 {
-            return None;
-        }
-
-        let value = LittleEndian::read_u32(data);
-
-        let mask = self.writable_bits[reg_idx as usize];
-        if !(u16::from(BAR0_REG)..u16::from(BAR0_REG + NUM_BAR_REGS)).contains(&reg_idx) {
-            return None;
-        }
-
-        // Ignore the case where the BAR size is being asked for.
-        if value == 0xffff_ffff {
-            return None;
-        }
-
-        let bar_idx = (reg_idx - u16::from(BAR0_REG)) as usize;
-
-        // Do not reprogram BARs we are not using
-        if !self.bars[bar_idx].used {
-            return None;
-        }
-
-        // We are always using 64bit BARs, so two BAR registers. We don't do anything until
-        // the upper BAR is modified, otherwise we would be moving the BAR to a wrong
-        // location in memory.
-        if bar_idx == 0 {
-            return None;
-        }
-
-        // The lower BAR (of this 64bit BAR) has been reprogrammed to a different value
-        // than it used to be
-        let reg_idx = reg_idx as usize;
-        if (self.registers[reg_idx - 1] & self.writable_bits[reg_idx - 1])
-                    != (self.bars[bar_idx - 1].addr & self.writable_bits[reg_idx - 1]) ||
-                    // Or the lower BAR hasn't been changed but the upper one is being reprogrammed
-                    // now to a different value
-                    (value & mask) != (self.bars[bar_idx].addr & mask)
-        {
-            info!(
-                "Detected BAR reprogramming: (BAR {}) 0x{:x}->0x{:x}",
-                reg_idx, self.registers[reg_idx], value
-            );
-            let old_base = (u64::from(self.bars[bar_idx].addr & mask) << 32)
-                | u64::from(self.bars[bar_idx - 1].addr & self.writable_bits[reg_idx - 1]);
-            let new_base = (u64::from(value & mask) << 32)
-                | u64::from(self.registers[reg_idx - 1] & self.writable_bits[reg_idx - 1]);
-            let len = decode_64_bits_bar_size(self.bars[bar_idx].size, self.bars[bar_idx - 1].size);
-
-            self.bars[bar_idx].addr = value;
-            self.bars[bar_idx - 1].addr = self.registers[reg_idx - 1];
-
-            return Some(BarReprogrammingParams {
-                old_base,
-                new_base,
-                len,
-            });
-        }
-
-        None
     }
 }
 
@@ -828,104 +664,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_encode_zero_sized_bar() {
-        encode_64_bits_bar_size(0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_decode_zero_sized_bar() {
-        decode_64_bits_bar_size(0, 0);
-    }
-
-    #[test]
-    fn test_bar_size_encoding() {
-        // According to OSDev wiki (https://wiki.osdev.org/PCI#Address_and_size_of_the_BAR):
-        //
-        // > To determine the amount of address space needed by a PCI device, you must save the
-        // > original value of the BAR, write a value of all 1's to the register, then read it back.
-        // > The amount of memory can then be determined by masking the information bits, performing
-        // > a bitwise NOT ('~' in C), and incrementing the value by 1. The original value of the
-        // BAR > should then be restored. The BAR register is naturally aligned and as such you can
-        // only > modify the bits that are set. For example, if a device utilizes 16 MB it will
-        // have BAR0 > filled with 0xFF000000 (0x1000000 after decoding) and you can only modify
-        // the upper > 8-bits.
-        //
-        // So, we encode a 64 bits size and then store it as a 2 32bit addresses (we use
-        // two BARs).
-        let (hi, lo) = encode_64_bits_bar_size(0xffff_ffff_ffff_fff0);
-        assert_eq!(hi, 0);
-        assert_eq!(lo, 0x0000_0010);
-        assert_eq!(decode_64_bits_bar_size(hi, lo), 0xffff_ffff_ffff_fff0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_bar_size_no_power_of_two() {
-        let mut pci_config = default_pci_config();
-        pci_config.add_pci_bar(0, 0x1000, 0x1001);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_bad_bar_index() {
-        let mut pci_config = default_pci_config();
-        pci_config.add_pci_bar(NUM_BAR_REGS as u8, 0x1000, 0x1000);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_bad_64bit_bar_index() {
-        let mut pci_config = default_pci_config();
-        pci_config.add_pci_bar((NUM_BAR_REGS - 1) as u8, 0x1000, 0x1000);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_bar_size_overflows() {
-        let mut pci_config = default_pci_config();
-        pci_config.add_pci_bar(0, u64::MAX, 0x2);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_lower_bar_free_upper_used() {
-        let mut pci_config = default_pci_config();
-        pci_config.add_pci_bar(1, 0x1000, 0x1000);
-        pci_config.add_pci_bar(0, 0x1000, 0x1000);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_lower_bar_used() {
-        let mut pci_config = default_pci_config();
-        pci_config.add_pci_bar(0, 0x1000, 0x1000);
-        pci_config.add_pci_bar(0, 0x1000, 0x1000);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_upper_bar_used() {
-        let mut pci_config = default_pci_config();
-        pci_config.add_pci_bar(0, 0x1000, 0x1000);
-        pci_config.add_pci_bar(1, 0x1000, 0x1000);
-    }
-
-    #[test]
-    fn test_add_pci_bar() {
-        let mut pci_config = default_pci_config();
-
-        pci_config.add_pci_bar(0, 0x1_0000_0000, 0x1000);
-
-        assert_eq!(pci_config.get_bar_addr(0), 0x1_0000_0000);
-        assert_eq!(pci_config.read_reg(u16::from(BAR0_REG)) & 0xffff_fff0, 0x0);
-        assert!(pci_config.bars[0].used);
-        assert_eq!(pci_config.read_reg(u16::from(BAR0_REG) + 1), 1);
-        assert!(pci_config.bars[0].used);
-    }
-
-    #[test]
     fn test_access_invalid_reg() {
         let mut pci_config = default_pci_config();
 
@@ -972,95 +710,6 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_bar_reprogramming() {
-        let mut pci_config = default_pci_config();
-
-        // Trying to reprogram with something less than 4 bytes (length of the address) should fail
-        assert!(
-            pci_config
-                .detect_bar_reprogramming(u16::from(BAR0_REG), &[0x13])
-                .is_none()
-        );
-        assert!(
-            pci_config
-                .detect_bar_reprogramming(u16::from(BAR0_REG), &[0x13, 0x12])
-                .is_none()
-        );
-        assert!(
-            pci_config
-                .detect_bar_reprogramming(u16::from(BAR0_REG), &[0x13, 0x12])
-                .is_none()
-        );
-        assert!(
-            pci_config
-                .detect_bar_reprogramming(u16::from(BAR0_REG), &[0x13, 0x12, 0x16])
-                .is_none()
-        );
-
-        // Writing all 1s is a special case where we're actually asking for the size of the BAR
-        assert!(
-            pci_config
-                .detect_bar_reprogramming(u16::from(BAR0_REG), &u32::to_le_bytes(0xffff_ffff))
-                .is_none()
-        );
-
-        // Trying to reprogram a BAR that hasn't be initialized does nothing
-        for reg_idx in BAR0_REG..BAR0_REG + NUM_BAR_REGS {
-            assert!(
-                pci_config
-                    .detect_bar_reprogramming(u16::from(reg_idx), &u32::to_le_bytes(0x1312_4243))
-                    .is_none()
-            );
-        }
-
-        // Reprogramming of a 64bit BAR
-        pci_config.add_pci_bar(0, 0x13_1200_0000, 0x8000);
-
-        // First we write the lower 32 bits and this shouldn't cause any reprogramming
-        assert!(
-            pci_config
-                .detect_bar_reprogramming(u16::from(BAR0_REG), &u32::to_le_bytes(0x4200_0000))
-                .is_none()
-        );
-        pci_config.write_config_register(u16::from(BAR0_REG), 0, &u32::to_le_bytes(0x4200_0000));
-
-        // Writing the upper 32 bits should trigger the reprogramming
-        assert_eq!(
-            pci_config.detect_bar_reprogramming(u16::from(BAR0_REG) + 1, &u32::to_le_bytes(0x84)),
-            Some(BarReprogrammingParams {
-                old_base: 0x13_1200_0000,
-                new_base: 0x84_4200_0000,
-                len: 0x8000,
-            })
-        );
-        pci_config.write_config_register(u16::from(BAR0_REG) + 1, 0, &u32::to_le_bytes(0x84));
-
-        // Trying to reprogram the upper bits directly (without first touching the lower bits)
-        // should trigger a reprogramming
-        assert_eq!(
-            pci_config.detect_bar_reprogramming(u16::from(BAR0_REG) + 1, &u32::to_le_bytes(0x1312)),
-            Some(BarReprogrammingParams {
-                old_base: 0x84_4200_0000,
-                new_base: 0x1312_4200_0000,
-                len: 0x8000,
-            })
-        );
-        pci_config.write_config_register(u16::from(BAR0_REG) + 1, 0, &u32::to_le_bytes(0x1312));
-
-        // Attempting to reprogram the BAR with the same address should not have any effect
-        assert!(
-            pci_config
-                .detect_bar_reprogramming(u16::from(BAR0_REG), &u32::to_le_bytes(0x4200_0000))
-                .is_none()
-        );
-        assert!(
-            pci_config
-                .detect_bar_reprogramming(u16::from(BAR0_REG) + 1, &u32::to_le_bytes(0x1312))
-                .is_none()
-        );
-    }
-
-    #[test]
     fn test_rom_bar() {
         let mut pci_config = default_pci_config();
 
@@ -1072,6 +721,12 @@ mod tests {
         // Reading the size of the BAR should always return 0 as well
         pci_config.write_reg(ROM_BAR_REG, 0xffff_ffff);
         assert_eq!(pci_config.read_reg(ROM_BAR_REG), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_encode_zero_sized_bar() {
+        encode_64_bits_bar_size(0);
     }
 
     #[test]

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -5,13 +5,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::sync::{Arc, Mutex};
-
 use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
 use zerocopy::{FromBytes, IntoBytes};
 
-use super::msix::MsixConfig;
 use crate::logger::warn;
 use crate::pci::{PciCapabilityId, PciClassCode};
 
@@ -186,7 +183,6 @@ pub struct PciConfigurationState {
     registers: Vec<u32>,
     writable_bits: Vec<u32>,
     last_capability: Option<(u8, u8)>,
-    msix_cap_reg_idx: Option<u16>,
 }
 
 #[derive(Debug)]
@@ -199,8 +195,6 @@ pub struct PciConfiguration {
     writable_bits: [u32; NUM_CONFIGURATION_REGISTERS], // writable bits for each register.
     // Contains the byte offset and size of the last capability.
     last_capability: Option<(u8, u8)>,
-    msix_cap_reg_idx: Option<u16>,
-    msix_config: Option<Arc<Mutex<MsixConfig>>>,
 }
 
 impl PciConfiguration {
@@ -214,7 +208,6 @@ impl PciConfiguration {
         subclass: u8,
         subsystem_vendor_id: u16,
         subsystem_id: u16,
-        msix_config: Option<Arc<Mutex<MsixConfig>>>,
     ) -> Self {
         let mut registers = [0u32; NUM_CONFIGURATION_REGISTERS];
         let mut writable_bits = [0u32; NUM_CONFIGURATION_REGISTERS];
@@ -233,16 +226,11 @@ impl PciConfiguration {
             registers,
             writable_bits,
             last_capability: None,
-            msix_cap_reg_idx: None,
-            msix_config,
         }
     }
 
     /// Create a type 0 PCI configuration from snapshot state
-    pub fn type0_from_state(
-        state: PciConfigurationState,
-        msix_config: Option<Arc<Mutex<MsixConfig>>>,
-    ) -> Result<Self, PciConfigurationError> {
+    pub fn type0_from_state(state: PciConfigurationState) -> Result<Self, PciConfigurationError> {
         let reg_len = state.registers.len();
         let registers = state
             .registers
@@ -259,8 +247,6 @@ impl PciConfiguration {
             registers,
             writable_bits,
             last_capability: state.last_capability,
-            msix_cap_reg_idx: state.msix_cap_reg_idx,
-            msix_config,
         })
     }
 
@@ -270,7 +256,6 @@ impl PciConfiguration {
             registers: self.registers.to_vec(),
             writable_bits: self.writable_bits.to_vec(),
             last_capability: self.last_capability,
-            msix_cap_reg_idx: self.msix_cap_reg_idx,
         }
     }
 
@@ -384,9 +369,7 @@ impl PciConfiguration {
                 self.writable_bits[(cap_offset / 4) as usize] = MSI_CAPABILITY_REGISTER_MASK;
             }
             PciCapabilityId::MsiX => {
-                self.msix_cap_reg_idx = Some(u16::from(cap_offset) / 4);
-                self.writable_bits[self.msix_cap_reg_idx.unwrap() as usize] =
-                    MSIX_CAPABILITY_REGISTER_MASK;
+                self.writable_bits[(cap_offset / 4) as usize] = MSIX_CAPABILITY_REGISTER_MASK;
             }
             _ => {}
         }
@@ -408,26 +391,6 @@ impl PciConfiguration {
 
         if offset as usize + data.len() > 4 {
             return;
-        }
-
-        // Handle potential write to MSI-X message control register
-        if let Some(msix_cap_reg_idx) = self.msix_cap_reg_idx
-            && let Some(msix_config) = &self.msix_config
-        {
-            if msix_cap_reg_idx == reg_idx && offset == 2 && data.len() == 2 {
-                // 2-bytes write in the Message Control field
-                msix_config
-                    .lock()
-                    .unwrap()
-                    .set_msg_ctl(LittleEndian::read_u16(data));
-            } else if msix_cap_reg_idx == reg_idx && offset == 0 && data.len() == 4 {
-                // 4 bytes write at the beginning. Ignore the first 2 bytes which are the
-                // capability id and next capability pointer
-                msix_config
-                    .lock()
-                    .unwrap()
-                    .set_msg_ctl((LittleEndian::read_u32(data) >> 16) as u16);
-            }
         }
 
         match data.len() {
@@ -647,7 +610,6 @@ mod tests {
             PciMultimediaSubclass::AudioController as u8,
             0xABCD,
             0x2468,
-            None,
         )
     }
 

--- a/src/vmm/src/pci/mod.rs
+++ b/src/vmm/src/pci/mod.rs
@@ -42,14 +42,6 @@ pub trait PciDevice: Send {
     /// Gets a register from the configuration space.
     /// * `reg_idx` - The index of the config register to read.
     fn read_config_register(&mut self, reg_idx: u16) -> u32;
-    /// Detects if a BAR is being reprogrammed.
-    fn detect_bar_reprogramming(
-        &mut self,
-        _reg_idx: u16,
-        _data: &[u8],
-    ) -> Option<BarReprogrammingParams> {
-        None
-    }
     /// Reads from a BAR region mapped into the device.
     /// * `addr` - The guest address inside the BAR.
     /// * `data` - Filled with the data from `addr`.
@@ -60,31 +52,6 @@ pub trait PciDevice: Send {
     fn write_bar(&mut self, _base: u64, _offset: u64, _data: &[u8]) -> Option<Arc<Barrier>> {
         None
     }
-    /// Relocates the BAR to a different address in guest address space.
-    fn move_bar(&mut self, _old_base: u64, _new_base: u64) -> Result<(), DeviceRelocationError> {
-        Ok(())
-    }
-}
-
-/// Errors for device manager.
-#[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub enum DeviceRelocationError {
-    /// Device relocation not supported.
-    NotSupported,
-}
-
-/// This trait defines a set of functions which can be triggered whenever a
-/// PCI device is modified in any way.
-pub trait DeviceRelocation: Send + Sync {
-    /// The BAR needs to be moved to a different location in the guest address
-    /// space. This follows a decision from the software running in the guest.
-    fn move_bar(
-        &self,
-        old_base: u64,
-        new_base: u64,
-        len: u64,
-        pci_dev: &mut dyn PciDevice,
-    ) -> Result<(), DeviceRelocationError>;
 }
 
 /// Segment with associated Device BDF

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
 use vm_memory::ByteValued;
+use zerocopy::FromBytes;
 
 use crate::Vm;
 use crate::logger::{debug, error, warn};
@@ -206,6 +207,18 @@ impl MsixConfig {
                     self.inject_msix_and_clear_pba(index);
                 }
             }
+        }
+    }
+
+    /// Write to the Message Control register
+    pub fn write_msg_ctl_register(&mut self, offset: u8, data: &[u8]) {
+        if offset == 2 && data.len() == 2 {
+            // 2-bytes write in the Message Control field
+            self.set_msg_ctl(u16::read_from_bytes(data).unwrap());
+        } else if offset == 0 && data.len() == 4 {
+            // 4 bytes write at the beginning. Ignore the first 2 bytes which are the
+            // capability id and next capability pointer
+            self.set_msg_ctl((u32::read_from_bytes(data).unwrap() >> 16) as u16);
         }
     }
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -26,7 +26,6 @@ use vmm_sys_util::eventfd::EventFd;
 pub use crate::arch::{ArchVm as Vm, ArchVmError, VmState};
 use crate::arch::{GSI_MSI_END, host_page_size};
 use crate::logger::{debug, info};
-use crate::pci::{DeviceRelocation, DeviceRelocationError, PciDevice};
 use crate::persist::CreateSnapshotError;
 use crate::vmm_config::snapshot::SnapshotType;
 use crate::vstate::bus::Bus;
@@ -520,18 +519,6 @@ fn mincore_bitmap(addr: *mut u8, len: usize) -> Result<Vec<u64>, VmError> {
     }
 
     Ok(bitmap)
-}
-
-impl DeviceRelocation for Vm {
-    fn move_bar(
-        &self,
-        _old_base: u64,
-        _new_base: u64,
-        _len: u64,
-        _pci_dev: &mut dyn PciDevice,
-    ) -> Result<(), DeviceRelocationError> {
-        Err(DeviceRelocationError::NotSupported)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Changes
Main change here is the detachment of BAR and MsixConfig handling from the `PciConfiguration` type. `BAR`s and `MsixConfig` will be used as separate components by the `VFIO`, so to prevent duplication, move them away from `PciConfiguration`.

## Reason
Preparation for VFIO

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
