### PR TITLE
feat(snapshot): allow block device path override on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- [#5774](https://github.com/firecracker-microvm/firecracker/pull/5774): Add
+  support for block device path overriding on snapshot restore.
 - [#5323](https://github.com/firecracker-microvm/firecracker/pull/5323): Add
   support for Vsock Unix domain socket path overriding on snapshot restore. More
   information can be found in the

--- a/docs/snapshotting/network-for-clones.md
+++ b/docs/snapshotting/network-for-clones.md
@@ -200,6 +200,65 @@ ip addr add 172.16.3.2/30 dev eth0
 ip route add default via 172.16.3.1/30 dev eth0
 ```
 
+### Overriding block device paths
+
+When restoring a VM from a snapshot on a different host or in an environment
+where disk paths are non-deterministic (e.g. container runtimes using
+devmapper), the block device paths baked into the snapshot state may no longer
+be valid. In this case you can use the `drive_overrides` parameter of the
+snapshot restore API to specify a new backing path for each block device.
+
+Each entry mirrors the conventions of the `PUT /drives` API: use `path_on_host`
+for virtio-block devices and `socket` for vhost-user-block devices. Exactly one
+of the two must be set per entry, and it must match the type of the device
+identified by `drive_id`.
+
+For a virtio-block device with drive ID `rootfs`, override its host path during
+snapshot resume:
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i \
+    -X PUT 'http://localhost/snapshot/load' \
+    -H  'Accept: application/json' \
+    -H  'Content-Type: application/json' \
+    -d '{
+            "snapshot_path": "./snapshot_file",
+            "mem_backend": {
+                "backend_path": "./mem_file",
+                "backend_type": "File"
+            },
+            "drive_overrides": [
+                 {
+                     "drive_id": "rootfs",
+                     "path_on_host": "/new/path/to/rootfs.ext4"
+                 }
+            ]
+    }'
+```
+
+For a vhost-user-block device with drive ID `scratch`, override its backend
+socket path:
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i \
+    -X PUT 'http://localhost/snapshot/load' \
+    -H  'Accept: application/json' \
+    -H  'Content-Type: application/json' \
+    -d '{
+            "snapshot_path": "./snapshot_file",
+            "mem_backend": {
+                "backend_path": "./mem_file",
+                "backend_type": "File"
+            },
+            "drive_overrides": [
+                 {
+                     "drive_id": "scratch",
+                     "socket": "/new/path/to/vhost-user.sock"
+                 }
+            ]
+    }'
+```
+
 # Ingress connectivity
 
 The above setup only provides egress connectivity. If in addition we also want

--- a/src/firecracker/src/api_server/request/snapshot.rs
+++ b/src/firecracker/src/api_server/request/snapshot.rs
@@ -5,8 +5,8 @@ use serde::de::Error as DeserializeError;
 use vmm::logger::{IncMetric, METRICS};
 use vmm::rpc_interface::VmmAction;
 use vmm::vmm_config::snapshot::{
-    CreateSnapshotParams, LoadSnapshotConfig, LoadSnapshotParams, MemBackendConfig, MemBackendType,
-    Vm, VmState,
+    CreateSnapshotParams, DriveOverride, DriveOverrideBacking, DriveOverrideConfig,
+    LoadSnapshotConfig, LoadSnapshotParams, MemBackendConfig, MemBackendType, Vm, VmState,
 };
 
 use super::super::parsed_request::{ParsedRequest, RequestError};
@@ -22,6 +22,12 @@ pub const MISSING_FIELD: &str =
 /// Only specifying one of them is allowed.
 pub const TOO_MANY_FIELDS: &str =
     "too many fields: either `mem_backend` or `mem_file_path` exclusively is required";
+/// None of the `path_on_host` or `socket` fields has been specified for a drive override.
+pub const DRIVE_OVERRIDE_MISSING_FIELD: &str =
+    "missing field: either `path_on_host` or `socket` is required for each drive override";
+/// Both the `path_on_host` and `socket` fields have been specified for a drive override.
+/// Only specifying one of them is allowed.
+pub const DRIVE_OVERRIDE_TOO_MANY_FIELDS: &str = "too many fields: either `path_on_host` or `socket` exclusively is required for each drive override";
 
 pub(crate) fn parse_put_snapshot(
     body: &Body,
@@ -57,6 +63,29 @@ fn parse_put_snapshot_create(body: &Body) -> Result<ParsedRequest, RequestError>
     Ok(ParsedRequest::new_sync(VmmAction::CreateSnapshot(
         snapshot_config,
     )))
+}
+
+/// Validate that a [`DriveOverrideConfig`] specifies exactly one of
+/// `path_on_host` or `socket`, and convert it to the internal [`DriveOverride`].
+fn convert_drive_override(cfg: DriveOverrideConfig) -> Result<DriveOverride, RequestError> {
+    let backing = match (cfg.path_on_host, cfg.socket) {
+        (Some(path), None) => DriveOverrideBacking::PathOnHost(path),
+        (None, Some(socket)) => DriveOverrideBacking::Socket(socket),
+        (Some(_), Some(_)) => {
+            return Err(RequestError::SerdeJson(serde_json::Error::custom(
+                DRIVE_OVERRIDE_TOO_MANY_FIELDS,
+            )));
+        }
+        (None, None) => {
+            return Err(RequestError::SerdeJson(serde_json::Error::custom(
+                DRIVE_OVERRIDE_MISSING_FIELD,
+            )));
+        }
+    };
+    Ok(DriveOverride {
+        drive_id: cfg.drive_id,
+        backing,
+    })
 }
 
 fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, RequestError> {
@@ -102,6 +131,13 @@ fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, RequestError> {
         }
     };
 
+    // Validate each drive override and convert to the internal representation.
+    let drive_overrides = snapshot_config
+        .drive_overrides
+        .into_iter()
+        .map(convert_drive_override)
+        .collect::<Result<Vec<_>, _>>()?;
+
     let snapshot_params = LoadSnapshotParams {
         snapshot_path: snapshot_config.snapshot_path,
         mem_backend,
@@ -111,6 +147,7 @@ fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, RequestError> {
         resume_vm: snapshot_config.resume_vm,
         network_overrides: snapshot_config.network_overrides,
         vsock_override: snapshot_config.vsock_override,
+        drive_overrides,
         clock_realtime: snapshot_config.clock_realtime,
     };
 
@@ -127,7 +164,9 @@ fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, RequestError> {
 
 #[cfg(test)]
 mod tests {
-    use vmm::vmm_config::snapshot::{MemBackendConfig, MemBackendType, NetworkOverride};
+    use vmm::vmm_config::snapshot::{
+        DriveOverride, DriveOverrideBacking, MemBackendConfig, MemBackendType, NetworkOverride,
+    };
 
     use super::*;
     use crate::api_server::parsed_request::tests::{depr_action_from_req, vmm_action_from_request};
@@ -190,6 +229,7 @@ mod tests {
             resume_vm: false,
             network_overrides: vec![],
             vsock_override: None,
+            drive_overrides: vec![],
             clock_realtime: false,
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
@@ -222,6 +262,7 @@ mod tests {
             resume_vm: false,
             network_overrides: vec![],
             vsock_override: None,
+            drive_overrides: vec![],
             clock_realtime: false,
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
@@ -254,6 +295,7 @@ mod tests {
             resume_vm: true,
             network_overrides: vec![],
             vsock_override: None,
+            drive_overrides: vec![],
             clock_realtime: false,
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
@@ -295,6 +337,49 @@ mod tests {
                 host_dev_name: String::from("vmtap2"),
             }],
             vsock_override: None,
+            drive_overrides: vec![],
+            clock_realtime: false,
+        };
+        let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
+        assert!(
+            parsed_request
+                .parsing_info()
+                .take_deprecation_message()
+                .is_none()
+        );
+        assert_eq!(
+            vmm_action_from_request(parsed_request),
+            VmmAction::LoadSnapshot(expected_config)
+        );
+
+        let body = r#"{
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "File"
+            },
+            "resume_vm": true,
+            "drive_overrides": [
+                {
+                    "drive_id": "rootfs",
+                    "path_on_host": "/new/path/rootfs.ext4"
+                }
+            ]
+        }"#;
+        let expected_config = LoadSnapshotParams {
+            snapshot_path: PathBuf::from("foo"),
+            mem_backend: MemBackendConfig {
+                backend_path: PathBuf::from("bar"),
+                backend_type: MemBackendType::File,
+            },
+            track_dirty_pages: false,
+            resume_vm: true,
+            network_overrides: vec![],
+            vsock_override: None,
+            drive_overrides: vec![DriveOverride {
+                drive_id: String::from("rootfs"),
+                backing: DriveOverrideBacking::PathOnHost(String::from("/new/path/rootfs.ext4")),
+            }],
             clock_realtime: false,
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
@@ -324,6 +409,7 @@ mod tests {
             resume_vm: true,
             network_overrides: vec![],
             vsock_override: None,
+            drive_overrides: vec![],
             clock_realtime: false,
         };
         let parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
@@ -407,6 +493,54 @@ mod tests {
         );
         parse_put_snapshot(&Body::new(body), Some("invalid")).unwrap_err();
         parse_put_snapshot(&Body::new(body), None).unwrap_err();
+
+        // Drive override that supplies both `path_on_host` and `socket` must be rejected.
+        let body = r#"{
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "File"
+            },
+            "drive_overrides": [
+                {
+                    "drive_id": "rootfs",
+                    "path_on_host": "/p",
+                    "socket": "/s"
+                }
+            ]
+        }"#;
+        assert_eq!(
+            parse_put_snapshot(&Body::new(body), Some("load"))
+                .err()
+                .unwrap()
+                .to_string(),
+            RequestError::SerdeJson(serde_json::Error::custom(
+                DRIVE_OVERRIDE_TOO_MANY_FIELDS.to_string()
+            ))
+            .to_string()
+        );
+
+        // Drive override that supplies neither field must be rejected.
+        let body = r#"{
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "File"
+            },
+            "drive_overrides": [
+                { "drive_id": "rootfs" }
+            ]
+        }"#;
+        assert_eq!(
+            parse_put_snapshot(&Body::new(body), Some("load"))
+                .err()
+                .unwrap()
+                .to_string(),
+            RequestError::SerdeJson(serde_json::Error::custom(
+                DRIVE_OVERRIDE_MISSING_FIELD.to_string()
+            ))
+            .to_string()
+        );
     }
 
     #[test]

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1647,6 +1647,30 @@ definitions:
         description:
           The new path for the backing Unix Domain Socket.
 
+  DriveOverride:
+    type: object
+    description:
+      Allows for changing the backing host path of a block device
+      during snapshot restore. Exactly one of `path_on_host` or `socket`
+      must be set, matching the device type.
+    required:
+      - drive_id
+    properties:
+      drive_id:
+        type: string
+        description:
+          The ID of the drive to modify
+      path_on_host:
+        type: string
+        description:
+          The new host path for a virtio-block device's backing file.
+          This field is required for virtio-block overrides and should be omitted for vhost-user-block overrides.
+      socket:
+        type: string
+        description:
+          The new path to the vhost-user-block backend socket.
+          This field is required for vhost-user-block overrides and should be omitted for virtio-block overrides.
+
   SnapshotLoadParams:
     type: object
     description:
@@ -1694,6 +1718,11 @@ definitions:
           for restoring a snapshot with a different socket path than the one used
           when the snapshot was created. For example, when the original socket path
           is no longer available or when deploying to a different environment.
+      drive_overrides:
+        type: array
+        description: Block device host paths to override
+        items:
+          $ref: "#/definitions/DriveOverride"
       clock_realtime:
         type: boolean
         description:

--- a/src/vmm/src/devices/virtio/block/persist.rs
+++ b/src/vmm/src/devices/virtio/block/persist.rs
@@ -8,7 +8,15 @@ use serde::{Deserialize, Serialize};
 use super::vhost_user::persist::VhostUserBlockState;
 use super::virtio::persist::VirtioBlockState;
 use crate::devices::virtio::transport::VirtioInterrupt;
+use crate::vmm_config::snapshot::DriveOverrideBacking;
 use crate::vstate::memory::GuestMemoryMmap;
+
+/// Errors associated with applying a drive override.
+#[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
+pub enum DriveOverrideError {
+    /// Drive override for `{0}` does not match the device type.
+    Mismatch(String),
+}
 
 /// Block device state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,8 +28,34 @@ pub enum BlockState {
 impl BlockState {
     pub fn is_activated(&self) -> bool {
         match self {
-            BlockState::Virtio(virtio_block_state) => virtio_block_state.virtio_state.activated,
-            BlockState::VhostUser(vhost_user_block_state) => false,
+            BlockState::Virtio(state) => state.virtio_state.activated,
+            BlockState::VhostUser(_) => false,
+        }
+    }
+
+    /// Returns the drive ID.
+    pub fn id(&self) -> &str {
+        match self {
+            BlockState::Virtio(state) => &state.id,
+            BlockState::VhostUser(state) => &state.id,
+        }
+    }
+
+    /// Apply a backing-path override to the block device.
+    pub fn apply_override(
+        &mut self,
+        backing: &DriveOverrideBacking,
+    ) -> Result<(), DriveOverrideError> {
+        match (self, backing) {
+            (BlockState::Virtio(state), DriveOverrideBacking::PathOnHost(path)) => {
+                state.disk_path.clone_from(path);
+                Ok(())
+            }
+            (BlockState::VhostUser(state), DriveOverrideBacking::Socket(path)) => {
+                state.socket_path.clone_from(path);
+                Ok(())
+            }
+            (state, _) => Err(DriveOverrideError::Mismatch(state.id().to_string())),
         }
     }
 }
@@ -30,4 +64,94 @@ impl BlockState {
 #[derive(Debug)]
 pub struct BlockConstructorArgs {
     pub mem: GuestMemoryMmap,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::devices::virtio::block::CacheType;
+    use crate::devices::virtio::block::virtio::persist::FileEngineTypeState;
+    use crate::devices::virtio::device::VirtioDeviceType;
+    use crate::devices::virtio::persist::VirtioDeviceState;
+    use crate::rate_limiter::RateLimiter;
+    use crate::snapshot::Persist;
+
+    fn virtio_block_state(id: &str, disk_path: &str) -> VirtioBlockState {
+        VirtioBlockState {
+            id: id.to_string(),
+            partuuid: None,
+            cache_type: CacheType::Unsafe,
+            root_device: false,
+            disk_path: disk_path.to_string(),
+            virtio_state: VirtioDeviceState {
+                device_type: VirtioDeviceType::Block,
+                avail_features: 0,
+                acked_features: 0,
+                queues: vec![],
+                activated: false,
+            },
+            rate_limiter_state: RateLimiter::default().save(),
+            file_engine_type: FileEngineTypeState::Sync,
+        }
+    }
+
+    fn vhost_user_block_state(id: &str, socket_path: &str) -> VhostUserBlockState {
+        VhostUserBlockState {
+            id: id.to_string(),
+            partuuid: None,
+            cache_type: CacheType::Unsafe,
+            root_device: false,
+            socket_path: socket_path.to_string(),
+            vu_acked_protocol_features: 0,
+            config_space: vec![],
+            virtio_state: VirtioDeviceState {
+                device_type: VirtioDeviceType::Block,
+                avail_features: 0,
+                acked_features: 0,
+                queues: vec![],
+                activated: false,
+            },
+        }
+    }
+
+    #[test]
+    fn test_apply_override_virtio() {
+        let mut virtio = BlockState::Virtio(virtio_block_state("rootfs", "/old/path"));
+        virtio
+            .apply_override(&DriveOverrideBacking::PathOnHost("/new/path".to_string()))
+            .unwrap();
+        match &virtio {
+            BlockState::Virtio(state) => assert_eq!(state.disk_path, "/new/path"),
+            _ => panic!("expected Virtio variant"),
+        }
+    }
+
+    #[test]
+    fn test_apply_override_vhost_user() {
+        let mut vhost = BlockState::VhostUser(vhost_user_block_state("rootfs", "/old/sock"));
+        vhost
+            .apply_override(&DriveOverrideBacking::Socket("/new/sock".to_string()))
+            .unwrap();
+        match &vhost {
+            BlockState::VhostUser(state) => assert_eq!(state.socket_path, "/new/sock"),
+            _ => panic!("expected VhostUser variant"),
+        }
+    }
+
+    #[test]
+    fn test_apply_override_mismatch() {
+        // path_on_host against a vhost-user-block device should be rejected.
+        let mut vhost = BlockState::VhostUser(vhost_user_block_state("scratch", "/sock"));
+        assert_eq!(
+            vhost.apply_override(&DriveOverrideBacking::PathOnHost("/p".to_string())),
+            Err(DriveOverrideError::Mismatch("scratch".to_string()))
+        );
+
+        // socket against a virtio-block device should be rejected.
+        let mut virtio = BlockState::Virtio(virtio_block_state("rootfs", "/path"));
+        assert_eq!(
+            virtio.apply_override(&DriveOverrideBacking::Socket("/s".to_string())),
+            Err(DriveOverrideError::Mismatch("rootfs".to_string()))
+        );
+    }
 }

--- a/src/vmm/src/devices/virtio/block/vhost_user/persist.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/persist.rs
@@ -15,14 +15,14 @@ use crate::snapshot::Persist;
 /// vhost-user block device state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VhostUserBlockState {
-    id: String,
-    partuuid: Option<String>,
-    cache_type: CacheType,
-    root_device: bool,
-    socket_path: String,
-    vu_acked_protocol_features: u64,
-    config_space: Vec<u8>,
-    virtio_state: VirtioDeviceState,
+    pub id: String,
+    pub partuuid: Option<String>,
+    pub cache_type: CacheType,
+    pub root_device: bool,
+    pub socket_path: String,
+    pub vu_acked_protocol_features: u64,
+    pub config_space: Vec<u8>,
+    pub virtio_state: VirtioDeviceState,
 }
 
 impl Persist<'_> for VhostUserBlock {

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -52,14 +52,14 @@ impl From<FileEngineTypeState> for FileEngineType {
 /// Holds info about the block device. Gets saved in snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VirtioBlockState {
-    id: String,
-    partuuid: Option<String>,
-    cache_type: CacheType,
-    root_device: bool,
-    disk_path: String,
+    pub id: String,
+    pub partuuid: Option<String>,
+    pub cache_type: CacheType,
+    pub root_device: bool,
+    pub disk_path: String,
     pub virtio_state: VirtioDeviceState,
-    rate_limiter_state: RateLimiterState,
-    file_engine_type: FileEngineTypeState,
+    pub rate_limiter_state: RateLimiterState,
+    pub file_engine_type: FileEngineTypeState,
 }
 
 impl Persist<'_> for VirtioBlock {

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -26,6 +26,7 @@ use crate::cpu_config::x86_64::cpuid::CpuidTrait;
 #[cfg(target_arch = "x86_64")]
 use crate::cpu_config::x86_64::cpuid::common::get_vendor_id_from_host;
 use crate::device_manager::{DevicePersistError, DevicesState};
+use crate::devices::virtio::block::persist::DriveOverrideError;
 use crate::logger::{info, warn};
 use crate::resources::VmResources;
 use crate::seccomp::BpfThreadMap;
@@ -408,6 +409,27 @@ pub fn restore_from_snapshot(
             .clone_from(&vsock_override.uds_path);
     }
 
+    for entry in &params.drive_overrides {
+        microvm_state
+            .device_states
+            .mmio_state
+            .block_devices
+            .iter_mut()
+            .map(|device| &mut device.device_state)
+            .chain(
+                microvm_state
+                    .device_states
+                    .pci_state
+                    .block_devices
+                    .iter_mut()
+                    .map(|device| &mut device.device_state),
+            )
+            .find(|x| x.id() == entry.drive_id)
+            .ok_or_else(|| SnapshotStateFromFileError::UnknownBlockDevice(entry.drive_id.clone()))?
+            .apply_override(&entry.backing)
+            .map_err(SnapshotStateFromFileError::from)?;
+    }
+
     let track_dirty_pages = params.track_dirty_pages;
 
     let vcpu_count = microvm_state
@@ -482,6 +504,10 @@ pub enum SnapshotStateFromFileError {
     UnknownNetworkDevice,
     /// Unknown Vsock Device.
     UnknownVsockDevice,
+    /// Unknown Block Device: `{0}`.
+    UnknownBlockDevice(String),
+    /// Failed to apply drive override: {0}
+    DriveOverride(#[from] DriveOverrideError),
 }
 
 fn snapshot_state_from_file(

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1313,6 +1313,7 @@ mod tests {
                 resume_vm: false,
                 network_overrides: vec![],
                 vsock_override: None,
+                drive_overrides: vec![],
                 clock_realtime: false,
             },
         )));

--- a/src/vmm/src/vmm_config/snapshot.rs
+++ b/src/vmm/src/vmm_config/snapshot.rs
@@ -64,6 +64,38 @@ pub struct VsockOverride {
     pub uds_path: String,
 }
 
+/// Configuration for a single drive override that is provided by the user.
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DriveOverrideConfig {
+    /// The ID of the drive to modify
+    pub drive_id: String,
+    /// The new host path for a virtio-block device's backing file
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_on_host: Option<String>,
+    /// The new socket path for a vhost-user-block device's backend
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub socket: Option<String>,
+}
+
+/// Allows for changing the backing host path of a block device during snapshot restore
+#[derive(Debug, PartialEq, Eq)]
+pub struct DriveOverride {
+    /// The ID of the drive to modify
+    pub drive_id: String,
+    /// The new backing path
+    pub backing: DriveOverrideBacking,
+}
+
+/// The new backing path for a [`DriveOverride`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum DriveOverrideBacking {
+    /// New host path for a virtio-block device's backing file
+    PathOnHost(String),
+    /// New socket path for a vhost-user-block device's backend
+    Socket(String),
+}
+
 /// Stores the configuration that will be used for loading a snapshot.
 #[derive(Debug, PartialEq, Eq)]
 pub struct LoadSnapshotParams {
@@ -81,6 +113,8 @@ pub struct LoadSnapshotParams {
     pub network_overrides: Vec<NetworkOverride>,
     /// When set, the vsock backend UDS path will be overridden
     pub vsock_override: Option<VsockOverride>,
+    /// The block devices to override on load.
+    pub drive_overrides: Vec<DriveOverride>,
     /// [x86_64 only] When set to true, passes `KVM_CLOCK_REALTIME` to `KVM_SET_CLOCK` on restore,
     /// advancing kvmclock by the wall-clock time elapsed since the snapshot was taken. When false
     /// (default), kvmclock resumes from where it was at snapshot time.
@@ -117,6 +151,9 @@ pub struct LoadSnapshotConfig {
     /// Whether or not to override the vsock backend UDS path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vsock_override: Option<VsockOverride>,
+    /// The block devices to override on load.
+    #[serde(default)]
+    pub drive_overrides: Vec<DriveOverrideConfig>,
     /// [x86_64 only] When set to true, passes `KVM_CLOCK_REALTIME` to `KVM_SET_CLOCK` on restore.
     #[serde(default)]
     pub clock_realtime: bool,

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -296,6 +296,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
             resume_vm: true,
             network_overrides: vec![],
             vsock_override: None,
+            drive_overrides: vec![],
             clock_realtime: false,
         }))
         .unwrap();
@@ -382,6 +383,7 @@ fn verify_load_snap_disallowed_after_boot_resources(res: VmmAction, res_name: &s
         resume_vm: false,
         network_overrides: vec![],
         vsock_override: None,
+        drive_overrides: vec![],
         clock_realtime: false,
     });
     let err = preboot_api_controller.handle_preboot_request(req);

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -1085,6 +1085,7 @@ class Microvm:
         rename_interfaces: dict = None,
         vsock_override: str = None,
         clock_realtime: bool = False,
+        drive_overrides: list = None,
         *,
         uffd_handler_name: str = None,
     ):
@@ -1102,8 +1103,15 @@ class Microvm:
         jailed_mem = Path("/") / jailed_snapshot.mem.name
         jailed_vmstate = Path("/") / jailed_snapshot.vmstate.name
 
-        snapshot_disks = [v for k, v in jailed_snapshot.disks.items()]
-        assert len(snapshot_disks) > 0, "Snapshot requires at least one disk."
+        # Skip auto-jailing drives that have an override - the caller is
+        # responsible for placing the backing file at the override path.
+        overridden_drive_ids = {o["drive_id"] for o in (drive_overrides or [])}
+        snapshot_disks = [
+            v for k, v in jailed_snapshot.disks.items() if k not in overridden_drive_ids
+        ]
+        assert (
+            len(snapshot_disks) > 0 or overridden_drive_ids
+        ), "Snapshot requires at least one disk."
         jailed_disks = []
         for disk in snapshot_disks:
             jailed_disks.append(self.create_jailed_resource(disk))
@@ -1146,6 +1154,9 @@ class Microvm:
 
         if clock_realtime:
             optional_kwargs["clock_realtime"] = clock_realtime
+
+        if drive_overrides is not None:
+            optional_kwargs["drive_overrides"] = drive_overrides
 
         self.api.snapshot_load.put(
             mem_backend=mem_backend,

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -709,3 +709,95 @@ def test_clocksource_snapshot_restore(
     assert (
         jumped == clock_realtime
     ), f"Clock {jumped_str} but clock_realtime was {"not" if clock_realtime else ""} set."
+
+
+def test_snapshot_override_drive(uvm_nano, microvm_factory):
+    """
+    Test that we can restore a snapshot and point a block device to a
+    different host path.
+    """
+    vm = uvm_nano
+    vm.add_net_iface()
+    vm.start()
+
+    snapshot = vm.snapshot_full()
+
+    restored_vm = microvm_factory.build()
+    restored_vm.spawn()
+
+    # Place the rootfs at the override path. The framework skips auto-jailing
+    # for overridden drives, so the snapshot's original path is absent from
+    # the new jail and the override must take effect for restore to succeed.
+    shutil.copy(
+        snapshot.disks["rootfs"], Path(restored_vm.chroot()) / "rootfs_override.ext4"
+    )
+
+    restored_vm.restore_from_snapshot(
+        snapshot,
+        drive_overrides=[
+            {"drive_id": "rootfs", "path_on_host": "/rootfs_override.ext4"},
+        ],
+        resume=True,
+    )
+
+    restored_vm.ssh.check_output("blockdev --getsize64 /dev/vda")
+
+
+def test_snapshot_override_multiple_drives(uvm_nano, microvm_factory):
+    """
+    Test that multiple drives can be overridden at once on snapshot restore,
+    and that each override applies to the correct device.
+    """
+    vm = uvm_nano
+    vm.add_net_iface()
+
+    scratch = drive_tools.FilesystemFile(str(Path(vm.path) / "scratch.ext4"), size=64)
+    vm.add_drive("scratch", scratch.path)
+
+    vm.start()
+    snapshot = vm.snapshot_full()
+
+    restored_vm = microvm_factory.build()
+    restored_vm.spawn()
+
+    chroot = Path(restored_vm.chroot())
+    shutil.copy(snapshot.disks["rootfs"], chroot / "rootfs_override.ext4")
+    shutil.copy(snapshot.disks["scratch"], chroot / "scratch_override.ext4")
+
+    restored_vm.restore_from_snapshot(
+        snapshot,
+        drive_overrides=[
+            {"drive_id": "rootfs", "path_on_host": "/rootfs_override.ext4"},
+            {"drive_id": "scratch", "path_on_host": "/scratch_override.ext4"},
+        ],
+        resume=True,
+    )
+
+    restored_vm.ssh.check_output("blockdev --getsize64 /dev/vda")
+    restored_vm.ssh.check_output("blockdev --getsize64 /dev/vdb")
+
+
+def test_drive_override_fails_unknown_id(uvm_nano, microvm_factory):
+    """
+    Providing a drive override with an unknown drive_id should fail.
+    """
+    vm = uvm_nano
+    vm.start()
+
+    snapshot = vm.snapshot_full()
+    vm.kill()
+
+    restored_vm = microvm_factory.build()
+    restored_vm.spawn()
+
+    # The failed snapshot load causes Firecracker to exit.
+    with pytest.raises(RuntimeError, match="Unknown Block Device"):
+        restored_vm.restore_from_snapshot(
+            snapshot,
+            drive_overrides=[
+                {"drive_id": "nonexistent", "path_on_host": "/fake/path"},
+            ],
+            resume=True,
+        )
+
+    restored_vm.mark_killed()


### PR DESCRIPTION
Allow overriding block device host paths when restoring from a snapshot. This is useful when disk paths are non-deterministic (e.g. container runtimes using devmapper) or when restoring on a different host where the backing file is at a different location.

Adds a `drive_overrides` parameter to the snapshot load API, following the same pattern as the existing `network_overrides` (#4731) and `vsock_override` (#5323).

Closes #4014

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md