### PR TITLE
pci: Return error from add_device() instead of asserting

### DIFF
--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -121,7 +121,7 @@ impl PciDevices {
             .pci_bus
             .lock()
             .expect("Poisoned lock")
-            .add_device(sbdf.device(), virtio_device.clone());
+            .add_device(sbdf.device(), virtio_device.clone())?;
 
         self.virtio_devices
             .insert((device_type, id), virtio_device.clone());

--- a/src/vmm/src/pci/bus.rs
+++ b/src/vmm/src/pci/bus.rs
@@ -21,6 +21,8 @@ use crate::vstate::bus::BusDevice;
 pub enum PciRootError {
     /// Could not find an available device slot on the PCI bus.
     NoPciDeviceSlotAvailable,
+    /// PCI device ID {0} is already in use.
+    DuplicateDeviceId(u8),
 }
 
 const VENDOR_ID_INTEL: u16 = 0x8086;
@@ -105,13 +107,17 @@ impl PciBus {
     }
 
     /// Insert a device in the bus
-    pub fn add_device(&mut self, device_id: u8, device: Arc<Mutex<dyn PciDevice>>) {
-        assert!(
-            !self.devices.contains_key(&device_id),
-            "PCI device ID {device_id} already in use"
-        );
+    pub fn add_device(
+        &mut self,
+        device_id: u8,
+        device: Arc<Mutex<dyn PciDevice>>,
+    ) -> Result<(), PciRootError> {
+        if self.devices.contains_key(&device_id) {
+            return Err(PciRootError::DuplicateDeviceId(device_id));
+        }
         self.devices.insert(device_id, device);
         self.device_ids[device_id as usize] = true;
+        Ok(())
     }
 
     /// Remove a device from the bus and free its device ID slot
@@ -582,7 +588,8 @@ mod tests {
     fn initialize_bus() -> (PciConfigMmio, PciConfigIo) {
         let root = PciRoot::new(None);
         let mut bus = PciBus::new(root);
-        bus.add_device(1, Arc::new(Mutex::new(PciDevMock::new())));
+        bus.add_device(1, Arc::new(Mutex::new(PciDevMock::new())))
+            .unwrap();
 
         let bus = Arc::new(Mutex::new(bus));
         (PciConfigMmio::new(bus.clone()), PciConfigIo::new(bus))


### PR DESCRIPTION
Replace the assert in PciBus::add_device() with a proper error return, allowing callers to handle duplicate device IDs gracefully. This is important for the snapshot restore path where a corrupted snapshot should not crash the VMM.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
