### PR TITLE
fix: duplicated words in RELEASE_POLICY and virtio/net/device comments

### DIFF
--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -71,7 +71,7 @@ since less than 6 months elapsed from their MINOR release time.
 - v2.11.0 released on 2022-07-10
 - v2.12.0 released on 2022-09-11
 
-In case of of an event occurring in 2023-05-04, v2.11 and v2.12 will be patched
+In case of an event occurring in 2023-05-04, v2.11 and v2.12 will be patched
 since those were the last 2 Firecracker major releases and less than an year
 passed since their release time.
 
@@ -81,7 +81,7 @@ passed since their release time.
 - v3.0.0 released on 2022-07-10
 - v3.1.0 released on 2022-09-11
 
-In case of of an event occurring in 2023-01-13, v2.14 will be patched since is
+In case of an event occurring in 2023-01-13, v2.14 will be patched since is
 the last minor of v2 and has less than one year since release while v3.0 and
 v3.1 will be patched since were the last two Firecracker releases and less than
 6 months have passed since release time.

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -71,7 +71,7 @@ since less than 6 months elapsed from their MINOR release time.
 - v2.11.0 released on 2022-07-10
 - v2.12.0 released on 2022-09-11
 
-In case of of an event occurring in 2023-05-04, v2.11 and v2.12 will be patched
+In case of an event occurring in 2023-05-04, v2.11 and v2.12 will be patched
 since those were the last 2 Firecracker major releases and less than an year
 passed since their release time.
 
@@ -81,10 +81,10 @@ passed since their release time.
 - v3.0.0 released on 2022-07-10
 - v3.1.0 released on 2022-09-11
 
-In case of of an event occurring in 2023-01-13, v2.14 will be patched since is
-the last minor of v2 and has less than one year since release while v3.0 and
-v3.1 will be patched since were the last two Firecracker releases and less than
-6 months have passed since release time.
+In case of an event occurring in 2023-01-13, v2.14 will be patched since is the
+last minor of v2 and has less than one year since release while v3.0 and v3.1
+will be patched since were the last two Firecracker releases and less than 6
+months have passed since release time.
 
 ## Release Status
 

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -522,7 +522,7 @@ impl Net {
         //    does not filter IPv4 packets. Operators deploying Firecracker
         //    based services should implement host-level firewall rules to
         //    restrict guest egress traffic.
-        // 3. Preventing this TOCTOU by copying packets to to a host buffer
+        // 3. Preventing this TOCTOU by copying packets to a host buffer
         //    before routing decisions would significantly reduce guest-to-host
         //    TCP throughput, which is not justifiable given the mitigations
         //    available at host-level.

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -556,7 +556,7 @@ impl Net {
         //    does not filter IPv4 packets. Operators deploying Firecracker
         //    based services should implement host-level firewall rules to
         //    restrict guest egress traffic.
-        // 3. Preventing this TOCTOU by copying packets to to a host buffer
+        // 3. Preventing this TOCTOU by copying packets to a host buffer
         //    before routing decisions would significantly reduce guest-to-host
         //    TCP throughput, which is not justifiable given the mitigations
         //    available at host-level.


### PR DESCRIPTION
Three one-line typo fixes for duplicated words:
- `docs/RELEASE_POLICY.md` (two occurrences) — "In case of of an event occurring in 2023-..." → "In case of an event occurring in 2023-..."
- `src/vmm/src/devices/virtio/net/device.rs` — "// 3. Preventing this TOCTOU by copying packets to to a host buffer" → "...copying packets to a host buffer"

No code/behavior change.

Signed-off-by: Noa Levi <275430404+lphuc2250gma@users.noreply.github.com>