### PR TITLE
fix(nested): handle CPU features and microcode for nested cmr8i

### DIFF
--- a/src/cpu-template-helper/src/fingerprint/compare.rs
+++ b/src/cpu-template-helper/src/fingerprint/compare.rs
@@ -25,40 +25,43 @@ pub fn compare(
     curr: Fingerprint,
     filters: Vec<FingerprintField>,
 ) -> Result<(), FingerprintCompareError> {
-    let compare =
-        |field: &FingerprintField, val1, val2| -> Option<Result<String, serde_json::Error>> {
-            if val1 != val2 {
-                let diff = Diff {
-                    name: format!("{field:#?}"),
-                    prev: val1,
-                    curr: val2,
-                };
-                Some(serde_json::to_string_pretty(&diff))
-            } else {
-                None
-            }
-        };
+    fn compare_field<T: Serialize + PartialEq>(
+        field: &FingerprintField,
+        val1: &T,
+        val2: &T,
+    ) -> Option<Result<String, serde_json::Error>> {
+        if val1 != val2 {
+            let diff = Diff {
+                name: format!("{field:#?}"),
+                prev: val1,
+                curr: val2,
+            };
+            Some(serde_json::to_string_pretty(&diff))
+        } else {
+            None
+        }
+    }
 
     let results = filters
         .into_iter()
         .filter_map(|filter| {
             match filter {
-                FingerprintField::firecracker_version => compare(
+                FingerprintField::firecracker_version => compare_field(
                     &filter,
                     &prev.firecracker_version,
                     &curr.firecracker_version,
                 ),
                 FingerprintField::kernel_version => {
-                    compare(&filter, &prev.kernel_version, &curr.kernel_version)
+                    compare_field(&filter, &prev.kernel_version, &curr.kernel_version)
                 }
                 FingerprintField::microcode_version => {
-                    compare(&filter, &prev.microcode_version, &curr.microcode_version)
+                    compare_field(&filter, &prev.microcode_version, &curr.microcode_version)
                 }
                 FingerprintField::bios_version => {
-                    compare(&filter, &prev.bios_version, &curr.bios_version)
+                    compare_field(&filter, &prev.bios_version, &curr.bios_version)
                 }
                 FingerprintField::bios_revision => {
-                    compare(&filter, &prev.bios_revision, &curr.bios_revision)
+                    compare_field(&filter, &prev.bios_revision, &curr.bios_revision)
                 }
                 FingerprintField::guest_cpu_config => {
                     if prev.guest_cpu_config != curr.guest_cpu_config {
@@ -103,7 +106,7 @@ mod tests {
         Fingerprint {
             firecracker_version: crate::utils::CPU_TEMPLATE_HELPER_VERSION.to_string(),
             kernel_version: "sample_kernel_version".to_string(),
-            microcode_version: "sample_microcode_version".to_string(),
+            microcode_version: Some("sample_microcode_version".to_string()),
             bios_version: "sample_bios_version".to_string(),
             bios_revision: "sample_bios_revision".to_string(),
             guest_cpu_config: CustomCpuTemplate::default(),
@@ -128,7 +131,7 @@ mod tests {
         let f1 = build_sample_fingerprint();
         let mut f2 = build_sample_fingerprint();
         f2.kernel_version = "different_kernel_version".to_string();
-        f2.microcode_version = "different_microcode_version".to_string();
+        f2.microcode_version = Some("different_microcode_version".to_string());
         let filters = vec![FingerprintField::kernel_version];
         let result = compare(f1, f2, filters);
         match result {

--- a/src/cpu-template-helper/src/fingerprint/dump.rs
+++ b/src/cpu-template-helper/src/fingerprint/dump.rs
@@ -23,15 +23,35 @@ pub fn dump(vmm: Arc<Mutex<Vmm>>) -> Result<Fingerprint, FingerprintDumpError> {
         firecracker_version: crate::utils::CPU_TEMPLATE_HELPER_VERSION.to_string(),
         kernel_version: get_kernel_version()?,
         #[cfg(target_arch = "x86_64")]
-        microcode_version: read_sysfs_file("/sys/devices/system/cpu/cpu0/microcode/version")?,
+        microcode_version: read_microcode_version(
+            "/sys/devices/system/cpu/cpu0/microcode/version",
+        )?,
         #[cfg(target_arch = "aarch64")]
-        microcode_version: read_sysfs_file(
+        microcode_version: read_microcode_version(
             "/sys/devices/system/cpu/cpu0/regs/identification/revidr_el1",
         )?,
         bios_version: read_sysfs_file("/sys/devices/virtual/dmi/id/bios_version")?,
         bios_revision: read_sysfs_file("/sys/devices/virtual/dmi/id/bios_release")?,
         guest_cpu_config: crate::template::dump::dump(vmm)?,
     })
+}
+
+fn is_running_nested() -> bool {
+    read_to_string("/proc/cpuinfo")
+        .map(|s| s.contains("hypervisor"))
+        .unwrap_or(false)
+}
+
+fn read_microcode_version(path: &str) -> Result<Option<String>, FingerprintDumpError> {
+    match read_sysfs_file(path) {
+        Ok(v) => Ok(Some(v)),
+        Err(FingerprintDumpError::ReadSysfsFile(_, ref io_err))
+            if io_err.kind() == std::io::ErrorKind::NotFound && is_running_nested() =>
+        {
+            Ok(None)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 fn get_kernel_version() -> Result<String, FingerprintDumpError> {

--- a/src/cpu-template-helper/src/fingerprint/mod.rs
+++ b/src/cpu-template-helper/src/fingerprint/mod.rs
@@ -29,7 +29,7 @@ macro_rules! declare_fingerprint_struct_and_enum {
 // pub struct Fingerprint {
 //     pub firecracker_version: String,
 //     pub kernel_version: String,
-//     pub microcode_version: String,
+//     pub microcode_version: Option<String>,
 //     pub bios_version: String,
 //     pub bios_revision: String,
 //     pub guest_cpu_config: CustomCpuTemplate,
@@ -50,7 +50,7 @@ macro_rules! declare_fingerprint_struct_and_enum {
 declare_fingerprint_struct_and_enum!(
     firecracker_version: String,
     kernel_version: String,
-    microcode_version: String,
+    microcode_version: Option<String>,
     bios_version: String,
     bios_revision: String,
     guest_cpu_config: CustomCpuTemplate

--- a/src/cpu-template-helper/src/main.rs
+++ b/src/cpu-template-helper/src/main.rs
@@ -281,7 +281,7 @@ mod tests {
         let fingerprint = fingerprint::Fingerprint {
             firecracker_version: crate::utils::CPU_TEMPLATE_HELPER_VERSION.to_string(),
             kernel_version: "sample_kernel_version".to_string(),
-            microcode_version: "sample_microcode_version".to_string(),
+            microcode_version: Some("sample_microcode_version".to_string()),
             bios_version: "sample_bios_version".to_string(),
             bios_revision: "sample_bios_revision".to_string(),
             guest_cpu_config: serde_json::from_str(SAMPLE_MODIFIERS).unwrap(),

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -106,6 +106,12 @@ class GlobalProps:
         return tuple(int(x) for x in self.host_linux_version.split("."))
 
     @property
+    def is_nested_virt(self):
+        """Are we running under a hypervisor (e.g. non-metal EC2 instance)?"""
+        with open("/proc/cpuinfo", encoding="utf-8") as f:
+            return "hypervisor" in f.read()
+
+    @property
     def is_ec2(self):
         """Are we running on an EC2 instance?"""
         return self.environment == "ec2"

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -359,6 +359,14 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
                 "tsc_known_freq",
             }
 
+            # On nested virt (non-metal instances), the L0 hypervisor does not
+            # expose many host-only features. Only expect features actually
+            # present on this host. Additionally, "hypervisor" is present on
+            # the host itself, so it is no longer guest-only.
+            if global_props.is_nested_virt:
+                expected_host_minus_guest &= host_feats
+                expected_guest_minus_host.discard("hypervisor")
+
             assert host_feats - guest_feats == expected_host_minus_guest
             assert guest_feats - host_feats == expected_guest_minus_host
         case CpuModel.ARM_NEOVERSE_N1:


### PR DESCRIPTION
## Reason

When running Firecracker as a nested virtual machine on virt cmr8i instances, we were encountering failures related to the CPU features being a smaller subset on L1, and microcode not being available to L1.

To fix this, check for nested via `/proc/cpinfo`, and change tests to expect a subset of CPU features as well as microcode not being available when running nested.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
