### PR TITLE
fix(tests): gate heavy post-failure dump behind FC_TEST_DUMP_ON_FAILURE

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -125,6 +125,10 @@ pipeline = BKPipeline(
     # use ag=1 instances to make sure no two performance tests are scheduled on the same instance
     agents={"ag": 1},
     retry=retry,
+    # Heavy post-failure dumps (full snapshot + chroot copy) are useful
+    # for triaging performance flakes that are hard to reproduce locally.
+    # Cheap dumps are always on; this flag turns the heavy block on.
+    env={"FC_TEST_DUMP_ON_FAILURE": "1"},
 )
 
 tests = [perf_test[test] for test in pipeline.args.test or perf_test.keys()]

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,6 +57,22 @@ or natively on your dev box:
 python3 -m pytest [<pytest argument>...]
 ```
 
+### Environment variables
+
+A handful of `FC_TEST_*` environment variables tweak runtime behaviour of the
+test framework. They are allowlisted by `tools/devtool` and forwarded into the
+dev container automatically, so setting them on the host before invoking
+`tools/devtool -y test` is enough.
+
+- `FC_TEST_SKIP_ARTIFACT_COPY=1` — skip copying CI artifacts into
+  `/srv/test_artifacts` (used by `devtool test_debug`).
+- `FC_TEST_DUMP_ON_FAILURE=1` — on test failure, also collect the heavy
+  post-failure artifacts: a full memory snapshot (`post_failure.mem` +
+  `post_failure.vmstate`), a copy of the test `id_rsa`, and every regular file
+  at the uVM chroot root. The cheap artifacts (`host-dmesg.log` and the guest
+  serial console) are always collected. Default off. The nightly performance
+  pipeline sets this.
+
 ### Output
 
 Output, including testrun results, goes to `stdout`. Errors go to `stderr`. By

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -410,17 +410,11 @@ def microvm_factory(request, record_property, results_dir, netns_factory):
     # if the test failed, save important files from the root of the uVM into `test_results` for troubleshooting
     report = request.node.stash[PHASE_REPORT_KEY]
     if "call" in report and report["call"].failed:
+        dump_full = os.environ.get("FC_TEST_DUMP_ON_FAILURE") == "1"
         for uvm in uvm_factory.vms:
             # This is best effort. We want to proceed even if the VM is not responding.
             try:
                 uvm.flush_metrics()
-            except:  # pylint: disable=bare-except
-                pass
-
-            try:
-                uvm.snapshot_full(
-                    mem_path="post_failure.mem", vmstate_path="post_failure.vmstate"
-                )
             except:  # pylint: disable=bare-except
                 pass
 
@@ -429,9 +423,20 @@ def microvm_factory(request, record_property, results_dir, netns_factory):
             uvm_data.joinpath("host-dmesg.log").write_text(
                 utils.run_cmd(["dmesg", "-dPx"]).stdout
             )
-            shutil.copy(ARTIFACT_DIR / "id_rsa", uvm_data)
             if Path(uvm.screen_log).exists():
                 shutil.copy(uvm.screen_log, uvm_data)
+
+            if not dump_full:
+                continue
+
+            try:
+                uvm.snapshot_full(
+                    mem_path="post_failure.mem", vmstate_path="post_failure.vmstate"
+                )
+            except:  # pylint: disable=bare-except
+                pass
+
+            shutil.copy(ARTIFACT_DIR / "id_rsa", uvm_data)
 
             uvm_root = Path(uvm.chroot())
             for item in os.listdir(uvm_root):


### PR DESCRIPTION
The microvm_factory failure block previously took a full snapshot and
copied every regular file at the uVM chroot root for every failed test,
on every developer machine and PR run. This is wasteful: dmesg and the
guest serial console triage most failures on their own.

Cheap artifacts (host-dmesg.log, screen_log, flush_metrics) stay always
on. Heavy artifacts (post_failure.mem, post_failure.vmstate, id_rsa,
chroot file copy) now run only when FC_TEST_DUMP_ON_FAILURE=1.

Signed-off-by: Jack Thomson <jackabt@amazon.com>## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
