### PR TITLE
docs: Add device hotplugging documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ### Added
 
+- [#5786](https://github.com/firecracker-microvm/firecracker/pull/5786): Added
+  developer preview support for hotplugging and hot-unplugging PCI virtio
+  devices (block, pmem, net) on a running microVM. The guest must manually
+  rescan the PCI bus after hotplug and remove the device before unplug since no
+  automatic notification mechanism is implemented yet. More information can be
+  found in the [Device Hotplugging](docs/device-hotplug.md) documentation page.
 - [#5323](https://github.com/firecracker-microvm/firecracker/pull/5323): Add
   support for Vsock Unix domain socket path overriding on snapshot restore. More
   information can be found in the

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The **API endpoint** can be used to:
 - Add a [entropy device](docs/entropy.md) to the microVM.
 - Add a [pmem device](docs/pmem.md) to the microVM.
 - Configure and manage [memory hotplugging](docs/memory-hotplug.md).
+- `[Developer Preview]` [Hot-plug and hot-unplug](docs/device-hotplug.md) virtio
+  PCI devices while the VM is running.
 - Start the microVM using a given kernel image, root file system, and boot
   arguments.
 - [x86_64 only] Stop the microVM.

--- a/docs/device-hotplug.md
+++ b/docs/device-hotplug.md
@@ -1,0 +1,91 @@
+# Device Hotplugging [Developer Preview]
+
+> [!WARNING]
+>
+> This feature is currently in
+> [Developer Preview](RELEASE_POLICY.md#developer-preview-features). It may have
+> limitations, and its API or behavior may change in future releases.
+
+Device hotplugging allows attaching and detaching PCI virtio devices to a
+running microVM without requiring a reboot. Supported device types are:
+
+- `virtio-block`
+- `virtio-pmem`
+- `virtio-net`
+
+## Prerequisites
+
+- **PCI transport enabled**: Firecracker must be started with the `--enable-pci`
+  flag. Device hotplugging is not supported with MMIO transport.
+- **Guest kernel with PCI support**: The guest kernel must have PCI and the
+  relevant virtio drivers enabled. See the
+  [kernel policy documentation](kernel-policy.md) for details.
+
+## Limitations
+
+- **No automatic guest notification**: Firecracker does not currently deliver a
+  hotplug notification to the guest. After hotplugging a device, the guest must
+  manually rescan the PCI bus to discover it. Similarly, before unplugging, the
+  guest must manually remove the device.
+
+## Hotplugging a device
+
+Hotplugging uses the same API endpoints used for pre-boot device configuration.
+The only difference is that the request is issued after the VM has started.
+
+```console
+socket_location=/run/firecracker.socket
+
+curl --unix-socket $socket_location -i \
+    -X PUT 'http://localhost/drives/block1' \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "drive_id": "block1",
+        "path_on_host": "/path/to/block.ext4",
+        "is_root_device": false,
+        "is_read_only": false
+    }'
+```
+
+### Discovering the device in the guest
+
+Since no hotplug notification is delivered to the guest, a PCI bus rescan is
+required to make the guest discover the new device:
+
+```bash
+echo 1 > /sys/bus/pci/rescan
+```
+
+After the rescan, the device will appear in `lspci` and the corresponding device
+node (e.g. `/dev/vdb`, `/dev/pmem1`) will be created by the guest kernel.
+
+## Hot-unplugging a device
+
+Hot-unplugging is a two-step process: first the guest must release the device,
+then the host issues the unplug request.
+
+### Step 1: Remove the device from the guest
+
+Before issuing the unplug API call, the guest must gracefully release the
+device. For example, unmount any mounted filesystems and remove the PCI device:
+
+```bash
+# Unmount the filesystem (if applicable)
+umount /mnt/block1
+
+# Remove the device from the guest
+echo 1 > /sys/bus/pci/devices/0000:00:01.0/remove
+```
+
+Replace `0000:00:01.0` with the actual PCI BDF (Bus:Device.Function) address of
+the device, which can be found via `lspci`.
+
+### Step 2: Unplug from the host
+
+Issue a `DELETE` request to the corresponding device endpoint:
+
+```console
+curl --unix-socket $socket_location -i \
+    -X DELETE 'http://localhost/drives/block1'
+```

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -143,7 +143,7 @@ use crate::devices::virtio::net::Net;
 use crate::devices::virtio::pmem::device::Pmem;
 use crate::devices::virtio::rng::Entropy;
 use crate::devices::virtio::vsock::{Vsock, VsockUnixBackend};
-use crate::logger::{METRICS, MetricsError};
+use crate::logger::{METRICS, MetricsError, log_dev_preview_warning};
 use crate::mmds::data_store::Mmds;
 use crate::persist::{MicrovmState, MicrovmStateError, VmInfo};
 use crate::rate_limiter::BucketUpdate;
@@ -706,6 +706,7 @@ impl Vmm {
         config: HotplugDeviceConfig,
         event_manager: &mut EventManager,
     ) -> Result<(), VmmActionError> {
+        log_dev_preview_warning("PCI device hotplug", None);
         let kvm_vm = self
             .vm
             .as_kvm()
@@ -722,6 +723,7 @@ impl Vmm {
         device_id: VirtioDeviceId,
         event_manager: &mut EventManager,
     ) -> Result<(), VmmActionError> {
+        log_dev_preview_warning("PCI device hot-unplug", None);
         let kvm_vm = self
             .vm
             .as_kvm()


### PR DESCRIPTION
Add documentation for the new PCI device hotplug/unplug feature (developer preview) and update the CHANGELOG.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
