### PR TITLE
fix(vmclock): validate guest address is plugged before activate write

### DIFF
--- a/src/vmm/src/devices/acpi/vmclock.rs
+++ b/src/vmm/src/devices/acpi/vmclock.rs
@@ -19,7 +19,7 @@ use crate::devices::acpi::generated::vmclock_abi::{
 use crate::devices::legacy::EventFdTrigger;
 use crate::logger::debug;
 use crate::snapshot::Persist;
-use crate::vstate::memory::GuestMemoryMmap;
+use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryMmap};
 use crate::vstate::resources::ResourceAllocator;
 
 // SAFETY: `vmclock_abi` is a POD
@@ -114,6 +114,7 @@ impl VmClock {
 
     /// Activate [`VmClock`] device
     pub fn activate(&self, mem: &GuestMemoryMmap) -> Result<(), VmClockError> {
+        mem.check_range_plugged(self.guest_address, self.inner.as_slice().len())?;
         mem.write_slice(self.inner.as_slice(), self.guest_address)?;
         Ok(())
     }

--- a/src/vmm/src/devices/acpi/vmgenid.rs
+++ b/src/vmm/src/devices/acpi/vmgenid.rs
@@ -14,7 +14,7 @@ use vmm_sys_util::eventfd::EventFd;
 use super::super::legacy::EventFdTrigger;
 use crate::logger::debug;
 use crate::snapshot::Persist;
-use crate::vstate::memory::{Bytes, GuestMemoryMmap};
+use crate::vstate::memory::{Bytes, GuestMemoryExtension, GuestMemoryMmap};
 use crate::vstate::resources::ResourceAllocator;
 
 /// Bytes of memory we allocate for VMGenID device
@@ -117,6 +117,7 @@ impl VmGenId {
             "vmgenid: writing new generation ID to guest: {:#034x}",
             self.gen_id
         );
+        mem.check_range_plugged(self.guest_address, self.gen_id.to_le_bytes().len())?;
         mem.write_slice(&self.gen_id.to_le_bytes(), self.guest_address)
             .map_err(VmGenIdError::WriteGuestMemory)?;
 

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -510,7 +510,7 @@ impl VirtioMem {
                 updated_range.addr,
                 self.nb_blocks_to_len(updated_range.nb_blocks),
             )
-            .try_for_each(|slot| {
+            .try_for_each(|(slot, _)| {
                 let slot_range = RequestedRange {
                     addr: slot.guest_addr,
                     nb_blocks: slot.slice.len() / u64_to_usize(self.config.block_size),

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -347,8 +347,8 @@ impl GuestRegionMmapExt {
         &self,
         from: GuestAddress,
         len: usize,
-    ) -> impl Iterator<Item = GuestMemorySlot<'_>> {
-        self.slots().map(|(slot, _)| slot).filter(move |slot| {
+    ) -> impl Iterator<Item = (GuestMemorySlot<'_>, bool)> {
+        self.slots().filter(move |(slot, _)| {
             // Two intervals [a, b) and [c, d) intersect iff a < d && c < b.
             // This correctly handles the containment case where the slot fully
             // contains the range (or vice versa).
@@ -1520,7 +1520,7 @@ mod tests {
             let from = base.unchecked_add((offset_pages * page_size) as u64);
             let len = len_pages * page_size;
             let found: Vec<_> = region.slots_intersecting_range(from, len).collect();
-            let addrs: Vec<_> = found.iter().map(|s| s.guest_addr).collect();
+            let addrs: Vec<_> = found.iter().map(|(s, _)| s.guest_addr).collect();
             assert_eq!(
                 addrs, expected,
                 "offset={offset_pages} pages, len={len_pages} pages"

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -296,6 +296,27 @@ impl GuestRegionMmapExt {
         })
     }
 
+    /// Check whether the given guest address range falls within plugged slots.
+    pub(crate) fn check_range_plugged(
+        &self,
+        caddr: MemoryRegionAddress,
+        len: usize,
+    ) -> Result<(), GuestMemoryError> {
+        // caddr is guaranteed to be within the region by the caller
+        // (try_for_each_region_in_range validates this).
+        let from = self
+            .start_addr()
+            .checked_add(caddr.raw_value())
+            .expect("caddr should be within the region");
+        if self
+            .slots_intersecting_range(from, len)
+            .any(|(_, plugged)| !plugged)
+        {
+            return Err(GuestMemoryError::HostAddressNotAvailable);
+        }
+        Ok(())
+    }
+
     pub(crate) fn slot_cnt(&self) -> u32 {
         u32::try_from(u64_to_usize(self.len()) / self.slot_size).unwrap()
     }
@@ -640,6 +661,10 @@ where
 
     /// Discards a memory range, freeing up memory pages
     fn discard_range(&self, addr: GuestAddress, range_len: usize) -> Result<(), GuestMemoryError>;
+
+    /// Check whether the given guest address range falls entirely within plugged memory.
+    /// Returns Err if the address is not in any region or is in an unplugged slot.
+    fn check_range_plugged(&self, addr: GuestAddress, len: usize) -> Result<(), GuestMemoryError>;
 }
 
 /// State of a guest memory region saved to file/buffer.
@@ -820,6 +845,12 @@ impl GuestMemoryExtension for GuestMemoryMmap {
     fn discard_range(&self, addr: GuestAddress, range_len: usize) -> Result<(), GuestMemoryError> {
         self.try_for_each_region_in_range(addr, range_len, |region, start, len| {
             region.discard_range(start, len)
+        })
+    }
+
+    fn check_range_plugged(&self, addr: GuestAddress, len: usize) -> Result<(), GuestMemoryError> {
+        self.try_for_each_region_in_range(addr, len, |region, offset, chunk_len| {
+            region.check_range_plugged(offset, chunk_len)
         })
     }
 }
@@ -1811,5 +1842,52 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_check_range_plugged() {
+        let region_size = 0x4000usize; // 4 slots of 0x1000
+        let regions = anonymous(
+            vec![(GuestAddress(0x10_0000), region_size)].into_iter(),
+            false,
+            HugePageConfig::None,
+        )
+        .unwrap();
+        let region = regions.into_iter().next().unwrap();
+
+        let state = GuestMemoryRegionState {
+            base_address: 0x10_0000,
+            size: region_size,
+            region_type: GuestRegionType::Hotpluggable,
+            plugged: vec![true, true, false, true],
+        };
+
+        let ext = GuestRegionMmapExt::from_state(region, &state, 0).unwrap();
+
+        // Slot 0 (offset 0..0x1000): plugged
+        ext.check_range_plugged(MemoryRegionAddress(0), 0x100)
+            .unwrap();
+        // Slot 1 (offset 0x1000..0x2000): plugged
+        ext.check_range_plugged(MemoryRegionAddress(0x1000), 0x100)
+            .unwrap();
+        // Slot 2 (offset 0x2000..0x3000): unplugged
+        assert!(
+            ext.check_range_plugged(MemoryRegionAddress(0x2000), 0x100)
+                .is_err()
+        );
+        // Spanning slots 1-2: fails because slot 2 is unplugged
+        assert!(
+            ext.check_range_plugged(MemoryRegionAddress(0x1800), 0x1000)
+                .is_err()
+        );
+        // Spanning slots 0-1: both plugged
+        ext.check_range_plugged(MemoryRegionAddress(0x800), 0x1000)
+            .unwrap();
+        // Slot 3 (offset 0x3000..0x4000): plugged
+        ext.check_range_plugged(MemoryRegionAddress(0x3000), 0x100)
+            .unwrap();
+        // Zero length: always ok
+        ext.check_range_plugged(MemoryRegionAddress(0x2000), 0)
+            .unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Fix SIGSEGV during snapshot restore when a malformed snapshot places the vmclock `guest_address` in an unplugged (PROT_NONE) hotpluggable memory region.

Crashing on such accesses is the right thing to do as they're unexpected, but we try to keep the snapshot restoration path clean to test it via the fuzzer.

## Root Cause

1. Malformed snapshot has `plugged` bitvec marking slots as unplugged
2. `restore_memory_regions` calls `mprotect(PROT_NONE)` on unplugged slots
3. `VmClock::activate` writes to `guest_address` (from snapshot) which falls in the unplugged region
4. `write_slice` → `copy_nonoverlapping` → SIGSEGV on the protected page

## Changes

1. **refactor(memory):** Change `slots_intersecting_range` to return `(GuestMemorySlot, bool)` tuples, exposing the plugged state alongside each slot.
2. **feat(memory):** Add `check_range_plugged()` to `GuestRegionMmapExt` and `GuestMemoryExtension` trait. Validates that a guest address range falls within plugged memory slots before performing writes.
3. **fix(vmclock):** Call `check_range_plugged()` before `write_slice` in `VmClock::activate`, converting the SIGSEGV into a graceful error.

## Testing

- New unit test `test_check_range_plugged` covering plugged, unplugged, spanning, and zero-length cases
- Existing `test_slots_intersecting_range` updated for new return type
- Found by the snapshot fuzzer — 488 sig:11 crashes all reproduce this path