### PR TITLE
vmm: decouple KVM-specific state from Vmm

### DIFF
--- a/src/vmm/src/acpi/mod.rs
+++ b/src/vmm/src/acpi/mod.rs
@@ -247,9 +247,9 @@ mod tests {
         // A mocke Vmm object with 128MBs of memory
         let vmm = default_vmm();
         let mut writer = AcpiTableWriter {
-            mem: vmm.vm.guest_memory(),
+            mem: vmm.vm.as_kvm().unwrap().guest_memory(),
         };
-        let mut resource_allocator = vmm.vm.resource_allocator();
+        let mut resource_allocator = vmm.vm.as_kvm().unwrap().resource_allocator();
 
         // This should succeed
         let mut sdt = MockSdt(vec![0; 4096]);

--- a/src/vmm/src/acpi/mod.rs
+++ b/src/vmm/src/acpi/mod.rs
@@ -309,7 +309,7 @@ mod tests {
     // change in the future.
     #[test]
     fn test_write_acpi_table_small_memory() {
-        let (_, vm) = setup_vm_with_memory(u64_to_usize(SYSTEM_MEM_START + SYSTEM_MEM_SIZE - 4096));
+        let vm = setup_vm_with_memory(u64_to_usize(SYSTEM_MEM_START + SYSTEM_MEM_SIZE - 4096));
         let mut writer = AcpiTableWriter {
             mem: vm.guest_memory(),
         };

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -564,7 +564,8 @@ mod tests {
     use crate::device_manager::tests::default_device_manager;
     use crate::test_utils::arch_mem;
     use crate::vstate::memory::GuestAddress;
-    use crate::{EventManager, Kvm, Vm};
+    use crate::vstate::vm::KvmVm;
+    use crate::{EventManager, Kvm};
 
     // The `load` function from the `device_tree` will mistakenly check the actual size
     // of the buffer with the allocated size. This works around that.
@@ -581,7 +582,7 @@ mod tests {
         let mut event_manager = EventManager::new().unwrap();
         let mut device_manager = default_device_manager();
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Vm::new(&kvm).unwrap();
+        let vm = KvmVm::new(&kvm).unwrap();
         let gic = create_gic(vm.fd(), 1, None).unwrap();
         let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         cmdline.insert("console", "/dev/tty0").unwrap();
@@ -618,7 +619,7 @@ mod tests {
         let mem = arch_mem(layout::FDT_MAX_SIZE + 0x1000);
         let device_manager = default_device_manager();
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Vm::new(&kvm).unwrap();
+        let vm = KvmVm::new(&kvm).unwrap();
         let gic = create_gic(vm.fd(), 1, None).unwrap();
 
         let saved_dtb_bytes = match gic.fdt_compatibility() {
@@ -675,7 +676,7 @@ mod tests {
         let mem = arch_mem(layout::FDT_MAX_SIZE + 0x1000);
         let device_manager = default_device_manager();
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Vm::new(&kvm).unwrap();
+        let vm = KvmVm::new(&kvm).unwrap();
         let gic = create_gic(vm.fd(), 1, None).unwrap();
 
         let saved_dtb_bytes = match gic.fdt_compatibility() {

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -582,7 +582,7 @@ mod tests {
         let mut event_manager = EventManager::new().unwrap();
         let mut device_manager = default_device_manager();
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = KvmVm::new(&kvm).unwrap();
+        let vm = KvmVm::new(kvm).unwrap();
         let gic = create_gic(vm.fd(), 1, None).unwrap();
         let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         cmdline.insert("console", "/dev/tty0").unwrap();
@@ -619,7 +619,7 @@ mod tests {
         let mem = arch_mem(layout::FDT_MAX_SIZE + 0x1000);
         let device_manager = default_device_manager();
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = KvmVm::new(&kvm).unwrap();
+        let vm = KvmVm::new(kvm).unwrap();
         let gic = create_gic(vm.fd(), 1, None).unwrap();
 
         let saved_dtb_bytes = match gic.fdt_compatibility() {
@@ -676,7 +676,7 @@ mod tests {
         let mem = arch_mem(layout::FDT_MAX_SIZE + 0x1000);
         let device_manager = default_device_manager();
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = KvmVm::new(&kvm).unwrap();
+        let vm = KvmVm::new(kvm).unwrap();
         let gic = create_gic(vm.fd(), 1, None).unwrap();
 
         let saved_dtb_bytes = match gic.fdt_compatibility() {

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -37,7 +37,8 @@ use crate::vstate::memory::{
     Address, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestRegionType,
 };
 use crate::vstate::vcpu::KvmVcpuError;
-use crate::{DeviceManager, Kvm, Vcpu, VcpuConfig, Vm, logger};
+use crate::vstate::vm::KvmVm;
+use crate::{DeviceManager, Kvm, Vcpu, VcpuConfig, logger};
 
 /// Errors thrown while configuring aarch64 system.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -92,7 +93,7 @@ pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize)> {
 #[allow(clippy::too_many_arguments)]
 pub fn configure_system_for_boot(
     kvm: &Kvm,
-    vm: &Vm,
+    vm: &KvmVm,
     device_manager: &mut DeviceManager,
     vcpus: &mut [Vcpu],
     machine_config: &MachineConfig,

--- a/src/vmm/src/arch/aarch64/vcpu.rs
+++ b/src/vmm/src/arch/aarch64/vcpu.rs
@@ -26,7 +26,7 @@ use crate::vcpu::{VcpuConfig, VcpuError};
 use crate::vstate::bus::Bus;
 use crate::vstate::memory::{Address, GuestMemoryMmap};
 use crate::vstate::vcpu::VcpuEmulation;
-use crate::vstate::vm::Vm;
+use crate::vstate::vm::KvmVm;
 
 /// Errors thrown while setting aarch64 registers.
 #[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
@@ -133,7 +133,7 @@ impl KvmVcpu {
     ///
     /// * `index` - Represents the 0-based CPU index between [0, max vcpus).
     /// * `vm` - The vm to which this vcpu will get attached.
-    pub fn new(index: u8, vm: &Vm) -> Result<Self, KvmVcpuError> {
+    pub fn new(index: u8, vm: &KvmVm) -> Result<Self, KvmVcpuError> {
         let kvm_vcpu = vm
             .fd()
             .create_vcpu(index.into())
@@ -562,17 +562,16 @@ mod tests {
     use crate::test_utils::arch_mem;
     use crate::vcpu::VcpuConfig;
     use crate::vstate::kvm::Kvm;
-    use crate::vstate::vm::Vm;
     use crate::vstate::vm::tests::setup_vm_with_memory;
 
-    fn setup_vcpu(mem_size: usize) -> (Kvm, Vm, KvmVcpu) {
+    fn setup_vcpu(mem_size: usize) -> (Kvm, KvmVm, KvmVcpu) {
         let (kvm, mut vm, mut vcpu) = setup_vcpu_no_init(mem_size);
         vcpu.init(&[]).unwrap();
         vm.setup_irqchip(1).unwrap();
         (kvm, vm, vcpu)
     }
 
-    fn setup_vcpu_no_init(mem_size: usize) -> (Kvm, Vm, KvmVcpu) {
+    fn setup_vcpu_no_init(mem_size: usize) -> (Kvm, KvmVm, KvmVcpu) {
         let (kvm, vm) = setup_vm_with_memory(mem_size);
         let vcpu = KvmVcpu::new(0, &vm).unwrap();
 

--- a/src/vmm/src/arch/aarch64/vcpu.rs
+++ b/src/vmm/src/arch/aarch64/vcpu.rs
@@ -561,26 +561,25 @@ mod tests {
     use crate::cpu_config::templates::RegisterValueFilter;
     use crate::test_utils::arch_mem;
     use crate::vcpu::VcpuConfig;
-    use crate::vstate::kvm::Kvm;
     use crate::vstate::vm::tests::setup_vm_with_memory;
 
-    fn setup_vcpu(mem_size: usize) -> (Kvm, KvmVm, KvmVcpu) {
-        let (kvm, mut vm, mut vcpu) = setup_vcpu_no_init(mem_size);
+    fn setup_vcpu(mem_size: usize) -> (KvmVm, KvmVcpu) {
+        let (mut vm, mut vcpu) = setup_vcpu_no_init(mem_size);
         vcpu.init(&[]).unwrap();
         vm.setup_irqchip(1).unwrap();
-        (kvm, vm, vcpu)
+        (vm, vcpu)
     }
 
-    fn setup_vcpu_no_init(mem_size: usize) -> (Kvm, KvmVm, KvmVcpu) {
-        let (kvm, vm) = setup_vm_with_memory(mem_size);
+    fn setup_vcpu_no_init(mem_size: usize) -> (KvmVm, KvmVcpu) {
+        let vm = setup_vm_with_memory(mem_size);
         let vcpu = KvmVcpu::new(0, &vm).unwrap();
 
-        (kvm, vm, vcpu)
+        (vm, vcpu)
     }
 
     #[test]
     fn test_create_vcpu() {
-        let (_, vm) = setup_vm_with_memory(0x1000);
+        let vm = setup_vm_with_memory(0x1000);
 
         unsafe { libc::close(vm.fd().as_raw_fd()) };
 
@@ -599,8 +598,8 @@ mod tests {
 
     #[test]
     fn test_configure_vcpu() {
-        let (kvm, vm, mut vcpu) = setup_vcpu(0x10000);
-        let optional_capabilities = kvm.optional_capabilities();
+        let (vm, mut vcpu) = setup_vcpu(0x10000);
+        let optional_capabilities = vm.kvm().optional_capabilities();
 
         let vcpu_config = VcpuConfig {
             vcpu_count: 1,
@@ -648,7 +647,7 @@ mod tests {
 
     #[test]
     fn test_init_vcpu() {
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         let mut vcpu = KvmVcpu::new(0, &vm).unwrap();
         vm.setup_irqchip(1).unwrap();
 
@@ -667,7 +666,7 @@ mod tests {
 
     #[test]
     fn test_pmu_v3_feature_invalid() {
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         let mut vcpu = KvmVcpu::new(0, &vm).unwrap();
         vm.setup_irqchip(1).unwrap();
 
@@ -687,7 +686,7 @@ mod tests {
 
     #[test]
     fn test_vcpu_save_restore_state() {
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         let mut vcpu = KvmVcpu::new(0, &vm).unwrap();
         vm.setup_irqchip(1).unwrap();
 
@@ -731,7 +730,7 @@ mod tests {
         //
         // This should fail with ENOEXEC.
         // https://elixir.bootlin.com/linux/v5.10.176/source/arch/arm64/kvm/arm.c#L1165
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         let vcpu = KvmVcpu::new(0, &vm).unwrap();
         vm.setup_irqchip(1).unwrap();
 
@@ -741,7 +740,7 @@ mod tests {
     #[test]
     fn test_dump_cpu_config_after_init() {
         // Test `dump_cpu_config()` after `KVM_VCPU_INIT`.
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         let mut vcpu = KvmVcpu::new(0, &vm).unwrap();
         vm.setup_irqchip(1).unwrap();
         vcpu.init(&[]).unwrap();
@@ -751,7 +750,7 @@ mod tests {
 
     #[test]
     fn test_setup_non_boot_vcpu() {
-        let (_, vm) = setup_vm_with_memory(0x1000);
+        let vm = setup_vm_with_memory(0x1000);
         let mut vcpu1 = KvmVcpu::new(0, &vm).unwrap();
         vcpu1.init(&[]).unwrap();
         let mut vcpu2 = KvmVcpu::new(1, &vm).unwrap();
@@ -763,7 +762,7 @@ mod tests {
         // Test `get_regs()` with valid register IDs.
         // - X0: 0x6030 0000 0010 0000
         // - X1: 0x6030 0000 0010 0002
-        let (_, _, vcpu) = setup_vcpu(0x10000);
+        let (_, vcpu) = setup_vcpu(0x10000);
         let reg_list = Vec::<u64>::from([0x6030000000100000, 0x6030000000100002]);
         get_registers(&vcpu.fd, &reg_list, &mut Aarch64RegisterVec::default()).unwrap();
     }
@@ -771,16 +770,16 @@ mod tests {
     #[test]
     fn test_get_invalid_regs() {
         // Test `get_regs()` with invalid register IDs.
-        let (_, _, vcpu) = setup_vcpu(0x10000);
+        let (_, vcpu) = setup_vcpu(0x10000);
         let reg_list = Vec::<u64>::from([0x6030000000100001, 0x6030000000100003]);
         get_registers(&vcpu.fd, &reg_list, &mut Aarch64RegisterVec::default()).unwrap_err();
     }
 
     #[test]
     fn test_setup_regs() {
-        let (kvm, _, vcpu) = setup_vcpu_no_init(0x10000);
+        let (vm, vcpu) = setup_vcpu_no_init(0x10000);
         let mem = arch_mem(layout::FDT_MAX_SIZE + 0x1000);
-        let optional_capabilities = kvm.optional_capabilities();
+        let optional_capabilities = vm.kvm().optional_capabilities();
 
         let res = vcpu.setup_boot_regs(0x0, &mem, &optional_capabilities);
         assert!(matches!(
@@ -815,7 +814,7 @@ mod tests {
 
     #[test]
     fn test_read_mpidr() {
-        let (_, _, vcpu) = setup_vcpu_no_init(0x10000);
+        let (_, vcpu) = setup_vcpu_no_init(0x10000);
 
         // Must fail when vcpu is not initialized yet.
         let res = vcpu.get_mpidr();
@@ -830,7 +829,7 @@ mod tests {
 
     #[test]
     fn test_get_set_regs() {
-        let (_, _, vcpu) = setup_vcpu_no_init(0x10000);
+        let (_, vcpu) = setup_vcpu_no_init(0x10000);
 
         // Must fail when vcpu is not initialized yet.
         let mut regs = Aarch64RegisterVec::default();
@@ -848,7 +847,7 @@ mod tests {
     fn test_mpstate() {
         use std::os::unix::io::AsRawFd;
 
-        let (_, _, vcpu) = setup_vcpu(0x10000);
+        let (_, vcpu) = setup_vcpu(0x10000);
 
         let res = vcpu.get_mpstate();
         vcpu.set_mpstate(res.unwrap()).unwrap();

--- a/src/vmm/src/arch/aarch64/vm.rs
+++ b/src/vmm/src/arch/aarch64/vm.rs
@@ -33,7 +33,7 @@ pub enum KvmVmError {
 
 impl KvmVm {
     /// Create a new `KvmVm` struct.
-    pub fn new(kvm: &Kvm) -> Result<KvmVm, VmError> {
+    pub fn new(kvm: Kvm) -> Result<KvmVm, VmError> {
         let common = Self::create_common(kvm)?;
         Ok(KvmVm {
             common,

--- a/src/vmm/src/arch/aarch64/vm.rs
+++ b/src/vmm/src/arch/aarch64/vm.rs
@@ -13,16 +13,16 @@ use crate::vstate::vm::{VmCommon, VmError};
 
 /// Structure representing the current architecture's understand of what a "virtual machine" is.
 #[derive(Debug)]
-pub struct ArchVm {
+pub struct KvmVm {
     /// Architecture independent parts of a vm.
     pub common: VmCommon,
     // On aarch64 we need to keep around the fd obtained by creating the VGIC device.
     irqchip_handle: Option<crate::arch::aarch64::gic::GICDevice>,
 }
 
-/// Error type for [`Vm::restore_state`]
+/// Error type for [`KvmVm::restore_state`]
 #[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
-pub enum ArchVmError {
+pub enum KvmVmError {
     /// Error creating the global interrupt controller: {0}
     VmCreateGIC(crate::arch::aarch64::gic::GicError),
     /// Failed to save the VM's GIC state: {0}
@@ -31,23 +31,23 @@ pub enum ArchVmError {
     RestoreGic(crate::arch::aarch64::gic::GicError),
 }
 
-impl ArchVm {
-    /// Create a new `Vm` struct.
-    pub fn new(kvm: &Kvm) -> Result<ArchVm, VmError> {
+impl KvmVm {
+    /// Create a new `KvmVm` struct.
+    pub fn new(kvm: &Kvm) -> Result<KvmVm, VmError> {
         let common = Self::create_common(kvm)?;
-        Ok(ArchVm {
+        Ok(KvmVm {
             common,
             irqchip_handle: None,
         })
     }
 
     /// Pre-vCPU creation setup.
-    pub fn arch_pre_create_vcpus(&mut self, _: u8) -> Result<(), ArchVmError> {
+    pub fn arch_pre_create_vcpus(&mut self, _: u8) -> Result<(), KvmVmError> {
         Ok(())
     }
 
     /// Post-vCPU creation setup.
-    pub fn arch_post_create_vcpus(&mut self, nr_vcpus: u8) -> Result<(), ArchVmError> {
+    pub fn arch_post_create_vcpus(&mut self, nr_vcpus: u8) -> Result<(), KvmVmError> {
         // On aarch64, the vCPUs need to be created (i.e call KVM_CREATE_VCPU) before setting up the
         // IRQ chip because the `KVM_CREATE_VCPU` ioctl will return error if the IRQCHIP
         // was already initialized.
@@ -56,10 +56,10 @@ impl ArchVm {
     }
 
     /// Creates the GIC (Global Interrupt Controller).
-    pub fn setup_irqchip(&mut self, vcpu_count: u8) -> Result<(), ArchVmError> {
+    pub fn setup_irqchip(&mut self, vcpu_count: u8) -> Result<(), KvmVmError> {
         self.irqchip_handle = Some(
             crate::arch::aarch64::gic::create_gic(self.fd(), vcpu_count.into(), None)
-                .map_err(ArchVmError::VmCreateGIC)?,
+                .map_err(KvmVmError::VmCreateGIC)?,
         );
         Ok(())
     }
@@ -69,14 +69,14 @@ impl ArchVm {
         self.irqchip_handle.as_ref().expect("IRQ chip not set")
     }
 
-    /// Saves and returns the Kvm Vm state.
-    pub fn save_state(&self, mpidrs: &[u64]) -> Result<VmState, ArchVmError> {
+    /// Saves and returns the KVM VM state.
+    pub fn save_state(&self, mpidrs: &[u64]) -> Result<VmState, KvmVmError> {
         Ok(VmState {
             memory: self.common.guest_memory.describe(),
             gic: self
                 .get_irqchip()
                 .save_device(mpidrs)
-                .map_err(ArchVmError::SaveGic)?,
+                .map_err(KvmVmError::SaveGic)?,
             resource_allocator: self.resource_allocator().clone(),
         })
     }
@@ -86,10 +86,10 @@ impl ArchVm {
     /// # Errors
     ///
     /// When [`crate::arch::aarch64::gic::GICDevice::restore_device`] errors.
-    pub fn restore_state(&mut self, mpidrs: &[u64], state: &VmState) -> Result<(), ArchVmError> {
+    pub fn restore_state(&mut self, mpidrs: &[u64], state: &VmState) -> Result<(), KvmVmError> {
         self.get_irqchip()
             .restore_device(mpidrs, &state.gic)
-            .map_err(ArchVmError::RestoreGic)?;
+            .map_err(KvmVmError::RestoreGic)?;
         self.common.resource_allocator = Mutex::new(state.resource_allocator.clone());
 
         Ok(())

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -18,7 +18,7 @@ pub use aarch64::kvm::{Kvm, KvmArchError, OptionalCapabilities};
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::vcpu::*;
 #[cfg(target_arch = "aarch64")]
-pub use aarch64::vm::{ArchVm, ArchVmError, VmState};
+pub use aarch64::vm::{KvmVm, KvmVmError, VmState};
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     ConfigurationError, arch_memory_regions, configure_system_for_boot, get_kernel_start,
@@ -34,7 +34,7 @@ pub use x86_64::kvm::{Kvm, KvmArchError};
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::vcpu::*;
 #[cfg(target_arch = "x86_64")]
-pub use x86_64::vm::{ArchVm, ArchVmError, VmState};
+pub use x86_64::vm::{KvmVm, KvmVmError, VmState};
 
 #[cfg(target_arch = "x86_64")]
 pub use crate::arch::x86_64::{

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -48,7 +48,8 @@ use crate::vstate::memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionType,
 };
 use crate::vstate::vcpu::KvmVcpuConfigureError;
-use crate::{Vcpu, VcpuConfig, Vm, logger};
+use crate::vstate::vm::KvmVm;
+use crate::{Vcpu, VcpuConfig, logger};
 use kvm::Kvm;
 use layout::{
     CMDLINE_START, MMIO32_MEM_SIZE, MMIO32_MEM_START, MMIO64_MEM_SIZE, MMIO64_MEM_START,
@@ -174,7 +175,7 @@ pub fn initrd_load_addr(guest_mem: &GuestMemoryMmap, initrd_size: usize) -> Opti
 #[allow(clippy::too_many_arguments)]
 pub fn configure_system_for_boot(
     kvm: &Kvm,
-    vm: &Vm,
+    vm: &KvmVm,
     device_manager: &mut DeviceManager,
     vcpus: &mut [Vcpu],
     machine_config: &MachineConfig,

--- a/src/vmm/src/arch/x86_64/vcpu.rs
+++ b/src/vmm/src/arch/x86_64/vcpu.rs
@@ -27,7 +27,7 @@ use crate::logger::{IncMetric, METRICS, error, warn};
 use crate::vstate::bus::Bus;
 use crate::vstate::memory::GuestMemoryMmap;
 use crate::vstate::vcpu::{VcpuConfig, VcpuEmulation, VcpuError};
-use crate::vstate::vm::Vm;
+use crate::vstate::vm::KvmVm;
 
 // Tolerance for TSC frequency expected variation.
 // The value of 250 parts per million is based on
@@ -172,7 +172,7 @@ impl KvmVcpu {
     ///
     /// * `index` - Represents the 0-based CPU index between [0, max vcpus).
     /// * `vm` - The vm to which this vcpu will get attached.
-    pub fn new(index: u8, vm: &Vm) -> Result<Self, KvmVcpuError> {
+    pub fn new(index: u8, vm: &KvmVm) -> Result<Self, KvmVcpuError> {
         let kvm_vcpu = vm
             .fd()
             .create_vcpu(index.into())
@@ -820,7 +820,6 @@ mod tests {
     };
     use crate::cpu_config::x86_64::cpuid::{Cpuid, CpuidEntry, CpuidKey};
     use crate::vstate::kvm::Kvm;
-    use crate::vstate::vm::Vm;
     use crate::vstate::vm::tests::{setup_vm, setup_vm_with_memory};
 
     impl Default for VcpuState {
@@ -841,7 +840,7 @@ mod tests {
         }
     }
 
-    fn setup_vcpu(mem_size: usize) -> (Kvm, Vm, KvmVcpu) {
+    fn setup_vcpu(mem_size: usize) -> (Kvm, KvmVm, KvmVcpu) {
         let (kvm, vm) = setup_vm_with_memory(mem_size);
         vm.setup_irqchip().unwrap();
         let vcpu = KvmVcpu::new(0, &vm).unwrap();

--- a/src/vmm/src/arch/x86_64/vcpu.rs
+++ b/src/vmm/src/arch/x86_64/vcpu.rs
@@ -819,7 +819,6 @@ mod tests {
         StaticCpuTemplate,
     };
     use crate::cpu_config::x86_64::cpuid::{Cpuid, CpuidEntry, CpuidKey};
-    use crate::vstate::kvm::Kvm;
     use crate::vstate::vm::tests::{setup_vm, setup_vm_with_memory};
 
     impl Default for VcpuState {
@@ -840,19 +839,19 @@ mod tests {
         }
     }
 
-    fn setup_vcpu(mem_size: usize) -> (Kvm, KvmVm, KvmVcpu) {
-        let (kvm, vm) = setup_vm_with_memory(mem_size);
+    fn setup_vcpu(mem_size: usize) -> (KvmVm, KvmVcpu) {
+        let vm = setup_vm_with_memory(mem_size);
         vm.setup_irqchip().unwrap();
         let vcpu = KvmVcpu::new(0, &vm).unwrap();
-        (kvm, vm, vcpu)
+        (vm, vcpu)
     }
 
     fn create_vcpu_config(
-        kvm: &Kvm,
+        vm: &KvmVm,
         vcpu: &KvmVcpu,
         template: &CustomCpuTemplate,
     ) -> Result<VcpuConfig, GuestConfigError> {
-        let cpuid = Cpuid::try_from(kvm.supported_cpuid.clone())
+        let cpuid = Cpuid::try_from(vm.kvm().supported_cpuid.clone())
             .map_err(GuestConfigError::CpuidFromKvmCpuid)?;
         let msrs = vcpu
             .get_msrs(template.msr_index_iter())
@@ -868,9 +867,9 @@ mod tests {
 
     #[test]
     fn test_configure_vcpu() {
-        let (kvm, vm, mut vcpu) = setup_vcpu(0x10000);
+        let (vm, mut vcpu) = setup_vcpu(0x10000);
 
-        let vcpu_config = create_vcpu_config(&kvm, &vcpu, &CustomCpuTemplate::default()).unwrap();
+        let vcpu_config = create_vcpu_config(&vm, &vcpu, &CustomCpuTemplate::default()).unwrap();
         assert_eq!(
             vcpu.configure(
                 vm.guest_memory(),
@@ -883,11 +882,11 @@ mod tests {
             Ok(())
         );
 
-        let try_configure = |kvm: &Kvm, vcpu: &mut KvmVcpu, template| -> bool {
+        let try_configure = |vm: &KvmVm, vcpu: &mut KvmVcpu, template| -> bool {
             let cpu_template = Some(CpuTemplateType::Static(template));
             let template = cpu_template.get_cpu_template();
             match template {
-                Ok(template) => match create_vcpu_config(kvm, vcpu, &template) {
+                Ok(template) => match create_vcpu_config(vm, vcpu, &template) {
                     Ok(config) => vcpu
                         .configure(
                             vm.guest_memory(),
@@ -905,19 +904,19 @@ mod tests {
         };
 
         // Test configure while using the T2 template.
-        let t2_res = try_configure(&kvm, &mut vcpu, StaticCpuTemplate::T2);
+        let t2_res = try_configure(&vm, &mut vcpu, StaticCpuTemplate::T2);
 
         // Test configure while using the C3 template.
-        let c3_res = try_configure(&kvm, &mut vcpu, StaticCpuTemplate::C3);
+        let c3_res = try_configure(&vm, &mut vcpu, StaticCpuTemplate::C3);
 
         // Test configure while using the T2S template.
-        let t2s_res = try_configure(&kvm, &mut vcpu, StaticCpuTemplate::T2S);
+        let t2s_res = try_configure(&vm, &mut vcpu, StaticCpuTemplate::T2S);
 
         // Test configure while using the T2CL template.
-        let t2cl_res = try_configure(&kvm, &mut vcpu, StaticCpuTemplate::T2CL);
+        let t2cl_res = try_configure(&vm, &mut vcpu, StaticCpuTemplate::T2CL);
 
         // Test configure while using the T2S template.
-        let t2a_res = try_configure(&kvm, &mut vcpu, StaticCpuTemplate::T2A);
+        let t2a_res = try_configure(&vm, &mut vcpu, StaticCpuTemplate::T2A);
 
         let cpu_model = CpuModel::get_cpu_model();
         match &cpuid::common::get_vendor_id_from_host().unwrap() {
@@ -972,8 +971,8 @@ mod tests {
 
     #[test]
     fn test_vcpu_cpuid_restore() {
-        let (kvm, _, vcpu) = setup_vcpu(0x10000);
-        vcpu.fd.set_cpuid2(&kvm.supported_cpuid).unwrap();
+        let (vm, vcpu) = setup_vcpu(0x10000);
+        vcpu.fd.set_cpuid2(&vm.kvm().supported_cpuid).unwrap();
 
         // Mutate the CPUID.
         // Leaf 0x3 / EAX that is an unused (reserved to be accurate) register, so it's harmless.
@@ -990,7 +989,7 @@ mod tests {
         drop(vcpu);
 
         // Restore the state into a new vcpu.
-        let (_, _vm, vcpu) = setup_vcpu(0x10000);
+        let (_vm, vcpu) = setup_vcpu(0x10000);
         let result2 = vcpu.restore_state(&state);
         assert!(result2.is_ok(), "{}", result2.unwrap_err());
 
@@ -1010,12 +1009,12 @@ mod tests {
     #[test]
     fn test_empty_cpuid_entries_removed() {
         // Test that `get_cpuid()` removes zeroed empty entries from the `KVM_GET_CPUID2` result.
-        let (kvm, vm, mut vcpu) = setup_vcpu(0x10000);
+        let (vm, mut vcpu) = setup_vcpu(0x10000);
         let vcpu_config = VcpuConfig {
             vcpu_count: 1,
             smt: false,
             cpu_config: CpuConfiguration {
-                cpuid: Cpuid::try_from(kvm.supported_cpuid.clone()).unwrap(),
+                cpuid: Cpuid::try_from(vm.kvm().supported_cpuid.clone()).unwrap(),
                 msrs: BTreeMap::new(),
             },
         };
@@ -1068,7 +1067,7 @@ mod tests {
         // Since `KVM_SET_CPUID2` has not been called before vcpu configuration, all leaves should
         // be filled with zero. Therefore, `KvmVcpu::dump_cpu_config()` should fail with CPUID type
         // conversion error due to the lack of brand string info in leaf 0x0.
-        let (_, _, vcpu) = setup_vcpu(0x10000);
+        let (_, vcpu) = setup_vcpu(0x10000);
         match vcpu.dump_cpu_config() {
             Err(KvmVcpuError::ConvertCpuidType(_)) => (),
             Err(err) => panic!("Unexpected error: {err}"),
@@ -1079,12 +1078,12 @@ mod tests {
     #[test]
     fn test_dump_cpu_config_with_configured_vcpu() {
         // Test `dump_cpu_config()` after vcpu configuration.
-        let (kvm, vm, mut vcpu) = setup_vcpu(0x10000);
+        let (vm, mut vcpu) = setup_vcpu(0x10000);
         let vcpu_config = VcpuConfig {
             vcpu_count: 1,
             smt: false,
             cpu_config: CpuConfiguration {
-                cpuid: Cpuid::try_from(kvm.supported_cpuid.clone()).unwrap(),
+                cpuid: Cpuid::try_from(vm.kvm().supported_cpuid.clone()).unwrap(),
                 msrs: BTreeMap::new(),
             },
         };
@@ -1106,7 +1105,7 @@ mod tests {
     fn test_is_tsc_scaling_required() {
         // Test `is_tsc_scaling_required` as if it were on the same
         // CPU model as the one in the snapshot state.
-        let (_, _, vcpu) = setup_vcpu(0x1000);
+        let (_, vcpu) = setup_vcpu(0x1000);
 
         {
             // The frequency difference is within tolerance.
@@ -1148,7 +1147,7 @@ mod tests {
 
     #[test]
     fn test_set_tsc() {
-        let (kvm, _, vcpu) = setup_vcpu(0x1000);
+        let (vm, vcpu) = setup_vcpu(0x1000);
         let mut state = vcpu.save_state().unwrap();
         state.tsc_khz = Some(
             state.tsc_khz.unwrap()
@@ -1157,9 +1156,9 @@ mod tests {
                     * 2,
         );
 
-        if kvm.fd.check_extension(Cap::TscControl) {
+        if vm.kvm().fd.check_extension(Cap::TscControl) {
             vcpu.set_tsc_khz(state.tsc_khz.unwrap()).unwrap();
-            if kvm.fd.check_extension(Cap::GetTscKhz) {
+            if vm.kvm().fd.check_extension(Cap::GetTscKhz) {
                 assert_eq!(vcpu.get_tsc_khz().ok(), state.tsc_khz);
             } else {
                 vcpu.get_tsc_khz().unwrap_err();
@@ -1173,7 +1172,7 @@ mod tests {
     fn test_get_msrs_with_msrs_to_save() {
         // Test `get_msrs()` with the MSR indices that should be serialized into snapshots.
         // The MSR indices should be valid and this test should succeed.
-        let (_, _, vcpu) = setup_vcpu(0x1000);
+        let (_, vcpu) = setup_vcpu(0x1000);
         vcpu.get_msrs(vcpu.msrs_to_save.iter().copied()).unwrap();
     }
 
@@ -1181,7 +1180,7 @@ mod tests {
     fn test_get_msrs_with_msrs_to_dump() {
         // Test `get_msrs()` with the MSR indices that should be dumped.
         // All the MSR indices should be valid and the call should succeed.
-        let (_, _, vcpu) = setup_vcpu(0x1000);
+        let (_, vcpu) = setup_vcpu(0x1000);
 
         let kvm = kvm_ioctls::Kvm::new().unwrap();
         let msrs_to_dump = crate::arch::x86_64::msr::get_msrs_to_dump(&kvm).unwrap();
@@ -1194,7 +1193,7 @@ mod tests {
         // Test `get_msrs()` with unsupported MSR indices. This should return `VcpuGetMsr` error
         // that happens when `KVM_GET_MSRS` fails to populate MSR values in the middle and exits.
         // Currently, MSR indices 2..=4 are not listed as supported MSRs.
-        let (_, _, vcpu) = setup_vcpu(0x1000);
+        let (_, vcpu) = setup_vcpu(0x1000);
         let msr_index_list: Vec<u32> = vec![2, 3, 4];
         match vcpu.get_msrs(msr_index_list.iter().copied()) {
             Err(KvmVcpuError::VcpuGetMsr(_)) => (),
@@ -1300,7 +1299,7 @@ mod tests {
     #[test]
     fn test_get_msr_chunks_preserved_order() {
         // Regression test for #4666
-        let (_, vm) = setup_vm();
+        let vm = setup_vm();
         let vcpu = KvmVcpu::new(0, &vm).unwrap();
 
         // The list of supported MSR indices, in the order they were returned by KVM

--- a/src/vmm/src/arch/x86_64/vm.rs
+++ b/src/vmm/src/arch/x86_64/vm.rs
@@ -19,11 +19,11 @@ use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryState};
 use crate::vstate::resources::ResourceAllocator;
 use crate::vstate::vm::{VmCommon, VmError};
 
-/// Error type for [`Vm::restore_state`]
+/// Error type for [`KvmVm::restore_state`]
 #[allow(missing_docs)]
 #[cfg(target_arch = "x86_64")]
 #[derive(Debug, PartialEq, Eq, thiserror::Error, displaydoc::Display)]
-pub enum ArchVmError {
+pub enum KvmVmError {
     /// Failed to check KVM capability (0): {1}
     CheckCapability(Cap, kvm_ioctls::Error),
     /// Set PIT2 error: {0}
@@ -54,7 +54,7 @@ pub enum ArchVmError {
 
 /// Structure representing the current architecture's understand of what a "virtual machine" is.
 #[derive(Debug)]
-pub struct ArchVm {
+pub struct KvmVm {
     /// Architecture independent parts of a vm
     pub common: VmCommon,
     msrs_to_save: MsrList,
@@ -66,12 +66,12 @@ pub struct ArchVm {
     pub pio_bus: Arc<Bus>,
 }
 
-impl ArchVm {
-    /// Create a new `Vm` struct.
-    pub fn new(kvm: &crate::vstate::kvm::Kvm) -> Result<ArchVm, VmError> {
+impl KvmVm {
+    /// Create a new `KvmVm` struct.
+    pub fn new(kvm: &crate::vstate::kvm::Kvm) -> Result<KvmVm, VmError> {
         let common = Self::create_common(kvm)?;
 
-        let msrs_to_save = kvm.msrs_to_save().map_err(ArchVmError::GetMsrsToSave)?;
+        let msrs_to_save = kvm.msrs_to_save().map_err(KvmVmError::GetMsrsToSave)?;
 
         // `KVM_CAP_XSAVE2` was introduced to support dynamically-sized XSTATE buffer in kernel
         // v5.17. `KVM_GET_EXTENSION(KVM_CAP_XSAVE2)` returns the required size in byte if
@@ -83,7 +83,7 @@ impl ArchVm {
             // Catch all negative values just in case although the possible negative return value
             // of ioctl() is only -1.
             ..=-1 => {
-                return Err(VmError::Arch(ArchVmError::CheckCapability(
+                return Err(VmError::Arch(KvmVmError::CheckCapability(
                     Cap::Xsave2,
                     vmm_sys_util::errno::Error::last(),
                 )));
@@ -96,11 +96,11 @@ impl ArchVm {
         common
             .fd
             .set_tss_address(u64_to_usize(crate::arch::x86_64::layout::KVM_TSS_ADDRESS))
-            .map_err(ArchVmError::SetTssAddress)?;
+            .map_err(KvmVmError::SetTssAddress)?;
 
         let pio_bus = Arc::new(Bus::new());
 
-        Ok(ArchVm {
+        Ok(KvmVm {
             common,
             msrs_to_save,
             xsave2_size,
@@ -109,13 +109,13 @@ impl ArchVm {
     }
 
     /// Pre-vCPU creation setup.
-    pub fn arch_pre_create_vcpus(&mut self, _: u8) -> Result<(), ArchVmError> {
+    pub fn arch_pre_create_vcpus(&mut self, _: u8) -> Result<(), KvmVmError> {
         // For x86_64 we need to create the interrupt controller before calling `KVM_CREATE_VCPUS`
         self.setup_irqchip()
     }
 
     /// Post-vCPU creation setup.
-    pub fn arch_post_create_vcpus(&mut self, _: u8) -> Result<(), ArchVmError> {
+    pub fn arch_post_create_vcpus(&mut self, _: u8) -> Result<(), KvmVmError> {
         Ok(())
     }
 
@@ -133,39 +133,39 @@ impl ArchVm {
         &mut self,
         state: &VmState,
         clock_realtime: bool,
-    ) -> Result<(), ArchVmError> {
+    ) -> Result<(), KvmVmError> {
         self.fd()
             .set_pit2(&state.pitstate)
-            .map_err(ArchVmError::SetPit2)?;
+            .map_err(KvmVmError::SetPit2)?;
         let mut clock = state.clock;
         clock.flags = if clock_realtime {
             // clock_realtime needs to be present in the snapshot
             if clock.flags & KVM_CLOCK_REALTIME == 0 {
-                return Err(ArchVmError::ClockRealtimeNotInState);
+                return Err(KvmVmError::ClockRealtimeNotInState);
             }
             KVM_CLOCK_REALTIME
         } else {
             0
         };
-        self.fd().set_clock(&clock).map_err(ArchVmError::SetClock)?;
+        self.fd().set_clock(&clock).map_err(KvmVmError::SetClock)?;
         self.fd()
             .set_irqchip(&state.pic_master)
-            .map_err(ArchVmError::SetIrqChipPicMaster)?;
+            .map_err(KvmVmError::SetIrqChipPicMaster)?;
         self.fd()
             .set_irqchip(&state.pic_slave)
-            .map_err(ArchVmError::SetIrqChipPicSlave)?;
+            .map_err(KvmVmError::SetIrqChipPicSlave)?;
         self.fd()
             .set_irqchip(&state.ioapic)
-            .map_err(ArchVmError::SetIrqChipIoAPIC)?;
+            .map_err(KvmVmError::SetIrqChipIoAPIC)?;
         self.common.resource_allocator = Mutex::new(state.resource_allocator.clone());
         Ok(())
     }
 
     /// Creates the irq chip and an in-kernel device model for the PIT.
-    pub fn setup_irqchip(&self) -> Result<(), ArchVmError> {
+    pub fn setup_irqchip(&self) -> Result<(), KvmVmError> {
         self.fd()
             .create_irq_chip()
-            .map_err(ArchVmError::VmSetIrqChip)?;
+            .map_err(KvmVmError::VmSetIrqChip)?;
         // We need to enable the emulation of a dummy speaker port stub so that writing to port 0x61
         // (i.e. KVM_SPEAKER_BASE_ADDRESS) does not trigger an exit to user space.
         let pit_config = kvm_pit_config {
@@ -174,14 +174,14 @@ impl ArchVm {
         };
         self.fd()
             .create_pit2(pit_config)
-            .map_err(ArchVmError::VmSetIrqChip)
+            .map_err(KvmVmError::VmSetIrqChip)
     }
 
-    /// Saves and returns the Kvm Vm state.
-    pub fn save_state(&self) -> Result<VmState, ArchVmError> {
-        let pitstate = self.fd().get_pit2().map_err(ArchVmError::VmGetPit2)?;
+    /// Saves and returns the KVM VM state.
+    pub fn save_state(&self) -> Result<VmState, KvmVmError> {
+        let pitstate = self.fd().get_pit2().map_err(KvmVmError::VmGetPit2)?;
 
-        let clock = self.fd().get_clock().map_err(ArchVmError::VmGetClock)?;
+        let clock = self.fd().get_clock().map_err(KvmVmError::VmGetClock)?;
 
         let mut pic_master = kvm_irqchip {
             chip_id: KVM_IRQCHIP_PIC_MASTER,
@@ -189,7 +189,7 @@ impl ArchVm {
         };
         self.fd()
             .get_irqchip(&mut pic_master)
-            .map_err(ArchVmError::VmGetIrqChip)?;
+            .map_err(KvmVmError::VmGetIrqChip)?;
 
         let mut pic_slave = kvm_irqchip {
             chip_id: KVM_IRQCHIP_PIC_SLAVE,
@@ -197,7 +197,7 @@ impl ArchVm {
         };
         self.fd()
             .get_irqchip(&mut pic_slave)
-            .map_err(ArchVmError::VmGetIrqChip)?;
+            .map_err(KvmVmError::VmGetIrqChip)?;
 
         let mut ioapic = kvm_irqchip {
             chip_id: KVM_IRQCHIP_IOAPIC,
@@ -205,7 +205,7 @@ impl ArchVm {
         };
         self.fd()
             .get_irqchip(&mut ioapic)
-            .map_err(ArchVmError::VmGetIrqChip)?;
+            .map_err(KvmVmError::VmGetIrqChip)?;
 
         Ok(VmState {
             memory: self.common.guest_memory.describe(),
@@ -266,7 +266,7 @@ mod tests {
     use kvm_ioctls::Cap;
     use std::time::SystemTime;
 
-    use crate::arch::ArchVmError;
+    use crate::arch::KvmVmError;
     use crate::vstate::vm::VmState;
     use crate::vstate::vm::tests::{setup_vm, setup_vm_with_memory};
 
@@ -312,7 +312,7 @@ mod tests {
         vm.setup_irqchip().unwrap();
 
         let res = vm.restore_state(&vm_state, true);
-        assert!(res == Err(ArchVmError::ClockRealtimeNotInState));
+        assert!(res == Err(KvmVmError::ClockRealtimeNotInState));
 
         // mock a state with realtime information
         vm_state.clock.flags |= KVM_CLOCK_REALTIME;
@@ -330,7 +330,7 @@ mod tests {
         if clock_realtime_supported {
             res.unwrap()
         } else {
-            assert!(matches!(res, Err(ArchVmError::SetClock(err)) if err.errno() == libc::EINVAL))
+            assert!(matches!(res, Err(KvmVmError::SetClock(err)) if err.errno() == libc::EINVAL))
         }
     }
 

--- a/src/vmm/src/arch/x86_64/vm.rs
+++ b/src/vmm/src/arch/x86_64/vm.rs
@@ -15,6 +15,7 @@ use crate::arch::x86_64::msr::MsrError;
 use crate::snapshot::Persist;
 use crate::utils::u64_to_usize;
 use crate::vstate::bus::Bus;
+use crate::vstate::kvm::Kvm;
 use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryState};
 use crate::vstate::resources::ResourceAllocator;
 use crate::vstate::vm::{VmCommon, VmError};
@@ -68,10 +69,12 @@ pub struct KvmVm {
 
 impl KvmVm {
     /// Create a new `KvmVm` struct.
-    pub fn new(kvm: &crate::vstate::kvm::Kvm) -> Result<KvmVm, VmError> {
+    pub fn new(kvm: Kvm) -> Result<KvmVm, VmError> {
         let common = Self::create_common(kvm)?;
-
-        let msrs_to_save = kvm.msrs_to_save().map_err(KvmVmError::GetMsrsToSave)?;
+        let msrs_to_save = common
+            .kvm
+            .msrs_to_save()
+            .map_err(KvmVmError::GetMsrsToSave)?;
 
         // `KVM_CAP_XSAVE2` was introduced to support dynamically-sized XSTATE buffer in kernel
         // v5.17. `KVM_GET_EXTENSION(KVM_CAP_XSAVE2)` returns the required size in byte if
@@ -273,11 +276,11 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_vm_save_restore_state() {
-        let (_, vm) = setup_vm();
+        let vm = setup_vm();
         // Irqchips, clock and pitstate are not configured so trying to save state should fail.
         vm.save_state().unwrap_err();
 
-        let (_, vm) = setup_vm_with_memory(0x1000);
+        let vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
         let vm_state = vm.save_state().unwrap();
@@ -289,7 +292,7 @@ mod tests {
         assert_eq!(vm_state.pic_slave.chip_id, KVM_IRQCHIP_PIC_SLAVE);
         assert_eq!(vm_state.ioapic.chip_id, KVM_IRQCHIP_IOAPIC);
 
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
         vm.restore_state(&vm_state, false).unwrap();
@@ -298,17 +301,22 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_vm_save_restore_state_kvm_clock_realtime() {
-        let (kvm, vm) = setup_vm_with_memory(0x1000);
+        let vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
-        let clock_realtime_supported =
-            kvm.fd.check_extension_int(Cap::AdjustClock).cast_unsigned() & KVM_CLOCK_REALTIME != 0;
+        let clock_realtime_supported = vm
+            .kvm()
+            .fd
+            .check_extension_int(Cap::AdjustClock)
+            .cast_unsigned()
+            & KVM_CLOCK_REALTIME
+            != 0;
 
         // mock a state without realtime information
         let mut vm_state = vm.save_state().unwrap();
         vm_state.clock.flags &= !KVM_CLOCK_REALTIME;
 
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
         let res = vm.restore_state(&vm_state, true);
@@ -323,7 +331,7 @@ mod tests {
             .try_into()
             .unwrap();
 
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
         let res = vm.restore_state(&vm_state, true);
@@ -339,11 +347,11 @@ mod tests {
     fn test_vm_save_restore_state_bad_irqchip() {
         use kvm_bindings::KVM_NR_IRQCHIPS;
 
-        let (_, vm) = setup_vm_with_memory(0x1000);
+        let vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
         let mut vm_state = vm.save_state().unwrap();
 
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
         // Try to restore an invalid PIC Master chip ID
@@ -366,7 +374,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_vmstate_serde() {
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
         let state = vm.save_state().unwrap();
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -173,7 +173,7 @@ pub fn build_microvm_for_boot(
     let kvm = Kvm::new(cpu_template.kvm_capabilities.clone())?;
     // Set up KVM VM and register memory regions.
     // Build custom CPU config if a custom template is provided.
-    let mut vm = KvmVm::new(&kvm)?;
+    let mut vm = KvmVm::new(kvm)?;
     let (mut vcpus, vcpus_exit_evt) = vm.create_vcpus(vm_resources.machine_config.vcpu_count)?;
     vm.register_dram_memory_regions(guest_memory)?;
 
@@ -303,7 +303,7 @@ pub fn build_microvm_for_boot(
     }
 
     configure_system_for_boot(
-        &kvm,
+        vm.kvm(),
         &vm,
         &mut device_manager,
         vcpus.as_mut(),
@@ -319,7 +319,6 @@ pub fn build_microvm_for_boot(
         machine_config: vm_resources.machine_config.clone(),
         boot_source_config: vm_resources.boot_source.config.clone(),
         shutdown_exit_code: None,
-        kvm,
         vm,
         uffd: None,
         vcpus_handles: Vec::new(),
@@ -454,7 +453,7 @@ pub fn build_microvm_from_snapshot(
         .map_err(StartMicrovmError::Kvm)?;
     // Set up KVM VM and register memory regions.
     // Build custom CPU config if a custom template is provided.
-    let mut vm = KvmVm::new(&kvm).map_err(StartMicrovmError::KvmVm)?;
+    let mut vm = KvmVm::new(kvm).map_err(StartMicrovmError::KvmVm)?;
 
     let (mut vcpus, vcpus_exit_evt) = vm
         .create_vcpus(vm_resources.machine_config.vcpu_count)
@@ -525,7 +524,6 @@ pub fn build_microvm_from_snapshot(
         machine_config: vm_resources.machine_config.clone(),
         boot_source_config: vm_resources.boot_source.config.clone(),
         shutdown_exit_code: None,
-        kvm,
         vm,
         uffd,
         vcpus_handles: Vec::new(),
@@ -855,7 +853,7 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn default_vmm() -> Vmm {
-        let (kvm, mut vm) = setup_vm_with_memory(mib_to_bytes(128));
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
 
         let (_, vcpus_exit_evt) = vm.create_vcpus(1).unwrap();
 
@@ -864,7 +862,6 @@ pub(crate) mod tests {
             machine_config: MachineConfig::default(),
             boot_source_config: BootSourceConfig::default(),
             shutdown_exit_code: None,
-            kvm,
             vm: Arc::new(vm),
             uffd: None,
             vcpus_handles: Vec::new(),

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -57,7 +57,7 @@ use crate::vstate::memory::GuestRegionMmap;
 #[cfg(target_arch = "aarch64")]
 use crate::vstate::resources::ResourceAllocator;
 use crate::vstate::vcpu::VcpuError;
-use crate::vstate::vm::{Vm, VmError};
+use crate::vstate::vm::{KvmVm, VmError};
 use crate::{EventManager, Vmm, VmmError};
 
 /// Errors associated with starting the instance.
@@ -125,8 +125,8 @@ pub enum StartMicrovmError {
     /// Error cloning Vcpu fds
     #[cfg(feature = "gdb")]
     VcpuFdCloneError(#[from] crate::vstate::vcpu::CopyKvmFdError),
-    /// Error with the Vm object: {0}
-    Vm(#[from] VmError),
+    /// Error with the KvmVm object: {0}
+    KvmVm(#[from] VmError),
 }
 
 /// It's convenient to automatically convert `linux_loader::cmdline::Error`s
@@ -171,9 +171,9 @@ pub fn build_microvm_for_boot(
         .get_cpu_template()?;
 
     let kvm = Kvm::new(cpu_template.kvm_capabilities.clone())?;
-    // Set up Kvm Vm and register memory regions.
+    // Set up KVM VM and register memory regions.
     // Build custom CPU config if a custom template is provided.
-    let mut vm = Vm::new(&kvm)?;
+    let mut vm = KvmVm::new(&kvm)?;
     let (mut vcpus, vcpus_exit_evt) = vm.create_vcpus(vm_resources.machine_config.vcpu_count)?;
     vm.register_dram_memory_regions(guest_memory)?;
 
@@ -411,7 +411,7 @@ pub enum BuildMicrovmFromSnapshotError {
     /// Could not set TSC scaling within the snapshot: {0}
     SetTsc(#[from] crate::arch::SetTscError),
     /// Failed to restore microVM state: {0}
-    RestoreState(#[from] crate::vstate::vm::ArchVmError),
+    RestoreState(#[from] crate::vstate::vm::KvmVmError),
     /// Failed to update microVM configuration: {0}
     VmUpdateConfig(#[from] MachineConfigError),
     /// Failed to restore MMIO device: {0}
@@ -452,16 +452,16 @@ pub fn build_microvm_from_snapshot(
 
     let kvm = Kvm::new(microvm_state.kvm_state.kvm_cap_modifiers.clone())
         .map_err(StartMicrovmError::Kvm)?;
-    // Set up Kvm Vm and register memory regions.
+    // Set up KVM VM and register memory regions.
     // Build custom CPU config if a custom template is provided.
-    let mut vm = Vm::new(&kvm).map_err(StartMicrovmError::Vm)?;
+    let mut vm = KvmVm::new(&kvm).map_err(StartMicrovmError::KvmVm)?;
 
     let (mut vcpus, vcpus_exit_evt) = vm
         .create_vcpus(vm_resources.machine_config.vcpu_count)
-        .map_err(StartMicrovmError::Vm)?;
+        .map_err(StartMicrovmError::KvmVm)?;
 
     vm.restore_memory_regions(guest_memory, &microvm_state.vm_state.memory)
-        .map_err(StartMicrovmError::Vm)?;
+        .map_err(StartMicrovmError::KvmVm)?;
 
     #[cfg(target_arch = "x86_64")]
     {
@@ -602,7 +602,7 @@ fn setup_pvtime(
 
 fn attach_entropy_device(
     device_manager: &mut DeviceManager,
-    vm: &Arc<Vm>,
+    vm: &Arc<KvmVm>,
     cmdline: &mut LoaderKernelCmdline,
     entropy_device: &Arc<Mutex<Entropy>>,
     event_manager: &mut EventManager,
@@ -624,7 +624,7 @@ fn attach_entropy_device(
 }
 
 fn allocate_virtio_mem_address(
-    vm: &Vm,
+    vm: &KvmVm,
     total_size_mib: usize,
 ) -> Result<GuestAddress, StartMicrovmError> {
     let addr = vm
@@ -641,7 +641,7 @@ fn allocate_virtio_mem_address(
 
 fn attach_virtio_mem_device(
     device_manager: &mut DeviceManager,
-    vm: &Arc<Vm>,
+    vm: &Arc<KvmVm>,
     cmdline: &mut LoaderKernelCmdline,
     config: &MemoryHotplugConfig,
     event_manager: &mut EventManager,
@@ -672,7 +672,7 @@ fn attach_virtio_mem_device(
 
 fn attach_block_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Block>>> + Debug>(
     device_manager: &mut DeviceManager,
-    vm: &Arc<Vm>,
+    vm: &Arc<KvmVm>,
     cmdline: &mut LoaderKernelCmdline,
     blocks: I,
     event_manager: &mut EventManager,
@@ -707,7 +707,7 @@ fn attach_block_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Block>>> + Debug>(
 
 fn attach_net_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Net>>> + Debug>(
     device_manager: &mut DeviceManager,
-    vm: &Arc<Vm>,
+    vm: &Arc<KvmVm>,
     cmdline: &mut LoaderKernelCmdline,
     net_devices: I,
     event_manager: &mut EventManager,
@@ -729,7 +729,7 @@ fn attach_net_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Net>>> + Debug>(
 
 fn attach_pmem_devices(
     device_manager: &mut DeviceManager,
-    vm: &Arc<Vm>,
+    vm: &Arc<KvmVm>,
     cmdline: &mut LoaderKernelCmdline,
     configs: &[PmemConfig],
     event_manager: &mut EventManager,
@@ -753,7 +753,7 @@ fn attach_pmem_devices(
 
 fn attach_unixsock_vsock_device(
     device_manager: &mut DeviceManager,
-    vm: &Arc<Vm>,
+    vm: &Arc<KvmVm>,
     cmdline: &mut LoaderKernelCmdline,
     unix_vsock: &Arc<Mutex<Vsock<VsockUnixBackend>>>,
     event_manager: &mut EventManager,
@@ -765,7 +765,7 @@ fn attach_unixsock_vsock_device(
 
 fn attach_balloon_device(
     device_manager: &mut DeviceManager,
-    vm: &Arc<Vm>,
+    vm: &Arc<KvmVm>,
     cmdline: &mut LoaderKernelCmdline,
     balloon: &Arc<Mutex<Balloon>>,
     event_manager: &mut EventManager,

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -48,7 +48,7 @@ use crate::resources::VmResources;
 use crate::seccomp::BpfThreadMap;
 use crate::snapshot::Persist;
 use crate::utils::mib_to_bytes;
-use crate::vmm_config::instance_info::InstanceInfo;
+use crate::vmm_config::instance_info::{InstanceInfo, VmState};
 use crate::vmm_config::machine_config::MachineConfigError;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
 use crate::vmm_config::pmem::PmemConfig;
@@ -319,9 +319,8 @@ pub fn build_microvm_for_boot(
         machine_config: vm_resources.machine_config.clone(),
         boot_source_config: vm_resources.boot_source.config.clone(),
         shutdown_exit_code: None,
-        vm,
+        vm: vm.clone(),
         uffd: None,
-        vcpus_handles: Vec::new(),
         device_manager,
     };
     let vmm = Arc::new(Mutex::new(vmm));
@@ -335,16 +334,15 @@ pub fn build_microvm_for_boot(
         .for_each(|vcpu| vcpu.attach_debug_info(gdb_tx.clone()));
 
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
-    vmm.lock()
-        .unwrap()
-        .start_vcpus(
-            vcpus,
-            seccomp_filters
-                .get("vcpu")
-                .ok_or_else(|| StartMicrovmError::MissingSeccompFilters("vcpu".to_string()))?
-                .clone(),
-        )
-        .map_err(VmmError::VcpuStart)?;
+    vm.start_vcpus(
+        vcpus,
+        seccomp_filters
+            .get("vcpu")
+            .ok_or_else(|| StartMicrovmError::MissingSeccompFilters("vcpu".to_string()))?
+            .clone(),
+    )
+    .map_err(VmmError::VcpuStart)?;
+    vmm.lock().unwrap().instance_info.state = VmState::Paused;
 
     #[cfg(feature = "gdb")]
     if let Some(gdb_socket_path) = &vm_resources.machine_config.gdb_socket_path {
@@ -518,19 +516,18 @@ pub fn build_microvm_from_snapshot(
     let mut device_manager =
         DeviceManager::restore(device_ctor_args, &microvm_state.device_states)?;
 
-    let mut vmm = Vmm {
+    let vmm = Vmm {
         instance_info: instance_info.clone(),
         machine_config: vm_resources.machine_config.clone(),
         boot_source_config: vm_resources.boot_source.config.clone(),
         shutdown_exit_code: None,
-        vm,
+        vm: vm.clone(),
         uffd,
-        vcpus_handles: Vec::new(),
         device_manager,
     };
 
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
-    vmm.start_vcpus(
+    vm.start_vcpus(
         vcpus,
         seccomp_filters
             .get("vcpu")
@@ -539,6 +536,7 @@ pub fn build_microvm_from_snapshot(
     )?;
 
     let vmm = Arc::new(Mutex::new(vmm));
+    vmm.lock().unwrap().instance_info.state = VmState::Paused;
     event_manager.add_subscriber(vmm.clone());
 
     // Load seccomp filters for the VMM thread.
@@ -862,7 +860,6 @@ pub(crate) mod tests {
             shutdown_exit_code: None,
             vm: Arc::new(vm),
             uffd: None,
-            vcpus_handles: Vec::new(),
             device_manager: default_device_manager(),
         }
     }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -320,7 +320,6 @@ pub fn build_microvm_for_boot(
         boot_source_config: vm_resources.boot_source.config.clone(),
         shutdown_exit_code: None,
         vm: vm.clone(),
-        uffd: None,
         device_manager,
     };
     let vmm = Arc::new(Mutex::new(vmm));
@@ -498,6 +497,8 @@ pub fn build_microvm_from_snapshot(
     // Restore the boot source config paths.
     vm_resources.boot_source.config = microvm_state.vm_info.boot_source;
 
+    vm.set_uffd(uffd);
+
     let vm = Arc::new(vm);
 
     // Restore devices states.
@@ -522,7 +523,6 @@ pub fn build_microvm_from_snapshot(
         boot_source_config: vm_resources.boot_source.config.clone(),
         shutdown_exit_code: None,
         vm: vm.clone(),
-        uffd,
         device_manager,
     };
 
@@ -859,7 +859,6 @@ pub(crate) mod tests {
             boot_source_config: BootSourceConfig::default(),
             shutdown_exit_code: None,
             vm: Arc::new(vm),
-            uffd: None,
             device_manager: default_device_manager(),
         }
     }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -174,7 +174,7 @@ pub fn build_microvm_for_boot(
     // Set up KVM VM and register memory regions.
     // Build custom CPU config if a custom template is provided.
     let mut vm = KvmVm::new(kvm)?;
-    let (mut vcpus, vcpus_exit_evt) = vm.create_vcpus(vm_resources.machine_config.vcpu_count)?;
+    let mut vcpus = vm.create_vcpus(vm_resources.machine_config.vcpu_count)?;
     vm.register_dram_memory_regions(guest_memory)?;
 
     // Allocate memory as soon as possible to make hotpluggable memory available to all consumers,
@@ -195,7 +195,7 @@ pub fn build_microvm_for_boot(
 
     let mut device_manager = DeviceManager::new(
         event_manager,
-        &vcpus_exit_evt,
+        vm.vcpus_exit_evt(),
         &vm,
         vm_resources.serial_out_path.as_ref(),
         vm_resources.serial_rate_limiter(),
@@ -322,7 +322,6 @@ pub fn build_microvm_for_boot(
         vm,
         uffd: None,
         vcpus_handles: Vec::new(),
-        vcpus_exit_evt,
         device_manager,
     };
     let vmm = Arc::new(Mutex::new(vmm));
@@ -455,7 +454,7 @@ pub fn build_microvm_from_snapshot(
     // Build custom CPU config if a custom template is provided.
     let mut vm = KvmVm::new(kvm).map_err(StartMicrovmError::KvmVm)?;
 
-    let (mut vcpus, vcpus_exit_evt) = vm
+    let mut vcpus = vm
         .create_vcpus(vm_resources.machine_config.vcpu_count)
         .map_err(StartMicrovmError::KvmVm)?;
 
@@ -513,7 +512,7 @@ pub fn build_microvm_from_snapshot(
         event_manager,
         vm_resources,
         instance_id: &instance_info.id,
-        vcpus_exit_evt: &vcpus_exit_evt,
+        vcpus_exit_evt: vm.vcpus_exit_evt(),
     };
     #[allow(unused_mut)]
     let mut device_manager =
@@ -527,7 +526,6 @@ pub fn build_microvm_from_snapshot(
         vm,
         uffd,
         vcpus_handles: Vec::new(),
-        vcpus_exit_evt,
         device_manager,
     };
 
@@ -855,7 +853,7 @@ pub(crate) mod tests {
     pub(crate) fn default_vmm() -> Vmm {
         let mut vm = setup_vm_with_memory(mib_to_bytes(128));
 
-        let (_, vcpus_exit_evt) = vm.create_vcpus(1).unwrap();
+        vm.create_vcpus(1).unwrap();
 
         Vmm {
             instance_info: InstanceInfo::default(),
@@ -865,7 +863,6 @@ pub(crate) mod tests {
             vm: Arc::new(vm),
             uffd: None,
             vcpus_handles: Vec::new(),
-            vcpus_exit_evt,
             device_manager: default_device_manager(),
         }
     }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -57,7 +57,7 @@ use crate::vstate::memory::GuestRegionMmap;
 #[cfg(target_arch = "aarch64")]
 use crate::vstate::resources::ResourceAllocator;
 use crate::vstate::vcpu::VcpuError;
-use crate::vstate::vm::{KvmVm, VmError};
+use crate::vstate::vm::{KvmVm, Vm, VmError};
 use crate::{EventManager, Vmm, VmmError};
 
 /// Errors associated with starting the instance.
@@ -193,21 +193,23 @@ pub fn build_microvm_for_boot(
         None
     };
 
+    let kvm_vm = Arc::new(vm);
+    let vm = Vm::Kvm(kvm_vm.clone());
+
     let mut device_manager = DeviceManager::new(
         event_manager,
-        vm.vcpus_exit_evt(),
-        &vm,
+        kvm_vm.vcpus_exit_evt(),
+        &kvm_vm,
         vm_resources.serial_out_path.as_ref(),
         vm_resources.serial_rate_limiter(),
     )?;
 
-    let vm = Arc::new(vm);
-
-    let entry_point = load_kernel(&boot_config.kernel_file, vm.guest_memory())?;
-    let initrd = InitrdConfig::from_config(boot_config, vm.guest_memory())?;
+    let guest_memory = kvm_vm.guest_memory();
+    let entry_point = load_kernel(&boot_config.kernel_file, guest_memory)?;
+    let initrd = InitrdConfig::from_config(boot_config, guest_memory)?;
 
     if vm_resources.pci_enabled {
-        device_manager.enable_pci(&vm)?;
+        device_manager.enable_pci(&kvm_vm)?;
     } else {
         boot_cmdline.insert("pci", "off")?;
     }
@@ -216,7 +218,7 @@ pub fn build_microvm_for_boot(
     // to maintain the same MMIO address referenced in the documentation
     // and tests.
     if vm_resources.boot_timer {
-        device_manager.attach_boot_timer_device(&vm, request_ts)?;
+        device_manager.attach_boot_timer_device(&kvm_vm, request_ts)?;
     }
 
     if let Some(balloon) = vm_resources.balloon.get() {
@@ -285,26 +287,26 @@ pub fn build_microvm_for_boot(
 
     #[cfg(target_arch = "aarch64")]
     device_manager.attach_legacy_devices_aarch64(
-        &vm,
+        &kvm_vm,
         event_manager,
         &mut boot_cmdline,
         vm_resources.serial_out_path.as_ref(),
         vm_resources.serial_rate_limiter(),
     )?;
 
-    device_manager.attach_vmgenid_device(&vm)?;
-    device_manager.attach_vmclock_device(&vm)?;
+    device_manager.attach_vmgenid_device(&kvm_vm)?;
+    device_manager.attach_vmclock_device(&kvm_vm)?;
 
     #[cfg(target_arch = "aarch64")]
     if vcpus[0].kvm_vcpu.supports_pvtime() {
-        setup_pvtime(&mut vm.resource_allocator(), &mut vcpus)?;
+        setup_pvtime(&mut kvm_vm.resource_allocator(), &mut vcpus)?;
     } else {
         warn!("Vcpus do not support pvtime, steal time will not be reported to guest");
     }
 
     configure_system_for_boot(
-        vm.kvm(),
-        &vm,
+        kvm_vm.kvm(),
+        &kvm_vm,
         &mut device_manager,
         vcpus.as_mut(),
         &vm_resources.machine_config,
@@ -319,7 +321,7 @@ pub fn build_microvm_for_boot(
         machine_config: vm_resources.machine_config.clone(),
         boot_source_config: vm_resources.boot_source.config.clone(),
         shutdown_exit_code: None,
-        vm: vm.clone(),
+        vm,
         device_manager,
     };
     let vmm = Arc::new(Mutex::new(vmm));
@@ -333,14 +335,15 @@ pub fn build_microvm_for_boot(
         .for_each(|vcpu| vcpu.attach_debug_info(gdb_tx.clone()));
 
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
-    vm.start_vcpus(
-        vcpus,
-        seccomp_filters
-            .get("vcpu")
-            .ok_or_else(|| StartMicrovmError::MissingSeccompFilters("vcpu".to_string()))?
-            .clone(),
-    )
-    .map_err(VmmError::VcpuStart)?;
+    kvm_vm
+        .start_vcpus(
+            vcpus,
+            seccomp_filters
+                .get("vcpu")
+                .ok_or_else(|| StartMicrovmError::MissingSeccompFilters("vcpu".to_string()))?
+                .clone(),
+        )
+        .map_err(VmmError::VcpuStart)?;
     vmm.lock().unwrap().instance_info.state = VmState::Paused;
 
     #[cfg(feature = "gdb")]
@@ -499,19 +502,20 @@ pub fn build_microvm_from_snapshot(
 
     vm.set_uffd(uffd);
 
-    let vm = Arc::new(vm);
+    let kvm_vm = Arc::new(vm);
+    let vm = Vm::Kvm(kvm_vm.clone());
 
     // Restore devices states.
     // Restoring VMGenID injects an interrupt in the guest to notify it about the new generation
     // ID. As a result, we need to restore DeviceManager after restoring the KVM state, otherwise
     // the injected interrupt will be overwritten.
     let device_ctor_args = DeviceRestoreArgs {
-        mem: vm.guest_memory(),
-        vm: &vm,
+        mem: kvm_vm.guest_memory(),
+        vm: &kvm_vm,
         event_manager,
         vm_resources,
         instance_id: &instance_info.id,
-        vcpus_exit_evt: vm.vcpus_exit_evt(),
+        vcpus_exit_evt: kvm_vm.vcpus_exit_evt(),
     };
     #[allow(unused_mut)]
     let mut device_manager =
@@ -522,12 +526,12 @@ pub fn build_microvm_from_snapshot(
         machine_config: vm_resources.machine_config.clone(),
         boot_source_config: vm_resources.boot_source.config.clone(),
         shutdown_exit_code: None,
-        vm: vm.clone(),
+        vm,
         device_manager,
     };
 
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
-    vm.start_vcpus(
+    kvm_vm.start_vcpus(
         vcpus,
         seccomp_filters
             .get("vcpu")
@@ -596,7 +600,7 @@ fn setup_pvtime(
 
 fn attach_entropy_device(
     device_manager: &mut DeviceManager,
-    vm: &Arc<KvmVm>,
+    vm: &Vm,
     cmdline: &mut LoaderKernelCmdline,
     entropy_device: &Arc<Mutex<Entropy>>,
     event_manager: &mut EventManager,
@@ -635,15 +639,19 @@ fn allocate_virtio_mem_address(
 
 fn attach_virtio_mem_device(
     device_manager: &mut DeviceManager,
-    vm: &Arc<KvmVm>,
+    vm: &Vm,
     cmdline: &mut LoaderKernelCmdline,
     config: &MemoryHotplugConfig,
     event_manager: &mut EventManager,
     addr: GuestAddress,
 ) -> Result<(), StartMicrovmError> {
+    let kvm_vm = vm
+        .as_kvm()
+        .cloned()
+        .ok_or(AttachDeviceError::NotSupported)?;
     let virtio_mem = Arc::new(Mutex::new(
         VirtioMem::new(
-            Arc::clone(vm),
+            kvm_vm,
             addr,
             config.total_size_mib,
             config.block_size_mib,
@@ -666,7 +674,7 @@ fn attach_virtio_mem_device(
 
 fn attach_block_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Block>>> + Debug>(
     device_manager: &mut DeviceManager,
-    vm: &Arc<KvmVm>,
+    vm: &Vm,
     cmdline: &mut LoaderKernelCmdline,
     blocks: I,
     event_manager: &mut EventManager,
@@ -701,7 +709,7 @@ fn attach_block_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Block>>> + Debug>(
 
 fn attach_net_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Net>>> + Debug>(
     device_manager: &mut DeviceManager,
-    vm: &Arc<KvmVm>,
+    vm: &Vm,
     cmdline: &mut LoaderKernelCmdline,
     net_devices: I,
     event_manager: &mut EventManager,
@@ -723,11 +731,12 @@ fn attach_net_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Net>>> + Debug>(
 
 fn attach_pmem_devices(
     device_manager: &mut DeviceManager,
-    vm: &Arc<KvmVm>,
+    vm: &Vm,
     cmdline: &mut LoaderKernelCmdline,
     configs: &[PmemConfig],
     event_manager: &mut EventManager,
 ) -> Result<(), StartMicrovmError> {
+    let kvm_vm = vm.as_kvm().ok_or(AttachDeviceError::NotSupported)?;
     for (i, config) in configs.iter().enumerate() {
         if config.root_device {
             cmdline.insert_str(format!("root=/dev/pmem{i}"))?;
@@ -737,7 +746,7 @@ fn attach_pmem_devices(
             }
         }
         let id = config.id.clone();
-        let pmem = Pmem::new(vm.clone(), config.clone())?;
+        let pmem = Pmem::new(kvm_vm.clone(), config.clone())?;
         let device = Arc::new(Mutex::new(pmem));
 
         device_manager.attach_virtio_device(vm, id, device, cmdline, event_manager, false)?;
@@ -747,7 +756,7 @@ fn attach_pmem_devices(
 
 fn attach_unixsock_vsock_device(
     device_manager: &mut DeviceManager,
-    vm: &Arc<KvmVm>,
+    vm: &Vm,
     cmdline: &mut LoaderKernelCmdline,
     unix_vsock: &Arc<Mutex<Vsock<VsockUnixBackend>>>,
     event_manager: &mut EventManager,
@@ -759,11 +768,12 @@ fn attach_unixsock_vsock_device(
 
 fn attach_balloon_device(
     device_manager: &mut DeviceManager,
-    vm: &Arc<KvmVm>,
+    vm: &Vm,
     cmdline: &mut LoaderKernelCmdline,
     balloon: &Arc<Mutex<Balloon>>,
     event_manager: &mut EventManager,
 ) -> Result<(), AttachDeviceError> {
+    let _kvm_vm = vm.as_kvm().ok_or(AttachDeviceError::NotSupported)?;
     let id = String::from(balloon.lock().expect("Poisoned lock").id());
     // The device mutex mustn't be locked here otherwise it will deadlock.
     device_manager.attach_virtio_device(vm, id, balloon.clone(), cmdline, event_manager, false)
@@ -793,6 +803,7 @@ pub(crate) mod tests {
     use crate::vmm_config::pmem::{PmemBuilder, PmemConfig};
     use crate::vmm_config::vsock::tests::default_config;
     use crate::vmm_config::vsock::{VsockBuilder, VsockDeviceConfig};
+    use crate::vstate::vm::Vm;
     use crate::vstate::vm::tests::setup_vm_with_memory;
 
     #[derive(Debug)]
@@ -851,14 +862,14 @@ pub(crate) mod tests {
     pub(crate) fn default_vmm() -> Vmm {
         let mut vm = setup_vm_with_memory(mib_to_bytes(128));
 
-        vm.create_vcpus(1).unwrap();
+        let _ = vm.create_vcpus(1).unwrap();
 
         Vmm {
             instance_info: InstanceInfo::default(),
             machine_config: MachineConfig::default(),
             boot_source_config: BootSourceConfig::default(),
             shutdown_exit_code: None,
-            vm: Arc::new(vm),
+            vm: Vm::Kvm(Arc::new(vm)),
             device_manager: default_device_manager(),
         }
     }
@@ -1039,12 +1050,16 @@ pub(crate) mod tests {
 
     #[cfg(target_arch = "x86_64")]
     pub(crate) fn insert_vmgenid_device(vmm: &mut Vmm) {
-        vmm.device_manager.attach_vmgenid_device(&vmm.vm).unwrap();
+        vmm.device_manager
+            .attach_vmgenid_device(vmm.vm.as_kvm().unwrap())
+            .unwrap();
     }
 
     #[cfg(target_arch = "x86_64")]
     pub(crate) fn insert_vmclock_device(vmm: &mut Vmm) {
-        vmm.device_manager.attach_vmclock_device(&vmm.vm).unwrap();
+        vmm.device_manager
+            .attach_vmclock_device(vmm.vm.as_kvm().unwrap())
+            .unwrap();
     }
 
     pub(crate) fn insert_balloon_device(
@@ -1316,7 +1331,7 @@ pub(crate) mod tests {
 
         let res = vmm
             .device_manager
-            .attach_boot_timer_device(&vmm.vm, request_ts);
+            .attach_boot_timer_device(vmm.vm.as_kvm().unwrap(), request_ts);
         res.unwrap();
         assert!(vmm.device_manager.mmio_devices.boot_timer.is_some());
     }

--- a/src/vmm/src/device_manager/acpi.rs
+++ b/src/vmm/src/device_manager/acpi.rs
@@ -4,10 +4,10 @@
 #[cfg(target_arch = "x86_64")]
 use acpi_tables::{Aml, aml};
 
-use crate::Vm;
 use crate::devices::acpi::vmclock::{VmClock, VmClockError};
 use crate::devices::acpi::vmgenid::{VmGenId, VmGenIdError};
 use crate::vstate::memory::GuestMemoryMmap;
+use crate::vstate::vm::KvmVm;
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum ACPIDeviceError {
@@ -38,12 +38,12 @@ impl ACPIDeviceManager {
         }
     }
 
-    pub fn attach_vmgenid(&mut self, vm: &Vm) -> Result<(), ACPIDeviceError> {
+    pub fn attach_vmgenid(&mut self, vm: &KvmVm) -> Result<(), ACPIDeviceError> {
         self.vmgenid = Some(VmGenId::new(&mut vm.resource_allocator())?);
         Ok(())
     }
 
-    pub fn attach_vmclock(&mut self, vm: &Vm) -> Result<(), ACPIDeviceError> {
+    pub fn attach_vmclock(&mut self, vm: &KvmVm) -> Result<(), ACPIDeviceError> {
         self.vmclock = Some(VmClock::new(&mut vm.resource_allocator())?);
         Ok(())
     }
@@ -56,13 +56,13 @@ impl ACPIDeviceManager {
         self.vmclock.as_ref().expect("Missing VMClock device")
     }
 
-    pub fn activate_vmgenid(&self, vm: &Vm) -> Result<(), ACPIDeviceError> {
+    pub fn activate_vmgenid(&self, vm: &KvmVm) -> Result<(), ACPIDeviceError> {
         vm.register_irq(&self.vmgenid().interrupt_evt, self.vmgenid().gsi)?;
         self.vmgenid().activate(vm.guest_memory())?;
         Ok(())
     }
 
-    pub fn activate_vmclock(&self, vm: &Vm) -> Result<(), ACPIDeviceError> {
+    pub fn activate_vmclock(&self, vm: &KvmVm) -> Result<(), ACPIDeviceError> {
         vm.register_irq(&self.vmclock().interrupt_evt, self.vmclock().gsi)?;
         self.vmclock().activate(vm.guest_memory())?;
         Ok(())

--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_register_legacy_devices() {
-        let (_, vm) = setup_vm_with_memory(0x1000);
+        let vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
         let mut ldm = PortIODeviceManager {
             stdio_serial: Arc::new(Mutex::new(SerialDevice {

--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -11,9 +11,9 @@ use std::sync::{Arc, Mutex};
 use acpi_tables::aml::AmlError;
 use acpi_tables::{Aml, aml};
 
-use crate::Vm;
 use crate::devices::legacy::{I8042Device, SerialDevice};
 use crate::vstate::bus::BusError;
+use crate::vstate::vm::KvmVm;
 
 /// Errors corresponding to the `PortIODeviceManager`.
 #[derive(Debug, derive_more::From, thiserror::Error, displaydoc::Display)]
@@ -52,7 +52,7 @@ impl PortIODeviceManager {
     const I8042_KDB_DATA_REGISTER_SIZE: u64 = 0x5;
 
     /// Register supported legacy devices.
-    pub fn register_devices(&mut self, vm: &Vm) -> Result<(), LegacyDeviceError> {
+    pub fn register_devices(&mut self, vm: &KvmVm) -> Result<(), LegacyDeviceError> {
         let io_bus = &vm.pio_bus;
         io_bus.insert(
             self.stdio_serial.clone(),

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -595,7 +595,7 @@ pub(crate) mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem = multi_region_mem_raw(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        let mut vm = KvmVm::new(&kvm).unwrap();
+        let mut vm = KvmVm::new(kvm).unwrap();
         vm.register_dram_memory_regions(guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
 
@@ -649,7 +649,7 @@ pub(crate) mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem = multi_region_mem_raw(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        let mut vm = KvmVm::new(&kvm).unwrap();
+        let mut vm = KvmVm::new(kvm).unwrap();
         vm.register_dram_memory_regions(guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
 
@@ -705,7 +705,7 @@ pub(crate) mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem = multi_region_mem_raw(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        let mut vm = KvmVm::new(&kvm).unwrap();
+        let mut vm = KvmVm::new(kvm).unwrap();
         vm.register_dram_memory_regions(guest_mem).unwrap();
 
         #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -17,6 +17,7 @@ use linux_loader::cmdline as kernel_cmdline;
 use serde::{Deserialize, Serialize};
 use vm_allocator::AllocPolicy;
 
+use crate::EventManager;
 use crate::arch::BOOT_DEVICE_MEM_START;
 #[cfg(target_arch = "aarch64")]
 use crate::arch::{RTC_MEM_START, SERIAL_MEM_START};
@@ -31,7 +32,7 @@ use crate::vstate::bus::{Bus, BusError};
 #[cfg(target_arch = "x86_64")]
 use crate::vstate::memory::GuestAddress;
 use crate::vstate::resources::ResourceAllocator;
-use crate::{EventManager, Vm};
+use crate::vstate::vm::KvmVm;
 
 /// Errors for MMIO device manager.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -175,7 +176,7 @@ impl MMIODeviceManager {
     /// Register a virtio-over-MMIO device to be used via MMIO transport at a specific slot.
     pub fn register_mmio_virtio(
         &mut self,
-        vm: &Vm,
+        vm: &KvmVm,
         device_id: String,
         mut device: MMIODevice<MmioTransport>,
         event_manager: &mut EventManager,
@@ -240,7 +241,7 @@ impl MMIODeviceManager {
     /// to the boot cmdline.
     pub fn register_mmio_virtio_for_boot(
         &mut self,
-        vm: &Vm,
+        vm: &KvmVm,
         device_id: String,
         mmio_device: MmioTransport,
         event_manager: &mut EventManager,
@@ -273,7 +274,7 @@ impl MMIODeviceManager {
     /// otherwise allocate a new MMIO resources for it.
     pub fn register_mmio_serial(
         &mut self,
-        vm: &Vm,
+        vm: &KvmVm,
         serial: Arc<Mutex<SerialDevice>>,
         device_info_opt: Option<MMIODeviceInfo>,
     ) -> Result<(), MmioError> {
@@ -333,7 +334,7 @@ impl MMIODeviceManager {
     /// given as parameter, otherwise allocate a new MMIO resources for it.
     pub fn register_mmio_rtc(
         &mut self,
-        vm: &Vm,
+        vm: &KvmVm,
         rtc: Arc<Mutex<RTCDevice>>,
         device_info_opt: Option<MMIODeviceInfo>,
     ) -> Result<(), MmioError> {
@@ -461,14 +462,14 @@ pub(crate) mod tests {
     use crate::test_utils::multi_region_mem_raw;
     use crate::vstate::kvm::Kvm;
     use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
-    use crate::{Vm, arch, impl_device_type};
+    use crate::{arch, impl_device_type};
 
     const QUEUE_SIZES: &[u16] = &[64];
 
     impl MMIODeviceManager {
         pub(crate) fn register_virtio_test_device(
             &mut self,
-            vm: &Vm,
+            vm: &KvmVm,
             guest_mem: GuestMemoryMmap,
             device: Arc<Mutex<dyn VirtioDevice>>,
             event_manager: &mut EventManager,
@@ -594,7 +595,7 @@ pub(crate) mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem = multi_region_mem_raw(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        let mut vm = Vm::new(&kvm).unwrap();
+        let mut vm = KvmVm::new(&kvm).unwrap();
         vm.register_dram_memory_regions(guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
 
@@ -648,7 +649,7 @@ pub(crate) mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem = multi_region_mem_raw(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        let mut vm = Vm::new(&kvm).unwrap();
+        let mut vm = KvmVm::new(&kvm).unwrap();
         vm.register_dram_memory_regions(guest_mem).unwrap();
         let mut device_manager = MMIODeviceManager::new();
 
@@ -704,7 +705,7 @@ pub(crate) mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem = multi_region_mem_raw(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]);
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        let mut vm = Vm::new(&kvm).unwrap();
+        let mut vm = KvmVm::new(&kvm).unwrap();
         vm.register_dram_memory_regions(guest_mem).unwrap();
 
         #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -23,6 +23,7 @@ use utils::time::TimestampUs;
 use vm_superio::serial;
 use vmm_sys_util::eventfd::EventFd;
 
+use crate::EventManager;
 use crate::device_manager::acpi::ACPIDeviceError;
 #[cfg(target_arch = "x86_64")]
 use crate::devices::legacy::I8042Device;
@@ -58,7 +59,7 @@ use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig, NetworkInterfac
 use crate::vmm_config::pmem::{PmemConfig, PmemConfigError};
 use crate::vstate::bus::BusError;
 use crate::vstate::memory::GuestMemoryMmap;
-use crate::{EventManager, Vm};
+use crate::vstate::vm::KvmVm;
 
 /// ACPI device manager.
 pub mod acpi;
@@ -196,7 +197,7 @@ impl DeviceManager {
     fn create_legacy_devices(
         event_manager: &mut EventManager,
         vcpus_exit_evt: &EventFd,
-        vm: &Vm,
+        vm: &KvmVm,
         serial_output: Option<&PathBuf>,
         serial_state: Option<&serial::SerialState>,
         serial_rate_limiter: Option<TokenBucket>,
@@ -227,7 +228,7 @@ impl DeviceManager {
     pub fn new(
         event_manager: &mut EventManager,
         vcpus_exit_evt: &EventFd,
-        vm: &Vm,
+        vm: &KvmVm,
         serial_output: Option<&PathBuf>,
         serial_rate_limiter: Option<TokenBucket>,
     ) -> Result<Self, DeviceManagerCreateError> {
@@ -255,7 +256,7 @@ impl DeviceManager {
         T: 'static + VirtioDevice + MutEventSubscriber + Debug,
     >(
         &mut self,
-        vm: &Vm,
+        vm: &KvmVm,
         id: String,
         device: Arc<Mutex<T>>,
         cmdline: &mut Cmdline,
@@ -275,7 +276,7 @@ impl DeviceManager {
     /// Attaches a VirtioDevice device to the device manager and event manager.
     pub(crate) fn attach_virtio_device<T: 'static + VirtioDevice + MutEventSubscriber + Debug>(
         &mut self,
-        vm: &Arc<Vm>,
+        vm: &Arc<KvmVm>,
         id: String,
         device: Arc<Mutex<T>>,
         cmdline: &mut Cmdline,
@@ -295,7 +296,7 @@ impl DeviceManager {
     /// Attaches a [`BootTimer`] to the VM
     pub(crate) fn attach_boot_timer_device(
         &mut self,
-        vm: &Vm,
+        vm: &KvmVm,
         request_ts: TimestampUs,
     ) -> Result<(), AttachDeviceError> {
         let boot_timer = Arc::new(Mutex::new(BootTimer::new(request_ts)));
@@ -306,13 +307,13 @@ impl DeviceManager {
         Ok(())
     }
 
-    pub(crate) fn attach_vmgenid_device(&mut self, vm: &Vm) -> Result<(), AttachDeviceError> {
+    pub(crate) fn attach_vmgenid_device(&mut self, vm: &KvmVm) -> Result<(), AttachDeviceError> {
         self.acpi_devices.attach_vmgenid(vm)?;
         self.acpi_devices.activate_vmgenid(vm)?;
         Ok(())
     }
 
-    pub(crate) fn attach_vmclock_device(&mut self, vm: &Vm) -> Result<(), AttachDeviceError> {
+    pub(crate) fn attach_vmclock_device(&mut self, vm: &KvmVm) -> Result<(), AttachDeviceError> {
         self.acpi_devices.attach_vmclock(vm)?;
         self.acpi_devices.activate_vmclock(vm)?;
         Ok(())
@@ -321,7 +322,7 @@ impl DeviceManager {
     #[cfg(target_arch = "aarch64")]
     pub(crate) fn attach_legacy_devices_aarch64(
         &mut self,
-        vm: &Vm,
+        vm: &KvmVm,
         event_manager: &mut EventManager,
         cmdline: &mut Cmdline,
         serial_out_path: Option<&PathBuf>,
@@ -352,7 +353,7 @@ impl DeviceManager {
     }
 
     /// Enables PCIe support for Firecracker devices
-    pub fn enable_pci(&mut self, vm: &Arc<Vm>) -> Result<(), PciManagerError> {
+    pub fn enable_pci(&mut self, vm: &Arc<KvmVm>) -> Result<(), PciManagerError> {
         self.pci_devices.attach_pci_segment(vm)
     }
 
@@ -477,7 +478,7 @@ impl DeviceManager {
     /// Attaches a device after VM start
     pub fn hotplug_device(
         &mut self,
-        vm: Arc<Vm>,
+        vm: Arc<KvmVm>,
         config: HotplugDeviceConfig,
         event_manager: &mut EventManager,
     ) -> Result<(), VmmActionError> {
@@ -519,7 +520,7 @@ impl DeviceManager {
     }
 
     fn hotplug_make_pmem(
-        vm: Arc<Vm>,
+        vm: Arc<KvmVm>,
         config: PmemConfig,
     ) -> Result<Arc<Mutex<dyn VirtioDevice>>, VmmActionError> {
         if config.root_device {
@@ -566,7 +567,7 @@ impl DeviceManager {
     /// Detaches a device after VM start
     pub fn hot_unplug_device(
         &mut self,
-        vm: Arc<Vm>,
+        vm: Arc<KvmVm>,
         device_id: VirtioDeviceId,
         event_manager: &mut EventManager,
     ) -> Result<(), VmmActionError> {
@@ -679,7 +680,7 @@ pub enum DeviceManagerPersistError {
 
 pub struct DeviceRestoreArgs<'a> {
     pub mem: &'a GuestMemoryMmap,
-    pub vm: &'a Arc<Vm>,
+    pub vm: &'a Arc<KvmVm>,
     pub event_manager: &'a mut EventManager,
     pub vcpus_exit_evt: &'a EventFd,
     pub vm_resources: &'a mut VmResources,

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -59,7 +59,7 @@ use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig, NetworkInterfac
 use crate::vmm_config::pmem::{PmemConfig, PmemConfigError};
 use crate::vstate::bus::BusError;
 use crate::vstate::memory::GuestMemoryMmap;
-use crate::vstate::vm::KvmVm;
+use crate::vstate::vm::{KvmVm, Vm};
 
 /// ACPI device manager.
 pub mod acpi;
@@ -101,6 +101,8 @@ pub enum AttachDeviceError {
     CreateSerial(#[from] std::io::Error),
     /// Error attach PCI device: {0}
     PciTransport(#[from] PciManagerError),
+    /// Operation not supported on this VM type
+    NotSupported,
 }
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -276,18 +278,29 @@ impl DeviceManager {
     /// Attaches a VirtioDevice device to the device manager and event manager.
     pub(crate) fn attach_virtio_device<T: 'static + VirtioDevice + MutEventSubscriber + Debug>(
         &mut self,
-        vm: &Arc<KvmVm>,
+        vm: &Vm,
         id: String,
         device: Arc<Mutex<T>>,
         cmdline: &mut Cmdline,
         event_manager: &mut EventManager,
         is_vhost_user: bool,
     ) -> Result<(), AttachDeviceError> {
+        let kvm_vm = vm
+            .as_kvm()
+            .cloned()
+            .ok_or(AttachDeviceError::NotSupported)?;
         if self.is_pci_enabled() {
             self.pci_devices
-                .attach_pci_virtio_device(vm, id, device, event_manager)?;
+                .attach_pci_virtio_device(&kvm_vm, id, device, event_manager)?;
         } else {
-            self.attach_mmio_virtio_device(vm, id, device, cmdline, event_manager, is_vhost_user)?;
+            self.attach_mmio_virtio_device(
+                &kvm_vm,
+                id,
+                device,
+                cmdline,
+                event_manager,
+                is_vhost_user,
+            )?;
         }
 
         Ok(())
@@ -822,7 +835,13 @@ pub(crate) mod tests {
         let mut cmdline = Cmdline::new(4096).unwrap();
         let mut event_manager = EventManager::new().unwrap();
         vmm.device_manager
-            .attach_legacy_devices_aarch64(&vmm.vm, &mut event_manager, &mut cmdline, None, None)
+            .attach_legacy_devices_aarch64(
+                vmm.vm.as_kvm().unwrap(),
+                &mut event_manager,
+                &mut cmdline,
+                None,
+                None,
+            )
             .unwrap();
         assert!(vmm.device_manager.mmio_devices.rtc.is_some());
         assert!(vmm.device_manager.mmio_devices.serial.is_none());
@@ -830,7 +849,13 @@ pub(crate) mod tests {
         let mut vmm = default_vmm();
         cmdline.insert("console", "/dev/blah").unwrap();
         vmm.device_manager
-            .attach_legacy_devices_aarch64(&vmm.vm, &mut event_manager, &mut cmdline, None, None)
+            .attach_legacy_devices_aarch64(
+                vmm.vm.as_kvm().unwrap(),
+                &mut event_manager,
+                &mut cmdline,
+                None,
+                None,
+            )
             .unwrap();
         assert!(vmm.device_manager.mmio_devices.rtc.is_some());
         assert!(vmm.device_manager.mmio_devices.serial.is_some());
@@ -872,7 +897,9 @@ pub(crate) mod tests {
     fn test_hotplug_block() {
         let mut evt_manager = EventManager::new().unwrap();
         let mut vmm = default_vmm();
-        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        vmm.device_manager
+            .enable_pci(vmm.vm.as_kvm().unwrap())
+            .unwrap();
         let f = TempFile::new().unwrap();
 
         // Successful case
@@ -960,7 +987,9 @@ pub(crate) mod tests {
     #[test]
     fn test_hotplug_pmem() {
         let mut vmm = default_vmm();
-        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        vmm.device_manager
+            .enable_pci(vmm.vm.as_kvm().unwrap())
+            .unwrap();
         let mut evt_manager = EventManager::new().unwrap();
         let f = TempFile::new().unwrap();
         f.as_file().set_len(0x1000).unwrap();
@@ -1019,7 +1048,9 @@ pub(crate) mod tests {
     #[test]
     fn test_hotplug_net() {
         let mut vmm = default_vmm();
-        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        vmm.device_manager
+            .enable_pci(vmm.vm.as_kvm().unwrap())
+            .unwrap();
         let mut evt_manager = EventManager::new().unwrap();
 
         let mac = "AA:FC:00:00:00:01";
@@ -1078,7 +1109,9 @@ pub(crate) mod tests {
     fn test_unplug_root_block() {
         let mut evt_manager = EventManager::new().unwrap();
         let mut vmm = default_vmm();
-        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        vmm.device_manager
+            .enable_pci(vmm.vm.as_kvm().unwrap())
+            .unwrap();
         let f = TempFile::new().unwrap();
 
         // Simulate a root block device added pre-boot by attaching it
@@ -1089,7 +1122,7 @@ pub(crate) mod tests {
         vmm.device_manager
             .pci_devices
             .attach_pci_virtio_device(
-                &vmm.vm,
+                vmm.vm.as_kvm().unwrap(),
                 "rootfs".to_string(),
                 Arc::new(Mutex::new(block)),
                 &mut evt_manager,
@@ -1108,7 +1141,9 @@ pub(crate) mod tests {
     fn test_unplug_root_pmem() {
         let mut evt_manager = EventManager::new().unwrap();
         let mut vmm = default_vmm();
-        vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+        vmm.device_manager
+            .enable_pci(vmm.vm.as_kvm().unwrap())
+            .unwrap();
         let f = TempFile::new().unwrap();
         f.as_file().set_len(0x1000).unwrap();
 
@@ -1121,11 +1156,11 @@ pub(crate) mod tests {
             read_only: false,
             ..Default::default()
         };
-        let pmem = Pmem::new(vmm.vm.clone(), cfg).unwrap();
+        let pmem = Pmem::new(vmm.vm.as_kvm().unwrap().clone(), cfg).unwrap();
         vmm.device_manager
             .pci_devices
             .attach_pci_virtio_device(
-                &vmm.vm,
+                vmm.vm.as_kvm().unwrap(),
                 "pmem_root".to_string(),
                 Arc::new(Mutex::new(pmem)),
                 &mut evt_manager,

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -10,6 +10,7 @@ use event_manager::{MutEventSubscriber, SubscriberOps};
 use serde::{Deserialize, Serialize};
 
 use super::persist::MmdsState;
+use crate::EventManager;
 use crate::device_manager::DevicePersistError;
 use crate::devices::pci::PciSegment;
 use crate::devices::virtio::balloon::Balloon;
@@ -41,7 +42,7 @@ use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
 use crate::vstate::bus::BusError;
 use crate::vstate::interrupts::InterruptError;
 use crate::vstate::memory::GuestMemoryMmap;
-use crate::{EventManager, Vm};
+use crate::vstate::vm::KvmVm;
 
 #[derive(Debug, Default)]
 pub struct PciDevices {
@@ -72,7 +73,7 @@ impl PciDevices {
         Default::default()
     }
 
-    pub fn attach_pci_segment(&mut self, vm: &Arc<Vm>) -> Result<(), PciManagerError> {
+    pub fn attach_pci_segment(&mut self, vm: &Arc<KvmVm>) -> Result<(), PciManagerError> {
         // We only support a single PCIe segment. Calling this function twice is a Firecracker
         // internal error.
         assert!(self.pci_segment.is_none());
@@ -86,7 +87,7 @@ impl PciDevices {
     }
 
     fn register_bars_with_bus(
-        vm: &Vm,
+        vm: &KvmVm,
         virtio_device: &Arc<Mutex<VirtioPciDevice>>,
     ) -> Result<(), PciManagerError> {
         let virtio_device_locked = virtio_device.lock().expect("Poisoned lock");
@@ -107,7 +108,7 @@ impl PciDevices {
 
     fn attach_common(
         &mut self,
-        vm: &Arc<Vm>,
+        vm: &Arc<KvmVm>,
         device_type: VirtioDeviceType,
         id: String,
         sbdf: PciSBDF,
@@ -139,7 +140,7 @@ impl PciDevices {
 
     pub(crate) fn attach_pci_virtio_device(
         &mut self,
-        vm: &Arc<Vm>,
+        vm: &Arc<KvmVm>,
         id: String,
         device: Arc<Mutex<dyn VirtioDevice>>,
         event_manager: &mut EventManager,
@@ -156,7 +157,7 @@ impl PciDevices {
         let msix_num =
             u16::try_from(device.lock().expect("Poisoned lock").queues().len() + 1).unwrap();
 
-        let msix_vectors = Vm::create_msix_group(vm.clone(), msix_num)?;
+        let msix_vectors = KvmVm::create_msix_group(vm.clone(), msix_num)?;
 
         // Create the transport
         let mut virtio_device =
@@ -175,7 +176,7 @@ impl PciDevices {
 
     fn restore_pci_device<T: 'static + VirtioDevice + MutEventSubscriber + Debug>(
         &mut self,
-        vm: &Arc<Vm>,
+        vm: &Arc<KvmVm>,
         device: Arc<Mutex<T>>,
         device_id: &str,
         transport_state: &VirtioPciDeviceState,
@@ -256,7 +257,7 @@ pub struct PciDevicesState {
 }
 
 pub struct PciDevicesConstructorArgs<'a> {
-    pub vm: &'a Arc<Vm>,
+    pub vm: &'a Arc<KvmVm>,
     pub mem: &'a GuestMemoryMmap,
     pub vm_resources: &'a mut VmResources,
     pub instance_id: &'a str,
@@ -731,7 +732,7 @@ mod tests {
         let mut event_manager = EventManager::new().expect("Unable to create EventManager");
         // Keep in mind we are re-creating here an empty DeviceManager. Restoring later on
         // will create a new PciDevices manager different than vmm.pci_devices. We're doing
-        // this to avoid restoring the whole Vmm, since what we really need from Vmm is the Vm
+        // this to avoid restoring the whole Vmm, since what we really need from Vmm is the KvmVm
         // object and calling default_vmm() is the easiest way to create one.
         let vmm = default_vmm();
         let device_manager_state: device_manager::DevicesState =

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -108,7 +108,7 @@ impl PciDevices {
 
     fn attach_common(
         &mut self,
-        vm: &Arc<KvmVm>,
+        vm: &KvmVm,
         device_type: VirtioDeviceType,
         id: String,
         sbdf: PciSBDF,
@@ -650,7 +650,9 @@ mod tests {
         {
             let mut event_manager = EventManager::new().expect("Unable to create EventManager");
             let mut vmm = default_vmm();
-            vmm.device_manager.enable_pci(&vmm.vm).unwrap();
+            vmm.device_manager
+                .enable_pci(&vmm.vm.as_kvm().unwrap().clone())
+                .unwrap();
             let mut cmdline = default_kernel_cmdline();
 
             // Add a balloon device.
@@ -738,9 +740,10 @@ mod tests {
         let device_manager_state: device_manager::DevicesState =
             bitcode::deserialize(&serialized_data).unwrap();
         let vm_resources = &mut VmResources::default();
+        let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let restore_args = PciDevicesConstructorArgs {
-            vm: &vmm.vm,
-            mem: vmm.vm.guest_memory(),
+            vm: &kvm_vm,
+            mem: kvm_vm.guest_memory(),
             vm_resources,
             instance_id: "microvm-id",
             event_manager: &mut event_manager,

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::acpi::ACPIDeviceManager;
 use super::mmio::*;
+use crate::EventManager;
 #[cfg(target_arch = "aarch64")]
 use crate::arch::DeviceType;
 use crate::device_manager::DevicePersistError;
@@ -42,7 +43,7 @@ use crate::resources::VmResources;
 use crate::snapshot::Persist;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
 use crate::vstate::memory::GuestMemoryMmap;
-use crate::{EventManager, Vm};
+use crate::vstate::vm::KvmVm;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct SerialState {
@@ -147,7 +148,7 @@ pub struct DeviceStates {
 
 pub struct MMIODevManagerConstructorArgs<'a> {
     pub mem: &'a GuestMemoryMmap,
-    pub vm: &'a Arc<Vm>,
+    pub vm: &'a Arc<KvmVm>,
     pub event_manager: &'a mut EventManager,
     pub vm_resources: &'a mut VmResources,
     pub instance_id: &'a str,
@@ -174,7 +175,7 @@ pub struct ACPIDeviceManagerState {
 
 impl<'a> Persist<'a> for ACPIDeviceManager {
     type State = ACPIDeviceManagerState;
-    type ConstructorArgs = &'a Vm;
+    type ConstructorArgs = &'a KvmVm;
     type Error = ACPIDeviceError;
 
     fn save(&self) -> Self::State {

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -765,9 +765,10 @@ mod tests {
         let device_manager_state: device_manager::DevicesState =
             bitcode::deserialize(&serialized_data).unwrap();
         let vm_resources = &mut VmResources::default();
+        let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let restore_args = MMIODevManagerConstructorArgs {
-            mem: vmm.vm.guest_memory(),
-            vm: &vmm.vm,
+            mem: kvm_vm.guest_memory(),
+            vm: &kvm_vm,
             event_manager: &mut event_manager,
             vm_resources,
             instance_id: "microvm-id",

--- a/src/vmm/src/devices/acpi/vmclock.rs
+++ b/src/vmm/src/devices/acpi/vmclock.rs
@@ -12,7 +12,6 @@ use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryError};
 use vm_superio::Trigger;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::Vm;
 use crate::devices::acpi::generated::vmclock_abi::{
     VMCLOCK_COUNTER_INVALID, VMCLOCK_FLAG_NOTIFICATION_PRESENT,
     VMCLOCK_FLAG_VM_GEN_COUNTER_PRESENT, VMCLOCK_MAGIC, VMCLOCK_STATUS_UNKNOWN, vmclock_abi,
@@ -225,7 +224,6 @@ mod tests {
     use vm_memory::{Bytes, GuestAddress};
     use vmm_sys_util::tempfile::TempFile;
 
-    use crate::Vm;
     #[cfg(target_arch = "x86_64")]
     use crate::arch::x86_64::layout;
     use crate::arch::{self, Kvm};

--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -17,7 +17,7 @@ use acpi_tables::{Aml, aml};
 use uuid::Uuid;
 use vm_allocator::AddressAllocator;
 
-use crate::arch::{ArchVm as Vm, PCI_MMCONFIG_START, PCI_MMIO_CONFIG_SIZE_PER_SEGMENT};
+use crate::arch::{KvmVm, PCI_MMCONFIG_START, PCI_MMIO_CONFIG_SIZE_PER_SEGMENT};
 use crate::logger::info;
 use crate::pci::PciSBDF;
 #[cfg(target_arch = "x86_64")]
@@ -69,7 +69,7 @@ impl std::fmt::Debug for PciSegment {
 }
 
 impl PciSegment {
-    fn build(id: u16, vm: &Arc<Vm>, pci_irq_slots: &[u8; 32]) -> Result<PciSegment, BusError> {
+    fn build(id: u16, vm: &Arc<KvmVm>, pci_irq_slots: &[u8; 32]) -> Result<PciSegment, BusError> {
         let pci_root = PciRoot::new(None);
         let pci_bus = Arc::new(Mutex::new(PciBus::new(pci_root)));
 
@@ -113,11 +113,9 @@ impl PciSegment {
     #[cfg(target_arch = "x86_64")]
     pub(crate) fn new(
         id: u16,
-        vm: &Arc<Vm>,
+        vm: &Arc<KvmVm>,
         pci_irq_slots: &[u8; 32],
     ) -> Result<PciSegment, BusError> {
-        use crate::Vm;
-
         let mut segment = Self::build(id, vm, pci_irq_slots)?;
         let pci_config_io = Arc::new(Mutex::new(PciConfigIo::new(Arc::clone(&segment.pci_bus))));
 
@@ -147,7 +145,7 @@ impl PciSegment {
     #[cfg(target_arch = "aarch64")]
     pub(crate) fn new(
         id: u16,
-        vm: &Arc<Vm>,
+        vm: &Arc<KvmVm>,
         pci_irq_slots: &[u8; 32],
     ) -> Result<PciSegment, BusError> {
         let segment = Self::build(id, vm, pci_irq_slots)?;

--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -17,7 +17,7 @@ use acpi_tables::{Aml, aml};
 use uuid::Uuid;
 use vm_allocator::AddressAllocator;
 
-use crate::arch::{KvmVm, PCI_MMCONFIG_START, PCI_MMIO_CONFIG_SIZE_PER_SEGMENT};
+use crate::arch::{PCI_MMCONFIG_START, PCI_MMIO_CONFIG_SIZE_PER_SEGMENT};
 use crate::logger::info;
 use crate::pci::PciSBDF;
 #[cfg(target_arch = "x86_64")]
@@ -25,6 +25,7 @@ use crate::pci::bus::{PCI_CONFIG_IO_PORT, PCI_CONFIG_IO_PORT_SIZE};
 use crate::pci::bus::{PciBus, PciConfigIo, PciConfigMmio, PciRoot, PciRootError};
 use crate::vstate::bus::{BusDeviceSync, BusError};
 use crate::vstate::resources::ResourceAllocator;
+use crate::vstate::vm::KvmVm;
 
 pub struct PciSegment {
     pub(crate) id: u16,
@@ -467,8 +468,9 @@ mod tests {
     #[test]
     fn test_pci_segment_build() {
         let vmm = default_vmm();
+        let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let pci_irq_slots = &[0u8; 32];
-        let pci_segment = PciSegment::new(0, &vmm.vm, pci_irq_slots).unwrap();
+        let pci_segment = PciSegment::new(0, &kvm_vm, pci_irq_slots).unwrap();
 
         assert_eq!(pci_segment.id, 0);
         assert_eq!(
@@ -498,13 +500,14 @@ mod tests {
     #[test]
     fn test_io_bus() {
         let vmm = default_vmm();
+        let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let pci_irq_slots = &[0u8; 32];
-        let pci_segment = PciSegment::new(0, &vmm.vm, pci_irq_slots).unwrap();
+        let pci_segment = PciSegment::new(0, &kvm_vm, pci_irq_slots).unwrap();
 
         let mut data = [0u8; u64_to_usize(PCI_CONFIG_IO_PORT_SIZE)];
-        vmm.vm.pio_bus.read(PCI_CONFIG_IO_PORT, &mut data).unwrap();
+        kvm_vm.pio_bus.read(PCI_CONFIG_IO_PORT, &mut data).unwrap();
 
-        vmm.vm
+        kvm_vm
             .pio_bus
             .read(PCI_CONFIG_IO_PORT + PCI_CONFIG_IO_PORT_SIZE, &mut data)
             .unwrap_err();
@@ -513,17 +516,18 @@ mod tests {
     #[test]
     fn test_mmio_bus() {
         let vmm = default_vmm();
+        let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let pci_irq_slots = &[0u8; 32];
-        let pci_segment = PciSegment::new(0, &vmm.vm, pci_irq_slots).unwrap();
+        let pci_segment = PciSegment::new(0, &kvm_vm, pci_irq_slots).unwrap();
 
         let mut data = [0u8; u64_to_usize(PCI_MMIO_CONFIG_SIZE_PER_SEGMENT)];
 
-        vmm.vm
+        kvm_vm
             .common
             .mmio_bus
             .read(pci_segment.mmio_config_address, &mut data)
             .unwrap();
-        vmm.vm
+        kvm_vm
             .common
             .mmio_bus
             .read(
@@ -536,8 +540,9 @@ mod tests {
     #[test]
     fn test_next_device_bdf() {
         let vmm = default_vmm();
+        let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let pci_irq_slots = &[0u8; 32];
-        let pci_segment = PciSegment::new(0, &vmm.vm, pci_irq_slots).unwrap();
+        let pci_segment = PciSegment::new(0, &kvm_vm, pci_irq_slots).unwrap();
 
         // Start checking from device id 1, since 0 is allocated to the Root port.
         for dev_id in 1..32 {

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -28,14 +28,14 @@ use crate::devices::virtio::queue::{
     DescriptorChain, FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue, QueueError,
 };
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
+use crate::impl_device_type;
 use crate::logger::{IncMetric, debug, error, info};
 use crate::utils::{bytes_to_mib, mib_to_bytes, u64_to_usize, usize_to_u64};
 use crate::vstate::interrupts::InterruptError;
 use crate::vstate::memory::{
     ByteValued, GuestMemoryExtension, GuestMemoryMmap, GuestRegionMmap, GuestRegionType,
 };
-use crate::vstate::vm::VmError;
-use crate::{Vm, impl_device_type};
+use crate::vstate::vm::{KvmVm, VmError};
 
 // SAFETY: virtio_mem_config only contains plain data types
 unsafe impl ByteValued for virtio_mem_config {}
@@ -97,7 +97,7 @@ pub struct VirtioMem {
     pub(crate) slot_size: usize,
     // Bitmap to track which blocks are plugged
     pub(crate) plugged_blocks: BitVec,
-    vm: Arc<Vm>,
+    vm: Arc<KvmVm>,
 }
 
 /// Memory hotplug device status information.
@@ -118,7 +118,7 @@ pub struct VirtioMemStatus {
 
 impl VirtioMem {
     pub fn new(
-        vm: Arc<Vm>,
+        vm: Arc<KvmVm>,
         addr: GuestAddress,
         total_size_mib: usize,
         block_size_mib: usize,
@@ -143,7 +143,7 @@ impl VirtioMem {
     }
 
     pub fn from_state(
-        vm: Arc<Vm>,
+        vm: Arc<KvmVm>,
         queues: Vec<Queue>,
         config: virtio_mem_config,
         slot_size: usize,

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -714,7 +714,7 @@ pub(crate) mod test_utils {
     }
 
     pub(crate) fn default_virtio_mem() -> VirtioMem {
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         let addr = GuestAddress(512 << 30);
         vm.register_hotpluggable_memory_region(
             memory::anonymous(
@@ -769,7 +769,7 @@ mod tests {
 
     #[test]
     fn test_from_state() {
-        let (_, vm) = setup_vm_with_memory(0x1000);
+        let vm = setup_vm_with_memory(0x1000);
         let vm = Arc::new(vm);
         let queues = vec![Queue::new(FIRECRACKER_MAX_QUEUE_SIZE); MEM_NUM_QUEUES];
         let addr = 512 << 30;

--- a/src/vmm/src/devices/virtio/mem/persist.rs
+++ b/src/vmm/src/devices/virtio/mem/persist.rs
@@ -9,7 +9,6 @@ use bitvec::vec::BitVec;
 use serde::{Deserialize, Serialize};
 use vm_memory::Address;
 
-use crate::Vm;
 use crate::devices::virtio::device::VirtioDeviceType;
 use crate::devices::virtio::generated::virtio_ids::VIRTIO_ID_MEM;
 use crate::devices::virtio::generated::virtio_mem::virtio_mem_config;
@@ -19,6 +18,7 @@ use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
 use crate::snapshot::Persist;
 use crate::utils::usize_to_u64;
 use crate::vstate::memory::{GuestMemoryMmap, GuestRegionMmap};
+use crate::vstate::vm::KvmVm;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VirtioMemState {
@@ -34,11 +34,11 @@ pub struct VirtioMemState {
 
 #[derive(Debug)]
 pub struct VirtioMemConstructorArgs {
-    vm: Arc<Vm>,
+    vm: Arc<KvmVm>,
 }
 
 impl VirtioMemConstructorArgs {
-    pub fn new(vm: Arc<Vm>) -> Self {
+    pub fn new(vm: Arc<KvmVm>) -> Self {
         Self { vm }
     }
 }

--- a/src/vmm/src/devices/virtio/mem/persist.rs
+++ b/src/vmm/src/devices/virtio/mem/persist.rs
@@ -137,7 +137,7 @@ mod tests {
         let state = original_dev.save();
 
         // Create a "new" VM for restore
-        let (_, vm) = setup_vm_with_memory(0x1000);
+        let vm = setup_vm_with_memory(0x1000);
         let vm = Arc::new(vm);
         let constructor_args = VirtioMemConstructorArgs::new(vm);
         let restored_dev = VirtioMem::restore(constructor_args, &state).unwrap();

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -608,7 +608,7 @@ mod tests {
     #[test]
     fn test_from_config() {
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Arc::new(KvmVm::new(&kvm).unwrap());
+        let vm = Arc::new(KvmVm::new(kvm).unwrap());
 
         let config = PmemConfig {
             id: "1".into(),
@@ -650,7 +650,7 @@ mod tests {
     #[test]
     fn test_process_chain() {
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Arc::new(KvmVm::new(&kvm).unwrap());
+        let vm = Arc::new(KvmVm::new(kvm).unwrap());
 
         let dummy_file = TempFile::new().unwrap();
         dummy_file.as_file().set_len(0x20_0000);

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -20,14 +20,14 @@ use crate::devices::virtio::pmem::PMEM_QUEUE_SIZE;
 use crate::devices::virtio::pmem::metrics::{PmemMetrics, PmemMetricsPerDevice};
 use crate::devices::virtio::queue::{DescriptorChain, InvalidAvailIdx, Queue, QueueError};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
+use crate::impl_device_type;
 use crate::logger::{IncMetric, error, info};
 use crate::rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 use crate::utils::{align_up, u64_to_usize};
 use crate::vmm_config::RateLimiterConfig;
 use crate::vmm_config::pmem::PmemConfig;
 use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap, GuestMmapRegion};
-use crate::vstate::vm::VmError;
-use crate::{Vm, impl_device_type};
+use crate::vstate::vm::{KvmVm, VmError};
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum PmemError {
@@ -84,13 +84,13 @@ unsafe impl ByteValued for ConfigSpace {}
 /// RAII wrapper for a guest address allocation. Frees the allocated region on drop.
 #[derive(Debug)]
 pub struct GuestPmemRegion {
-    vm: Arc<Vm>,
+    vm: Arc<KvmVm>,
     pub config_space: ConfigSpace,
 }
 
 impl GuestPmemRegion {
     /// Allocate a new region in past_mmio64 memory.
-    fn new(vm: Arc<Vm>, size: u64) -> Result<Self, PmemError> {
+    fn new(vm: Arc<KvmVm>, size: u64) -> Result<Self, PmemError> {
         let start = {
             let mut alloc = vm.resource_allocator();
             alloc
@@ -106,7 +106,7 @@ impl GuestPmemRegion {
     }
 
     /// Wrap an existing allocation (e.g. from a snapshot) for RAII cleanup.
-    pub fn from_state(vm: Arc<Vm>, config_space: ConfigSpace) -> Self {
+    pub fn from_state(vm: Arc<KvmVm>, config_space: ConfigSpace) -> Self {
         Self { vm, config_space }
     }
 }
@@ -126,13 +126,13 @@ impl Drop for GuestPmemRegion {
 /// RAII wrapper for the KVM user memory region. Removes the region on drop.
 #[derive(Debug)]
 pub struct KvmMemSlot {
-    vm: Arc<Vm>,
+    vm: Arc<KvmVm>,
     slot: u32,
 }
 
 impl KvmMemSlot {
     fn new(
-        vm: Arc<Vm>,
+        vm: Arc<KvmVm>,
         gpa: u64,
         memory_size: u64,
         hva: u64,
@@ -300,14 +300,14 @@ impl Pmem {
     pub const ALIGNMENT: u64 = 2 * 1024 * 1024;
 
     /// Create a new Pmem device with a backing file at `disk_image_path` path.
-    pub fn new(vm: Arc<Vm>, config: PmemConfig) -> Result<Self, PmemError> {
+    pub fn new(vm: Arc<KvmVm>, config: PmemConfig) -> Result<Self, PmemError> {
         Self::new_with_queues(vm, config, vec![Queue::new(PMEM_QUEUE_SIZE)], 0u64, None)
     }
 
     /// Create a new Pmem device with a backing file at `disk_image_path` path using a pre-created
     /// set of queues.
     pub fn new_with_queues(
-        vm: Arc<Vm>,
+        vm: Arc<KvmVm>,
         config: PmemConfig,
         queues: Vec<Queue>,
         acked_features: u64,
@@ -608,7 +608,7 @@ mod tests {
     #[test]
     fn test_from_config() {
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Arc::new(Vm::new(&kvm).unwrap());
+        let vm = Arc::new(KvmVm::new(&kvm).unwrap());
 
         let config = PmemConfig {
             id: "1".into(),
@@ -650,7 +650,7 @@ mod tests {
     #[test]
     fn test_process_chain() {
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Arc::new(Vm::new(&kvm).unwrap());
+        let vm = Arc::new(KvmVm::new(&kvm).unwrap());
 
         let dummy_file = TempFile::new().unwrap();
         dummy_file.as_file().set_len(0x20_0000);

--- a/src/vmm/src/devices/virtio/pmem/persist.rs
+++ b/src/vmm/src/devices/virtio/pmem/persist.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use vm_memory::GuestAddress;
 
 use super::device::{ConfigSpace, Pmem, PmemError};
-use crate::Vm;
 use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
 use crate::devices::virtio::persist::{PersistError as VirtioStateError, VirtioDeviceState};
 use crate::devices::virtio::pmem::{PMEM_NUM_QUEUES, PMEM_QUEUE_SIZE};
@@ -16,7 +15,7 @@ use crate::rate_limiter::persist::RateLimiterState;
 use crate::snapshot::Persist;
 use crate::vmm_config::pmem::PmemConfig;
 use crate::vstate::memory::{GuestMemoryMmap, GuestRegionMmap};
-use crate::vstate::vm::VmError;
+use crate::vstate::vm::{KvmVm, VmError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PmemState {
@@ -29,7 +28,7 @@ pub struct PmemState {
 #[derive(Debug)]
 pub struct PmemConstructorArgs<'a> {
     pub mem: &'a GuestMemoryMmap,
-    pub vm: Arc<Vm>,
+    pub vm: Arc<KvmVm>,
 }
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -39,7 +38,7 @@ pub enum PmemPersistError {
     /// Error creating Pmem devie: {0}
     Pmem(#[from] PmemError),
     /// Error registering memory region: {0}
-    Vm(#[from] VmError),
+    KvmVm(#[from] VmError),
     /// Error restoring rate limiter: {0}
     RateLimiter(std::io::Error),
 }
@@ -107,7 +106,7 @@ mod tests {
         };
         let guest_mem = default_mem();
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Arc::new(Vm::new(&kvm).unwrap());
+        let vm = Arc::new(KvmVm::new(&kvm).unwrap());
         let pmem = Pmem::new(vm.clone(), config).unwrap();
 
         // Save the block device.

--- a/src/vmm/src/devices/virtio/pmem/persist.rs
+++ b/src/vmm/src/devices/virtio/pmem/persist.rs
@@ -106,7 +106,7 @@ mod tests {
         };
         let guest_mem = default_mem();
         let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Arc::new(KvmVm::new(&kvm).unwrap());
+        let vm = Arc::new(KvmVm::new(kvm).unwrap());
         let pmem = Pmem::new(vm.clone(), config).unwrap();
 
         // Save the block device.

--- a/src/vmm/src/devices/virtio/pmem/persist.rs
+++ b/src/vmm/src/devices/virtio/pmem/persist.rs
@@ -87,9 +87,9 @@ mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::arch::Kvm;
     use crate::devices::virtio::device::VirtioDevice;
     use crate::devices::virtio::test_utils::default_mem;
+    use crate::vstate::vm::tests::setup_vm;
 
     #[test]
     fn test_persistence() {
@@ -105,8 +105,7 @@ mod tests {
             ..Default::default()
         };
         let guest_mem = default_mem();
-        let kvm = Kvm::new(vec![]).unwrap();
-        let vm = Arc::new(KvmVm::new(kvm).unwrap());
+        let vm = Arc::new(setup_vm());
         let pmem = Pmem::new(vm.clone(), config).unwrap();
 
         // Save the block device.

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -1028,7 +1028,9 @@ mod tests {
 
     fn create_vmm_with_virtio_pci_device() -> Vmm {
         let mut vmm = default_vmm();
-        vmm.device_manager.enable_pci(&vmm.vm);
+        vmm.device_manager
+            .enable_pci(&vmm.vm.as_kvm().unwrap().clone())
+            .unwrap();
         let entropy = Arc::new(Mutex::new(Entropy::new(RateLimiter::default()).unwrap()));
         let mut event_manager = crate::EventManager::new().unwrap();
         vmm.device_manager
@@ -1704,8 +1706,9 @@ mod tests {
         drop(locked);
 
         let new_entropy = Arc::new(Mutex::new(Entropy::new(RateLimiter::default()).unwrap()));
+        let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let restored =
-            VirtioPciDevice::new_from_state("rng".to_string(), &vmm.vm, new_entropy, saved_state)
+            VirtioPciDevice::new_from_state("rng".to_string(), &kvm_vm, new_entropy, saved_state)
                 .unwrap();
 
         assert!(restored.device_activated.load(Ordering::SeqCst));

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -23,7 +23,6 @@ use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 use zerocopy::IntoBytes;
 
-use crate::Vm;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_ids;
 use crate::devices::virtio::queue::Queue;
@@ -47,6 +46,7 @@ use crate::vstate::bus::BusDevice;
 use crate::vstate::interrupts::{InterruptError, MsixVectorGroup};
 use crate::vstate::memory::GuestMemoryMmap;
 use crate::vstate::resources::ResourceAllocator;
+use crate::vstate::vm::KvmVm;
 
 /// Vector value used to disable MSI for a queue.
 pub const VIRTQ_MSI_NO_VECTOR: u16 = 0xffff;
@@ -414,7 +414,7 @@ impl VirtioPciDevice {
 
     pub fn new_from_state(
         id: String,
-        vm: &Arc<Vm>,
+        vm: &Arc<KvmVm>,
         device: Arc<Mutex<dyn VirtioDevice>>,
         state: VirtioPciDeviceState,
     ) -> Result<Self, VirtioPciDeviceError> {
@@ -604,7 +604,7 @@ impl VirtioPciDevice {
     }
 
     /// Register the IoEvent notification for a VirtIO device
-    pub fn register_notification_ioevent(&self, vm: &Vm) -> Result<(), errno::Error> {
+    pub fn register_notification_ioevent(&self, vm: &KvmVm) -> Result<(), errno::Error> {
         let bar_addr = self.config_bar_addr();
         for (i, queue_evt) in self
             .device
@@ -1006,6 +1006,7 @@ mod tests {
     use vm_memory::{ByteValued, Le32};
 
     use super::{PciCapabilityType, VirtioPciDevice};
+    use crate::Vmm;
     use crate::arch::MEM_64BIT_DEVICES_START;
     use crate::builder::tests::default_vmm;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
@@ -1024,7 +1025,6 @@ mod tests {
     use crate::pci::msix::MsixCap;
     use crate::pci::{PciCapabilityId, PciClassCode, PciDevice};
     use crate::rate_limiter::RateLimiter;
-    use crate::{Vm, Vmm};
 
     fn create_vmm_with_virtio_pci_device() -> Vmm {
         let mut vmm = default_vmm();

--- a/src/vmm/src/gdb/arch/aarch64.rs
+++ b/src/vmm/src/gdb/arch/aarch64.rs
@@ -64,6 +64,8 @@ const PTE_ADDRESS_MASK: u64 = !0b111u64;
 fn read_address(vmm: &Vmm, address: u64) -> Result<u64, GdbTargetError> {
     let mut buf = [0; 8];
     vmm.vm
+        .as_kvm()
+        .expect("GDB requires KVM")
         .guest_memory()
         .read(&mut buf, GuestAddress(address))?;
 

--- a/src/vmm/src/gdb/mod.rs
+++ b/src/vmm/src/gdb/mod.rs
@@ -44,8 +44,9 @@ pub fn gdb_thread(
     // when resumed will be removed
     {
         let vmm = vmm.lock().unwrap();
-        vcpu_set_debug(&vmm.vcpus_handles[0].vcpu_fd, &[entry_addr], false)?;
-        for handle in &vmm.vcpus_handles[1..] {
+        let handles = vmm.vm.vcpus_handles();
+        vcpu_set_debug(&handles[0].vcpu_fd, &[entry_addr], false)?;
+        for handle in &handles[1..] {
             vcpu_set_debug(&handle.vcpu_fd, &[], false)?;
         }
     }

--- a/src/vmm/src/gdb/mod.rs
+++ b/src/vmm/src/gdb/mod.rs
@@ -44,7 +44,8 @@ pub fn gdb_thread(
     // when resumed will be removed
     {
         let vmm = vmm.lock().unwrap();
-        let handles = vmm.vm.vcpus_handles();
+        let kvm_vm = vmm.vm.as_kvm().expect("GDB requires KVM");
+        let handles = kvm_vm.vcpus_handles();
         vcpu_set_debug(&handles[0].vcpu_fd, &[entry_addr], false)?;
         for handle in &handles[1..] {
             vcpu_set_debug(&handle.vcpu_fd, &[], false)?;

--- a/src/vmm/src/gdb/target.rs
+++ b/src/vmm/src/gdb/target.rs
@@ -166,7 +166,7 @@ impl FirecrackerTarget {
     pub fn new(vmm: Arc<Mutex<Vmm>>, gdb_event: Receiver<usize>, entry_addr: GuestAddress) -> Self {
         let vcpus_count = {
             let vmm = vmm.lock().unwrap();
-            let kvm_vm = &vmm.vm;
+            let kvm_vm = vmm.vm.as_kvm().expect("GDB requires KVM");
             kvm_vm.vcpus_handles().len()
         };
         let mut vcpu_state = vec![VcpuState::default(); vcpus_count];
@@ -187,6 +187,17 @@ impl FirecrackerTarget {
         }
     }
 
+    fn with_vcpu_fd<R>(
+        &self,
+        vcpu_idx: usize,
+        f: impl FnOnce(&kvm_ioctls::VcpuFd, &Vmm) -> R,
+    ) -> R {
+        let vmm = self.vmm.lock().unwrap();
+        let kvm_vm = vmm.vm.as_kvm().expect("GDB requires KVM");
+        let handles = kvm_vm.vcpus_handles();
+        f(&handles[vcpu_idx].vcpu_fd, &vmm)
+    }
+
     // Update KVM debug info for a specific vcpu index.
     fn update_vcpu_kvm_debug(
         &self,
@@ -199,18 +210,16 @@ impl FirecrackerTarget {
             return Ok(());
         }
 
-        let vmm = self.vmm.lock().unwrap();
-        let handles = vmm.vm.vcpus_handles();
-        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
-        arch::vcpu_set_debug(vcpu_fd, hw_breakpoints, state.single_step)
+        self.with_vcpu_fd(vcpu_idx, |vcpu_fd, _| {
+            arch::vcpu_set_debug(vcpu_fd, hw_breakpoints, state.single_step)
+        })
     }
 
     /// Translate guest virtual address to guest pysical address.
     fn translate_gva(&self, vcpu_idx: usize, addr: u64) -> Result<u64, GdbTargetError> {
-        let vmm = self.vmm.lock().unwrap();
-        let handles = vmm.vm.vcpus_handles();
-        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
-        arch::translate_gva(vcpu_fd, addr, &vmm)
+        self.with_vcpu_fd(vcpu_idx, |vcpu_fd, vmm| {
+            arch::translate_gva(vcpu_fd, addr, vmm)
+        })
     }
 
     /// Retrieves the currently paused Vcpu id returns an error if there is no currently paused Vcpu
@@ -276,7 +285,8 @@ impl FirecrackerTarget {
         }
 
         let vmm = self.vmm.lock()?;
-        let mut handles = vmm.vm.vcpus_handles();
+        let kvm_vm = vmm.vm.as_kvm().expect("GDB requires KVM");
+        let mut handles = kvm_vm.vcpus_handles();
         let cpu_handle = &mut handles[tid_to_vcpuid(tid)];
 
         cpu_handle.send_event(VcpuEvent::Pause)?;
@@ -288,11 +298,9 @@ impl FirecrackerTarget {
 
     /// A helper function to allow the event loop to inject this breakpoint back into the Vcpu
     pub fn inject_bp_to_guest(&mut self, tid: Tid) -> Result<(), GdbTargetError> {
-        let vmm = self.vmm.lock().unwrap();
-        let handles = vmm.vm.vcpus_handles();
-        let vcpu_idx = tid_to_vcpuid(tid);
-        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
-        arch::vcpu_inject_bp(vcpu_fd, &self.hw_breakpoints, false)
+        self.with_vcpu_fd(tid_to_vcpuid(tid), |vcpu_fd, _| {
+            arch::vcpu_inject_bp(vcpu_fd, &self.hw_breakpoints, false)
+        })
     }
 
     /// Resumes the Vcpu, will return early if the Vcpu is already running
@@ -306,7 +314,8 @@ impl FirecrackerTarget {
         }
 
         let vmm = self.vmm.lock()?;
-        let mut handles = vmm.vm.vcpus_handles();
+        let kvm_vm = vmm.vm.as_kvm().expect("GDB requires KVM");
+        let mut handles = kvm_vm.vcpus_handles();
         let cpu_handle = &mut handles[tid_to_vcpuid(tid)];
         cpu_handle.send_event(VcpuEvent::Resume)?;
 
@@ -336,11 +345,10 @@ impl FirecrackerTarget {
         }
 
         let vmm = self.vmm.lock().unwrap();
-        let handles = vmm.vm.vcpus_handles();
+        let kvm_vm = vmm.vm.as_kvm().expect("GDB requires KVM");
+        let handles = kvm_vm.vcpus_handles();
         let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
         let Ok(ip) = arch::get_instruction_pointer(vcpu_fd) else {
-            // If we error here we return an arbitrary Software Breakpoint, GDB will handle
-            // this gracefully
             return Ok(Some(MultiThreadStopReason::SwBreak(tid)));
         };
 
@@ -387,24 +395,18 @@ impl Target for FirecrackerTarget {
 impl MultiThreadBase for FirecrackerTarget {
     /// Reads the registers for the Vcpu
     fn read_registers(&mut self, regs: &mut CoreRegs, tid: Tid) -> TargetResult<(), Self> {
-        let vmm = self.vmm.lock().unwrap();
-        let vcpu_idx = tid_to_vcpuid(tid);
-        let handles = vmm.vm.vcpus_handles();
-        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
-        arch::read_registers(vcpu_fd, regs)?;
-
-        Ok(())
+        self.with_vcpu_fd(tid_to_vcpuid(tid), |vcpu_fd, _| {
+            arch::read_registers(vcpu_fd, regs)?;
+            Ok(())
+        })
     }
 
     /// Writes to the registers for the Vcpu
     fn write_registers(&mut self, regs: &CoreRegs, tid: Tid) -> TargetResult<(), Self> {
-        let vmm = self.vmm.lock().unwrap();
-        let vcpu_idx = tid_to_vcpuid(tid);
-        let handles = vmm.vm.vcpus_handles();
-        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
-        arch::write_registers(vcpu_fd, regs)?;
-
-        Ok(())
+        self.with_vcpu_fd(tid_to_vcpuid(tid), |vcpu_fd, _| {
+            arch::write_registers(vcpu_fd, regs)?;
+            Ok(())
+        })
     }
 
     /// Writes data to a guest virtual address for the Vcpu
@@ -417,7 +419,8 @@ impl MultiThreadBase for FirecrackerTarget {
         let data_len = data.len();
         let vmm = self.vmm.lock().unwrap();
         let vcpu_idx = tid_to_vcpuid(tid);
-        let handles = vmm.vm.vcpus_handles();
+        let kvm_vm = vmm.vm.as_kvm().expect("GDB requires KVM");
+        let handles = kvm_vm.vcpus_handles();
         let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
 
         while !data.is_empty() {
@@ -432,6 +435,8 @@ impl MultiThreadBase for FirecrackerTarget {
             );
 
             vmm.vm
+                .as_kvm()
+                .expect("GDB requires KVM")
                 .guest_memory()
                 .read(&mut data[..read_len], GuestAddress(gpa))
                 .map_err(|e| {
@@ -454,7 +459,8 @@ impl MultiThreadBase for FirecrackerTarget {
     ) -> TargetResult<(), Self> {
         let vmm = self.vmm.lock().unwrap();
         let vcpu_idx = tid_to_vcpuid(tid);
-        let handles = vmm.vm.vcpus_handles();
+        let kvm_vm = vmm.vm.as_kvm().expect("GDB requires KVM");
+        let handles = kvm_vm.vcpus_handles();
         let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
 
         while !data.is_empty() {
@@ -469,6 +475,8 @@ impl MultiThreadBase for FirecrackerTarget {
             );
 
             vmm.vm
+                .as_kvm()
+                .expect("GDB requires KVM")
                 .guest_memory()
                 .write(&data[..write_len], GuestAddress(gpa))
                 .map_err(|e| {

--- a/src/vmm/src/gdb/target.rs
+++ b/src/vmm/src/gdb/target.rs
@@ -164,7 +164,12 @@ impl FirecrackerTarget {
     /// will handle requests from GDB and perform the appropriate actions, while also updating GDB
     /// with the state of the VMM / Vcpu's as we hit debug events
     pub fn new(vmm: Arc<Mutex<Vmm>>, gdb_event: Receiver<usize>, entry_addr: GuestAddress) -> Self {
-        let mut vcpu_state = vec![VcpuState::default(); vmm.lock().unwrap().vcpus_handles.len()];
+        let vcpus_count = {
+            let vmm = vmm.lock().unwrap();
+            let kvm_vm = &vmm.vm;
+            kvm_vm.vcpus_handles().len()
+        };
+        let mut vcpu_state = vec![VcpuState::default(); vcpus_count];
         // By default vcpu 1 will be paused at the entry point
         vcpu_state[0].paused = true;
 
@@ -194,14 +199,17 @@ impl FirecrackerTarget {
             return Ok(());
         }
 
-        let vcpu_fd = &self.vmm.lock().unwrap().vcpus_handles[vcpu_idx].vcpu_fd;
+        let vmm = self.vmm.lock().unwrap();
+        let handles = vmm.vm.vcpus_handles();
+        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
         arch::vcpu_set_debug(vcpu_fd, hw_breakpoints, state.single_step)
     }
 
     /// Translate guest virtual address to guest pysical address.
     fn translate_gva(&self, vcpu_idx: usize, addr: u64) -> Result<u64, GdbTargetError> {
         let vmm = self.vmm.lock().unwrap();
-        let vcpu_fd = &vmm.vcpus_handles[vcpu_idx].vcpu_fd;
+        let handles = vmm.vm.vcpus_handles();
+        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
         arch::translate_gva(vcpu_fd, addr, &vmm)
     }
 
@@ -267,7 +275,9 @@ impl FirecrackerTarget {
             return Ok(());
         }
 
-        let cpu_handle = &mut self.vmm.lock()?.vcpus_handles[tid_to_vcpuid(tid)];
+        let vmm = self.vmm.lock()?;
+        let mut handles = vmm.vm.vcpus_handles();
+        let cpu_handle = &mut handles[tid_to_vcpuid(tid)];
 
         cpu_handle.send_event(VcpuEvent::Pause)?;
         let _ = cpu_handle.response_receiver().recv()?;
@@ -279,8 +289,9 @@ impl FirecrackerTarget {
     /// A helper function to allow the event loop to inject this breakpoint back into the Vcpu
     pub fn inject_bp_to_guest(&mut self, tid: Tid) -> Result<(), GdbTargetError> {
         let vmm = self.vmm.lock().unwrap();
+        let handles = vmm.vm.vcpus_handles();
         let vcpu_idx = tid_to_vcpuid(tid);
-        let vcpu_fd = &vmm.vcpus_handles[vcpu_idx].vcpu_fd;
+        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
         arch::vcpu_inject_bp(vcpu_fd, &self.hw_breakpoints, false)
     }
 
@@ -294,7 +305,9 @@ impl FirecrackerTarget {
             return Ok(());
         }
 
-        let cpu_handle = &mut self.vmm.lock()?.vcpus_handles[tid_to_vcpuid(tid)];
+        let vmm = self.vmm.lock()?;
+        let mut handles = vmm.vm.vcpus_handles();
+        let cpu_handle = &mut handles[tid_to_vcpuid(tid)];
         cpu_handle.send_event(VcpuEvent::Resume)?;
 
         let response = cpu_handle.response_receiver().recv()?;
@@ -323,7 +336,8 @@ impl FirecrackerTarget {
         }
 
         let vmm = self.vmm.lock().unwrap();
-        let vcpu_fd = &vmm.vcpus_handles[vcpu_idx].vcpu_fd;
+        let handles = vmm.vm.vcpus_handles();
+        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
         let Ok(ip) = arch::get_instruction_pointer(vcpu_fd) else {
             // If we error here we return an arbitrary Software Breakpoint, GDB will handle
             // this gracefully
@@ -375,7 +389,8 @@ impl MultiThreadBase for FirecrackerTarget {
     fn read_registers(&mut self, regs: &mut CoreRegs, tid: Tid) -> TargetResult<(), Self> {
         let vmm = self.vmm.lock().unwrap();
         let vcpu_idx = tid_to_vcpuid(tid);
-        let vcpu_fd = &vmm.vcpus_handles[vcpu_idx].vcpu_fd;
+        let handles = vmm.vm.vcpus_handles();
+        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
         arch::read_registers(vcpu_fd, regs)?;
 
         Ok(())
@@ -385,7 +400,8 @@ impl MultiThreadBase for FirecrackerTarget {
     fn write_registers(&mut self, regs: &CoreRegs, tid: Tid) -> TargetResult<(), Self> {
         let vmm = self.vmm.lock().unwrap();
         let vcpu_idx = tid_to_vcpuid(tid);
-        let vcpu_fd = &vmm.vcpus_handles[vcpu_idx].vcpu_fd;
+        let handles = vmm.vm.vcpus_handles();
+        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
         arch::write_registers(vcpu_fd, regs)?;
 
         Ok(())
@@ -401,7 +417,8 @@ impl MultiThreadBase for FirecrackerTarget {
         let data_len = data.len();
         let vmm = self.vmm.lock().unwrap();
         let vcpu_idx = tid_to_vcpuid(tid);
-        let vcpu_fd = &vmm.vcpus_handles[vcpu_idx].vcpu_fd;
+        let handles = vmm.vm.vcpus_handles();
+        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
 
         while !data.is_empty() {
             let gpa = arch::translate_gva(vcpu_fd, gva, &vmm).map_err(|e| {
@@ -437,7 +454,8 @@ impl MultiThreadBase for FirecrackerTarget {
     ) -> TargetResult<(), Self> {
         let vmm = self.vmm.lock().unwrap();
         let vcpu_idx = tid_to_vcpuid(tid);
-        let vcpu_fd = &vmm.vcpus_handles[vcpu_idx].vcpu_fd;
+        let handles = vmm.vm.vcpus_handles();
+        let vcpu_fd = &handles[vcpu_idx].vcpu_fd;
 
         while !data.is_empty() {
             let gpa = arch::translate_gva(vcpu_fd, gva, &vmm).map_err(|e| {

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -122,15 +122,12 @@ use std::os::unix::io::AsRawFd;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-pub use crate::vstate::vm::StartVcpusError;
 use device_manager::DeviceManager;
 use event_manager::{EventManager as BaseEventManager, EventOps, Events, MutEventSubscriber};
 use snapshot::Persist;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::terminal::Terminal;
-pub use vstate::kvm::Kvm;
 use vstate::vcpu::{self, VcpuSendEventError};
-use vstate::vm::KvmVm;
 
 use crate::cpu_config::templates::CpuConfiguration;
 use crate::devices::virtio::balloon::device::{HintingStatus, StartHintingCmd};
@@ -162,10 +159,12 @@ use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
 use crate::vmm_config::mmds::MmdsConfig;
 use crate::vmm_config::net::NetworkInterfaceConfig;
 use crate::vmm_config::vsock::VsockDeviceConfig;
+pub use crate::vstate::kvm::Kvm;
 use crate::vstate::memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 #[cfg(target_arch = "aarch64")]
 use crate::vstate::vcpu::VcpuState;
 pub use crate::vstate::vcpu::{Vcpu, VcpuConfig, VcpuEvent, VcpuHandle, VcpuResponse};
+pub use crate::vstate::vm::{StartVcpusError, Vm};
 
 /// Shorthand type for the EventManager flavour used by Firecracker.
 pub type EventManager = BaseEventManager<Arc<Mutex<dyn MutEventSubscriber>>>;
@@ -255,6 +254,8 @@ pub enum VmmError {
     VcpuResume,
     /// Failed to message the vCPUs.
     VcpuMessage,
+    /// Operation not supported on {0} VMs.
+    NotSupportedOnVmType(&'static str),
     /// Cannot spawn Vcpu thread: {0}
     VcpuSpawn(io::Error),
     /// KvmVm error: {0}
@@ -302,8 +303,8 @@ pub struct Vmm {
     boot_source_config: BootSourceConfig,
     shutdown_exit_code: Option<FcExitCode>,
 
-    /// VM object
-    pub vm: Arc<KvmVm>,
+    /// VM object.
+    pub vm: Vm,
     // Device manager
     device_manager: DeviceManager,
 }
@@ -459,15 +460,23 @@ impl Vmm {
 
     /// Sends a resume command to the vCPUs.
     pub fn resume_vm(&mut self) -> Result<(), VmmError> {
+        let kvm_vm = self
+            .vm
+            .as_kvm()
+            .ok_or_else(|| VmmError::NotSupportedOnVmType(self.vm.type_name()))?;
         self.device_manager.kick_virtio_devices();
-        self.vm.resume_vcpus()?;
+        kvm_vm.resume_vcpus()?;
         self.instance_info.state = VmState::Running;
         Ok(())
     }
 
     /// Sends a pause command to the vCPUs.
     pub fn pause_vm(&mut self) -> Result<(), VmmError> {
-        self.vm.pause_vcpus()?;
+        let kvm_vm = self
+            .vm
+            .as_kvm()
+            .ok_or_else(|| VmmError::NotSupportedOnVmType(self.vm.type_name()))?;
+        kvm_vm.pause_vcpus()?;
         self.instance_info.state = VmState::Paused;
         Ok(())
     }
@@ -494,12 +503,16 @@ impl Vmm {
         // state before we save device state, that interrupt will never be delivered to the guest
         // upon resuming from the snapshot.
         let device_states = self.device_manager.save();
-        let vcpu_states = self.vm.save_vcpu_states()?;
-        let kvm_state = self.vm.kvm().save_state();
+        let kvm_vm = self
+            .vm
+            .as_kvm()
+            .ok_or_else(|| MicrovmStateError::NotAllowed("save_state requires KVM".into()))?;
+        let vcpu_states = kvm_vm.save_vcpu_states()?;
+        let kvm_state = kvm_vm.kvm().save_state();
         let vm_state = {
             #[cfg(target_arch = "x86_64")]
             {
-                self.vm
+                kvm_vm
                     .save_state()
                     .map_err(MicrovmStateError::SaveVmState)?
             }
@@ -507,7 +520,7 @@ impl Vmm {
             {
                 let mpidrs = construct_kvm_mpidrs(&vcpu_states);
 
-                self.vm
+                kvm_vm
                     .save_state(&mpidrs)
                     .map_err(MicrovmStateError::SaveVmState)?
             }
@@ -524,7 +537,11 @@ impl Vmm {
 
     /// Dumps CPU configuration.
     pub fn dump_cpu_config(&mut self) -> Result<Vec<CpuConfiguration>, DumpCpuConfigError> {
-        self.vm.dump_cpu_config_states()
+        let kvm_vm = self
+            .vm
+            .as_kvm()
+            .ok_or_else(|| DumpCpuConfigError::NotAllowed("dump_cpu_config requires KVM".into()))?;
+        kvm_vm.dump_cpu_config_states()
     }
 
     /// Updates the path of the host file backing the emulated block device with id `drive_id`.
@@ -678,7 +695,7 @@ impl Vmm {
 
     /// Gets a reference to kvm-ioctls KvmVm
     #[cfg(feature = "gdb")]
-    pub fn vm(&self) -> &KvmVm {
+    pub fn vm(&self) -> &Vm {
         &self.vm
     }
 
@@ -689,8 +706,13 @@ impl Vmm {
         config: HotplugDeviceConfig,
         event_manager: &mut EventManager,
     ) -> Result<(), VmmActionError> {
+        let kvm_vm = self
+            .vm
+            .as_kvm()
+            .ok_or_else(|| VmmActionError::NotSupported("Operation requires KVM".to_string()))?
+            .clone();
         self.device_manager
-            .hotplug_device(self.vm.clone(), config, event_manager)
+            .hotplug_device(kvm_vm, config, event_manager)
     }
 
     /// Detaches a device after VM start
@@ -700,8 +722,13 @@ impl Vmm {
         device_id: VirtioDeviceId,
         event_manager: &mut EventManager,
     ) -> Result<(), VmmActionError> {
+        let kvm_vm = self
+            .vm
+            .as_kvm()
+            .ok_or_else(|| VmmActionError::NotSupported("Operation requires KVM".to_string()))?
+            .clone();
         self.device_manager
-            .hot_unplug_device(self.vm.clone(), device_id, event_manager)
+            .hot_unplug_device(kvm_vm, device_id, event_manager)
     }
 }
 
@@ -732,8 +759,10 @@ fn construct_kvm_mpidrs(vcpu_states: &[VcpuState]) -> Vec<u64> {
 
 impl Drop for Vmm {
     fn drop(&mut self) {
-        info!("Killing vCPU threads");
-        self.vm.shutdown_vcpus();
+        if let Some(kvm_vm) = self.vm.as_kvm() {
+            info!("Killing vCPU threads");
+            kvm_vm.shutdown_vcpus();
+        }
 
         if let Err(err) = std::io::stdin().lock().set_canon_mode() {
             warn!("Cannot set canonical mode for the terminal. {:?}", err);
@@ -744,7 +773,9 @@ impl Drop for Vmm {
             error!("Failed to write metrics while stopping: {}", err);
         }
 
-        if !self.vm.vcpus_handles().is_empty() {
+        if let Some(kvm_vm) = self.vm.as_kvm()
+            && !kvm_vm.vcpus_handles().is_empty()
+        {
             error!("Failed to tear down Vmm: the vcpu threads have not finished execution.");
         }
     }
@@ -756,40 +787,48 @@ impl MutEventSubscriber for Vmm {
         let source = event.fd();
         let event_set = event.event_set();
 
-        if source == self.vm.vcpus_exit_evt().as_raw_fd() && event_set == EventSet::IN {
-            // Exit event handling should never do anything more than call 'self.stop()'.
-            let _ = self.vm.vcpus_exit_evt().read();
+        match &self.vm {
+            Vm::Kvm(kvm_vm) => {
+                if source == kvm_vm.vcpus_exit_evt().as_raw_fd() && event_set == EventSet::IN {
+                    // Exit event handling should never do anything more than call 'self.stop()'.
+                    let _ = kvm_vm.vcpus_exit_evt().read();
 
-            let exit_code = 'exit_code: {
-                // Query each vcpu for their exit_code.
-                let handles = self.vm.vcpus_handles();
-                for handle in handles.iter() {
-                    // Drain all vcpu responses that are pending from this vcpu until we find an
-                    // exit status.
-                    for response in handle.response_receiver().try_iter() {
-                        if let VcpuResponse::Exited(status) = response {
-                            // It could be that some vcpus exited successfully while others
-                            // errored out. Thus make sure that error exits from one vcpu always
-                            // takes precedence over "ok" exits
-                            if status != FcExitCode::Ok {
-                                break 'exit_code status;
+                    let exit_code = 'exit_code: {
+                        // Query each vcpu for their exit_code.
+                        let handles = kvm_vm.vcpus_handles();
+                        for handle in handles.iter() {
+                            // Drain all vcpu responses that are pending from this vcpu
+                            // until we find an exit status.
+                            for response in handle.response_receiver().try_iter() {
+                                if let VcpuResponse::Exited(status) = response {
+                                    // It could be that some vcpus exited successfully while
+                                    // others errored out. Thus make sure that error exits from
+                                    // one vcpu always takes precedence over "ok" exits
+                                    if status != FcExitCode::Ok {
+                                        break 'exit_code status;
+                                    }
+                                }
                             }
                         }
-                    }
-                }
 
-                // No CPUs exited with error status code, report "Ok"
-                FcExitCode::Ok
-            };
-            self.stop(exit_code);
-        } else {
-            error!("Spurious EventManager event for handler: Vmm");
+                        // No CPUs exited with error status code, report "Ok"
+                        FcExitCode::Ok
+                    };
+                    self.stop(exit_code);
+                } else {
+                    error!("Spurious EventManager event for handler: Vmm");
+                }
+            }
         }
     }
 
     fn init(&mut self, ops: &mut EventOps) {
-        if let Err(err) = ops.add(Events::new(self.vm.vcpus_exit_evt(), EventSet::IN)) {
-            error!("Failed to register vmm exit event: {}", err);
+        match &self.vm {
+            Vm::Kvm(kvm_vm) => {
+                if let Err(err) = ops.add(Events::new(kvm_vm.vcpus_exit_evt(), EventSet::IN)) {
+                    error!("Failed to register vmm exit event: {}", err);
+                }
+            }
         }
     }
 }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -129,7 +129,6 @@ use seccomp::BpfProgram;
 use snapshot::Persist;
 use userfaultfd::Uffd;
 use vmm_sys_util::epoll::EventSet;
-use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
 pub use vstate::kvm::Kvm;
 use vstate::vcpu::{self, StartThreadedError, VcpuSendEventError};
@@ -320,8 +319,6 @@ pub struct Vmm {
     uffd: Option<Uffd>,
     /// Handles to the vcpu threads with vcpu_fds inside them.
     pub vcpus_handles: Vec<VcpuHandle>,
-    // Used by Vcpus and devices to initiate teardown; Vmm should never write here.
-    vcpus_exit_evt: EventFd,
     // Device manager
     device_manager: DeviceManager,
 }
@@ -911,9 +908,9 @@ impl MutEventSubscriber for Vmm {
         let source = event.fd();
         let event_set = event.event_set();
 
-        if source == self.vcpus_exit_evt.as_raw_fd() && event_set == EventSet::IN {
+        if source == self.vm.vcpus_exit_evt().as_raw_fd() && event_set == EventSet::IN {
             // Exit event handling should never do anything more than call 'self.stop()'.
-            let _ = self.vcpus_exit_evt.read();
+            let _ = self.vm.vcpus_exit_evt().read();
 
             let exit_code = 'exit_code: {
                 // Query each vcpu for their exit_code.
@@ -942,7 +939,7 @@ impl MutEventSubscriber for Vmm {
     }
 
     fn init(&mut self, ops: &mut EventOps) {
-        if let Err(err) = ops.add(Events::new(&self.vcpus_exit_evt, EventSet::IN)) {
+        if let Err(err) = ops.add(Events::new(self.vm.vcpus_exit_evt(), EventSet::IN)) {
             error!("Failed to register vmm exit event: {}", err);
         }
     }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -133,6 +133,7 @@ use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
 use vstate::kvm::Kvm;
 use vstate::vcpu::{self, StartThreadedError, VcpuSendEventError};
+use vstate::vm::KvmVm;
 
 use crate::cpu_config::templates::CpuConfiguration;
 use crate::devices::virtio::balloon::device::{HintingStatus, StartHintingCmd};
@@ -167,7 +168,6 @@ use crate::vmm_config::vsock::VsockDeviceConfig;
 use crate::vstate::memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 use crate::vstate::vcpu::VcpuState;
 pub use crate::vstate::vcpu::{Vcpu, VcpuConfig, VcpuEvent, VcpuHandle, VcpuResponse};
-pub use crate::vstate::vm::Vm;
 
 /// Shorthand type for the EventManager flavour used by Firecracker.
 pub type EventManager = BaseEventManager<Arc<Mutex<dyn MutEventSubscriber>>>;
@@ -259,8 +259,8 @@ pub enum VmmError {
     VcpuMessage,
     /// Cannot spawn Vcpu thread: {0}
     VcpuSpawn(io::Error),
-    /// Vm error: {0}
-    Vm(#[from] vstate::vm::VmError),
+    /// KvmVm error: {0}
+    KvmVm(#[from] vstate::vm::VmError),
     /// Kvm error: {0}
     Kvm(#[from] vstate::kvm::KvmError),
     /// Failed perform action on device: {0}
@@ -316,7 +316,7 @@ pub struct Vmm {
     // Guest VM core resources.
     kvm: Kvm,
     /// VM object
-    pub vm: Arc<Vm>,
+    pub vm: Arc<KvmVm>,
     // Save UFFD in order to keep it open in the Firecracker process, as well.
     #[allow(unused)]
     uffd: Option<Uffd>,
@@ -824,9 +824,9 @@ impl Vmm {
         self.shutdown_exit_code = Some(exit_code);
     }
 
-    /// Gets a reference to kvm-ioctls Vm
+    /// Gets a reference to kvm-ioctls KvmVm
     #[cfg(feature = "gdb")]
-    pub fn vm(&self) -> &Vm {
+    pub fn vm(&self) -> &KvmVm {
         &self.vm
     }
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -119,19 +119,18 @@ pub mod initrd;
 use std::collections::HashMap;
 use std::io;
 use std::os::unix::io::AsRawFd;
-use std::sync::mpsc::RecvTimeoutError;
-use std::sync::{Arc, Barrier, Mutex};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+pub use crate::vstate::vm::StartVcpusError;
 use device_manager::DeviceManager;
 use event_manager::{EventManager as BaseEventManager, EventOps, Events, MutEventSubscriber};
-use seccomp::BpfProgram;
 use snapshot::Persist;
 use userfaultfd::Uffd;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::terminal::Terminal;
 pub use vstate::kvm::Kvm;
-use vstate::vcpu::{self, StartThreadedError, VcpuSendEventError};
+use vstate::vcpu::{self, VcpuSendEventError};
 use vstate::vm::KvmVm;
 
 use crate::cpu_config::templates::CpuConfiguration;
@@ -165,6 +164,7 @@ use crate::vmm_config::mmds::MmdsConfig;
 use crate::vmm_config::net::NetworkInterfaceConfig;
 use crate::vmm_config::vsock::VsockDeviceConfig;
 use crate::vstate::memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+#[cfg(target_arch = "aarch64")]
 use crate::vstate::vcpu::VcpuState;
 pub use crate::vstate::vcpu::{Vcpu, VcpuConfig, VcpuEvent, VcpuHandle, VcpuResponse};
 
@@ -280,15 +280,6 @@ pub(crate) fn mem_size_mib(guest_memory: &GuestMemoryMmap) -> u64 {
     guest_memory.iter().map(|region| region.len()).sum::<u64>() >> 20
 }
 
-/// Error type for [`Vmm::start_vcpus`].
-#[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub enum StartVcpusError {
-    /// VMM observer init error: {0}
-    VmmObserverInit(#[from] vmm_sys_util::errno::Error),
-    /// Vcpu handle error: {0}
-    VcpuHandle(#[from] StartThreadedError),
-}
-
 /// Error type for [`Vmm::dump_cpu_config()`]
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum DumpCpuConfigError {
@@ -317,8 +308,6 @@ pub struct Vmm {
     // Save UFFD in order to keep it open in the Firecracker process, as well.
     #[allow(unused)]
     uffd: Option<Uffd>,
-    /// Handles to the vcpu threads with vcpu_fds inside them.
-    pub vcpus_handles: Vec<VcpuHandle>,
     // Device manager
     device_manager: DeviceManager,
 }
@@ -472,94 +461,17 @@ impl Vmm {
         }
     }
 
-    /// Starts the microVM vcpus.
-    ///
-    /// # Errors
-    ///
-    /// When:
-    /// - [`vmm::VmmEventsObserver::on_vmm_boot`] errors.
-    /// - [`vmm::vstate::vcpu::Vcpu::start_threaded`] errors.
-    pub fn start_vcpus(
-        &mut self,
-        mut vcpus: Vec<Vcpu>,
-        vcpu_seccomp_filter: Arc<BpfProgram>,
-    ) -> Result<(), StartVcpusError> {
-        let vcpu_count = vcpus.len();
-        let barrier = Arc::new(Barrier::new(vcpu_count + 1));
-
-        let stdin = std::io::stdin().lock();
-        // Set raw mode for stdin.
-        stdin.set_raw_mode().inspect_err(|&err| {
-            warn!("Cannot set raw mode for the terminal. {:?}", err);
-        })?;
-
-        // Set non blocking stdin.
-        stdin.set_non_block(true).inspect_err(|&err| {
-            warn!("Cannot set non block for the terminal. {:?}", err);
-        })?;
-
-        self.vcpus_handles.reserve(vcpu_count);
-
-        for mut vcpu in vcpus.drain(..) {
-            vcpu.set_mmio_bus(self.vm.common.mmio_bus.clone());
-            #[cfg(target_arch = "x86_64")]
-            vcpu.kvm_vcpu.set_pio_bus(self.vm.pio_bus.clone());
-
-            self.vcpus_handles.push(vcpu.start_threaded(
-                &self.vm,
-                vcpu_seccomp_filter.clone(),
-                barrier.clone(),
-            )?);
-        }
-        self.instance_info.state = VmState::Paused;
-        // Wait for vCPUs to initialize their TLS before moving forward.
-        barrier.wait();
-
-        Ok(())
-    }
-
     /// Sends a resume command to the vCPUs.
     pub fn resume_vm(&mut self) -> Result<(), VmmError> {
         self.device_manager.kick_virtio_devices();
-
-        // Send the events.
-        self.vcpus_handles
-            .iter_mut()
-            .try_for_each(|handle| handle.send_event(VcpuEvent::Resume))
-            .map_err(|_| VmmError::VcpuMessage)?;
-
-        // Check the responses.
-        if self
-            .vcpus_handles
-            .iter()
-            .map(|handle| handle.response_receiver().recv_timeout(RECV_TIMEOUT_SEC))
-            .any(|response| !matches!(response, Ok(VcpuResponse::Resumed)))
-        {
-            return Err(VmmError::VcpuMessage);
-        }
-
+        self.vm.resume_vcpus()?;
         self.instance_info.state = VmState::Running;
         Ok(())
     }
 
     /// Sends a pause command to the vCPUs.
     pub fn pause_vm(&mut self) -> Result<(), VmmError> {
-        // Send the events.
-        self.vcpus_handles
-            .iter_mut()
-            .try_for_each(|handle| handle.send_event(VcpuEvent::Pause))
-            .map_err(|_| VmmError::VcpuMessage)?;
-
-        // Check the responses.
-        if self
-            .vcpus_handles
-            .iter()
-            .map(|handle| handle.response_receiver().recv_timeout(RECV_TIMEOUT_SEC))
-            .any(|response| !matches!(response, Ok(VcpuResponse::Paused)))
-        {
-            return Err(VmmError::VcpuMessage);
-        }
-
+        self.vm.pause_vcpus()?;
         self.instance_info.state = VmState::Paused;
         Ok(())
     }
@@ -586,7 +498,7 @@ impl Vmm {
         // state before we save device state, that interrupt will never be delivered to the guest
         // upon resuming from the snapshot.
         let device_states = self.device_manager.save();
-        let vcpu_states = self.save_vcpu_states()?;
+        let vcpu_states = self.vm.save_vcpu_states()?;
         let kvm_state = self.vm.kvm().save_state();
         let vm_state = {
             #[cfg(target_arch = "x86_64")]
@@ -614,60 +526,9 @@ impl Vmm {
         })
     }
 
-    fn save_vcpu_states(&mut self) -> Result<Vec<VcpuState>, MicrovmStateError> {
-        for handle in self.vcpus_handles.iter_mut() {
-            handle
-                .send_event(VcpuEvent::SaveState)
-                .map_err(MicrovmStateError::SignalVcpu)?;
-        }
-
-        let vcpu_responses = self
-            .vcpus_handles
-            .iter()
-            // `Iterator::collect` can transform a `Vec<Result>` into a `Result<Vec>`.
-            .map(|handle| handle.response_receiver().recv_timeout(RECV_TIMEOUT_SEC))
-            .collect::<Result<Vec<VcpuResponse>, RecvTimeoutError>>()
-            .map_err(|_| MicrovmStateError::UnexpectedVcpuResponse)?;
-
-        let vcpu_states = vcpu_responses
-            .into_iter()
-            .map(|response| match response {
-                VcpuResponse::SavedState(state) => Ok(*state),
-                VcpuResponse::Error(err) => Err(MicrovmStateError::SaveVcpuState(err)),
-                VcpuResponse::NotAllowed(reason) => Err(MicrovmStateError::NotAllowed(reason)),
-                _ => Err(MicrovmStateError::UnexpectedVcpuResponse),
-            })
-            .collect::<Result<Vec<VcpuState>, MicrovmStateError>>()?;
-
-        Ok(vcpu_states)
-    }
-
     /// Dumps CPU configuration.
     pub fn dump_cpu_config(&mut self) -> Result<Vec<CpuConfiguration>, DumpCpuConfigError> {
-        for handle in self.vcpus_handles.iter_mut() {
-            handle
-                .send_event(VcpuEvent::DumpCpuConfig)
-                .map_err(DumpCpuConfigError::SendEvent)?;
-        }
-
-        let vcpu_responses = self
-            .vcpus_handles
-            .iter()
-            .map(|handle| handle.response_receiver().recv_timeout(RECV_TIMEOUT_SEC))
-            .collect::<Result<Vec<VcpuResponse>, RecvTimeoutError>>()
-            .map_err(|_| DumpCpuConfigError::UnexpectedResponse)?;
-
-        let cpu_configs = vcpu_responses
-            .into_iter()
-            .map(|response| match response {
-                VcpuResponse::DumpedCpuConfig(cpu_config) => Ok(*cpu_config),
-                VcpuResponse::Error(err) => Err(DumpCpuConfigError::DumpCpuConfig(err)),
-                VcpuResponse::NotAllowed(reason) => Err(DumpCpuConfigError::NotAllowed(reason)),
-                _ => Err(DumpCpuConfigError::UnexpectedResponse),
-            })
-            .collect::<Result<Vec<CpuConfiguration>, DumpCpuConfigError>>()?;
-
-        Ok(cpu_configs)
+        self.vm.dump_cpu_config_states()
     }
 
     /// Updates the path of the host file backing the emulated block device with id `drive_id`.
@@ -876,16 +737,7 @@ fn construct_kvm_mpidrs(vcpu_states: &[VcpuState]) -> Vec<u64> {
 impl Drop for Vmm {
     fn drop(&mut self) {
         info!("Killing vCPU threads");
-
-        // Send a "Finish" event to the vCPU threads so that they terminate.
-        for (idx, handle) in self.vcpus_handles.iter_mut().enumerate() {
-            if let Err(err) = handle.send_event(VcpuEvent::Finish) {
-                error!("Failed to send VcpuEvent::Finish to vCPU {}: {}", idx, err);
-            }
-        }
-
-        // Join the vCPU threads by running VcpuHandle::drop().
-        self.vcpus_handles.clear();
+        self.vm.shutdown_vcpus();
 
         if let Err(err) = std::io::stdin().lock().set_canon_mode() {
             warn!("Cannot set canonical mode for the terminal. {:?}", err);
@@ -896,7 +748,7 @@ impl Drop for Vmm {
             error!("Failed to write metrics while stopping: {}", err);
         }
 
-        if !self.vcpus_handles.is_empty() {
+        if !self.vm.vcpus_handles().is_empty() {
             error!("Failed to tear down Vmm: the vcpu threads have not finished execution.");
         }
     }
@@ -914,7 +766,8 @@ impl MutEventSubscriber for Vmm {
 
             let exit_code = 'exit_code: {
                 // Query each vcpu for their exit_code.
-                for handle in &self.vcpus_handles {
+                let handles = self.vm.vcpus_handles();
+                for handle in handles.iter() {
                     // Drain all vcpu responses that are pending from this vcpu until we find an
                     // exit status.
                     for response in handle.response_receiver().try_iter() {

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -126,7 +126,6 @@ pub use crate::vstate::vm::StartVcpusError;
 use device_manager::DeviceManager;
 use event_manager::{EventManager as BaseEventManager, EventOps, Events, MutEventSubscriber};
 use snapshot::Persist;
-use userfaultfd::Uffd;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::terminal::Terminal;
 pub use vstate::kvm::Kvm;
@@ -305,9 +304,6 @@ pub struct Vmm {
 
     /// VM object
     pub vm: Arc<KvmVm>,
-    // Save UFFD in order to keep it open in the Firecracker process, as well.
-    #[allow(unused)]
-    uffd: Option<Uffd>,
     // Device manager
     device_manager: DeviceManager,
 }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -131,7 +131,7 @@ use userfaultfd::Uffd;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
-use vstate::kvm::Kvm;
+pub use vstate::kvm::Kvm;
 use vstate::vcpu::{self, StartThreadedError, VcpuSendEventError};
 use vstate::vm::KvmVm;
 
@@ -313,8 +313,6 @@ pub struct Vmm {
     boot_source_config: BootSourceConfig,
     shutdown_exit_code: Option<FcExitCode>,
 
-    // Guest VM core resources.
-    kvm: Kvm,
     /// VM object
     pub vm: Arc<KvmVm>,
     // Save UFFD in order to keep it open in the Firecracker process, as well.
@@ -592,7 +590,7 @@ impl Vmm {
         // upon resuming from the snapshot.
         let device_states = self.device_manager.save();
         let vcpu_states = self.save_vcpu_states()?;
-        let kvm_state = self.kvm.save_state();
+        let kvm_state = self.vm.kvm().save_state();
         let vm_state = {
             #[cfg(target_arch = "x86_64")]
             {

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -11,12 +11,12 @@ use serde::{Deserialize, Serialize};
 use vm_memory::ByteValued;
 use zerocopy::FromBytes;
 
-use crate::Vm;
 use crate::logger::{debug, error, warn};
 use crate::pci::configuration::PciCapability;
 use crate::pci::{PciCapabilityId, PciSBDF};
 use crate::snapshot::Persist;
 use crate::vstate::interrupts::{InterruptError, MsixVectorConfig, MsixVectorGroup};
+use crate::vstate::vm::KvmVm;
 
 const MAX_MSIX_VECTORS_PER_DEVICE: u16 = 2048;
 const MSIX_TABLE_ENTRIES_MODULO: u64 = 16;
@@ -118,7 +118,7 @@ impl MsixConfig {
     /// Create an MSI-X configuration from snapshot state
     pub fn from_state(
         state: MsixConfigState,
-        vm: Arc<Vm>,
+        vm: Arc<KvmVm>,
         sbdf: PciSBDF,
     ) -> Result<Self, InterruptError> {
         let vectors = Arc::new(MsixVectorGroup::restore(vm, &state.vectors)?);
@@ -523,12 +523,13 @@ impl MsixCap {
 mod tests {
     use super::*;
     use crate::builder::tests::default_vmm;
+    use crate::check_metric_after_block;
     use crate::logger::{IncMetric, METRICS};
-    use crate::{Vm, check_metric_after_block};
+    use crate::vstate::vm::KvmVm;
 
     fn msix_vector_group(nr_vectors: u16) -> Arc<MsixVectorGroup> {
         let vmm = default_vmm();
-        Arc::new(Vm::create_msix_group(vmm.vm.clone(), nr_vectors).unwrap())
+        Arc::new(KvmVm::create_msix_group(vmm.vm.clone(), nr_vectors).unwrap())
     }
 
     #[test]

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -529,7 +529,7 @@ mod tests {
 
     fn msix_vector_group(nr_vectors: u16) -> Arc<MsixVectorGroup> {
         let vmm = default_vmm();
-        Arc::new(KvmVm::create_msix_group(vmm.vm.clone(), nr_vectors).unwrap())
+        Arc::new(KvmVm::create_msix_group(vmm.vm.as_kvm().unwrap().clone(), nr_vectors).unwrap())
     }
 
     #[test]

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -133,8 +133,8 @@ pub enum MicrovmStateError {
     RestoreDevices(#[from] DevicePersistError),
     /// Cannot save Vcpu state: {0}
     SaveVcpuState(vstate::vcpu::VcpuError),
-    /// Cannot save Vm state: {0}
-    SaveVmState(vstate::vm::ArchVmError),
+    /// Cannot save KvmVm state: {0}
+    SaveVmState(vstate::vm::KvmVmError),
     /// Cannot signal Vcpu: {0}
     SignalVcpu(VcpuSendEventError),
     /// Vcpu is in unexpected state.

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -174,14 +174,18 @@ pub fn create_snapshot(
 
     snapshot_state_to_file(&microvm_state, &params.snapshot_path)?;
 
-    vmm.vm
-        .snapshot_memory_to_file(&params.mem_file_path, params.snapshot_type)?;
+    let kvm_vm = vmm.vm.as_kvm().ok_or_else(|| {
+        CreateSnapshotError::MicrovmState(MicrovmStateError::NotAllowed(
+            "snapshot requires KVM".into(),
+        ))
+    })?;
+    kvm_vm.snapshot_memory_to_file(&params.mem_file_path, params.snapshot_type)?;
 
     // We need to mark queues as dirty again for all activated devices. The reason we
     // do it here is that we don't mark pages as dirty during runtime
     // for queue objects.
     vmm.device_manager
-        .mark_virtio_queue_memory_dirty(vmm.vm.guest_memory());
+        .mark_virtio_queue_memory_dirty(kvm_vm.guest_memory());
 
     Ok(())
 }
@@ -744,9 +748,9 @@ mod tests {
                 ..Default::default()
             },
             #[cfg(target_arch = "aarch64")]
-            vm_state: vmm.vm.save_state(&mpidrs).unwrap(),
+            vm_state: vmm.vm.as_kvm().unwrap().save_state(&mpidrs).unwrap(),
             #[cfg(target_arch = "x86_64")]
-            vm_state: vmm.vm.save_state().unwrap(),
+            vm_state: vmm.vm.as_kvm().unwrap().save_state().unwrap(),
         };
 
         let serialized_data = bitcode::serialize(&microvm_state).unwrap();

--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -7,10 +7,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use kvm_ioctls::VmFd;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::Vm;
 use crate::logger::{IncMetric, METRICS};
 use crate::pci::PciSBDF;
 use crate::snapshot::Persist;
+use crate::vstate::vm::KvmVm;
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 /// Errors related with Firecracker interrupts
@@ -87,9 +87,9 @@ impl MsixVector {
 #[derive(Debug)]
 /// MSI interrupts created for a VirtIO device
 pub struct MsixVectorGroup {
-    /// Reference to the Vm object, which we'll need for interacting with the underlying KVM Vm
+    /// Reference to the KvmVm object, which we'll need for interacting with the underlying KVM KvmVm
     /// file descriptor
-    pub vm: Arc<Vm>,
+    pub vm: Arc<KvmVm>,
     /// A list of all the MSI-X vectors
     pub vectors: Vec<MsixVector>,
 }
@@ -98,7 +98,7 @@ impl MsixVectorGroup {
     /// Returns the number of vectors in this group
     pub fn num_vectors(&self) -> u16 {
         // It is safe to unwrap here. We are creating `MsixVectorGroup` objects through the
-        // `Vm::create_msix_group` where the argument for the number of `vectors` is a `u16`.
+        // `KvmVm::create_msix_group` where the argument for the number of `vectors` is a `u16`.
         u16::try_from(self.vectors.len()).unwrap()
     }
 
@@ -175,7 +175,7 @@ impl MsixVectorGroup {
 
 impl<'a> Persist<'a> for MsixVectorGroup {
     type State = Vec<u32>;
-    type ConstructorArgs = Arc<Vm>;
+    type ConstructorArgs = Arc<KvmVm>;
     type Error = InterruptError;
 
     fn save(&self) -> Self::State {

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -22,12 +22,12 @@ pub use vm_memory::{
 };
 use vm_memory::{GuestMemoryError, GuestMemoryRegionBytes, VolatileSlice, WriteVolatile};
 
+use crate::DirtyBitmap;
 use crate::arch::host_page_size;
 use crate::logger::error;
 use crate::utils::u64_to_usize;
 use crate::vmm_config::machine_config::HugePageConfig;
-use crate::vstate::vm::VmError;
-use crate::{DirtyBitmap, Vm};
+use crate::vstate::vm::{KvmVm, VmError};
 
 /// Type of GuestRegionMmap.
 pub type GuestRegionMmap = vm_memory::GuestRegionMmap<Option<AtomicBitmap>>;
@@ -352,7 +352,7 @@ impl GuestRegionMmapExt {
     /// (un)plug a slot from an Hotpluggable memory region
     pub(crate) fn update_slot(
         &self,
-        vm: &Vm,
+        vm: &KvmVm,
         mem_slot: &GuestMemorySlot<'_>,
         plug: bool,
     ) -> Result<(), VmError> {

--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -828,7 +828,7 @@ pub(crate) mod tests {
     pub(crate) fn setup_vcpu(mem_size: usize) -> (KvmVm, Vcpu) {
         let mut vm = setup_vm_with_memory(mem_size);
 
-        let (mut vcpus, _) = vm.create_vcpus(1).unwrap();
+        let mut vcpus = vm.create_vcpus(1).unwrap();
         let mut vcpu = vcpus.remove(0);
 
         #[cfg(target_arch = "aarch64")]

--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -27,7 +27,7 @@ use crate::seccomp::{BpfProgram, BpfProgramRef};
 use crate::utils::signal::{Killable, register_signal_handler, sigrtmin};
 use crate::utils::sm::StateMachine;
 use crate::vstate::bus::Bus;
-use crate::vstate::vm::Vm;
+use crate::vstate::vm::KvmVm;
 
 /// Signal number (SIGRTMIN) used to kick Vcpus.
 pub const VCPU_RTSIG_OFFSET: i32 = 0;
@@ -124,7 +124,7 @@ impl Vcpu {
     /// * `index` - Represents the 0-based CPU index between [0, max vcpus).
     /// * `vm` - The vm to which this vcpu will get attached.
     /// * `exit_evt` - An `EventFd` that will be written into when this vcpu exits.
-    pub fn new(index: u8, vm: &Vm, exit_evt: EventFd) -> Result<Self, VcpuError> {
+    pub fn new(index: u8, vm: &KvmVm, exit_evt: EventFd) -> Result<Self, VcpuError> {
         let (event_sender, event_receiver) = channel();
         let (response_sender, response_receiver) = channel();
         let kvm_vcpu = KvmVcpu::new(index, vm).unwrap();
@@ -153,7 +153,7 @@ impl Vcpu {
     }
 
     /// Obtains a copy of the VcpuFd
-    pub fn copy_kvm_vcpu_fd(&self, vm: &Vm) -> Result<VcpuFd, CopyKvmFdError> {
+    pub fn copy_kvm_vcpu_fd(&self, vm: &KvmVm) -> Result<VcpuFd, CopyKvmFdError> {
         // SAFETY: We own this fd so it is considered safe to clone
         let r = unsafe { libc::dup(self.kvm_vcpu.fd.as_raw_fd()) };
         if r < 0 {
@@ -167,7 +167,7 @@ impl Vcpu {
     /// The handle can be used to control the remote vcpu.
     pub fn start_threaded(
         mut self,
-        vm: &Vm,
+        vm: &KvmVm,
         seccomp_filter: Arc<BpfProgram>,
         barrier: Arc<Barrier>,
     ) -> Result<VcpuHandle, StartThreadedError> {
@@ -671,7 +671,6 @@ pub(crate) mod tests {
     use crate::vstate::kvm::Kvm;
     use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
     use crate::vstate::vcpu::VcpuError as EmulationError;
-    use crate::vstate::vm::Vm;
     use crate::vstate::vm::tests::setup_vm_with_memory;
 
     struct DummyDevice;
@@ -827,7 +826,7 @@ pub(crate) mod tests {
 
     // Auxiliary function being used throughout the tests.
     #[allow(unused_mut)]
-    pub(crate) fn setup_vcpu(mem_size: usize) -> (Kvm, Vm, Vcpu) {
+    pub(crate) fn setup_vcpu(mem_size: usize) -> (Kvm, KvmVm, Vcpu) {
         let (kvm, mut vm) = setup_vm_with_memory(mem_size);
 
         let (mut vcpus, _) = vm.create_vcpus(1).unwrap();
@@ -866,7 +865,7 @@ pub(crate) mod tests {
         entry_addr.kernel_load
     }
 
-    fn vcpu_configured_for_boot() -> (Vm, VcpuHandle, EventFd) {
+    fn vcpu_configured_for_boot() -> (KvmVm, VcpuHandle, EventFd) {
         // Need enough mem to boot linux.
         let mem_size = mib_to_bytes(64);
         let (kvm, vm, mut vcpu) = setup_vcpu(mem_size);

--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -668,7 +668,6 @@ pub(crate) mod tests {
     use crate::utils::mib_to_bytes;
     use crate::utils::signal::validate_signal_num;
     use crate::vstate::bus::BusDevice;
-    use crate::vstate::kvm::Kvm;
     use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
     use crate::vstate::vcpu::VcpuError as EmulationError;
     use crate::vstate::vm::tests::setup_vm_with_memory;
@@ -685,7 +684,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_handle_kvm_exit() {
-        let (_, _, mut vcpu) = setup_vcpu(0x1000);
+        let (_, mut vcpu) = setup_vcpu(0x1000);
         let res = handle_kvm_exit(&mut vcpu.kvm_vcpu.peripherals, Ok(VcpuExit::Hlt));
         assert!(matches!(
             res,
@@ -826,8 +825,8 @@ pub(crate) mod tests {
 
     // Auxiliary function being used throughout the tests.
     #[allow(unused_mut)]
-    pub(crate) fn setup_vcpu(mem_size: usize) -> (Kvm, KvmVm, Vcpu) {
-        let (kvm, mut vm) = setup_vm_with_memory(mem_size);
+    pub(crate) fn setup_vcpu(mem_size: usize) -> (KvmVm, Vcpu) {
+        let mut vm = setup_vm_with_memory(mem_size);
 
         let (mut vcpus, _) = vm.create_vcpus(1).unwrap();
         let mut vcpu = vcpus.remove(0);
@@ -835,7 +834,7 @@ pub(crate) mod tests {
         #[cfg(target_arch = "aarch64")]
         vcpu.kvm_vcpu.init(&[]).unwrap();
 
-        (kvm, vm, vcpu)
+        (vm, vcpu)
     }
 
     fn load_good_kernel(vm_memory: &GuestMemoryMmap) -> GuestAddress {
@@ -868,7 +867,7 @@ pub(crate) mod tests {
     fn vcpu_configured_for_boot() -> (KvmVm, VcpuHandle, EventFd) {
         // Need enough mem to boot linux.
         let mem_size = mib_to_bytes(64);
-        let (kvm, vm, mut vcpu) = setup_vcpu(mem_size);
+        let (vm, mut vcpu) = setup_vcpu(mem_size);
 
         let vcpu_exit_evt = vcpu.exit_evt.try_clone().unwrap();
 
@@ -889,7 +888,7 @@ pub(crate) mod tests {
                         vcpu_count: 1,
                         smt: false,
                         cpu_config: CpuConfiguration {
-                            cpuid: Cpuid::try_from(kvm.supported_cpuid.clone()).unwrap(),
+                            cpuid: Cpuid::try_from(vm.kvm().supported_cpuid.clone()).unwrap(),
                             msrs: BTreeMap::new(),
                         },
                     },
@@ -907,7 +906,7 @@ pub(crate) mod tests {
                     smt: false,
                     cpu_config: crate::cpu_config::aarch64::CpuConfiguration::default(),
                 },
-                &kvm.optional_capabilities(),
+                &vm.kvm().optional_capabilities(),
             )
             .expect("failed to configure vcpu");
 
@@ -928,7 +927,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_set_mmio_bus() {
-        let (_, _, mut vcpu) = setup_vcpu(0x1000);
+        let (_, mut vcpu) = setup_vcpu(0x1000);
         assert!(vcpu.kvm_vcpu.peripherals.mmio_bus.is_none());
         vcpu.set_mmio_bus(Arc::new(Bus::new()));
         assert!(vcpu.kvm_vcpu.peripherals.mmio_bus.is_some());
@@ -936,7 +935,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_vcpu_kick() {
-        let (_, vm, mut vcpu) = setup_vcpu(0x1000);
+        let (vm, mut vcpu) = setup_vcpu(0x1000);
 
         let mut kvm_run =
             kvm_ioctls::KvmRunWrapper::mmap_from_fd(&vcpu.kvm_vcpu.fd, vm.fd().run_size())
@@ -998,7 +997,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_immediate_exit_shortcircuits_execution() {
-        let (_, _, mut vcpu) = setup_vcpu(0x1000);
+        let (_, mut vcpu) = setup_vcpu(0x1000);
 
         vcpu.kvm_vcpu.fd.set_kvm_immediate_exit(1);
         // Set a dummy value to be returned by the emulate call

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -23,8 +23,8 @@ use serde::{Deserialize, Serialize};
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 
-pub use crate::arch::{ArchVm as Vm, ArchVmError, VmState};
 use crate::arch::{GSI_MSI_END, host_page_size};
+pub use crate::arch::{KvmVm, KvmVmError, VmState};
 use crate::logger::{debug, info};
 use crate::persist::CreateSnapshotError;
 use crate::vmm_config::snapshot::SnapshotType;
@@ -48,13 +48,13 @@ pub struct RoutingEntry {
 /// Architecture independent parts of a VM.
 #[derive(Debug)]
 pub struct VmCommon {
-    /// The KVM file descriptor used to access this Vm.
+    /// The KVM file descriptor used to access this KvmVm.
     pub fd: VmFd,
     max_memslots: u32,
-    /// The guest memory of this Vm.
+    /// The guest memory of this KvmVm.
     pub guest_memory: GuestMemoryMmap,
     next_kvm_slot: AtomicU32,
-    /// Interrupts used by Vm's devices
+    /// Interrupts used by KvmVm's devices
     pub interrupts: Mutex<HashMap<u32, RoutingEntry>>,
     /// Allocator for VM resources
     pub resource_allocator: Mutex<ResourceAllocator>,
@@ -74,7 +74,7 @@ pub enum VmError {
     /// Failed to get KVM's dirty log: {0}
     GetDirtyLog(kvm_ioctls::Error),
     /// {0}
-    Arch(#[from] ArchVmError),
+    Arch(#[from] KvmVmError),
     /// Error during eventfd operations: {0}
     EventFd(std::io::Error),
     /// Failed to create vcpu: {0}
@@ -91,8 +91,8 @@ pub enum VmError {
     MemoryError(#[from] MemoryError),
 }
 
-/// Contains Vm functions that are usable across CPU architectures
-impl Vm {
+/// Contains KvmVm functions that are usable across CPU architectures
+impl KvmVm {
     /// Create a KVM VM
     pub fn create_common(kvm: &crate::vstate::kvm::Kvm) -> Result<VmCommon, VmError> {
         // It is known that KVM_CREATE_VM occasionally fails with EINTR on heavily loaded machines
@@ -207,7 +207,7 @@ impl Vm {
         Ok(())
     }
 
-    /// Register a list of new memory regions to this [`Vm`].
+    /// Register a list of new memory regions to this [`KvmVm`].
     pub fn register_dram_memory_regions(
         &mut self,
         regions: Vec<GuestRegionMmap>,
@@ -226,7 +226,7 @@ impl Vm {
         Ok(())
     }
 
-    /// Register a new hotpluggable region to this [`Vm`].
+    /// Register a new hotpluggable region to this [`KvmVm`].
     pub fn register_hotpluggable_memory_region(
         &mut self,
         region: GuestRegionMmap,
@@ -247,7 +247,7 @@ impl Vm {
         self.register_memory_region(arcd_region)
     }
 
-    /// Register a list of new memory regions to this [`Vm`].
+    /// Register a list of new memory regions to this [`KvmVm`].
     ///
     /// Note: regions and state.regions need to be in the same order.
     pub fn restore_memory_regions(
@@ -279,12 +279,12 @@ impl Vm {
         &self.common.fd
     }
 
-    /// Gets a reference to this [`Vm`]'s [`GuestMemoryMmap`] object
+    /// Gets a reference to this [`KvmVm`]'s [`GuestMemoryMmap`] object
     pub fn guest_memory(&self) -> &GuestMemoryMmap {
         &self.common.guest_memory
     }
 
-    /// Gets a mutable reference to this [`Vm`]'s [`ResourceAllocator`] object
+    /// Gets a mutable reference to this [`KvmVm`]'s [`ResourceAllocator`] object
     pub fn resource_allocator(&self) -> MutexGuard<'_, ResourceAllocator> {
         self.common
             .resource_allocator
@@ -455,7 +455,10 @@ impl Vm {
     }
 
     /// Create a group of MSI-X interrupts
-    pub fn create_msix_group(vm: Arc<Vm>, count: u16) -> Result<MsixVectorGroup, InterruptError> {
+    pub fn create_msix_group(
+        vm: Arc<KvmVm>,
+        count: u16,
+    ) -> Result<MsixVectorGroup, InterruptError> {
         debug!("Creating new MSI group with {count} vectors");
         let mut vectors = Vec::with_capacity(count as usize);
         for gsi in vm
@@ -537,14 +540,14 @@ pub(crate) mod tests {
     use crate::vstate::memory::GuestRegionMmap;
 
     // Auxiliary function being used throughout the tests.
-    pub(crate) fn setup_vm() -> (Kvm, Vm) {
+    pub(crate) fn setup_vm() -> (Kvm, KvmVm) {
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        let vm = Vm::new(&kvm).expect("Cannot create new vm");
+        let vm = KvmVm::new(&kvm).expect("Cannot create new vm");
         (kvm, vm)
     }
 
     // Auxiliary function being used throughout the tests.
-    pub(crate) fn setup_vm_with_memory(mem_size: usize) -> (Kvm, Vm) {
+    pub(crate) fn setup_vm_with_memory(mem_size: usize) -> (Kvm, KvmVm) {
         let (kvm, mut vm) = setup_vm();
         let gm = single_region_mem_raw(mem_size);
         vm.register_dram_memory_regions(gm).unwrap();
@@ -555,7 +558,7 @@ pub(crate) mod tests {
     fn test_new() {
         // Testing with a valid /dev/kvm descriptor.
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        Vm::new(&kvm).unwrap();
+        KvmVm::new(&kvm).unwrap();
     }
 
     #[test]
@@ -638,15 +641,15 @@ pub(crate) mod tests {
         assert_eq!(vcpu_vec.len(), vcpu_count as usize);
     }
 
-    fn enable_irqchip(vm: &mut Vm) {
+    fn enable_irqchip(vm: &mut KvmVm) {
         #[cfg(target_arch = "x86_64")]
         vm.setup_irqchip().unwrap();
         #[cfg(target_arch = "aarch64")]
         vm.setup_irqchip(1).unwrap();
     }
 
-    fn create_msix_group(vm: &Arc<Vm>) -> MsixVectorGroup {
-        Vm::create_msix_group(vm.clone(), 4).unwrap()
+    fn create_msix_group(vm: &Arc<KvmVm>) -> MsixVectorGroup {
+        KvmVm::create_msix_group(vm.clone(), 4).unwrap()
     }
 
     #[test]

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -20,6 +20,7 @@ use kvm_bindings::{
 };
 use kvm_ioctls::VmFd;
 use serde::{Deserialize, Serialize};
+use userfaultfd::Uffd;
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
@@ -73,6 +74,8 @@ pub struct VmCommon {
     pub mmio_bus: Arc<Bus>,
     /// The global KVM state (fd + capabilities).
     pub kvm: Kvm,
+    /// Userfaultfd kept open for snapshot restore.
+    pub uffd: Option<Uffd>,
     /// Handles to vCPU threads.
     pub vcpus_handles: Mutex<Vec<VcpuHandle>>,
     /// Event fd written to by vCPUs on exit.
@@ -159,6 +162,7 @@ impl KvmVm {
             resource_allocator: Mutex::new(ResourceAllocator::new()),
             mmio_bus: Arc::new(Bus::new()),
             kvm,
+            uffd: None,
             vcpus_handles: Mutex::new(Vec::new()),
             vcpus_exit_evt,
         })
@@ -198,6 +202,11 @@ impl KvmVm {
     /// Returns a locked reference to the vCPU handles.
     pub fn vcpus_handles(&self) -> MutexGuard<'_, Vec<VcpuHandle>> {
         self.common.vcpus_handles.lock().expect("Poisoned lock")
+    }
+
+    /// Sets the userfaultfd (used during snapshot restore).
+    pub fn set_uffd(&mut self, uffd: Option<Uffd>) {
+        self.common.uffd = uffd;
     }
 
     /// Starts the microVM vCPUs.

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -111,6 +111,29 @@ pub enum VmError {
     MemoryError(#[from] MemoryError),
 }
 
+/// VM abstraction: either a KVM-based VM or (in the future) a Nitro Enclave.
+#[derive(Debug)]
+pub enum Vm {
+    /// KVM-backed virtual machine.
+    Kvm(Arc<KvmVm>),
+}
+
+impl Vm {
+    /// Returns the name of the VM type.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Vm::Kvm(_) => "Kvm",
+        }
+    }
+
+    /// Returns a reference to the inner KVM VM, or `None` if this is not a KVM VM.
+    pub fn as_kvm(&self) -> Option<&Arc<KvmVm>> {
+        match self {
+            Vm::Kvm(v) => Some(v),
+        }
+    }
+}
+
 /// Contains KvmVm functions that are usable across CPU architectures
 impl KvmVm {
     /// Create a KVM VM
@@ -1034,7 +1057,7 @@ pub(crate) mod tests {
 
         msix_group.enable().unwrap();
         let state = msix_group.save();
-        let restored_group = MsixVectorGroup::restore(vm, &state).unwrap();
+        let restored_group = MsixVectorGroup::restore(vm.clone(), &state).unwrap();
 
         assert_eq!(msix_group.num_vectors(), restored_group.num_vectors());
         // Even if an MSI group is enabled, we don't save it as such. During restoration, the PCI

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -63,6 +63,8 @@ pub struct VmCommon {
     pub mmio_bus: Arc<Bus>,
     /// The global KVM state (fd + capabilities).
     pub kvm: Kvm,
+    /// Event fd written to by vCPUs on exit.
+    pub vcpus_exit_evt: EventFd,
 }
 
 /// Errors associated with the wrappers over KVM ioctls.
@@ -134,6 +136,8 @@ impl KvmVm {
             attempt += 1;
         };
 
+        let vcpus_exit_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(VmError::EventFd)?;
+
         Ok(VmCommon {
             fd,
             max_memslots: kvm.max_nr_memslots(),
@@ -143,32 +147,39 @@ impl KvmVm {
             resource_allocator: Mutex::new(ResourceAllocator::new()),
             mmio_bus: Arc::new(Bus::new()),
             kvm,
+            vcpus_exit_evt,
         })
     }
 
     /// Creates the specified number of [`Vcpu`]s.
     ///
-    /// The returned [`EventFd`] is written to whenever any of the vcpus exit.
-    pub fn create_vcpus(&mut self, vcpu_count: u8) -> Result<(Vec<Vcpu>, EventFd), VmError> {
+    /// Each vCPU gets a clone of the `vcpus_exit_evt` EventFd stored on this KvmVm.
+    pub fn create_vcpus(&mut self, vcpu_count: u8) -> Result<Vec<Vcpu>, VmError> {
         self.arch_pre_create_vcpus(vcpu_count)?;
-
-        let exit_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(VmError::EventFd)?;
 
         let mut vcpus = Vec::with_capacity(vcpu_count as usize);
         for cpu_idx in 0..vcpu_count {
-            let exit_evt = exit_evt.try_clone().map_err(VmError::EventFd)?;
+            let exit_evt = self
+                .vcpus_exit_evt()
+                .try_clone()
+                .map_err(VmError::EventFd)?;
             let vcpu = Vcpu::new(cpu_idx, self, exit_evt).map_err(VmError::CreateVcpu)?;
             vcpus.push(vcpu);
         }
 
         self.arch_post_create_vcpus(vcpu_count)?;
 
-        Ok((vcpus, exit_evt))
+        Ok(vcpus)
     }
 
     /// Returns a reference to the [`Kvm`] instance.
     pub fn kvm(&self) -> &Kvm {
         &self.common.kvm
+    }
+
+    /// Returns a reference to the vCPU exit [`EventFd`].
+    pub fn vcpus_exit_evt(&self) -> &EventFd {
+        &self.common.vcpus_exit_evt
     }
 
     /// Reserves the next `slot_cnt` contiguous kvm slot ids and returns the first one
@@ -644,7 +655,7 @@ pub(crate) mod tests {
         let vcpu_count = 2;
         let mut vm = setup_vm_with_memory(mib_to_bytes(128));
 
-        let (vcpu_vec, _) = vm.create_vcpus(vcpu_count).unwrap();
+        let vcpu_vec = vm.create_vcpus(vcpu_count).unwrap();
 
         assert_eq!(vcpu_vec.len(), vcpu_count as usize);
     }

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -30,6 +30,7 @@ use crate::persist::CreateSnapshotError;
 use crate::vmm_config::snapshot::SnapshotType;
 use crate::vstate::bus::Bus;
 use crate::vstate::interrupts::{InterruptError, MsixVector, MsixVectorConfig, MsixVectorGroup};
+use crate::vstate::kvm::Kvm;
 use crate::vstate::memory::{
     GuestMemory, GuestMemoryExtension, GuestMemoryMmap, GuestMemoryRegion, GuestMemoryState,
     GuestRegionMmap, GuestRegionMmapExt, MemoryError,
@@ -60,6 +61,8 @@ pub struct VmCommon {
     pub resource_allocator: Mutex<ResourceAllocator>,
     /// MMIO bus
     pub mmio_bus: Arc<Bus>,
+    /// The global KVM state (fd + capabilities).
+    pub kvm: Kvm,
 }
 
 /// Errors associated with the wrappers over KVM ioctls.
@@ -94,7 +97,7 @@ pub enum VmError {
 /// Contains KvmVm functions that are usable across CPU architectures
 impl KvmVm {
     /// Create a KVM VM
-    pub fn create_common(kvm: &crate::vstate::kvm::Kvm) -> Result<VmCommon, VmError> {
+    pub fn create_common(kvm: Kvm) -> Result<VmCommon, VmError> {
         // It is known that KVM_CREATE_VM occasionally fails with EINTR on heavily loaded machines
         // with many VMs.
         //
@@ -139,6 +142,7 @@ impl KvmVm {
             interrupts: Mutex::new(HashMap::with_capacity(GSI_MSI_END as usize + 1)),
             resource_allocator: Mutex::new(ResourceAllocator::new()),
             mmio_bus: Arc::new(Bus::new()),
+            kvm,
         })
     }
 
@@ -160,6 +164,11 @@ impl KvmVm {
         self.arch_post_create_vcpus(vcpu_count)?;
 
         Ok((vcpus, exit_evt))
+    }
+
+    /// Returns a reference to the [`Kvm`] instance.
+    pub fn kvm(&self) -> &Kvm {
+        &self.common.kvm
     }
 
     /// Reserves the next `slot_cnt` contiguous kvm slot ids and returns the first one
@@ -540,30 +549,29 @@ pub(crate) mod tests {
     use crate::vstate::memory::GuestRegionMmap;
 
     // Auxiliary function being used throughout the tests.
-    pub(crate) fn setup_vm() -> (Kvm, KvmVm) {
+    pub(crate) fn setup_vm() -> KvmVm {
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        let vm = KvmVm::new(&kvm).expect("Cannot create new vm");
-        (kvm, vm)
+        KvmVm::new(kvm).expect("Cannot create new vm")
     }
 
     // Auxiliary function being used throughout the tests.
-    pub(crate) fn setup_vm_with_memory(mem_size: usize) -> (Kvm, KvmVm) {
-        let (kvm, mut vm) = setup_vm();
+    pub(crate) fn setup_vm_with_memory(mem_size: usize) -> KvmVm {
+        let mut vm = setup_vm();
         let gm = single_region_mem_raw(mem_size);
         vm.register_dram_memory_regions(gm).unwrap();
-        (kvm, vm)
+        vm
     }
 
     #[test]
     fn test_new() {
         // Testing with a valid /dev/kvm descriptor.
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
-        KvmVm::new(&kvm).unwrap();
+        KvmVm::new(kvm).unwrap();
     }
 
     #[test]
     fn test_register_memory_regions() {
-        let (_, mut vm) = setup_vm();
+        let mut vm = setup_vm();
 
         // Trying to set a memory region with a size that is not a multiple of GUEST_PAGE_SIZE
         // will result in error.
@@ -581,8 +589,8 @@ pub(crate) mod tests {
 
     #[test]
     fn test_too_many_regions() {
-        let (kvm, mut vm) = setup_vm();
-        let max_nr_regions = kvm.max_nr_memslots();
+        let mut vm = setup_vm();
+        let max_nr_regions = vm.kvm().max_nr_memslots();
 
         // SAFETY: valid mmap parameters
         let ptr = unsafe {
@@ -634,7 +642,7 @@ pub(crate) mod tests {
     #[test]
     fn test_create_vcpus() {
         let vcpu_count = 2;
-        let (_, mut vm) = setup_vm_with_memory(mib_to_bytes(128));
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
 
         let (vcpu_vec, _) = vm.create_vcpus(vcpu_count).unwrap();
 
@@ -654,7 +662,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_msi_vector_group_new() {
-        let (_, vm) = setup_vm_with_memory(mib_to_bytes(128));
+        let vm = setup_vm_with_memory(mib_to_bytes(128));
         let vm = Arc::new(vm);
         let msix_group = create_msix_group(&vm);
         assert_eq!(msix_group.num_vectors(), 4);
@@ -662,7 +670,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_msi_vector_group_enable_disable() {
-        let (_, mut vm) = setup_vm_with_memory(mib_to_bytes(128));
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
         let msix_group = create_msix_group(&vm);
@@ -690,7 +698,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_msi_vector_group_trigger() {
-        let (_, mut vm) = setup_vm_with_memory(mib_to_bytes(128));
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
         enable_irqchip(&mut vm);
 
         let vm = Arc::new(vm);
@@ -707,7 +715,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_msi_vector_group_notifier() {
-        let (_, vm) = setup_vm_with_memory(mib_to_bytes(128));
+        let vm = setup_vm_with_memory(mib_to_bytes(128));
         let vm = Arc::new(vm);
         let msix_group = create_msix_group(&vm);
 
@@ -720,7 +728,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_msi_vector_group_update_invalid_vector() {
-        let (_, mut vm) = setup_vm_with_memory(mib_to_bytes(128));
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
         let msix_group = create_msix_group(&vm);
@@ -736,7 +744,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_msi_vector_group_update() {
-        let (_, mut vm) = setup_vm_with_memory(mib_to_bytes(128));
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
         assert!(vm.common.interrupts.lock().unwrap().is_empty());
@@ -812,7 +820,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_msi_vector_group_persistence() {
-        let (_, mut vm) = setup_vm_with_memory(mib_to_bytes(128));
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
         let msix_group = create_msix_group(&vm);
@@ -837,7 +845,7 @@ pub(crate) mod tests {
     fn test_restore_state_resource_allocator() {
         use vm_allocator::AllocPolicy;
 
-        let (_, mut vm) = setup_vm_with_memory(0x1000);
+        let mut vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
         // Allocate a GSI and some memory and make sure they are still allocated after restore

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -10,7 +10,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Barrier, Mutex, MutexGuard};
 
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::KVM_IRQCHIP_IOAPIC;
@@ -22,6 +22,7 @@ use kvm_ioctls::VmFd;
 use serde::{Deserialize, Serialize};
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::terminal::Terminal;
 
 use crate::arch::{GSI_MSI_END, host_page_size};
 pub use crate::arch::{KvmVm, KvmVmError, VmState};
@@ -36,8 +37,17 @@ use crate::vstate::memory::{
     GuestRegionMmap, GuestRegionMmapExt, MemoryError,
 };
 use crate::vstate::resources::ResourceAllocator;
-use crate::vstate::vcpu::VcpuError;
+use crate::vstate::vcpu::{StartThreadedError, VcpuError, VcpuHandle};
 use crate::{DirtyBitmap, Vcpu, mem_size_mib};
+
+/// Error type for [`KvmVm::start_vcpus`].
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub enum StartVcpusError {
+    /// Failed to set terminal mode: {0}
+    SetTerminalMode(#[from] vmm_sys_util::errno::Error),
+    /// Vcpu handle error: {0}
+    VcpuHandle(#[from] StartThreadedError),
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 /// A struct representing an interrupt line used by some device of the microVM
@@ -63,6 +73,8 @@ pub struct VmCommon {
     pub mmio_bus: Arc<Bus>,
     /// The global KVM state (fd + capabilities).
     pub kvm: Kvm,
+    /// Handles to vCPU threads.
+    pub vcpus_handles: Mutex<Vec<VcpuHandle>>,
     /// Event fd written to by vCPUs on exit.
     pub vcpus_exit_evt: EventFd,
 }
@@ -147,6 +159,7 @@ impl KvmVm {
             resource_allocator: Mutex::new(ResourceAllocator::new()),
             mmio_bus: Arc::new(Bus::new()),
             kvm,
+            vcpus_handles: Mutex::new(Vec::new()),
             vcpus_exit_evt,
         })
     }
@@ -180,6 +193,180 @@ impl KvmVm {
     /// Returns a reference to the vCPU exit [`EventFd`].
     pub fn vcpus_exit_evt(&self) -> &EventFd {
         &self.common.vcpus_exit_evt
+    }
+
+    /// Returns a locked reference to the vCPU handles.
+    pub fn vcpus_handles(&self) -> MutexGuard<'_, Vec<VcpuHandle>> {
+        self.common.vcpus_handles.lock().expect("Poisoned lock")
+    }
+
+    /// Starts the microVM vCPUs.
+    ///
+    /// Sets the terminal to raw/non-blocking mode, then spawns a thread per vCPU
+    /// and stores the resulting handles. The barrier is used to synchronize TLS
+    /// initialization across all vCPU threads before returning.
+    pub fn start_vcpus(
+        self: &Arc<Self>,
+        mut vcpus: Vec<Vcpu>,
+        vcpu_seccomp_filter: Arc<crate::seccomp::BpfProgram>,
+    ) -> Result<(), StartVcpusError> {
+        let vcpu_count = vcpus.len();
+        let barrier = Arc::new(Barrier::new(vcpu_count + 1));
+
+        let stdin = std::io::stdin().lock();
+        stdin.set_raw_mode().inspect_err(|&err| {
+            crate::logger::warn!("Cannot set raw mode for the terminal. {:?}", err);
+        })?;
+        stdin.set_non_block(true).inspect_err(|&err| {
+            crate::logger::warn!("Cannot set non block for the terminal. {:?}", err);
+        })?;
+
+        let mut handles = self.vcpus_handles();
+        handles.reserve(vcpu_count);
+        for mut vcpu in vcpus.drain(..) {
+            vcpu.set_mmio_bus(self.common.mmio_bus.clone());
+            #[cfg(target_arch = "x86_64")]
+            vcpu.kvm_vcpu.set_pio_bus(self.pio_bus.clone());
+
+            handles.push(vcpu.start_threaded(
+                self,
+                vcpu_seccomp_filter.clone(),
+                barrier.clone(),
+            )?);
+        }
+        drop(handles);
+        barrier.wait();
+
+        Ok(())
+    }
+
+    /// Sends a pause event to all vCPUs and waits for acknowledgement.
+    pub fn pause_vcpus(&self) -> Result<(), crate::VmmError> {
+        let mut handles = self.vcpus_handles();
+        handles
+            .iter_mut()
+            .try_for_each(|handle| handle.send_event(crate::VcpuEvent::Pause))
+            .map_err(|_| crate::VmmError::VcpuMessage)?;
+
+        if handles
+            .iter()
+            .map(|handle| {
+                handle
+                    .response_receiver()
+                    .recv_timeout(crate::RECV_TIMEOUT_SEC)
+            })
+            .any(|response| !matches!(response, Ok(crate::VcpuResponse::Paused)))
+        {
+            return Err(crate::VmmError::VcpuMessage);
+        }
+        Ok(())
+    }
+
+    /// Sends a resume event to all vCPUs and waits for acknowledgement.
+    pub fn resume_vcpus(&self) -> Result<(), crate::VmmError> {
+        let mut handles = self.vcpus_handles();
+        handles
+            .iter_mut()
+            .try_for_each(|handle| handle.send_event(crate::VcpuEvent::Resume))
+            .map_err(|_| crate::VmmError::VcpuMessage)?;
+
+        if handles
+            .iter()
+            .map(|handle| {
+                handle
+                    .response_receiver()
+                    .recv_timeout(crate::RECV_TIMEOUT_SEC)
+            })
+            .any(|response| !matches!(response, Ok(crate::VcpuResponse::Resumed)))
+        {
+            return Err(crate::VmmError::VcpuMessage);
+        }
+        Ok(())
+    }
+
+    /// Saves vCPU states by requesting each vCPU thread to serialize its state.
+    pub fn save_vcpu_states(
+        &self,
+    ) -> Result<Vec<crate::vstate::vcpu::VcpuState>, crate::persist::MicrovmStateError> {
+        use crate::persist::MicrovmStateError;
+
+        let mut handles = self.vcpus_handles();
+        for handle in handles.iter_mut() {
+            handle
+                .send_event(crate::VcpuEvent::SaveState)
+                .map_err(MicrovmStateError::SignalVcpu)?;
+        }
+
+        let vcpu_responses = handles
+            .iter()
+            .map(|handle| {
+                handle
+                    .response_receiver()
+                    .recv_timeout(crate::RECV_TIMEOUT_SEC)
+            })
+            .collect::<Result<Vec<crate::VcpuResponse>, _>>()
+            .map_err(|_| MicrovmStateError::UnexpectedVcpuResponse)?;
+
+        vcpu_responses
+            .into_iter()
+            .map(|response| match response {
+                crate::VcpuResponse::SavedState(state) => Ok(*state),
+                crate::VcpuResponse::Error(err) => Err(MicrovmStateError::SaveVcpuState(err)),
+                crate::VcpuResponse::NotAllowed(reason) => {
+                    Err(MicrovmStateError::NotAllowed(reason))
+                }
+                _ => Err(MicrovmStateError::UnexpectedVcpuResponse),
+            })
+            .collect()
+    }
+
+    /// Dumps CPU configuration from all vCPU threads.
+    pub fn dump_cpu_config_states(
+        &self,
+    ) -> Result<Vec<crate::cpu_config::templates::CpuConfiguration>, crate::DumpCpuConfigError>
+    {
+        use crate::DumpCpuConfigError;
+
+        let mut handles = self.vcpus_handles();
+        for handle in handles.iter_mut() {
+            handle
+                .send_event(crate::VcpuEvent::DumpCpuConfig)
+                .map_err(DumpCpuConfigError::SendEvent)?;
+        }
+
+        let vcpu_responses = handles
+            .iter()
+            .map(|handle| {
+                handle
+                    .response_receiver()
+                    .recv_timeout(crate::RECV_TIMEOUT_SEC)
+            })
+            .collect::<Result<Vec<crate::VcpuResponse>, _>>()
+            .map_err(|_| DumpCpuConfigError::UnexpectedResponse)?;
+
+        vcpu_responses
+            .into_iter()
+            .map(|response| match response {
+                crate::VcpuResponse::DumpedCpuConfig(cpu_config) => Ok(*cpu_config),
+                crate::VcpuResponse::Error(err) => Err(DumpCpuConfigError::DumpCpuConfig(err)),
+                crate::VcpuResponse::NotAllowed(reason) => {
+                    Err(DumpCpuConfigError::NotAllowed(reason))
+                }
+                _ => Err(DumpCpuConfigError::UnexpectedResponse),
+            })
+            .collect()
+    }
+
+    /// Sends finish events to all vCPU threads and joins them.
+    pub fn shutdown_vcpus(&self) {
+        let mut handles = self.vcpus_handles();
+        for (idx, handle) in handles.iter_mut().enumerate() {
+            if let Err(err) = handle.send_event(crate::VcpuEvent::Finish) {
+                crate::logger::error!("Failed to send VcpuEvent::Finish to vCPU {}: {}", idx, err);
+            }
+        }
+        // Join the vCPU threads by running VcpuHandle::drop().
+        handles.clear();
     }
 
     /// Reserves the next `slot_cnt` contiguous kvm slot ids and returns the first one

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -145,7 +145,14 @@ fn test_dirty_bitmap_success() {
     for (vmm, _) in vmms {
         // Let it churn for a while and dirty some pages...
         thread::sleep(Duration::from_millis(100));
-        let bitmap = vmm.lock().unwrap().vm.get_dirty_bitmap().unwrap();
+        let bitmap = vmm
+            .lock()
+            .unwrap()
+            .vm
+            .as_kvm()
+            .unwrap()
+            .get_dirty_bitmap()
+            .unwrap();
         let num_dirty_pages: u32 = bitmap
             .values()
             .map(|bitmap_per_region| {


### PR DESCRIPTION
## Changes

Refactor the VMM to decouple KVM-specific state from the generic `Vmm` struct:

1. Rename `ArchVm` to `KvmVm` to clarify it represents a KVM-backed VM
2. Move `kvm`, `vcpus_exit_evt`, `vcpus_handles`, and `uffd` fields from `Vmm` into `KvmVm`/`VmCommon`
3. Move vCPU lifecycle methods (`start_vcpus`, `pause_vcpus`, `resume_vcpus`, `save_vcpu_states`, `dump_cpu_config_states`, `shutdown_vcpus`) from `Vmm` to `KvmVm`
4. Introduce a `Vm` enum with a single `Kvm` variant, preparing for alternative VM backends

## Reason

Prepare the codebase for supporting alternative VM backends (e.g. Nitro Enclaves) by isolating all KVM-specific state and logic behind the `KvmVm` type, accessed through a `Vm` enum. This allows the same `Vmm` struct to drive different VM types in the future without scattering conditional logic across callers.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md