### PR TITLE
fix(artifacts): add fio-engine-libaio to AL2023 rootfs

### DIFF
--- a/resources/rootfs/setup-al2023-ci.sh
+++ b/resources/rootfs/setup-al2023-ci.sh
@@ -9,7 +9,7 @@ set -eu -o pipefail
 set -x
 PS4='+\t '
 
-packages="systemd-udev openssh-server iproute socat iperf3 iputils fio kmod tmux hwloc vim-minimal trace-cmd strace python3-boto3 pciutils tar passwd procps-ng findutils e2fsprogs"
+packages="systemd-udev openssh-server iproute socat iperf3 iputils fio fio-engine-libaio kmod tmux hwloc vim-minimal trace-cmd strace python3-boto3 pciutils tar passwd procps-ng findutils e2fsprogs"
 
 # certain packages that are required in our CI tests are not available on Amazon Linux.
 # Build these from source so tests work properly.


### PR DESCRIPTION
As part of our non CI tests, we run fio with both psync and libaio engines. On ubuntu, just installing `fio` is enough to have both required engines, but on AL2023, `libaio` must be installed via a separate package, `fio-engine-libaio`. Add this to prevent test failures.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
