### PR TITLE
Pmem: Fix resource leaks

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -51,6 +51,7 @@ use crate::utils::mib_to_bytes;
 use crate::vmm_config::instance_info::InstanceInfo;
 use crate::vmm_config::machine_config::MachineConfigError;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
+use crate::vmm_config::pmem::PmemConfig;
 use crate::vstate::kvm::{Kvm, KvmError};
 use crate::vstate::memory::GuestRegionMmap;
 #[cfg(target_arch = "aarch64")]
@@ -246,7 +247,7 @@ pub fn build_microvm_for_boot(
         &mut device_manager,
         &vm,
         &mut boot_cmdline,
-        vm_resources.pmem.devices.iter(),
+        &vm_resources.pmem.configs,
         event_manager,
     )?;
 
@@ -726,36 +727,28 @@ fn attach_net_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Net>>> + Debug>(
     Ok(())
 }
 
-fn attach_pmem_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Pmem>>> + Debug>(
+fn attach_pmem_devices(
     device_manager: &mut DeviceManager,
     vm: &Arc<Vm>,
     cmdline: &mut LoaderKernelCmdline,
-    pmem_devices: I,
+    configs: &[PmemConfig],
     event_manager: &mut EventManager,
 ) -> Result<(), StartMicrovmError> {
-    for (i, device) in pmem_devices.enumerate() {
-        let id = {
-            let mut locked_dev = device.lock().expect("Poisoned lock");
-            if locked_dev.config.root_device {
-                cmdline.insert_str(format!("root=/dev/pmem{i}"))?;
-                match locked_dev.config.read_only {
-                    true => cmdline.insert_str("ro")?,
-                    false => cmdline.insert_str("rw")?,
-                }
+    for (i, config) in configs.iter().enumerate() {
+        if config.root_device {
+            cmdline.insert_str(format!("root=/dev/pmem{i}"))?;
+            match config.read_only {
+                true => cmdline.insert_str("ro")?,
+                false => cmdline.insert_str("rw")?,
             }
-            locked_dev.alloc_region(vm.as_ref())?;
-            locked_dev.set_mem_region(vm.as_ref())?;
-            locked_dev.config.id.to_string()
-        };
+        }
+        let id = config.id.clone();
+        let mut pmem = Pmem::new(config.clone())?;
+        pmem.alloc_region(vm.as_ref())?;
+        pmem.set_mem_region(vm.as_ref())?;
+        let device = Arc::new(Mutex::new(pmem));
 
-        device_manager.attach_virtio_device(
-            vm,
-            id,
-            device.clone(),
-            cmdline,
-            event_manager,
-            false,
-        )?;
+        device_manager.attach_virtio_device(vm, id, device, cmdline, event_manager, false)?;
     }
     Ok(())
 }
@@ -1049,7 +1042,7 @@ pub(crate) mod tests {
             &mut vmm.device_manager,
             &vmm.vm,
             cmdline,
-            builder.devices.iter(),
+            &builder.configs,
             event_manager,
         )
         .unwrap();

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -743,7 +743,7 @@ fn attach_pmem_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Pmem>>> + Debug>(
                     false => cmdline.insert_str("rw")?,
                 }
             }
-            locked_dev.alloc_region(vm.as_ref());
+            locked_dev.alloc_region(vm.as_ref())?;
             locked_dev.set_mem_region(vm.as_ref())?;
             locked_dev.config.id.to_string()
         };

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -743,9 +743,7 @@ fn attach_pmem_devices(
             }
         }
         let id = config.id.clone();
