### PR TITLE
tests: Fix device removal order in test_hotplug_max_devices

### DIFF
--- a/tests/integration_tests/functional/test_hotplug.py
+++ b/tests/integration_tests/functional/test_hotplug.py
@@ -480,11 +480,7 @@ def test_hotplug_max_devices(uvm_any_with_pci):
             is_read_only=False,
         )
 
-    # Unplug all hotplugged devices
-    for i in range(free_slots):
-        vm.api.drive.delete(f"block{i}")
-
-    # Remove the stale devices from the guest
+    # Remove the devices from the guest first
     new_bdfs = [
         l.split()[0]
         for l in set(lspci_full.strip().splitlines())
@@ -492,6 +488,10 @@ def test_hotplug_max_devices(uvm_any_with_pci):
     ]
     for bdf in new_bdfs:
         vm.ssh.check_output(f"echo 1 > /sys/bus/pci/devices/0000:{bdf}/remove")
+
+    # Then unplug all hotplugged devices via the API
+    for i in range(free_slots):
+        vm.api.drive.delete(f"block{i}")
 
     # Verify we're back to the initial number of devices
     _, lspci, _ = vm.ssh.check_output("lspci -n")


### PR DESCRIPTION
Remove devices from the guest before sending the API delete request, not after. The guest should release the device first before the VMM removes it.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
