### PR TITLE
[SH] chore(linux_patches): direct map removal v12

### DIFF
--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0023-set_memory-set_direct_map_-to-take-address.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0023-set_memory-set_direct_map_-to-take-address.patch
@@ -1,32 +1,32 @@
-From 70f123dfb4f7fb3cc11b4bc6725780212a8effcf Mon Sep 17 00:00:00 2001
+From be23bb10b169ad92b9b0055dcd71212d3c47860f Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 19 Jan 2026 15:03:18 +0000
-Subject: [PATCH 23/87] set_memory: set_direct_map_* to take address
+Subject: [PATCH 23/94] set_memory: set_direct_map_* to take address
 
-From: Nikita Kalyazin <kalyazin@amazon.com>
+From: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 
 This is to avoid excessive conversions folio->page->address when adding
 helpers on top of set_direct_map_valid_noflush() in the next patch.
 
 Acked-by: David Hildenbrand (Arm) <david@kernel.org>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  arch/arm64/include/asm/set_memory.h     |  7 ++++---
- arch/arm64/mm/pageattr.c                | 19 +++++++++----------
+ arch/arm64/mm/pageattr.c                | 19 +++++++++--------
  arch/loongarch/include/asm/set_memory.h |  7 ++++---
- arch/loongarch/mm/pageattr.c            | 25 +++++++++++--------------
+ arch/loongarch/mm/pageattr.c            | 25 ++++++++++-------------
  arch/riscv/include/asm/set_memory.h     |  7 ++++---
- arch/riscv/mm/pageattr.c                | 17 +++++++++--------
+ arch/riscv/mm/pageattr.c                | 17 ++++++++--------
  arch/s390/include/asm/set_memory.h      |  7 ++++---
- arch/s390/mm/pageattr.c                 | 13 +++++++------
+ arch/s390/mm/pageattr.c                 | 13 ++++++------
  arch/x86/include/asm/set_memory.h       |  7 ++++---
- arch/x86/mm/pat/set_memory.c            | 23 ++++++++++++-----------
+ arch/x86/mm/pat/set_memory.c            | 27 +++++++++++++------------
  include/linux/set_memory.h              |  9 +++++----
  kernel/power/snapshot.c                 |  4 ++--
  mm/execmem.c                            |  6 ++++--
  mm/secretmem.c                          |  6 +++---
- mm/vmalloc.c                            | 11 +++++++----
- 15 files changed, 89 insertions(+), 79 deletions(-)
+ mm/vmalloc.c                            | 11 ++++++----
+ 15 files changed, 91 insertions(+), 81 deletions(-)
 
 diff --git a/arch/arm64/include/asm/set_memory.h b/arch/arm64/include/asm/set_memory.h
 index 90f61b17275e..c71a2a6812c4 100644
@@ -307,7 +307,7 @@ index 61f56cdaccb5..f912191f0853 100644
  
  extern int kernel_set_to_readonly;
 diff --git a/arch/x86/mm/pat/set_memory.c b/arch/x86/mm/pat/set_memory.c
-index 970981893c9b..99b72447a4b4 100644
+index 970981893c9b..fdf259aa81d1 100644
 --- a/arch/x86/mm/pat/set_memory.c
 +++ b/arch/x86/mm/pat/set_memory.c
 @@ -2600,9 +2600,9 @@ int set_pages_rw(struct page *page, int numpages)
@@ -365,6 +365,18 @@ index 970981893c9b..99b72447a4b4 100644
  }
  
  #ifdef CONFIG_DEBUG_PAGEALLOC
+@@ -2672,9 +2673,9 @@ void __kernel_map_pages(struct page *page, int numpages, int enable)
+ 	 * and hence no memory allocations during large page split.
+ 	 */
+ 	if (enable)
+-		__set_pages_p(page, numpages);
++		__set_pages_p(page_address(page), numpages);
+ 	else
+-		__set_pages_np(page, numpages);
++		__set_pages_np(page_address(page), numpages);
+ 
+ 	/*
+ 	 * We should perform an IPI and flush all tlbs,
 diff --git a/include/linux/set_memory.h b/include/linux/set_memory.h
 index 3030d9245f5a..1a2563f525fc 100644
 --- a/include/linux/set_memory.h

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0024-set_memory-add-folio_-zap-restore-_direct_map-helper.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0024-set_memory-add-folio_-zap-restore-_direct_map-helper.patch
@@ -1,14 +1,16 @@
-From c7152d2f08f30476300f9d02eff69baea318b15f Mon Sep 17 00:00:00 2001
+From 450885230ddd9a7cae794d7e5b2cca295d6dbeb9 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 12 Jan 2026 14:24:52 +0000
-Subject: [PATCH 24/87] set_memory: add folio_{zap,restore}_direct_map helpers
+Subject: [PATCH 24/94] set_memory: add folio_{zap,restore}_direct_map helpers
 
-From: Nikita Kalyazin <kalyazin@amazon.com>
+From: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 
 Let's provide folio_{zap,restore}_direct_map helpers as preparation for
 supporting removal of the direct map for guest_memfd folios.
 In folio_zap_direct_map(), flush TLB to make sure the data is not
-accessible.
+accessible.  On some architectures, there may be a double TLB flush
+issued because set_direct_map_valid_noflush already performs a flush
+internally.
 
 The new helpers need to be accessible to KVM on architectures that
 support guest_memfd (x86 and arm64).
@@ -17,11 +19,12 @@ Direct map removal gives guest_memfd the same protection that
 memfd_secret does, such as hardening against Spectre-like attacks
 through in-kernel gadgets.
 
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Acked-by: David Hildenbrand (Arm) <david@kernel.org>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
- include/linux/set_memory.h | 13 ++++++++++++
- mm/memory.c                | 42 ++++++++++++++++++++++++++++++++++++++
- 2 files changed, 55 insertions(+)
+ include/linux/set_memory.h | 13 +++++++++++
+ mm/memory.c                | 45 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 58 insertions(+)
 
 diff --git a/include/linux/set_memory.h b/include/linux/set_memory.h
 index 1a2563f525fc..24caea2931f9 100644
@@ -55,7 +58,7 @@ index 1a2563f525fc..24caea2931f9 100644
  
  #ifdef CONFIG_X86_64
 diff --git a/mm/memory.c b/mm/memory.c
-index b59ae7ce42eb..078558b21cfb 100644
+index b59ae7ce42eb..1ec36299e963 100644
 --- a/mm/memory.c
 +++ b/mm/memory.c
 @@ -76,6 +76,7 @@
@@ -66,7 +69,7 @@ index b59ae7ce42eb..078558b21cfb 100644
  
  #include <trace/events/kmem.h>
  
-@@ -7324,3 +7325,44 @@ void vma_pgtable_walk_end(struct vm_area_struct *vma)
+@@ -7324,3 +7325,47 @@ void vma_pgtable_walk_end(struct vm_area_struct *vma)
  	if (is_vm_hugetlb_page(vma))
  		hugetlb_vma_unlock_read(vma);
  }
@@ -78,7 +81,7 @@ index b59ae7ce42eb..078558b21cfb 100644
 + *
 + * Removes the folio from the kernel direct map and flushes the TLB.  This may
 + * require splitting huge pages in the direct map, which can fail due to memory
-+ * allocation.
++ * allocation.  So far, only order-0 folios are supported.
 + *
 + * Return: 0 on success, or a negative error code on failure.
 + */
