### PR TITLE
serial: Add TX backpressure to prevent guest soft lockup

### DIFF
--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -144,13 +144,10 @@ impl PortIODeviceManager {
 
 #[cfg(test)]
 mod tests {
-    use libc::EFD_NONBLOCK;
-    use vm_superio::Serial;
     use vmm_sys_util::eventfd::EventFd;
 
     use super::*;
     use crate::devices::legacy::serial::{SerialOut, SerialOutInner};
-    use crate::devices::legacy::{EventFdTrigger, SerialEventsWrapper};
     use crate::vstate::vm::tests::setup_vm_with_memory;
 
     #[test]
@@ -158,16 +155,9 @@ mod tests {
         let (_, vm) = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
         let mut ldm = PortIODeviceManager {
-            stdio_serial: Arc::new(Mutex::new(SerialDevice {
-                serial: Serial::with_events(
-                    EventFdTrigger::new(EventFd::new(EFD_NONBLOCK).unwrap()),
-                    SerialEventsWrapper {
-                        buffer_ready_event_fd: None,
-                    },
-                    SerialOut::new(SerialOutInner::Sink, None),
-                ),
-                input: None,
-            })),
+            stdio_serial: Arc::new(Mutex::new(
+                SerialDevice::new(None, SerialOut::new(SerialOutInner::Sink, None), None).unwrap(),
+            )),
             i8042: Arc::new(Mutex::new(
                 I8042Device::new(EventFd::new(libc::EFD_NONBLOCK).unwrap()).unwrap(),
             )),

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -174,21 +174,22 @@ impl DeviceManager {
         {
             self.mmio_devices.serial.as_ref().map(|device| {
                 let locked = device.inner.lock().expect("Poisoned lock");
-                locked.serial.state().into()
+                let mut s: persist::SerialState = locked.serial.state().into();
+                s.tx_queue = locked.tx_queue_snapshot();
+                s
             })
         }
 
         #[cfg(target_arch = "x86_64")]
         {
-            Some(
-                self.legacy_devices
-                    .stdio_serial
-                    .lock()
-                    .expect("Poisoned lock")
-                    .serial
-                    .state()
-                    .into(),
-            )
+            let locked = self
+                .legacy_devices
+                .stdio_serial
+                .lock()
+                .expect("Poisoned lock");
+            let mut s: persist::SerialState = locked.serial.state().into();
+            s.tx_queue = locked.tx_queue_snapshot();
+            Some(s)
         }
     }
 
@@ -728,6 +729,17 @@ impl<'a> Persist<'a> for DeviceManager {
             serial_state.as_ref(),
             constructor_args.vm_resources.serial_rate_limiter(),
         )?;
+        // Restore any in-flight TX bytes that were captured at snapshot time.
+        // Older snapshots (pre-v10.1.0) carry an empty `tx_queue`, so this
+        // is a no-op on the upgrade path.
+        #[cfg(target_arch = "x86_64")]
+        if let Some(snap) = state.serial_state.as_ref() {
+            legacy_devices
+                .stdio_serial
+                .lock()
+                .expect("Poisoned lock")
+                .restore_tx_queue(&snap.tx_queue);
+        }
 
         // Restore MMIO devices
         let mmio_ctor_args = MMIODevManagerConstructorArgs {

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -56,6 +56,13 @@ pub struct SerialState {
     pub modem_status: u8,
     pub scratch: u8,
     pub in_buffer: Vec<u8>,
+    /// Bytes that the guest has written to the data register but that the
+    /// host hasn't drained to the underlying writer yet. Persisted so that
+    /// snapshot/restore (and live migration) does not drop pending console
+    /// output. New in snapshot v10.1.0; serde `default` so older snapshots
+    /// restore as empty.
+    #[serde(default)]
+    pub tx_queue: Vec<u8>,
 }
 
 impl From<vm_superio::serial::SerialState> for SerialState {
@@ -71,6 +78,7 @@ impl From<vm_superio::serial::SerialState> for SerialState {
             modem_status: s.modem_status,
             scratch: s.scratch,
             in_buffer: s.in_buffer,
+            tx_queue: Vec::new(),
         }
     }
 }
@@ -371,6 +379,16 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                         serial_state.as_ref(),
                         constructor_args.vm_resources.serial_rate_limiter(),
                     )?;
+
+                    // Restore any in-flight TX bytes captured at snapshot
+                    // time. Older snapshots (pre-v10.1.0) have an empty
+                    // `tx_queue`, so this is a no-op on the upgrade path.
+                    if let Some(snap) = constructor_args.serial_state {
+                        serial
+                            .lock()
+                            .expect("Poisoned lock")
+                            .restore_tx_queue(&snap.tx_queue);
+                    }
 
                     dev_manager.register_mmio_serial(vm, serial, Some(state.device_info))?;
                 }

--- a/src/vmm/src/devices/legacy/serial.rs
+++ b/src/vmm/src/devices/legacy/serial.rs
@@ -6,15 +6,18 @@
 // found in the THIRD-PARTY file.
 
 //! Implements a wrapper over an UART serial device.
+use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::{self, Read, Stdin, Write};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{Arc, Barrier};
+use std::time::Duration;
 
 use event_manager::{EventOps, Events, MutEventSubscriber};
 use libc::EFD_NONBLOCK;
 use serde::Serialize;
+use utils::time::TimerFd;
 use vm_superio::serial::{Error as SerialError, SerialEvents, SerialState};
 use vm_superio::{Serial, Trigger};
 use vmm_sys_util::epoll::EventSet;
@@ -25,6 +28,49 @@ use crate::logger::{IncMetric, SharedIncMetric, error, warn};
 use crate::rate_limiter::{BucketReduction, TokenBucket};
 use crate::utils::usize_to_u64;
 use crate::vstate::bus::BusDevice;
+
+// Register offsets we need to intercept. These mirror the values used inside
+// vm-superio (they are not re-exported), see
+// https://docs.rs/vm-superio/0.8.1/src/vm_superio/serial.rs.html
+const DATA_OFFSET: u8 = 0;
+const LSR_OFFSET: u8 = 5;
+
+// MCR offset and the loopback bit, used to detect whether the guest has put
+// the UART in local-loopback mode. In loopback mode vm-superio routes the
+// transmitted byte back into the receive FIFO synchronously, so we must NOT
+// queue it through our drain path — let the underlying `Serial::write` run
+// directly so the receive interrupt and FIFO state stay in sync.
+const MCR_OFFSET: u8 = 4;
+const MCR_LOOP_BIT: u8 = 0b0001_0000;
+
+// LSR bits we mask while a TX byte is in flight. Real 16550 hardware clears
+// these while the transmit shift register holds a byte and the THR is full,
+// causing a polling driver (e.g. Linux `wait_for_xmitr`) to wait. vm-superio
+// keeps both bits set unconditionally, which is what allows a tight
+// `cat /dev/zero > /dev/ttyS0` loop to pin a vCPU thread in MMIO exits.
+const LSR_EMPTY_THR_BIT: u8 = 0b0010_0000;
+const LSR_IDLE_BIT: u8 = 0b0100_0000;
+
+// Soft "TX FIFO" depth. We accept up to this many bytes from the guest
+// without applying backpressure, mirroring a real 16550A's 16-byte transmit
+// FIFO (we run a touch deeper to avoid stalling kernel `console_unlock`
+// bursts). Once the queue grows past this, the guest sees LSR_THR_EMPTY
+// clear and waits — that's what stops a `cat /dev/zero` runaway from
+// monopolising the vCPU thread in MMIO exits.
+const TX_FIFO_DEPTH: usize = 64;
+
+// Hard cap on the queue. Beyond this we drop bytes and bump the existing
+// `tx_lost_byte` metric, matching real-hardware FIFO overrun. Sized to
+// absorb a full kernel-boot worth of `printk` so normal operation never
+// drops.
+const TX_QUEUE_CAPACITY: usize = 64 * 1024;
+
+// One drain tick. timerfd resolution caps at ~1ms in practice. Drain rate
+// (bytes/sec) is roughly `TX_FIFO_DEPTH / TX_DRAIN_INTERVAL`, i.e. ~64 KB/s
+// at these settings — well above 115200 baud (≈12 KB/s) so we don't slow
+// kernel boot, while still cheap enough that the vCPU thread spends most of
+// its time in KVM_RUN instead of in MMIO-exit syscalls.
+const TX_DRAIN_INTERVAL: Duration = Duration::from_millis(1);
 
 /// Metrics specific to the UART device.
 #[derive(Debug, Serialize, Default)]
@@ -186,12 +232,28 @@ impl std::io::Write for SerialOut {
 }
 
 /// Wrapper over the imported serial device.
+///
+/// Adds host-side TX backpressure on top of the underlying vm-superio device:
+/// guest writes to the data register are queued and drained on a timer rather
+/// than written through synchronously, and the LSR bits that signal "TX
+/// ready" are masked off while bytes are queued. This prevents a guest tight
+/// loop (e.g. `cat /dev/zero > /dev/ttyS0`) from monopolising the vCPU
+/// thread in MMIO exits, which otherwise produces guest soft-lockup and RCU
+/// stall warnings on the *other* vCPUs.
 #[derive(Debug)]
 pub struct SerialWrapper<T: Trigger, EV: SerialEvents, I: Read + AsRawFd + Send> {
     /// Serial device object.
     pub serial: Serial<T, EV, SerialOut>,
     /// Input to the serial device (needs to be readable).
     pub input: Option<I>,
+    /// Bytes accepted from the guest that have not yet been drained to the
+    /// underlying output. Bounded by `TX_QUEUE_CAPACITY`.
+    tx_queue: VecDeque<u8>,
+    /// Periodic drain timer. Armed while `tx_queue` is non-empty.
+    tx_drain_timer: TimerFd,
+    /// Whether the drain timer is currently armed. Tracking this here avoids
+    /// querying the kernel via `timerfd_gettime` on the hot read path.
+    tx_drain_timer_armed: bool,
 }
 
 impl<I: Read + AsRawFd + Send + Debug> SerialWrapper<EventFdTrigger, SerialEventsWrapper, I> {
@@ -264,9 +326,12 @@ impl<I: Read + AsRawFd + Send + Debug> SerialWrapper<EventFdTrigger, SerialEvent
 /// Type for representing a serial device.
 pub type SerialDevice = SerialWrapper<EventFdTrigger, SerialEventsWrapper, Stdin>;
 
-impl SerialDevice {
-    pub fn new(
-        serial_in: Option<Stdin>,
+impl<I: Read + AsRawFd + Send> SerialWrapper<EventFdTrigger, SerialEventsWrapper, I> {
+    /// Construct a new serial wrapper backed by an arbitrary input source.
+    /// Used by integration tests that wire up a mock input fd; production
+    /// code goes through [`SerialDevice::new`].
+    pub fn with_input(
+        serial_in: Option<I>,
         serial_out: SerialOut,
         state: Option<&SerialState>,
     ) -> Result<Self, std::io::Error> {
@@ -286,10 +351,86 @@ impl SerialDevice {
                 None => Serial::with_events(interrupt_evt, events, serial_out),
             };
 
-        Ok(SerialDevice {
+        Ok(SerialWrapper {
             serial,
             input: serial_in,
+            tx_queue: VecDeque::with_capacity(TX_QUEUE_CAPACITY),
+            tx_drain_timer: TimerFd::new(),
+            tx_drain_timer_armed: false,
         })
+    }
+}
+
+impl SerialDevice {
+    pub fn new(
+        serial_in: Option<Stdin>,
+        serial_out: SerialOut,
+        state: Option<&SerialState>,
+    ) -> Result<Self, std::io::Error> {
+        Self::with_input(serial_in, serial_out, state)
+    }
+}
+
+impl<T: Trigger, EV: SerialEvents, I: Read + AsRawFd + Send> SerialWrapper<T, EV, I> {
+    /// True when the soft TX FIFO is at or above its modelled depth and
+    /// guest writes should be told to wait. We do NOT mask LSR while there
+    /// are simply *some* bytes queued, only when the queue is full enough to
+    /// emulate a real FIFO holding off the driver — otherwise the guest
+    /// would write one byte per drain tick and console output would crawl.
+    #[inline]
+    fn tx_fifo_full(&self) -> bool {
+        self.tx_queue.len() >= TX_FIFO_DEPTH
+    }
+
+    /// Mask the THR-empty / line-idle bits while the soft FIFO is at depth.
+    /// Real hardware clears these bits while the FIFO is full; vm-superio
+    /// always reports them set, so we patch the value here.
+    fn lsr_with_tx_mask(&self, raw: u8) -> u8 {
+        if self.tx_fifo_full() {
+            raw & !(LSR_EMPTY_THR_BIT | LSR_IDLE_BIT)
+        } else {
+            raw
+        }
+    }
+
+    fn arm_tx_drain_timer(&mut self) {
+        if !self.tx_drain_timer_armed {
+            self.tx_drain_timer.arm(TX_DRAIN_INTERVAL, None);
+            self.tx_drain_timer_armed = true;
+        }
+    }
+
+    /// Whether the underlying device has loopback enabled. Read via the
+    /// public `Serial::read` API (the inner `modem_control` field is
+    /// private). The MCR read path has no side effects.
+    fn is_in_loop_mode(&mut self) -> bool {
+        (self.serial.read(MCR_OFFSET) & MCR_LOOP_BIT) != 0
+    }
+
+    /// Drain up to one FIFO's worth of bytes from the queue into the
+    /// underlying serial device. Each byte goes through the regular
+    /// `Serial::write(DATA, b)` path so it produces the same observable
+    /// effects (stdout write, `flush`, optional THR-empty IRQ) as the
+    /// unbuffered path — just on the event-manager thread instead of the
+    /// vCPU thread.
+    ///
+    /// We deliberately stop at one FIFO so that, when the guest is flooding
+    /// the port, each tick produces one IRQ (or one batch of IRQs) and the
+    /// guest then has to wait for the next tick. That is what prevents the
+    /// IRQ-storm flavour of vCPU saturation: without the cap, draining a
+    /// large queue here would raise hundreds of THR-empty IRQs back-to-back,
+    /// which the guest would service inside one IRQ context and spend just
+    /// as long pegged as before.
+    fn drain_tx_queue(&mut self) {
+        for _ in 0..TX_FIFO_DEPTH {
+            let Some(byte) = self.tx_queue.pop_front() else {
+                break;
+            };
+            if let Err(err) = self.serial.write(DATA_OFFSET, byte) {
+                error!("Failed to drain serial TX byte: {:?}", err);
+                METRICS.error_count.inc();
+            }
+        }
     }
 }
 
@@ -304,6 +445,21 @@ impl<I: Read + AsRawFd + Send + Debug> MutEventSubscriber
                 Ok(_) => (),
                 Err(_) => error!("Could not unregister source fd: {}", source.as_raw_fd()),
             }
+        }
+
+        // The TX drain timer is independent of the input path: it can fire
+        // even when no input source is registered (e.g. when stdin is
+        // /dev/null in jailer-daemonised setups), so handle it before the
+        // input-fd checks below.
+        if self.tx_drain_timer.as_raw_fd() == event.fd() {
+            // Consume the timer expirations.
+            let _ = self.tx_drain_timer.read();
+            self.tx_drain_timer_armed = false;
+            self.drain_tx_queue();
+            if !self.tx_queue.is_empty() {
+                self.arm_tx_drain_timer();
+            }
+            return;
         }
 
         let input_fd = self.serial_input_fd();
@@ -367,7 +523,14 @@ impl<I: Read + AsRawFd + Send + Debug> MutEventSubscriber
 
     /// Initial registration of pollable objects.
     /// If serial input is present, register the serial input FD as readable.
+    /// The TX drain timer is registered unconditionally — it is required for
+    /// flushing buffered output regardless of whether an input source exists.
     fn init(&mut self, ops: &mut EventOps) {
+        let drain_fd = self.tx_drain_timer.as_raw_fd();
+        if let Err(err) = ops.add(Events::new(&drain_fd, EventSet::IN)) {
+            warn!("Failed to register serial TX drain timer fd: {}", err);
+        }
+
         if self.input.is_some() && self.serial.events().buffer_ready_event_fd.is_some() {
             let serial_fd = self.serial_input_fd();
             let buf_ready_evt = self.buffer_ready_evt_fd();
@@ -414,21 +577,54 @@ where
 {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         if let (Ok(offset), 1) = (u8::try_from(offset), data.len()) {
-            data[0] = self.serial.read(offset);
+            let value = self.serial.read(offset);
+            // Real 16550 hardware reports the THR/idle bits cleared while a
+            // byte is in flight. vm-superio always reports them set, so we
+            // mask them here whenever our drain queue holds bytes. Without
+            // this, a polling-mode guest writer (e.g. the kernel tty layer
+            // when an IRQ is unhandled) sees "always ready" and never lets
+            // the vCPU return to KVM_RUN, producing soft-lockup warnings.
+            data[0] = if offset == LSR_OFFSET {
+                self.lsr_with_tx_mask(value)
+            } else {
+                value
+            };
         } else {
             METRICS.missed_read_count.inc();
         }
     }
 
     fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
-        if let (Ok(offset), 1) = (u8::try_from(offset), data.len()) {
-            if let Err(err) = self.serial.write(offset, data[0]) {
-                // Counter incremented for any handle_write() error.
-                error!("Failed the write to serial: {:?}", err);
-                METRICS.error_count.inc();
-            }
-        } else {
+        let Ok(offset_u8) = u8::try_from(offset) else {
             METRICS.missed_write_count.inc();
+            return None;
+        };
+        if data.len() != 1 {
+            METRICS.missed_write_count.inc();
+            return None;
+        }
+        let value = data[0];
+
+        // Loopback writes are routed back into the receive buffer
+        // synchronously by vm-superio. They are not a flooding hazard (the
+        // RX FIFO is bounded), so let them go through unchanged to keep RX
+        // FIFO state and RDA interrupts in sync with the guest's view.
+        if offset_u8 == DATA_OFFSET && !self.is_in_loop_mode() {
+            if self.tx_queue.len() < TX_QUEUE_CAPACITY {
+                self.tx_queue.push_back(value);
+                self.arm_tx_drain_timer();
+            } else {
+                // Match real-hardware FIFO overrun. `tx_lost_byte` already
+                // bumps `missed_write_count` via the events trait, so we
+                // don't double-count here.
+                self.serial.events().tx_lost_byte();
+            }
+            return None;
+        }
+
+        if let Err(err) = self.serial.write(offset_u8, value) {
+            error!("Failed the write to serial: {:?}", err);
+            METRICS.error_count.inc();
         }
         None
     }
@@ -464,6 +660,9 @@ mod tests {
                 test_serial_out_sink(),
             ),
             input: None::<std::io::Stdin>,
+            tx_queue: VecDeque::with_capacity(TX_QUEUE_CAPACITY),
+            tx_drain_timer: TimerFd::new(),
+            tx_drain_timer_armed: false,
         };
         serial.serial.raw_input(b"abc").unwrap();
 
@@ -588,5 +787,212 @@ mod tests {
         let result = serial_out.write(b"anything").unwrap();
         assert_eq!(result, 8);
         assert_eq!(METRICS.rate_limiter_dropped_bytes.count(), dropped_before);
+    }
+
+    /// Build a `SerialDevice` writing into the provided `SerialOut`, with no
+    /// input source. Used by the TX backpressure tests below.
+    fn test_serial_device(out: SerialOut) -> SerialDevice {
+        SerialDevice::new(None, out, None).unwrap()
+    }
+
+    /// Drive the device through `BusDevice::write` rather than calling the
+    /// inner `serial.write` directly — this is what the TX backpressure path
+    /// hooks, so unit tests must go through the same entry point as a
+    /// guest-issued MMIO write.
+    fn bus_write(dev: &mut SerialDevice, offset: u64, byte: u8) {
+        dev.write(0, offset, &[byte]);
+    }
+
+    fn bus_read(dev: &mut SerialDevice, offset: u64) -> u8 {
+        let mut buf = [0u8; 1];
+        dev.read(0, offset, &mut buf);
+        buf[0]
+    }
+
+    #[test]
+    fn test_tx_data_writes_are_queued_not_passed_through() {
+        // Guest data writes should *not* reach the underlying writer
+        // synchronously: they are buffered and only drained on the timer
+        // tick. This is the property that prevents the vCPU thread from
+        // doing per-byte syscalls. We assert by inspecting the backing
+        // file: it must still be empty after the bus write.
+        let tmp = vmm_sys_util::tempfile::TempFile::new().unwrap();
+        let file = tmp.into_file();
+        let mut dev = test_serial_device(SerialOut::new(
+            SerialOutInner::File(file.try_clone().unwrap()),
+            None,
+        ));
+        bus_write(&mut dev, DATA_OFFSET as u64, b'X');
+
+        assert_eq!(dev.tx_queue.len(), 1);
+        assert!(dev.tx_drain_timer_armed);
+
+        use std::io::Seek;
+        let mut file = file;
+        file.seek(std::io::SeekFrom::Start(0)).unwrap();
+        let mut readback = Vec::new();
+        file.read_to_end(&mut readback).unwrap();
+        assert!(
+            readback.is_empty(),
+            "byte must not have reached the writer yet, got {readback:?}"
+        );
+    }
+
+    #[test]
+    fn test_drain_flushes_queued_bytes_to_writer() {
+        // After a manual drain, every queued byte must reach the underlying
+        // writer. We assert by inspecting the file contents, not by reading
+        // the (global, racy) `write_count` metric.
+        let tmp = vmm_sys_util::tempfile::TempFile::new().unwrap();
+        let file = tmp.into_file();
+        let mut dev = test_serial_device(SerialOut::new(
+            SerialOutInner::File(file.try_clone().unwrap()),
+            None,
+        ));
+        for &b in b"hello" {
+            bus_write(&mut dev, DATA_OFFSET as u64, b);
+        }
+        assert_eq!(dev.tx_queue.len(), 5);
+
+        dev.drain_tx_queue();
+        assert_eq!(dev.tx_queue.len(), 0);
+
+        use std::io::Seek;
+        let mut file = file;
+        file.seek(std::io::SeekFrom::Start(0)).unwrap();
+        let mut readback = Vec::new();
+        file.read_to_end(&mut readback).unwrap();
+        assert_eq!(readback, b"hello");
+    }
+
+    #[test]
+    fn test_drain_caps_at_one_fifo_per_tick() {
+        // A single drain tick should pop at most `TX_FIFO_DEPTH` bytes,
+        // leaving the remainder for the next tick. This is what gates the
+        // guest IRQ rate when it's flooding the port.
+        let mut dev = test_serial_device(SerialOut::new(SerialOutInner::Sink, None));
+        let burst = TX_FIFO_DEPTH * 2 + 7;
+        for _ in 0..burst {
+            bus_write(&mut dev, DATA_OFFSET as u64, b'.');
+        }
+        assert_eq!(dev.tx_queue.len(), burst);
+
+        dev.drain_tx_queue();
+        assert_eq!(dev.tx_queue.len(), burst - TX_FIFO_DEPTH);
+        dev.drain_tx_queue();
+        assert_eq!(dev.tx_queue.len(), burst - 2 * TX_FIFO_DEPTH);
+        dev.drain_tx_queue();
+        assert_eq!(dev.tx_queue.len(), 0);
+    }
+
+    #[test]
+    fn test_drain_preserves_byte_order() {
+        // Round-trip a payload through the queue + drain into a real File
+        // sink and confirm bytes come out in submission order.
+        let tmp = vmm_sys_util::tempfile::TempFile::new().unwrap();
+        let file = tmp.into_file();
+        let mut dev = test_serial_device(SerialOut::new(
+            SerialOutInner::File(file.try_clone().unwrap()),
+            None,
+        ));
+        let payload: Vec<u8> = (0u8..32).collect();
+        for &b in &payload {
+            bus_write(&mut dev, DATA_OFFSET as u64, b);
+        }
+        dev.drain_tx_queue();
+
+        use std::io::Seek;
+        let mut file = file;
+        file.seek(std::io::SeekFrom::Start(0)).unwrap();
+        let mut readback = Vec::new();
+        file.read_to_end(&mut readback).unwrap();
+        assert_eq!(readback, payload);
+    }
+
+    #[test]
+    fn test_lsr_thr_empty_masked_only_when_fifo_full() {
+        // Real 16550 hardware clears LSR_THR_EMPTY when the TX FIFO is
+        // full. Our wrapper applies the same mask via `lsr_with_tx_mask`.
+        // Below the FIFO depth: the bits stay set so the guest can keep
+        // submitting bytes (otherwise console output would crawl at one
+        // byte per drain tick).
+        let mut dev = test_serial_device(SerialOut::new(SerialOutInner::Sink, None));
+
+        // Empty queue: both bits set.
+        let lsr = bus_read(&mut dev, LSR_OFFSET as u64);
+        assert_eq!(lsr & LSR_EMPTY_THR_BIT, LSR_EMPTY_THR_BIT);
+        assert_eq!(lsr & LSR_IDLE_BIT, LSR_IDLE_BIT);
+
+        // Below the FIFO depth: still set.
+        for _ in 0..TX_FIFO_DEPTH - 1 {
+            bus_write(&mut dev, DATA_OFFSET as u64, 0);
+        }
+        assert!(!dev.tx_fifo_full());
+        let lsr = bus_read(&mut dev, LSR_OFFSET as u64);
+        assert_eq!(lsr & LSR_EMPTY_THR_BIT, LSR_EMPTY_THR_BIT);
+        assert_eq!(lsr & LSR_IDLE_BIT, LSR_IDLE_BIT);
+
+        // At depth: both bits cleared.
+        bus_write(&mut dev, DATA_OFFSET as u64, 0);
+        assert!(dev.tx_fifo_full());
+        let lsr = bus_read(&mut dev, LSR_OFFSET as u64);
+        assert_eq!(lsr & LSR_EMPTY_THR_BIT, 0);
+        assert_eq!(lsr & LSR_IDLE_BIT, 0);
+
+        // After draining one FIFO's worth, bits return.
+        dev.drain_tx_queue();
+        assert!(!dev.tx_fifo_full());
+        let lsr = bus_read(&mut dev, LSR_OFFSET as u64);
+        assert_eq!(lsr & LSR_EMPTY_THR_BIT, LSR_EMPTY_THR_BIT);
+    }
+
+    #[test]
+    fn test_tx_queue_overflow_drops_bytes() {
+        // Past `TX_QUEUE_CAPACITY` we drop bytes, matching real-hardware
+        // FIFO overrun. The queue length must not exceed the cap. The
+        // associated metric (`missed_write_count`) is global and bumped by
+        // other tests in parallel, so we don't assert on it here — see
+        // `test_serial_bus_read` for coverage of that counter.
+        let mut dev = test_serial_device(SerialOut::new(SerialOutInner::Sink, None));
+        for _ in 0..TX_QUEUE_CAPACITY + 100 {
+            bus_write(&mut dev, DATA_OFFSET as u64, b'!');
+        }
+        assert_eq!(dev.tx_queue.len(), TX_QUEUE_CAPACITY);
+    }
+
+    #[test]
+    fn test_loopback_writes_bypass_queue() {
+        // Loopback writes are routed back into the receive FIFO by
+        // vm-superio synchronously. They must NOT take our queued path —
+        // otherwise RX FIFO state and RDA interrupts would lag behind the
+        // guest's view of its own writes.
+        let mut dev = test_serial_device(SerialOut::new(SerialOutInner::Sink, None));
+
+        // Set MCR loopback bit via the BusDevice path.
+        bus_write(&mut dev, MCR_OFFSET as u64, MCR_LOOP_BIT);
+        assert!(dev.is_in_loop_mode());
+
+        // A data write must not enqueue.
+        bus_write(&mut dev, DATA_OFFSET as u64, b'L');
+        assert!(dev.tx_queue.is_empty());
+
+        // The byte should be readable back from the data register (it was
+        // routed into the RX FIFO by vm-superio's loopback path).
+        let got = bus_read(&mut dev, DATA_OFFSET as u64);
+        assert_eq!(got, b'L');
+    }
+
+    #[test]
+    fn test_non_data_writes_passthrough() {
+        // Writes to non-DATA registers (e.g. IER, LCR, MCR) must reach
+        // vm-superio synchronously — they configure the device, not move
+        // data — so they must never be queued.
+        let mut dev = test_serial_device(SerialOut::new(SerialOutInner::Sink, None));
+
+        // LCR is offset 3.
+        bus_write(&mut dev, 3, 0x55);
+        assert!(dev.tx_queue.is_empty());
+        // Read it back through the bus path.
+        assert_eq!(bus_read(&mut dev, 3), 0x55);
     }
 }

--- a/src/vmm/src/devices/legacy/serial.rs
+++ b/src/vmm/src/devices/legacy/serial.rs
@@ -407,6 +407,28 @@ impl<T: Trigger, EV: SerialEvents, I: Read + AsRawFd + Send> SerialWrapper<T, EV
         (self.serial.read(MCR_OFFSET) & MCR_LOOP_BIT) != 0
     }
 
+    /// Snapshot view of the soft TX FIFO. Used by the persistence layer to
+    /// include in-flight bytes in the snapshot file so they survive
+    /// snapshot/restore and live migration.
+    pub fn tx_queue_snapshot(&self) -> Vec<u8> {
+        self.tx_queue.iter().copied().collect()
+    }
+
+    /// Restore the soft TX FIFO from a snapshot. Bytes are appended in
+    /// order; if the snapshot exceeds the current capacity (e.g. it was
+    /// taken with a larger cap) the excess is dropped to preserve the
+    /// invariant that `tx_queue.len() <= TX_QUEUE_CAPACITY`. The drain
+    /// timer is armed if the queue ends up non-empty so that bytes start
+    /// flowing immediately on the restored side.
+    pub fn restore_tx_queue(&mut self, bytes: &[u8]) {
+        self.tx_queue.clear();
+        let take = bytes.len().min(TX_QUEUE_CAPACITY);
+        self.tx_queue.extend(&bytes[..take]);
+        if !self.tx_queue.is_empty() {
+            self.arm_tx_drain_timer();
+        }
+    }
+
     /// Drain up to one FIFO's worth of bytes from the queue into the
     /// underlying serial device. Each byte goes through the regular
     /// `Serial::write(DATA, b)` path so it produces the same observable
@@ -994,5 +1016,63 @@ mod tests {
         assert!(dev.tx_queue.is_empty());
         // Read it back through the bus path.
         assert_eq!(bus_read(&mut dev, 3), 0x55);
+    }
+
+    #[test]
+    fn test_tx_queue_snapshot_round_trip() {
+        // The TX FIFO is part of the snapshot (snapshot v10.1.0+) so that
+        // pending console output survives snapshot/restore. Round-trip a
+        // payload through `tx_queue_snapshot` -> `restore_tx_queue` and
+        // confirm the bytes drain in order on the restored side.
+        let mut sender = test_serial_device(SerialOut::new(SerialOutInner::Sink, None));
+        let payload: &[u8] = b"snapshot-pending-bytes";
+        for &b in payload {
+            bus_write(&mut sender, DATA_OFFSET as u64, b);
+        }
+        let snap = sender.tx_queue_snapshot();
+        assert_eq!(snap, payload);
+
+        let tmp = vmm_sys_util::tempfile::TempFile::new().unwrap();
+        let file = tmp.into_file();
+        let mut receiver = test_serial_device(SerialOut::new(
+            SerialOutInner::File(file.try_clone().unwrap()),
+            None,
+        ));
+        receiver.restore_tx_queue(&snap);
+        assert_eq!(receiver.tx_queue.len(), payload.len());
+        assert!(receiver.tx_drain_timer_armed);
+
+        // Drain enough times to flush the entire queue (queue is shorter
+        // than one FIFO so a single drain suffices).
+        receiver.drain_tx_queue();
+        assert!(receiver.tx_queue.is_empty());
+
+        use std::io::Seek;
+        let mut file = file;
+        file.seek(std::io::SeekFrom::Start(0)).unwrap();
+        let mut readback = Vec::new();
+        file.read_to_end(&mut readback).unwrap();
+        assert_eq!(readback, payload);
+    }
+
+    #[test]
+    fn test_restore_tx_queue_truncates_to_capacity() {
+        // A snapshot taken with a larger cap (or a corrupted one) must not
+        // be allowed to push the queue past its current capacity.
+        let mut dev = test_serial_device(SerialOut::new(SerialOutInner::Sink, None));
+        let oversized = vec![0xABu8; TX_QUEUE_CAPACITY + 1024];
+        dev.restore_tx_queue(&oversized);
+        assert_eq!(dev.tx_queue.len(), TX_QUEUE_CAPACITY);
+    }
+
+    #[test]
+    fn test_restore_tx_queue_empty_does_not_arm_timer() {
+        // Old (pre-v10.1.0) snapshots carry an empty `tx_queue`. Restoring
+        // an empty queue must be a no-op — in particular it must not arm
+        // the drain timer (which would cause a spurious wakeup).
+        let mut dev = test_serial_device(SerialOut::new(SerialOutInner::Sink, None));
+        dev.restore_tx_queue(&[]);
+        assert!(dev.tx_queue.is_empty());
+        assert!(!dev.tx_drain_timer_armed);
     }
 }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -160,7 +160,7 @@ pub enum CreateSnapshotError {
 }
 
 /// Snapshot version
-pub const SNAPSHOT_VERSION: Version = Version::new(10, 0, 0);
+pub const SNAPSHOT_VERSION: Version = Version::new(10, 1, 0);
 
 /// Creates a Microvm snapshot.
 pub fn create_snapshot(

--- a/src/vmm/tests/devices.rs
+++ b/src/vmm/tests/devices.rs
@@ -11,30 +11,24 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{Arc, Mutex};
 
 use event_manager::{EventManager, SubscriberOps};
-use libc::EFD_NONBLOCK;
-use vm_superio::Serial;
 use vmm::devices::legacy::serial::{SerialOut, SerialOutInner};
 use vmm::devices::legacy::{EventFdTrigger, SerialEventsWrapper, SerialWrapper};
 use vmm::vstate::bus::BusDevice;
-use vmm_sys_util::eventfd::EventFd;
 
 fn create_serial(
     pipe: c_int,
 ) -> Arc<Mutex<SerialWrapper<EventFdTrigger, SerialEventsWrapper, Box<MockSerialInput>>>> {
     // Serial input is the reading end of the pipe.
     let serial_in = MockSerialInput(pipe);
-    let kick_stdin_evt = EventFdTrigger::new(EventFd::new(libc::EFD_NONBLOCK).unwrap());
 
-    Arc::new(Mutex::new(SerialWrapper {
-        serial: Serial::with_events(
-            EventFdTrigger::new(EventFd::new(EFD_NONBLOCK).unwrap()),
-            SerialEventsWrapper {
-                buffer_ready_event_fd: Some(kick_stdin_evt.try_clone().unwrap()),
-            },
+    Arc::new(Mutex::new(
+        SerialWrapper::with_input(
+            Some(Box::new(serial_in)),
             SerialOut::new(SerialOutInner::Stdout(std::io::stdout()), None),
-        ),
-        input: Some(Box::new(serial_in)),
-    }))
+            None,
+        )
+        .unwrap(),
+    ))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
