### PR TITLE
feat(logger): replace Mutex limiter with lock-free GCRA

### DIFF
--- a/src/vmm/src/logger/mod.rs
+++ b/src/vmm/src/logger/mod.rs
@@ -103,11 +103,8 @@ macro_rules! __log_rate_limited_impl {
     ($level:expr, $level_macro:path, $($arg:tt)+) => {{
         #[allow(clippy::disallowed_macros)]
         if $crate::logger::log_enabled!($level) {
-            static LIMITER: $crate::logger::rate_limited::LogRateLimiter =
-                $crate::logger::rate_limited::LogRateLimiter::new(
-                    $crate::logger::rate_limited::DEFAULT_BURST,
-                    $crate::logger::rate_limited::DEFAULT_REFILL_TIME_MS,
-                );
+            static LIMITER: $crate::logger::rate_limited::DefaultLogRateLimiter =
+                $crate::logger::rate_limited::DefaultLogRateLimiter::new();
             if LIMITER.check_maybe_suppressed() {
                 $level_macro!($($arg)+);
             }

--- a/src/vmm/src/logger/rate_limited.rs
+++ b/src/vmm/src/logger/rate_limited.rs
@@ -1,16 +1,47 @@
 // Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Per-callsite rate limiter for logging, reusing the existing `TokenBucket`
-//! implementation. Each macro invocation site gets its own independent
-//! `LogRateLimiter` instance via a `static`, so flooding one callsite does
-//! not suppress unrelated log messages.
+//! Per-callsite, lock-free rate limiter for logging.
+//!
+//! Each macro invocation site gets its own independent `LogRateLimiter`
+//! instance via a `static`, so flooding one callsite does not suppress
+//! unrelated log messages.
+//!
+//! # Algorithm
+//!
+//! Generic Cell Rate Algorithm (GCRA), stored in a single `AtomicU64`:
+//!
+//! ```text
+//! bit 63                                                    bit 0
+//!  ┌───────────────────┬────────────────────────────────────────┐
+//!  │  suppressed (24)  │              tat_ms (40)               │
+//!  └───────────────────┴────────────────────────────────────────┘
+//! ```
+//!
+//! - `tat_ms`: theoretical arrival time, ms since process epoch.
+//!   40 bits ≈ 34 years before wrap.
+//! - `suppressed`: saturating count of denied calls awaiting a
+//!   "messages were suppressed" report (max 16 777 215).
+//!
+//! On each call: `earliest = max(tat, now)`, `new_tat = earliest + T`
+//! where `T = REFILL_MS / BURST`. Deny if `new_tat - now > REFILL_MS`,
+//! otherwise CAS-advance `tat`. Equivalent to a token-bucket of capacity
+//! `BURST` refilling `BURST` tokens per `REFILL_MS`.
+//!
+//! For the default config (`BURST = 10`, `REFILL_MS = 5000`):
+//! `T = 500 ms`/token. After a cold start the bucket allows 10 calls
+//! back-to-back, then one call every 500 ms thereafter.
+//!
+//! Guest-triggerable log paths **must** use the rate-limited macros
+//! (`error!`, `warn!`, `info!`) to prevent log flooding. Reserve
+//! `*_unrestricted!` for host-only paths (startup, snapshot save/
+//! restore).
 
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
 
 use crate::logger::{IncMetric, METRICS};
-use crate::rate_limiter::TokenBucket;
 
 /// Maximum number of messages allowed per refill period.
 pub const DEFAULT_BURST: u64 = 10;
@@ -18,75 +49,143 @@ pub const DEFAULT_BURST: u64 = 10;
 /// Refill period in milliseconds (5 seconds).
 pub const DEFAULT_REFILL_TIME_MS: u64 = 5000;
 
-/// Per-callsite rate limiter wrapping a `TokenBucket` in a `Mutex`.
-///
-/// Uses `OnceLock` for lazy initialization since `TokenBucket::new()`
-/// is not `const` (it calls `Instant::now()`).
-#[derive(Debug)]
-pub struct LogRateLimiter {
-    inner: OnceLock<Mutex<TokenBucket>>,
-    burst: u64,
-    refill_time_ms: u64,
-    suppressed: AtomicU64,
+/// Process-wide reference point for `tat_ms`.
+static EPOCH: OnceLock<Instant> = OnceLock::new();
+
+/// Returns ms since the process epoch.
+#[inline]
+fn now_ms_since_epoch() -> u64 {
+    let epoch = *EPOCH.get_or_init(Instant::now);
+    let d = Instant::now().saturating_duration_since(epoch);
+    d.as_secs() * 1_000 + u64::from(d.subsec_millis())
 }
 
-impl Default for LogRateLimiter {
+/// Per-callsite, lock-free rate limiter parameterised on burst capacity
+/// and refill window. See [module docs](self) for the state layout.
+#[derive(Debug)]
+pub struct LogRateLimiter<const BURST: u64, const REFILL_MS: u64> {
+    state: AtomicU64,
+}
+
+/// Convenience alias for the default-configured rate limiter, used by
+/// the rate-limited log macros (10 messages per 5-second window).
+pub type DefaultLogRateLimiter = LogRateLimiter<DEFAULT_BURST, DEFAULT_REFILL_TIME_MS>;
+
+impl<const BURST: u64, const REFILL_MS: u64> Default for LogRateLimiter<BURST, REFILL_MS> {
     fn default() -> Self {
-        Self::new(DEFAULT_BURST, DEFAULT_REFILL_TIME_MS)
+        Self::new()
     }
 }
 
-impl LogRateLimiter {
-    /// Create a new uninitialized rate limiter with the given
-    /// burst capacity and refill period.
-    ///
-    /// This is `const` so it can be used in `static` declarations.
-    /// The inner `TokenBucket` is lazily initialized on first use.
-    pub const fn new(burst: u64, refill_time_ms: u64) -> Self {
+impl<const BURST: u64, const REFILL_MS: u64> LogRateLimiter<BURST, REFILL_MS> {
+    /// Width of the `tat_ms` field in the packed state.
+    const TAT_BITS: u32 = 40;
+
+    /// Mask covering `tat_ms` (low bits).
+    const TAT_MASK: u64 = (1u64 << Self::TAT_BITS) - 1;
+
+    /// Maximum value the `suppressed` field can hold; further increments
+    /// saturate at this value.
+    const MAX_SUPPRESSED: u64 = u64::MAX >> Self::TAT_BITS;
+
+    /// CAS-retry cap. Bounds pathological scheduler-induced livelock;
+    /// on overflow the call is denied and the suppression metric bumped.
+    const CAS_RETRY_LIMIT: u32 = 16;
+
+    /// Milliseconds it takes to issue one token (the inter-token period).
+    /// Validated at const-eval time: refusing to compile callsites that
+    /// would round to 0 ms/token under integer division.
+    const PERIOD_PER_TOKEN_MS: u64 = {
+        assert!(BURST > 0, "LogRateLimiter BURST must be > 0");
+        assert!(REFILL_MS > 0, "LogRateLimiter REFILL_MS must be > 0");
+        let v = REFILL_MS / BURST;
+        assert!(
+            v > 0,
+            "LogRateLimiter: REFILL_MS / BURST must yield at least 1 ms/token"
+        );
+        v
+    };
+
+    /// Maximum permitted "deficit" of the bucket — the largest gap
+    /// between `tat` and `now` we accept before denying a call.
+    /// Equal to `REFILL_MS`.
+    const MAX_DEFICIT_MS: u64 = REFILL_MS;
+
+    /// Pack `(tat_ms, suppressed)` into a single 64-bit state word.
+    /// `suppressed` is saturated to `MAX_SUPPRESSED`.
+    #[inline]
+    const fn pack(tat_ms: u64, suppressed: u64) -> u64 {
+        let s = if suppressed > Self::MAX_SUPPRESSED {
+            Self::MAX_SUPPRESSED
+        } else {
+            suppressed
+        };
+        (s << Self::TAT_BITS) | (tat_ms & Self::TAT_MASK)
+    }
+
+    /// Unpack a 64-bit state word into `(tat_ms, suppressed)`.
+    #[inline]
+    const fn unpack(state: u64) -> (u64, u64) {
+        (state & Self::TAT_MASK, state >> Self::TAT_BITS)
+    }
+
+    /// Create a fresh rate limiter. `const`-callable so it can appear in
+    /// `static` declarations.
+    pub const fn new() -> Self {
+        // Force monomorphisation of the const-asserts above.
+        let _ = Self::PERIOD_PER_TOKEN_MS;
+        let _ = Self::MAX_DEFICIT_MS;
         Self {
-            inner: OnceLock::new(),
-            burst,
-            refill_time_ms,
-            suppressed: AtomicU64::new(0),
+            state: AtomicU64::new(0),
         }
     }
 
-    /// Check whether a message should be emitted.
+    /// Check if a log should be emitted, atomically updating both the
+    /// token-bucket state and the suppressed counter.
     ///
-    /// Returns `true` if the message should be logged, `false` if
-    /// it should be suppressed.
-    pub fn check(&self) -> bool {
-        let mutex = self.inner.get_or_init(|| {
-            Mutex::new(
-                TokenBucket::new(self.burst, 0, self.refill_time_ms)
-                    .expect("invalid rate limiter configuration"),
-            )
-        });
-        let mut bucket = mutex.lock().expect("rate limiter lock poisoned");
-        matches!(
-            bucket.reduce(1),
-            crate::rate_limiter::BucketReduction::Success
-        )
-    }
-
-    /// Check if log is should be emitted and print a warning if it was
-    /// suppressed before. Marked to be never inlined since it is called in a
-    /// lot of macros and would blow up the binary size otherwise.
+    /// On allow: clears `suppressed` and emits a one-shot warning if
+    /// any messages were suppressed since the last allowed emit.
+    /// On deny: increments `suppressed` (saturating) and bumps the
+    /// global `rate_limited_log_count` metric.
     #[inline(never)]
     pub fn check_maybe_suppressed(&self) -> bool {
-        if self.check() {
-            let suppressed = self.suppressed.swap(0, Ordering::Relaxed);
-            if 0 < suppressed {
-                crate::logger::warn_unrestricted!(
-                    "{suppressed} messages were suppressed due to rate limiting"
-                );
+        let now_ms = now_ms_since_epoch();
+        for _ in 0..Self::CAS_RETRY_LIMIT {
+            let state = self.state.load(Ordering::Relaxed);
+            let (tat_ms, suppressed) = Self::unpack(state);
+
+            let earliest = tat_ms.max(now_ms);
+            let new_tat_ms = earliest.saturating_add(Self::PERIOD_PER_TOKEN_MS);
+
+            let denied = new_tat_ms.saturating_sub(now_ms) > Self::MAX_DEFICIT_MS;
+            let new_state = if denied {
+                Self::pack(tat_ms, suppressed.saturating_add(1))
+            } else {
+                Self::pack(new_tat_ms, 0)
+            };
+
+            if self
+                .state
+                .compare_exchange_weak(state, new_state, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                if denied {
+                    METRICS.logger.rate_limited_log_count.inc();
+                } else if suppressed > 0 {
+                    crate::logger::warn_unrestricted!(
+                        "{suppressed} messages were suppressed due to rate limiting"
+                    );
+                }
+                return !denied;
             }
-            true
-        } else {
-            self.suppressed.fetch_add(1, Ordering::Relaxed);
-            METRICS.logger.rate_limited_log_count.inc();
-            false
         }
+        METRICS.logger.rate_limited_log_count.inc();
+        false
+    }
+
+    #[cfg(test)]
+    fn suppressed_count(&self) -> u64 {
+        Self::unpack(self.state.load(Ordering::Relaxed)).1
     }
 }
 
@@ -94,50 +193,114 @@ impl LogRateLimiter {
 mod tests {
     use super::*;
 
+    type Limiter = DefaultLogRateLimiter;
+
     #[test]
     fn test_burst_capacity_enforcement() {
-        let limiter = LogRateLimiter::default();
+        let limiter = Limiter::default();
 
-        // First DEFAULT_BURST calls should be allowed.
         for _ in 0..DEFAULT_BURST {
-            assert!(limiter.check(), "expected allow within burst");
+            assert!(limiter.check_maybe_suppressed());
         }
-
-        // The next call should be suppressed.
-        assert!(!limiter.check(), "expected suppress after burst");
-        assert!(!limiter.check(), "expected suppress after burst");
+        assert!(!limiter.check_maybe_suppressed());
+        assert!(!limiter.check_maybe_suppressed());
     }
 
     #[test]
     fn test_callsite_independence() {
-        let limiter_a = LogRateLimiter::default();
-        let limiter_b = LogRateLimiter::default();
+        let limiter_a = Limiter::default();
+        let limiter_b = Limiter::default();
 
-        // Exhaust limiter_a.
         for _ in 0..DEFAULT_BURST {
-            limiter_a.check();
+            limiter_a.check_maybe_suppressed();
         }
-        assert!(!limiter_a.check());
-
-        // limiter_b should be unaffected.
-        assert!(limiter_b.check());
+        assert!(!limiter_a.check_maybe_suppressed());
+        assert!(limiter_b.check_maybe_suppressed());
     }
 
     #[test]
     fn test_refill_after_time() {
-        // Use a short refill period to avoid slow tests.
         const TEST_BURST: u64 = 2;
         const TEST_REFILL_MS: u64 = 100;
-        let limiter = LogRateLimiter::new(TEST_BURST, TEST_REFILL_MS);
+        let limiter: LogRateLimiter<TEST_BURST, TEST_REFILL_MS> = LogRateLimiter::new();
 
-        // Exhaust burst.
         for _ in 0..TEST_BURST {
-            limiter.check();
+            assert!(limiter.check_maybe_suppressed());
         }
-        assert!(!limiter.check());
+        assert!(!limiter.check_maybe_suppressed());
 
-        // Wait for refill.
         std::thread::sleep(std::time::Duration::from_millis(TEST_REFILL_MS * 2));
-        assert!(limiter.check(), "expected allow after refill");
+        assert!(limiter.check_maybe_suppressed());
+    }
+
+    #[test]
+    fn test_check_maybe_suppressed_increments_metric() {
+        let limiter = Limiter::default();
+        let baseline = METRICS.logger.rate_limited_log_count.count();
+
+        for _ in 0..DEFAULT_BURST {
+            assert!(limiter.check_maybe_suppressed());
+        }
+        assert_eq!(METRICS.logger.rate_limited_log_count.count(), baseline);
+
+        for _ in 0..3 {
+            assert!(!limiter.check_maybe_suppressed());
+        }
+        assert_eq!(METRICS.logger.rate_limited_log_count.count(), baseline + 3);
+    }
+
+    #[test]
+    fn test_check_maybe_suppressed_state_machine() {
+        const TEST_BURST: u64 = 1;
+        const TEST_REFILL_MS: u64 = 50;
+        let limiter: LogRateLimiter<TEST_BURST, TEST_REFILL_MS> = LogRateLimiter::new();
+
+        assert!(limiter.check_maybe_suppressed());
+        assert!(!limiter.check_maybe_suppressed());
+        assert_eq!(limiter.suppressed_count(), 1);
+
+        std::thread::sleep(std::time::Duration::from_millis(TEST_REFILL_MS * 2));
+        assert!(limiter.check_maybe_suppressed());
+        assert_eq!(limiter.suppressed_count(), 0);
+    }
+
+    #[test]
+    fn test_suppressed_saturates_at_max() {
+        // Inject a near-saturated state to avoid 16M real denies.
+        type Tight = LogRateLimiter<1, 100>;
+        let limiter = Tight::new();
+
+        assert!(limiter.check_maybe_suppressed());
+        let (tat_ms, _) = Tight::unpack(limiter.state.load(Ordering::Relaxed));
+        limiter.state.store(
+            Tight::pack(tat_ms, Tight::MAX_SUPPRESSED - 1),
+            Ordering::Relaxed,
+        );
+
+        for _ in 0..5 {
+            assert!(!limiter.check_maybe_suppressed());
+        }
+        assert_eq!(limiter.suppressed_count(), Tight::MAX_SUPPRESSED);
+    }
+
+    #[test]
+    fn test_pack_unpack_roundtrip() {
+        type L = DefaultLogRateLimiter;
+        let cases: &[(u64, u64)] = &[
+            (0, 0),
+            (1, 0),
+            (0, 1),
+            (123_456_789, 42),
+            (L::TAT_MASK, 0),
+            (0, L::MAX_SUPPRESSED),
+            (L::TAT_MASK, L::MAX_SUPPRESSED),
+        ];
+        for &(tat, sup) in cases {
+            let (tat_back, sup_back) = L::unpack(L::pack(tat, sup));
+            assert_eq!(tat_back, tat);
+            assert_eq!(sup_back, sup);
+        }
+        let saturated = L::pack(0, L::MAX_SUPPRESSED + 1);
+        assert_eq!(L::unpack(saturated).1, L::MAX_SUPPRESSED);
     }
 }


### PR DESCRIPTION
Pack rate-limiter state into a single AtomicU64 (24-bit suppressed count + 40-bit GCRA tat_ms) and make BURST/REFILL_MS const-generic. Drops per-callsite cost from 112 B to 8 B and removes the OnceLock<Mutex<...>> path; contention reduces to a single CAS on the state word.

Caller-visible behaviour unchanged: same burst, same refill window, same suppression summary, same metric semantics, same per-callsite isolation. Snapshot wire format unaffected.

Across 321 vmm callsites: -35.06 KiB stripped binary, -14.0 kB cold-start RSS (n=10).

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
