### PR TITLE
test(serial): mark tx post snapshot as flaky

### DIFF
--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -10,6 +10,8 @@ import termios
 import time
 from pathlib import Path
 
+import pytest
+
 from framework import utils
 from framework.microvm import Serial
 
@@ -57,6 +59,8 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
     assert "/root" in res
 
 
+# The VM can become unresponsive in the test due to the interrupt storm .
+@pytest.mark.flaky(reruns=2)
 def test_serial_active_tx_snapshot(uvm_plain, microvm_factory):
     """
     Snapshot a guest that is actively transmitting on the serial console and


### PR DESCRIPTION
The test can fail sporadically due to the interrupt storm created from the serial in the test. For now mark this as flaky so it will be auto retried

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