-        let mut pmem = Pmem::new(config.clone())?;
-        pmem.alloc_region(vm.as_ref())?;
-        pmem.set_mem_region(vm.as_ref())?;
+        let pmem = Pmem::new(vm.clone(), config.clone())?;
         let device = Arc::new(Mutex::new(pmem));
 
         device_manager.attach_virtio_device(vm, id, device, cmdline, event_manager, false)?;

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -576,7 +576,7 @@ impl<'a> Persist<'a> for PciDevices {
             let device = Arc::new(Mutex::new(Pmem::restore(
                 PmemConstructorArgs {
                     mem,
-                    vm: constructor_args.vm.as_ref(),
+                    vm: constructor_args.vm.clone(),
                 },
                 &pmem_state.device_state,
             )?));

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -584,7 +584,8 @@ impl<'a> Persist<'a> for PciDevices {
             constructor_args
                 .vm_resources
                 .pmem
-                .add_device(device.clone());
+                .configs
+                .push(pmem_state.device_state.config.clone());
 
             pci_devices.restore_pci_device(
                 constructor_args.vm,

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -570,7 +570,8 @@ impl<'a> Persist<'a> for MMIODeviceManager {
             constructor_args
                 .vm_resources
                 .pmem
-                .add_device(device.clone());
+                .configs
+                .push(pmem_state.device_state.config.clone());
 
             restore_helper(
                 device,

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -562,7 +562,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
             let device = Arc::new(Mutex::new(Pmem::restore(
                 PmemConstructorArgs {
                     mem,
-                    vm: vm.as_ref(),
+                    vm: vm.clone(),
                 },
                 &pmem_state.device_state,
             )?));

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::{File, OpenOptions};
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::os::fd::AsRawFd;
 use std::sync::{Arc, Mutex};
 
 use kvm_bindings::{KVM_MEM_READONLY, kvm_userspace_memory_region};
-use kvm_ioctls::VmFd;
 use serde::{Deserialize, Serialize};
-use vm_allocator::AllocPolicy;
+use vm_allocator::{AllocPolicy, RangeInclusive};
 use vm_memory::mmap::{MmapRegionBuilder, MmapRegionError};
 use vm_memory::{GuestAddress, GuestMemoryError};
 use vmm_sys_util::eventfd::EventFd;
@@ -81,6 +80,94 @@ pub struct ConfigSpace {
 
 // SAFETY: `ConfigSpace` contains only PODs in `repr(c)`, without padding.
 unsafe impl ByteValued for ConfigSpace {}
+
+/// RAII wrapper for a guest address allocation. Frees the allocated region on drop.
+#[derive(Debug)]
+pub struct GuestPmemRegion {
+    vm: Arc<Vm>,
+    pub config_space: ConfigSpace,
+}
+
+impl GuestPmemRegion {
+    /// Allocate a new region in past_mmio64 memory.
+    fn new(vm: Arc<Vm>, size: u64) -> Result<Self, PmemError> {
+        let start = {
+            let mut alloc = vm.resource_allocator();
+            alloc
+                .past_mmio64_memory
+                .allocate(size, Pmem::ALIGNMENT, AllocPolicy::FirstMatch)
+                .map_err(|_| PmemError::AllocationFailed)?
+                .start()
+        };
+        Ok(Self {
+            vm,
+            config_space: ConfigSpace { start, size },
+        })
+    }
+
+    /// Wrap an existing allocation (e.g. from a snapshot) for RAII cleanup.
+    pub fn from_state(vm: Arc<Vm>, config_space: ConfigSpace) -> Self {
+        Self { vm, config_space }
+    }
+}
+
+impl Drop for GuestPmemRegion {
+    fn drop(&mut self) {
+        let range = RangeInclusive::new(
+            self.config_space.start,
+            self.config_space.start + self.config_space.size - 1,
+        )
+        .expect("Invalid config_space range");
+        let mut alloc = self.vm.resource_allocator();
+        _ = alloc.past_mmio64_memory.free(&range);
+    }
+}
+
+/// RAII wrapper for the KVM user memory region. Removes the region on drop.
+#[derive(Debug)]
+pub struct KvmMemSlot {
+    vm: Arc<Vm>,
+    slot: u32,
+}
+
+impl KvmMemSlot {
+    fn new(
+        vm: Arc<Vm>,
+        gpa: u64,
+        memory_size: u64,
+        hva: u64,
+        flags: u32,
+    ) -> Result<Self, PmemError> {
+        // FIXME: The KVM slot number itself is not returned. This is not an
+        // issue currently since there are at least 32K slots available. But we
+        // could improve this by implementing a slot allocator that allows us
+        // to free slot numbers.
+        let slot = vm.next_kvm_slot(1).ok_or(PmemError::NoKvmSlotAvailable)?;
+        let region = kvm_userspace_memory_region {
+            slot,
+            guest_phys_addr: gpa,
+            memory_size,
+            userspace_addr: hva,
+            flags,
+        };
+        vm.set_user_memory_region(region)
+            .map_err(PmemError::SetUserMemoryRegion)?;
+        Ok(Self { vm, slot })
+    }
+}
+
+impl Drop for KvmMemSlot {
+    fn drop(&mut self) {
+        let region = kvm_userspace_memory_region {
+            slot: self.slot,
+            guest_phys_addr: 0,
+            memory_size: 0,
+            userspace_addr: 0,
+            flags: 0,
+        };
+        _ = self.vm.set_user_memory_region(region);
+    }
+}
 
 /// RAII wrapper for the pmem mmap region. Performs mmap on construction and munmap on drop.
 #[derive(Debug)]
@@ -196,7 +283,10 @@ pub struct Pmem {
     pub queue_events: Vec<EventFd>,
 
     // Pmem specific fields
-    pub config_space: ConfigSpace,
+    // kvm_mem_slot must be declared before mmap so that its drop function runs
+    // first before the HVA gets unmapped
+    pub kvm_mem_slot: KvmMemSlot,
+    pub guest_region: GuestPmemRegion,
     pub mmap: PmemMmap,
     pub metrics: Arc<PmemMetrics>,
     pub rate_limiter: RateLimiter,
@@ -210,13 +300,14 @@ impl Pmem {
     pub const ALIGNMENT: u64 = 2 * 1024 * 1024;
 
     /// Create a new Pmem device with a backing file at `disk_image_path` path.
-    pub fn new(config: PmemConfig) -> Result<Self, PmemError> {
-        Self::new_with_queues(config, vec![Queue::new(PMEM_QUEUE_SIZE)], 0u64, None)
+    pub fn new(vm: Arc<Vm>, config: PmemConfig) -> Result<Self, PmemError> {
+        Self::new_with_queues(vm, config, vec![Queue::new(PMEM_QUEUE_SIZE)], 0u64, None)
     }
 
     /// Create a new Pmem device with a backing file at `disk_image_path` path using a pre-created
     /// set of queues.
     pub fn new_with_queues(
+        vm: Arc<Vm>,
         config: PmemConfig,
         queues: Vec<Queue>,
         acked_features: u64,
@@ -224,10 +315,18 @@ impl Pmem {
     ) -> Result<Self, PmemError> {
         let mmap = PmemMmap::new(&config.path_on_host, config.read_only)?;
 
-        let config_space = config_space.unwrap_or(ConfigSpace {
-            start: 0,
-            size: mmap.mmap_len,
-        });
+        let guest_region = match config_space {
+            Some(cs) => GuestPmemRegion::from_state(vm.clone(), cs),
+            None => GuestPmemRegion::new(vm.clone(), mmap.mmap_len)?,
+        };
+
+        let cs = &guest_region.config_space;
+        let flags = if config.read_only {
+            KVM_MEM_READONLY
+        } else {
+            0
+        };
+        let kvm_mem_slot = KvmMemSlot::new(vm, cs.start, cs.size, mmap.mmap_ptr, flags)?;
 
         let rate_limiter = config
             .rate_limiter
@@ -243,47 +342,13 @@ impl Pmem {
             device_state: DeviceState::Inactive,
             queues,
             queue_events: vec![EventFd::new(libc::EFD_NONBLOCK).map_err(PmemError::EventFd)?],
-            config_space,
+            guest_region,
             metrics: PmemMetricsPerDevice::alloc(config.id.clone()),
             rate_limiter,
             config,
             mmap,
+            kvm_mem_slot,
         })
-    }
-
-    /// Allocate memory in past_mmio64 memory region
-    pub fn alloc_region(&mut self, vm: &Vm) -> Result<(), PmemError> {
-        let mut resource_allocator_lock = vm.resource_allocator();
-        let resource_allocator = resource_allocator_lock.deref_mut();
-        let addr = resource_allocator
-            .past_mmio64_memory
-            .allocate(
-                self.config_space.size,
-                Pmem::ALIGNMENT,
-                AllocPolicy::FirstMatch,
-            )
-            .map_err(|_| PmemError::AllocationFailed)?;
-        self.config_space.start = addr.start();
-        Ok(())
-    }
-
-    /// Set user memory region in KVM
-    pub fn set_mem_region(&mut self, vm: &Vm) -> Result<(), PmemError> {
-        let next_slot = vm.next_kvm_slot(1).ok_or(PmemError::NoKvmSlotAvailable)?;
-        let memory_region = kvm_userspace_memory_region {
-            slot: next_slot,
-            guest_phys_addr: self.config_space.start,
-            memory_size: self.config_space.size,
-            userspace_addr: self.mmap.mmap_ptr,
-            flags: if self.config.read_only {
-                KVM_MEM_READONLY
-            } else {
-                0
-            },
-        };
-
-        vm.set_user_memory_region(memory_region)
-            .map_err(PmemError::SetUserMemoryRegion)
     }
 
     pub fn handle_queue(&mut self) -> Result<(), PmemError> {
@@ -485,7 +550,12 @@ impl VirtioDevice for Pmem {
     }
 
     fn read_config(&self, offset: u64, data: &mut [u8]) {
-        if let Some(config_space_bytes) = self.config_space.as_slice().get(u64_to_usize(offset)..) {
+        if let Some(config_space_bytes) = self
+            .guest_region
+            .config_space
+            .as_slice()
+            .get(u64_to_usize(offset)..)
+        {
             let len = config_space_bytes.len().min(data.len());
             data[..len].copy_from_slice(&config_space_bytes[..len]);
         } else {
@@ -531,11 +601,15 @@ mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
+    use crate::arch::Kvm;
     use crate::devices::virtio::queue::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
     use crate::devices::virtio::test_utils::{VirtQueue, default_interrupt, default_mem};
 
     #[test]
     fn test_from_config() {
+        let kvm = Kvm::new(vec![]).unwrap();
+        let vm = Arc::new(Vm::new(&kvm).unwrap());
+
         let config = PmemConfig {
             id: "1".into(),
             path_on_host: "not_a_path".into(),
@@ -544,7 +618,7 @@ mod tests {
             ..Default::default()
         };
         assert!(matches!(
-            Pmem::new(config).unwrap_err(),
+            Pmem::new(vm.clone(), config).unwrap_err(),
             PmemError::BackingFile(_),
         ));
 
@@ -558,7 +632,7 @@ mod tests {
             ..Default::default()
         };
         assert!(matches!(
-            Pmem::new(config).unwrap_err(),
+            Pmem::new(vm.clone(), config).unwrap_err(),
             PmemError::BackingFileZeroSize,
         ));
 
@@ -570,11 +644,14 @@ mod tests {
             read_only: false,
             ..Default::default()
         };
-        Pmem::new(config).unwrap();
+        Pmem::new(vm.clone(), config).unwrap();
     }
 
     #[test]
     fn test_process_chain() {
+        let kvm = Kvm::new(vec![]).unwrap();
+        let vm = Arc::new(Vm::new(&kvm).unwrap());
+
         let dummy_file = TempFile::new().unwrap();
         dummy_file.as_file().set_len(0x20_0000);
         let dummy_path = dummy_file.as_path().to_str().unwrap().to_string();
@@ -585,7 +662,7 @@ mod tests {
             read_only: false,
             ..Default::default()
         };
-        let mut pmem = Pmem::new(config).unwrap();
+        let mut pmem = Pmem::new(vm.clone(), config).unwrap();
 
         let mem = default_mem();
         let interrupt = default_interrupt();

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -211,13 +211,23 @@ impl Pmem {
 
     /// Create a new Pmem device with a backing file at `disk_image_path` path.
     pub fn new(config: PmemConfig) -> Result<Self, PmemError> {
-        Self::new_with_queues(config, vec![Queue::new(PMEM_QUEUE_SIZE)])
+        Self::new_with_queues(config, vec![Queue::new(PMEM_QUEUE_SIZE)], 0u64, None)
     }
 
     /// Create a new Pmem device with a backing file at `disk_image_path` path using a pre-created
     /// set of queues.
-    pub fn new_with_queues(config: PmemConfig, queues: Vec<Queue>) -> Result<Self, PmemError> {
+    pub fn new_with_queues(
+        config: PmemConfig,
+        queues: Vec<Queue>,
+        acked_features: u64,
+        config_space: Option<ConfigSpace>,
+    ) -> Result<Self, PmemError> {
         let mmap = PmemMmap::new(&config.path_on_host, config.read_only)?;
+
+        let config_space = config_space.unwrap_or(ConfigSpace {
+            start: 0,
+            size: mmap.mmap_len,
+        });
 
         let rate_limiter = config
             .rate_limiter
@@ -228,15 +238,12 @@ impl Pmem {
 
         Ok(Self {
             avail_features: 1u64 << VIRTIO_F_VERSION_1,
-            acked_features: 0u64,
+            acked_features,
             activate_event: EventFd::new(libc::EFD_NONBLOCK).map_err(PmemError::EventFd)?,
             device_state: DeviceState::Inactive,
             queues,
             queue_events: vec![EventFd::new(libc::EFD_NONBLOCK).map_err(PmemError::EventFd)?],
-            config_space: ConfigSpace {
-                start: 0,
-                size: mmap.mmap_len,
-            },
+            config_space,
             metrics: PmemMetricsPerDevice::alloc(config.id.clone()),
             rate_limiter,
             config,

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -82,84 +82,18 @@ pub struct ConfigSpace {
 // SAFETY: `ConfigSpace` contains only PODs in `repr(c)`, without padding.
 unsafe impl ByteValued for ConfigSpace {}
 
+/// RAII wrapper for the pmem mmap region. Performs mmap on construction and munmap on drop.
 #[derive(Debug)]
-pub struct Pmem {
-    // VirtIO fields
-    pub avail_features: u64,
-    pub acked_features: u64,
-    pub activate_event: EventFd,
-
-    // Transport fields
-    pub device_state: DeviceState,
-    pub queues: Vec<Queue>,
-    pub queue_events: Vec<EventFd>,
-
-    // Pmem specific fields
-    pub config_space: ConfigSpace,
-    pub file: File,
+pub struct PmemMmap {
     pub file_len: u64,
     pub mmap_ptr: u64,
-    pub metrics: Arc<PmemMetrics>,
-    pub rate_limiter: RateLimiter,
-
-    pub config: PmemConfig,
+    pub mmap_len: u64,
 }
 
-impl Drop for Pmem {
-    fn drop(&mut self) {
-        let mmap_len = align_up(self.file_len, Self::ALIGNMENT);
-        // SAFETY: `mmap_ptr` is a valid pointer since Pmem can only be created with `new*` methods.
-        //         Mapping size calculation is same for original mmap call.
-        unsafe {
-            _ = libc::munmap(self.mmap_ptr as *mut libc::c_void, u64_to_usize(mmap_len));
-        }
-    }
-}
+impl PmemMmap {
+    const ALIGNMENT: u64 = Pmem::ALIGNMENT;
 
-impl Pmem {
-    // Pmem devices need to have address and size to be
-    // a multiple of 2MB
-    pub const ALIGNMENT: u64 = 2 * 1024 * 1024;
-
-    /// Create a new Pmem device with a backing file at `disk_image_path` path.
-    pub fn new(config: PmemConfig) -> Result<Self, PmemError> {
-        Self::new_with_queues(config, vec![Queue::new(PMEM_QUEUE_SIZE)])
-    }
-
-    /// Create a new Pmem device with a backing file at `disk_image_path` path using a pre-created
-    /// set of queues.
-    pub fn new_with_queues(config: PmemConfig, queues: Vec<Queue>) -> Result<Self, PmemError> {
-        let (file, file_len, mmap_ptr, mmap_len) =
-            Self::mmap_backing_file(&config.path_on_host, config.read_only)?;
-
-        let rate_limiter = config
-            .rate_limiter
-            .map(RateLimiterConfig::try_into)
-            .transpose()
-            .map_err(PmemError::RateLimiter)?
-            .unwrap_or_default();
-
-        Ok(Self {
-            avail_features: 1u64 << VIRTIO_F_VERSION_1,
-            acked_features: 0u64,
-            activate_event: EventFd::new(libc::EFD_NONBLOCK).map_err(PmemError::EventFd)?,
-            device_state: DeviceState::Inactive,
-            queues,
-            queue_events: vec![EventFd::new(libc::EFD_NONBLOCK).map_err(PmemError::EventFd)?],
-            config_space: ConfigSpace {
-                start: 0,
-                size: mmap_len,
-            },
-            file,
-            file_len,
-            mmap_ptr,
-            metrics: PmemMetricsPerDevice::alloc(config.id.clone()),
-            rate_limiter,
-            config,
-        })
-    }
-
-    fn mmap_backing_file(path: &str, read_only: bool) -> Result<(File, u64, u64, u64), PmemError> {
+    pub fn new(path: &str, read_only: bool) -> Result<Self, PmemError> {
         let file = OpenOptions::new()
             .read(true)
             .write(!read_only)
@@ -228,7 +162,86 @@ impl Pmem {
                 mmap_ptr
             }
         };
-        Ok((file, file_len, mmap_ptr as u64, mmap_len))
+        Ok(Self {
+            file_len,
+            mmap_ptr: mmap_ptr as u64,
+            mmap_len,
+        })
+    }
+}
+
+impl Drop for PmemMmap {
+    fn drop(&mut self) {
+        // SAFETY: `mmap_ptr` is a valid pointer since PmemMmap can only be created via `new()`.
+        //         `mmap_len` is the same value used for the original mmap call.
+        unsafe {
+            _ = libc::munmap(
+                self.mmap_ptr as *mut libc::c_void,
+                u64_to_usize(self.mmap_len),
+            );
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Pmem {
+    // VirtIO fields
+    pub avail_features: u64,
+    pub acked_features: u64,
+    pub activate_event: EventFd,
+
+    // Transport fields
+    pub device_state: DeviceState,
+    pub queues: Vec<Queue>,
+    pub queue_events: Vec<EventFd>,
+
+    // Pmem specific fields
+    pub config_space: ConfigSpace,
+    pub mmap: PmemMmap,
+    pub metrics: Arc<PmemMetrics>,
+    pub rate_limiter: RateLimiter,
+
+    pub config: PmemConfig,
+}
+
+impl Pmem {
+    // Pmem devices need to have address and size to be
+    // a multiple of 2MB
+    pub const ALIGNMENT: u64 = 2 * 1024 * 1024;
+
+    /// Create a new Pmem device with a backing file at `disk_image_path` path.
+    pub fn new(config: PmemConfig) -> Result<Self, PmemError> {
+        Self::new_with_queues(config, vec![Queue::new(PMEM_QUEUE_SIZE)])
+    }
+
+    /// Create a new Pmem device with a backing file at `disk_image_path` path using a pre-created
+    /// set of queues.
+    pub fn new_with_queues(config: PmemConfig, queues: Vec<Queue>) -> Result<Self, PmemError> {
+        let mmap = PmemMmap::new(&config.path_on_host, config.read_only)?;
+
+        let rate_limiter = config
+            .rate_limiter
+            .map(RateLimiterConfig::try_into)
+            .transpose()
+            .map_err(PmemError::RateLimiter)?
+            .unwrap_or_default();
+
+        Ok(Self {
+            avail_features: 1u64 << VIRTIO_F_VERSION_1,
+            acked_features: 0u64,
+            activate_event: EventFd::new(libc::EFD_NONBLOCK).map_err(PmemError::EventFd)?,
+            device_state: DeviceState::Inactive,
+            queues,
+            queue_events: vec![EventFd::new(libc::EFD_NONBLOCK).map_err(PmemError::EventFd)?],
+            config_space: ConfigSpace {
+                start: 0,
+                size: mmap.mmap_len,
+            },
+            metrics: PmemMetricsPerDevice::alloc(config.id.clone()),
+            rate_limiter,
+            config,
+            mmap,
+        })
     }
 
     /// Allocate memory in past_mmio64 memory region
@@ -254,7 +267,7 @@ impl Pmem {
             slot: next_slot,
             guest_phys_addr: self.config_space.start,
             memory_size: self.config_space.size,
-            userspace_addr: self.mmap_ptr,
+            userspace_addr: self.mmap.mmap_ptr,
             flags: if self.config.read_only {
                 KVM_MEM_READONLY
             } else {
@@ -284,7 +297,10 @@ impl Pmem {
             self.metrics.rate_limiter_throttled_events.inc();
             return Ok(());
         }
-        if !self.rate_limiter.consume(self.file_len, TokenType::Bytes) {
+        if !self
+            .rate_limiter
+            .consume(self.mmap.file_len, TokenType::Bytes)
+        {
             self.rate_limiter.manual_replenish(1, TokenType::Ops);
             self.metrics.rate_limiter_throttled_events.inc();
             return Ok(());
@@ -367,8 +383,8 @@ impl Pmem {
             // value
             unsafe {
                 let ret = libc::msync(
-                    self.mmap_ptr as *mut libc::c_void,
-                    u64_to_usize(self.file_len),
+                    self.mmap.mmap_ptr as *mut libc::c_void,
+                    u64_to_usize(self.mmap.file_len),
                     libc::MS_SYNC,
                 );
                 if ret < 0 {

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -32,6 +32,8 @@ use crate::{Vm, impl_device_type};
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum PmemError {
+    /// Failed to allocate memory region
+    AllocationFailed,
     /// Cannot set the memory regions: {0}
     SetUserMemoryRegion(VmError),
     /// Unablet to allocate a KVM slot for the device
@@ -230,7 +232,7 @@ impl Pmem {
     }
 
     /// Allocate memory in past_mmio64 memory region
-    pub fn alloc_region(&mut self, vm: &Vm) {
+    pub fn alloc_region(&mut self, vm: &Vm) -> Result<(), PmemError> {
         let mut resource_allocator_lock = vm.resource_allocator();
         let resource_allocator = resource_allocator_lock.deref_mut();
         let addr = resource_allocator
@@ -240,8 +242,9 @@ impl Pmem {
                 Pmem::ALIGNMENT,
                 AllocPolicy::FirstMatch,
             )
-            .unwrap();
+            .map_err(|_| PmemError::AllocationFailed)?;
         self.config_space.start = addr.start();
+        Ok(())
     }
 
     /// Set user memory region in KVM

--- a/src/vmm/src/devices/virtio/pmem/persist.rs
+++ b/src/vmm/src/devices/virtio/pmem/persist.rs
@@ -67,10 +67,12 @@ impl<'a> Persist<'a> for Pmem {
             PMEM_QUEUE_SIZE,
         )?;
 
-        let mut pmem = Pmem::new_with_queues(state.config.clone(), queues)?;
-        pmem.config_space = state.config_space;
-        pmem.avail_features = state.virtio_state.avail_features;
-        pmem.acked_features = state.virtio_state.acked_features;
+        let mut pmem = Pmem::new_with_queues(
+            state.config.clone(),
+            queues,
+            state.virtio_state.acked_features,
+            Some(state.config_space),
+        )?;
         pmem.rate_limiter = RateLimiter::restore((), &state.rate_limiter_state)
             .map_err(PmemPersistError::RateLimiter)?;
 

--- a/src/vmm/src/devices/virtio/pmem/persist.rs
+++ b/src/vmm/src/devices/virtio/pmem/persist.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 use vm_memory::GuestAddress;
 
@@ -27,7 +29,7 @@ pub struct PmemState {
 #[derive(Debug)]
 pub struct PmemConstructorArgs<'a> {
     pub mem: &'a GuestMemoryMmap,
-    pub vm: &'a Vm,
+    pub vm: Arc<Vm>,
 }
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -50,7 +52,7 @@ impl<'a> Persist<'a> for Pmem {
     fn save(&self) -> Self::State {
         PmemState {
             virtio_state: VirtioDeviceState::from_device(self),
-            config_space: self.config_space,
+            config_space: self.guest_region.config_space,
             config: self.config.clone(),
             rate_limiter_state: self.rate_limiter.save(),
         }
@@ -68,6 +70,7 @@ impl<'a> Persist<'a> for Pmem {
         )?;
 
         let mut pmem = Pmem::new_with_queues(
+            constructor_args.vm,
             state.config.clone(),
             queues,
             state.virtio_state.acked_features,
@@ -75,8 +78,6 @@ impl<'a> Persist<'a> for Pmem {
         )?;
         pmem.rate_limiter = RateLimiter::restore((), &state.rate_limiter_state)
             .map_err(PmemPersistError::RateLimiter)?;
-
-        pmem.set_mem_region(constructor_args.vm)?;
 
         Ok(pmem)
     }
@@ -104,21 +105,22 @@ mod tests {
             read_only: false,
             ..Default::default()
         };
-        let pmem = Pmem::new(config).unwrap();
         let guest_mem = default_mem();
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Vm::new(&kvm).unwrap();
+        let vm = Arc::new(Vm::new(&kvm).unwrap());
+        let pmem = Pmem::new(vm.clone(), config).unwrap();
 
         // Save the block device.
         let pmem_state = pmem.save();
         let serialized_data = bitcode::serialize(&pmem_state).unwrap();
+        drop(pmem);
 
         // Restore the block device.
         let restored_state = bitcode::deserialize(&serialized_data).unwrap();
         let restored_pmem = Pmem::restore(
             PmemConstructorArgs {
                 mem: &guest_mem,
-                vm: &vm,
+                vm: vm.clone(),
             },
             &restored_state,
         )
@@ -126,11 +128,15 @@ mod tests {
 
         // Test that virtio specific fields are the same.
         assert_eq!(restored_pmem.device_type(), VirtioDeviceType::Pmem);
-        assert_eq!(restored_pmem.avail_features(), pmem.avail_features());
-        assert_eq!(restored_pmem.acked_features(), pmem.acked_features());
-        assert_eq!(restored_pmem.queues(), pmem.queues());
-        assert!(!pmem.is_activated());
+        assert_eq!(
+            restored_pmem.avail_features(),
+            pmem_state.virtio_state.avail_features
+        );
+        assert_eq!(
+            restored_pmem.acked_features(),
+            pmem_state.virtio_state.acked_features
+        );
         assert!(!restored_pmem.is_activated());
-        assert_eq!(restored_pmem.config, pmem.config);
+        assert_eq!(restored_pmem.config, pmem_state.config);
     }
 }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -120,7 +120,7 @@ pub struct VmResources {
     pub net_builder: NetBuilder,
     /// The entropy device builder.
     pub entropy: EntropyDeviceBuilder,
-    /// The pmem devices.
+    /// The pmem device configs.
     pub pmem: PmemBuilder,
     /// The memory hotplug configuration.
     pub memory_hotplug: Option<MemoryHotplugConfig>,
@@ -549,7 +549,7 @@ impl From<&VmResources> for VmmConfig {
             network_interfaces: resources.net_builder.configs(),
             vsock: resources.vsock.config(),
             entropy: resources.entropy.config(),
-            pmem_devices: resources.pmem.configs(),
+            pmem_devices: resources.pmem.configs.clone(),
             // serial_config is marked serde(skip) so that it doesnt end up in snapshots.
             serial_config: None,
             memory_hotplug: resources.memory_hotplug.clone(),
@@ -1681,8 +1681,8 @@ mod tests {
             path_on_host: tmp_file.as_path().to_str().unwrap().to_string(),
             ..Default::default()
         };
-        assert_eq!(vm_resources.pmem.devices.len(), 0);
+        assert_eq!(vm_resources.pmem.configs.len(), 0);
         vm_resources.build_pmem_device(cfg).unwrap();
-        assert_eq!(vm_resources.pmem.devices.len(), 1);
+        assert_eq!(vm_resources.pmem.configs.len(), 1);
     }
 }

--- a/src/vmm/src/vmm_config/pmem.rs
+++ b/src/vmm/src/vmm_config/pmem.rs
@@ -1,11 +1,9 @@
 // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, Mutex};
-
 use serde::{Deserialize, Serialize};
 
-use crate::devices::virtio::pmem::device::{Pmem, PmemError};
+use crate::devices::virtio::pmem::device::PmemError;
 use crate::vmm_config::RateLimiterConfig;
 
 /// Errors associated wit the operations allowed on a pmem device
@@ -52,22 +50,20 @@ pub struct PmemConfig {
     pub rate_limiter: Option<RateLimiterConfig>,
 }
 
-/// Wrapper for the collection that holds all the Pmem devices.
+/// Wrapper for the collection that holds all the Pmem device configs.
 #[derive(Debug, Default)]
 pub struct PmemBuilder {
-    /// The list of pmem devices
-    pub devices: Vec<Arc<Mutex<Pmem>>>,
+    /// The list of pmem device configs
+    pub configs: Vec<PmemConfig>,
 }
 
 impl PmemBuilder {
     /// Specifies whether there is a root block device already present in the list.
     pub fn has_root_device(&self) -> bool {
-        self.devices
-            .iter()
-            .any(|d| d.lock().unwrap().config.root_device)
+        self.configs.iter().any(|c| c.root_device)
     }
 
-    /// Build a device from the config
+    /// Add or replace a config, validating root device constraints.
     pub fn build(
         &mut self,
         config: PmemConfig,
@@ -76,75 +72,45 @@ impl PmemBuilder {
         if config.root_device && has_block_root {
             return Err(PmemConfigError::AddingSecondRootDevice);
         }
-        let position = self
-            .devices
-            .iter()
-            .position(|d| d.lock().unwrap().config.id == config.id);
+        let position = self.configs.iter().position(|c| c.id == config.id);
         if let Some(index) = position {
-            if !self.devices[index].lock().unwrap().config.root_device
-                && config.root_device
-                && self.has_root_device()
-            {
+            if !self.configs[index].root_device && config.root_device && self.has_root_device() {
                 return Err(PmemConfigError::RootPmemDeviceAlreadyExist);
             }
-            let pmem = Pmem::new(config)?;
-            let pmem = Arc::new(Mutex::new(pmem));
-            self.devices[index] = pmem;
+            self.configs[index] = config;
         } else {
             if config.root_device && self.has_root_device() {
                 return Err(PmemConfigError::RootPmemDeviceAlreadyExist);
             }
-            let pmem = Pmem::new(config)?;
-            let pmem = Arc::new(Mutex::new(pmem));
-            self.devices.push(pmem);
+            self.configs.push(config);
         }
         Ok(())
-    }
-
-    /// Adds an existing pmem device in the builder. This function should
-    /// only be used during snapshot restoration process and should add
-    /// devices in the same order as they were in the original VM.
-    pub fn add_device(&mut self, device: Arc<Mutex<Pmem>>) {
-        self.devices.push(device);
-    }
-
-    /// Returns a vec with the structures used to configure the devices.
-    pub fn configs(&self) -> Vec<PmemConfig> {
-        self.devices
-            .iter()
-            .map(|b| b.lock().unwrap().config.clone())
-            .collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use vmm_sys_util::tempfile::TempFile;
-
     use super::*;
 
     #[test]
     fn test_pmem_builder_build() {
         let mut builder = PmemBuilder::default();
 
-        let dummy_file = TempFile::new().unwrap();
-        dummy_file.as_file().set_len(Pmem::ALIGNMENT).unwrap();
-        let dummy_path = dummy_file.as_path().to_str().unwrap().to_string();
         let mut config = PmemConfig {
             id: "1".into(),
-            path_on_host: dummy_path,
+            path_on_host: "/dummy".into(),
             root_device: true,
             read_only: false,
             ..Default::default()
         };
         builder.build(config.clone(), false).unwrap();
-        assert_eq!(builder.devices.len(), 1);
+        assert_eq!(builder.configs.len(), 1);
         assert!(builder.has_root_device());
 
         // First device got replaced with new one
         config.root_device = false;
         builder.build(config, false).unwrap();
-        assert_eq!(builder.devices.len(), 1);
+        assert_eq!(builder.configs.len(), 1);
         assert!(!builder.has_root_device());
     }
 
@@ -152,12 +118,9 @@ mod tests {
     fn test_pmem_builder_build_seconde_root() {
         let mut builder = PmemBuilder::default();
 
-        let dummy_file = TempFile::new().unwrap();
-        dummy_file.as_file().set_len(Pmem::ALIGNMENT).unwrap();
-        let dummy_path = dummy_file.as_path().to_str().unwrap().to_string();
         let mut config = PmemConfig {
             id: "1".into(),
-            path_on_host: dummy_path,
+            path_on_host: "/dummy".into(),
             root_device: true,
             read_only: false,
             ..Default::default()
@@ -175,12 +138,9 @@ mod tests {
     fn test_pmem_builder_build_root_with_block_already_a_root() {
         let mut builder = PmemBuilder::default();
 
-        let dummy_file = TempFile::new().unwrap();
-        dummy_file.as_file().set_len(Pmem::ALIGNMENT).unwrap();
-        let dummy_path = dummy_file.as_path().to_str().unwrap().to_string();
         let config = PmemConfig {
             id: "1".into(),
-            path_on_host: dummy_path,
+            path_on_host: "/dummy".into(),
             root_device: true,
             read_only: false,
             ..Default::default()

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1123,10 +1123,6 @@ def test_pmem_api(uvm_plain_any, rootfs):
     vm.spawn()
     vm.basic_config(add_root_device=False)
 
-    invalid_pmem_path_on_host = os.path.join(vm.fsfiles, "invalid_scratch")
-    utils.check_output(f"touch {invalid_pmem_path_on_host}")
-    invalid_pmem_file_path = vm.create_jailed_resource(str(invalid_pmem_path_on_host))
-
     pmem_size_mb = 2
     pmem_path_on_host = drive_tools.FilesystemFile(
         os.path.join(vm.fsfiles, "scratch"), size=pmem_size_mb
@@ -1139,11 +1135,6 @@ def test_pmem_api(uvm_plain_any, rootfs):
     )
     with pytest.raises(RuntimeError, match=expected_msg):
         vm.api.pmem.put(id="pmem")
-
-    # Try to add pmem with 0 sized backing file
-    expected_msg = re.escape("Error backing file size is 0")
-    with pytest.raises(RuntimeError, match=expected_msg):
-        vm.api.pmem.put(id="pmem", path_on_host=invalid_pmem_file_path)
 
     # Try to add pmem as root while block is set as root
     vm.api.drive.put(drive_id="drive", path_on_host=pmem_file_path, is_root_device=True)

--- a/tests/integration_tests/functional/test_pmem.py
+++ b/tests/integration_tests/functional/test_pmem.py
@@ -4,6 +4,9 @@
 
 import json
 import os
+import re
+
+import pytest
 
 import host_tools.drive as drive_tools
 from framework import utils
@@ -44,6 +47,25 @@ def check_pmem_exist(vm, index, root, read_only, size, extension):
                 assert "/" in block["mountpoints"]
             return
     assert False
+
+
+def test_pmem_zero_size_backing_file(uvm_plain_any):
+    """
+    Test that a pmem device with a zero-sized backing file fails at boot time.
+    """
+    vm = uvm_plain_any
+    vm.spawn()
+    vm.basic_config(add_root_device=True)
+
+    zero_size_path = os.path.join(vm.fsfiles, "zero_scratch")
+    utils.check_output(f"touch {zero_size_path}")
+    jailed_path = vm.create_jailed_resource(zero_size_path)
+
+    vm.api.pmem.put(id="pmem", path_on_host=jailed_path)
+
+    expected_msg = re.escape("Error backing file size is 0")
+    with pytest.raises(RuntimeError, match=expected_msg):
+        vm.start()
 
 
 def test_pmem_add(uvm_plain_any, microvm_factory):


### PR DESCRIPTION
There are resource leaks in Pmem which are not a problem currently, but will be a problem once we have device hotplugging support.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
