### PR TITLE
vmm: interrupts: fix: add Drop for MsixVectorGroup

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -606,6 +606,19 @@
             },
             {
                 "syscall": "ioctl",
+                "comment": "Needed for unregistering irqfds during device hot-unplug and VM teardown (called from MsixVectorGroup::drop)",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1075883638,
+                        "comment": "KVM_IRQFD"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
                 "comment": "Needed for opening tap device during net hotplug",
                 "args": [
                     {

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -618,6 +618,19 @@
             },
             {
                 "syscall": "ioctl",
+                "comment": "Needed for unregistering irqfds during device hot-unplug and VM teardown (called from MsixVectorGroup::drop)",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1075883638,
+                        "comment": "KVM_IRQFD"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
                 "comment": "Needed for opening tap device during net hotplug",
                 "args": [
                     {

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -646,6 +646,7 @@ mod tests {
         tmp_sock_file.remove().unwrap();
 
         let serialized_data;
+        let saved_allocator;
         // Set up a vmm with one of each device, and get the serialized DeviceStates.
         {
             let mut event_manager = EventManager::new().expect("Unable to create EventManager");
@@ -727,6 +728,7 @@ mod tests {
 
             let device_state = vmm.device_manager.save();
             serialized_data = bitcode::serialize(&device_state).unwrap();
+            saved_allocator = vmm.vm.as_kvm().unwrap().resource_allocator().clone()
         }
 
         tmp_sock_file.remove().unwrap();
@@ -737,6 +739,10 @@ mod tests {
         // this to avoid restoring the whole Vmm, since what we really need from Vmm is the KvmVm
         // object and calling default_vmm() is the easiest way to create one.
         let vmm = default_vmm();
+        // Restore the source allocator's state so the restored devices' GSIs match what their
+        // `MsixVectorGroup::Drop` will try to free at end-of-test.
+        *vmm.vm.as_kvm().unwrap().resource_allocator() = saved_allocator;
+
         let device_manager_state: device_manager::DevicesState =
             bitcode::deserialize(&serialized_data).unwrap();
         let vm_resources = &mut VmResources::default();

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -1705,8 +1705,18 @@ mod tests {
         let saved_state = locked.state();
         drop(locked);
 
-        let new_entropy = Arc::new(Mutex::new(Entropy::new(RateLimiter::default()).unwrap()));
+        // Fully drop the original device before constructing the restored copy: the restored
+        // copy reuses the same MSI-X GSIs, so the two `MsixVectorGroup` instances must never
+        // exist concurrently. This is how it will happen in real scenario anyway.
         let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
+        let saved_allocator = kvm_vm.resource_allocator().clone();
+        drop(device);
+        drop(vmm);
+        // Restore the allocator state so the restored group's GSIs are marked allocated and
+        // its `MsixVectorGroup::drop` will succeed when the test ends.
+        *kvm_vm.resource_allocator() = saved_allocator;
+
+        let new_entropy = Arc::new(Mutex::new(Entropy::new(RateLimiter::default()).unwrap()));
         let restored =
             VirtioPciDevice::new_from_state("rng".to_string(), &kvm_vm, new_entropy, saved_state)
                 .unwrap();

--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use kvm_ioctls::VmFd;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::logger::{IncMetric, METRICS};
+use crate::logger::{IncMetric, METRICS, error};
 use crate::pci::PciSBDF;
 use crate::snapshot::Persist;
 use crate::vstate::vm::KvmVm;
@@ -87,8 +87,8 @@ impl MsixVector {
 #[derive(Debug)]
 /// MSI interrupts created for a VirtIO device
 pub struct MsixVectorGroup {
-    /// Reference to the KvmVm object, which we'll need for interacting with the underlying KVM KvmVm
-    /// file descriptor
+    /// Reference to the KvmVm object, which we'll need for interacting with the underlying KVM
+    /// KvmVm file descriptor
     pub vm: Arc<KvmVm>,
     /// A list of all the MSI-X vectors
     pub vectors: Vec<MsixVector>,
@@ -170,6 +170,33 @@ impl MsixVectorGroup {
         }
 
         Err(InterruptError::InvalidVectorIndex(index))
+    }
+}
+
+impl Drop for MsixVectorGroup {
+    fn drop(&mut self) {
+        let vmfd = &self.vm.common.fd;
+
+        {
+            let mut interrupts = self.vm.common.interrupts.lock().expect("Poisoned lock");
+            for vector in &self.vectors {
+                if let Err(e) = vector.disable(vmfd) {
+                    error!("Failed to unregister irqfd for GSI {}: {e}", vector.gsi);
+                }
+                interrupts.remove(&vector.gsi);
+            }
+        }
+
+        let mut allocator = self
+            .vm
+            .common
+            .resource_allocator
+            .lock()
+            .expect("Poisoned lock");
+        for vector in &self.vectors {
+            // SAFETY: we allocated gsi from this allocator.
+            allocator.gsi_msi_allocator.free_id(vector.gsi).unwrap();
+        }
     }
 }
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -1068,6 +1068,45 @@ pub(crate) mod tests {
             assert_eq!(vector.gsi, new_vector.gsi);
             assert!(!new_vector.enabled.load(Ordering::Acquire));
         }
+
+        // Both groups own the same GSIs in this test so dropping both will result in panic. Resolve
+        // this by simply forgetting about the restored version.
+        std::mem::forget(restored_group);
+    }
+
+    #[test]
+    fn test_msi_vector_group_drop_frees_gsis() {
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
+        enable_irqchip(&mut vm);
+        let vm = Arc::new(vm);
+
+        let gsis_before = vm.resource_allocator().allocate_gsi_msi(1).unwrap();
+        for id in gsis_before.iter() {
+            vm.resource_allocator()
+                .gsi_msi_allocator
+                .free_id(*id)
+                .unwrap();
+        }
+
+        // Allocating, configuring and dropping a group must leave the allocator and the routing
+        // table in the same state as before.
+        {
+            let group = create_msix_group(&vm);
+            let config = MsixVectorConfig {
+                high_addr: 0x42,
+                low_addr: 0x13,
+                data: 0x12,
+                devid: PciSBDF::from(0xafa),
+            };
+            for i in 0..group.num_vectors() as usize {
+                group.update(i, config, false, true).unwrap();
+            }
+            assert_eq!(vm.common.interrupts.lock().unwrap().len(), 4);
+        }
+
+        assert!(vm.common.interrupts.lock().unwrap().is_empty());
+        let gsis_after = vm.resource_allocator().allocate_gsi_msi(1).unwrap();
+        assert_eq!(gsis_before, gsis_after);
     }
 
     #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -886,15 +886,11 @@ pub(crate) mod tests {
         vm.setup_irqchip(1).unwrap();
     }
 
-    fn create_msix_group(vm: &Arc<KvmVm>) -> MsixVectorGroup {
-        KvmVm::create_msix_group(vm.clone(), 4).unwrap()
-    }
-
     #[test]
     fn test_msi_vector_group_new() {
         let vm = setup_vm_with_memory(mib_to_bytes(128));
         let vm = Arc::new(vm);
-        let msix_group = create_msix_group(&vm);
+        let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
         assert_eq!(msix_group.num_vectors(), 4);
     }
 
@@ -903,7 +899,7 @@ pub(crate) mod tests {
         let mut vm = setup_vm_with_memory(mib_to_bytes(128));
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
-        let msix_group = create_msix_group(&vm);
+        let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
 
         // Initially all vectors are disabled
         for route in &msix_group.vectors {
@@ -932,7 +928,7 @@ pub(crate) mod tests {
         enable_irqchip(&mut vm);
 
         let vm = Arc::new(vm);
-        let msix_group = create_msix_group(&vm);
+        let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
 
         // We can now trigger all vectors
         for i in 0..4 {
@@ -947,7 +943,7 @@ pub(crate) mod tests {
     fn test_msi_vector_group_notifier() {
         let vm = setup_vm_with_memory(mib_to_bytes(128));
         let vm = Arc::new(vm);
-        let msix_group = create_msix_group(&vm);
+        let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
 
         for i in 0..4 {
             assert!(msix_group.notifier(i).is_some());
@@ -961,7 +957,7 @@ pub(crate) mod tests {
         let mut vm = setup_vm_with_memory(mib_to_bytes(128));
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
-        let msix_group = create_msix_group(&vm);
+        let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
         let config = MsixVectorConfig {
             high_addr: 0x42,
             low_addr: 0x12,
@@ -978,7 +974,7 @@ pub(crate) mod tests {
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
         assert!(vm.common.interrupts.lock().unwrap().is_empty());
-        let msix_group = create_msix_group(&vm);
+        let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
 
         // Set some configuration for the vectors. Initially all are masked
         let mut config = MsixVectorConfig {
@@ -1053,7 +1049,7 @@ pub(crate) mod tests {
         let mut vm = setup_vm_with_memory(mib_to_bytes(128));
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
-        let msix_group = create_msix_group(&vm);
+        let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
 
         msix_group.enable().unwrap();
         let state = msix_group.save();
@@ -1091,7 +1087,7 @@ pub(crate) mod tests {
         // Allocating, configuring and dropping a group must leave the allocator and the routing
         // table in the same state as before.
         {
-            let group = create_msix_group(&vm);
+            let group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
             let config = MsixVectorConfig {
                 high_addr: 0x42,
                 low_addr: 0x13,


### PR DESCRIPTION
## Changes
Currently without Drop on MsixVectorGroup destroying devices during hot-unplug leaks interrupt ids because there is no code to clean them up. Implementing Drop on MsixVectorGroup is the simplest way to fix this issue.

## Reason
Don't leak irqs

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
