### PR TITLE
fix(tests): do not construct GuestDistro for docker-popular

### DIFF
--- a/tests/framework/guest.py
+++ b/tests/framework/guest.py
@@ -5,6 +5,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -17,8 +18,8 @@ class GuestDistro:
     shell_prompt: str
 
     @classmethod
-    def from_rootfs(cls, rootfs_path: Path) -> "GuestDistro":
-        """Return a guest distro object based on the rootfs name"""
+    def from_rootfs(cls, rootfs_path: Path) -> Optional["GuestDistro"]:
+        """Return a guest distro object based on the rootfs name, or None if unrecognized."""
         name = rootfs_path.stem.lower()
         if "ubuntu" in name:
             hostname = "ubuntu-fc-uvm"
@@ -36,4 +37,4 @@ class GuestDistro:
                 os_release_token='ID="amzn"',
                 shell_prompt=f"[root@{hostname} ~]#",
             )
-        raise ValueError(f"Unknown guest distro for rootfs: {rootfs_path}")
+        return None


### PR DESCRIPTION
We saw failures on the docker popular tests because it was trying to create a GuestDistro instance but could not find a matching entry. In reality, we don't need this object for the docker popular tests, so just return None if it's not AL2023 or Ubuntu.

## Changes

- If rootfs is neither Ubuntu or AL2023, return None for `GuestDistro`

## Reason

Docker popular tests were trying to construct `GuestDistro` dataclasses for the test rootfs'. `GuestDistro` itself is never accessed during the tests, so we can just return None to fix this.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
