### PR TITLE
[1.14] fix(audit): ignore RUSTSEC-2026-0097

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,4 +9,12 @@ ignore = [
         # Temporary exclusion of the bincode crate advisory
         # while we are working on migration to a substitution.
         "RUSTSEC-2025-0141",
+        # `rand` unsoundness when a custom logger re-enters `rand::rng()`/`thread_rng()`
+        # during ThreadRng reseeding. Firecracker is not affected:
+        # - uuid (1.23.0): does not enable `fast-rng` or `rng-rand` features, so it uses
+        #   `getrandom` directly and never calls into rand.
+        # - proptest: uses rand 0.9 with `default-features = false` and does not enable
+        #   the `thread_rng` feature, so the affected functions are not compiled in.
+        # See https://rustsec.org/advisories/RUSTSEC-2026-0097.html
+        "RUSTSEC-2026-0097",
 ]


### PR DESCRIPTION
RUSTSEC-2026-0097 is an informational advisory about potential undefined behaviour within the `rand` crate. `rand` is a transitive dependency, pulled in by `uuid` and `proptest`. Our use of these crates cannot trigger the pre-conditions for this undefined behaviour.

In particular, it relies on both the `log` and `thread_rng` features of `rand` being enabled:
- uuid (1.23.0): does not enable `fast-rng` or `rng-rand` features, so it uses `getrandom` directly and never calls into rand.
- proptest: uses rand 0.9 with `default-features = false` and does not enable the `thread_rng` feature, so the affected functions are not compiled in.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