@@ -86,6 +89,9 @@ index b59ae7ce42eb..078558b21cfb 100644
 +{
 +	const void *addr = folio_address(folio);
 +	int ret;
++
++	if (folio_test_large(folio))
++		return -EINVAL;
 +
 +	ret = set_direct_map_valid_noflush(addr, folio_nr_pages(folio), false);
 +	flush_tlb_kernel_range((unsigned long)addr,

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0025-mm-secretmem-make-use-of-folio_-zap-restore-_direct_.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0025-mm-secretmem-make-use-of-folio_-zap-restore-_direct_.patch
@@ -1,12 +1,19 @@
-From bf5093ba9500c16984682946f9d530b6781380a1 Mon Sep 17 00:00:00 2001
+From b3746976d985bf8dab3c661bf0ff54c42ffeae90 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 6 Mar 2026 11:07:31 +0000
-Subject: [PATCH 25/87] mm/secretmem: make use of
+Subject: [PATCH 25/94] mm/secretmem: make use of
  folio_{zap,restore}_direct_map
 
-From: Nikita Kalyazin <kalyazin@amazon.com>
+From: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Replace set_direct_map_*_noflush with newly available
+folio_zap_direct_map calls that take folio's address internally.  A side
+effect is even if filemap_add_folio fails, the TLB is still flushed,
+which is not expected to be on the hot path.
+
+Acked-by: David Hildenbrand (Arm) <david@kernel.org>
+Reviewed-by: Ackerley Tng <ackerleytng@google.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  mm/secretmem.c | 8 ++------
  1 file changed, 2 insertions(+), 6 deletions(-)

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0026-mm-gup-drop-secretmem-optimization-from-gup_fast_fol.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0026-mm-gup-drop-secretmem-optimization-from-gup_fast_fol.patch
@@ -1,7 +1,7 @@
-From 80d6f598c545e3bb7817732be3ee915987c026d7 Mon Sep 17 00:00:00 2001
+From c3a55cd499a97f9dbbeaac1054d57f7610466b8f Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Mon, 12 Jan 2026 15:22:56 +0000
-Subject: [PATCH 26/87] mm/gup: drop secretmem optimization from
+Subject: [PATCH 26/94] mm/gup: drop secretmem optimization from
  gup_fast_folio_allowed
 
 This drops an optimization in gup_fast_folio_allowed() where
@@ -9,6 +9,10 @@ secretmem_mapping() was only called if CONFIG_SECRETMEM=y. secretmem is
 enabled by default since commit b758fe6df50d ("mm/secretmem: make it on
 by default"), so the secretmem check did not actually end up elided in
 most cases anymore anyway.
+
+To make sure the fast path for ZONE_DEVICE pages (like Device DAX and
+PCI P2PDMA) is still allowed, check for folio_is_zone_device() if
+mapping is NULL.
 
 This is in preparation of the generalization of handling mappings where
 direct map entries of folios are set to not present.  Currently,
@@ -19,13 +23,13 @@ into this category.
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
 Acked-by: Vlastimil Babka <vbabka@suse.cz>
 Acked-by: David Hildenbrand (Red Hat) <david@kernel.org>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
- mm/gup.c | 11 +----------
- 1 file changed, 1 insertion(+), 10 deletions(-)
+ mm/gup.c | 17 ++++++-----------
+ 1 file changed, 6 insertions(+), 11 deletions(-)
 
 diff --git a/mm/gup.c b/mm/gup.c
-index a8ba5112e4d0..6fb2eddfc9d2 100644
+index a8ba5112e4d0..3101dcf6f995 100644
 --- a/mm/gup.c
 +++ b/mm/gup.c
 @@ -2739,7 +2739,6 @@ static bool gup_fast_folio_allowed(struct folio *folio, unsigned int flags)
@@ -51,7 +55,22 @@ index a8ba5112e4d0..6fb2eddfc9d2 100644
  	if (WARN_ON_ONCE(folio_test_slab(folio)))
  		return false;
  
-@@ -2800,7 +2791,7 @@ static bool gup_fast_folio_allowed(struct folio *folio, unsigned int flags)
+@@ -2787,9 +2778,13 @@ static bool gup_fast_folio_allowed(struct folio *folio, unsigned int flags)
+ 	 * The mapping may have been truncated, in any case we cannot determine
+ 	 * if this mapping is safe - fall back to slow path to determine how to
+ 	 * proceed.
++	 *
++	 * ZONE_DEVICE folios (e.g. Device DAX, PCI P2PDMA) may legitimately
++	 * have a NULL mapping. They are never secretmem/no-direct-map folios,
++	 * so let them through.
+ 	 */
+ 	if (!mapping)
+-		return false;
++		return folio_is_zone_device(folio);
+ 
+ 	/* Anonymous folios pose no problem. */
+ 	mapping_flags = (unsigned long)mapping & FOLIO_MAPPING_FLAGS;
+@@ -2800,7 +2795,7 @@ static bool gup_fast_folio_allowed(struct folio *folio, unsigned int flags)
  	 * At this point, we know the mapping is non-null and points to an
  	 * address_space object.
  	 */

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0027-mm-gup-drop-local-variable-in-gup_fast_folio_allowed.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0027-mm-gup-drop-local-variable-in-gup_fast_folio_allowed.patch
@@ -1,20 +1,21 @@
-From 26506204e20bc01987099d35faa63f1b200a87b9 Mon Sep 17 00:00:00 2001
+From db06ed267d4d4f4017f33abd2936d6736d3ff21c Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 19 Jan 2026 15:33:01 +0000
-Subject: [PATCH 27/87] mm/gup: drop local variable in gup_fast_folio_allowed
+Subject: [PATCH 27/94] mm/gup: drop local variable in gup_fast_folio_allowed
 
-From: Nikita Kalyazin <kalyazin@amazon.com>
+From: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 
 Move the check for pinning closer to where the result is used.
 No functional changes.
 
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Acked-by: David Hildenbrand (Arm) <david@kernel.org>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  mm/gup.c | 23 ++++++++++++-----------
  1 file changed, 12 insertions(+), 11 deletions(-)
 
 diff --git a/mm/gup.c b/mm/gup.c
-index 6fb2eddfc9d2..65d80625c90c 100644
+index 3101dcf6f995..9ec6b3499109 100644
 --- a/mm/gup.c
 +++ b/mm/gup.c
 @@ -2737,18 +2737,9 @@ EXPORT_SYMBOL(get_user_pages_unlocked);
@@ -36,7 +37,7 @@ index 6fb2eddfc9d2..65d80625c90c 100644
  	/* We hold a folio reference, so we can safely access folio fields. */
  	if (WARN_ON_ONCE(folio_test_slab(folio)))
  		return false;
-@@ -2793,8 +2784,18 @@ static bool gup_fast_folio_allowed(struct folio *folio, unsigned int flags)
+@@ -2797,8 +2788,18 @@ static bool gup_fast_folio_allowed(struct folio *folio, unsigned int flags)
  	 */
  	if (secretmem_mapping(mapping))
  		return false;

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0028-mm-introduce-AS_NO_DIRECT_MAP.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0028-mm-introduce-AS_NO_DIRECT_MAP.patch
@@ -1,7 +1,7 @@
-From 3cbe82fbe24722544c05598a611b7c98d161799f Mon Sep 17 00:00:00 2001
+From abc867c00868f03e7641bd285186a0848f8f40c1 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Mon, 12 Jan 2026 15:29:36 +0000
-Subject: [PATCH 28/87] mm: introduce AS_NO_DIRECT_MAP
+Subject: [PATCH 28/94] mm: introduce AS_NO_DIRECT_MAP
 
 Add AS_NO_DIRECT_MAP for mappings where direct map entries of folios are
 set to not present. Currently, mappings that match this description are
@@ -26,15 +26,15 @@ Acked-by: David Hildenbrand (Red Hat) <david@kernel.org>
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
 Acked-by: Vlastimil Babka <vbabka@suse.cz>
 Reviewed-by: Ackerley Tng <ackerleytng@google.com>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  include/linux/pagemap.h   | 16 ++++++++++++++++
  include/linux/secretmem.h | 18 ------------------
- lib/buildid.c             | 22 ++++++++++++++++++++--
+ lib/buildid.c             | 11 +++++++++--
  mm/gup.c                  |  9 ++++-----
  mm/mlock.c                |  2 +-
  mm/secretmem.c            |  8 ++------
- 6 files changed, 43 insertions(+), 32 deletions(-)
+ 6 files changed, 32 insertions(+), 32 deletions(-)
 
 diff --git a/include/linux/pagemap.h b/include/linux/pagemap.h
 index a17fabbc0269..d51e0c0404e2 100644
@@ -104,10 +104,10 @@ index e918f96881f5..0ae1fb057b3d 100644
  {
  	return false;
 diff --git a/lib/buildid.c b/lib/buildid.c
-index c4b0f376fb34..caeff8f077bc 100644
+index c4b0f376fb34..e27ff5d8c4fc 100644
 --- a/lib/buildid.c
 +++ b/lib/buildid.c
-@@ -65,8 +65,8 @@ static int freader_get_folio(struct freader *r, loff_t file_off)
+@@ -65,10 +65,11 @@ static int freader_get_folio(struct freader *r, loff_t file_off)
  
  	freader_put_folio(r);
  
@@ -117,8 +117,11 @@ index c4b0f376fb34..caeff8f077bc 100644
 +	if (mapping_no_direct_map(r->file->f_mapping))
  		return -EFAULT;
  
++	/* only use page cache lookup - fail if not already cached */
  	r->folio = filemap_get_folio(r->file->f_mapping, file_off >> PAGE_SHIFT);
-@@ -116,6 +116,24 @@ static const void *freader_fetch(struct freader *r, loff_t file_off, size_t sz)
+ 
+ 	/* if sleeping is allowed, wait for the page, if necessary */
+@@ -116,6 +117,12 @@ static const void *freader_fetch(struct freader *r, loff_t file_off, size_t sz)
  		return r->data + file_off;
  	}
  
@@ -128,23 +131,11 @@ index c4b0f376fb34..caeff8f077bc 100644
 +		return NULL;
 +	}
 +
-+	/* use __kernel_read() for sleepable context */
-+	if (r->may_fault) {
-+		ssize_t ret;
-+
-+		ret = __kernel_read(r->file, r->buf, sz, &file_off);
-+		if (ret != sz) {
-+			r->err = (ret < 0) ? ret : -EIO;
-+			return NULL;
-+		}
-+		return r->buf;
-+	}
-+
  	/* fetch or reuse folio for given file offset */
  	r->err = freader_get_folio(r, file_off);
  	if (r->err)
 diff --git a/mm/gup.c b/mm/gup.c
-index 65d80625c90c..8e8e52e39bd4 100644
+index 9ec6b3499109..9c945c7f82ae 100644
 --- a/mm/gup.c
 +++ b/mm/gup.c
 @@ -11,7 +11,6 @@
@@ -182,7 +173,7 @@ index 65d80625c90c..8e8e52e39bd4 100644
  	if (folio_test_hugetlb(folio))
  		return true;
  
-@@ -2782,7 +2781,7 @@ static bool gup_fast_folio_allowed(struct folio *folio, unsigned int flags)
+@@ -2786,7 +2785,7 @@ static bool gup_fast_folio_allowed(struct folio *folio, unsigned int flags)
  	 * At this point, we know the mapping is non-null and points to an
  	 * address_space object.
  	 */

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0029-KVM-guest_memfd-Add-stub-for-kvm_arch_gmem_invalidat.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0029-KVM-guest_memfd-Add-stub-for-kvm_arch_gmem_invalidat.patch
@@ -1,7 +1,7 @@
-From 80afbc7cde66f8b2b195664c8a272c9315b1d0ff Mon Sep 17 00:00:00 2001
+From a6cd2ad6f9f715a264fd5a697a40e637be77f5b7 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:33 +0100
-Subject: [PATCH 29/87] KVM: guest_memfd: Add stub for kvm_arch_gmem_invalidate
+Subject: [PATCH 29/94] KVM: guest_memfd: Add stub for kvm_arch_gmem_invalidate
 
 Add a no-op stub for kvm_arch_gmem_invalidate if
 CONFIG_HAVE_KVM_ARCH_GMEM_INVALIDATE=n. This allows defining
@@ -13,7 +13,7 @@ Acked-by: David Hildenbrand (Red Hat) <david@kernel.org>
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
 Acked-by: Vlastimil Babka <vbabka@suse.cz>
 Reviewed-by: Ackerley Tng <ackerleytng@google.com>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  include/linux/kvm_host.h | 2 ++
  virt/kvm/guest_memfd.c   | 4 ----

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0030-KVM-x86-define-kvm_arch_gmem_supports_no_direct_map.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0030-KVM-x86-define-kvm_arch_gmem_supports_no_direct_map.patch
@@ -1,20 +1,22 @@
-From 2fed243f323702416314ae0f5c5f9cbe0d25918f Mon Sep 17 00:00:00 2001
+From 7aa5dc6e40e7eed20dc0df9153420aa105c61a3d Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:34 +0100
-Subject: [PATCH 30/87] KVM: x86: define kvm_arch_gmem_supports_no_direct_map()
+Subject: [PATCH 30/94] KVM: x86: define kvm_arch_gmem_supports_no_direct_map()
 
 x86 supports GUEST_MEMFD_FLAG_NO_DIRECT_MAP whenever direct map
-modifications are possible (which is always the case).
+modifications are possible.  Exclude TDX and SEV-SNP as they access
+pages via direct map in certain operations, such as population.
 
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
 Reviewed-by: Ackerley Tng <ackerleytng@google.com>
 Reviewed-by: David Hildenbrand (Arm) <david@kernel.org>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Co-developed-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  arch/x86/include/asm/kvm_host.h | 6 ++++++
- arch/x86/kvm/x86.c              | 5 +++++
+ arch/x86/kvm/x86.c              | 7 +++++++
  include/linux/kvm_host.h        | 9 +++++++++
- 3 files changed, 20 insertions(+)
+ 3 files changed, 22 insertions(+)
 
 diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
 index 48598d017d6f..2a10d439d4bb 100644
@@ -39,17 +41,19 @@ index 48598d017d6f..2a10d439d4bb 100644
 +
  #endif /* _ASM_X86_KVM_HOST_H */
 diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
-index c9c2aa6f4705..652345b161aa 100644
+index c9c2aa6f4705..d1aeefd014c0 100644
 --- a/arch/x86/kvm/x86.c
 +++ b/arch/x86/kvm/x86.c
-@@ -13973,6 +13973,11 @@ void kvm_arch_gmem_invalidate(kvm_pfn_t start, kvm_pfn_t end)
+@@ -13973,6 +13973,13 @@ void kvm_arch_gmem_invalidate(kvm_pfn_t start, kvm_pfn_t end)
  	kvm_x86_call(gmem_invalidate)(start, end);
  }
  #endif
 +
 +bool kvm_arch_gmem_supports_no_direct_map(struct kvm *kvm)
 +{
-+	return can_set_direct_map() && kvm->arch.vm_type != KVM_X86_TDX_VM;
++	return can_set_direct_map() &&
++	    kvm->arch.vm_type != KVM_X86_TDX_VM &&
++	    kvm->arch.vm_type != KVM_X86_SNP_VM;
 +}
  #endif
  

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0031-KVM-arm64-define-kvm_arch_gmem_supports_no_direct_ma.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0031-KVM-arm64-define-kvm_arch_gmem_supports_no_direct_ma.patch
@@ -1,7 +1,7 @@
-From bd7b4492c95099eaa2a53e88ed129b42c43c0096 Mon Sep 17 00:00:00 2001
+From 421bd3d7ed91f92cae86a368a741597616096a7e Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:34 +0100
-Subject: [PATCH 31/87] KVM: arm64: define
+Subject: [PATCH 31/94] KVM: arm64: define
  kvm_arch_gmem_supports_no_direct_map()
 
 Support for GUEST_MEMFD_FLAG_NO_DIRECT_MAP on arm64 depends on 1) direct
@@ -24,7 +24,7 @@ kvm_gmem_get_pfn()).
 Cc: Will Deacon <will@kernel.org>
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
 Reviewed-by: David Hildenbrand (Arm) <david@kernel.org>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  arch/arm64/include/asm/kvm_host.h | 13 +++++++++++++
  1 file changed, 13 insertions(+)

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0032-KVM-guest_memfd-Add-flag-to-remove-from-direct-map.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0032-KVM-guest_memfd-Add-flag-to-remove-from-direct-map.patch
@@ -1,7 +1,7 @@
-From d81c05381e6a68667fd539ccfd2e0cdb0e59a358 Mon Sep 17 00:00:00 2001
+From 9ab240194c5bfefcc0d0d2913bd995e7bca0424b Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:33 +0100
-Subject: [PATCH 32/87] KVM: guest_memfd: Add flag to remove from direct map
+Subject: [PATCH 32/94] KVM: guest_memfd: Add flag to remove from direct map
 
 Add GUEST_MEMFD_FLAG_NO_DIRECT_MAP flag for KVM_CREATE_GUEST_MEMFD()
 ioctl. When set, guest_memfd folios will be removed from the direct map
@@ -28,23 +28,23 @@ to work.
 
 Direct map entries are zapped right before guest or userspace mappings
 of gmem folios are set up, e.g. in kvm_gmem_fault_user_mapping() or
-kvm_gmem_get_pfn() [called from the KVM MMU code]. The only place where
-a gmem folio can be allocated without being mapped anywhere is
-kvm_gmem_populate(), where handling potential failures of direct map
-removal is not possible (by the time direct map removal is attempted,
-the folio is already marked as prepared, meaning attempting to re-try
-kvm_gmem_populate() would just result in -EEXIST without fixing up the
-direct map state). These folios are then removed form the direct map
-upon kvm_gmem_get_pfn(), e.g. when they are mapped into the guest later.
+kvm_gmem_get_pfn() [called from the KVM MMU code].  At present, direct
+map removal is not supported on platforms that support
+kvm_gmem_populate().  In case such support is added in the future, the
+following ordering is maintained: zap then prepare, invalidate then
+restore, to avoid having guest-owned pages being temporarily mapped on
+by host.  This assumes that preparation or invalidation code does not
+access the page content.
 
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Co-developed-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  Documentation/virt/kvm/api.rst | 21 +++++-----
  include/linux/kvm_host.h       |  3 ++
  include/uapi/linux/kvm.h       |  1 +
