### PR TITLE
fix(vmm): close cold-boot BSP/AP race on dual-socket NUMA hosts

### DIFF
--- a/src/vmm/src/arch/x86_64/vcpu.rs
+++ b/src/vmm/src/arch/x86_64/vcpu.rs
@@ -10,8 +10,9 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use kvm_bindings::{
-    CpuId, KVM_MAX_CPUID_ENTRIES, KVM_MAX_MSR_ENTRIES, Msrs, Xsave, kvm_debugregs, kvm_lapic_state,
-    kvm_mp_state, kvm_regs, kvm_sregs, kvm_vcpu_events, kvm_xcrs, kvm_xsave, kvm_xsave2,
+    CpuId, KVM_MAX_CPUID_ENTRIES, KVM_MAX_MSR_ENTRIES, KVM_MP_STATE_INIT_RECEIVED,
+    KVM_MP_STATE_RUNNABLE, Msrs, Xsave, kvm_debugregs, kvm_lapic_state, kvm_mp_state, kvm_regs,
+    kvm_sregs, kvm_vcpu_events, kvm_xcrs, kvm_xsave, kvm_xsave2,
 };
 use kvm_ioctls::{VcpuExit, VcpuFd};
 use serde::{Deserialize, Serialize};
@@ -136,6 +137,8 @@ pub enum KvmVcpuConfigureError {
     SetupSpecialRegisters(#[from] SetupSpecialRegistersError),
     /// Failed to configure LAPICs: {0}
     SetLint(#[from] interrupts::InterruptError),
+    /// Failed to set initial multiprocessor state: {0}
+    SetMpState(vmm_sys_util::errno::Error),
 }
 
 /// A wrapper around creating and using a kvm x86_64 vcpu.
@@ -263,6 +266,19 @@ impl KvmVcpu {
         crate::arch::x86_64::regs::setup_fpu(&self.fd)?;
         crate::arch::x86_64::regs::setup_sregs(guest_mem, &self.fd, kernel_entry_point.protocol)?;
         crate::arch::x86_64::interrupts::set_lint(&self.fd)?;
+
+        // BSP runnable, APs wait-for-SIPI.
+        let mp_state = kvm_mp_state {
+            mp_state: if self.index == 0 {
+                KVM_MP_STATE_RUNNABLE
+            } else {
+                KVM_MP_STATE_INIT_RECEIVED
+            },
+        };
+        self.fd
+            .set_mp_state(mp_state)
+            .map_err(KvmVcpuConfigureError::SetMpState)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
## Changes

With the current approach of vCPU initialisation it leaves a potential race condition
in which the BP enters the kernel and attempts to init AP's before they are initialised
and ready to start up.

Update the flow so that AP's are started into vCPU run before start BP to eliminate
this race condition.

## Reason

Fixing https://github.com/firecracker-microvm/firecracker/issues/5744

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
