### PR TITLE
virtio/net: Advertise MTU to the guest via VIRTIO_NET_F_MTU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to
 - [#5872](https://github.com/firecracker-microvm/firecracker/pull/5872): Add
   notification suppression support in the virtio-vsock device via the EVENT_IDX
   virtio feature to reduce device overhead.
+- [#5828](https://github.com/firecracker-microvm/firecracker/pull/5828):
+  Advertise MTU to the guest via `VIRTIO_NET_F_MTU` using a new optional `mtu`
+  field in the `network-interfaces` API. When set, a compatible guest driver
+  will configure the interface with the specified MTU.
 
 ### Changed
 

--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -83,6 +83,7 @@ specification:
 | `NetworkInterface`        | guest_mac          |    O     |       O        |      O       |        O         |   **R**    |      O       |     O      |      O      |     O      |
 |                           | host_dev_name      |    O     |       O        |      O       |        O         |   **R**    |      O       |     O      |      O      |     O      |
 |                           | iface_id           |    O     |       O        |      O       |        O         |   **R**    |      O       |     O      |      O      |     O      |
+|                           | mtu                |    O     |       O        |      O       |        O         |   **R**    |      O       |     O      |      O      |     O      |
 |                           | rx_rate_limiter    |    O     |       O        |      O       |        O         |   **R**    |      O       |     O      |      O      |     O      |
 |                           | tx_rate_limiter    |    O     |       O        |      O       |        O         |   **R**    |      O       |     O      |      O      |     O      |
 | `PartialDrive`            | drive_id           |    O     |       O        |    **R**     |        O         |     O      |      O       |     O      |      O      |     O      |

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1534,6 +1534,14 @@ definitions:
         description: Host level path for the guest network interface
       iface_id:
         type: string
+      mtu:
+        type: integer
+        description:
+          MTU to advertise to the guest via VIRTIO_NET_F_MTU. When set, a compatible
+          guest driver will configure the interface with this MTU. When absent,
+          VIRTIO_NET_F_MTU is not advertised and the guest uses its default MTU.
+        minimum: 68
+        maximum: 65535
       rx_rate_limiter:
         $ref: "#/definitions/RateLimiter"
       tx_rate_limiter:

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1099,6 +1099,7 @@ pub(crate) mod tests {
             iface_id: String::from("netif"),
             host_dev_name: String::from("hostname"),
             guest_mac: None,
+            mtu: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
         };

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -1060,6 +1060,7 @@ pub(crate) mod tests {
             iface_id: "eth0".to_string(),
             host_dev_name: "hostname".to_string(),
             guest_mac: Some(mac.parse().unwrap()),
+            mtu: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
         });
@@ -1076,6 +1077,7 @@ pub(crate) mod tests {
             iface_id: "eth1".to_string(),
             host_dev_name: "hostname2".to_string(),
             guest_mac: Some(mac.parse().unwrap()),
+            mtu: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
         });

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -681,6 +681,7 @@ mod tests {
                 iface_id: String::from("netif"),
                 host_dev_name: String::from("hostname"),
                 guest_mac: None,
+                mtu: None,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
             };
@@ -807,6 +808,7 @@ mod tests {
       "iface_id": "netif",
       "host_dev_name": "hostname",
       "guest_mac": null,
+      "mtu": null,
       "rx_rate_limiter": null,
       "tx_rate_limiter": null
     }}

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -709,6 +709,7 @@ mod tests {
                 iface_id: String::from("netif"),
                 host_dev_name: String::from("hostname"),
                 guest_mac: None,
+                mtu: None,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
             };