- virt/kvm/guest_memfd.c         | 70 +++++++++++++++++++++++++++++++---
- 4 files changed, 81 insertions(+), 14 deletions(-)
+ virt/kvm/guest_memfd.c         | 74 +++++++++++++++++++++++++++++++---
+ 4 files changed, 85 insertions(+), 14 deletions(-)
 
 diff --git a/Documentation/virt/kvm/api.rst b/Documentation/virt/kvm/api.rst
 index 57061fa29e6a..3286e003decc 100644
@@ -105,7 +105,7 @@ index 52f6000ab020..13ee57c09669 100644
  struct kvm_create_guest_memfd {
  	__u64 size;
 diff --git a/virt/kvm/guest_memfd.c b/virt/kvm/guest_memfd.c
-index 658b611760ff..5beeb6866dcf 100644
+index 658b611760ff..9e493d049798 100644
 --- a/virt/kvm/guest_memfd.c
 +++ b/virt/kvm/guest_memfd.c
 @@ -7,6 +7,7 @@
@@ -116,7 +116,7 @@ index 658b611760ff..5beeb6866dcf 100644
  
  #include "kvm_mm.h"
  
-@@ -81,6 +82,35 @@ static inline void kvm_gmem_mark_prepared(struct folio *folio)
+@@ -81,6 +82,39 @@ static inline void kvm_gmem_mark_prepared(struct folio *folio)
  	folio_mark_uptodate(folio);
  }
  
