### PR TITLE
feat(sandbox): Add --boot-args option for custom kernel boot arguments

### DIFF
--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -92,6 +92,9 @@ parser.add_argument("--rootfs-size", type=parse_byte_size, default=1 * 2**30)  #
 parser.add_argument("--binary-dir", help="Path to the firecracker binaries")
 parser.add_argument("--cpu-template-path", help="CPU template to use", type=Path)
 parser.add_argument(
+    "--boot-args", help="Kernel boot arguments", type=str, default=None, nargs="+"
+)
+parser.add_argument(
     "--debug", action="store_true", default=False, help="Use debug kernel"
 )
 parser.add_argument(
@@ -137,7 +140,11 @@ uvm.help.resize_disk(uvm.rootfs_file, args.rootfs_size)
 uvm.spawn(log_show_level=True, validate_api=False)
 uvm.help.print_log()
 uvm.add_net_iface()
-uvm.basic_config(vcpu_count=args.vcpus, mem_size_mib=args.guest_mem_size // 2**20)
+uvm.basic_config(
+    vcpu_count=args.vcpus,
+    mem_size_mib=args.guest_mem_size // 2**20,
+    boot_args=" ".join(args.boot_args) if args.boot_args else None,
+)
 if cpu_template is not None:
     uvm.api.cpu_config.put(**cpu_template)
     print(cpu_template)


### PR DESCRIPTION
Allow passing custom kernel boot arguments to the microVM via the sandbox tool. Arguments are joined with spaces and forwarded to basic_config.

## Changes

* Added `argparse` option to specify the kernel boot arguments

## Reason

* Allows to configure kernel boot arguments from command line for easier debugging
* Example usage:

```
// From shell
sudo tools/devtool sandbox -- --boot-args "console=ttyS0 reboot=k panic=1 pci=off loglevel=8"

// From python interactive shell
uvm.help.tmux_ssh()

// From uvm
cat /proc/cmdline
console=ttyS0 reboot=k panic=1 pci=off loglevel=8 ...
```

```
// From shell
sudo tools/devtool sandbox -- --boot-args "console=ttyS0 reboot=k panic=1 pci=off loglevel=1"

// From python interactive shell
uvm.help.tmux_ssh()

// From uvm
cat /proc/cmdline
console=ttyS0 reboot=k panic=1 pci=off loglevel=1 ...
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
