### PR TITLE
feat: logger: decrease binary size

### DIFF
--- a/src/vmm/src/logger/mod.rs
+++ b/src/vmm/src/logger/mod.rs
@@ -108,23 +108,8 @@ macro_rules! __log_rate_limited_impl {
                     $crate::logger::rate_limited::DEFAULT_BURST,
                     $crate::logger::rate_limited::DEFAULT_REFILL_TIME_MS,
                 );
-            static SUPPRESSED: std::sync::atomic::AtomicU64 =
-                std::sync::atomic::AtomicU64::new(0);
-
-            if LIMITER.check() {
-                let suppressed =
-                    SUPPRESSED.swap(0, std::sync::atomic::Ordering::Relaxed);
-                if suppressed > 0 {
-                    $crate::warn_unrestricted!(
-                        "{suppressed} messages were suppressed due to rate limiting"
-                    );
-                }
+            if LIMITER.check_maybe_suppressed() {
                 $level_macro!($($arg)+);
-            } else {
-                SUPPRESSED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                $crate::logger::IncMetric::inc(
-                    &$crate::logger::METRICS.logger.rate_limited_log_count,
-                );
             }
         }
     }};

--- a/src/vmm/src/logger/rate_limited.rs
+++ b/src/vmm/src/logger/rate_limited.rs
@@ -6,8 +6,10 @@
 //! `LogRateLimiter` instance via a `static`, so flooding one callsite does
 //! not suppress unrelated log messages.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
+use crate::logger::{IncMetric, METRICS};
 use crate::rate_limiter::TokenBucket;
 
 /// Maximum number of messages allowed per refill period.
@@ -25,6 +27,7 @@ pub struct LogRateLimiter {
     inner: OnceLock<Mutex<TokenBucket>>,
     burst: u64,
     refill_time_ms: u64,
+    suppressed: AtomicU64,
 }
 
 impl Default for LogRateLimiter {
@@ -44,6 +47,7 @@ impl LogRateLimiter {
             inner: OnceLock::new(),
             burst,
             refill_time_ms,
+            suppressed: AtomicU64::new(0),
         }
     }
 
@@ -63,6 +67,26 @@ impl LogRateLimiter {
             bucket.reduce(1),
             crate::rate_limiter::BucketReduction::Success
         )
+    }
+
+    /// Check if log is should be emitted and print a warning if it was
+    /// suppressed before. Marked to be never inlined since it is called in a
+    /// lot of macros and would blow up the binary size otherwise.
+    #[inline(never)]
+    pub fn check_maybe_suppressed(&self) -> bool {
+        if self.check() {
+            let suppressed = self.suppressed.swap(0, Ordering::Relaxed);
+            if 0 < suppressed {
+                crate::logger::warn_unrestricted!(
+                    "{suppressed} messages were suppressed due to rate limiting"
+                );
+            }
+            true
+        } else {
+            self.suppressed.fetch_add(1, Ordering::Relaxed);
+            METRICS.logger.rate_limited_log_count.inc();
+            false
+        }
     }
 }
 


### PR DESCRIPTION
## Changes
When new rate-limiter log macros were added, the binary size increased by ~150KiB. (mainly the .text section got bigger by ~105KiB)

In order to partially mitigate this move duplicated checking logic into a `LogRateLimiter` type and mark that function with `inline(never)`

This saves ~70KiB of .text section space.

## Reason
Smaller binary

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
