### PR TITLE
fix: correct typos in comments and remove leftover debug println

### DIFF
--- a/src/snapshot-editor/src/edit_memory.rs
+++ b/src/snapshot-editor/src/edit_memory.rs
@@ -246,7 +246,7 @@ mod tests {
             // expected:  [d] [b] [d] [d] [b]
             let base_block = rand::rand_bytes(block_size);
             // Adding to the base file 2 times because
-            // it is 1 block smaller then diff right now.
+            // it is 1 block smaller than diff right now.
             base_file.write_all(&base_block).unwrap();
             base_file.write_all(&base_block).unwrap();
             expected_result.extend(base_block);

--- a/src/vmm/src/arch/aarch64/regs.rs
+++ b/src/vmm/src/arch/aarch64/regs.rs
@@ -127,7 +127,7 @@ pub const KVM_REG_ARM64_SVE_VLS: u64 =
     KVM_REG_ARM64 | KVM_REG_ARM64_SVE as u64 | KVM_REG_SIZE_U512 | 0xffff;
 
 /// Program Counter
-/// The offset value (0x100 = 32 * 8) is calcuated as follows:
+/// The offset value (0x100 = 32 * 8) is calculated as follows:
 /// - `kvm_regs` includes `regs` field of type `user_pt_regs` at the beginning (i.e., at offset 0).
 /// - `pc` follows `regs[31]` and `sp` within `user_pt_regs` and they are 8 bytes each (i.e. the
 ///   offset is (31 + 1) * 8 = 256).
@@ -196,7 +196,7 @@ impl From<usize> for RegSize {
             RegSize::U512_SIZE => RegSize::U512,
             RegSize::U1024_SIZE => RegSize::U1024,
             RegSize::U2048_SIZE => RegSize::U2048,
-            _ => unreachable!("Registers bigger then 2048 bits are not supported"),
+            _ => unreachable!("Registers bigger than 2048 bits are not supported"),
         }
     }
 }

--- a/src/vmm/src/cpu_config/x86_64/cpuid/amd/normalize.rs
+++ b/src/vmm/src/cpu_config/x86_64/cpuid/amd/normalize.rs
@@ -214,7 +214,7 @@ impl super::AmdCpuid {
         /// This value allows at most 64 logical threads within a package.
         const THREAD_ID_MAX_SIZE: u32 = 7;
 
-        // We don't support more then 128 threads right now.
+        // We don't support more than 128 threads right now.
         // It's safe to put them all on the same processor.
         let leaf_80000008 = self
             .get_mut(&CpuidKey::leaf(0x80000008))

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -92,7 +92,7 @@ fn default_ack_on_stop() -> bool {
     true
 }
 
-/// Command recieved from the API to start a hinting run
+/// Command received from the API to start a hinting run
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]
 pub struct StartHintingCmd {
     /// If we should automatically acknowledge end of the run after stop.

--- a/src/vmm/src/devices/virtio/net/metrics.rs
+++ b/src/vmm/src/devices/virtio/net/metrics.rs
@@ -126,7 +126,7 @@ static METRICS: RwLock<NetMetricsPerDevice> = RwLock::new(NetMetricsPerDevice {
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let net_metrics = METRICS.read().unwrap();
     let metrics_len = net_metrics.metrics.len();
-    // +1 to accomodate aggregate net metrics
+    // +1 to accommodate aggregate net metrics
     let mut seq = serializer.serialize_map(Some(1 + metrics_len))?;
 
     let mut net_aggregated: NetDeviceMetrics = NetDeviceMetrics::default();

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -282,7 +282,7 @@ impl VsockEpollListener for VsockMuxer {
         EventSet::IN
     }
 
-    /// Notify the muxer about a pending event having occured under its nested epoll FD.
+    /// Notify the muxer about a pending event having occurred under its nested epoll FD.
     fn notify(&mut self, _: EventSet) {
         let mut epoll_events = vec![EpollEvent::new(EventSet::empty(), 0); 32];
         match self.epoll.wait(0, epoll_events.as_mut_slice()) {

--- a/src/vmm/src/mmds/ns.rs
+++ b/src/vmm/src/mmds/ns.rs
@@ -140,7 +140,7 @@ impl MmdsNetworkStack {
     ///
     /// # Returns
     ///
-    /// `true` if the frame was consumed by `mmds` or `false` if an error occured
+    /// `true` if the frame was consumed by `mmds` or `false` if an error occurred
     pub fn detour_frame(&mut self, src: &[u8]) -> bool {
         if let Ok(eth) = EthernetFrame::from_bytes(src) {
             match eth.ethertype() {

--- a/src/vmm/src/snapshot/mod.rs
+++ b/src/vmm/src/snapshot/mod.rs
@@ -251,9 +251,6 @@ mod tests {
         let mut snapshot_data = Vec::new();
         snapshot.save(&mut snapshot_data).unwrap();
 
-        // Debug: print the length to understand what's happening
-        println!("Snapshot data length: {}", snapshot_data.len());
-
         assert_eq!(
             get_format_version(&mut std::io::Cursor::new(&snapshot_data)).unwrap(),
             SNAPSHOT_VERSION

--- a/src/vmm/src/snapshot/mod.rs
+++ b/src/vmm/src/snapshot/mod.rs
@@ -57,7 +57,7 @@ pub enum SnapshotError {
     InvalidFormatVersion(Version),
     /// Magic value does not match arch: {0}
     InvalidMagic(u64),
-    /// An error occured during bitcode serialization: {0}
+    /// An error occurred during bitcode serialization: {0}
     Bitcode(#[from] bitcode::Error),
     /// IO Error: {0}
     Io(#[from] std::io::Error),
@@ -206,7 +206,7 @@ impl<Data: DeserializeOwned> Snapshot<Data> {
         let computed_checksum = crc64(0, buf.as_slice());
         // When we read the entire file, we also read the checksum into the buffer. The CRC has the
         // property that crc(0, buf.as_slice()) == 0 iff the last 8 bytes of buf are the checksum
-        // of all the preceeding bytes, and this is the property we are using here.
+        // of all the preceding bytes, and this is the property we are using here.
         if computed_checksum != 0 {
             return Err(SnapshotError::Crc64);
         }


### PR DESCRIPTION
## What

Handful of spelling/grammar fixes scattered across the codebase, plus one debug `println!` that got left in a test during the bincode→bitcode migration.

**Typos fixed:**
- `calcuated` → `calculated` (aarch64 PC register doc)
- `accomodate` → `accommodate` (net metrics comment)
- `recieved` → `received` (balloon device doc)
- `occured` → `occurred` (snapshot error enum, mmds, vsock muxer)
- `preceeding` → `preceding` (snapshot CRC comment)
- `bigger/more/smaller then` → `...than` (regs, amd cpuid normalize, snapshot-editor)

**Debug println removed:**  
`src/vmm/src/snapshot/mod.rs` — added in 37480d9c (bincode→bitcode migration) with a literal comment `// Debug: print the length to understand what's happening`. Never cleaned up.

## How to reproduce

```
grep -rn "calcuated\|accomodate\|recieved\|occured\|preceeding\|bigger then\|more then\|smaller then" src/
grep -n "Debug: print\|println.*Snapshot data" src/vmm/src/snapshot/mod.rs
```

Both greps should come back empty after this patch.

## Testing

No logic changed — only comments, doc strings, an error enum message, and one test-only `println!`. Existing tests cover all the affected code paths.
