### PR TITLE
Fix/vsock reset race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@ and this project adheres to
   Corrected the OpenAPI spec for `PATCH /balloon/hinting/start` and
   `PATCH /balloon/hinting/stop` to declare `204 No Content` instead of `200`,
   matching the actual runtime response.
+- [#5882](https://github.com/firecracker-microvm/firecracker/pull/5882): Fixed a
+  race in the vsock device where, after snapshot restore, the RX queue could
+  deliver data to the guest before it had acknowledged the TRANSPORT_RESET
+  event, causing established connections to break.
 
 ## [1.15.0]
 

--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -645,6 +645,20 @@ impl Queue {
         self.uses_notif_suppression = true;
     }
 
+    /// Arm `avail_event` at the current `avail.idx` so the driver's next
+    /// publish produces a notification. Unlike [`Self::try_enable_notification`],
+    /// does not require the queue to be drained and does not recheck
+    /// `avail.idx`; only correct when the driver does not add to the avail
+    /// ring until it has observed our used-ring update.
+    pub fn enable_notification(&mut self) {
+        if !self.uses_notif_suppression {
+            return;
+        }
+
+        self.used_ring_avail_event_set(self.avail_ring_idx_get());
+        fence(Ordering::Release);
+    }
+
     /// Check if we need to kick the guest.
     ///
     /// Please note this method has side effects: once it returns `true`, it considers the

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -78,6 +78,9 @@ pub struct Vsock<B> {
 
     pub rx_packet: VsockPacketRx,
     pub tx_packet: VsockPacketTx,
+
+    /// Gates RX delivery while a TRANSPORT_RESET is awaiting guest ack.
+    pub(crate) pending_event_ack: bool,
 }
 
 // TODO: Detect / handle queue deadlock:
@@ -112,6 +115,7 @@ where
             device_state: DeviceState::Inactive,
             rx_packet: VsockPacketRx::new()?,
             tx_packet: VsockPacketTx::default(),
+            pending_event_ack: false,
         })
     }
 
