### PR TITLE
fix(aarch64): override fabricated CLIDR_EL1 to match host cache topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to
   HID (Hardware ID) of VMGenID device so that it aligns with the upstream Linux
   kernel. This caused the driver not to be bound correctly to the device prior
   to Linux kernel 6.10.
+- [#5780](https://github.com/firecracker-microvm/firecracker/pull/5780): Fixed
+  missing `/sys/devices/system/cpu/cpu*/cache/*` in aarch64 guests when running
+  on host kernels >= 6.3 with guest kernels >= 6.1.156.
 
 ## [1.15.0]
 

--- a/src/vmm/src/arch/aarch64/cache_info.rs
+++ b/src/vmm/src/arch/aarch64/cache_info.rs
@@ -10,7 +10,7 @@ use crate::logger::warn;
 const MAX_CACHE_LEVEL: u8 = 7;
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub(crate) enum CacheInfoError {
+pub enum CacheInfoError {
     /// Failed to read cache information: {0}
     FailedToReadCacheInfo(#[from] io::Error),
     /// Invalid cache configuration found for {0}: {1}
@@ -32,7 +32,7 @@ trait CacheStore: std::fmt::Debug {
 }
 
 #[derive(Debug)]
-pub(crate) struct CacheEntry {
+pub struct CacheEntry {
     // Cache Level: 1, 2, 3..
     pub level: u8,
     // Type of cache: Unified, Data, Instruction.
@@ -154,7 +154,7 @@ impl Default for CacheEntry {
 
 #[derive(Debug)]
 // Based on https://elixir.free-electrons.com/linux/v4.9.62/source/include/linux/cacheinfo.h#L11.
-pub(crate) enum CacheType {
+pub enum CacheType {
     Instruction,
     Data,
     Unified,
@@ -312,6 +312,105 @@ pub(crate) fn read_cache_config(
         }
     }
     Ok(())
+}
+
+// CLIDR_EL1 field positions
+// https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/CLIDR-EL1--Cache-Level-ID-Register
+const CLIDR_CTYPE_SHIFT: u8 = 3; // Each Ctype field is 3 bits
+const CLIDR_LOC_SHIFT: u8 = 24;
+
+// CLIDR_EL1 Ctype field values
+const CLIDR_CTYPE_NO_CACHE: u64 = 0;
+const CLIDR_CTYPE_INSTRUCTION: u64 = 1;
+const CLIDR_CTYPE_DATA: u64 = 2;
+const CLIDR_CTYPE_SEPARATE: u64 = 3;
+const CLIDR_CTYPE_UNIFIED: u64 = 4;
+
+/// Classify a set of cache entries at the same level into a CLIDR Ctype value.
+fn ctype_for_entries<'a>(entries: impl Iterator<Item = &'a CacheEntry>) -> u64 {
+    let (mut has_data, mut has_inst, mut has_unified) = (false, false, false);
+    let mut any = false;
+    for c in entries {
+        any = true;
+        match c.type_ {
+            CacheType::Data => has_data = true,
+            CacheType::Instruction => has_inst = true,
+            CacheType::Unified => has_unified = true,
+        }
+    }
+    if !any {
+        return CLIDR_CTYPE_NO_CACHE;
+    }
+    if has_unified {
+        CLIDR_CTYPE_UNIFIED
+    } else if has_data && has_inst {
+        CLIDR_CTYPE_SEPARATE
+    } else if has_data {
+        CLIDR_CTYPE_DATA
+    } else if has_inst {
+        CLIDR_CTYPE_INSTRUCTION
+    } else {
+        CLIDR_CTYPE_NO_CACHE
+    }
+}
+
+/// Build a CLIDR_EL1 value from the host's cache topology read from sysfs.
+///
+/// Since host kernel 6.3 (commit 7af0c2534f4c), KVM fabricates CLIDR_EL1 to
+/// expose a different cache topology than the host. Guest kernels >= 6.1.156
+/// backported `init_of_cache_level()` which counts cache leaves from the DT,
+/// while `populate_cache_leaves()` uses CLIDR_EL1. If the DT (built from
+/// sysfs) describes different cache entries than CLIDR_EL1, the mismatch
+/// causes cache sysfs entries to not be created in the guest.
+///
+/// This function builds a CLIDR_EL1 value that matches the host's real cache
+/// topology so it can be written to each vCPU, making CLIDR_EL1 consistent
+/// with the FDT.
+pub(crate) fn build_clidr_from_caches(
+    l1_caches: &[CacheEntry],
+    non_l1_caches: &[CacheEntry],
+) -> u64 {
+    let mut clidr: u64 = 0;
+    let mut max_level: u8 = 0;
+
+    let l1_ctype = ctype_for_entries(l1_caches.iter());
+    if l1_ctype != CLIDR_CTYPE_NO_CACHE {
+        clidr |= l1_ctype;
+        max_level = 1;
+    }
+
+    for level in 2..=MAX_CACHE_LEVEL {
+        let ctype = ctype_for_entries(non_l1_caches.iter().filter(|c| c.level == level));
+        if ctype == CLIDR_CTYPE_NO_CACHE {
+            break;
+        }
+
+        let shift = CLIDR_CTYPE_SHIFT * (level - 1);
+        clidr |= ctype << shift;
+        max_level = level;
+    }
+
+    // Set LoC (Level of Coherence) to the highest cache level
+    clidr |= u64::from(max_level) << CLIDR_LOC_SHIFT;
+
+    clidr
+}
+
+/// Merge sysfs-derived ctype/LoC fields into an existing CLIDR_EL1 value,
+/// preserving LoUU, LoUIS, ICB, and Ttype fields from the original.
+///
+/// This ensures that on pre-6.3 kernels (where CLIDR already matches sysfs),
+/// the write is effectively a no-op, and fields we can't derive from sysfs
+/// (like LoUU, LoUIS, ICB) are never clobbered.
+pub(crate) fn merge_clidr(current: u64, sysfs: u64) -> u64 {
+    // Ctype fields: bits [20:0] (7 levels × 3 bits each = 21 bits)
+    // LoC field: bits [26:24]
+    // We replace only these fields from sysfs, preserving LoUIS [23:21],
+    // LoUU [29:27], ICB [32:30], and Ttype [46:33] from the original.
+    const CTYPE_MASK: u64 = 0x001F_FFFF; // bits [20:0]
+    const LOC_MASK: u64 = 0x0700_0000; // bits [26:24]
+    const REPLACE_MASK: u64 = CTYPE_MASK | LOC_MASK;
+    (current & !REPLACE_MASK) | (sysfs & REPLACE_MASK)
 }
 
 #[cfg(test)]
@@ -575,5 +674,102 @@ mod tests {
         read_cache_config(&mut l1_caches, &mut non_l1_caches).unwrap();
         assert_eq!(l1_caches.len(), 2);
         assert_eq!(l1_caches.len(), 2);
+    }
+
+    #[test]
+    fn test_build_clidr_from_caches() {
+        // L1 Separate (Data + Instruction) + L2 Unified + L3 Unified
+        let l1 = vec![
+            CacheEntry {
+                level: 1,
+                type_: CacheType::Data,
+                ..CacheEntry::default()
+            },
+            CacheEntry {
+                level: 1,
+                type_: CacheType::Instruction,
+                ..CacheEntry::default()
+            },
+        ];
+        let non_l1 = vec![
+            CacheEntry {
+                level: 2,
+                type_: CacheType::Unified,
+                ..CacheEntry::default()
+            },
+            CacheEntry {
+                level: 3,
+                type_: CacheType::Unified,
+                ..CacheEntry::default()
+            },
+        ];
+        let clidr = build_clidr_from_caches(&l1, &non_l1);
+        // ctype1=3 (Separate), ctype2=4 (Unified), ctype3=4 (Unified), LoC=3
+        assert_eq!(clidr & 0x7, 3, "L1 should be Separate");
+        assert_eq!((clidr >> 3) & 0x7, 4, "L2 should be Unified");
+        assert_eq!((clidr >> 6) & 0x7, 4, "L3 should be Unified");
+        assert_eq!((clidr >> 24) & 0x7, 3, "LoC should be 3");
+
+        // L1 Unified only (no higher levels)
+        let l1_unified = vec![CacheEntry {
+            level: 1,
+            type_: CacheType::Unified,
+            ..CacheEntry::default()
+        }];
+        let clidr = build_clidr_from_caches(&l1_unified, &[]);
+        assert_eq!(clidr & 0x7, 4, "L1 should be Unified");
+        assert_eq!((clidr >> 3) & 0x7, 0, "L2 should be NoCache");
+        assert_eq!((clidr >> 24) & 0x7, 1, "LoC should be 1");
+
+        // No caches at all
+        let clidr = build_clidr_from_caches(&[], &[]);
+        assert_eq!(clidr, 0, "Empty caches should produce CLIDR=0");
+
+        // Mock store default: L1 Data + L1 Instruction + L2 Unified
+        let mut l1_mock: Vec<CacheEntry> = Vec::new();
+        let mut non_l1_mock: Vec<CacheEntry> = Vec::new();
+        read_cache_config(&mut l1_mock, &mut non_l1_mock).unwrap();
+        let clidr = build_clidr_from_caches(&l1_mock, &non_l1_mock);
+        assert_eq!(clidr & 0x7, 3, "Mock L1 should be Separate");
+        assert_eq!((clidr >> 3) & 0x7, 4, "Mock L2 should be Unified");
+        assert_eq!((clidr >> 24) & 0x7, 2, "Mock LoC should be 2");
+    }
+
+    #[test]
+    fn test_merge_clidr() {
+        // CLIDR_EL1 layout:
+        //   [20:0]  Ctype1..Ctype7 (7 × 3 bits)
+        //   [23:21] LoUIS
+        //   [26:24] LoC
+        //   [29:27] LoUU
+        //   [32:30] ICB
+        //   [46:33] Ttype1..Ttype7
+        //
+        // merge_clidr replaces only Ctype [20:0] and LoC [26:24] from sysfs,
+        // preserving LoUIS, LoUU, ICB, and Ttype from current.
+
+        // current: LoUU=2 [29:27], LoUIS=1 [23:21], ICB=1 [32:30]
+        //          Ctype1=Unified(4) [2:0], LoC=1 [26:24]
+        let current: u64 = (1 << 30) // ICB=1
+            | (2 << 27)              // LoUU=2
+            | (1 << 24)              // LoC=1
+            | (1 << 21)              // LoUIS=1
+            | 4; // Ctype1=Unified
+        // sysfs: Ctype1=Separate(3), Ctype2=Unified(4), Ctype3=Unified(4), LoC=3
+        let sysfs: u64 = (3 << 24) | (4 << 6) | (4 << 3) | 3;
+        let merged = merge_clidr(current, sysfs);
+
+        // Ctype and LoC should come from sysfs
+        assert_eq!(merged & 0x001F_FFFF, sysfs & 0x001F_FFFF, "Ctype mismatch");
+        assert_eq!((merged >> 24) & 0x7, 3, "LoC should be 3 from sysfs");
+        // LoUIS, LoUU, ICB should be preserved from current
+        assert_eq!((merged >> 21) & 0x7, 1, "LoUIS should be preserved");
+        assert_eq!((merged >> 27) & 0x7, 2, "LoUU should be preserved");
+        assert_eq!((merged >> 30) & 0x7, 1, "ICB should be preserved");
+
+        // When current == sysfs in the replaced region, merge is identity
+        let current = 0x0000_0000_0300_0123_u64;
+        let sysfs = 0x0000_0000_0300_0123_u64;
+        assert_eq!(merge_clidr(current, sysfs), current);
     }
 }

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -28,6 +28,9 @@ use crate::arch::{BootProtocol, EntryPoint, arch_memory_regions_with_gap};
 use crate::cpu_config::aarch64::{CpuConfiguration, CpuConfigurationError};
 use crate::cpu_config::templates::CustomCpuTemplate;
 use crate::initrd::InitrdConfig;
+use zerocopy::IntoBytes;
+
+use crate::logger::warn;
 use crate::utils::{align_up, u64_to_usize, usize_to_u64};
 use crate::vmm_config::machine_config::MachineConfig;
 use crate::vstate::memory::{
@@ -51,6 +54,8 @@ pub enum ConfigurationError {
     VcpuConfig(#[from] CpuConfigurationError),
     /// Error configuring the vcpu: {0}
     VcpuConfigure(#[from] KvmVcpuError),
+    /// Failed to read host cache information: {0}
+    CacheInfo(#[from] cache_info::CacheInfoError),
 }
 
 /// Returns a Vec of the valid memory addresses for aarch64.
@@ -118,6 +123,11 @@ pub fn configure_system_for_boot(
             &optional_capabilities,
         )?;
     }
+
+    // Override CLIDR_EL1 ctype/LoC fields on each vCPU to match the host's
+    // real cache topology. See `override_clidr` for details.
+    override_clidr(vcpus)?;
+
     let vcpu_mpidr = vcpus
         .iter_mut()
         .map(|cpu| cpu.kvm_vcpu.get_mpidr())
@@ -138,6 +148,70 @@ pub fn configure_system_for_boot(
 
     let fdt_address = GuestAddress(get_fdt_addr(vm.guest_memory()));
     vm.guest_memory().write_slice(fdt.as_slice(), fdt_address)?;
+
+    Ok(())
+}
+
+/// Override CLIDR_EL1 ctype/LoC fields on each vCPU to match the host's real
+/// cache topology.
+///
+/// Since host kernel 6.3 (commit 7af0c2534f4c), KVM fabricates CLIDR_EL1
+/// instead of passing through the host's real value. This can cause the guest
+/// to see fewer cache levels than actually exist. Guest kernels >= 6.1.156
+/// backported `init_of_cache_level()` which counts cache leaves from the DT,
+/// while `populate_cache_leaves()` uses CLIDR_EL1. If the DT (built from host
+/// sysfs) describes different cache entries than CLIDR_EL1, the mismatch
+/// causes cache sysfs entries to not be created.
+///
+/// We read the current (possibly fabricated) CLIDR_EL1, replace only the ctype
+/// and LoC fields with values derived from sysfs, and preserve all other fields
+/// (LoUU, LoUIS, ICB, Ttype). This is safe on pre-6.3 kernels where CLIDR
+/// already matches sysfs — the write is skipped as a no-op.
+fn override_clidr(vcpus: &[Vcpu]) -> Result<(), ConfigurationError> {
+    let mut l1_caches = Vec::new();
+    let mut non_l1_caches = Vec::new();
+    cache_info::read_cache_config(&mut l1_caches, &mut non_l1_caches)?;
+
+    // If sysfs reports no L1 caches, we cannot build a meaningful CLIDR.
+    // Writing an all-zero CLIDR would tell the guest there are no caches,
+    // which is worse than whatever KVM fabricated. Leave it alone.
+    if l1_caches.is_empty() {
+        warn!("No L1 caches found in sysfs, skipping CLIDR override");
+        return Ok(());
+    }
+
+    let sysfs_clidr = cache_info::build_clidr_from_caches(&l1_caches, &non_l1_caches);
+
+    let mut cur_clidr: u64 = 0;
+    // Reading/writing CLIDR_EL1 via KVM_SET_ONE_REG may not be supported on
+    // older kernels (pre-6.3). In that case KVM passes through the real host
+    // CLIDR and the override is unnecessary, so we warn and continue.
+    if let Err(e) = vcpus[0]
+        .kvm_vcpu
+        .fd
+        .get_one_reg(regs::CLIDR_EL1, cur_clidr.as_mut_bytes())
+    {
+        warn!("Failed to read CLIDR_EL1, skipping override: {e}");
+        return Ok(());
+    }
+
+    let new_clidr = cache_info::merge_clidr(cur_clidr, sysfs_clidr);
+
+    if new_clidr != cur_clidr {
+        for vcpu in vcpus.iter() {
+            if let Err(e) = vcpu
+                .kvm_vcpu
+                .fd
+                .set_one_reg(regs::CLIDR_EL1, new_clidr.as_bytes())
+            {
+                warn!(
+                    "Failed to set CLIDR_EL1 to {:#x} on vCPU {}, skipping override: {e}",
+                    new_clidr, vcpu.kvm_vcpu.index
+                );
+                return Ok(());
+            }
+        }
+    }
 
     Ok(())
 }

--- a/src/vmm/src/arch/aarch64/regs.rs
+++ b/src/vmm/src/arch/aarch64/regs.rs
@@ -90,6 +90,10 @@ arm64_sys_reg!(ID_AA64ISAR0_EL1, 3, 0, 0, 6, 0);
 arm64_sys_reg!(ID_AA64ISAR1_EL1, 3, 0, 0, 6, 1);
 arm64_sys_reg!(ID_AA64MMFR2_EL1, 3, 0, 0, 7, 2);
 
+// Cache Level ID Register
+// https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/CLIDR-EL1--Cache-Level-ID-Register
+arm64_sys_reg!(CLIDR_EL1, 3, 1, 0, 0, 1);
+
 // Counter-timer Virtual Timer CompareValue register.
 // https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/CNTV-CVAL-EL0--Counter-timer-Virtual-Timer-CompareValue-register
 // https://elixir.bootlin.com/linux/v6.8/source/arch/arm64/include/asm/sysreg.h#L468


### PR DESCRIPTION
Since host kernel 6.3 (commit 7af0c2534f4c), KVM fabricates CLIDR_EL1 instead of passing through the host's real value. On hosts with IDC=1 and DIC=0 (e.g. Neoverse V1), the fabricated CLIDR exposes only L1=Unified when the host actually has separate L1d+L1i, L2, and L3.

Guest kernels >= 6.1.156 backported init_of_cache_level() which counts cache leaves from the DT, while populate_cache_leaves() uses CLIDR_EL1. When the DT (built from host sysfs) describes more cache entries than CLIDR_EL1, the mismatch causes cache sysfs entries to not be created, breaking /sys/devices/system/cpu/cpu*/cache/* in the guest.

Fix this by reading the current CLIDR_EL1 from vCPU 0, merging in the ctype and LoC fields derived from the host's sysfs cache topology, and writing the result back to each vCPU via KVM_SET_ONE_REG. Fields that cannot be derived from sysfs (LoUU, LoUIS, ICB, Ttype) are preserved from the original CLIDR_EL1. This makes CLIDR_EL1 consistent with the FDT, which already describes the real host caches.

On pre-6.3 kernels, KVM passes through the real host CLIDR rather than fabricating one. Since the sysfs cache topology already matches the real CLIDR, the merge produces the same value, the write is skipped, and the override is effectively a no-op.

This approach preserves the full host cache information for the guest rather than stripping the FDT to match the fabricated CLIDR.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
