### PR TITLE
feat(snapshot): allow pmem backing file path override on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to
   support for booting `bzImage` guest kernels on x86_64, in addition to the
   existing uncompressed ELF (`vmlinux`) images. The kernel image format is
   detected automatically, so no configuration change is required.
+- [#5896](https://github.com/firecracker-microvm/firecracker/pull/5896): Add
+  support for overriding virtio-pmem device backing file paths on snapshot
+  restore via the new `pmem_overrides` field on the `PUT /snapshot/load` API.
+  This mirrors the existing network and vsock override mechanisms and is useful
+  when the host file path baked into the snapshot is no longer valid (for
+  example, when restoring on a different host or under a different jailer
+  chroot).
 
 ### Changed
 

--- a/docs/pmem.md
+++ b/docs/pmem.md
@@ -260,6 +260,38 @@ same backing file as it was configured in the first place. This means all
 `virtio-pmem` backing files should be present in the same locations during
 restore as they were during initial `virtio-pmem` configuration.
 
+### Overriding pmem backing file paths on restore
+
+When the host file path baked into the snapshot is no longer valid - for
+example, when restoring on a different host or under a different jailer chroot -
+the `pmem_overrides` parameter of the snapshot load API can be used to point
+each `virtio-pmem` device at the same backing file in its new location.
+
+This is only intended for relocating the original backing file; it is not a
+mechanism for swapping in a different backing file on restore. The overriding
+file must therefore be the same backing file (and hence the same size) as the
+one used when the snapshot was taken.
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i \
+    -X PUT 'http://localhost/snapshot/load' \
+    -H  'Accept: application/json' \
+    -H  'Content-Type: application/json' \
+    -d '{
+            "snapshot_path": "./snapshot_file",
+            "mem_backend": {
+                "backend_path": "./mem_file",
+                "backend_type": "File"
+            },
+            "pmem_overrides": [
+                {
+                    "id": "pmem0",
+                    "path_on_host": "/new/path/to/pmem0.img"
+                }
+            ]
+    }'
+```
+
 ## Performance
 
 Even though `virtio-pmem` allows for the direct access of host pages from the

--- a/src/firecracker/src/api_server/request/snapshot.rs
+++ b/src/firecracker/src/api_server/request/snapshot.rs
@@ -112,6 +112,7 @@ fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, RequestError> {
         network_overrides: snapshot_config.network_overrides,
         vsock_override: snapshot_config.vsock_override,
         clock_realtime: snapshot_config.clock_realtime,
+        pmem_overrides: snapshot_config.pmem_overrides,
     };
 
     // Construct the `ParsedRequest` object.
@@ -127,7 +128,9 @@ fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, RequestError> {
 
 #[cfg(test)]
 mod tests {
-    use vmm::vmm_config::snapshot::{MemBackendConfig, MemBackendType, NetworkOverride};
+    use vmm::vmm_config::snapshot::{
+        MemBackendConfig, MemBackendType, NetworkOverride, PmemOverride,
+    };
 
     use super::*;
     use crate::api_server::parsed_request::tests::{depr_action_from_req, vmm_action_from_request};
@@ -191,6 +194,7 @@ mod tests {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            pmem_overrides: vec![],
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(
@@ -223,6 +227,7 @@ mod tests {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            pmem_overrides: vec![],
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(
@@ -255,6 +260,7 @@ mod tests {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            pmem_overrides: vec![],
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(
@@ -296,6 +302,49 @@ mod tests {
             }],
             vsock_override: None,
             clock_realtime: false,
+            pmem_overrides: vec![],
+        };
+        let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
+        assert!(
+            parsed_request
+                .parsing_info()
+                .take_deprecation_message()
+                .is_none()
+        );
+        assert_eq!(
+            vmm_action_from_request(parsed_request),
+            VmmAction::LoadSnapshot(expected_config)
+        );
+
+        let body = r#"{
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "File"
+            },
+            "resume_vm": true,
+            "pmem_overrides": [
+                {
+                    "id": "pmem0",
+                    "path_on_host": "/new/path/pmem0.img"
+                }
+            ]
+        }"#;
+        let expected_config = LoadSnapshotParams {
+            snapshot_path: PathBuf::from("foo"),
+            mem_backend: MemBackendConfig {
+                backend_path: PathBuf::from("bar"),
+                backend_type: MemBackendType::File,
+            },
+            track_dirty_pages: false,
+            resume_vm: true,
+            network_overrides: vec![],
+            vsock_override: None,
+            clock_realtime: false,
+            pmem_overrides: vec![PmemOverride {
+                id: String::from("pmem0"),
+                path_on_host: String::from("/new/path/pmem0.img"),
+            }],
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(
@@ -325,6 +374,7 @@ mod tests {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            pmem_overrides: vec![],
         };
         let parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert_eq!(

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1673,6 +1673,26 @@ definitions:
         description:
           The new path for the backing Unix Domain Socket.
 
+  PmemOverride:
+    type: object
+    description:
+      Allows for changing the backing host file of a virtio-pmem device
+      during snapshot restore.
+    required:
+      - id
+      - path_on_host
+    properties:
+      id:
+        type: string
+        description:
+          The ID of the pmem device to modify.
+      path_on_host:
+        type: string
+        description:
+          The new host path for the pmem device's backing file. This is only
+          meant for pointing at the same backing file in a new location; the
+          file must be identical to the one used when the snapshot was taken.
+
   SnapshotLoadParams:
     type: object
     description:
@@ -1728,6 +1748,11 @@ definitions:
           elapsed since the snapshot was taken. When false (default), kvmclock resumes
           from where it was at snapshot time. This option may be extended to other clock
           sources and CPU architectures in the future."
+      pmem_overrides:
+        type: array
+        description: Pmem device backing file paths to override on snapshot restore.
+        items:
+          $ref: "#/definitions/PmemOverride"
 
 
   TokenBucket:

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -37,7 +37,9 @@ use crate::utils::u64_to_usize;
 use crate::vmm_config::boot_source::BootSourceConfig;
 use crate::vmm_config::instance_info::InstanceInfo;
 use crate::vmm_config::machine_config::{HugePageConfig, MachineConfigError, MachineConfigUpdate};
-use crate::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams, MemBackendType};
+use crate::vmm_config::snapshot::{
+    CreateSnapshotParams, LoadSnapshotParams, MemBackendType, PmemOverride,
+};
 use crate::vstate::kvm::KvmState;
 use crate::vstate::memory::{
     self, GuestMemoryState, GuestRegionMmap, GuestRegionType, MemoryError,
@@ -412,6 +414,8 @@ pub fn restore_from_snapshot(
             .clone_from(&vsock_override.uds_path);
     }
 
+    apply_pmem_overrides(&mut microvm_state, &params.pmem_overrides)?;
+
     let track_dirty_pages = params.track_dirty_pages;
 
     let vcpu_count = microvm_state
@@ -480,6 +484,36 @@ pub fn restore_from_snapshot(
     .map_err(RestoreFromSnapshotError::Build)
 }
 
+/// Applies the pmem backing file path overrides to the restored microVM state.
+///
+/// Each override identifies a pmem device by its id and replaces its
+/// `path_on_host`. Both MMIO and PCI transports are searched. An override
+/// targeting an id that does not match any pmem device returns an error.
+fn apply_pmem_overrides(
+    microvm_state: &mut MicrovmState,
+    overrides: &[PmemOverride],
+) -> Result<(), SnapshotStateFromFileError> {
+    for entry in overrides {
+        let device_state = match &mut microvm_state.device_states.virtio_state {
+            VirtioDevicesState::Mmio(mmio_state) => mmio_state
+                .pmem_devices
+                .iter_mut()
+                .map(|device| &mut device.device_state)
+                .find(|state| state.config.id == entry.id),
+            VirtioDevicesState::Pci(pci_state) => pci_state
+                .pmem_devices
+                .iter_mut()
+                .map(|device| &mut device.device_state)
+                .find(|state| state.config.id == entry.id),
+        };
+        device_state
+            .map(|state| state.config.path_on_host.clone_from(&entry.path_on_host))
+            .ok_or_else(|| SnapshotStateFromFileError::UnknownPmemDevice(entry.id.clone()))?;
+    }
+
+    Ok(())
+}
+
 /// Error type for [`snapshot_state_from_file`]
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum SnapshotStateFromFileError {
@@ -491,6 +525,8 @@ pub enum SnapshotStateFromFileError {
     UnknownNetworkDevice,
     /// Unknown Vsock Device.
     UnknownVsockDevice,
+    /// Unknown Pmem device: {0}
+    UnknownPmemDevice(String),
 }
 
 fn snapshot_state_from_file(
@@ -664,7 +700,7 @@ mod tests {
     use crate::builder::tests::insert_vmgenid_device;
     use crate::builder::tests::{
         CustomBlockConfig, default_kernel_cmdline, default_vmm, insert_balloon_device,
-        insert_block_devices, insert_net_device, insert_vsock_device,
+        insert_block_devices, insert_net_device, insert_pmem_devices, insert_vsock_device,
     };
     #[cfg(target_arch = "aarch64")]
     use crate::construct_kvm_mpidrs;
@@ -672,6 +708,7 @@ mod tests {
     use crate::snapshot::Persist;
     use crate::vmm_config::balloon::BalloonDeviceConfig;
     use crate::vmm_config::net::NetworkInterfaceConfig;
+    use crate::vmm_config::pmem::PmemConfig;
     use crate::vmm_config::vsock::tests::default_config;
     use crate::vstate::memory::{GuestMemoryRegionState, GuestRegionType};
 
@@ -723,6 +760,18 @@ mod tests {
         let vsock_config = default_config(&tmp_sock_file);
 
         insert_vsock_device(&mut vmm, &mut cmdline, &mut event_manager, vsock_config);
+
+        // Add a pmem device. The returned temp file is dropped immediately; only
+        // the saved device state (which carries the configured id/path) is needed.
+        let pmem_config = PmemConfig {
+            id: String::from("pmem0"),
+            path_on_host: String::new(),
+            root_device: false,
+            read_only: false,
+            rate_limiter: None,
+        };
+        let _pmem_files =
+            insert_pmem_devices(&mut vmm, &mut cmdline, &mut event_manager, vec![pmem_config]);
 
         #[cfg(target_arch = "x86_64")]
         insert_vmgenid_device(&mut vmm);
@@ -776,6 +825,94 @@ mod tests {
             panic!("expected MMIO virtio device state");
         };
         assert_eq!(restored_mmio, mmio)
+    }
+
+    fn microvm_state_with_devices() -> MicrovmState {
+        let vmm = default_vmm_with_devices();
+        let device_states = vmm.device_manager.save();
+
+        let vcpu_states = vec![VcpuState::default()];
+        #[cfg(target_arch = "aarch64")]
+        let mpidrs = construct_kvm_mpidrs(&vcpu_states);
+        MicrovmState {
+            device_states,
+            vcpu_states,
+            kvm_state: Default::default(),
+            vm_info: VmInfo {
+                mem_size_mib: 1u64,
+                ..Default::default()
+            },
+            #[cfg(target_arch = "aarch64")]
+            vm_state: vmm.vm.as_kvm().unwrap().save_state(&mpidrs).unwrap(),
+            #[cfg(target_arch = "x86_64")]
+            vm_state: vmm.vm.as_kvm().unwrap().save_state().unwrap(),
+        }
+    }
+
+    fn pmem_path(state: &MicrovmState, id: &str) -> Option<String> {
+        match &state.device_states.virtio_state {
+            VirtioDevicesState::Mmio(mmio_state) => mmio_state
+                .pmem_devices
+                .iter()
+                .map(|device| &device.device_state)
+                .find(|s| s.config.id == id),
+            VirtioDevicesState::Pci(pci_state) => pci_state
+                .pmem_devices
+                .iter()
+                .map(|device| &device.device_state)
+                .find(|s| s.config.id == id),
+        }
+        .map(|s| s.config.path_on_host.clone())
+    }
+
+    #[test]
+    fn test_apply_pmem_overrides_happy_path() {
+        let mut microvm_state = microvm_state_with_devices();
+        // Sanity: the device exists and its path differs from what we override to.
+        assert!(pmem_path(&microvm_state, "pmem0").is_some());
+
+        let overrides = vec![PmemOverride {
+            id: String::from("pmem0"),
+            path_on_host: String::from("/new/backing/file"),
+        }];
+
+        apply_pmem_overrides(&mut microvm_state, &overrides).unwrap();
+
+        assert_eq!(
+            pmem_path(&microvm_state, "pmem0").as_deref(),
+            Some("/new/backing/file")
+        );
+    }
+
+    #[test]
+    fn test_apply_pmem_overrides_unknown_device() {
+        let mut microvm_state = microvm_state_with_devices();
+
+        let overrides = vec![PmemOverride {
+            id: String::from("does-not-exist"),
+            path_on_host: String::from("/new/backing/file"),
+        }];
+
+        let err = apply_pmem_overrides(&mut microvm_state, &overrides).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                SnapshotStateFromFileError::UnknownPmemDevice(id) if id == "does-not-exist"
+            ),
+            "unexpected error: {err:?}"
+        );
+        // The existing device must be left untouched.
+        assert!(pmem_path(&microvm_state, "pmem0").is_some());
+    }
+
+    #[test]
+    fn test_apply_pmem_overrides_empty_is_noop() {
+        let mut microvm_state = microvm_state_with_devices();
+        let original = pmem_path(&microvm_state, "pmem0");
+
+        apply_pmem_overrides(&mut microvm_state, &[]).unwrap();
+
+        assert_eq!(pmem_path(&microvm_state, "pmem0"), original);
     }
 
     #[test]

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1333,6 +1333,7 @@ mod tests {
                 network_overrides: vec![],
                 vsock_override: None,
                 clock_realtime: false,
+                pmem_overrides: vec![],
             },
         )));
         check_unsupported(runtime_request(VmmAction::SetEntropyDevice(

--- a/src/vmm/src/vmm_config/snapshot.rs
+++ b/src/vmm/src/vmm_config/snapshot.rs
@@ -64,6 +64,16 @@ pub struct VsockOverride {
     pub uds_path: String,
 }
 
+/// Allows for changing the host backing file of a virtio-pmem device during
+/// snapshot restore.
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct PmemOverride {
+    /// The ID of the pmem device to modify.
+    pub id: String,
+    /// The new host path for the pmem device's backing file.
+    pub path_on_host: String,
+}
+
 /// Stores the configuration that will be used for loading a snapshot.
 #[derive(Debug, PartialEq, Eq)]
 pub struct LoadSnapshotParams {
@@ -85,6 +95,8 @@ pub struct LoadSnapshotParams {
     /// advancing kvmclock by the wall-clock time elapsed since the snapshot was taken. When false
     /// (default), kvmclock resumes from where it was at snapshot time.
     pub clock_realtime: bool,
+    /// The pmem devices to override on load.
+    pub pmem_overrides: Vec<PmemOverride>,
 }
 
 /// Stores the configuration for loading a snapshot that is provided by the user.
@@ -120,6 +132,9 @@ pub struct LoadSnapshotConfig {
     /// [x86_64 only] When set to true, passes `KVM_CLOCK_REALTIME` to `KVM_SET_CLOCK` on restore.
     #[serde(default)]
     pub clock_realtime: bool,
+    /// The pmem devices to override on load.
+    #[serde(default)]
+    pub pmem_overrides: Vec<PmemOverride>,
 }
 
 /// Stores the configuration used for managing snapshot memory.

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -310,6 +310,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            pmem_overrides: vec![],
         }))
         .unwrap();
 
@@ -396,6 +397,7 @@ fn verify_load_snap_disallowed_after_boot_resources(res: VmmAction, res_name: &s
         network_overrides: vec![],
         vsock_override: None,
         clock_realtime: false,
+        pmem_overrides: vec![],
     });
     let err = preboot_api_controller.handle_preboot_request(req);
     assert!(

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -1097,6 +1097,7 @@ class Microvm:
         rename_interfaces: dict = None,
         vsock_override: str = None,
         clock_realtime: bool = False,
+        pmem_overrides: list = None,
         *,
         uffd_handler_name: str = None,
     ):
@@ -1114,8 +1115,17 @@ class Microvm:
         jailed_mem = Path("/") / jailed_snapshot.mem.name
         jailed_vmstate = Path("/") / jailed_snapshot.vmstate.name
 
-        snapshot_disks = [v for k, v in jailed_snapshot.disks.items()]
-        assert len(snapshot_disks) > 0, "Snapshot requires at least one disk."
+        # Skip auto-jailing pmem backing files that have an override - the caller
+        # is responsible for placing the backing file at the override path. This
+        # ensures the test exercises the override path rather than silently
+        # falling back to the snapshot's baked-in path.
+        overridden_pmem_ids = {o["id"] for o in (pmem_overrides or [])}
+        snapshot_disks = [
+            v for k, v in jailed_snapshot.disks.items() if k not in overridden_pmem_ids
+        ]
+        assert (
+            len(snapshot_disks) > 0 or overridden_pmem_ids
+        ), "Snapshot requires at least one disk."
         jailed_disks = []
         for disk in snapshot_disks:
             jailed_disks.append(self.create_jailed_resource(disk))
@@ -1161,6 +1171,9 @@ class Microvm:
 
         if clock_realtime:
             optional_kwargs["clock_realtime"] = clock_realtime
+
+        if pmem_overrides is not None:
+            optional_kwargs["pmem_overrides"] = pmem_overrides
 
         self.api.snapshot_load.put(
             mem_backend=mem_backend,

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -632,6 +632,94 @@ def test_snapshot_rename_vsock(
     restored_vm.restore_from_snapshot(snapshot, vsock_override="/v.sock2", resume=True)
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_snapshot_override_pmem(uvm_configured, microvm_factory):
+    """
+    Test that we can restore a snapshot and point a virtio-pmem device to a
+    different host backing file.
+    """
+    vm = uvm_configured
+
+    pmem_fs = drive_tools.FilesystemFile(
+        os.path.join(vm.fsfiles, "pmem_scratch"), size=2
+    )
+    vm.add_pmem("pmem0", pmem_fs.path, False, False)
+    vm.add_net_iface()
+    vm.start()
+
+    # Write a marker to the pmem device so we can verify the overridden file
+    # is used after restore.
+    marker = "pmem_override_marker"
+    vm.ssh.check_output("mkdir -p /tmp/pmem_mnt")
+    vm.ssh.check_output("mount /dev/pmem0 -o dax=always /tmp/pmem_mnt")
+    vm.ssh.check_output(f'echo "{marker}" > /tmp/pmem_mnt/marker')
+
+    snapshot = vm.snapshot_full()
+    # Killing the VM flushes any guest writes to the backing file.
+    vm.kill()
+
+    restored_vm = microvm_factory.build()
+    restored_vm.spawn()
+
+    # Move (not copy) the snapshot's pmem backing file to a new path with a
+    # different basename. `restore_from_snapshot` skips auto-jailing pmem files
+    # that have an override, so the file is no longer reachable at its baked-in
+    # path. This guarantees the restore can only succeed if it actually consults
+    # the override path - otherwise the test fails.
+    original_pmem = snapshot.disks["pmem0"]
+    override_src = Path(vm.fsfiles) / "pmem0_override.img"
+    shutil.move(original_pmem, override_src)
+    # Hardlink the override into the restored VM's chroot and chown it to the
+    # jailer's uid:gid so Firecracker can open it.
+    override_jailed = restored_vm.create_jailed_resource(override_src)
+
+    restored_vm.restore_from_snapshot(
+        snapshot,
+        pmem_overrides=[
+            {"id": "pmem0", "path_on_host": override_jailed},
+        ],
+        resume=True,
+    )
+
+    # The override file is the same backing file moved aside after the marker
+    # was written, so the marker must still be readable through the pmem device.
+    _, stdout, _ = restored_vm.ssh.check_output("cat /tmp/pmem_mnt/marker")
+    assert stdout.strip() == marker
+
+
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_pmem_override_fails_unknown_id(uvm_configured, microvm_factory):
+    """
+    Providing a pmem override with an unknown id should fail snapshot
+    restore and cause Firecracker to exit.
+    """
+    vm = uvm_configured
+
+    pmem_fs = drive_tools.FilesystemFile(
+        os.path.join(vm.fsfiles, "pmem_scratch"), size=2
+    )
+    vm.add_pmem("pmem0", pmem_fs.path, False, False)
+    vm.add_net_iface()
+    vm.start()
+
+    snapshot = vm.snapshot_full()
+    vm.kill()
+
+    restored_vm = microvm_factory.build()
+    restored_vm.spawn()
+
+    with pytest.raises(RuntimeError, match="Unknown Pmem device"):
+        restored_vm.restore_from_snapshot(
+            snapshot,
+            pmem_overrides=[
+                {"id": "nonexistent", "path_on_host": "/fake/path"},
+            ],
+            resume=True,
+        )
+
+    restored_vm.mark_killed()
+
+
 SLEEP_SECONDS = 30
 
 CLOCK_SOURCES = {"x86_64": ["tsc", "kvm-clock"], "aarch64": ["arch_sys_counter"]}[


### PR DESCRIPTION
Allow overriding virtio-pmem device backing file paths when restoring from a snapshot. This is useful when the host path baked into the snapshot is no longer valid, for example when restoring on a different host or under a different jailer chroot.

Adds a `pmem_overrides` parameter to the snapshot load API, following the same pattern as the existing `network_overrides` (#4731) and `vsock_override` (#5323). Each entry identifies a pmem device by its `pmem_id` and supplies a new `path_on_host`. Both MMIO and PCI transports are covered. Overrides targeting an unknown `pmem_id` fail the restore with a clear error.

Part of #4992.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the automated style checks.
- [x] I have described what is done in these changes, why they are needed, and how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs) in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