@@ -161,6 +165,10 @@ where
     /// have pending. Return `true` if the guest needs to be notified (respecting notification
     /// suppression).
     pub fn process_rx(&mut self) -> Result<bool, InvalidAvailIdx> {
+        if self.pending_event_ack {
+            return Ok(false);
+        }
+
         // This is safe since we checked in the event handler that the device is activated.
         let mem = &self.device_state.active_state().unwrap().mem;
 
@@ -275,6 +283,8 @@ where
         // Arm it so the driver's refill of the consumed head is not
         // suppressed by EVENT_IDX.
         queue.enable_notification();
+
+        self.pending_event_ack = true;
 
         // NOTE: kick() will be called on resume and it will trigger the interrupt again. As calling
         // it multiple times should not cause any harm, it would be safer to call it here as well
@@ -403,6 +413,8 @@ where
         // The only reason we still `kick` it is to make guest process
         // `TRANSPORT_RESET_EVENT` event we sent during snapshot creation.
         if self.is_activated() {
+            self.pending_event_ack = true;
+
             info!(
                 "[{:?}:{}] signaling event queue",
                 self.device_type(),

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -270,6 +270,12 @@ where
         });
         queue.advance_used_ring_idx();
 
+        // The evq is only popped here, not via a drain loop, so
+        // `avail_event` is not advanced by `pop_or_enable_notification`.
+        // Arm it so the driver's refill of the consumed head is not
+        // suppressed by EVENT_IDX.
+        queue.enable_notification();
+
         // NOTE: kick() will be called on resume and it will trigger the interrupt again. As calling
         // it multiple times should not cause any harm, it would be safer to call it here as well
         // as part of the sequence of actions that signal the reset event, prior to saving the

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -437,9 +437,26 @@ where
 
 #[cfg(test)]
 mod tests {
+    use vmm_sys_util::epoll::EventSet;
+
     use super::*;
+    use crate::devices::virtio::queue::VIRTQ_DESC_F_WRITE;
     use crate::devices::virtio::vsock::defs::uapi;
-    use crate::devices::virtio::vsock::test_utils::TestContext;
+    use crate::devices::virtio::vsock::test_utils::{EventHandlerContext, TestContext};
+    use crate::vstate::memory::GuestAddress;
+
+    /// Guest address used for the writable evq descriptor payload in tests.
+    const EVQ_PAYLOAD_GUEST_ADDR: u64 = 0x0040_2000;
+
+    /// Publish a single 4-byte writable descriptor on the event virtqueue and reload the
+    /// device-side queue so it sees the new avail index. Required by any test that exercises
+    /// `send_transport_reset_event` directly.
+    fn publish_evq_descriptor(ctx: &mut EventHandlerContext<'_>) {
+        ctx.guest_evvq.dtable[0].set(EVQ_PAYLOAD_GUEST_ADDR, 4, VIRTQ_DESC_F_WRITE, 0);
+        ctx.guest_evvq.avail.ring[0].set(0);
+        ctx.guest_evvq.avail.idx.set(1);
+        ctx.device.queues[EVQ_INDEX] = ctx.guest_evvq.create_queue();
+    }
 
     #[test]
     fn test_virtio_device() {
@@ -511,5 +528,148 @@ mod tests {
         ctx.device
             .activate(ctx.mem.clone(), ctx.interrupt.clone())
             .unwrap();
+    }
+
+    #[test]
+    fn test_send_transport_reset_event_sets_pending_event_ack() {
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+        publish_evq_descriptor(&mut ctx);
+
+        assert!(!ctx.device.pending_event_ack);
+
+        ctx.device.send_transport_reset_event().unwrap();
+
+        assert!(
+            ctx.device.pending_event_ack,
+            "TRANSPORT_RESET emission must arm the RX gate"
+        );
+        assert_eq!(
+            ctx.guest_evvq.used.idx.get(),
+            1,
+            "evq used ring must advance once the event is published"
+        );
+
+        // The 4-byte payload must be VIRTIO_VSOCK_EVENT_TRANSPORT_RESET (== 0).
+        let mut buf = [0xffu8; 4];
+        test_ctx
+            .mem
+            .read_slice(&mut buf, GuestAddress(EVQ_PAYLOAD_GUEST_ADDR))
+            .unwrap();
+        assert_eq!(u32::from_le_bytes(buf), VIRTIO_VSOCK_EVENT_TRANSPORT_RESET);
+    }
+
+    #[test]
+    fn test_send_transport_reset_event_empty_queue() {
+        // No available descriptors on the evq -> the device cannot publish the event.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        let err = ctx.device.send_transport_reset_event().unwrap_err();
+        match err {
+            DeviceError::VsockError(VsockError::EmptyQueue) => (),
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+        assert!(
+            !ctx.device.pending_event_ack,
+            "flag must not be armed if the event was never published"
+        );
+    }
+
+    #[test]
+    fn test_kick_when_inactive_is_a_noop() {
+        // The fix runs `kick()` only when activated. The inactive branch must not arm
+        // the RX gate, otherwise a freshly restored-but-unactivated device would refuse
+        // RX forever.
+        let mut ctx = TestContext::new();
+        assert!(!ctx.device.is_activated());
+
+        ctx.device.kick();
+
+        assert!(
+            !ctx.device.pending_event_ack,
+            "kick() on an inactive device must remain a no-op"
+        );
+    }
+
+    #[test]
+    fn test_kick_when_active_arms_pending_event_ack() {
+        // Restore path: kick() is invoked after the snapshot is loaded to re-deliver the
+        // TRANSPORT_RESET interrupt. It must arm the RX gate so the post-restore RX/EVQ
+        // race cannot deliver data ahead of the guest ack.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        ctx.device.pending_event_ack = false;
+        ctx.device.kick();
+
+        assert!(
+            ctx.device.pending_event_ack,
+            "kick() on an active device must arm the RX gate"
+        );
+
+        // After kick(), the gate must actually suppress RX delivery.
+        ctx.device.backend.set_pending_rx(true);
+        let progressed = ctx.device.process_rx().unwrap();
+        assert!(!progressed);
+        assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
+    }
+
+    #[test]
+    fn test_prepare_save_emits_transport_reset_when_active() {
+        // The snapshot path goes through prepare_save -> send_transport_reset_event.
+        // Both the evq publication and the RX gate must be observable afterwards.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+        publish_evq_descriptor(&mut ctx);
+
+        ctx.device.prepare_save();
+
+        assert!(ctx.device.pending_event_ack);
+        assert_eq!(ctx.guest_evvq.used.idx.get(), 1);
+    }
+
+    #[test]
+    fn test_prepare_save_inactive_is_a_noop() {
+        let mut ctx = TestContext::new();
+        assert!(!ctx.device.is_activated());
+
+        // Must not panic, must not arm the gate.
+        ctx.device.prepare_save();
+
+        assert!(!ctx.device.pending_event_ack);
+    }
+
+    #[test]
+    fn test_pending_event_ack_default_is_false() {
+        let ctx = TestContext::new();
+        assert!(
+            !ctx.device.pending_event_ack,
+            "freshly created device must have the RX gate disarmed"
+        );
+    }
+
+    #[test]
+    fn test_evq_event_with_non_in_evset_is_a_noop() {
+        // Spurious evset flavours must not flip the gate or drain the RX queue.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        ctx.device.pending_event_ack = true;
+        ctx.device.backend.set_pending_rx(true);
+
+        let used = ctx.device.handle_evq_event(EventSet::OUT);
+
+        assert!(used.is_empty());
+        assert!(
+            ctx.device.pending_event_ack,
+            "non-IN evset must not clear the gate"
+        );
+        assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
     }
 }

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -92,17 +92,31 @@ where
         used_queues
     }
 
-    pub fn handle_evq_event(&mut self, evset: EventSet) {
+    pub fn handle_evq_event(&mut self, evset: EventSet) -> Vec<u16> {
+        let mut used_queues = Vec::new();
         if evset != EventSet::IN {
             warn!("vsock: evq unexpected event {:?}", evset);
             METRICS.ev_queue_event_fails.inc();
-            return;
+            return used_queues;
         }
 
         if let Err(err) = self.queue_events[EVQ_INDEX].read() {
             error!("Failed to consume vsock evq event: {:?}", err);
             METRICS.ev_queue_event_fails.inc();
         }
+
+        // Guest's evq kick = TRANSPORT_RESET ack. Clear the gate and drain any RX the
+        // backend buffered while it was up. Assumes TRANSPORT_RESET is the only evq event
+        // we publish; new event types would need to disambiguate before clearing.
+        self.pending_event_ack = false;
+        if self.backend.has_pending_rx() {
+            match self.process_rx() {
+                Ok(true) => used_queues.push(RXQ_INDEX.try_into().unwrap()),
+                Ok(false) => {}
+                Err(err) => error!("vsock: process_rx after evq ack failed: {:?}", err),
+            }
+        }
+        used_queues
     }
 
     /// Notify backend of new events.
@@ -196,10 +210,7 @@ where
                 }
                 Self::PROCESS_RXQ => self.handle_rxq_event(evset),
                 Self::PROCESS_TXQ => self.handle_txq_event(evset),
-                Self::PROCESS_EVQ => {
-                    self.handle_evq_event(evset);
-                    Vec::new()
-                }
+                Self::PROCESS_EVQ => self.handle_evq_event(evset),
                 Self::PROCESS_NOTIFY_BACKEND => self.notify_backend(evset).unwrap(),
                 _ => {
                     warn!("Unexpected vsock event received: {:?}", source);
@@ -395,6 +406,46 @@ mod tests {
             ctx.device.handle_evq_event(EventSet::IN);
             assert_eq!(metric_before + 1, METRICS.ev_queue_event_fails.count());
         }
+    }
+
+    #[test]
+    fn test_pending_event_ack_gates_rx() {
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        ctx.device.pending_event_ack = true;
+        ctx.device.backend.set_pending_rx(true);
+
+        let used = ctx.device.notify_backend(EventSet::IN).unwrap();
+        assert!(
+            !used.contains(&RXQ_INDEX.try_into().unwrap()),
+            "RX vq must not be signalled while pending_event_ack is set"
+        );
+        assert_eq!(
+            ctx.guest_rxvq.used.idx.get(),
+            0,
+            "RX vq used ring must be untouched while pending_event_ack is set"
+        );
+
+        ctx.device.queue_events[EVQ_INDEX].write(1).unwrap();
+        ctx.device.backend.set_pending_rx(true);
+
+        let used = ctx.device.handle_evq_event(EventSet::IN);
+
+        assert!(
+            !ctx.device.pending_event_ack,
+            "pending_event_ack must be cleared by guest's evq ack"
+        );
+        assert!(
+            used.contains(&RXQ_INDEX.try_into().unwrap()),
+            "evq ack should drain pending RX and signal the RX vq"
+        );
+        assert_eq!(
+            ctx.guest_rxvq.used.idx.get(),
+            1,
+            "RX vq must be drained immediately after evq ack"
+        );
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -449,6 +449,114 @@ mod tests {
     }
 
     #[test]
+    fn test_pending_event_ack_gates_rxq_event() {
+        // RX queue events arriving before the guest acks the TRANSPORT_RESET must not
+        // drain the RX virtqueue.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        ctx.device.pending_event_ack = true;
+        ctx.device.backend.set_pending_rx(true);
+
+        ctx.signal_rxq_event();
+
+        assert_eq!(
+            ctx.guest_rxvq.used.idx.get(),
+            0,
+            "RX vq must stay empty while pending_event_ack is set"
+        );
+        assert_eq!(
+            ctx.device.backend.rx_ok_cnt, 0,
+            "backend recv_pkt must not be called while gated"
+        );
+    }
+
+    #[test]
+    fn test_pending_event_ack_gates_txq_drain() {
+        // The trailing RX drain in handle_txq_event must also be gated.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        ctx.device.pending_event_ack = true;
+        ctx.device.backend.set_pending_rx(true);
+
+        ctx.signal_txq_event();
+
+        // TX still drains - it is unrelated to the RX/EVQ race.
+        assert_eq!(ctx.guest_txvq.used.idx.get(), 1);
+        // RX drain must be suppressed by the gate.
+        assert_eq!(
+            ctx.guest_rxvq.used.idx.get(),
+            0,
+            "RX vq must stay empty during txq drain while gated"
+        );
+    }
+
+    #[test]
+    fn test_evq_event_clears_flag_without_pending_rx() {
+        // The evq ack must clear pending_event_ack even when the backend has nothing
+        // queued, otherwise a later RX would stay gated forever.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        ctx.device.pending_event_ack = true;
+        ctx.device.backend.set_pending_rx(false);
+        ctx.device.queue_events[EVQ_INDEX].write(1).unwrap();
+
+        let used = ctx.device.handle_evq_event(EventSet::IN);
+
+        assert!(
+            !ctx.device.pending_event_ack,
+            "pending_event_ack must be cleared by evq ack regardless of RX backlog"
+        );
+        assert!(used.is_empty(), "no queues should be signalled");
+        assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
+    }
+
+    #[test]
+    fn test_evq_event_logs_eventfd_read_failure() {
+        // Driving handle_evq_event without writing to the eventfd first triggers the
+        // EAGAIN read error branch. The flag must still be cleared so the device can
+        // recover.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        ctx.device.pending_event_ack = true;
+        ctx.device.backend.set_pending_rx(false);
+
+        let metric_before = METRICS.ev_queue_event_fails.count();
+        let used = ctx.device.handle_evq_event(EventSet::IN);
+
+        assert_eq!(metric_before + 1, METRICS.ev_queue_event_fails.count());
+        assert!(used.is_empty());
+        assert!(
+            !ctx.device.pending_event_ack,
+            "flag must clear even when the eventfd read errors"
+        );
+    }
+
+    #[test]
+    fn test_process_rx_short_circuits_on_pending_event_ack() {
+        // Direct call to process_rx must respect the flag and not touch the queue.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        ctx.device.pending_event_ack = true;
+        ctx.device.backend.set_pending_rx(true);
+
+        let progressed = ctx.device.process_rx().unwrap();
+
+        assert!(!progressed, "process_rx must report no progress when gated");
+        assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
+        assert_eq!(ctx.device.backend.rx_ok_cnt, 0);
+    }
+
+    #[test]
     fn test_backend_event() {
         // Test case:
         // - a backend event is received; and

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -15,7 +15,7 @@ use crate::devices::virtio::device::VirtioDevice;
 use crate::devices::virtio::queue::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
 use crate::devices::virtio::test_utils::{VirtQueue as GuestQ, default_interrupt};
 use crate::devices::virtio::transport::VirtioInterrupt;
-use crate::devices::virtio::vsock::device::{RXQ_INDEX, TXQ_INDEX};
+use crate::devices::virtio::vsock::device::{EVQ_INDEX, RXQ_INDEX, TXQ_INDEX};
 use crate::devices::virtio::vsock::packet::VSOCK_PKT_HDR_SIZE;
 use crate::devices::virtio::vsock::{
     Vsock, VsockBackend, VsockChannel, VsockEpollListener, VsockError,

--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -39,7 +39,7 @@ class HostEchoWorker(Thread):
         self.blob_path = blob_path
         self.hash = None
         self.error = None
-        self.sock = _vsock_connect_to_guest(self.uds_path, ECHO_SERVER_PORT)
+        self.sock = vsock_connect_to_guest(self.uds_path, ECHO_SERVER_PORT)
 
     def run(self):
         """Thread code payload.
@@ -246,16 +246,27 @@ def make_host_port_path(uds_path, port):
     return "{}_{}".format(uds_path, port)
 
 
-def _vsock_connect_to_guest(uds_path, port):
-    """Return a Unix socket, connected to the guest vsock port `port`."""
+def vsock_connect_to_guest(uds_path, port):
+    """Return a Unix socket, connected to the guest vsock port `port`.
+
+    The returned socket is a regular `socket.socket`, so callers can
+    pass it to `contextlib.ExitStack.enter_context` (or wrap it in a
+    `with` block) to get deterministic cleanup. On any failure during
+    the CONNECT/ACK handshake the socket is closed before raising, so
+    the caller never receives a half-open descriptor.
+    """
     sock = socket(AF_UNIX, SOCK_STREAM)
-    sock.connect(uds_path)
+    try:
+        sock.connect(uds_path)
 
-    buf = bytearray("CONNECT {}\n".format(port).encode("utf-8"))
-    sock.send(buf)
+        buf = bytearray("CONNECT {}\n".format(port).encode("utf-8"))
+        sock.send(buf)
 
-    ack_buf = sock.recv(32)
-    assert re.match("^OK [0-9]+\n$", ack_buf.decode("utf-8")) is not None
+        ack_buf = sock.recv(32)
+        assert re.match("^OK [0-9]+\n$", ack_buf.decode("utf-8")) is not None
+    except BaseException:
+        sock.close()
+        raise
 
     return sock
 

--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -6,6 +6,7 @@ import hashlib
 import os.path
 import re
 import time
+from contextlib import ExitStack
 from pathlib import Path
 from socket import AF_UNIX, SOCK_STREAM, socket
 from subprocess import Popen
@@ -56,6 +57,14 @@ class HostEchoWorker(Thread):
     def close_uds(self):
         """Close vsock UDS connection."""
         self.sock.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self.is_alive():
+            self.join()
+        self.close_uds()
 
     def _run(self):
         with open(self.blob_path, "rb") as blob_file:
@@ -152,17 +161,19 @@ def check_host_connections(uds_path, blob_path, blob_hash):
     checked against `blob_hash`.
     """
 
-    workers = []
-    for _ in range(TEST_CONNECTION_COUNT):
-        worker = HostEchoWorker(uds_path, blob_path)
-        workers.append(worker)
-        worker.start()
+    with ExitStack() as stack:
+        workers = [
+            stack.enter_context(HostEchoWorker(uds_path, blob_path))
+            for _ in range(TEST_CONNECTION_COUNT)
+        ]
+        for wrk in workers:
+            wrk.start()
 
-    for wrk in workers:
-        wrk.join()
+        for wrk in workers:
+            wrk.join()
 
-    for wrk in workers:
-        assert wrk.hash == blob_hash
+        for wrk in workers:
+            assert wrk.hash == blob_hash
 
 
 def check_guest_connections(vm, server_port_path, blob_path, blob_hash):

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -14,8 +14,11 @@ In order to test the vsock device connection state machine, these tests will:
 """
 
 import os.path
+import socket
 import subprocess
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
 from pathlib import Path
 from socket import timeout as SocketTimeout
@@ -34,6 +37,7 @@ from framework.utils_vsock import (
     make_blob,
     make_host_port_path,
     start_guest_echo_server,
+    vsock_connect_to_guest,
 )
 from host_tools.fcmetrics import validate_fc_metrics
 
@@ -376,3 +380,97 @@ def test_vsock_override_fails_without_device(uvm_plain_any, microvm_factory):
         )
 
     vm2.mark_killed()
+
+
+@pytest.mark.nonci
+def test_vsock_post_restore_connect_storm(
+    microvm_factory,
+    guest_kernel,
+    rootfs,
+    bin_vsock_path,
+    test_fc_session_root_path,
+):
+    """Regression test for the post-snapshot-restore RX/EVQ race.
+
+    Requires PCI MSI-X and >=2 vCPUs. `storm_size` must stay <= guest
+    socat backlog (128) to avoid unrelated sk_acceptq_is_full OP_RST.
+    """
+    blob_path, _blob_hash = make_blob(test_fc_session_root_path)
+    vm_blob_path = "/tmp/vsock/test.blob"
+
+    test_vm = microvm_factory.build(guest_kernel, rootfs, pci=True)
+    test_vm.spawn()
+    test_vm.basic_config(vcpu_count=4, mem_size_mib=256)
+    test_vm.add_net_iface()
+    test_vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path=f"/{VSOCK_UDS_PATH}")
+    test_vm.start()
+
+    _copy_vsock_data_to_guest(test_vm.ssh, blob_path, vm_blob_path, bin_vsock_path)
+    uds_path_pre = start_guest_echo_server(test_vm)
+
+    with ExitStack() as stack:
+        for _ in range(32):
+            stack.enter_context(vsock_connect_to_guest(uds_path_pre, ECHO_SERVER_PORT))
+
+        snapshot = test_vm.snapshot_full()
+        test_vm.kill()
+
+    storm_size = 64
+    iterations = 30
+    payload = b"vsock-race-probe-" + b"x" * 4096 + b"\n"
+
+    def worker(sock, ready):
+        sock.settimeout(5.0)
+        ready.wait()
+        try:
+            sock.send(f"CONNECT {ECHO_SERVER_PORT}\n".encode("utf-8"))
+            ack = sock.recv(32)
+            if not ack.startswith(b"OK "):
+                return f"bad ack: {ack!r}"
+            sock.send(payload)
+            received = b""
+            while len(received) < len(payload):
+                chunk = sock.recv(len(payload) - len(received))
+                if not chunk:
+                    return f"echo truncated: {received!r}"
+                received += chunk
+            if received != payload:
+                return f"echo mismatch: {received!r}"
+            return None
+        except (ConnectionResetError, BrokenPipeError, SocketTimeout) as exc:
+            return f"socket error: {type(exc).__name__}: {exc}"
+
+    for _ in range(iterations):
+        vm = microvm_factory.build()
+        try:
+            vm.spawn()
+            vm.restore_from_snapshot(snapshot, resume=False)
+
+            uds_path = os.path.join(vm.jailer.chroot_path(), VSOCK_UDS_PATH)
+
+            with ExitStack() as stack:
+                socks = []
+                for _ in range(storm_size):
+                    s = stack.enter_context(
+                        socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    )
+                    s.connect(uds_path)
+                    socks.append(s)
+
+                ready = threading.Barrier(storm_size + 1)
+                with ThreadPoolExecutor(max_workers=storm_size) as pool:
+                    futures = [pool.submit(worker, s, ready) for s in socks]
+                    vm.resume()
+                    ready.wait()
+                    errors = [f.result() for f in as_completed(futures)]
+
+                failed = [e for e in errors if e is not None]
+                assert not failed, (
+                    f"post-restore connect storm hit the RX/EVQ race "
+                    f"({len(failed)}/{storm_size} connections broken): {failed[:5]}"
+                )
+
+                metrics = vm.flush_metrics()
+                validate_fc_metrics(metrics)
+        finally:
+            vm.kill()

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -263,35 +263,39 @@ def test_vsock_transport_reset_g2h(vsock_uvm, microvm_factory):
             host_socat_commmand, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
-        # Give some time for host socat to create socket
-        time.sleep(0.5)
-        assert Path(host_socket_path).exists()
-        new_vm.create_jailed_resource(host_socket_path)
+        try:
+            # Give some time for host socat to create socket
+            time.sleep(0.5)
+            assert Path(host_socket_path).exists()
+            new_vm.create_jailed_resource(host_socket_path)
 
-        # Create a socat process in the guest which will connect to the host socat
-        guest_socat_commmand = (
-            f"tmux new -d 'socat - vsock-connect:2:{ECHO_SERVER_PORT}'"
-        )
-        new_vm.ssh.run(guest_socat_commmand)
+            # Create a socat process in the guest which will connect to the host socat
+            guest_socat_commmand = (
+                f"tmux new -d 'socat - vsock-connect:2:{ECHO_SERVER_PORT}'"
+            )
+            new_vm.ssh.run(guest_socat_commmand)
 
-        # socat should be running in the guest now
-        code, _, _ = new_vm.ssh.run("pidof socat")
-        assert code == 0
+            # socat should be running in the guest now
+            code, _, _ = new_vm.ssh.run("pidof socat")
+            assert code == 0
 
-        # Create snapshot.
-        snapshot = new_vm.snapshot_full()
-        new_vm.resume()
+            # Create snapshot.
+            snapshot = new_vm.snapshot_full()
+            new_vm.resume()
 
-        # After `create_snapshot` + 'restore' calls, connection should be dropped
-        code, _, _ = new_vm.ssh.run("pidof socat")
-        assert code == 1
+            # After `create_snapshot` + 'restore' calls, connection should be dropped
+            code, _, _ = new_vm.ssh.run("pidof socat")
+            assert code == 1
+        finally:
+            # Kill host socat as it is not useful anymore. Done in `finally`
+            # so that an assertion failure earlier in the iteration does not
+            # leak a `socat` process into the next iteration (or the next
+            # test).
+            host_socat.kill()
+            host_socat.communicate()
 
-        # Kill host socat as it is not useful anymore
-        host_socat.kill()
-        host_socat.communicate()
-
-        # Terminate VM.
-        new_vm.kill()
+            # Terminate VM.
+            new_vm.kill()
 
 
 def test_vsock_after_override(

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -16,6 +16,7 @@ In order to test the vsock device connection state machine, these tests will:
 import os.path
 import subprocess
 import time
+from contextlib import ExitStack
 from pathlib import Path
 from socket import timeout as SocketTimeout
 
@@ -85,15 +86,17 @@ def negative_test_host_connections(vm, blob_path, blob_hash):
 
     uds_path = start_guest_echo_server(vm)
 
-    workers = []
-    for _ in range(NEGATIVE_TEST_CONNECTION_COUNT):
-        worker = HostEchoWorker(uds_path, blob_path)
-        workers.append(worker)
-        worker.start()
+    with ExitStack() as stack:
+        workers = [
+            stack.enter_context(HostEchoWorker(uds_path, blob_path))
+            for _ in range(NEGATIVE_TEST_CONNECTION_COUNT)
+        ]
+        for wrk in workers:
+            wrk.start()
 
-    for wrk in workers:
-        wrk.close_uds()
-        wrk.join()
+        for wrk in workers:
+            wrk.close_uds()
+            wrk.join()
 
     # Validate that guest is still up and running.
     # Should fail if Firecracker exited from SIGPIPE handler.
@@ -174,40 +177,42 @@ def test_vsock_transport_reset_h2g(
     path = start_guest_echo_server(test_vm)
 
     # Start host workers that connect to the guest server.
-    workers = []
-    for _ in range(TEST_WORKER_COUNT):
-        worker = HostEchoWorker(path, blob_path)
-        workers.append(worker)
-        worker.start()
+    with ExitStack() as stack:
+        workers = [
+            stack.enter_context(HostEchoWorker(path, blob_path))
+            for _ in range(TEST_WORKER_COUNT)
+        ]
+        for wrk in workers:
+            wrk.start()
 
-    for wrk in workers:
-        wrk.join()
+        for wrk in workers:
+            wrk.join()
 
-    # Create snapshot.
-    snapshot = test_vm.snapshot_full()
-    test_vm.resume()
+        # Create snapshot.
+        snapshot = test_vm.snapshot_full()
+        test_vm.resume()
 
-    # Check that sockets are no longer working on workers.
-    for worker in workers:
-        # Whatever we send to the server, it should return the same
-        # value.
-        buf = bytearray("TEST\n".encode("utf-8"))
-        try:
-            worker.sock.send(buf)
-            # Arbitrary timeout, we set this so the socket won't block as
-            # it shouldn't receive anything.
-            worker.sock.settimeout(0.25)
-            response = worker.sock.recv(32)
-            assert (
-                response == b""
-            ), f"Connection not closed: response received '{response.decode('utf-8')}'"
-        except (SocketTimeout, ConnectionResetError, BrokenPipeError):
-            pass
+        # Check that sockets are no longer working on workers.
+        for worker in workers:
+            # Whatever we send to the server, it should return the same
+            # value.
+            buf = bytearray("TEST\n".encode("utf-8"))
+            try:
+                worker.sock.send(buf)
+                # Arbitrary timeout, we set this so the socket won't block as
+                # it shouldn't receive anything.
+                worker.sock.settimeout(0.25)
+                response = worker.sock.recv(32)
+                assert (
+                    response == b""
+                ), f"Connection not closed: response received '{response.decode('utf-8')}'"
+            except (SocketTimeout, ConnectionResetError, BrokenPipeError):
+                pass
 
-    # Terminate VM.
-    metrics = test_vm.flush_metrics()
-    validate_fc_metrics(metrics)
-    test_vm.kill()
+        # Terminate VM.
+        metrics = test_vm.flush_metrics()
+        validate_fc_metrics(metrics)
+        test_vm.kill()
 
     # Load snapshot.
     vm2 = microvm_factory.build_from_snapshot(snapshot)


### PR DESCRIPTION
There's a certain race which can happen on vsock on resume, with a storm of connections going through which can arrive before the device reset has completed leading to dropped connections.

Update FC to now block these pending connections until the guest has acked that the reset has been completed.

We were allocating an empty vec every call anyway, so no new allocations added other than when we fill it

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
