### PR TITLE
fix(tests): poll for vhost-user socket readiness instead of sleeping

### DIFF
--- a/tests/framework/utils_drive.py
+++ b/tests/framework/utils_drive.py
@@ -5,11 +5,12 @@
 
 import os
 import subprocess
-import time
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 from subprocess import check_output
+
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 from framework import utils
 
@@ -81,17 +82,19 @@ class VhostUserBlkBackend(ABC):
         args = self._spawn_cmd()
         proc = subprocess.Popen(args)
 
-        # Give the backend time to initialise.
-        time.sleep(1)
-
         assert proc is not None and proc.poll() is None, "backend is not up"
-        assert self.socket_path.exists()
+        self._wait_for_socket()
 
         os.chown(self.socket_path, uid, gid)
 
         self.proc = proc
 
         return str(Path("/") / os.path.basename(self.socket_path))
+
+    @retry(wait=wait_fixed(0.1), stop=stop_after_attempt(50), reraise=True)
+    def _wait_for_socket(self):
+        """Wait for the backend socket to appear (up to 5s)."""
+        assert self.socket_path.exists(), f"socket {self.socket_path} not ready"
 
     @abstractmethod
     def _spawn_cmd(self):


### PR DESCRIPTION
## Summary

Replace `time.sleep(1)` + bare `assert self.socket_path.exists()` in `VhostUserBlkBackend.spawn()` with a tenacity retry loop (5 attempts, 200ms apart).

## Problem

`test_vhost_user_block[vmlinux-5.10.252-PCI_ON]` intermittently fails on aarch64 because crosvm hasn't bound its vhost-user socket by the time the assertion fires. The fixed 1s sleep is both too long (wastes CI time on every invocation) and too short (races on slower hosts).

Example failure from [ubuntu-nightly-ci-run #1614](https://buildkite.com/firecracker/ubuntu-nightly-ci-run/builds/1614):
```
framework/utils_drive.py:88: in spawn
    assert self.socket_path.exists()
E   AssertionError
```

## Fix

Use the same `@retry(wait_fixed(0.2), stop_after_attempt(5))` pattern already established in `microvm.py`. This gives crosvm up to 1s total (5 × 200ms) to bind the socket while checking every 200ms — faster on the happy path and more robust on the slow path.

## Testing

- `devtool checkstyle` — 20 passed
- `devtool checkbuild` — passed (x86_64)