### PR TITLE
perf(ab_test): ignore noisy network and MMDS metrics on flaky instances

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -140,6 +140,22 @@ IGNORED = [
         }
         for instance in ["m8i.metal-48xl", "m8i.metal-96xl"]
     ],
+    # Network latencies on m5n.metal w/ al2 host
+    {
+        "instance": "m5n.metal",
+        "performance_test": "test_network_latency",
+        "host_kernel": "linux-5.10",
+    },
+    # Network latencies on m8g
+    *[
+        {"instance": instance, "performance_test": "test_network_latency"}
+        for instance in ["m8g.metal-24xl", "m8g.metal-48xl"]
+    ],
+    # MMDS metrics on m8i
+    *[
+        {"instance": instance, "performance_test": "test_mmds_performance"}
+        for instance in ["m8i.metal-48xl", "m8i.metal-96xl"]
+    ],
     # block latencies if guest uses async request submission
     {"fio_engine": "libaio", "metric": "clat_read"},
     {"fio_engine": "libaio", "metric": "clat_write"},


### PR DESCRIPTION
## Summary

Add noisy instance/metric combinations to the A/B test `IGNORED` list to stop false-positive pipeline failures.

## Changes

- **m5n.metal** (al2/linux-5.10 host): ignore `test_network_latency` — repeated identical false positives
- **m8g.metal-{24,48}xl**: ignore `test_network_latency` — up to 67% swings in both directions since the May 2 AL2023 rootfs update, exclusively on guest kernel linux-6.1
- **m8i.metal-{48,96}xl**: ignore `test_mmds_performance` — bidirectional noise (e.g. +13% PCI on, -19% PCI off in the same build)

## Evidence

Occurrence matrix from recent builds:

**`ping_latency` on m8g (started May 5, after AL2023 rootfs update May 2):**
- Build 899: +67% (m8g-48xl, PCI on), -38% (m8g-24xl, PCI off), -48% (m8g-48xl, PCI on) — all guest linux-6.1
- Build 903: +53% (m8g-48xl, PCI on, guest linux-6.1)

**`ping_latency` on m5n (recurring since March):**
- Build 900: +11.84%, +5.33%, +14.21% — identical numbers repeated in 903
- Always vcpus=1, al2 host, both guest kernels

**MMDS on m8i (recurring since March):**
- Build 903: +13% PCI on, -19% PCI off (same build, same instance)
- Build 896: +11% PCI on, -5% PCI off
- Exclusively m8i, exclusively al2 host

## Impact

The A/B alarm has not cleared in 6+ weeks due to these false positives, generating 7+ duplicate tickets. Tests still run and collect data — they just no longer fail the pipeline.

## Testing

No functional change — the `IGNORED` list only suppresses the assertion in `analyze_data()`. Metrics are still collected and available in artifacts for manual inspection.