### PR TITLE
Add PCI hotplug support

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -285,6 +285,112 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used by pmem device to mmap the backing file",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 16385,
+                        "comment": "libc::MAP_SHARED | libc::MAP_NORESERVE"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used by pmem device for aligned anonymous mapping",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 16418,
+                        "comment": "libc::MAP_PRIVATE | libc::MAP_NORESERVE | libc::MAP_ANONYMOUS"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used by pmem device to overlay file mapping on anonymous region",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 16401,
+                        "comment": "libc::MAP_SHARED | libc::MAP_NORESERVE | libc::MAP_FIXED"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used by IovDeque ring buffer for net device hotplug",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 17,
+                        "comment": "libc::MAP_SHARED | libc::MAP_FIXED"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "libc::PROT_READ | libc::PROT_WRITE"
+                    }
+                ]
+            },
+            {
+                "syscall": "memfd_create",
+                "comment": "Used by IovDeque ring buffer for net device hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "MFD_CLOEXEC | MFD_ALLOW_SEALING"
+                    }
+                ]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "Used by IovDeque to seal memfd during net device hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1033,
+                        "comment": "F_ADD_SEALS"
+                    }
+                ]
+            },
+            {
                 "syscall": "rt_sigaction",
                 "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
                 "args": [
@@ -350,6 +456,26 @@
                         "op": "eq",
                         "val": 35,
                         "comment": "sigrtmin() + vcpu::VCPU_RTSIG_OFFSET"
+                    }
+                ]
+            },
+            {
+                "syscall": "timerfd_create",
+                "comment": "Needed for creating rate limiters during device hotplug",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "CLOCK_MONOTONIC"
+                    },
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 526336,
+                        "comment": "TFD_NONBLOCK | TFD_CLOEXEC"
                     }
                 ]
             },
@@ -462,6 +588,58 @@
                         "op": "eq",
                         "val": 1075883590,
                         "comment": "KVM_SET_USER_MEMORY_REGION, used to (un)plug memory for the virtio-mem device"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for registering ioeventfds during device hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1077980793,
+                        "comment": "KVM_IOEVENTFD"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for opening tap device during net hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1074025674,
+                        "comment": "TUNSETIFF"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for configuring tap offload during net hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1074025680,
+                        "comment": "TUNSETOFFLOAD"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for setting tap vnet header size during net hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1074025688,
+                        "comment": "TUNSETVNETHDRSZ"
                     }
                 ]
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -285,6 +285,112 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used by pmem device to mmap the backing file",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 16385,
+                        "comment": "libc::MAP_SHARED | libc::MAP_NORESERVE"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used by pmem device for aligned anonymous mapping",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 16418,
+                        "comment": "libc::MAP_PRIVATE | libc::MAP_NORESERVE | libc::MAP_ANONYMOUS"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used by pmem device to overlay file mapping on anonymous region",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 16401,
+                        "comment": "libc::MAP_SHARED | libc::MAP_NORESERVE | libc::MAP_FIXED"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used by IovDeque ring buffer for net device hotplug",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 17,
+                        "comment": "libc::MAP_SHARED | libc::MAP_FIXED"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "libc::PROT_READ | libc::PROT_WRITE"
+                    }
+                ]
+            },
+            {
+                "syscall": "memfd_create",
+                "comment": "Used by IovDeque ring buffer for net device hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "MFD_CLOEXEC | MFD_ALLOW_SEALING"
+                    }
+                ]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "Used by IovDeque to seal memfd during net device hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1033,
+                        "comment": "F_ADD_SEALS"
+                    }
+                ]
+            },
+            {
                 "syscall": "rt_sigaction",
                 "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
                 "args": [
@@ -350,6 +456,26 @@
                         "op": "eq",
                         "val": 35,
                         "comment": "sigrtmin() + vcpu::VCPU_RTSIG_OFFSET"
+                    }
+                ]
+            },
+            {
+                "syscall": "timerfd_create",
+                "comment": "Needed for creating rate limiters during device hotplug",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "CLOCK_MONOTONIC"
+                    },
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 526336,
+                        "comment": "TFD_NONBLOCK | TFD_CLOEXEC"
                     }
                 ]
             },
@@ -474,6 +600,58 @@
                         "op": "eq",
                         "val": 1075883590,
                         "comment": "KVM_SET_USER_MEMORY_REGION, used to (un)plug memory for the virtio-mem device"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for registering ioeventfds during device hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1077980793,
+                        "comment": "KVM_IOEVENTFD"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for opening tap device during net hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1074025674,
+                        "comment": "TUNSETIFF"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for configuring tap offload during net hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1074025680,
+                        "comment": "TUNSETOFFLOAD"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for setting tap vnet header size during net hotplug",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1074025688,
+                        "comment": "TUNSETVNETHDRSZ"
                     }
                 ]
             },

--- a/src/firecracker/src/api_server/parsed_request.rs
+++ b/src/firecracker/src/api_server/parsed_request.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use serde::ser::Serialize;
 use serde_json::Value;
+use vmm::devices::virtio::device::VirtioDeviceType;
 use vmm::logger::{Level, error_unrestricted, info_unrestricted, log_enabled};
 use vmm::rpc_interface::{VmmAction, VmmActionError, VmmData};
 
@@ -31,6 +32,7 @@ use super::request::vsock::parse_put_vsock;
 use crate::api_server::request::hotplug::memory::{
     parse_get_memory_hotplug, parse_patch_memory_hotplug, parse_put_memory_hotplug,
 };
+use crate::api_server::request::hotplug::parse_unplug_device;
 use crate::api_server::request::serial::parse_put_serial;
 
 #[derive(Debug)]
@@ -126,6 +128,16 @@ impl TryFrom<&Request> for ParsedRequest {
                 parse_patch_memory_hotplug(body)
             }
             (Method::Patch, _, None) => method_to_error(Method::Patch),
