### PR TITLE
[v1.15] chore: Update aws-lc-rs 1.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted",
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",

--- a/deny.toml
+++ b/deny.toml
@@ -5,8 +5,7 @@ allow = [
     "Apache-2.0",
     "BSD-3-Clause",
     "ISC",
-    "Unicode-3.0",
-    "OpenSSL"
+    "Unicode-3.0"
 ]
 
 [[bans.deny]]

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -17,7 +17,7 @@ gdb = ["arrayvec", "gdbstub", "gdbstub_arch"]
 
 acpi_tables = { path = "../acpi-tables" }
 arrayvec = { version = "0.7.6", optional = true }
-aws-lc-rs = "1.16.1"
+aws-lc-rs = "1.16.2"
 base64 = "0.22.1"
 bitcode = { version = "0.6.9", features = ["serde"] }
 bitflags = "2.10.0"


### PR DESCRIPTION
## Changes / Reason

A vulnerability was found in aws-lc-sys [1].  Although Firecracker isn't affected as it doesn't use AWS-LC to validate CN, update aws-lc-rs (and aws-lc-sys indirectly) to suppress cargo-audit failure.

[1]: https://rustsec.org/advisories/RUSTSEC-2026-0044.html

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [na] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [na] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [na] If a specific issue led to this PR, this PR closes the issue.
- [na] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [na] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