@@ -129,10 +129,14 @@ index 658b611760ff..5beeb6866dcf 100644
 +
 +static int kvm_gmem_folio_zap_direct_map(struct folio *folio)
 +{
-+	u64 gmem_flags = GMEM_I(folio_inode(folio))->flags;
 +	int r = 0;
 +
-+	if (kvm_gmem_folio_no_direct_map(folio) || !(gmem_flags & GUEST_MEMFD_FLAG_NO_DIRECT_MAP))
++	VM_WARN_ON_FOLIO(!folio_test_locked(folio), folio);
++
++	if (WARN_ON_ONCE(!(GMEM_I(folio_inode(folio))->flags & GUEST_MEMFD_FLAG_NO_DIRECT_MAP)))
++		return -EINVAL;
++
++	if (kvm_gmem_folio_no_direct_map(folio))
 +		goto out;
 +
 +	r = folio_zap_direct_map(folio);
@@ -152,7 +156,7 @@ index 658b611760ff..5beeb6866dcf 100644
  /*
   * Process @folio, which contains @gfn, so that the guest can use it.
   * The folio must be locked and the gfn must be contained in @slot.
-@@ -393,11 +423,17 @@ static bool kvm_gmem_supports_mmap(struct inode *inode)
+@@ -393,11 +427,17 @@ static bool kvm_gmem_supports_mmap(struct inode *inode)
  	return GMEM_I(inode)->flags & GUEST_MEMFD_FLAG_MMAP;
  }
  
@@ -170,7 +174,7 @@ index 658b611760ff..5beeb6866dcf 100644
  
  	if (((loff_t)vmf->pgoff << PAGE_SHIFT) >= i_size_read(inode))
  		return VM_FAULT_SIGBUS;
-@@ -423,6 +459,14 @@ static vm_fault_t kvm_gmem_fault_user_mapping(struct vm_fault *vmf)
+@@ -423,6 +463,14 @@ static vm_fault_t kvm_gmem_fault_user_mapping(struct vm_fault *vmf)
  		kvm_gmem_mark_prepared(folio);
  	}
  
@@ -185,17 +189,17 @@ index 658b611760ff..5beeb6866dcf 100644
  	vmf->page = folio_file_page(folio, vmf->pgoff);
  
  out_folio:
-@@ -533,6 +577,9 @@ static void kvm_gmem_free_folio(struct folio *folio)
- 	kvm_pfn_t pfn = page_to_pfn(page);
+@@ -534,6 +582,9 @@ static void kvm_gmem_free_folio(struct folio *folio)
  	int order = folio_order(folio);
  
+ 	kvm_arch_gmem_invalidate(pfn, pfn + (1ul << order));
++
 +	if (kvm_gmem_folio_no_direct_map(folio))
 +		kvm_gmem_folio_restore_direct_map(folio);
-+
- 	kvm_arch_gmem_invalidate(pfn, pfn + (1ul << order));
  }
  
-@@ -596,6 +643,9 @@ static int __kvm_gmem_create(struct kvm *kvm, loff_t size, u64 flags)
+ static const struct address_space_operations kvm_gmem_aops = {
+@@ -596,6 +647,9 @@ static int __kvm_gmem_create(struct kvm *kvm, loff_t size, u64 flags)
  	/* Unmovable mappings are supposed to be marked unevictable as well. */
  	WARN_ON_ONCE(!mapping_unevictable(inode->i_mapping));
  
@@ -205,7 +209,7 @@ index 658b611760ff..5beeb6866dcf 100644
  	GMEM_I(inode)->flags = flags;
  
  	file = alloc_file_pseudo(inode, kvm_gmem_mnt, name, O_RDWR, &kvm_gmem_fops);
-@@ -786,15 +836,25 @@ int kvm_gmem_get_pfn(struct kvm *kvm, struct kvm_memory_slot *slot,
+@@ -786,15 +840,25 @@ int kvm_gmem_get_pfn(struct kvm *kvm, struct kvm_memory_slot *slot,
  	if (IS_ERR(folio))
  		return PTR_ERR(folio);
  

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0033-KVM-selftests-load-elf-via-bounce-buffer.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0033-KVM-selftests-load-elf-via-bounce-buffer.patch
@@ -1,7 +1,7 @@
-From e6b105a314d205051913b562f92793f6a5120388 Mon Sep 17 00:00:00 2001
+From f4e56592c7e30e9989a9f37c4e182a9a9cc0c2b8 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:34 +0100
-Subject: [PATCH 33/87] KVM: selftests: load elf via bounce buffer
+Subject: [PATCH 33/94] KVM: selftests: load elf via bounce buffer
 
 If guest memory is backed using a VMA that does not allow GUP (e.g. a
 userspace mapping of guest_memfd when the fd was allocated using
@@ -11,7 +11,7 @@ support loading binaries in this cases, do the read(2) syscall using a
 bounce buffer, and then memcpy from the bounce buffer into guest memory.
 
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  .../testing/selftests/kvm/include/test_util.h |  1 +
  tools/testing/selftests/kvm/lib/elf.c         |  8 +++----

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0034-KVM-selftests-set-KVM_MEM_GUEST_MEMFD-in-vm_mem_add-.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0034-KVM-selftests-set-KVM_MEM_GUEST_MEMFD-in-vm_mem_add-.patch
@@ -1,7 +1,7 @@
-From 5682c4e060895dc0fb47c37a1db375195d0678de Mon Sep 17 00:00:00 2001
+From 5b17ba63eb7bd7449d0f4efbd5a6807246ea0752 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:34 +0100
-Subject: [PATCH 34/87] KVM: selftests: set KVM_MEM_GUEST_MEMFD in vm_mem_add()
+Subject: [PATCH 34/94] KVM: selftests: set KVM_MEM_GUEST_MEMFD in vm_mem_add()
  if guest_memfd != -1
 
 Have vm_mem_add() always set KVM_MEM_GUEST_MEMFD in the memslot flags if
@@ -20,7 +20,7 @@ vm_mem_backing_src_type, at which point having to make sure the src_type
 and flags are in-sync becomes cumbersome.
 
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  tools/testing/selftests/kvm/lib/kvm_util.c | 24 +++++++++++++---------
  1 file changed, 14 insertions(+), 10 deletions(-)

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0035-KVM-selftests-Add-guest_memfd-based-vm_mem_backing_s.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0035-KVM-selftests-Add-guest_memfd-based-vm_mem_backing_s.patch
@@ -1,7 +1,7 @@
-From 232a9968e0c92b5a6944dd8282cf01af944d8fc0 Mon Sep 17 00:00:00 2001
+From 7c7b83cc07e603fbd0df907fe3f428131261629c Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:35 +0100
-Subject: [PATCH 35/87] KVM: selftests: Add guest_memfd based
+Subject: [PATCH 35/94] KVM: selftests: Add guest_memfd based
  vm_mem_backing_src_types
 
 Allow selftests to configure their memslots such that userspace_addr is
@@ -15,7 +15,7 @@ Add backing types for normal guest_memfd, as well as direct map removed
 guest_memfd.
 
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  .../testing/selftests/kvm/include/kvm_util.h  | 18 ++++++
  .../testing/selftests/kvm/include/test_util.h |  7 +++

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0036-KVM-selftests-cover-GUEST_MEMFD_FLAG_NO_DIRECT_MAP-i.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0036-KVM-selftests-cover-GUEST_MEMFD_FLAG_NO_DIRECT_MAP-i.patch
@@ -1,7 +1,7 @@
-From e67b3d6d0f84158724ef06a2f7107809028921d6 Mon Sep 17 00:00:00 2001
+From 5a2e2b0f96d4f66f94d39fb00346611bdd235895 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:35 +0100
-Subject: [PATCH 36/87] KVM: selftests: cover GUEST_MEMFD_FLAG_NO_DIRECT_MAP in
+Subject: [PATCH 36/94] KVM: selftests: cover GUEST_MEMFD_FLAG_NO_DIRECT_MAP in
  existing selftests
 
 Extend mem conversion selftests to cover the scenario that the guest can
@@ -9,7 +9,7 @@ fault in and write gmem-backed guest memory even if its direct map
 removed. Also cover the new flag in guest_memfd_test.c tests.
 
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  tools/testing/selftests/kvm/guest_memfd_test.c  | 17 ++++++++++++++++-
  .../kvm/x86/private_mem_conversions_test.c      |  7 ++++---

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0037-KVM-selftests-stuff-vm_mem_backing_src_type-into-vm_.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0037-KVM-selftests-stuff-vm_mem_backing_src_type-into-vm_.patch
@@ -1,7 +1,7 @@
-From 7e9f5dac38454a207f9e7f5a0c860b89d131a5bb Mon Sep 17 00:00:00 2001
+From 114f04d4747068059cf565881b9b046801480c05 Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:35 +0100
-Subject: [PATCH 37/87] KVM: selftests: stuff vm_mem_backing_src_type into
+Subject: [PATCH 37/94] KVM: selftests: stuff vm_mem_backing_src_type into
  vm_shape
 
 Use one of the padding fields in struct vm_shape to carry an enum
@@ -12,7 +12,7 @@ Overwriting this default will allow tests to create VMs where the test
 code is backed by mmap'd guest_memfd instead of anonymous memory.
 
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  .../testing/selftests/kvm/include/kvm_util.h  | 19 ++++++++++---------
  tools/testing/selftests/kvm/lib/kvm_util.c    |  2 +-

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0038-KVM-selftests-Test-guest-execution-from-direct-map-r.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0038-KVM-selftests-Test-guest-execution-from-direct-map-r.patch
@@ -1,7 +1,7 @@
-From df7109021c0ca1d5351bf5fee04f2153e08c5e4e Mon Sep 17 00:00:00 2001
+From 666ac08672164616e1b0c2cd9833e18420867fcb Mon Sep 17 00:00:00 2001
 From: Patrick Roy <patrick.roy@linux.dev>
 Date: Sun, 23 Nov 2025 18:44:36 +0100
-Subject: [PATCH 38/87] KVM: selftests: Test guest execution from direct map
+Subject: [PATCH 38/94] KVM: selftests: Test guest execution from direct map
  removed gmem
 
 Add a selftest that loads itself into guest_memfd (via
@@ -14,7 +14,7 @@ that's been reflected into the memslot's userspace_addr field (instead
 of trying to do direct map accesses).
 
 Signed-off-by: Patrick Roy <patrick.roy@linux.dev>
-Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
+Signed-off-by: Nikita Kalyazin <nikita.kalyazin@linux.dev>
 ---
  .../selftests/kvm/set_memory_region_test.c    | 52 +++++++++++++++++--
  1 file changed, 48 insertions(+), 4 deletions(-)

--- a/resources/hiding_ci/linux_patches/10-direct-map-removal/0039-internal-x86-conditional-tlb-flush-after-zapping-dir.patch
+++ b/resources/hiding_ci/linux_patches/10-direct-map-removal/0039-internal-x86-conditional-tlb-flush-after-zapping-dir.patch
@@ -1,7 +1,7 @@
-From 0e0ec50c14c25b4aaf62d6e59d668a4aeeba5a98 Mon Sep 17 00:00:00 2001
+From 4b09417fd0a5698dcb9a935c1e23584b8bc070dd Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 12 Jan 2026 15:51:48 +0000
-Subject: [PATCH 39/87] internal: x86: conditional tlb flush after zapping
+Subject: [PATCH 39/94] internal: x86: conditional tlb flush after zapping
  direct map
 
 Gate TLB flushes after removing pages from direct map on x86 by a
@@ -81,11 +81,11 @@ index 9f34afa27d00..685e56404533 100644
  struct kvm_device {
  	const struct kvm_device_ops *ops;
 diff --git a/mm/memory.c b/mm/memory.c
-index 078558b21cfb..4f200c3e7d24 100644
+index 1ec36299e963..5b07a6ac5027 100644
 --- a/mm/memory.c
 +++ b/mm/memory.c
-@@ -7343,8 +7343,6 @@ int folio_zap_direct_map(struct folio *folio)
- 	int ret;
+@@ -7346,8 +7346,6 @@ int folio_zap_direct_map(struct folio *folio)
+ 		return -EINVAL;
  
  	ret = set_direct_map_valid_noflush(addr, folio_nr_pages(folio), false);
 -	flush_tlb_kernel_range((unsigned long)addr,
@@ -94,7 +94,7 @@ index 078558b21cfb..4f200c3e7d24 100644
  	return ret;
  }
 diff --git a/virt/kvm/guest_memfd.c b/virt/kvm/guest_memfd.c
-index 5beeb6866dcf..ed68a3b635ca 100644
+index 9e493d049798..5757949ff13a 100644
 --- a/virt/kvm/guest_memfd.c
 +++ b/virt/kvm/guest_memfd.c
 @@ -91,6 +91,7 @@ static bool kvm_gmem_folio_no_direct_map(struct folio *folio)
@@ -102,10 +102,10 @@ index 5beeb6866dcf..ed68a3b635ca 100644
  static int kvm_gmem_folio_zap_direct_map(struct folio *folio)
  {
 +	unsigned long addr = (unsigned long)folio_address(folio);
- 	u64 gmem_flags = GMEM_I(folio_inode(folio))->flags;
  	int r = 0;
  
-@@ -100,6 +101,8 @@ static int kvm_gmem_folio_zap_direct_map(struct folio *folio)
+ 	VM_WARN_ON_FOLIO(!folio_test_locked(folio), folio);
+@@ -104,6 +105,8 @@ static int kvm_gmem_folio_zap_direct_map(struct folio *folio)
  	r = folio_zap_direct_map(folio);
  	if (!r)
  		folio->private = (void *)((u64)folio->private | KVM_GMEM_FOLIO_NO_DIRECT_MAP);

--- a/resources/hiding_ci/linux_patches/11-kvm-clock/0040-KVM-pfncache-Add-guest_memfd-support-to-pfncache.patch
+++ b/resources/hiding_ci/linux_patches/11-kvm-clock/0040-KVM-pfncache-Add-guest_memfd-support-to-pfncache.patch
@@ -1,7 +1,7 @@
-From 3bbc2d9d49fa16a4710de84916e447c34f82ea36 Mon Sep 17 00:00:00 2001
+From 8d5a7c97aa58182ab5dce31ef8065e7a3cf35ded Mon Sep 17 00:00:00 2001
 From: Takahiro Itazuri <itazur@amazon.com>
 Date: Tue, 10 Mar 2026 06:08:41 +0000
-Subject: [PATCH 40/86] KVM: pfncache: Add guest_memfd support to pfncache
+Subject: [PATCH 40/94] KVM: pfncache: Add guest_memfd support to pfncache
 
 [ based on v6.18 with [1] ]
 

--- a/resources/hiding_ci/linux_patches/11-kvm-clock/0041-KVM-pfncache-Resolve-PFNs-via-kvm_gmem_get_pfn-for-g.patch
+++ b/resources/hiding_ci/linux_patches/11-kvm-clock/0041-KVM-pfncache-Resolve-PFNs-via-kvm_gmem_get_pfn-for-g.patch
@@ -1,7 +1,7 @@
-From 330d5d4a29bcf5432f4dc69a085a2aeef25f7c2b Mon Sep 17 00:00:00 2001
+From 6176d7e13f3bcc14083402dbf803b68ff64b67e1 Mon Sep 17 00:00:00 2001
 From: Takahiro Itazuri <itazur@amazon.com>
 Date: Sun, 22 Feb 2026 13:31:50 +0000
-Subject: [PATCH 41/86] KVM: pfncache: Resolve PFNs via kvm_gmem_get_pfn() for
+Subject: [PATCH 41/94] KVM: pfncache: Resolve PFNs via kvm_gmem_get_pfn() for
  gmem-backed GPAs
 
 Currently, pfncaches always resolve PFNs via hva_to_pfn(), which

--- a/resources/hiding_ci/linux_patches/11-kvm-clock/0042-KVM-pfncache-Obtain-KHVA-via-vmap-for-gmem-with-NO_D.patch
+++ b/resources/hiding_ci/linux_patches/11-kvm-clock/0042-KVM-pfncache-Obtain-KHVA-via-vmap-for-gmem-with-NO_D.patch
@@ -1,7 +1,7 @@
-From e2f55577e626359f6356b6e5e84ada75d9ade47a Mon Sep 17 00:00:00 2001
+From 46d084369ead434c29b98d7beb7ff97164123359 Mon Sep 17 00:00:00 2001
 From: Takahiro Itazuri <itazur@amazon.com>
 Date: Sun, 22 Feb 2026 14:30:14 +0000
-Subject: [PATCH 42/86] KVM: pfncache: Obtain KHVA via vmap() for gmem with
+Subject: [PATCH 42/94] KVM: pfncache: Obtain KHVA via vmap() for gmem with
  NO_DIRECT_MAP
 
 Currently, pfncaches map RAM pages via kmap(), which typically returns a

--- a/resources/hiding_ci/linux_patches/11-kvm-clock/0043-KVM-Rename-invalidate_begin-to-invalidate_start-for-.patch
+++ b/resources/hiding_ci/linux_patches/11-kvm-clock/0043-KVM-Rename-invalidate_begin-to-invalidate_start-for-.patch
@@ -1,7 +1,7 @@
-From d87b178794ec0d7192871892bf08162e07d06302 Mon Sep 17 00:00:00 2001
+From b45009d8ca32ef06466622537643340d1c75ff66 Mon Sep 17 00:00:00 2001
 From: Takahiro Itazuri <itazur@amazon.com>
 Date: Thu, 19 Feb 2026 08:09:45 +0000
-Subject: [PATCH 43/86] KVM: Rename invalidate_begin to invalidate_start for
+Subject: [PATCH 43/94] KVM: Rename invalidate_begin to invalidate_start for
  consistency
 
 Most MMU-related helpers use "_start" suffix.  Align with the prevailing
@@ -68,10 +68,10 @@ index d1094c2d5fb6..8ecf36a84e3b 100644
  	 * invalidate_range_start() is called when all pages in the
  	 * range are still mapped and have at least a refcount of one.
 diff --git a/virt/kvm/guest_memfd.c b/virt/kvm/guest_memfd.c
-index ed68a3b635ca..cc39ab9f8d85 100644
+index 5757949ff13a..68396333586f 100644
 --- a/virt/kvm/guest_memfd.c
 +++ b/virt/kvm/guest_memfd.c
-@@ -195,7 +195,7 @@ static enum kvm_gfn_range_filter kvm_gmem_get_invalidate_filter(struct inode *in
+@@ -199,7 +199,7 @@ static enum kvm_gfn_range_filter kvm_gmem_get_invalidate_filter(struct inode *in
  	return KVM_FILTER_PRIVATE;
  }
  
@@ -80,7 +80,7 @@ index ed68a3b635ca..cc39ab9f8d85 100644
  					pgoff_t end,
  					enum kvm_gfn_range_filter attr_filter)
  {
-@@ -219,7 +219,7 @@ static void __kvm_gmem_invalidate_begin(struct gmem_file *f, pgoff_t start,
+@@ -223,7 +223,7 @@ static void __kvm_gmem_invalidate_begin(struct gmem_file *f, pgoff_t start,
  			found_memslot = true;
  
  			KVM_MMU_LOCK(kvm);
@@ -89,7 +89,7 @@ index ed68a3b635ca..cc39ab9f8d85 100644
  		}
  
  		flush |= kvm_mmu_unmap_gfn_range(kvm, &gfn_range);
-@@ -232,7 +232,7 @@ static void __kvm_gmem_invalidate_begin(struct gmem_file *f, pgoff_t start,
+@@ -236,7 +236,7 @@ static void __kvm_gmem_invalidate_begin(struct gmem_file *f, pgoff_t start,
  		KVM_MMU_UNLOCK(kvm);
  }
  
@@ -98,7 +98,7 @@ index ed68a3b635ca..cc39ab9f8d85 100644
  				      pgoff_t end)
  {
  	enum kvm_gfn_range_filter attr_filter;
-@@ -241,7 +241,7 @@ static void kvm_gmem_invalidate_begin(struct inode *inode, pgoff_t start,
+@@ -245,7 +245,7 @@ static void kvm_gmem_invalidate_begin(struct inode *inode, pgoff_t start,
  	attr_filter = kvm_gmem_get_invalidate_filter(inode);
  
  	kvm_gmem_for_each_file(f, inode->i_mapping)
@@ -107,7 +107,7 @@ index ed68a3b635ca..cc39ab9f8d85 100644
  }
  
  static void __kvm_gmem_invalidate_end(struct gmem_file *f, pgoff_t start,
-@@ -276,7 +276,7 @@ static long kvm_gmem_punch_hole(struct inode *inode, loff_t offset, loff_t len)
+@@ -280,7 +280,7 @@ static long kvm_gmem_punch_hole(struct inode *inode, loff_t offset, loff_t len)
  	 */
  	filemap_invalidate_lock(inode->i_mapping);
  
@@ -116,7 +116,7 @@ index ed68a3b635ca..cc39ab9f8d85 100644
  
  	truncate_inode_pages_range(inode->i_mapping, offset, offset + len - 1);
  
-@@ -390,7 +390,7 @@ static int kvm_gmem_release(struct inode *inode, struct file *file)
+@@ -394,7 +394,7 @@ static int kvm_gmem_release(struct inode *inode, struct file *file)
  	 * Zap all SPTEs pointed at by this file.  Do not free the backing
  	 * memory, as its lifetime is associated with the inode, not the file.
  	 */
@@ -125,7 +125,7 @@ index ed68a3b635ca..cc39ab9f8d85 100644
  				    kvm_gmem_get_invalidate_filter(inode));
  	__kvm_gmem_invalidate_end(f, 0, -1ul);
  
-@@ -556,7 +556,7 @@ static int kvm_gmem_error_folio(struct address_space *mapping, struct folio *fol
+@@ -560,7 +560,7 @@ static int kvm_gmem_error_folio(struct address_space *mapping, struct folio *fol
  	start = folio->index;
  	end = start + folio_nr_pages(folio);
  

--- a/resources/hiding_ci/linux_patches/11-kvm-clock/0044-KVM-pfncache-Rename-invalidate_start-helper.patch
+++ b/resources/hiding_ci/linux_patches/11-kvm-clock/0044-KVM-pfncache-Rename-invalidate_start-helper.patch
@@ -1,7 +1,7 @@
-From e5f2d5ee2b236dbc5116a2ad3f15b93f793db17b Mon Sep 17 00:00:00 2001
+From aa4927b33d7bb8d78ee9f314ec9c28c86a7390cc Mon Sep 17 00:00:00 2001
 From: Takahiro Itazuri <itazur@amazon.com>
 Date: Sun, 22 Feb 2026 14:43:29 +0000
-Subject: [PATCH 44/86] KVM: pfncache: Rename invalidate_start() helper
+Subject: [PATCH 44/94] KVM: pfncache: Rename invalidate_start() helper
 
 Rename gfn_to_pfn_cache_invalidate_start() to
 gpc_invalidate_hva_range_start() to explicitly indicate that it takes a

--- a/resources/hiding_ci/linux_patches/11-kvm-clock/0045-KVM-Rename-mn_-invalidate-related-fields-to-generic-.patch
+++ b/resources/hiding_ci/linux_patches/11-kvm-clock/0045-KVM-Rename-mn_-invalidate-related-fields-to-generic-.patch
@@ -1,7 +1,7 @@
-From c3bcbcf9415bca3d1653ec3a0b362592dd4bcfcc Mon Sep 17 00:00:00 2001
+From 05badd86cd3bc0ea82243a941e77bac176594890 Mon Sep 17 00:00:00 2001
 From: Takahiro Itazuri <itazur@amazon.com>
 Date: Sun, 22 Feb 2026 14:57:50 +0000
-Subject: [PATCH 45/86] KVM: Rename mn_* invalidate-related fields to generic
+Subject: [PATCH 45/94] KVM: Rename mn_* invalidate-related fields to generic
  ones
 
 The addition of guest_memfd support to pfncaches introduces additional

--- a/resources/hiding_ci/linux_patches/11-kvm-clock/0046-KVM-pfncache-Invalidate-on-gmem-invalidation-and-mem.patch
+++ b/resources/hiding_ci/linux_patches/11-kvm-clock/0046-KVM-pfncache-Invalidate-on-gmem-invalidation-and-mem.patch
@@ -1,7 +1,7 @@
-From 3562608604a8801f7205dc66d909e6a9fb5e73e8 Mon Sep 17 00:00:00 2001
+From 7c2504e349ddfd3bbcdef74d0450740741de737e Mon Sep 17 00:00:00 2001
 From: Takahiro Itazuri <itazur@amazon.com>
 Date: Sun, 22 Feb 2026 17:25:07 +0000
-Subject: [PATCH 46/86] KVM: pfncache: Invalidate on gmem invalidation and
+Subject: [PATCH 46/94] KVM: pfncache: Invalidate on gmem invalidation and
  memattr updates
 
 Invalidate pfncaches when guest_memfd invalidation or memory attribute
@@ -28,10 +28,10 @@ Suggested-by: David Hildenbrand (Red Hat) <david@kernel.org>
  3 files changed, 98 insertions(+), 3 deletions(-)
 
 diff --git a/virt/kvm/guest_memfd.c b/virt/kvm/guest_memfd.c
-index cc39ab9f8d85..6dd127203e4e 100644
+index 68396333586f..116d9346e87b 100644
 --- a/virt/kvm/guest_memfd.c
 +++ b/virt/kvm/guest_memfd.c
-@@ -204,6 +204,33 @@ static void __kvm_gmem_invalidate_start(struct gmem_file *f, pgoff_t start,
+@@ -208,6 +208,33 @@ static void __kvm_gmem_invalidate_start(struct gmem_file *f, pgoff_t start,
  	struct kvm *kvm = f->kvm;
  	unsigned long index;
  
@@ -65,7 +65,7 @@ index cc39ab9f8d85..6dd127203e4e 100644
  	xa_for_each_range(&f->bindings, index, slot, start, end - 1) {
  		pgoff_t pgoff = slot->gmem.pgoff;
  
-@@ -248,12 +275,35 @@ static void __kvm_gmem_invalidate_end(struct gmem_file *f, pgoff_t start,
+@@ -252,12 +279,35 @@ static void __kvm_gmem_invalidate_end(struct gmem_file *f, pgoff_t start,
  				      pgoff_t end)
  {
  	struct kvm *kvm = f->kvm;

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0047-KVM-Add-KVM_MEM_USERFAULT-memslot-flag-and-bitmap.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0047-KVM-Add-KVM_MEM_USERFAULT-memslot-flag-and-bitmap.patch
@@ -1,7 +1,7 @@
-From 43587e783a02a7698319d38c234d0aeb1ef071cc Mon Sep 17 00:00:00 2001
+From 854e8101f72f16764a92a847cb81436bb05e612a Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:17 +0000
-Subject: [PATCH 47/86] KVM: Add KVM_MEM_USERFAULT memslot flag and bitmap
+Subject: [PATCH 47/94] KVM: Add KVM_MEM_USERFAULT memslot flag and bitmap
 
 Use one of the 14 reserved u64s in struct kvm_userspace_memory_region2
 for the user to provide `userfault_bitmap`.

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0048-KVM-Add-KVM_MEMORY_EXIT_FLAG_USERFAULT.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0048-KVM-Add-KVM_MEMORY_EXIT_FLAG_USERFAULT.patch
@@ -1,7 +1,7 @@
-From bf9a06115ecb8f42462b8939c661a7fa68a5bd03 Mon Sep 17 00:00:00 2001
+From ed6c53c5a032943234d60e83e60d3e10d67e2fda Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:18 +0000
-Subject: [PATCH 48/86] KVM: Add KVM_MEMORY_EXIT_FLAG_USERFAULT
+Subject: [PATCH 48/94] KVM: Add KVM_MEMORY_EXIT_FLAG_USERFAULT
 
 This flag is used for vCPU memory faults caused by KVM Userfault; i.e.,
 the bit in `userfault_bitmap` corresponding to the faulting gfn was set.

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0049-KVM-Allow-late-setting-of-KVM_MEM_USERFAULT-on-guest.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0049-KVM-Allow-late-setting-of-KVM_MEM_USERFAULT-on-guest.patch
@@ -1,7 +1,7 @@
-From 972a8086a94aae8d36f4c6f6d4f29855dca8e49d Mon Sep 17 00:00:00 2001
+From e71201bc89e251cb9728d6c1e6041353a71572e9 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:19 +0000
-Subject: [PATCH 49/86] KVM: Allow late setting of KVM_MEM_USERFAULT on
+Subject: [PATCH 49/94] KVM: Allow late setting of KVM_MEM_USERFAULT on
  guest_memfd memslot
 
 Currently guest_memfd memslots can only be deleted. Slightly change the

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0050-KVM-x86-mmu-Add-support-for-KVM_MEM_USERFAULT.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0050-KVM-x86-mmu-Add-support-for-KVM_MEM_USERFAULT.patch
@@ -1,7 +1,7 @@
-From b40496f26936d17b8ccb7228a342f92f4781e17b Mon Sep 17 00:00:00 2001
+From f05f4adae3d4d1374b79ce0ed4dede8c421b86c2 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:21 +0000
-Subject: [PATCH 50/86] KVM: x86/mmu: Add support for KVM_MEM_USERFAULT
+Subject: [PATCH 50/94] KVM: x86/mmu: Add support for KVM_MEM_USERFAULT
 
 Adhering to the requirements of KVM Userfault:
 
@@ -124,7 +124,7 @@ index ed5c01df21ba..a08741d39b82 100644
  
  static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
 diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
-index 652345b161aa..a447663d5eff 100644
+index d1aeefd014c0..7e08203ab134 100644
 --- a/arch/x86/kvm/x86.c
 +++ b/arch/x86/kvm/x86.c
 @@ -13494,12 +13494,36 @@ static void kvm_mmu_slot_apply_flags(struct kvm *kvm,

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0051-KVM-Advertise-KVM_CAP_USERFAULT-in-KVM_CHECK_EXTENSI.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0051-KVM-Advertise-KVM_CAP_USERFAULT-in-KVM_CHECK_EXTENSI.patch
@@ -1,7 +1,7 @@
-From 9e0181c58028df564814ef15b37b9748d5e83736 Mon Sep 17 00:00:00 2001
+From 7b1a820c4bd3afe37f885d3aacbdb04669b09b4e Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:20 +0000
-Subject: [PATCH 51/86] KVM: Advertise KVM_CAP_USERFAULT in KVM_CHECK_EXTENSION
+Subject: [PATCH 51/94] KVM: Advertise KVM_CAP_USERFAULT in KVM_CHECK_EXTENSION
 
 Advertise support for KVM_CAP_USERFAULT when kvm_has_userfault() returns
 true. Currently this is merely IS_ENABLED(CONFIG_HAVE_KVM_USERFAULT), so

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0052-KVM-selftests-Fix-vm_mem_region_set_flags-docstring.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0052-KVM-selftests-Fix-vm_mem_region_set_flags-docstring.patch
@@ -1,7 +1,7 @@
-From 8f70b252f1f3364fd6aabd92bab51da695004c90 Mon Sep 17 00:00:00 2001
+From afb14864829e9cd2249e707e96cc4af0f92020bb Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Wed, 4 Dec 2024 19:13:42 +0000
-Subject: [PATCH 52/86] KVM: selftests: Fix vm_mem_region_set_flags docstring
+Subject: [PATCH 52/94] KVM: selftests: Fix vm_mem_region_set_flags docstring
 
 `flags` is what region->region.flags gets set to.
 

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0053-KVM-arm64-Add-support-for-KVM_MEM_USERFAULT.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0053-KVM-arm64-Add-support-for-KVM_MEM_USERFAULT.patch
@@ -1,7 +1,7 @@
-From b69f62b16a50d0a6b8c52faca3fac38299fc91b8 Mon Sep 17 00:00:00 2001
+From 7b241c46cd0f7b227ceb1f82a75544d161670434 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Thu, 9 Jan 2025 20:49:22 +0000
-Subject: [PATCH 53/86] KVM: arm64: Add support for KVM_MEM_USERFAULT
+Subject: [PATCH 53/94] KVM: arm64: Add support for KVM_MEM_USERFAULT
 
 Adhering to the requirements of KVM Userfault:
 1. When it is toggled on, zap the second stage with

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0054-KVM-selftests-Fix-prefault_mem-logic.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0054-KVM-selftests-Fix-prefault_mem-logic.patch
@@ -1,7 +1,7 @@
-From ba2bf51a0a560cc3d4e08afdca0737f8c445f958 Mon Sep 17 00:00:00 2001
+From 59f1f81dfc359bf6c207ce18c8ee4cc97fc9de60 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Wed, 4 Dec 2024 19:13:43 +0000
-Subject: [PATCH 54/86] KVM: selftests: Fix prefault_mem logic
+Subject: [PATCH 54/94] KVM: selftests: Fix prefault_mem logic
 
 The previous logic didn't handle the case where memory was partitioned
 AND we were using a single userfaultfd. It would only prefault the first

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0055-KVM-selftests-Add-va_start-end-into-uffd_desc.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0055-KVM-selftests-Add-va_start-end-into-uffd_desc.patch
@@ -1,7 +1,7 @@
-From ad8e343a94702b87b9fec53a9fba34acecda6b4e Mon Sep 17 00:00:00 2001
+From d09fdb5c8f49a64887e6577476280c5102b7ab88 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Wed, 4 Dec 2024 19:13:44 +0000
-Subject: [PATCH 55/86] KVM: selftests: Add va_start/end into uffd_desc
+Subject: [PATCH 55/94] KVM: selftests: Add va_start/end into uffd_desc
 
 This will be used for the self-test to look up which userfaultfd we
 should be using when handling a KVM Userfault (in the event KVM

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0056-KVM-selftests-Add-KVM-Userfault-mode-to-demand_pagin.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0056-KVM-selftests-Add-KVM-Userfault-mode-to-demand_pagin.patch
@@ -1,7 +1,7 @@
-From 1915acd819002936029c414aad2bffc443fe192c Mon Sep 17 00:00:00 2001
+From 489ae064258ce52f4c4088f713f0435249581564 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Wed, 4 Dec 2024 19:13:45 +0000
-Subject: [PATCH 56/86] KVM: selftests: Add KVM Userfault mode to
+Subject: [PATCH 56/94] KVM: selftests: Add KVM Userfault mode to
  demand_paging_test
 
 Add a way for the KVM_RUN loop to handle -EFAULT exits when they are for

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0057-KVM-selftests-Inform-set_memory_region_test-of-KVM_M.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0057-KVM-selftests-Inform-set_memory_region_test-of-KVM_M.patch
@@ -1,7 +1,7 @@
-From 7ce562add8c3add2f52b849d0a77097b3a9fe5f0 Mon Sep 17 00:00:00 2001
+From 68076b57cbd83499b84f32f5a578c354bea39692 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Wed, 4 Dec 2024 19:13:46 +0000
-Subject: [PATCH 57/86] KVM: selftests: Inform set_memory_region_test of
+Subject: [PATCH 57/94] KVM: selftests: Inform set_memory_region_test of
  KVM_MEM_USERFAULT
 
 The KVM_MEM_USERFAULT flag is supported iff KVM_CAP_USERFAULT is

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0058-KVM-selftests-Add-KVM_MEM_USERFAULT-guest_memfd-togg.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0058-KVM-selftests-Add-KVM_MEM_USERFAULT-guest_memfd-togg.patch
@@ -1,7 +1,7 @@
-From 5e0db77d58adae2f459bb27d77c60c059883e440 Mon Sep 17 00:00:00 2001
+From d28afd756826e401f31424b7bd135e3675d46b09 Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Wed, 4 Dec 2024 19:13:47 +0000
-Subject: [PATCH 58/86] KVM: selftests: Add KVM_MEM_USERFAULT + guest_memfd
+Subject: [PATCH 58/94] KVM: selftests: Add KVM_MEM_USERFAULT + guest_memfd
  toggle tests
 
 Make sure KVM_MEM_USERFAULT can be toggled on and off for

--- a/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0059-KVM-Documentation-Add-KVM_CAP_USERFAULT-and-KVM_MEM_.patch
+++ b/resources/hiding_ci/linux_patches/15-kvm-mem-userfault/0059-KVM-Documentation-Add-KVM_CAP_USERFAULT-and-KVM_MEM_.patch
@@ -1,7 +1,7 @@
-From 8b8a1b8f2a005987699ca8ef2444c938fae4faa1 Mon Sep 17 00:00:00 2001
+From efdb08cc8acc1e7a6105318ca9ea3d51ad314b7f Mon Sep 17 00:00:00 2001
 From: James Houghton <jthoughton@google.com>
 Date: Wed, 4 Dec 2024 19:13:48 +0000
-Subject: [PATCH 59/86] KVM: Documentation: Add KVM_CAP_USERFAULT and
+Subject: [PATCH 59/94] KVM: Documentation: Add KVM_CAP_USERFAULT and
  KVM_MEM_USERFAULT details
 
 Include the note about memory ordering when clearing bits in

--- a/resources/hiding_ci/linux_patches/20-gmem-write/0060-KVM-guest_memfd-add-generic-population-via-write.patch
+++ b/resources/hiding_ci/linux_patches/20-gmem-write/0060-KVM-guest_memfd-add-generic-population-via-write.patch
@@ -1,7 +1,7 @@
-From 40ea8b644a885e26bde0ddb38e66a3e1dd712477 Mon Sep 17 00:00:00 2001
+From fdfc2dacead5df7d31a03679dfffddca433bb8b2 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 14 Nov 2025 11:34:23 +0000
-Subject: [PATCH 60/86] KVM: guest_memfd: add generic population via write
+Subject: [PATCH 60/94] KVM: guest_memfd: add generic population via write
 
 On systems that support shared guest memory, write() is useful, for
 example, for population of the initial image.  Even though the same can
@@ -82,10 +82,10 @@ index b351b1ba6330..052c7c4876eb 100644
  struct kvm_create_guest_memfd {
  	__u64 size;
 diff --git a/virt/kvm/guest_memfd.c b/virt/kvm/guest_memfd.c
-index 6dd127203e4e..36f250801759 100644
+index 116d9346e87b..d60be4b52555 100644
 --- a/virt/kvm/guest_memfd.c
 +++ b/virt/kvm/guest_memfd.c
-@@ -584,6 +584,8 @@ static int kvm_gmem_mmap(struct file *file, struct vm_area_struct *vma)
+@@ -588,6 +588,8 @@ static int kvm_gmem_mmap(struct file *file, struct vm_area_struct *vma)
  
  static struct file_operations kvm_gmem_fops = {
  	.mmap		= kvm_gmem_mmap,
@@ -94,8 +94,8 @@ index 6dd127203e4e..36f250801759 100644
  	.open		= generic_file_open,
  	.release	= kvm_gmem_release,
  	.fallocate	= kvm_gmem_fallocate,
-@@ -636,8 +638,55 @@ static void kvm_gmem_free_folio(struct folio *folio)
- 	kvm_arch_gmem_invalidate(pfn, pfn + (1ul << order));
+@@ -640,8 +642,55 @@ static void kvm_gmem_free_folio(struct folio *folio)
+ 		kvm_gmem_folio_restore_direct_map(folio);
  }
  
 +static bool kvm_gmem_supports_write(struct inode *inode)
@@ -150,7 +150,7 @@ index 6dd127203e4e..36f250801759 100644
  	.migrate_folio	= kvm_gmem_migrate_folio,
  	.error_remove_folio = kvm_gmem_error_folio,
  	.free_folio = kvm_gmem_free_folio,
-@@ -708,6 +757,7 @@ static int __kvm_gmem_create(struct kvm *kvm, loff_t size, u64 flags)
+@@ -712,6 +761,7 @@ static int __kvm_gmem_create(struct kvm *kvm, loff_t size, u64 flags)
  	}
  
  	file->f_flags |= O_LARGEFILE;

--- a/resources/hiding_ci/linux_patches/20-gmem-write/0061-KVM-selftests-update-guest_memfd-write-tests.patch
+++ b/resources/hiding_ci/linux_patches/20-gmem-write/0061-KVM-selftests-update-guest_memfd-write-tests.patch
@@ -1,7 +1,7 @@
-From 34d5c022a51157a24b709290b5bba74f94678256 Mon Sep 17 00:00:00 2001
+From ff2ab2bf722e769ee4d2edb30bfc4f4c8a254c12 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 14 Nov 2025 11:35:11 +0000
-Subject: [PATCH 61/86] KVM: selftests: update guest_memfd write tests
+Subject: [PATCH 61/94] KVM: selftests: update guest_memfd write tests
 
 This is to reflect that the write syscall is now implemented for
 guest_memfd.

--- a/resources/hiding_ci/linux_patches/20-gmem-write/0062-fixup-for-write-and-direct-map-removal.patch
+++ b/resources/hiding_ci/linux_patches/20-gmem-write/0062-fixup-for-write-and-direct-map-removal.patch
@@ -1,7 +1,7 @@
-From a53182b4047d7636db03b84f69bb1948b34df904 Mon Sep 17 00:00:00 2001
+From 988f255b71288b9073cde95b17dd47f8f556516e Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 24 Nov 2025 12:25:09 +0000
-Subject: [PATCH 62/86] fixup for write and direct map removal
+Subject: [PATCH 62/94] fixup for write and direct map removal
 
 Make sure the two work together.
 ---
@@ -9,10 +9,10 @@ Make sure the two work together.
  1 file changed, 7 insertions(+)
 
 diff --git a/virt/kvm/guest_memfd.c b/virt/kvm/guest_memfd.c
-index 36f250801759..f8eac86e6931 100644
+index d60be4b52555..b5732e2299cd 100644
 --- a/virt/kvm/guest_memfd.c
 +++ b/virt/kvm/guest_memfd.c
-@@ -663,6 +663,12 @@ static int kvm_gmem_write_begin(const struct kiocb *kiocb,
+@@ -667,6 +667,12 @@ static int kvm_gmem_write_begin(const struct kiocb *kiocb,
  	if (IS_ERR(*folio))
  		return PTR_ERR(*folio);
  
@@ -25,7 +25,7 @@ index 36f250801759..f8eac86e6931 100644
  	return 0;
  }
  
-@@ -674,6 +680,7 @@ static int kvm_gmem_write_end(const struct kiocb *kiocb,
+@@ -678,6 +684,7 @@ static int kvm_gmem_write_end(const struct kiocb *kiocb,
  {
  	if (!folio_test_uptodate(folio)) {
  		folio_zero_range(folio, copied, len - copied);

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0063-userfaultfd-introduce-mfill_copy_folio_locked-helper.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0063-userfaultfd-introduce-mfill_copy_folio_locked-helper.patch
@@ -1,7 +1,7 @@
-From 4597f895b3ff1f8993d2914ef737f29c8a96c7a4 Mon Sep 17 00:00:00 2001
+From 390bdbdf1e65466f06ac70a95787738bd3bb954c Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:01 +0200
-Subject: [PATCH 63/86] userfaultfd: introduce mfill_copy_folio_locked() helper
+Subject: [PATCH 63/94] userfaultfd: introduce mfill_copy_folio_locked() helper
 
 Split copying of data when locks held from mfill_atomic_pte_copy() into
 a helper function mfill_copy_folio_locked().

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0064-userfaultfd-introduce-struct-mfill_state.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0064-userfaultfd-introduce-struct-mfill_state.patch
@@ -1,7 +1,7 @@
-From e7253d7e55eb0f2fc47b8ea866025d9c0966a7f5 Mon Sep 17 00:00:00 2001
+From 93149eb680f545bc9bde3d032d331579dd8bb9db Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:02 +0200
-Subject: [PATCH 64/86] userfaultfd: introduce struct mfill_state
+Subject: [PATCH 64/94] userfaultfd: introduce struct mfill_state
 
 mfill_atomic() passes a lot of parameters down to its callees.
 

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0065-userfaultfd-introduce-mfill_get_pmd-helper.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0065-userfaultfd-introduce-mfill_get_pmd-helper.patch
@@ -1,7 +1,7 @@
-From 96c0f87c9f648cacf44be5b5788c1a0ae2e9480b Mon Sep 17 00:00:00 2001
+From 90b7d3d185ed63dc243ae3a2db37ddf73daf6bc7 Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:03 +0200
-Subject: [PATCH 65/86] userfaultfd: introduce mfill_get_pmd() helper.
+Subject: [PATCH 65/94] userfaultfd: introduce mfill_get_pmd() helper.
 
 There is a lengthy code chunk in mfill_atomic() that establishes the PMD
 for UFFDIO operations. This code may be called twice: first time when

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0066-userfaultfd-introduce-mfill_get_vma-and-mfill_put_vm.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0066-userfaultfd-introduce-mfill_get_vma-and-mfill_put_vm.patch
@@ -1,7 +1,7 @@
-From e1dccc8f2f55bb0bff655504fd276fbcb4a8c745 Mon Sep 17 00:00:00 2001
+From 2bfd57d5273e01519f651e79051ea083ecb50a46 Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:04 +0200
-Subject: [PATCH 66/86] userfaultfd: introduce mfill_get_vma() and
+Subject: [PATCH 66/94] userfaultfd: introduce mfill_get_vma() and
  mfill_put_vma()
 
 Split the code that finds, locks and verifies VMA from mfill_atomic()

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0067-WARNING-in-folio_add_new_anon_rmap.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0067-WARNING-in-folio_add_new_anon_rmap.patch
@@ -1,7 +1,7 @@
-From fb902fcab7b495c3e8701eb9ec1186de60c0b0b5 Mon Sep 17 00:00:00 2001
+From 5f11ca704d8709e3ba91f39c7107e0305466ba8e Mon Sep 17 00:00:00 2001
 From: Harry Yoo <harry.yoo@oracle.com>
 Date: Mon, 16 Mar 2026 15:19:49 +0900
-Subject: [PATCH 67/86] WARNING in folio_add_new_anon_rmap
+Subject: [PATCH 67/94] WARNING in folio_add_new_anon_rmap
 
 #syz test
 ---

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0068-userfaultfd-unassigned-vma-leads-to-a-potential-unre.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0068-userfaultfd-unassigned-vma-leads-to-a-potential-unre.patch
@@ -1,7 +1,7 @@
-From f297dedaf188cb4bcef5f8412e5e6aff0070c0d7 Mon Sep 17 00:00:00 2001
+From e6c96ebb621f2d35923fcbbb3ffb6f9c10add7d5 Mon Sep 17 00:00:00 2001
 From: Edward Adam Davis <eadavis@qq.com>
 Date: Mon, 16 Mar 2026 11:11:03 +0800
-Subject: [PATCH 68/86] userfaultfd: unassigned vma leads to a potential
+Subject: [PATCH 68/94] userfaultfd: unassigned vma leads to a potential
  unreleased locks
 
 A deadlock [1] occurs in mfill_get_vma() because the locks mmap_lock

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0069-userfaultfd-retry-copying-with-locks-dropped-in-mfil.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0069-userfaultfd-retry-copying-with-locks-dropped-in-mfil.patch
@@ -1,7 +1,7 @@
-From 6da8203a45688f8e0f1395859d3fb57ebc874720 Mon Sep 17 00:00:00 2001
+From 89f310a7638432ec379309470c68707e6dc0b988 Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:05 +0200
-Subject: [PATCH 69/86] userfaultfd: retry copying with locks dropped in
+Subject: [PATCH 69/94] userfaultfd: retry copying with locks dropped in
  mfill_atomic_pte_copy()
 
 Implementation of UFFDIO_COPY for anonymous memory might fail to copy

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0070-userfaultfd-move-vma_can_userfault-out-of-line.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0070-userfaultfd-move-vma_can_userfault-out-of-line.patch
@@ -1,7 +1,7 @@
-From 6099924d5a4f5a7b92c971b4eaef466958f0e6b5 Mon Sep 17 00:00:00 2001
+From 1ead3e06371b92f11f35e9fd3d2c50d7f7ad7368 Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:06 +0200
-Subject: [PATCH 70/86] userfaultfd: move vma_can_userfault out of line
+Subject: [PATCH 70/94] userfaultfd: move vma_can_userfault out of line
 
 vma_can_userfault() has grown pretty big and it's not called on
 performance critical path.

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0071-userfaultfd-introduce-vm_uffd_ops.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0071-userfaultfd-introduce-vm_uffd_ops.patch
@@ -1,7 +1,7 @@
-From f7dff50433dca6a954a9de24174eb98a7e1473ac Mon Sep 17 00:00:00 2001
+From 685c846df4850741bdc21ee07f49d81969c7ad45 Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:07 +0200
-Subject: [PATCH 71/86] userfaultfd: introduce vm_uffd_ops
+Subject: [PATCH 71/94] userfaultfd: introduce vm_uffd_ops
 
 Current userfaultfd implementation works only with memory managed by
 core MM: anonymous, shmem and hugetlb.

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0072-userfaultfd-introduce-vm_uffd_ops.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0072-userfaultfd-introduce-vm_uffd_ops.patch
@@ -1,7 +1,7 @@
-From 37c68d03053d052c2e72f953e4a59fcf4f5f566d Mon Sep 17 00:00:00 2001
+From 4053792dca17ff25648b5b9453151aadc5daf03a Mon Sep 17 00:00:00 2001
 From: Mike Rapoport <rppt@kernel.org>
 Date: Wed, 11 Mar 2026 20:49:00 +0200
-Subject: [PATCH 72/86] userfaultfd: introduce vm_uffd_ops
+Subject: [PATCH 72/94] userfaultfd: introduce vm_uffd_ops
 
 On Fri, Mar 06, 2026 at 07:18:07PM +0200, Mike Rapoport wrote:
 >  bool vma_can_userfault(struct vm_area_struct *vma, vm_flags_t vm_flags,

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0073-shmem-userfaultfd-use-a-VMA-callback-to-handle-UFFDI.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0073-shmem-userfaultfd-use-a-VMA-callback-to-handle-UFFDI.patch
@@ -1,7 +1,7 @@
-From 77a4de592ebe187512445cc00def5859ec64c056 Mon Sep 17 00:00:00 2001
+From 6aaa5f0f23a254edccdce8d398e0132a87e7f440 Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:08 +0200
-Subject: [PATCH 73/86] shmem, userfaultfd: use a VMA callback to handle
+Subject: [PATCH 73/94] shmem, userfaultfd: use a VMA callback to handle
  UFFDIO_CONTINUE
 
 When userspace resolves a page fault in a shmem VMA with UFFDIO_CONTINUE

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0074-userfaultfd-introduce-vm_uffd_ops-alloc_folio.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0074-userfaultfd-introduce-vm_uffd_ops-alloc_folio.patch
@@ -1,7 +1,7 @@
-From 5b43455df19d4838a551e0536a6876a680ba29e2 Mon Sep 17 00:00:00 2001
+From 2283672a5623e50cb8353e653bc3ff27f859d1db Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:09 +0200
-Subject: [PATCH 74/86] userfaultfd: introduce vm_uffd_ops->alloc_folio()
+Subject: [PATCH 74/94] userfaultfd: introduce vm_uffd_ops->alloc_folio()
 
 and use it to refactor mfill_atomic_pte_zeroed_folio() and
 mfill_atomic_pte_copy().

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0075-shmem-userfaultfd-implement-shmem-uffd-operations-us.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0075-shmem-userfaultfd-implement-shmem-uffd-operations-us.patch
@@ -1,7 +1,7 @@
-From 58d089525628bc2bb27f5733141928ddc4a8a2d1 Mon Sep 17 00:00:00 2001
+From eaf0edecca76c574f4697cecb42a699636a50382 Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:10 +0200
-Subject: [PATCH 75/86] shmem, userfaultfd: implement shmem uffd operations
+Subject: [PATCH 75/94] shmem, userfaultfd: implement shmem uffd operations
  using vm_uffd_ops
 
 Add filemap_add() and filemap_remove() methods to vm_uffd_ops and use

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0076-userfaultfd-mfill_atomic-remove-retry-logic.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0076-userfaultfd-mfill_atomic-remove-retry-logic.patch
@@ -1,7 +1,7 @@
-From 32e824ea391781f15aa4a8e62d17eb5081f28ab1 Mon Sep 17 00:00:00 2001
+From a85448db9f0fd622c17fea2ef9c667c48a753802 Mon Sep 17 00:00:00 2001
 From: "Mike Rapoport (Microsoft)" <rppt@kernel.org>
 Date: Fri, 6 Mar 2026 19:18:11 +0200
-Subject: [PATCH 76/86] userfaultfd: mfill_atomic(): remove retry logic
+Subject: [PATCH 76/94] userfaultfd: mfill_atomic(): remove retry logic
 
 Since __mfill_atomic_pte() handles the retry for both anonymous and
 shmem, there is no need to retry copying the date from the userspace in

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0077-mm-generalize-handling-of-userfaults-in-__do_fault.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0077-mm-generalize-handling-of-userfaults-in-__do_fault.patch
@@ -1,7 +1,7 @@
-From 4b0df20f616ce065782d41d57a3bfde9d0b8dec4 Mon Sep 17 00:00:00 2001
+From f054d81910042cb280b77c8c4f0c59df3bb0e22a Mon Sep 17 00:00:00 2001
 From: Peter Xu <peterx@redhat.com>
 Date: Fri, 6 Mar 2026 19:18:12 +0200
-Subject: [PATCH 77/86] mm: generalize handling of userfaults in __do_fault()
+Subject: [PATCH 77/94] mm: generalize handling of userfaults in __do_fault()
 
 When a VMA is registered with userfaulfd, its ->fault()
 method should check if a folio exists in the page cache and call
@@ -32,7 +32,7 @@ Signed-off-by: Mike Rapoport (Microsoft) <rppt@kernel.org>
  3 files changed, 51 insertions(+), 12 deletions(-)
 
 diff --git a/mm/memory.c b/mm/memory.c
-index 4f200c3e7d24..3d09be163662 100644
+index 5b07a6ac5027..823a64791476 100644
 --- a/mm/memory.c
 +++ b/mm/memory.c
 @@ -5247,6 +5247,41 @@ static vm_fault_t do_anonymous_page(struct vm_fault *vmf)

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0078-KVM-guest_memfd-implement-userfaultfd-operations.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0078-KVM-guest_memfd-implement-userfaultfd-operations.patch
@@ -1,7 +1,7 @@
-From cae9db2062e2e5158b0b6b3465cbeb45014e8b00 Mon Sep 17 00:00:00 2001
+From 145e85601f3db583e1a51addeed9acce9934b293 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 6 Mar 2026 19:18:13 +0200
-Subject: [PATCH 78/86] KVM: guest_memfd: implement userfaultfd operations
+Subject: [PATCH 78/94] KVM: guest_memfd: implement userfaultfd operations
 
 userfaultfd notifications about page faults used for live migration
 and snapshotting of VMs.
@@ -37,7 +37,7 @@ index 3e4579e4b8bb..041c7719e524 100644
  /*
   * page_cache_delete_batch - delete several folios from page cache
 diff --git a/virt/kvm/guest_memfd.c b/virt/kvm/guest_memfd.c
-index f8eac86e6931..922839f044e0 100644
+index b5732e2299cd..eda34a3e6a98 100644
 --- a/virt/kvm/guest_memfd.c
 +++ b/virt/kvm/guest_memfd.c
 @@ -8,6 +8,7 @@
@@ -48,7 +48,7 @@ index f8eac86e6931..922839f044e0 100644
  
  #include "kvm_mm.h"
  
-@@ -154,6 +155,12 @@ static int kvm_gmem_prepare_folio(struct kvm *kvm, struct kvm_memory_slot *slot,
+@@ -158,6 +159,12 @@ static int kvm_gmem_prepare_folio(struct kvm *kvm, struct kvm_memory_slot *slot,
  	return r;
  }
  
@@ -61,7 +61,7 @@ index f8eac86e6931..922839f044e0 100644
  /*
   * Returns a locked folio on success.  The caller is responsible for
   * setting the up-to-date flag before the memory is mapped into the guest.
-@@ -173,8 +180,7 @@ static struct folio *kvm_gmem_get_folio(struct inode *inode, pgoff_t index)
+@@ -177,8 +184,7 @@ static struct folio *kvm_gmem_get_folio(struct inode *inode, pgoff_t index)
  	 * Fast-path: See if folio is already present in mapping to avoid
  	 * policy_lookup.
  	 */
@@ -71,7 +71,7 @@ index f8eac86e6931..922839f044e0 100644
  	if (!IS_ERR(folio))
  		return folio;
  
-@@ -559,12 +565,86 @@ static struct mempolicy *kvm_gmem_get_policy(struct vm_area_struct *vma,
+@@ -563,12 +569,86 @@ static struct mempolicy *kvm_gmem_get_policy(struct vm_area_struct *vma,
  }
  #endif /* CONFIG_NUMA */
  

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0079-KVM-selftests-test-userfaultfd-minor-for-guest_memfd.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0079-KVM-selftests-test-userfaultfd-minor-for-guest_memfd.patch
@@ -1,7 +1,7 @@
-From 220eeb46b2ddee0b2462fb8a37c272bd974a071a Mon Sep 17 00:00:00 2001
+From 38a95785d37c3285a1357782f9f9e72fb1b4109c Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 6 Mar 2026 19:18:14 +0200
-Subject: [PATCH 79/86] KVM: selftests: test userfaultfd minor for guest_memfd
+Subject: [PATCH 79/94] KVM: selftests: test userfaultfd minor for guest_memfd
 
 The test demonstrates that a minor userfaultfd event in guest_memfd can
 be resolved via a memcpy followed by a UFFDIO_CONTINUE ioctl.

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0080-KVM-selftests-test-userfaultfd-missing-for-guest_mem.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0080-KVM-selftests-test-userfaultfd-missing-for-guest_mem.patch
@@ -1,7 +1,7 @@
-From 23d74c28ea4637c55638032904871cdd9655954d Mon Sep 17 00:00:00 2001
+From 421bcf0a727f79523f383620583de0b7ca169790 Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 6 Mar 2026 19:18:15 +0200
-Subject: [PATCH 80/86] KVM: selftests: test userfaultfd missing for
+Subject: [PATCH 80/94] KVM: selftests: test userfaultfd missing for
  guest_memfd
 
 The test demonstrates that a missing userfaultfd event in guest_memfd

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0081-fixup-for-uffd-export-mm-symbols.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0081-fixup-for-uffd-export-mm-symbols.patch
@@ -1,7 +1,7 @@
-From 223719ccdd829c66acd4c7455715299fe2f24774 Mon Sep 17 00:00:00 2001
+From abdd00eb33d598c6fbfdb9bfbbe2882075f00eae Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 2 Mar 2026 15:13:17 +0000
-Subject: [PATCH 81/86] fixup for uffd: export mm symbols
+Subject: [PATCH 81/94] fixup for uffd: export mm symbols
 
 Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
 ---

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0082-fixup-for-uffd-v6.18.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0082-fixup-for-uffd-v6.18.patch
@@ -1,7 +1,7 @@
-From 4fbccbcf375efad73ada3ff3fb18687848ef6f4f Mon Sep 17 00:00:00 2001
+From 025abf18986f37352682b96547a1b6d22edddfbd Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Fri, 23 Jan 2026 16:07:52 +0000
-Subject: [PATCH 82/86] fixup for uffd + v6.18
+Subject: [PATCH 82/94] fixup for uffd + v6.18
 
 ---
  include/asm-generic/pgtable_uffd.h | 17 +++++++++++++++++

--- a/resources/hiding_ci/linux_patches/25-gmem-uffd/0083-fixup-for-uffd-dmr.patch
+++ b/resources/hiding_ci/linux_patches/25-gmem-uffd/0083-fixup-for-uffd-dmr.patch
@@ -1,7 +1,7 @@
-From c5107e90b70f8261f009754762abebb927e22785 Mon Sep 17 00:00:00 2001
+From 43206a265ef1ad72604e7940e8f72a11244d86ea Mon Sep 17 00:00:00 2001
 From: Nikita Kalyazin <kalyazin@amazon.com>
 Date: Mon, 26 Jan 2026 12:37:52 +0000
-Subject: [PATCH 83/86] fixup for uffd + dmr
+Subject: [PATCH 83/94] fixup for uffd + dmr
 
 Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Nikita Kalyazin <kalyazin@amazon.com>
  1 file changed, 6 insertions(+)
 
 diff --git a/virt/kvm/guest_memfd.c b/virt/kvm/guest_memfd.c
-index 922839f044e0..0da609ceef48 100644
+index eda34a3e6a98..7bd90e91c3bd 100644
 --- a/virt/kvm/guest_memfd.c
 +++ b/virt/kvm/guest_memfd.c
-@@ -617,6 +617,12 @@ static int kvm_gmem_filemap_add(struct folio *folio,
+@@ -621,6 +621,12 @@ static int kvm_gmem_filemap_add(struct folio *folio,
  		return err;
  	}
  

--- a/resources/hiding_ci/linux_patches/50-srcu/0084-srcu-Declare-exported-symbols-before-including-srcu-.patch
+++ b/resources/hiding_ci/linux_patches/50-srcu/0084-srcu-Declare-exported-symbols-before-including-srcu-.patch
@@ -1,7 +1,7 @@
-From 99a2176de13bcbb3f7c26368f02e3abc8031b145 Mon Sep 17 00:00:00 2001
+From 761a222782779c348a12ae07ef434299b63c5ce8 Mon Sep 17 00:00:00 2001
 From: Sean Christopherson <seanjc@google.com>
 Date: Mon, 9 Mar 2026 12:30:57 -0700
-Subject: [PATCH 84/86] srcu: Declare exported symbols before including
+Subject: [PATCH 84/94] srcu: Declare exported symbols before including
  srcu{tiny,tree}.h
 
 Move the declarations of call_srcu(), cleanup_srcu_struct(), and

--- a/resources/hiding_ci/linux_patches/50-srcu/0085-srcu-Add-and-export-call_srcu_expedited-to-avoid-tra.patch
+++ b/resources/hiding_ci/linux_patches/50-srcu/0085-srcu-Add-and-export-call_srcu_expedited-to-avoid-tra.patch
@@ -1,7 +1,7 @@
-From 01125ed6e07fe5c26bceee1cb6b9664a57bb465a Mon Sep 17 00:00:00 2001
+From 6280e0d3bc5d7ba137ecaf2e0ef3eab92e778559 Mon Sep 17 00:00:00 2001
 From: Sean Christopherson <seanjc@google.com>
 Date: Mon, 9 Mar 2026 12:30:58 -0700
-Subject: [PATCH 85/86] srcu: Add and export call_srcu_expedited() to avoid
+Subject: [PATCH 85/94] srcu: Add and export call_srcu_expedited() to avoid
  transferring grace periods
 
 Add and export an expedited version of call_srcu() so that users of

--- a/resources/hiding_ci/linux_patches/50-srcu/0086-KVM-Expedite-SRCU-callbacks-when-freeing-objects-dur.patch
+++ b/resources/hiding_ci/linux_patches/50-srcu/0086-KVM-Expedite-SRCU-callbacks-when-freeing-objects-dur.patch
@@ -1,7 +1,7 @@
-From 3980657de714a1696acad439c82a02481cdb65c5 Mon Sep 17 00:00:00 2001
+From 851e4318eaf7f95c09d4f2d88db4efac43c90993 Mon Sep 17 00:00:00 2001
 From: Sean Christopherson <seanjc@google.com>
 Date: Mon, 9 Mar 2026 12:30:59 -0700
-Subject: [PATCH 86/86] KVM: Expedite SRCU callbacks when freeing objects
+Subject: [PATCH 86/94] KVM: Expedite SRCU callbacks when freeing objects
  during I/O bus registration
 
 Use the recently introduced call_srcu_expedited() when freeing the old I/O

--- a/resources/hiding_ci/linux_patches/60-async-pf/0087-KVM-async_pf-Convert-queued-count-to-atomic-and-tigh.patch
+++ b/resources/hiding_ci/linux_patches/60-async-pf/0087-KVM-async_pf-Convert-queued-count-to-atomic-and-tigh.patch
@@ -1,8 +1,8 @@
-From 17ea82279f4ec3e15a63b9a88ee3f86ac249c5df Mon Sep 17 00:00:00 2001
+From 78c86721718b78b0043f60084d04549da804a540 Mon Sep 17 00:00:00 2001
 From: Jack Thomson <jackabt@amazon.com>
 Date: Fri, 16 Jan 2026 15:14:10 +0000
-Subject: [PATCH 1/7] KVM: async_pf: Convert queued count to atomic and tighten
- locking
+Subject: [PATCH 87/94] KVM: async_pf: Convert queued count to atomic and
+ tighten locking
 
 Userfaultfd-based async page faults will need to synchronize between the
 vCPU thread and ioctl callers operating on the same async_pf state.
@@ -205,5 +205,5 @@ index b8aaa96b799b..4d553f4d1caf 100644
  	return 0;
  }
 -- 
-2.43.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/60-async-pf/0088-KVM-async_pf-Add-userfaultfd-async-page-fault-defini.patch
+++ b/resources/hiding_ci/linux_patches/60-async-pf/0088-KVM-async_pf-Add-userfaultfd-async-page-fault-defini.patch
@@ -1,7 +1,7 @@
-From f16cb1056f66f925d116cffa83db455f7066f63f Mon Sep 17 00:00:00 2001
+From eacc66d4eaeed8db8a87767079887b68155c5892 Mon Sep 17 00:00:00 2001
 From: Jack Thomson <jackabt@amazon.com>
 Date: Fri, 16 Jan 2026 15:14:32 +0000
-Subject: [PATCH 2/7] KVM: async_pf: Add userfaultfd async page fault
+Subject: [PATCH 88/94] KVM: async_pf: Add userfaultfd async page fault
  definitions
 
 Define the UAPI and internal structures needed for userfaultfd-based async
@@ -129,5 +129,5 @@ index 052c7c4876eb..7ff327522a53 100644
  struct kvm_pre_fault_memory {
  	__u64 gpa;
 -- 
-2.43.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/60-async-pf/0089-KVM-async_pf-Implement-userfaultfd-async-page-fault-.patch
+++ b/resources/hiding_ci/linux_patches/60-async-pf/0089-KVM-async_pf-Implement-userfaultfd-async-page-fault-.patch
@@ -1,7 +1,7 @@
-From 53f3f5c13511d9362f707bd61d98d30f2b060339 Mon Sep 17 00:00:00 2001
+From a8abe61bcfc2730f052722f95e56fc016fc432ab Mon Sep 17 00:00:00 2001
 From: Jack Thomson <jackabt@amazon.com>
 Date: Fri, 16 Jan 2026 15:14:32 +0000
-Subject: [PATCH 3/7] KVM: async_pf: Implement userfaultfd async page fault
+Subject: [PATCH 89/94] KVM: async_pf: Implement userfaultfd async page fault
  core
 
 Implement the core operations for userfaultfd-based async page faults.
@@ -285,5 +285,5 @@ index 4d553f4d1caf..14aab70ad263 100644
  	return true;
  
 -- 
-2.43.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/60-async-pf/0090-KVM-Add-KVM_ASYNC_PF-ioctl-and-auto-complete-pending.patch
+++ b/resources/hiding_ci/linux_patches/60-async-pf/0090-KVM-Add-KVM_ASYNC_PF-ioctl-and-auto-complete-pending.patch
@@ -1,7 +1,7 @@
-From 61819894fd4f5bab48147fb16f199b0c765f7a30 Mon Sep 17 00:00:00 2001
+From d5c50670043e88b9420f798dd15cd3355f32ebbd Mon Sep 17 00:00:00 2001
 From: Jack Thomson <jackabt@amazon.com>
 Date: Fri, 16 Jan 2026 15:14:33 +0000
-Subject: [PATCH 4/7] KVM: Add KVM_ASYNC_PF ioctl and auto-complete pending
+Subject: [PATCH 90/94] KVM: Add KVM_ASYNC_PF ioctl and auto-complete pending
  APFs on re-entry
 
 Add the KVM_ASYNC_PF vCPU ioctl for managing userfaultfd-based async page
@@ -43,7 +43,7 @@ index 180781998aa7..b2c8e75c7d6f 100644
  	select KVM_ASYNC_PF
  	select USER_RETURN_NOTIFIER
 diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
-index a447663d5eff..0995a6e99250 100644
+index 7e08203ab134..6c151538280f 100644
 --- a/arch/x86/kvm/x86.c
 +++ b/arch/x86/kvm/x86.c
 @@ -6200,6 +6200,38 @@ static int kvm_get_reg_list(struct kvm_vcpu *vcpu,
@@ -240,5 +240,5 @@ index 14aab70ad263..81cdea301b83 100644
  
  void kvm_clear_async_pf_completion_queue(struct kvm_vcpu *vcpu)
 -- 
-2.43.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/60-async-pf/0091-KVM-x86-mmu-Integrate-userfaultfd-async-page-faults-.patch
+++ b/resources/hiding_ci/linux_patches/60-async-pf/0091-KVM-x86-mmu-Integrate-userfaultfd-async-page-faults-.patch
@@ -1,7 +1,7 @@
-From afde618d84cf20f61ce9f8c3a9b21d9cdebbbb62 Mon Sep 17 00:00:00 2001
+From 2e3175eafc403b5efb4337d16a6e1212272b7f37 Mon Sep 17 00:00:00 2001
 From: Jack Thomson <jackabt@amazon.com>
 Date: Mon, 9 Feb 2026 11:52:30 +0000
-Subject: [PATCH 5/7] KVM: x86/mmu: Integrate userfaultfd async page faults
+Subject: [PATCH 91/94] KVM: x86/mmu: Integrate userfaultfd async page faults
  into the MMU
 
 Wire up userfaultfd-based async page faults in __kvm_mmu_faultin_pfn().
@@ -81,5 +81,5 @@ index e82a357e2219..ab285e1ff80f 100644
  		}
  	}
 -- 
-2.43.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/60-async-pf/0092-KVM-x86-Add-exitless-async-page-fault-notification-v.patch
+++ b/resources/hiding_ci/linux_patches/60-async-pf/0092-KVM-x86-Add-exitless-async-page-fault-notification-v.patch
@@ -1,8 +1,8 @@
-From 1ef60d6e4842da5a797f59f8e14946e1f9154a0b Mon Sep 17 00:00:00 2001
+From ce0aeae2b44c279f241304644c6d5958f1362779 Mon Sep 17 00:00:00 2001
 From: Jack Thomson <jackabt@amazon.com>
 Date: Mon, 9 Feb 2026 11:52:46 +0000
-Subject: [PATCH 6/7] KVM: x86: Add exitless async page fault notification via
- eventfd
+Subject: [PATCH 92/94] KVM: x86: Add exitless async page fault notification
+ via eventfd
 
 When a VMM handles many userfault APFs (e.g. during snapshot restore),
 the KVM_RUN exit/re-entry overhead for each fault becomes significant.
@@ -53,7 +53,7 @@ index ab285e1ff80f..9e7bc9ac8555 100644
  
  		if (report_async) {
 diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
-index 0995a6e99250..a25be68305b2 100644
+index 6c151538280f..b3fbfb9413e9 100644
 --- a/arch/x86/kvm/x86.c
 +++ b/arch/x86/kvm/x86.c
 @@ -6067,6 +6067,9 @@ static int kvm_vcpu_ioctl_enable_cap(struct kvm_vcpu *vcpu,
@@ -521,5 +521,5 @@ index 81cdea301b83..76dc75ab4387 100644
 +	return true;
 +}
 -- 
-2.43.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/60-async-pf/0093-KVM-x86-Advertise-KVM_CAP_ASYNC_PF_USERFAULT.patch
+++ b/resources/hiding_ci/linux_patches/60-async-pf/0093-KVM-x86-Advertise-KVM_CAP_ASYNC_PF_USERFAULT.patch
@@ -1,7 +1,7 @@
-From 28fc7f7f2e04e54c556fe7987290c3e3dd890ae4 Mon Sep 17 00:00:00 2001
+From f30eac4b24a6f4043e9aeedaedbcd7dc66347020 Mon Sep 17 00:00:00 2001
 From: Jack Thomson <jackabt@amazon.com>
 Date: Mon, 16 Feb 2026 10:08:57 +0000
-Subject: [PATCH 7/7] KVM: x86: Advertise KVM_CAP_ASYNC_PF_USERFAULT
+Subject: [PATCH 93/94] KVM: x86: Advertise KVM_CAP_ASYNC_PF_USERFAULT
 
 Add KVM_CAP_ASYNC_PF_USERFAULT (246) so userspace can discover support for
 userfaultfd-based async page faults and the exitless eventfd mechanism.
@@ -205,7 +205,7 @@ index c15f45efca4f..5ee00cbb11c4 100644
  =========================
  
 diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
-index a25be68305b2..b55c47124922 100644
+index b3fbfb9413e9..40ba624a3fd8 100644
 --- a/arch/x86/kvm/x86.c
 +++ b/arch/x86/kvm/x86.c
 @@ -4894,6 +4894,7 @@ int kvm_vm_ioctl_check_extension(struct kvm *kvm, long ext)
@@ -825,5 +825,5 @@ index 76dc75ab4387..2e4f89db4d47 100644
  	trace_kvm_apf_exitless_signal(vcpu->vcpu_id, gpa);
  
 -- 
-2.43.0
+2.50.1
 

--- a/resources/hiding_ci/linux_patches/60-async-pf/0094-fixup-KVM-async_pf-Convert-queued-count-to-atomic-an.patch
+++ b/resources/hiding_ci/linux_patches/60-async-pf/0094-fixup-KVM-async_pf-Convert-queued-count-to-atomic-an.patch
@@ -1,8 +1,8 @@
-From 75ee570d5d68306eef0fc2e4b2055ca81fc267f3 Mon Sep 17 00:00:00 2001
+From 67112bb5ec0815b68680eba7ab89aa546bc2c138 Mon Sep 17 00:00:00 2001
 From: Jack Thomson <jackabt@amazon.com>
 Date: Wed, 25 Mar 2026 11:56:37 +0000
-Subject: [PATCH] fixup! KVM: async_pf: Convert queued count to atomic and
- tighten locking
+Subject: [PATCH 94/94] fixup! KVM: async_pf: Convert queued count to atomic
+ and tighten locking
 
 Don't hold async_pf.lock over kvm_arch_can_dequeue_async_page_present().
 
@@ -58,5 +58,5 @@ index 2e4f89db4d47..3a2341054781 100644
  
  /*
 -- 
-2.43.0
+2.50.1
 


### PR DESCRIPTION
Current patch set (based on v6.18):
 - NUMA support in guest_memfd (from v6.19-rc5)
 - v12 direct map removal (new: v11 -> v12)
 - x86: configurable TLB flushes after direct map removal
 - v3 kvmclock
 - v1 KVM userfault
 - v7 write syscall
 - fixup for direct map removal and write to work together
 - v2 UFFD support with fixups
 - RFC srcu_synchronize optimisation from Sean
 - Tmp RFCv2 Async PF (non-published)

Note: v12 contains reordering of operations to "zap then prepare" and "invalidate then restore" as requested in [v11 review](https://lore.kernel.org/kvm/20260317141031.514-1-kalyazin@amazon.com/T/#mf8ba9fbc697cb410c22edad46f4407475e5e9dfa), however I had to preserve the original order when porting v12 to CI because preparation in v6.18 was accessing the page content via direct map. Alternative is to backport the [preparation rework](https://lore.kernel.org/kvm/20260108214622.1084057-1-michael.roth@amd.com/T/) from mainline.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