+            (Method::Delete, "drives", None) => {
+                parse_unplug_device(VirtioDeviceType::Block, path_tokens.next())
+            }
+            (Method::Delete, "pmem", None) => {
+                parse_unplug_device(VirtioDeviceType::Pmem, path_tokens.next())
+            }
+            (Method::Delete, "network-interfaces", None) => {
+                parse_unplug_device(VirtioDeviceType::Net, path_tokens.next())
+            }
+            (Method::Delete, _, Some(_)) => method_to_error(Method::Delete),
             (method, unknown_uri, _) => Err(RequestError::InvalidPathMethod(
                 unknown_uri.to_string(),
                 method,

--- a/src/firecracker/src/api_server/request/hotplug/mod.rs
+++ b/src/firecracker/src/api_server/request/hotplug/mod.rs
@@ -2,3 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod memory;
+
+use vmm::devices::virtio::device::VirtioDeviceType;
+use vmm::rpc_interface::VmmAction;
+
+use super::super::parsed_request::{ParsedRequest, RequestError, checked_id};
+
+pub(crate) fn parse_unplug_device(
+    device_type: VirtioDeviceType,
+    id_from_path: Option<&str>,
+) -> Result<ParsedRequest, RequestError> {
+    let id = checked_id(id_from_path.ok_or(RequestError::EmptyID)?)?;
+    Ok(ParsedRequest::new_sync(VmmAction::HotUnplugDevice((
+        device_type,
+        id.to_string(),
+    ))))
+}

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -41,6 +41,7 @@ struct ApiServerAdapter {
     from_api: Receiver<ApiRequest>,
     to_api: Sender<ApiResponse>,
     controller: RuntimeApiController,
+    request: Option<ApiRequest>,
 }
 
 impl ApiServerAdapter {
@@ -58,12 +59,14 @@ impl ApiServerAdapter {
             from_api,
             to_api,
             controller: RuntimeApiController::new(vmm.clone()),
+            request: None,
         }));
-        event_manager.add_subscriber(api_adapter);
+        event_manager.add_subscriber(api_adapter.clone());
         loop {
             event_manager
                 .run()
                 .expect("EventManager events driver fatal error");
+            api_adapter.lock().expect("Poisoned lock").handle_request();
 
             match vmm.lock().unwrap().shutdown_exit_code() {
                 Some(FcExitCode::Ok) => break,
@@ -74,13 +77,38 @@ impl ApiServerAdapter {
         Ok(())
     }
 
-    fn handle_request(&mut self, req_action: VmmAction) {
+    fn _handle_request(&mut self, req_action: VmmAction) {
         let response = self.controller.handle_request(req_action);
         // Send back the result.
         self.to_api
             .send(Box::new(response))
             .map_err(|_| ())
             .expect("one-shot channel closed");
+    }
+
+    fn handle_request(&mut self) {
+        if let Some(api_request) = self.request.take() {
+            let request_is_pause = *api_request == VmmAction::Pause;
+            self._handle_request(*api_request);
+
+            // If the latest req is a pause request, temporarily switch to a mode where we
+            // do blocking `recv`s on the `from_api` receiver in a loop, until we get
+            // unpaused. The device emulation is implicitly paused since we do not
+            // relinquish control to the event manager because we're not returning from
+            // `process`.
+            if request_is_pause {
+                // This loop only attempts to process API requests, so things like the
+                // metric flush timerfd handling are frozen as well.
+                loop {
+                    let req = self.from_api.recv().expect("Error receiving API request.");
+                    let req_is_resume = *req == VmmAction::Resume;
+                    self._handle_request(*req);
+                    if req_is_resume {
+                        break;
+                    }
+                }
+            }
+        }
     }
 }
 impl MutEventSubscriber for ApiServerAdapter {
@@ -93,26 +121,7 @@ impl MutEventSubscriber for ApiServerAdapter {
             let _ = self.api_event_fd.read();
             match self.from_api.try_recv() {
                 Ok(api_request) => {
-                    let request_is_pause = *api_request == VmmAction::Pause;
-                    self.handle_request(*api_request);
-
-                    // If the latest req is a pause request, temporarily switch to a mode where we
-                    // do blocking `recv`s on the `from_api` receiver in a loop, until we get
-                    // unpaused. The device emulation is implicitly paused since we do not
-                    // relinquish control to the event manager because we're not returning from
-                    // `process`.
-                    if request_is_pause {
-                        // This loop only attempts to process API requests, so things like the
-                        // metric flush timerfd handling are frozen as well.
-                        loop {
-                            let req = self.from_api.recv().expect("Error receiving API request.");
-                            let req_is_resume = *req == VmmAction::Resume;
-                            self.handle_request(*req);
-                            if req_is_resume {
-                                break;
-                            }
-                        }
-                    }
+                    self.request = Some(api_request);
                 }
                 Err(TryRecvError::Empty) => {
                     warn_unrestricted!("Got a spurious notification from api thread");

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -66,7 +66,10 @@ impl ApiServerAdapter {
             event_manager
                 .run()
                 .expect("EventManager events driver fatal error");
-            api_adapter.lock().expect("Poisoned lock").handle_request();
+            api_adapter
+                .lock()
+                .expect("Poisoned lock")
+                .handle_request(event_manager);
 
             match vmm.lock().unwrap().shutdown_exit_code() {
                 Some(FcExitCode::Ok) => break,
@@ -77,8 +80,8 @@ impl ApiServerAdapter {
         Ok(())
     }
 
-    fn _handle_request(&mut self, req_action: VmmAction) {
-        let response = self.controller.handle_request(req_action);
+    fn _handle_request(&mut self, req_action: VmmAction, event_manager: &mut EventManager) {
+        let response = self.controller.handle_request(req_action, event_manager);
         // Send back the result.
         self.to_api
             .send(Box::new(response))
@@ -86,10 +89,10 @@ impl ApiServerAdapter {
             .expect("one-shot channel closed");
     }
 
-    fn handle_request(&mut self) {
+    fn handle_request(&mut self, event_manager: &mut EventManager) {
         if let Some(api_request) = self.request.take() {
             let request_is_pause = *api_request == VmmAction::Pause;
-            self._handle_request(*api_request);
+            self._handle_request(*api_request, event_manager);
 
             // If the latest req is a pause request, temporarily switch to a mode where we
             // do blocking `recv`s on the `from_api` receiver in a loop, until we get
@@ -102,7 +105,7 @@ impl ApiServerAdapter {
                 loop {
                     let req = self.from_api.recv().expect("Error receiving API request.");
                     let req_is_resume = *req == VmmAction::Resume;
-                    self._handle_request(*req);
+                    self._handle_request(*req, event_manager);
                     if req_is_resume {
                         break;
                     }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -23,7 +23,7 @@ use crate::arch::{RTC_MEM_START, SERIAL_MEM_START};
 #[cfg(target_arch = "aarch64")]
 use crate::devices::legacy::{RTCDevice, SerialDevice};
 use crate::devices::pseudo::BootTimer;
-use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
+use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceId, VirtioDeviceType};
 use crate::devices::virtio::transport::mmio::MmioTransport;
 #[cfg(target_arch = "x86_64")]
 use crate::logger::debug;
@@ -122,7 +122,7 @@ pub struct MMIODevice<T> {
 #[derive(Debug, Default)]
 pub struct MMIODeviceManager {
     /// VirtIO devices using an MMIO transport layer
-    pub(crate) virtio_devices: HashMap<(VirtioDeviceType, String), MMIODevice<MmioTransport>>,
+    pub(crate) virtio_devices: HashMap<VirtioDeviceId, MMIODevice<MmioTransport>>,
     /// Boot timer device
     pub(crate) boot_timer: Option<MMIODevice<BootTimer>>,
     #[cfg(target_arch = "aarch64")]

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -43,8 +43,9 @@ use crate::devices::virtio::pmem::device::Pmem;
 use crate::devices::virtio::pmem::persist::PmemPersistError;
 use crate::devices::virtio::rng::persist::EntropyPersistError;
 use crate::devices::virtio::transport::mmio::{IrqTrigger, MmioTransport};
+use crate::devices::virtio::transport::pci::device::CAPABILITY_BAR_SIZE;
 use crate::devices::virtio::vsock::{VsockError, VsockUnixBackendError};
-use crate::logger::{error, info};
+use crate::logger::{error, info, warn};
 use crate::rate_limiter::TokenBucket;
 use crate::resources::VmResources;
 use crate::rpc_interface::VmmActionError;
@@ -551,14 +552,64 @@ impl DeviceManager {
         Ok(Arc::new(Mutex::new(net)))
     }
 
+    /// Returns true if the given virtio device is a root block or pmem device.
+    fn is_root_device(device: &dyn VirtioDevice) -> bool {
+        if let Some(block) = device.as_any().downcast_ref::<Block>() {
+            return block.root_device();
+        }
+        if let Some(pmem) = device.as_any().downcast_ref::<Pmem>() {
+            return pmem.config.root_device;
+        }
+        false
+    }
+
     /// Detaches a device after VM start
     pub fn hot_unplug_device(
         &mut self,
-        _vm: Arc<Vm>,
-        _device_id: VirtioDeviceId,
-        _event_manager: &mut EventManager,
+        vm: Arc<Vm>,
+        device_id: VirtioDeviceId,
+        event_manager: &mut EventManager,
     ) -> Result<(), VmmActionError> {
-        todo!()
+        if !self.is_pci_enabled() {
+            return Err(VmmActionError::PciNotEnabled);
+        }
+
+        let virtio_device = self
+            .get_virtio_device(device_id.0, &device_id.1)
+            .ok_or(VmmActionError::DeviceNotFound)?;
+
+        if Self::is_root_device(&*virtio_device.lock().expect("Poisoned lock")) {
+            return Err(VmmActionError::CannotUnplugRootDevice);
+        }
+
+        let pci_device_arc = self.pci_devices.virtio_devices.remove(&device_id).unwrap();
+        let pci_device = pci_device_arc.lock().expect("Poisoned lock");
+
+        vm.common
+            .mmio_bus
+            .remove(pci_device.config_bar_addr(), CAPABILITY_BAR_SIZE)
+            .map_err(PciManagerError::Bus)?;
+
+        self.pci_devices
+            .pci_segment
+            .as_ref()
+            .unwrap()
+            .pci_bus
+            .lock()
+            .expect("Poisoned lock")
+            .remove_device(pci_device.sbdf.device());
+
+        if let Some(sub_id) = pci_device.sub_id
+            && event_manager.remove_subscriber(sub_id).is_err()
+        {
+            warn!("Failed to remove event subscriber for device {device_id:?}");
+        }
+
+        // Ensure no other references to the device remain, so it is freed when
+        // this function returns.
+        assert_eq!(Arc::strong_count(&pci_device_arc), 1);
+
+        Ok(())
     }
 }
 

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -34,9 +34,12 @@ use crate::devices::pseudo::BootTimer;
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::balloon::BalloonError;
 use crate::devices::virtio::block::BlockError;
+use crate::devices::virtio::block::device::Block;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::mem::persist::VirtioMemPersistError;
+use crate::devices::virtio::net::Net;
 use crate::devices::virtio::net::persist::NetPersistError;
+use crate::devices::virtio::pmem::device::Pmem;
 use crate::devices::virtio::pmem::persist::PmemPersistError;
 use crate::devices::virtio::rng::persist::EntropyPersistError;
 use crate::devices::virtio::transport::mmio::{IrqTrigger, MmioTransport};
@@ -44,9 +47,14 @@ use crate::devices::virtio::vsock::{VsockError, VsockUnixBackendError};
 use crate::logger::{error, info};
 use crate::rate_limiter::TokenBucket;
 use crate::resources::VmResources;
+use crate::rpc_interface::VmmActionError;
 use crate::snapshot::Persist;
 use crate::utils::open_file_nonblock;
+use crate::vmm_config::HotplugDeviceConfig;
+use crate::vmm_config::drive::{BlockDeviceConfig, DriveError};
 use crate::vmm_config::mmds::MmdsConfigError;
+use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig, NetworkInterfaceError};
+use crate::vmm_config::pmem::{PmemConfig, PmemConfigError};
 use crate::vstate::bus::BusError;
 use crate::vstate::memory::GuestMemoryMmap;
 use crate::{EventManager, Vm};
@@ -463,6 +471,84 @@ impl DeviceManager {
 
     pub fn is_pci_enabled(&self) -> bool {
         self.pci_devices.pci_segment.is_some()
+    }
+
+    /// Attaches a device after VM start
+    pub fn hotplug_device(
+        &mut self,
+        vm: Arc<Vm>,
+        config: HotplugDeviceConfig,
+        event_manager: &mut EventManager,
+    ) -> Result<(), VmmActionError> {
+        if !self.is_pci_enabled() {
+            return Err(VmmActionError::PciNotEnabled);
+        }
+
+        let dev_type = config.device_type();
+        let dev_id = config.device_id().to_string();
+
+        if self
+            .pci_devices
+            .virtio_devices
+            .contains_key(&(dev_type, dev_id.clone()))
+        {
+            return Err(VmmActionError::DeviceIdInUse);
+        }
+
+        let device = match config {
+            HotplugDeviceConfig::Block(cfg) => Self::hotplug_make_block(cfg)?,
+            HotplugDeviceConfig::Pmem(cfg) => Self::hotplug_make_pmem(vm.clone(), cfg)?,
+            HotplugDeviceConfig::Net(cfg) => self.hotplug_make_net(cfg)?,
+        };
+
+        self.pci_devices
+            .attach_pci_virtio_device(&vm, dev_id, device, event_manager)?;
+        Ok(())
+    }
+
+    fn hotplug_make_block(
+        config: BlockDeviceConfig,
+    ) -> Result<Arc<Mutex<dyn VirtioDevice>>, VmmActionError> {
+        if config.is_root_device {
+            return Err(DriveError::RootBlockDeviceAlreadyAdded.into());
+        }
+
+        let block = Block::new(config).map_err(DriveError::CreateBlockDevice)?;
+        Ok(Arc::new(Mutex::new(block)))
+    }
+
+    fn hotplug_make_pmem(
+        vm: Arc<Vm>,
+        config: PmemConfig,
+    ) -> Result<Arc<Mutex<dyn VirtioDevice>>, VmmActionError> {
+        if config.root_device {
+            return Err(PmemConfigError::AddingSecondRootDevice.into());
+        }
+
+        let pmem = Pmem::new(vm.clone(), config).map_err(PmemConfigError::from)?;
+        Ok(Arc::new(Mutex::new(pmem)))
+    }
+
+    fn hotplug_make_net(
+        &self,
+        config: NetworkInterfaceConfig,
+    ) -> Result<Arc<Mutex<dyn VirtioDevice>>, VmmActionError> {
+        if let Some(mac) = config.guest_mac {
+            let mut mac_in_use = false;
+            self.for_each_virtio_device(|_, device| {
+                if let Some(net) = device.as_any().downcast_ref::<Net>()
+                    && net.guest_mac() == Some(&mac)
+                {
+                    mac_in_use = true;
+                }
+            });
+            if mac_in_use {
+                return Err(NetworkInterfaceError::GuestMacAddressInUse(mac.to_string()).into());
+            }
+        }
+
+        let net = NetBuilder::create_net(config)?;
+        Ok(Arc::new(Mutex::new(net)))
     }
 }
 

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -770,7 +770,9 @@ pub(crate) mod tests {
     use super::*;
     use vmm_sys_util::tempfile::TempFile;
 
-    use crate::builder::tests::default_vmm;
+    use crate::builder::tests::{
+        CustomBlockConfig, default_kernel_cmdline, default_vmm, insert_block_devices,
+    };
     use crate::devices::acpi::vmclock::VmClock;
     use crate::devices::acpi::vmgenid::VmGenId;
     use crate::devices::virtio::block::CacheType;
@@ -897,6 +899,24 @@ pub(crate) mod tests {
                 DriveError::RootBlockDeviceAlreadyAdded
             ))
         ));
+
+        // Unplugging a non-existent device fails
+        let device_id = (VirtioDeviceType::Block, "block9".to_string());
+        assert!(matches!(
+            vmm.hot_unplug_device(device_id, &mut evt_manager),
+            Err(VmmActionError::DeviceNotFound)
+        ));
+
+        // Successful unplug
+        let device_id = (VirtioDeviceType::Block, "block0".to_string());
+        vmm.hot_unplug_device(device_id.clone(), &mut evt_manager)
+            .unwrap();
+        assert!(
+            !vmm.device_manager
+                .pci_devices
+                .virtio_devices
+                .contains_key(&device_id)
+        );
     }
 
     #[test]
@@ -908,6 +928,30 @@ pub(crate) mod tests {
         let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
         assert!(matches!(
             vmm.hotplug_device(cfg, &mut evt_manager),
+            Err(VmmActionError::PciNotEnabled)
+        ));
+    }
+
+    #[test]
+    fn test_hotunplug_pci_not_enabled() {
+        let mut vmm = default_vmm();
+        let mut evt_manager = EventManager::new().unwrap();
+        let mut cmdline = default_kernel_cmdline();
+
+        // Add an MMIO block device
+        let block_configs = vec![CustomBlockConfig::new(
+            "root".to_string(),
+            true,
+            None,
+            true,
+            CacheType::Unsafe,
+        )];
+        insert_block_devices(&mut vmm, &mut cmdline, &mut evt_manager, block_configs);
+
+        // Unplugging MMIO devices must be rejected
+        let device_id = (VirtioDeviceType::Block, "root".to_string());
+        assert!(matches!(
+            vmm.hot_unplug_device(device_id, &mut evt_manager),
             Err(VmmActionError::PciNotEnabled)
         ));
     }
@@ -951,6 +995,24 @@ pub(crate) mod tests {
                 PmemConfigError::AddingSecondRootDevice
             ))
         ));
+
+        // Unplugging a non-existent device fails
+        let device_id = (VirtioDeviceType::Pmem, "pmem9".to_string());
+        assert!(matches!(
+            vmm.hot_unplug_device(device_id, &mut evt_manager),
+            Err(VmmActionError::DeviceNotFound)
+        ));
+
+        // Successful unplug
+        let device_id = (VirtioDeviceType::Pmem, "pmem0".to_string());
+        vmm.hot_unplug_device(device_id.clone(), &mut evt_manager)
+            .unwrap();
+        assert!(
+            !vmm.device_manager
+                .pci_devices
+                .virtio_devices
+                .contains_key(&device_id)
+        );
     }
 
     #[test]
@@ -990,6 +1052,90 @@ pub(crate) mod tests {
             Err(VmmActionError::NetworkConfig(
                 NetworkInterfaceError::GuestMacAddressInUse(_)
             ))
+        ));
+
+        // Unplugging a non-existent device fails
+        let device_id = (VirtioDeviceType::Net, "eth9".to_string());
+        assert!(matches!(
+            vmm.hot_unplug_device(device_id, &mut evt_manager),
+            Err(VmmActionError::DeviceNotFound)
+        ));
+
+        // Successful unplug
+        let device_id = (VirtioDeviceType::Net, "eth0".to_string());
+        vmm.hot_unplug_device(device_id.clone(), &mut evt_manager)
+            .unwrap();
+        assert!(
+            !vmm.device_manager
+                .pci_devices
+                .virtio_devices
+                .contains_key(&device_id)
+        );
+    }
+
+    #[test]
+    fn test_unplug_root_block() {
+        let mut evt_manager = EventManager::new().unwrap();
+        let mut vmm = default_vmm();
+        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        let f = TempFile::new().unwrap();
+
+        // Simulate a root block device added pre-boot by attaching it
+        // directly to the PCI bus (bypassing the hotplug path which
+        // rejects root devices).
+        let cfg = make_hotplug_block_cfg("rootfs", &f, true);
+        let block = Block::new(cfg).unwrap();
+        vmm.device_manager
+            .pci_devices
+            .attach_pci_virtio_device(
+                &vmm.vm,
+                "rootfs".to_string(),
+                Arc::new(Mutex::new(block)),
+                &mut evt_manager,
+            )
+            .unwrap();
+
+        // Hot-unplugging the root block device must be rejected
+        let device_id = (VirtioDeviceType::Block, "rootfs".to_string());
+        assert!(matches!(
+            vmm.hot_unplug_device(device_id, &mut evt_manager),
+            Err(VmmActionError::CannotUnplugRootDevice)
+        ));
+    }
+
+    #[test]
+    fn test_unplug_root_pmem() {
+        let mut evt_manager = EventManager::new().unwrap();
+        let mut vmm = default_vmm();
+        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        let f = TempFile::new().unwrap();
+        f.as_file().set_len(0x1000).unwrap();
+
+        // Simulate a root pmem device added pre-boot by attaching it
+        // directly to the PCI bus.
+        let cfg = PmemConfig {
+            id: "pmem_root".to_string(),
+            path_on_host: f.as_path().to_str().unwrap().to_string(),
+            root_device: true,
+            read_only: false,
+            ..Default::default()
+        };
+        let pmem = Pmem::new(vmm.vm.clone(), cfg).unwrap();
+        vmm.device_manager
+            .pci_devices
+            .attach_pci_virtio_device(
+                &vmm.vm,
+                "pmem_root".to_string(),
+                Arc::new(Mutex::new(pmem)),
+                &mut evt_manager,
+            )
+            .unwrap();
+
+        // Hot-unplugging the root pmem device must be rejected
+        let device_id = (VirtioDeviceType::Pmem, "pmem_root".to_string());
+        assert!(matches!(
+            vmm.hot_unplug_device(device_id, &mut evt_manager),
+            Err(VmmActionError::CannotUnplugRootDevice)
         ));
     }
 }

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -35,7 +35,7 @@ use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::balloon::BalloonError;
 use crate::devices::virtio::block::BlockError;
 use crate::devices::virtio::block::device::Block;
-use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
+use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceId, VirtioDeviceType};
 use crate::devices::virtio::mem::persist::VirtioMemPersistError;
 use crate::devices::virtio::net::Net;
 use crate::devices::virtio::net::persist::NetPersistError;
@@ -549,6 +549,16 @@ impl DeviceManager {
 
         let net = NetBuilder::create_net(config)?;
         Ok(Arc::new(Mutex::new(net)))
+    }
+
+    /// Detaches a device after VM start
+    pub fn hot_unplug_device(
+        &mut self,
+        _vm: Arc<Vm>,
+        _device_id: VirtioDeviceId,
+        _event_manager: &mut EventManager,
+    ) -> Result<(), VmmActionError> {
+        todo!()
     }
 }
 

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -768,10 +768,17 @@ impl<'a> Persist<'a> for DeviceManager {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    #[cfg(target_arch = "aarch64")]
+    use vmm_sys_util::tempfile::TempFile;
+
     use crate::builder::tests::default_vmm;
     use crate::devices::acpi::vmclock::VmClock;
     use crate::devices::acpi::vmgenid::VmGenId;
+    use crate::devices::virtio::block::CacheType;
+    use crate::rpc_interface::VmmActionError;
+    use crate::vmm_config::HotplugDeviceConfig;
+    use crate::vmm_config::drive::{BlockDeviceConfig, DriveError};
+    use crate::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceError};
+    use crate::vmm_config::pmem::{PmemConfig, PmemConfigError};
     use crate::vstate::resources::ResourceAllocator;
 
     pub(crate) fn default_device_manager() -> DeviceManager {
@@ -842,5 +849,147 @@ pub(crate) mod tests {
                         .addr
                 ))
         );
+    }
+
+    fn make_hotplug_block_cfg(drive_id: &str, f: &TempFile, is_root: bool) -> BlockDeviceConfig {
+        BlockDeviceConfig {
+            drive_id: drive_id.to_string(),
+            partuuid: None,
+            is_root_device: is_root,
+            cache_type: CacheType::Unsafe,
+            is_read_only: Some(false),
+            path_on_host: Some(f.as_path().to_str().unwrap().to_string()),
+            rate_limiter: None,
+            file_engine_type: None,
+            socket: None,
+        }
+    }
+
+    #[test]
+    fn test_hotplug_block() {
+        let mut evt_manager = EventManager::new().unwrap();
+        let mut vmm = default_vmm();
+        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        let f = TempFile::new().unwrap();
+
+        // Successful case
+        let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
+        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        assert!(
+            vmm.device_manager
+                .pci_devices
+                .virtio_devices
+                .contains_key(&(VirtioDeviceType::Block, "block0".to_string()))
+        );
+
+        // Duplicate device ID is rejected
+        let cfg2 = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
+        assert!(matches!(
+            vmm.hotplug_device(cfg2, &mut evt_manager),
+            Err(VmmActionError::DeviceIdInUse)
+        ));
+
+        // Root block device is rejected
+        let cfg3 = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block1", &f, true));
+        assert!(matches!(
+            vmm.hotplug_device(cfg3, &mut evt_manager),
+            Err(VmmActionError::DriveConfig(
+                DriveError::RootBlockDeviceAlreadyAdded
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_hotplug_pci_not_enabled() {
+        let mut vmm = default_vmm();
+        let mut evt_manager = EventManager::new().unwrap();
+        let f = TempFile::new().unwrap();
+
+        let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
+        assert!(matches!(
+            vmm.hotplug_device(cfg, &mut evt_manager),
+            Err(VmmActionError::PciNotEnabled)
+        ));
+    }
+
+    #[test]
+    fn test_hotplug_pmem() {
+        let mut vmm = default_vmm();
+        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        let mut evt_manager = EventManager::new().unwrap();
+        let f = TempFile::new().unwrap();
+        f.as_file().set_len(0x1000).unwrap();
+
+        // Successful case
+        let cfg = HotplugDeviceConfig::Pmem(PmemConfig {
+            id: "pmem0".to_string(),
+            path_on_host: f.as_path().to_str().unwrap().to_string(),
+            root_device: false,
+            read_only: false,
+            ..Default::default()
+        });
+        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        assert!(
+            vmm.device_manager
+                .pci_devices
+                .virtio_devices
+                .contains_key(&(VirtioDeviceType::Pmem, "pmem0".to_string()))
+        );
+
+        // Root pmem device is rejected
+        let f2 = TempFile::new().unwrap();
+        let cfg2 = HotplugDeviceConfig::Pmem(PmemConfig {
+            id: "pmem1".to_string(),
+            path_on_host: f2.as_path().to_str().unwrap().to_string(),
+            root_device: true,
+            read_only: false,
+            ..Default::default()
+        });
+        assert!(matches!(
+            vmm.hotplug_device(cfg2, &mut evt_manager),
+            Err(VmmActionError::PmemConfig(
+                PmemConfigError::AddingSecondRootDevice
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_hotplug_net() {
+        let mut vmm = default_vmm();
+        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        let mut evt_manager = EventManager::new().unwrap();
+
+        let mac = "AA:FC:00:00:00:01";
+
+        // Successful case
+        let cfg = HotplugDeviceConfig::Net(NetworkInterfaceConfig {
+            iface_id: "eth0".to_string(),
+            host_dev_name: "hostname".to_string(),
+            guest_mac: Some(mac.parse().unwrap()),
+            rx_rate_limiter: None,
+            tx_rate_limiter: None,
+        });
+        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        assert!(
+            vmm.device_manager
+                .pci_devices
+                .virtio_devices
+                .contains_key(&(VirtioDeviceType::Net, "eth0".to_string()))
+        );
+
+        // Duplicate MAC is rejected
+        let cfg2 = HotplugDeviceConfig::Net(NetworkInterfaceConfig {
+            iface_id: "eth1".to_string(),
+            host_dev_name: "hostname2".to_string(),
+            guest_mac: Some(mac.parse().unwrap()),
+            rx_rate_limiter: None,
+            tx_rate_limiter: None,
+        });
+        assert!(matches!(
+            vmm.hotplug_device(cfg2, &mut evt_manager),
+            Err(VmmActionError::NetworkConfig(
+                NetworkInterfaceError::GuestMacAddressInUse(_)
+            ))
+        ));
     }
 }

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -16,7 +16,7 @@ use crate::devices::virtio::balloon::Balloon;
 use crate::devices::virtio::balloon::persist::{BalloonConstructorArgs, BalloonState};
 use crate::devices::virtio::block::device::Block;
 use crate::devices::virtio::block::persist::{BlockConstructorArgs, BlockState};
-use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
+use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceId, VirtioDeviceType};
 use crate::devices::virtio::mem::VirtioMem;
 use crate::devices::virtio::mem::persist::{VirtioMemConstructorArgs, VirtioMemState};
 use crate::devices::virtio::net::Net;
@@ -48,7 +48,7 @@ pub struct PciDevices {
     /// PCIe segment of the VMM, if PCI is enabled. We currently support a single PCIe segment.
     pub pci_segment: Option<PciSegment>,
     /// All VirtIO PCI devices of the system
-    pub virtio_devices: HashMap<(VirtioDeviceType, String), Arc<Mutex<VirtioPciDevice>>>,
+    pub virtio_devices: HashMap<VirtioDeviceId, Arc<Mutex<VirtioPciDevice>>>,
 }
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -137,13 +137,11 @@ impl PciDevices {
         Ok(())
     }
 
-    pub(crate) fn attach_pci_virtio_device<
-        T: 'static + VirtioDevice + MutEventSubscriber + Debug,
-    >(
+    pub(crate) fn attach_pci_virtio_device(
         &mut self,
         vm: &Arc<Vm>,
         id: String,
-        device: Arc<Mutex<T>>,
+        device: Arc<Mutex<dyn VirtioDevice>>,
         event_manager: &mut EventManager,
     ) -> Result<(), PciManagerError> {
         // We should only be reaching this point if PCI is enabled

--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -70,6 +70,9 @@ pub enum VirtioDeviceType {
     Pmem = virtio_ids::VIRTIO_ID_PMEM as u8,
 }
 
+/// Unique identifier for a virtio device: its type and string ID.
+pub type VirtioDeviceId = (VirtioDeviceType, String);
+
 /// Trait for virtio devices to be driven by a virtio transport.
 ///
 /// The lifecycle of a virtio device is to be moved to a virtio transport, which will then query the

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -262,7 +262,7 @@ pub struct VirtioPciDevice {
     pub sub_id: Option<event_manager::SubscriberId>,
 
     // SBDF assigned to the device
-    sbdf: PciSBDF,
+    pub sbdf: PciSBDF,
 
     // PCI configuration registers.
     configuration: PciConfiguration,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -153,6 +153,8 @@ use crate::mmds::data_store::Mmds;
 use crate::persist::{MicrovmState, MicrovmStateError, VmInfo};
 use crate::rate_limiter::BucketUpdate;
 use crate::resources::VmmConfig;
+use crate::rpc_interface::VmmActionError;
+use crate::vmm_config::HotplugDeviceConfig;
 use crate::vmm_config::balloon::BalloonDeviceConfig;
 use crate::vmm_config::boot_source::BootSourceConfig;
 use crate::vmm_config::entropy::EntropyDeviceConfig;
@@ -826,6 +828,17 @@ impl Vmm {
     #[cfg(feature = "gdb")]
     pub fn vm(&self) -> &Vm {
         &self.vm
+    }
+
+    /// Attaches a device after VM start
+    #[inline]
+    pub fn hotplug_device(
+        &mut self,
+        config: HotplugDeviceConfig,
+        event_manager: &mut EventManager,
+    ) -> Result<(), VmmActionError> {
+        self.device_manager
+            .hotplug_device(self.vm.clone(), config, event_manager)
     }
 }
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -141,7 +141,7 @@ use crate::devices::virtio::balloon::{
 };
 use crate::devices::virtio::block::BlockError;
 use crate::devices::virtio::block::device::Block;
-use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
+use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceId, VirtioDeviceType};
 use crate::devices::virtio::mem::device::VirtioMem;
 use crate::devices::virtio::mem::{VIRTIO_MEM_DEV_ID, VirtioMemError, VirtioMemStatus};
 use crate::devices::virtio::net::Net;
@@ -839,6 +839,17 @@ impl Vmm {
     ) -> Result<(), VmmActionError> {
         self.device_manager
             .hotplug_device(self.vm.clone(), config, event_manager)
+    }
+
+    /// Detaches a device after VM start
+    #[inline]
+    pub fn hot_unplug_device(
+        &mut self,
+        device_id: VirtioDeviceId,
+        event_manager: &mut EventManager,
+    ) -> Result<(), VmmActionError> {
+        self.device_manager
+            .hot_unplug_device(self.vm.clone(), device_id, event_manager)
     }
 }
 

--- a/src/vmm/src/pci/bus.rs
+++ b/src/vmm/src/pci/bus.rs
@@ -106,6 +106,10 @@ impl PciBus {
 
     /// Insert a device in the bus
     pub fn add_device(&mut self, device_id: u8, device: Arc<Mutex<dyn PciDevice>>) {
+        assert!(
+            !self.devices.contains_key(&device_id),
+            "PCI device ID {device_id} already in use"
+        );
         self.devices.insert(device_id, device);
     }
 

--- a/src/vmm/src/pci/bus.rs
+++ b/src/vmm/src/pci/bus.rs
@@ -111,6 +111,7 @@ impl PciBus {
             "PCI device ID {device_id} already in use"
         );
         self.devices.insert(device_id, device);
+        self.device_ids[device_id as usize] = true;
     }
 
     /// Get a new device ID

--- a/src/vmm/src/pci/bus.rs
+++ b/src/vmm/src/pci/bus.rs
@@ -114,6 +114,12 @@ impl PciBus {
         self.device_ids[device_id as usize] = true;
     }
 
+    /// Remove a device from the bus and free its device ID slot
+    pub fn remove_device(&mut self, device_id: u8) {
+        self.devices.remove(&device_id);
+        self.device_ids[device_id as usize] = false;
+    }
+
     /// Get a new device ID
     // idx is bounded by NUM_DEVICE_IDS (32), so it always fits in u8.
     #[allow(clippy::cast_possible_truncation)]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -63,9 +63,9 @@ pub enum ResourcesError {
     /// Vsock device error: {0}
     VsockDevice(#[from] VsockConfigError),
     /// Entropy device error: {0}
-    EntropyDevice(#[from] EntropyDeviceError),
+    EntropyConfig(#[from] EntropyDeviceError),
     /// Pmem device error: {0}
-    PmemDevice(#[from] PmemConfigError),
+    PmemConfig(#[from] PmemConfigError),
     /// Memory hotplug config error: {0}
     MemoryHotplugConfig(#[from] MemoryHotplugConfigError),
 }

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -14,6 +14,7 @@ use super::{Vmm, VmmError};
 use crate::EventManager;
 use crate::builder::StartMicrovmError;
 use crate::cpu_config::templates::{CustomCpuTemplate, GuestConfigError};
+use crate::device_manager::pci_mngr::PciManagerError;
 use crate::devices::virtio::balloon::device::{HintingStatus, StartHintingCmd};
 use crate::devices::virtio::mem::VirtioMemStatus;
 use crate::logger::{LoggerConfig, info, warn, *};
@@ -21,6 +22,7 @@ use crate::mmds::data_store::{self, Mmds, MmdsDatastoreError};
 use crate::persist::{CreateSnapshotError, RestoreFromSnapshotError, VmInfo};
 use crate::resources::VmmConfig;
 use crate::seccomp::BpfThreadMap;
+use crate::vmm_config::HotplugDeviceConfig;
 use crate::vmm_config::balloon::{
     BalloonConfigError, BalloonDeviceConfig, BalloonStats, BalloonUpdateConfig,
     BalloonUpdateStatsConfig,
@@ -203,6 +205,12 @@ pub enum VmmActionError {
     StartMicrovm(#[from] StartMicrovmError),
     /// Vsock config error: {0}
     VsockConfig(#[from] VsockConfigError),
+    /// Device ID in use
+    DeviceIdInUse,
+    /// PCI is not enabled
+    PciNotEnabled,
+    /// PCI manager error: {0}
+    PciManager(#[from] PciManagerError),
 }
 
 /// The enum represents the response sent by the VMM in case of success. The response is either
@@ -681,7 +689,7 @@ impl RuntimeApiController {
     pub fn handle_request(
         &mut self,
         request: VmmAction,
-        _event_manager: &mut EventManager,
+        event_manager: &mut EventManager,
     ) -> Result<VmmData, VmmActionError> {
         use self::VmmAction::*;
         match request {
@@ -745,6 +753,24 @@ impl RuntimeApiController {
                     .expect("Poisoned lock"),
                 value,
             ),
+            InsertBlockDevice(config) => self
+                .vmm
+                .lock()
+                .expect("Poisoned lock")
+                .hotplug_device(HotplugDeviceConfig::Block(config), event_manager)
+                .map(|()| VmmData::Empty),
+            InsertPmemDevice(config) => self
+                .vmm
+                .lock()
+                .expect("Poisoned lock")
+                .hotplug_device(HotplugDeviceConfig::Pmem(config), event_manager)
+                .map(|()| VmmData::Empty),
+            InsertNetworkDevice(config) => self
+                .vmm
+                .lock()
+                .expect("Poisoned lock")
+                .hotplug_device(HotplugDeviceConfig::Net(config), event_manager)
+                .map(|()| VmmData::Empty),
             Pause => self.pause(),
             PutMMDS(value) => mmds_put_data(
                 self.vmm
@@ -809,9 +835,6 @@ impl RuntimeApiController {
             | ConfigureLogger(_)
             | ConfigureMetrics(_)
             | ConfigureSerial(_)
-            | InsertBlockDevice(_)
-            | InsertPmemDevice(_)
-            | InsertNetworkDevice(_)
             | LoadSnapshot(_)
             | PutCpuConfiguration(_)
             | SetBalloonDevice(_)
@@ -998,7 +1021,6 @@ mod tests {
     use super::*;
     use crate::HTTP_MAX_PAYLOAD_SIZE;
     use crate::builder::tests::default_vmm;
-    use crate::devices::virtio::block::CacheType;
     use crate::mmds::data_store::MmdsVersion;
     use crate::seccomp::BpfThreadMap;
     use crate::vmm_config::snapshot::{MemBackendConfig, MemBackendType};
@@ -1255,30 +1277,6 @@ mod tests {
                 metrics_path: PathBuf::new(),
             },
         )));
-        check_unsupported(runtime_request(VmmAction::InsertBlockDevice(
-            BlockDeviceConfig {
-                drive_id: String::new(),
-                partuuid: None,
-                is_root_device: false,
-                cache_type: CacheType::Unsafe,
-
-                is_read_only: Some(false),
-                path_on_host: Some(String::new()),
-                rate_limiter: None,
-                file_engine_type: None,
-
-                socket: None,
-            },
-        )));
-        check_unsupported(runtime_request(VmmAction::InsertNetworkDevice(
-            NetworkInterfaceConfig {
-                iface_id: String::new(),
-                host_dev_name: String::new(),
-                guest_mac: None,
-                rx_rate_limiter: None,
-                tx_rate_limiter: None,
-            },
-        )));
         check_unsupported(runtime_request(VmmAction::SetVsockDevice(
             VsockDeviceConfig {
                 vsock_id: Some(String::new()),
@@ -1324,13 +1322,6 @@ mod tests {
         check_unsupported(runtime_request(VmmAction::SetEntropyDevice(
             EntropyDeviceConfig::default(),
         )));
-        check_unsupported(runtime_request(VmmAction::InsertPmemDevice(PmemConfig {
-            id: String::new(),
-            path_on_host: String::new(),
-            root_device: false,
-            read_only: false,
-            ..Default::default()
-        })));
         check_unsupported(runtime_request(VmmAction::SetMemoryHotplugDevice(
             MemoryHotplugConfig::default(),
         )));

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -210,6 +210,10 @@ pub enum VmmActionError {
     VsockConfig(#[from] VsockConfigError),
     /// Device ID in use
     DeviceIdInUse,
+    /// Device not found
+    DeviceNotFound,
+    /// Cannot unplug root device
+    CannotUnplugRootDevice,
     /// PCI is not enabled
     PciNotEnabled,
     /// PCI manager error: {0}

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -16,6 +16,7 @@ use crate::builder::StartMicrovmError;
 use crate::cpu_config::templates::{CustomCpuTemplate, GuestConfigError};
 use crate::device_manager::pci_mngr::PciManagerError;
 use crate::devices::virtio::balloon::device::{HintingStatus, StartHintingCmd};
+use crate::devices::virtio::device::VirtioDeviceId;
 use crate::devices::virtio::mem::VirtioMemStatus;
 use crate::logger::{LoggerConfig, info, warn, *};
 use crate::mmds::data_store::{self, Mmds, MmdsDatastoreError};
@@ -150,6 +151,8 @@ pub enum VmmAction {
     /// Update the microVM configuration (memory & vcpu) using `VmUpdateConfig` as input. This
     /// action can only be called before the microVM has booted.
     UpdateMachineConfiguration(MachineConfigUpdate),
+    /// Hot-unplug a device.
+    HotUnplugDevice(VirtioDeviceId),
 }
 
 /// Wrapper for all errors associated with VMM actions.
@@ -507,7 +510,8 @@ impl<'a> PrebootApiController<'a> {
             | UpdatePmemDevice(_)
             | StartFreePageHinting(_)
             | GetFreePageHintingStatus
-            | StopFreePageHinting => Err(VmmActionError::OperationNotSupportedPreBoot),
+            | StopFreePageHinting
+            | HotUnplugDevice(_) => Err(VmmActionError::OperationNotSupportedPreBoot),
             #[cfg(target_arch = "x86_64")]
             SendCtrlAltDel => Err(VmmActionError::OperationNotSupportedPreBoot),
         }
@@ -770,6 +774,12 @@ impl RuntimeApiController {
                 .lock()
                 .expect("Poisoned lock")
                 .hotplug_device(HotplugDeviceConfig::Net(config), event_manager)
+                .map(|()| VmmData::Empty),
+            HotUnplugDevice(device_id) => self
+                .vmm
+                .lock()
+                .expect("Poisoned lock")
+                .hot_unplug_device(device_id, event_manager)
                 .map(|()| VmmData::Empty),
             Pause => self.pause(),
             PutMMDS(value) => mmds_put_data(

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -165,10 +165,10 @@ pub enum VmmActionError {
     ConfigureCpu(#[from] GuestConfigError),
     /// Drive config error: {0}
     DriveConfig(#[from] DriveError),
-    /// Entropy device error: {0}
-    EntropyDevice(#[from] EntropyDeviceError),
-    /// Pmem device error: {0}
-    PmemDevice(#[from] PmemConfigError),
+    /// Entropy config error: {0}
+    EntropyConfig(#[from] EntropyDeviceError),
+    /// Pmem config error: {0}
+    PmemConfig(#[from] PmemConfigError),
     /// Memory hotplug config error: {0}
     MemoryHotplugConfig(#[from] MemoryHotplugConfigError),
     /// Memory hotplug update error: {0}
@@ -537,7 +537,7 @@ impl<'a> PrebootApiController<'a> {
         self.vm_resources
             .build_pmem_device(cfg)
             .map(|()| VmmData::Empty)
-            .map_err(VmmActionError::PmemDevice)
+            .map_err(VmmActionError::PmemConfig)
     }
 
     fn set_balloon_device(&mut self, cfg: BalloonDeviceConfig) -> Result<VmmData, VmmActionError> {

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -678,7 +678,11 @@ pub struct RuntimeApiController {
 
 impl RuntimeApiController {
     /// Handles the incoming runtime `VmmAction` request and provides a response for it.
-    pub fn handle_request(&mut self, request: VmmAction) -> Result<VmmData, VmmActionError> {
+    pub fn handle_request(
+        &mut self,
+        request: VmmAction,
+        _event_manager: &mut EventManager,
+    ) -> Result<VmmData, VmmActionError> {
         use self::VmmAction::*;
         match request {
             // Supported operations allowed post-boot.
@@ -1214,7 +1218,8 @@ mod tests {
     fn runtime_request(request: VmmAction) -> Result<VmmData, VmmActionError> {
         let vmm = Arc::new(Mutex::new(default_vmm()));
         let mut runtime = RuntimeApiController::new(vmm.clone());
-        runtime.handle_request(request)
+        let mut event_manager = EventManager::new().unwrap();
+        runtime.handle_request(request, &mut event_manager)
     }
 
     #[test]

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -6,7 +6,11 @@ use std::io;
 
 use serde::{Deserialize, Serialize};
 
+use crate::devices::virtio::device::VirtioDeviceType;
 use crate::rate_limiter::{BucketUpdate, RateLimiter, TokenBucket};
+use crate::vmm_config::drive::BlockDeviceConfig;
+use crate::vmm_config::net::NetworkInterfaceConfig;
+use crate::vmm_config::pmem::PmemConfig;
 
 /// Wrapper for configuring the balloon device.
 pub mod balloon;
@@ -35,6 +39,32 @@ pub mod serial;
 pub mod snapshot;
 /// Wrapper for configuring the vsock devices attached to the microVM.
 pub mod vsock;
+
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub enum HotplugDeviceConfig {
+    Block(BlockDeviceConfig),
+    Pmem(PmemConfig),
+    Net(NetworkInterfaceConfig),
+}
+
+impl HotplugDeviceConfig {
+    pub(crate) fn device_id(&self) -> &str {
+        match self {
+            Self::Block(cfg) => &cfg.drive_id,
+            Self::Pmem(cfg) => &cfg.id,
+            Self::Net(cfg) => &cfg.iface_id,
+        }
+    }
+
+    pub(crate) fn device_type(&self) -> VirtioDeviceType {
+        match self {
+            Self::Block(_) => VirtioDeviceType::Block,
+            Self::Pmem(_) => VirtioDeviceType::Pmem,
+            Self::Net(_) => VirtioDeviceType::Net,
+        }
+    }
+}
 
 // TODO: Migrate the VMM public-facing code (i.e. interface) to use stateless structures,
 // for receiving data/args, such as the below `RateLimiterConfig` and `TokenBucketConfig`.

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -103,14 +103,21 @@ fn test_build_microvm() {
 
 fn pause_resume_microvm(vmm: Arc<Mutex<Vmm>>) {
     let mut api_controller = RuntimeApiController::new(vmm.clone());
+    let mut event_manager = EventManager::new().unwrap();
 
     // There's a race between this thread and the vcpu thread, but this thread
     // should be able to pause vcpu thread before it finishes running its test-binary.
-    api_controller.handle_request(VmmAction::Pause).unwrap();
+    api_controller
+        .handle_request(VmmAction::Pause, &mut event_manager)
+        .unwrap();
     // Pausing again the microVM should not fail (microVM remains in the
     // `Paused` state).
-    api_controller.handle_request(VmmAction::Pause).unwrap();
-    api_controller.handle_request(VmmAction::Resume).unwrap();
+    api_controller
+        .handle_request(VmmAction::Pause, &mut event_manager)
+        .unwrap();
+    api_controller
+        .handle_request(VmmAction::Resume, &mut event_manager)
+        .unwrap();
 
     vmm.lock().unwrap().stop(FcExitCode::Ok);
 }
@@ -213,12 +220,15 @@ fn verify_create_snapshot(
 
     let vm_info = VmInfo::from(&*vmm.lock().unwrap());
     let mut controller = RuntimeApiController::new(vmm.clone());
+    let mut event_manager = EventManager::new().unwrap();
 
     // Be sure that the microVM is running.
     thread::sleep(Duration::from_millis(200));
 
     // Pause microVM.
-    controller.handle_request(VmmAction::Pause).unwrap();
+    controller
+        .handle_request(VmmAction::Pause, &mut event_manager)
+        .unwrap();
 
     // Create snapshot.
     let snapshot_type = match is_diff {
@@ -232,7 +242,10 @@ fn verify_create_snapshot(
     };
 
     controller
-        .handle_request(VmmAction::CreateSnapshot(snapshot_params))
+        .handle_request(
+            VmmAction::CreateSnapshot(snapshot_params),
+            &mut event_manager,
+        )
         .unwrap();
 
     vmm.lock().unwrap().stop(FcExitCode::Ok);

--- a/tests/framework/http_api.py
+++ b/tests/framework/http_api.py
@@ -84,6 +84,22 @@ class Resource:
 
         return res
 
+    def delete(self, resource_id):
+        """Make a DELETE request"""
+        path = self.resource + "/" + resource_id
+        url = self._api.endpoint + path
+        try:
+            res = self._api.session.delete(url)
+        except Exception as e:
+            if self._api.error_callback:
+                self._api.error_callback("DELETE", path, str(e))
+            raise
+        if res.status_code != HTTPStatus.NO_CONTENT:
+            json = res.json()
+            msg = json.get("fault_message", json.get("error", res.content))
+            raise RuntimeError(msg, json, res)
+        return res
+
     def request(self, method, path, **kwargs):
         """Make an HTTP request"""
         kwargs = {key: val for key, val in kwargs.items() if val is not None}

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -452,7 +452,7 @@ def test_api_cpu_config(uvm_plain, custom_cpu_template):
     test_microvm.api.cpu_config.put(**custom_cpu_template["template"])
 
 
-def test_api_put_update_post_boot(uvm_plain, io_engine):
+def test_api_put_update_post_boot(uvm_plain):
     """
     Test that PUT updates are rejected after the microvm boots.
     """
@@ -485,22 +485,6 @@ def test_api_put_update_post_boot(uvm_plain, io_engine):
 
     with pytest.raises(RuntimeError, match=NOT_SUPPORTED_AFTER_START):
         test_microvm.api.machine_config.put(vcpu_count=4, mem_size_mib=128)
-
-    # Network interface update is not allowed after boot.
-    with pytest.raises(RuntimeError, match=NOT_SUPPORTED_AFTER_START):
-        test_microvm.api.network.put(
-            iface_id="1", host_dev_name=tap1.name, guest_mac="06:00:00:00:00:02"
-        )
-
-    # Block device update is not allowed after boot.
-    with pytest.raises(RuntimeError, match=NOT_SUPPORTED_AFTER_START):
-        test_microvm.api.drive.put(
-            drive_id="rootfs",
-            path_on_host=test_microvm.jailer.jailed_path(test_microvm.rootfs_file),
-            is_read_only=False,
-            is_root_device=True,
-            io_engine=io_engine,
-        )
 
     # MMDS config is not allowed post-boot.
     mmds_config = {
@@ -1216,10 +1200,6 @@ def test_pmem_rate_limiter_api(uvm_plain_any, rootfs):
     # Boot with pmem as rootfs.
     vm.add_pmem("rootfs", rootfs, True, True)
     vm.start()
-
-    # PUT pmem after boot is not allowed.
-    with pytest.raises(RuntimeError, match=NOT_SUPPORTED_AFTER_START):
-        vm.api.pmem.put(id="pmem0", path_on_host=pmem_file_path)
 
     # PATCH pmem rate limiter after boot should succeed.
     vm.api.pmem.patch(

--- a/tests/integration_tests/functional/test_hotplug.py
+++ b/tests/integration_tests/functional/test_hotplug.py
@@ -1,0 +1,387 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for PCI device hotplug"""
+
+import os
+
+import pytest
+
+import host_tools.drive as drive_tools
+import host_tools.network as net_tools
+
+VIRTIO_PCI_VENDOR_ID = 0x1AF4
+VIRTIO_PCI_DEVICE_ID_NET = 0x1041
+VIRTIO_PCI_DEVICE_ID_BLOCK = 0x1042
+VIRTIO_PCI_DEVICE_ID_PMEM = 0x105B
+
+
+def test_hotplug_block(uvm_any_with_pci):
+    """
+    Test hotplugging a block device after VM start.
+    Test that the device appears in lspci and is usable.
+    Test that invalid hotplug request are rejected.
+    """
+    vm = uvm_any_with_pci
+
+    # Snapshot lspci output before hotplug
+    _, lspci_before, _ = vm.ssh.check_output("lspci -n")
+
+    # Hotplug a block device
+    host_file = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "block0"), size=4)
+    vm.api.drive.put(
+        drive_id="block0",
+        path_on_host=vm.create_jailed_resource(host_file.path),
+        is_root_device=False,
+        is_read_only=False,
+        rate_limiter={
+            "ops": {"size": 100, "refill_time": 100},
+        },
+    )
+
+    # Rescan PCI bus since no hotplug notification mechanism exists yet
+    vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
+
+    # Verify a new virtio-block device entry appeared in lspci
+    _, lspci_after, _ = vm.ssh.check_output("lspci -n")
+    new_entries = set(lspci_after.splitlines()) - set(lspci_before.splitlines())
+    assert len(new_entries) == 1
+    entry = new_entries.pop()
+    assert f"{VIRTIO_PCI_VENDOR_ID:04x}:{VIRTIO_PCI_DEVICE_ID_BLOCK:04x}" in entry
+
+    # Discover the block device node from the PCI BDF via sysfs
+    bdf = entry.split()[0]
+    _, dev_name, _ = vm.ssh.check_output(
+        f"ls /sys/bus/pci/devices/0000:{bdf}/virtio*/block/"
+    )
+    dev_path = f"/dev/{dev_name.strip()}"
+
+    # Ensure the device is usable by writing a file to it and reading it back
+    vm.ssh.check_output("mkdir -p /tmp/block0_mnt")
+    vm.ssh.check_output(f"mount {dev_path} /tmp/block0_mnt")
+    vm.ssh.check_output("echo hotplug_test > /tmp/block0_mnt/test")
+    _, stdout, _ = vm.ssh.check_output("cat /tmp/block0_mnt/test")
+    assert stdout.strip() == "hotplug_test"
+
+    # Hotplugging a device with a duplicate ID must be rejected
+    with pytest.raises(RuntimeError, match="Device ID in use"):
+        vm.api.drive.put(
+            drive_id="block0",
+            path_on_host=vm.create_jailed_resource(host_file.path),
+            is_root_device=False,
+            is_read_only=False,
+        )
+
+    # Hotplugging a root device must be rejected
+    with pytest.raises(RuntimeError, match="A root block device already exists"):
+        vm.api.drive.put(
+            drive_id="block_root",
+            path_on_host=vm.create_jailed_resource(host_file.path),
+            is_root_device=True,
+            is_read_only=False,
+        )
+
+    # Hotplugging with a non-existent backing file must be rejected
+    with pytest.raises(RuntimeError, match="No such file or directory"):
+        vm.api.drive.put(
+            drive_id="block_bad",
+            path_on_host="/nonexistent",
+            is_root_device=False,
+            is_read_only=False,
+        )
+
+    # Verify no further devices appeared after the rejected requests
+    vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
+    _, lspci_final, _ = vm.ssh.check_output("lspci -n")
+    assert lspci_final == lspci_after
+
+
+def test_hotplug_pmem(uvm_any_with_pci):
+    """
+    Test hotplugging a pmem device after VM start.
+    Test that the device appears in lspci and is usable.
+    Test that invalid hotplug request are rejected.
+    """
+    vm = uvm_any_with_pci
+
+    # Snapshot lspci output before hotplug
+    _, lspci_before, _ = vm.ssh.check_output("lspci -n")
+
+    # Hotplug a pmem device
+    host_file = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "pmem0"), size=4)
+    vm.api.pmem.put(
+        id="pmem0",
+        path_on_host=vm.create_jailed_resource(host_file.path),
+        root_device=False,
+        read_only=False,
+    )
+
+    # Rescan PCI bus since no hotplug notification mechanism exists yet
+    vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
+
+    # Verify a new virtio-pmem device entry appeared in lspci
+    _, lspci_after, _ = vm.ssh.check_output("lspci -n")
+    new_entries = set(lspci_after.splitlines()) - set(lspci_before.splitlines())
+    assert len(new_entries) == 1
+    entry = new_entries.pop()
+    assert f"{VIRTIO_PCI_VENDOR_ID:04x}:{VIRTIO_PCI_DEVICE_ID_PMEM:04x}" in entry
+
+    # Discover the pmem device node from the PCI BDF via sysfs.
+    # The NVDIMM subsystem in the guest creates the ndbus/region/namespace/block
+    # hierarchy asynchronously after driver probe, so we need to wait for it.
+    vm.ssh.check_output("sleep 1")
+    bdf = entry.split()[0]
+    _, dev_name, _ = vm.ssh.check_output(
+        f"ls /sys/bus/pci/devices/0000:{bdf}/virtio*/ndbus*/region*/namespace*/block/"
+    )
+    dev_path = f"/dev/{dev_name.strip()}"
+
+    # Ensure the device is usable by writing a file to it and reading it back
+    vm.ssh.check_output("mkdir -p /tmp/pmem0_mnt")
+    vm.ssh.check_output(f"mount {dev_path} /tmp/pmem0_mnt")
+    vm.ssh.check_output("echo hotplug_test > /tmp/pmem0_mnt/test")
+    _, stdout, _ = vm.ssh.check_output("cat /tmp/pmem0_mnt/test")
+    assert stdout.strip() == "hotplug_test"
+
+    # Hotplugging a root pmem device must be rejected
+    with pytest.raises(RuntimeError, match="Attempt to add pmem as a root device"):
+        vm.api.pmem.put(
+            id="pmem_root",
+            path_on_host=vm.create_jailed_resource(host_file.path),
+            root_device=True,
+            read_only=False,
+        )
+
+    # Hotplugging a device with a duplicate ID must be rejected
+    with pytest.raises(RuntimeError, match="Device ID in use"):
+        vm.api.pmem.put(
+            id="pmem0",
+            path_on_host=vm.create_jailed_resource(host_file.path),
+            root_device=False,
+            read_only=False,
+        )
+
+    # Hotplugging with a non-existent backing file must be rejected
+    with pytest.raises(RuntimeError, match="No such file or directory"):
+        vm.api.pmem.put(
+            id="pmem_bad",
+            path_on_host="/nonexistent",
+            root_device=False,
+            read_only=False,
+        )
+
+    # Verify no further devices appeared after the rejected requests
+    vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
+    _, lspci_final, _ = vm.ssh.check_output("lspci -n")
+    assert lspci_final == lspci_after
+
+
+def test_hotplug_net(uvm_any_with_pci):
+    """
+    Test hotplugging a net device after VM start.
+    Test that the device appears in lspci and is usable.
+    Test that invalid hotplug request are rejected.
+    """
+    vm = uvm_any_with_pci
+
+    # Snapshot lspci output before hotplug
+    _, lspci_before, _ = vm.ssh.check_output("lspci -n")
+
+    # Hotplug a network device
+    iface1 = net_tools.NetIfaceConfig.with_id(1)
+    vm.netns.add_tap(iface1.tap_name, ip=f"{iface1.host_ip}/{iface1.netmask_len}")
+    vm.api.network.put(
+        iface_id=iface1.dev_name,
+        host_dev_name=iface1.tap_name,
+        guest_mac=iface1.guest_mac,
+    )
+
+    # Rescan PCI bus since no hotplug notification mechanism exists yet
+    vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
+
+    # Verify a new net device entry appeared in lspci
+    _, lspci_after, _ = vm.ssh.check_output("lspci -n")
+    new_entries = set(lspci_after.splitlines()) - set(lspci_before.splitlines())
+    assert len(new_entries) == 1
+    entry = new_entries.pop()
+    assert f"{VIRTIO_PCI_VENDOR_ID:04x}:{VIRTIO_PCI_DEVICE_ID_NET:04x}" in entry
+
+    # Discover the net interface name from the PCI BDF via sysfs
+    bdf = entry.split()[0]
+    _, iface_name, _ = vm.ssh.check_output(
+        f"ls /sys/bus/pci/devices/0000:{bdf}/virtio*/net/"
+    )
+    iface_name = iface_name.strip()
+
+    # Verify the hotplugged interface is usable
+    vm.ssh.check_output(f"ip link show {iface_name}")
+    vm.ssh.check_output(
+        f"ip addr add {iface1.guest_ip}/{iface1.netmask_len} dev {iface_name}"
+    )
+    vm.ssh.check_output(f"ip link set {iface_name} up")
+
+    # Ping the host from the guest through the hotplugged interface
+    _, stdout, _ = vm.ssh.check_output(f"ping -c 3 -W 3 {iface1.host_ip}")
+    assert "3 packets transmitted, 3 received" in stdout
+
+    # Hotplugging a device with a duplicate ID must be rejected
+    iface2 = net_tools.NetIfaceConfig.with_id(2)
+    with pytest.raises(RuntimeError, match="Device ID in use"):
+        vm.api.network.put(
+            iface_id=iface1.dev_name,
+            host_dev_name=iface2.tap_name,
+            guest_mac=iface2.guest_mac,
+        )
+
+    # Hotplugging a device with a duplicate MAC must be rejected
+    with pytest.raises(RuntimeError, match="The MAC address is already in use"):
+        vm.api.network.put(
+            iface_id=iface2.dev_name,
+            host_dev_name=iface2.tap_name,
+            guest_mac=iface1.guest_mac,
+        )
+
+    # Hotplugging a device that reuses the same TAP must be rejected
+    with pytest.raises(RuntimeError, match="Resource busy"):
+        vm.api.network.put(
+            iface_id=iface2.dev_name,
+            host_dev_name=iface1.tap_name,
+            guest_mac=iface2.guest_mac,
+        )
+
+    # Hotplugging with a non-existent tap device must be rejected
+    with pytest.raises(RuntimeError, match="Open tap device failed"):
+        vm.api.network.put(
+            iface_id="eth_bad",
+            host_dev_name="nonexistent_tap",
+        )
+
+    # Verify no further devices appeared after the rejected requests
+    vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
+    _, lspci_final, _ = vm.ssh.check_output("lspci -n")
+    assert lspci_final == lspci_after
+
+
+def test_hotplug_no_pci(uvm_any_without_pci):
+    """
+    Hotplugging any device type must be rejected when PCI is not enabled.
+    """
+    vm = uvm_any_without_pci
+
+    host_file = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "disk"), size=4)
+
+    with pytest.raises(RuntimeError, match="PCI is not enabled"):
+        vm.api.drive.put(
+            drive_id="block0",
+            path_on_host=vm.create_jailed_resource(host_file.path),
+            is_root_device=False,
+            is_read_only=False,
+        )
+
+    with pytest.raises(RuntimeError, match="PCI is not enabled"):
+        vm.api.pmem.put(
+            id="pmem0",
+            path_on_host=vm.create_jailed_resource(host_file.path),
+            root_device=False,
+            read_only=False,
+        )
+
+    iface1 = net_tools.NetIfaceConfig.with_id(1)
+    vm.netns.add_tap(iface1.tap_name, ip=f"{iface1.host_ip}/{iface1.netmask_len}")
+    with pytest.raises(RuntimeError, match="PCI is not enabled"):
+        vm.api.network.put(
+            iface_id=iface1.dev_name,
+            host_dev_name=iface1.tap_name,
+            guest_mac=iface1.guest_mac,
+        )
+
+
+def test_hotplug_preserved_after_snapshot(uvm_any_with_pci, microvm_factory):
+    """
+    Test that a hotplugged device survives a full snapshot/restore cycle.
+    """
+    vm = uvm_any_with_pci
+
+    # Snapshot lspci output before hotplug
+    _, lspci_before, _ = vm.ssh.check_output("lspci -n")
+
+    # Hotplug a block device
+    host_file = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "block0"), size=4)
+    vm.api.drive.put(
+        drive_id="block0",
+        path_on_host=vm.create_jailed_resource(host_file.path),
+        is_root_device=False,
+        is_read_only=False,
+    )
+    vm.disks["block0"] = host_file.path
+
+    # Take a full snapshot and restore
+    snapshot = vm.snapshot_full()
+    restored_vm = microvm_factory.build_from_snapshot(snapshot)
+    restored_vm.resume()
+
+    # Rescan PCI bus since no hotplug notification mechanism exists yet
+    restored_vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
+
+    # Verify a new virtio-block device entry appeared in lspci
+    _, lspci_after, _ = restored_vm.ssh.check_output("lspci -n")
+    new_entries = set(lspci_after.splitlines()) - set(lspci_before.splitlines())
+    assert len(new_entries) == 1
+    entry = new_entries.pop()
+    assert f"{VIRTIO_PCI_VENDOR_ID:04x}:{VIRTIO_PCI_DEVICE_ID_BLOCK:04x}" in entry
+
+    # Discover the block device node from the PCI BDF via sysfs
+    bdf = entry.split()[0]
+    _, dev_name, _ = restored_vm.ssh.check_output(
+        f"ls /sys/bus/pci/devices/0000:{bdf}/virtio*/block/"
+    )
+    dev_path = f"/dev/{dev_name.strip()}"
+
+    # Ensure the device is usable by writing a file to it and reading it back
+    restored_vm.ssh.check_output("mkdir -p /tmp/block0_mnt")
+    restored_vm.ssh.check_output(f"mount {dev_path} /tmp/block0_mnt")
+    restored_vm.ssh.check_output("echo hotplug_test > /tmp/block0_mnt/test")
+    _, stdout, _ = restored_vm.ssh.check_output("cat /tmp/block0_mnt/test")
+    assert stdout.strip() == "hotplug_test"
+
+
+def test_hotplug_max_devices(uvm_any_with_pci):
+    """
+    Test that hotplugging more devices than available PCI slots is rejected.
+    """
+    pci_max_slots = 32
+    vm = uvm_any_with_pci
+
+    # Count how many PCI slots are already in use
+    _, lspci, _ = vm.ssh.check_output("lspci -n")
+    used_slots = len(lspci.strip().splitlines())
+    free_slots = pci_max_slots - used_slots
+
+    for i in range(free_slots):
+        host_file = drive_tools.FilesystemFile(
+            os.path.join(vm.fsfiles, f"block{i}"), size=1
+        )
+        vm.api.drive.put(
+            drive_id=f"block{i}",
+            path_on_host=vm.create_jailed_resource(host_file.path),
+            is_root_device=False,
+            is_read_only=False,
+        )
+
+    # Verify all PCI slots are occupied
+    vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
+    _, lspci, _ = vm.ssh.check_output("lspci -n")
+    assert len(lspci.strip().splitlines()) == pci_max_slots
+
+    # The next hotplug must fail — no PCI slots left
+    host_file = drive_tools.FilesystemFile(
+        os.path.join(vm.fsfiles, "block_overflow"), size=1
+    )
+    with pytest.raises(
+        RuntimeError, match="Could not find an available device slot on the PCI bus"
+    ):
+        vm.api.drive.put(
+            drive_id="block_overflow",
+            path_on_host=vm.create_jailed_resource(host_file.path),
+            is_root_device=False,
+            is_read_only=False,
+        )

--- a/tests/integration_tests/functional/test_hotplug.py
+++ b/tests/integration_tests/functional/test_hotplug.py
@@ -20,6 +20,7 @@ def test_hotplug_block(uvm_any_with_pci):
     Test hotplugging a block device after VM start.
     Test that the device appears in lspci and is usable.
     Test that invalid hotplug request are rejected.
+    Test hot-unplugging the device.
     """
     vm = uvm_any_with_pci
 
@@ -94,12 +95,37 @@ def test_hotplug_block(uvm_any_with_pci):
     _, lspci_final, _ = vm.ssh.check_output("lspci -n")
     assert lspci_final == lspci_after
 
+    # Unplugging a non-existent device must be rejected
+    with pytest.raises(RuntimeError, match="Device not found"):
+        vm.api.drive.delete("nonexistent")
+
+    # Unplugging the root block device must be rejected
+    with pytest.raises(RuntimeError, match="Cannot unplug root device"):
+        vm.api.drive.delete("rootfs")
+
+    # No unplug notification mechanism exists yet, so the guest needs to
+    # gracefully prepare for the detach before the host issues the unplug.
+    vm.ssh.check_output("umount /tmp/block0_mnt")
+    vm.ssh.check_output(f"echo 1 > /sys/bus/pci/devices/0000:{bdf}/remove")
+
+    # Unplug the block device
+    vm.api.drive.delete("block0")
+
+    # Verify the device is gone
+    _, lspci_after_unplug, _ = vm.ssh.check_output("lspci -n")
+    assert lspci_after_unplug == lspci_before
+
+    # Unplugging the same device again must be rejected
+    with pytest.raises(RuntimeError, match="Device not found"):
+        vm.api.drive.delete("block0")
+
 
 def test_hotplug_pmem(uvm_any_with_pci):
     """
     Test hotplugging a pmem device after VM start.
     Test that the device appears in lspci and is usable.
     Test that invalid hotplug request are rejected.
+    Test hot-unplugging the device.
     """
     vm = uvm_any_with_pci
 
@@ -174,12 +200,33 @@ def test_hotplug_pmem(uvm_any_with_pci):
     _, lspci_final, _ = vm.ssh.check_output("lspci -n")
     assert lspci_final == lspci_after
 
+    # Unplugging a non-existent device must be rejected
+    with pytest.raises(RuntimeError, match="Device not found"):
+        vm.api.pmem.delete("nonexistent")
+
+    # No unplug notification mechanism exists yet, so the guest needs to
+    # gracefully prepare for the detach before the host issues the unplug.
+    vm.ssh.check_output("umount /tmp/pmem0_mnt")
+    vm.ssh.check_output(f"echo 1 > /sys/bus/pci/devices/0000:{bdf}/remove")
+
+    # Unplug the pmem device
+    vm.api.pmem.delete("pmem0")
+
+    # Verify the device is gone
+    _, lspci_after_unplug, _ = vm.ssh.check_output("lspci -n")
+    assert lspci_after_unplug == lspci_before
+
+    # Unplugging the same device again must be rejected
+    with pytest.raises(RuntimeError, match="Device not found"):
+        vm.api.pmem.delete("pmem0")
+
 
 def test_hotplug_net(uvm_any_with_pci):
     """
     Test hotplugging a net device after VM start.
     Test that the device appears in lspci and is usable.
     Test that invalid hotplug request are rejected.
+    Test hot-unplugging the device.
     """
     vm = uvm_any_with_pci
 
@@ -260,10 +307,48 @@ def test_hotplug_net(uvm_any_with_pci):
     _, lspci_final, _ = vm.ssh.check_output("lspci -n")
     assert lspci_final == lspci_after
 
+    # Unplugging a non-existent device must be rejected
+    with pytest.raises(RuntimeError, match="Device not found"):
+        vm.api.network.delete("nonexistent")
+
+    # No unplug notification mechanism exists yet, so the guest needs to
+    # gracefully prepare for the detach before the host issues the unplug.
+    vm.ssh.check_output(f"ip link set {iface_name} down")
+    vm.ssh.check_output(f"echo 1 > /sys/bus/pci/devices/0000:{bdf}/remove")
+
+    # Unplug the net device
+    vm.api.network.delete(iface1.dev_name)
+
+    # Verify the device is gone
+    _, lspci_after_unplug, _ = vm.ssh.check_output("lspci -n")
+    assert lspci_after_unplug == lspci_before
+
+    # Unplugging the same device again must be rejected
+    with pytest.raises(RuntimeError, match="Device not found"):
+        vm.api.network.delete(iface1.dev_name)
+
+
+def test_unplug_root_pmem(microvm_factory, guest_kernel_acpi, rootfs):
+    """
+    Unplugging the root pmem device must be rejected.
+    """
+    vm = microvm_factory.build(guest_kernel_acpi, rootfs, pci=True)
+    vm.memory_monitor = None
+    vm.monitors = []
+    vm.spawn()
+    vm.basic_config(add_root_device=False)
+    vm.add_pmem("pmem_root", rootfs, root_device=True)
+    vm.add_net_iface()
+    vm.start()
+
+    with pytest.raises(RuntimeError, match="Cannot unplug root device"):
+        vm.api.pmem.delete("pmem_root")
+
 
 def test_hotplug_no_pci(uvm_any_without_pci):
     """
-    Hotplugging any device type must be rejected when PCI is not enabled.
+    Hotplugging and unplugging any device type must be rejected when PCI is not
+    enabled.
     """
     vm = uvm_any_without_pci
 
@@ -293,6 +378,15 @@ def test_hotplug_no_pci(uvm_any_without_pci):
             host_dev_name=iface1.tap_name,
             guest_mac=iface1.guest_mac,
         )
+
+    with pytest.raises(RuntimeError, match="PCI is not enabled"):
+        vm.api.drive.delete("block0")
+
+    with pytest.raises(RuntimeError, match="PCI is not enabled"):
+        vm.api.pmem.delete("pmem0")
+
+    with pytest.raises(RuntimeError, match="PCI is not enabled"):
+        vm.api.network.delete("eth0")
 
 
 def test_hotplug_preserved_after_snapshot(uvm_any_with_pci, microvm_factory):
@@ -352,8 +446,8 @@ def test_hotplug_max_devices(uvm_any_with_pci):
     vm = uvm_any_with_pci
 
     # Count how many PCI slots are already in use
-    _, lspci, _ = vm.ssh.check_output("lspci -n")
-    used_slots = len(lspci.strip().splitlines())
+    _, lspci_initial, _ = vm.ssh.check_output("lspci -n")
+    used_slots = len(lspci_initial.strip().splitlines())
     free_slots = pci_max_slots - used_slots
 
     for i in range(free_slots):
@@ -369,8 +463,8 @@ def test_hotplug_max_devices(uvm_any_with_pci):
 
     # Verify all PCI slots are occupied
     vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
-    _, lspci, _ = vm.ssh.check_output("lspci -n")
-    assert len(lspci.strip().splitlines()) == pci_max_slots
+    _, lspci_full, _ = vm.ssh.check_output("lspci -n")
+    assert len(lspci_full.strip().splitlines()) == pci_max_slots
 
     # The next hotplug must fail — no PCI slots left
     host_file = drive_tools.FilesystemFile(
@@ -385,3 +479,37 @@ def test_hotplug_max_devices(uvm_any_with_pci):
             is_root_device=False,
             is_read_only=False,
         )
+
+    # Unplug all hotplugged devices
+    for i in range(free_slots):
+        vm.api.drive.delete(f"block{i}")
+
+    # Remove the stale devices from the guest
+    new_bdfs = [
+        l.split()[0]
+        for l in set(lspci_full.strip().splitlines())
+        - set(lspci_initial.strip().splitlines())
+    ]
+    for bdf in new_bdfs:
+        vm.ssh.check_output(f"echo 1 > /sys/bus/pci/devices/0000:{bdf}/remove")
+
+    # Verify we're back to the initial number of devices
+    _, lspci, _ = vm.ssh.check_output("lspci -n")
+    assert len(lspci.strip().splitlines()) == used_slots
+
+    # Re-plug all devices to verify the slots were truly freed
+    for i in range(free_slots):
+        host_file = drive_tools.FilesystemFile(
+            os.path.join(vm.fsfiles, f"block_re{i}"), size=1
+        )
+        vm.api.drive.put(
+            drive_id=f"block_re{i}",
+            path_on_host=vm.create_jailed_resource(host_file.path),
+            is_root_device=False,
+            is_read_only=False,
+        )
+
+    # Verify all PCI slots are occupied again
+    vm.ssh.check_output("echo 1 > /sys/bus/pci/rescan")
+    _, lspci, _ = vm.ssh.check_output("lspci -n")
+    assert len(lspci.strip().splitlines()) == pci_max_slots

--- a/tests/integration_tests/security/test_seccomp_validate.py
+++ b/tests/integration_tests/security/test_seccomp_validate.py
@@ -69,11 +69,17 @@ def test_validate_filter(seccompiler, bin_test_syscall, monkeypatch, tmp_path):
                 assert utils.run_cmd(f"{cmd} {allowed_str}").returncode == 0
                 # for each allowed arg try a different number
                 for arg in rule["args"]:
-                    # We just add 1000000 to the allowed arg and assume it is
-                    # not something we allow in another rule. While not perfect
-                    # it works in practice.
                     bad_args = allowed_args.copy()
-                    bad_args[arg["index"]] = str(arg["val"] + 1_000_000)
+                    if isinstance(arg["op"], dict) and "masked_eq" in arg["op"]:
+                        # For masked_eq, flip the mask bit to violate the check
+                        bad_args[arg["index"]] = str(
+                            arg["val"] ^ arg["op"]["masked_eq"]
+                        )
+                    else:
+                        # We just add 1000000 to the allowed arg and assume it
+                        # is not something we allow in another rule. While not
+                        # perfect it works in practice.
+                        bad_args[arg["index"]] = str(arg["val"] + 1_000_000)
                     unallowed_str = " ".join(str(x) for x in bad_args)
                     outcome = utils.run_cmd(f"{cmd} {unallowed_str}")
                     # if we call it with unallowed args, it should exit 159


### PR DESCRIPTION
Add PCI hotplug support. No hotplug notification mechanism is implemented yet, so the the guest needs to rescan the PCI "bus" manually in order to see new attachments. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
