### PR TITLE
Fix 'occured' -> 'occurred' typos in vmm doc comments

### DIFF
--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -282,7 +282,7 @@ impl VsockEpollListener for VsockMuxer {
         EventSet::IN
     }
 
-    /// Notify the muxer about a pending event having occured under its nested epoll FD.
+    /// Notify the muxer about a pending event having occurred under its nested epoll FD.
     fn notify(&mut self, _: EventSet) {
         let mut epoll_events = vec![EpollEvent::new(EventSet::empty(), 0); 32];
         match self.epoll.wait(0, epoll_events.as_mut_slice()) {

--- a/src/vmm/src/mmds/ns.rs
+++ b/src/vmm/src/mmds/ns.rs
@@ -141,7 +141,7 @@ impl MmdsNetworkStack {
     ///
     /// # Returns
     ///
-    /// `true` if the frame was consumed by `mmds` or `false` if an error occured
+    /// `true` if the frame was consumed by `mmds` or `false` if an error occurred
     pub fn detour_frame(&mut self, src: &[u8]) -> bool {
         if let Ok(eth) = EthernetFrame::from_bytes(src) {
             match eth.ethertype() {

--- a/src/vmm/src/snapshot/mod.rs
+++ b/src/vmm/src/snapshot/mod.rs
@@ -57,7 +57,7 @@ pub enum SnapshotError {
     InvalidFormatVersion(Version),
     /// Magic value does not match arch: {0}
     InvalidMagic(u64),
-    /// An error occured during bitcode serialization: {0}
+    /// An error occurred during bitcode serialization: {0}
     Bitcode(#[from] bitcode::Error),
     /// IO Error: {0}
     Io(#[from] std::io::Error),


### PR DESCRIPTION
Fix 3 instances of `occured` → `occurred`:

- `src/vmm/src/mmds/ns.rs` line 144: Doc comment on return value of `is_mmds_frame`
- `src/vmm/src/snapshot/mod.rs` line 60: Error display string (`#[error(...)]`) — surfaced in error output
- `src/vmm/src/devices/virtio/vsock/unix/muxer.rs` line 285: Doc comment on `notify`

Comment/error-string-only change; no logic change.

## PR Checklist
- [x] If a specific issue led to this PR, this PR **closes** the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes](https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md).
- [x] User-facing changes are mentioned in `CHANGELOG.md`. N/A, doc-only change.
- [x] All added/changed functionality is tested. N/A, doc-only change.