@@ -827,6 +828,7 @@ mod tests {
       "iface_id": "netif",
       "host_dev_name": "hostname",
       "guest_mac": null,
+      "mtu": null,
       "rx_rate_limiter": null,
       "tx_rate_limiter": null
     }}

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -22,7 +22,7 @@ use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::generated::virtio_net::{
     VIRTIO_NET_F_CSUM, VIRTIO_NET_F_GUEST_CSUM, VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6,
     VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_TSO6, VIRTIO_NET_F_HOST_UFO,
-    VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF, virtio_net_hdr_v1,
+    VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF, VIRTIO_NET_F_MTU, virtio_net_hdr_v1,
 };
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use crate::devices::virtio::iovec::{
@@ -88,6 +88,13 @@ fn init_vnet_hdr(buf: &mut [u8]) {
 #[repr(C)]
 pub struct ConfigSpace {
     pub guest_mac: MacAddr,
+    // Padding fields to match the virtio_net_config layout:
+    // offset 6: status (u16, not advertised)
+    _status: u16,
+    // offset 8: max_virtqueue_pairs (u16, not advertised)
+    _max_virtqueue_pairs: u16,
+    // offset 10: mtu (u16, advertised via VIRTIO_NET_F_MTU)
+    pub mtu: u16,
 }
 
 // SAFETY: `ConfigSpace` contains only PODs in `repr(C)` or `repr(transparent)`, without padding.
@@ -275,6 +282,7 @@ impl Net {
         guest_mac: Option<MacAddr>,
         rx_rate_limiter: RateLimiter,
         tx_rate_limiter: RateLimiter,
+        mtu: Option<u16>,
     ) -> Result<Self, NetError> {
         let mut avail_features = (1 << VIRTIO_NET_F_GUEST_CSUM)
             | (1 << VIRTIO_NET_F_CSUM)
@@ -289,6 +297,13 @@ impl Net {
             | (1 << VIRTIO_RING_F_EVENT_IDX);
 
         let mut config_space = ConfigSpace::default();
+        if let Some(mtu) = mtu {
+            if !(68..=65535).contains(&mtu) {
+                return Err(NetError::InvalidMtu(mtu));
+            }
+            avail_features |= 1 << VIRTIO_NET_F_MTU;
+            config_space.mtu = mtu;
+        }
         if let Some(mac) = guest_mac {
             config_space.guest_mac = mac;
             // Enabling feature for MAC address configuration
@@ -332,6 +347,7 @@ impl Net {
         guest_mac: Option<MacAddr>,
         rx_rate_limiter: RateLimiter,
         tx_rate_limiter: RateLimiter,
+        mtu: Option<u16>,
     ) -> Result<Self, NetError> {
         let tap = Tap::open_named(tap_if_name).map_err(NetError::TapOpen)?;
 
@@ -339,7 +355,7 @@ impl Net {
         tap.set_vnet_hdr_size(vnet_hdr_size)
             .map_err(NetError::TapSetVnetHdrSize)?;
 
-        Self::new_with_tap(id, tap, guest_mac, rx_rate_limiter, tx_rate_limiter)
+        Self::new_with_tap(id, tap, guest_mac, rx_rate_limiter, tx_rate_limiter, mtu)
     }
 
     /// Provides the MAC of this net device.
@@ -350,6 +366,15 @@ impl Net {
     /// Provides the host IFACE name of this net device.
     pub fn iface_name(&self) -> String {
         self.tap.if_name_as_str().to_string()
+    }
+
+    /// Returns the configured MTU if `VIRTIO_NET_F_MTU` is advertised, otherwise `None`.
+    pub fn mtu(&self) -> Option<u16> {
+        if self.avail_features & (1 << VIRTIO_NET_F_MTU) != 0 {
+            Some(self.config_space.mtu)
+        } else {
+            None
+        }
     }
 
     /// Provides the MmdsNetworkStack of this net device.
@@ -1010,8 +1035,11 @@ impl VirtioDevice for Net {
         let config_space_bytes = self.config_space.as_mut_slice();
         let start = usize::try_from(offset).ok();
         let end = start.and_then(|s| s.checked_add(data.len()));
+        // Only the guest_mac field (bytes 0..size_of::<MacAddr>()) is writable by the guest.
+        // All other fields (status, max_virtqueue_pairs, mtu) are read-only device fields.
         let Some(dst) = start
             .zip(end)
+            .filter(|&(_, end)| end <= std::mem::size_of::<MacAddr>())
             .and_then(|(start, end)| config_space_bytes.get_mut(start..end))
         else {
             error!("Failed to write config space");
@@ -1103,8 +1131,8 @@ pub mod tests {
     };
     use crate::devices::virtio::net::test_utils::test::TestHelper;
     use crate::devices::virtio::net::test_utils::{
-        NetEvent, NetQueue, TapTrafficSimulator, default_net, if_index, inject_tap_tx_frame,
-        set_mac,
+        NetEvent, NetQueue, TapTrafficSimulator, default_net, enable, if_index,
+        inject_tap_tx_frame, set_mac,
     };
     use crate::devices::virtio::queue::VIRTQ_DESC_F_WRITE;
     use crate::devices::virtio::test_utils::VirtQueue;
@@ -1195,6 +1223,58 @@ pub mod tests {
             let supported_flags = Net::build_tap_offload_features(virtio_flag);
             assert_eq!(supported_flags, tap_flag);
         }
+    }
+
+    #[test]
+    fn test_mtu_advertised() {
+        // "net-device%d" asks the kernel to assign a unique tap index.
+        let mut net = Net::new(
+            "mtu-test".to_string(),
+            "net-device%d",
+            None,
+            RateLimiter::default(),
+            RateLimiter::default(),
+            Some(9000),
+        )
+        .unwrap();
+        enable(&net.tap);
+
+        // VIRTIO_NET_F_MTU must be advertised.
+        assert!(net.avail_features & (1 << VIRTIO_NET_F_MTU) != 0);
+        // mtu() must return the configured value.
+        assert_eq!(net.mtu(), Some(9000));
+        // config space must carry the value at the correct offset.
+        let mut buf = [0u8; 2];
+        net.read_config(10, &mut buf);
+        assert_eq!(u16::from_le_bytes(buf), 9000);
+    }
+
+    #[test]
+    fn test_mtu_not_advertised() {
+        let net = default_net();
+        assert!(net.avail_features & (1 << VIRTIO_NET_F_MTU) == 0);
+        assert_eq!(net.mtu(), None);
+    }
+
+    #[test]
+    fn test_mtu_out_of_range() {
+        let make = |mtu| {
+            Net::new(
+                "mtu-range-test".to_string(),
+                "net-device%d",
+                None,
+                RateLimiter::default(),
+                RateLimiter::default(),
+                Some(mtu),
+            )
+        };
+        assert!(matches!(make(0), Err(NetError::InvalidMtu(0))));
+        assert!(matches!(make(67), Err(NetError::InvalidMtu(67))));
+        // Boundary values must succeed (no tap needed to check the error path).
+        // 68 and 65535 are valid; we cannot call .unwrap() here because the
+        // tap creation requires CAP_NET_ADMIN, but the error must NOT be InvalidMtu.
+        assert!(!matches!(make(68), Err(NetError::InvalidMtu(_))));
+        assert!(!matches!(make(65535), Err(NetError::InvalidMtu(_))));
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/net/mod.rs
+++ b/src/vmm/src/devices/virtio/net/mod.rs
@@ -63,4 +63,6 @@ pub enum NetError {
     QueueError(#[from] QueueError),
     /// {0}
     InvalidAvailIdx(#[from] InvalidAvailIdx),
+    /// MTU {0} is out of range [68, 65535]
+    InvalidMtu(u16),
 }

--- a/src/vmm/src/devices/virtio/net/persist.rs
+++ b/src/vmm/src/devices/virtio/net/persist.rs
@@ -27,6 +27,8 @@ use crate::vstate::memory::GuestMemoryMmap;
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct NetConfigSpaceState {
     guest_mac: Option<MacAddr>,
+    #[serde(default)]
+    mtu: Option<u16>,
 }
 
 /// Information about the network device that are saved
@@ -81,6 +83,7 @@ impl Persist<'_> for Net {
             mmds_ns: self.mmds_ns.as_ref().map(|mmds| mmds.save()),
             config_space: NetConfigSpaceState {
                 guest_mac: self.guest_mac,
+                mtu: self.mtu(),
             },
             virtio_state: VirtioDeviceState::from_device(self),
         }
@@ -99,6 +102,7 @@ impl Persist<'_> for Net {
             state.config_space.guest_mac,
             rx_rate_limiter,
             tx_rate_limiter,
+            state.config_space.mtu,
         )?;
 
         // We trust the MMIODeviceManager::restore to pass us an MMDS data store reference if

--- a/src/vmm/src/devices/virtio/net/test_utils.rs
+++ b/src/vmm/src/devices/virtio/net/test_utils.rs
@@ -45,6 +45,7 @@ pub fn default_net() -> Net {
         Some(guest_mac),
         RateLimiter::default(),
         RateLimiter::default(),
+        None,
     )
     .unwrap();
     net.configure_mmds_network_stack(
@@ -68,6 +69,7 @@ pub fn default_net_no_mmds() -> Net {
         Some(guest_mac),
         RateLimiter::default(),
         RateLimiter::default(),
+        None,
     )
     .unwrap();
     enable(&net.tap);

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -699,6 +699,7 @@ mod tests {
             iface_id: String::from("netif"),
             host_dev_name: String::from("hostname"),
             guest_mac: None,
+            mtu: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
         };

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -598,6 +598,7 @@ mod tests {
                 .unwrap()
                 .to_string(),
             guest_mac: Some(MacAddr::from_str("01:23:45:67:89:0a").unwrap()),
+            mtu: None,
             rx_rate_limiter: Some(RateLimiterConfig::default()),
             tx_rate_limiter: Some(RateLimiterConfig::default()),
         }

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -24,6 +24,8 @@ pub struct NetworkInterfaceConfig {
     pub host_dev_name: String,
     /// Guest MAC address.
     pub guest_mac: Option<MacAddr>,
+    /// Maximum Transmission Unit to advertise to the guest via VIRTIO_NET_F_MTU.
+    pub mtu: Option<u16>,
     /// Rate Limiter for received packages.
     pub rx_rate_limiter: Option<RateLimiterConfig>,
     /// Rate Limiter for transmitted packages.
@@ -38,6 +40,7 @@ impl From<&Net> for NetworkInterfaceConfig {
             iface_id: net.id().to_string(),
             host_dev_name: net.iface_name(),
             guest_mac: net.guest_mac().copied(),
+            mtu: net.mtu(),
             rx_rate_limiter: rx_rl.into_option(),
             tx_rate_limiter: tx_rl.into_option(),
         }
@@ -157,6 +160,7 @@ impl NetBuilder {
             cfg.guest_mac,
             rx_rate_limiter.unwrap_or_default(),
             tx_rate_limiter.unwrap_or_default(),
+            cfg.mtu,
         )
         .map_err(NetworkInterfaceError::CreateNetworkDevice)
     }
@@ -189,6 +193,7 @@ mod tests {
             iface_id: String::from(id),
             host_dev_name: String::from(name),
             guest_mac: Some(MacAddr::from_str(mac).unwrap()),
+            mtu: None,
             rx_rate_limiter: RateLimiterConfig::default().into_option(),
             tx_rate_limiter: RateLimiterConfig::default().into_option(),
         }
@@ -200,6 +205,7 @@ mod tests {
                 iface_id: self.iface_id.clone(),
                 host_dev_name: self.host_dev_name.clone(),
                 guest_mac: self.guest_mac,
+                mtu: self.mtu,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
             }
@@ -334,6 +340,7 @@ mod tests {
             Some(MacAddr::from_str(guest_mac).unwrap()),
             RateLimiter::default(),
             RateLimiter::default(),
+            None,
         )
         .unwrap();
 

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -447,6 +447,7 @@ fn test_preboot_load_snap_disallowed_after_boot_resources() {
         iface_id: String::new(),
         host_dev_name: String::new(),
         guest_mac: None,
+        mtu: None,
         rx_rate_limiter: None,
         tx_rate_limiter: None,
     });

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1349,6 +1349,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
             "guest_mac": net_tools.mac_from_ip(net_iface.guest_ip),
             "iface_id": net_iface.dev_name,
             "host_dev_name": net_iface.tap_name,
+            "mtu": None,
             "rx_rate_limiter": None,
             "tx_rate_limiter": tx_rl,
         }
@@ -1480,6 +1481,7 @@ def test_get_full_config(uvm_plain):
             "iface_id": iface_id,
             "host_dev_name": tap1.name,
             "guest_mac": "06:00:00:00:00:01",
+            "mtu": None,
             "rx_rate_limiter": None,
             "tx_rate_limiter": tx_rl,
         }

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -8,10 +8,14 @@ import time
 import pytest
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 
+import host_tools.network as net_tools
 from framework import utils
 
 # The iperf version to run this tests with
 IPERF_BINARY = "iperf3"
+
+# VIRTIO_NET_F_MTU feature bit index (virtio spec, network device section)
+VIRTIO_NET_F_MTU_BIT = 3
 
 
 def test_high_ingress_traffic(uvm_plain_any):
@@ -127,3 +131,47 @@ def test_tap_offload(uvm_any):
         with attempt:
             ret = vm.ssh.check_output(f"sync; cat {out_filename}")
             assert ret.stdout == message, f"{ret.stdout=} {ret.stderr=}"
+
+
+def test_tap_mtu_advertised_to_guest(uvm_plain_any):
+    """
+    Verify that VIRTIO_NET_F_MTU correctly advertises the TAP MTU to the guest.
+
+    Configures multiple TAP interfaces with distinct MTU values and checks that
+    each guest network interface reports the MTU matching its host TAP.
+    """
+    vm = uvm_plain_any
+    vm.spawn()
+    vm.basic_config()
+
+    # (interface index, MTU) pairs with varied values
+    iface_mtus = [(0, 1450), (1, 1500), (2, 8935)]
+
+    for idx, mtu in iface_mtus:
+        iface = net_tools.NetIfaceConfig.with_id(idx)
+        vm.add_net_iface(iface, mtu=mtu)
+
+    vm.start()
+
+    # Verify each guest interface carries the expected MTU and has the feature flag set.
+    # SSH runs over eth0; we can still query other interfaces from there.
+    # /sys/class/net/{if}/device/features is a bitstring where index i is '1'
+    # when feature bit i is negotiated.
+    for idx, mtu in iface_mtus:
+        iface_name = f"eth{idx}"
+        guest_ip = vm.iface[iface_name]["iface"].guest_ip
+        guest_if = net_tools.get_guest_net_if_name(vm.ssh, guest_ip)
+        assert (
+            guest_if is not None
+        ), f"Could not find guest interface for {iface_name} ({guest_ip})"
+        mtu_out = vm.ssh.check_output(f"cat /sys/class/net/{guest_if}/mtu")
+        assert (
+            int(mtu_out.stdout.strip()) == mtu
+        ), f"{iface_name} (guest: {guest_if}): expected MTU {mtu}, got {mtu_out.stdout.strip()}"
+        features = vm.ssh.check_output(
+            f"cat /sys/class/net/{guest_if}/device/features"
+        ).stdout
+        assert features[VIRTIO_NET_F_MTU_BIT] == "1", (
+            f"{iface_name} (guest: {guest_if}): VIRTIO_NET_F_MTU (bit {VIRTIO_NET_F_MTU_BIT})"
+            f" not set in negotiated features: {features!r}"
+        )


### PR DESCRIPTION
## Changes

Add MTU negotiation support to the virtio-net device. The tap interface MTU is read using SIOCGIFMTU and stored in the ConfigSpace alongside the MAC address, with the intermediate padding fields (_status, _max_virtqueue_pairs) added to match the virtio_net_config layout.

VIRTIO_NET_F_MTU is advertised in the available features so the guest driver can read the MTU from the config space and configure the network interface accordingly, avoiding fragmentation or oversized-packet issues when the underlying tap MTU differs from the default.

## Reason

An MTU != 1500 is not honored in the VM, causing packet drops from the VM.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [X] I have read and understand [CONTRIBUTING.md][3].
- [X] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [X] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [X] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [X] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
