### PR TITLE
Refactor test fixtures

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -359,22 +359,94 @@ the [`pytest` documentation](https://docs.pytest.org/en/6.2.x/fixture.html) for
 details.
 
 Most integration tests use fixtures that abstract away the creation and teardown
-of Firecracker processes. The following fixtures spawn Firecracker processes
-that are pre-initialized with specific guest kernels and rootfs:
+of Firecracker processes. There are two layers:
 
-- `uvm_plain_any` is parametrized by the guest kernels
-  [supported](../docs/kernel-policy.md) by Firecracker and a read-only Ubuntu
-  24.04 squashfs as rootfs,
-- `uvm_plain` yields a Firecracker process pre-initialized with a 5.10 kernel
-  and the same Ubuntu 24.04 squashfs.
-- `uvm_any` yields started microvms, parametrized by all supported kernels, all
-  CPU templates (static, custom and none), and either booted or restored from a
-  snapshot.
-- `uvm_any_booted` works the same as `uvm_any`, but only for booted VMs.
+- **Consumer fixtures** spawn microVMs at progressively later lifecycle stages.
+  Pick one based on how much setup you want done for you:
 
-Generally, tests should use `uvm_plain_any` if you are testing some interaction
-between the guest and Firecracker, and `uvm_plain` should be used if Firecracker
-functionality unrelated to the guest is being tested.
+  - `uvm` — a built (chroot only) microVM. Caller drives
+    `spawn`/`basic_config`/`start`.
+  - `uvm_configured` — `uvm` plus `spawn` and `basic_config` (and `cpu_template`
+    if applicable). Caller adds devices and calls `start`.
+  - `uvm_booted` — `uvm_configured` plus `add_net_iface` and `start`. Ready to
+    ssh.
+  - `uvm_restored` — `uvm_booted`, snapshotted and restored from the snapshot.
+  - `uvm_any` — booted *or* restored, automatically parametrized over both via
+    `uvm_lifecycle`. Use when a test should exercise both lifecycles.
+
+- **Dimension fixtures** control the parameters of the microVM. They are
+  composed by the consumer fixtures above; tests can also request them directly.
+  The defaults are:
+
+  - `guest_kernel` — auto-parametrized over all
+    [supported](../docs/kernel-policy.md) guest kernels.
+  - `rootfs_mode` — `"ro"` (squashfs, default) or `"rw"` (ext4).
+  - `rootfs` — the rootfs disk path, composed from `guest_kernel` +
+    `rootfs_mode` (Ubuntu 24.04 for 5.10, Amazon Linux 2023 otherwise).
+  - `pci_enabled` — auto-parametrized over `True`/`False`.
+  - `cpu_template` — `None` by default.
+  - `huge_pages` — `HugePagesConfig.NONE` by default. See note below.
+  - `vcpu_count`, `mem_size_mib` — `2` and `256` by default.
+
+To restrict a dimension to a specific value or subset, use the helpers from
+`framework.artifacts` and `framework.utils_cpu_templates`:
+
+```python
+from framework.artifacts import pin_guest_kernel, GUEST_KERNEL_DEFAULT, ACPI_GUEST_KERNELS
+
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)  # single kernel, e.g. for non-guest-dependent tests
+def test_foo(uvm): ...
+
+@pin_guest_kernel(ACPI_GUEST_KERNELS)    # subset
+def test_bar(uvm): ...
+```
+
+The same pattern works at module level via `pytestmark = pin_guest_kernel(...)`,
+but use it sparingly: prefer per-test decorators by default and reserve
+`pytestmark` for files where the *subject of the file* makes the restriction
+necessary, so that any future test added to the file would be subject to the
+same restriction by construction. Examples where `pytestmark` is appropriate:
+
+- A file dedicated to a single feature whose support implies the pin (e.g.
+  `test_vmclock.py` requires ACPI; `performance/test_hotplug_memory.py` requires
+  kernel ≥ 6.1 because virtio-mem support is matured there).
+- A file dedicated to enumerating a dimension (e.g. `test_cpu_all.py` — the
+  file's purpose is to run every CPU template).
+- A performance test file: measurements need a fixed substrate so that results
+  are comparable over time.
+
+For "convenience" pins (e.g. "this test doesn't depend on the guest kernel,
+let's pin to default to keep CI fast"), prefer the per-test decorator. A
+module-level `pytestmark` on a kernel-independent file silently inherits onto
+the next test someone adds, even if that next test legitimately wants
+multi-kernel coverage.
+
+Note: pytest's `parametrize` markers do not merge — combining a module-level
+`pytestmark` with a per-test `parametrize` on the same dimension raises a
+"duplicate parametrization" error. Pick one.
+
+For tests of Firecracker functionality that don't depend on the guest kernel,
+prefer `@pin_guest_kernel(GUEST_KERNEL_DEFAULT)` to keep CI fast. Tests that
+exercise guest-Firecracker interactions should leave `guest_kernel` at the
+default so they run against every supported kernel.
+
+#### Huge pages
+
+`huge_pages` defaults to `HugePagesConfig.NONE` (anonymous memory). The
+distinction between `NONE` and `HUGETLBFS_2MB` only matters for performance
+characteristics — fault granularity, UFFD population time, EPT-violation counts
+— not functional correctness. Performance tests exercising the memory subsystem
+(memory hotplug, balloon page reporting/hinting, snapshot/UFFD restore, EPT)
+should parametrize over both variants explicitly:
+
+```python
+@pytest.mark.parametrize("huge_pages", HugePagesConfig)
+def test_my_perf_thing(uvm_booted, huge_pages):
+    ...
+```
+
+Functional tests can leave `huge_pages` at the default and don't need to declare
+it.
 
 ### Markers
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,15 +32,11 @@ import pytest
 
 import host_tools.cargo_build as build_tools
 from framework import defs, utils
-from framework.artifacts import disks, kernel_params
+from framework.artifacts import ALL_GUEST_KERNELS, disks
 from framework.defs import ARTIFACT_DIR, DEFAULT_BINARY_DIR
 from framework.microvm import HugePagesConfig, MicroVMFactory, SnapshotType
 from framework.properties import global_props
-from framework.utils_cpu_templates import (
-    custom_cpu_templates_params,
-    get_cpu_template_name,
-    static_cpu_templates_params,
-)
+from framework.utils_cpu_templates import get_cpu_template_name
 from host_tools.metrics import get_metrics_logger
 from host_tools.network import NetNs
 
@@ -449,26 +445,17 @@ def microvm_factory(request, record_property, results_dir, netns_factory):
     uvm_factory.kill()
 
 
-@pytest.fixture(params=custom_cpu_templates_params())
-def custom_cpu_template(request, record_property):
-    """Return all dummy custom CPU templates supported by the vendor."""
-    record_property("custom_cpu_template", request.param["name"])
-    return request.param
+@pytest.fixture
+def cpu_template(request, record_property):
+    """CPU template applied to the VM in `uvm_configured`. Default: None.
 
-
-@pytest.fixture(
-    params=[
-        pytest.param(None, id="NO_CPU_TMPL"),
-        *static_cpu_templates_params(),
-        *custom_cpu_templates_params(),
-    ],
-)
-def cpu_template_any(request, record_property):
-    """This fixture combines no template, static and custom CPU templates"""
-    record_property(
-        "cpu_template", get_cpu_template_name(request.param, with_type=True)
-    )
-    return request.param
+    Override with parametrize("cpu_template", ALL_CPU_TEMPLATES |
+    STATIC_CPU_TEMPLATES | CUSTOM_CPU_TEMPLATES | [<dict>], indirect=True),
+    or use `@pin_cpu_template(...)`.
+    """
+    template = getattr(request, "param", None)
+    record_property("cpu_template", get_cpu_template_name(template, with_type=True))
+    return template
 
 
 @pytest.fixture(params=["Sync", "Async"])
@@ -517,136 +504,22 @@ def results_dir(request, pytestconfig):
     return results_dir
 
 
-def guest_kernel_fxt(request, record_property):
-    """Return all supported guest kernels."""
-    kernel = request.param
-    if kernel is None:
-        pytest.fail(f"No kernel artifacts found in {ARTIFACT_DIR}")
-    # vmlinux-5.10.167 -> linux-5.10
-    prop = kernel.stem[2:]
-    record_property("guest_kernel", prop)
-    return kernel
-
-
-# Fixtures for all guest kernels, and specific versions
-guest_kernel = pytest.fixture(guest_kernel_fxt, params=kernel_params("vmlinux-*"))
-guest_kernel_acpi = pytest.fixture(
-    guest_kernel_fxt,
-    params=filter(
-        lambda kernel: "no-acpi" not in kernel.id, kernel_params("vmlinux-*")
-    ),
-)
-guest_kernel_linux_5_10 = pytest.fixture(
-    guest_kernel_fxt,
-    params=filter(
-        lambda kernel: "no-acpi" not in kernel.id, kernel_params("vmlinux-5.10*")
-    ),
-)
-guest_kernel_linux_6_1 = pytest.fixture(
-    guest_kernel_fxt,
-    params=kernel_params("vmlinux-6.1*"),
-)
-guest_kernel_default = guest_kernel_linux_6_1
-
-
-def match_rootfs_to_kernel(request):
-    """For 5.10, use Ubuntu as rootfs, otherwise use AL2023.
-    Reason: AL2023 does not officially support 5.10"""
-    for name in request.fixturenames:
-        if name.startswith("guest_kernel"):
-            kernel = request.getfixturevalue(name)
-            if kernel and kernel.stem[2:] == "linux-5.10":
-                return "ubuntu"
-            break
-    return "amazonlinux"
-
-
 @pytest.fixture
-def rootfs(request):
-    """Return a read-only rootfs. Ubuntu for 5.10, AL2023 for 6.1."""
-    distro = match_rootfs_to_kernel(request)
-    disk_list = disks(f"{distro}*.squashfs")
-    if not disk_list:
-        pytest.fail(f"No {distro} squashfs found in {ARTIFACT_DIR}")
-    return disk_list[0]
-
-
-@pytest.fixture
-def rootfs_rw(request):
-    """Return a writeable rootfs. Ubuntu for 5.10, AL2023 for 6.1."""
-    distro = match_rootfs_to_kernel(request)
-    disk_list = disks(f"{distro}*.ext4")
-    if not disk_list:
-        pytest.fail(f"No {distro} ext4 found in {ARTIFACT_DIR}")
-    return disk_list[0]
-
-
-@pytest.fixture
-def uvm_plain(microvm_factory, guest_kernel_default, rootfs, pci_enabled):
-    """Create a vanilla VM, non-parametrized"""
-    return microvm_factory.build(guest_kernel_default, rootfs, pci=pci_enabled)
-
-
-@pytest.fixture
-def uvm_plain_acpi(microvm_factory, guest_kernel_acpi, rootfs, pci_enabled):
-    """Create a vanilla VM, non-parametrized"""
-    return microvm_factory.build(guest_kernel_acpi, rootfs, pci=pci_enabled)
-
-
-@pytest.fixture
-def uvm_plain_rw(microvm_factory, guest_kernel_default, rootfs_rw):
-    """Create a vanilla VM, non-parametrized"""
-    return microvm_factory.build(guest_kernel_default, rootfs_rw)
-
-
-@pytest.fixture
-def uvm_nano(uvm_plain):
-    """A preconfigured uvm with 2vCPUs and 256MiB of memory
-    ready to .start()
-    """
-    uvm_plain.spawn()
-    uvm_plain.basic_config(vcpu_count=2, mem_size_mib=256)
-    return uvm_plain
-
-
-@pytest.fixture()
 def artifact_dir():
     """Return the location of the CI artifacts"""
     return defs.ARTIFACT_DIR
 
 
 @pytest.fixture
-def uvm_plain_any(microvm_factory, guest_kernel, rootfs, pci_enabled):
-    """All guest kernels
-    kernel: all
-    rootfs: Ubuntu for 5.10, AL2023 for 6.1
-    """
-    return microvm_factory.build(guest_kernel, rootfs, pci=pci_enabled)
-
-
-guest_kernel_6_1_debug = pytest.fixture(
-    guest_kernel_fxt,
-    params=kernel_params("vmlinux-6.1*", artifact_dir=defs.ARTIFACT_DIR / "debug"),
-)
-guest_kernel_default_debug = guest_kernel_6_1_debug
-
-
-@pytest.fixture
-def uvm_plain_debug(microvm_factory, guest_kernel_default_debug, rootfs_rw):
-    """VM running a kernel with debug/trace Kconfig options"""
-    return microvm_factory.build(guest_kernel_default_debug, rootfs_rw)
-
-
-@pytest.fixture
-def vcpu_count():
+def vcpu_count(request):
     """Return default vcpu_count. Use indirect parametrization to override."""
-    return 2
+    return getattr(request, "param", 2)
 
 
 @pytest.fixture
-def mem_size_mib():
+def mem_size_mib(request):
     """Return memory size. Use indirect parametrization to override."""
-    return 256
+    return getattr(request, "param", 256)
 
 
 @pytest.fixture(params=[True, False], ids=["PCI_ON", "PCI_OFF"])
@@ -655,160 +528,162 @@ def pci_enabled(request):
     yield request.param
 
 
-@pytest.fixture(
-    params=[HugePagesConfig.NONE, HugePagesConfig.HUGETLBFS_2MB],
-    ids=["NO_HUGE_PAGES", "2M_HUGE_PAGES"],
-)
+@pytest.fixture
 def huge_pages(request):
     """Fixture that allows configuring whether a microVM will have huge pages enabled or not"""
-    yield request.param
+    return getattr(request, "param", HugePagesConfig.NONE)
 
 
-def uvm_booted(
-    microvm_factory,
-    guest_kernel,
-    rootfs,
-    cpu_template,
-    pci_enabled,
-    vcpu_count=2,
-    mem_size_mib=256,
-):
-    """Return a booted uvm"""
-    uvm = microvm_factory.build(guest_kernel, rootfs, pci=pci_enabled)
+# =============================================================================
+# Composable uvm fixture system
+# =============================================================================
+#
+# Tests get a microVM by requesting one of:
+#
+#   uvm             — a built (chroot only) microVM
+#   uvm_configured  — spawned + basic_config + cpu_template applied
+#   uvm_booted      — uvm_configured + add_net_iface + start (ready to ssh)
+#   uvm_restored    — uvm_booted, snapshotted, restored from the snapshot
+#   uvm_any         — booted or restored, parametrized via `uvm_lifecycle`
+#
+# Each consumer fixture is composed from independent dimension fixtures with
+# defaults baked into their bodies. Override a dim with
+# `@pytest.mark.parametrize(<dim>, [...], indirect=True)` or use the helpers
+# from `framework.artifacts` (`pin_guest_kernel`, `pin_rootfs_mode`,
+# `pin_pci`, `pin_cpu_template`).
+#
+# Module-level `pytestmark` works for tests that don't override that same
+# dim per-test — pytest's parametrize markers do NOT merge: a pytestmark +
+# per-test parametrize on the same argname raises "duplicate parametrization".
+#
+# Dimensions:
+#   guest_kernel  Path to a guest kernel artifact              auto-multiplied
+#                                                              over ALL_GUEST_KERNELS
+#   rootfs_mode   "ro" | "rw"                                  default "ro"
+#   rootfs        Path to a rootfs disk, composed from         (composed)
+#                 guest_kernel + rootfs_mode (Ubuntu for 5.10, AL2023 otherwise)
+#   pci_enabled   True / False                                 auto-multiplied
+#   cpu_template  None | static name | custom dict             default None
+#   huge_pages    HugePagesConfig                              default NONE
+#   vcpu_count    int                                          default 2
+#   mem_size_mib  int                                          default 256
+
+
+@pytest.fixture(params=ALL_GUEST_KERNELS)
+def guest_kernel(request, record_property):
+    """Path to the guest kernel artifact.
+
+    Default: parametrized over every supported kernel, so every test that
+    requests this fixture (directly or via `uvm` etc.) runs once per kernel.
+
+    Override with `@pin_guest_kernel(<Path or catalogue>)` (from
+    `framework.artifacts`) to restrict to one kernel or a smaller subset —
+    e.g. for tests of Firecracker functionality that don't depend on the
+    guest kernel, use `@pin_guest_kernel(GUEST_KERNEL_DEFAULT)`.
+    """
+    kernel_path = request.param
+    if kernel_path is None:
+        pytest.fail(f"No kernel artifacts found in {ARTIFACT_DIR}")
+    record_property("guest_kernel", kernel_path.stem[2:])
+    return kernel_path
+
+
+@pytest.fixture
+def rootfs_mode(request):
+    """Rootfs access mode: "ro" (squashfs) or "rw" (ext4). Default: "ro"."""
+    mode = getattr(request, "param", "ro")
+    if mode not in ("ro", "rw"):
+        pytest.fail(f"rootfs_mode must be 'ro' or 'rw'; got {mode!r}")
+    return mode
+
+
+@pytest.fixture
+def rootfs(guest_kernel, rootfs_mode):
+    """Path to a rootfs disk matching `guest_kernel` and `rootfs_mode`.
+
+    Ubuntu for 5.10, AL2023 otherwise (AL2023 does not officially support 5.10).
+    """
+    distro = "ubuntu" if guest_kernel.stem[2:] == "linux-5.10" else "amazonlinux"
+    suffix = {"ro": "squashfs", "rw": "ext4"}[rootfs_mode]
+    disk_list = disks(f"{distro}*.{suffix}")
+    if not disk_list:
+        pytest.fail(f"No {distro} {suffix} found in {ARTIFACT_DIR}")
+    return disk_list[0]
+
+
+@pytest.fixture
+def uvm(microvm_factory, guest_kernel, rootfs, pci_enabled):
+    """Built microVM (chroot only). Caller drives spawn/basic_config/start."""
+    vm = microvm_factory.build(guest_kernel, rootfs, pci=pci_enabled)
+    return vm
+
+
+@pytest.fixture
+def uvm_configured(uvm, vcpu_count, mem_size_mib, huge_pages, cpu_template):
+    """Spawned + basic_config + cpu_template applied. Caller adds devices and starts."""
     uvm.spawn()
-    uvm.basic_config(vcpu_count=vcpu_count, mem_size_mib=mem_size_mib)
-    uvm.set_cpu_template(cpu_template)
-    uvm.add_net_iface()
-    uvm.start()
+    uvm.basic_config(
+        vcpu_count=vcpu_count,
+        mem_size_mib=mem_size_mib,
+        huge_pages=huge_pages,
+    )
+    if cpu_template is not None:
+        uvm.set_cpu_template(cpu_template)
     return uvm
 
 
-def uvm_restored(
-    microvm_factory, guest_kernel, rootfs, cpu_template, pci_enabled, **kwargs
-):
-    """Return a restored uvm"""
-    uvm = uvm_booted(
-        microvm_factory, guest_kernel, rootfs, cpu_template, pci_enabled, **kwargs
-    )
-    snapshot = uvm.snapshot_full()
-    uvm.kill()
-    uvm2 = microvm_factory.build_from_snapshot(snapshot)
-    uvm2.cpu_template_name = uvm.cpu_template_name
-    return uvm2
+@pytest.fixture
+def uvm_booted(uvm_configured):
+    """Booted microVM with a default net iface. Ready to ssh."""
+    uvm_configured.add_net_iface()
+    uvm_configured.start()
+    return uvm_configured
 
 
-@pytest.fixture(params=[uvm_booted, uvm_restored])
-def uvm_ctor(request):
-    """Fixture to return uvms with different constructors"""
+@pytest.fixture
+def uvm_restored(uvm_booted, microvm_factory):
+    """Booted microVM, snapshotted, restored from the snapshot."""
+    snapshot = uvm_booted.snapshot_full()
+    uvm_booted.kill()
+    restored = microvm_factory.build_from_snapshot(snapshot)
+    restored.cpu_template_name = uvm_booted.cpu_template_name
+    return restored
+
+
+@pytest.fixture(params=["booted", "restored"])
+def uvm_lifecycle(request):
+    """Parametrized over the two lifecycle end-states a test may want.
+
+    Tests that depend on it (directly, or transitively via `uvm_any`) run
+    once per state. Use this as the synchronisation point when a test
+    needs to build a secondary VM that matches the same lifecycle as
+    `uvm_any` (e.g. an A/B test against a different firecracker revision).
+    """
     return request.param
 
 
 @pytest.fixture
 def uvm_any(
-    microvm_factory,
-    uvm_ctor,
+    uvm_lifecycle,
+    request,
     guest_kernel,
     rootfs,
-    cpu_template_any,
     pci_enabled,
+    cpu_template,
     vcpu_count,
     mem_size_mib,
+    huge_pages,
 ):
-    """Return booted and restored uvms"""
-    return uvm_ctor(
-        microvm_factory,
-        guest_kernel,
-        rootfs,
-        cpu_template_any,
-        pci_enabled,
-        vcpu_count=vcpu_count,
-        mem_size_mib=mem_size_mib,
-    )
+    """A microVM in either the booted or restored lifecycle state.
 
+    Parametrized over both states via `uvm_lifecycle` — every test that
+    requests `uvm_any` runs twice (booted + restored). Replaces the old
+    `uvm_any` fixture which used function refs in `params=`.
 
-@pytest.fixture
-def uvm_any_booted(
-    microvm_factory,
-    guest_kernel,
-    rootfs,
-    cpu_template_any,
-    pci_enabled,
-    vcpu_count,
-    mem_size_mib,
-):
-    """Return booted uvms"""
-    return uvm_booted(
-        microvm_factory,
-        guest_kernel,
-        rootfs,
-        cpu_template_any,
-        pci_enabled,
-        vcpu_count=vcpu_count,
-        mem_size_mib=mem_size_mib,
-    )
-
-
-@pytest.fixture
-def uvm_any_with_pci(
-    uvm_ctor,
-    microvm_factory,
-    guest_kernel_acpi,
-    rootfs,
-    cpu_template_any,
-    vcpu_count,
-    mem_size_mib,
-):
-    """Return booted uvms with PCI enabled"""
-    return uvm_ctor(
-        microvm_factory,
-        guest_kernel_acpi,
-        rootfs,
-        cpu_template_any,
-        True,
-        vcpu_count=vcpu_count,
-        mem_size_mib=mem_size_mib,
-    )
-
-
-@pytest.fixture
-def uvm_any_without_pci(
-    uvm_ctor,
-    microvm_factory,
-    guest_kernel,
-    rootfs,
-    cpu_template_any,
-    vcpu_count,
-    mem_size_mib,
-):
-    """Return booted uvms with PCI disabled"""
-    return uvm_ctor(
-        microvm_factory,
-        guest_kernel,
-        rootfs,
-        cpu_template_any,
-        False,
-        vcpu_count=vcpu_count,
-        mem_size_mib=mem_size_mib,
-    )
-
-
-@pytest.fixture
-def uvm_with_fips(microvm_factory, guest_kernel_linux_6_1, rootfs_rw):
-    """Boot a microVM with FIPS mode enabled."""
-    uvm = microvm_factory.build(guest_kernel_linux_6_1, rootfs_rw)
-    uvm.spawn()
-    uvm.basic_config(boot_args="console=ttyS0 reboot=k panic=1 pci=off fips=1")
-    uvm.add_net_iface()
-    uvm.start()
-    return uvm
-
-
-@pytest.fixture
-def fips_snapshot_pair(uvm_with_fips, microvm_factory):
-    """Boot a FIPS VM, snapshot it, restore two VMs from the same snapshot."""
-    snapshot = uvm_with_fips.snapshot_full()
-    uvm_with_fips.kill()
-
-    uvm_a = microvm_factory.build_from_snapshot(snapshot)
-    uvm_b = microvm_factory.build_from_snapshot(snapshot)
-    yield uvm_a, uvm_b
+    Explicitly declares dependencies on every dim fixture used by the
+    underlying `uvm_booted` / `uvm_restored` fixtures so pytest puts them
+    all in the test's fixture closure (otherwise indirect parametrize on
+    those names would error with "function uses no fixture").
+    """
+    # pylint: disable=unused-argument
+    return request.getfixturevalue(f"uvm_{uvm_lifecycle}")

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -50,3 +50,56 @@ def kernel_params(glob="vmlinux-*", select=kernels, artifact_dir=ARTIFACT_DIR) -
     return [
         pytest.param(kernel, id=kernel.name) for kernel in select(glob, artifact_dir)
     ] or [pytest.param(None, id="no-kernel-found")]
+
+
+# Catalogues of guest kernel artifacts. Each entry is a `pytest.param` so test
+# ids carry the kernel filename (e.g. "vmlinux-6.1.123") rather than "kernel0".
+ALL_GUEST_KERNELS = list(kernel_params("vmlinux-*"))
+ACPI_GUEST_KERNELS = [p for p in kernel_params("vmlinux-*") if "no-acpi" not in p.id]
+GUEST_KERNELS_5_10 = list(kernel_params("vmlinux-5.10*"))
+GUEST_KERNELS_6_1 = list(kernel_params("vmlinux-6.1*"))
+GUEST_KERNELS_6_1_DEBUG = list(
+    kernel_params("vmlinux-6.1*", artifact_dir=ARTIFACT_DIR / "debug")
+)
+# The single canonical kernel used when a test pins to one specific kernel
+# (e.g. tests of Firecracker functionality that don't depend on guest kernel).
+# Update here when the default version changes. Stored as a `pytest.param`
+# so the test id carries the kernel filename (e.g. "vmlinux-6.1.168").
+GUEST_KERNEL_DEFAULT = GUEST_KERNELS_6_1[0] if GUEST_KERNELS_6_1 else None
+GUEST_KERNEL_DEFAULT_DEBUG = (
+    GUEST_KERNELS_6_1_DEBUG[0] if GUEST_KERNELS_6_1_DEBUG else None
+)
+
+
+def pin_guest_kernel(kernels_or_path):
+    """Convenience marker for pinning the `guest_kernel` dim.
+
+    The default `guest_kernel` fixture parametrizes over ALL_GUEST_KERNELS;
+    use this helper to restrict to a single kernel or a smaller subset.
+
+    Usage at module level:
+        pytestmark = pin_guest_kernel(ACPI_GUEST_KERNELS)
+
+    Usage at test level:
+        @pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+        def test_foo(uvm): ...
+
+    Accepts a kernel catalogue (e.g. ACPI_GUEST_KERNELS), a single
+    `pytest.param`, or a single Path.
+    """
+    # Wrap a single Path or pytest.param into a list. A bare ParameterSet
+    # passed to `parametrize` would be treated as a sequence of args and
+    # produce broken parameterizations.
+    if not isinstance(kernels_or_path, list):
+        kernels_or_path = [kernels_or_path]
+    return pytest.mark.parametrize("guest_kernel", kernels_or_path, indirect=True)
+
+
+def pin_rootfs_mode(mode):
+    """Convenience marker for pinning the `rootfs_mode` dim ("ro" | "rw")."""
+    return pytest.mark.parametrize("rootfs_mode", [mode], indirect=True)
+
+
+def pin_pci(enabled):
+    """Convenience marker for pinning the `pci_enabled` dim to a single value."""
+    return pytest.mark.parametrize("pci_enabled", [enabled], indirect=True)

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -1337,6 +1337,30 @@ class MicroVMFactory:
         )
         return vm
 
+    def build_booted(self, kernel, rootfs, *, pci=False, **basic_config_kwargs):
+        """Build, spawn, basic_config, add a default net iface, start.
+
+        Extra keyword arguments are forwarded to `Microvm.basic_config`.
+        """
+        vm = self.build(kernel, rootfs, pci=pci)
+        vm.spawn()
+        vm.basic_config(**basic_config_kwargs)
+        vm.add_net_iface()
+        vm.start()
+        return vm
+
+    def build_restored(self, kernel, rootfs, *, pci=False, **basic_config_kwargs):
+        """build_booted, then snapshot + kill + restore.
+
+        Extra keyword arguments are forwarded to `Microvm.basic_config`.
+        """
+        booted = self.build_booted(kernel, rootfs, pci=pci, **basic_config_kwargs)
+        snapshot = booted.snapshot_full()
+        booted.kill()
+        restored = self.build_from_snapshot(snapshot)
+        restored.cpu_template_name = booted.cpu_template_name
+        return restored
+
     def build_n_from_snapshot(
         self,
         current_snapshot,

--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -6,10 +6,10 @@
 # pylint:disable=too-many-return-statements
 
 import json
-from pathlib import Path
 
 import pytest
 
+from framework.defs import FC_WORKSPACE_DIR
 from framework.properties import global_props
 from framework.utils_cpuid import CpuModel, CpuVendor, get_cpu_vendor
 
@@ -77,7 +77,13 @@ def get_supported_custom_cpu_templates():
 def custom_cpu_templates_params():
     """Return Custom CPU templates as pytest parameters"""
     for name in sorted(get_supported_custom_cpu_templates()):
-        tmpl = Path(f"./data/custom_cpu_templates/{name}.json")
+        tmpl = (
+            FC_WORKSPACE_DIR
+            / "tests"
+            / "data"
+            / "custom_cpu_templates"
+            / f"{name}.json"
+        )
         yield pytest.param(
             {"name": name, "template": json.loads(tmpl.read_text("utf-8"))},
             id="custom_" + name,

--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -97,3 +97,24 @@ def get_cpu_template_name(cpu_template, with_type=False):
     if isinstance(cpu_template, dict):
         return ("custom_" if with_type else "") + cpu_template["name"]
     return "None"
+
+
+# Catalogues for indirect parametrize values.
+STATIC_CPU_TEMPLATES = list(static_cpu_templates_params())
+CUSTOM_CPU_TEMPLATES = list(custom_cpu_templates_params())
+ALL_CPU_TEMPLATES = [
+    pytest.param(None, id="NO_CPU_TMPL"),
+    *STATIC_CPU_TEMPLATES,
+    *CUSTOM_CPU_TEMPLATES,
+]
+
+
+def pin_cpu_template(templates):
+    """Convenience marker for pinning the `cpu_template` dim.
+
+    Usage:
+        pytestmark = pin_cpu_template(ALL_CPU_TEMPLATES)
+        @pin_cpu_template(STATIC_CPU_TEMPLATES)
+        def test_foo(uvm_configured): ...
+    """
+    return pytest.mark.parametrize("cpu_template", templates, indirect=True)

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -16,8 +16,13 @@ import semver
 import host_tools.drive as drive_tools
 import host_tools.network as net_tools
 from framework import utils, utils_cpuid
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.utils import get_firecracker_version_from_toml
-from framework.utils_cpu_templates import SUPPORTED_CPU_TEMPLATES
+from framework.utils_cpu_templates import (
+    CUSTOM_CPU_TEMPLATES,
+    SUPPORTED_CPU_TEMPLATES,
+    pin_cpu_template,
+)
 
 MEM_LIMIT = 1000000000
 
@@ -29,11 +34,12 @@ NOT_SUPPORTED_AFTER_START = (
 )
 
 
-def test_api_happy_start(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_happy_start(uvm):
     """
     Test that a regular microvm API config and boot sequence works.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Set up the microVM with 2 vCPUs, 256 MiB of RAM and
@@ -46,14 +52,15 @@ def test_api_happy_start(uvm_plain):
         assert "Kernel loaded using PVH boot protocol" in test_microvm.log_data
 
 
-def test_drive_io_engine(uvm_plain, io_engine):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_drive_io_engine(uvm, io_engine):
     """
     Test io_engine configuration.
 
     Test that the io_engine can be configured via the API on kernels that
     support the given type and that FC returns an error otherwise.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     test_microvm.basic_config(add_root_device=False)
@@ -75,13 +82,14 @@ def test_drive_io_engine(uvm_plain, io_engine):
     )
 
 
-def test_api_put_update_pre_boot(uvm_plain, io_engine):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_put_update_pre_boot(uvm, io_engine):
     """
     Test that PUT updates are allowed before the microvm boots.
 
     Tests updates on drives, boot source and machine config.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Set up the microVM with 2 vCPUs, 256 MiB of RAM  and
@@ -172,11 +180,12 @@ def test_api_put_update_pre_boot(uvm_plain, io_engine):
     assert response_json["track_dirty_pages"] == track_dirty_pages
 
 
-def test_net_api_put_update_pre_boot(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_net_api_put_update_pre_boot(uvm):
     """
     Test PUT updates on network configurations before the microvm boots.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     tap1name = test_microvm.id[:8] + "tap1"
@@ -220,13 +229,14 @@ def test_net_api_put_update_pre_boot(uvm_plain):
     )
 
 
-def test_api_mmds_config(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_mmds_config(uvm):
     """
     Test /mmds/config PUT scenarios that unit tests can't cover.
 
     Tests updates on MMDS config before and after attaching a network device.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Set up the microVM with 2 vCPUs, 256 MiB of RAM  and
@@ -298,11 +308,12 @@ def test_api_mmds_config(uvm_plain):
 
 
 # pylint: disable=too-many-statements
-def test_api_machine_config(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_machine_config(uvm):
     """
     Test /machine_config PUT/PATCH scenarios that unit tests can't cover.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Test invalid vcpu count < 0.
@@ -408,7 +419,8 @@ def test_api_machine_config(uvm_plain):
     assert json["machine-config"]["smt"] is False
 
 
-def test_negative_machine_config_api(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_negative_machine_config_api(uvm):
     """
     Test the deprecated `cpu_template` field in PUT and PATCH requests on
     `/machine-config` API is handled correctly.
@@ -416,7 +428,7 @@ def test_negative_machine_config_api(uvm_plain):
     When using the `cpu_template` field (even if the value is "None"), the HTTP
     response header should have "Deprecation: true".
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Use `cpu_template` field in PUT /machine-config
@@ -439,24 +451,27 @@ def test_negative_machine_config_api(uvm_plain):
     )
 
 
-def test_api_cpu_config(uvm_plain, custom_cpu_template):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+@pin_cpu_template(CUSTOM_CPU_TEMPLATES)
+def test_api_cpu_config(uvm, cpu_template):
     """
     Test /cpu-config PUT scenarios.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     with pytest.raises(RuntimeError):
         test_microvm.api.cpu_config.put(foo=False)
 
-    test_microvm.api.cpu_config.put(**custom_cpu_template["template"])
+    test_microvm.api.cpu_config.put(**cpu_template["template"])
 
 
-def test_api_put_update_post_boot(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_put_update_post_boot(uvm):
     """
     Test that PUT updates are rejected after the microvm boots.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Set up the microVM with 2 vCPUs, 256 MiB of RAM  and
@@ -496,11 +511,12 @@ def test_api_put_update_post_boot(uvm_plain):
         test_microvm.api.mmds_config.put(**mmds_config)
 
 
-def test_rate_limiters_api_config(uvm_plain, io_engine):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_rate_limiters_api_config(uvm, io_engine):
     """
     Test the IO rate limiter API config.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Test the DRIVE rate limiting API.
@@ -619,11 +635,12 @@ def test_rate_limiters_api_config(uvm_plain, io_engine):
     )
 
 
-def test_api_patch_pre_boot(uvm_plain, io_engine):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_patch_pre_boot(uvm, io_engine):
     """
     Test that PATCH updates are not allowed before the microvm boots.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Sets up the microVM with 2 vCPUs, 256 MiB of RAM, 1 network interface
@@ -678,11 +695,12 @@ def test_api_patch_pre_boot(uvm_plain, io_engine):
         )
 
 
-def test_negative_api_patch_post_boot(uvm_plain, io_engine):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_negative_api_patch_post_boot(uvm, io_engine):
     """
     Test PATCH updates that are not allowed after the microvm boots.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Sets up the microVM with 2 vCPUs, 256 MiB of RAM, 1 network iface and
@@ -720,11 +738,12 @@ def test_negative_api_patch_post_boot(uvm_plain, io_engine):
         test_microvm.api.logger.patch(level="Error")
 
 
-def test_drive_patch(uvm_plain, io_engine):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_drive_patch(uvm, io_engine):
     """
     Extensively test drive PATCH scenarios before and after boot.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Sets up the microVM with 2 vCPUs, 256 MiB of RAM and
@@ -757,13 +776,13 @@ def test_drive_patch(uvm_plain, io_engine):
 @pytest.mark.skipif(
     platform.machine() != "x86_64", reason="not yet implemented on aarch64"
 )
-def test_send_ctrl_alt_del(uvm_plain_any):
+def test_send_ctrl_alt_del(uvm):
     """
     Test shutting down the microVM gracefully on x86, by sending CTRL+ALT+DEL.
     """
     # This relies on the i8042 device and AT Keyboard support being present in
     # the guest kernel.
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     test_microvm.basic_config()
@@ -910,11 +929,12 @@ def _drive_patch(test_microvm, io_engine):
     )
 
 
-def test_api_version(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_version(uvm):
     """
     Test the permanent VM version endpoint.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
 
@@ -943,11 +963,12 @@ def test_api_version(uvm_plain):
     assert api_version == binary_version
 
 
-def test_api_vsock(uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_vsock(uvm_configured):
     """
     Test vsock related API commands.
     """
-    vm = uvm_nano
+    vm = uvm_configured
     # Create a vsock device.
     vm.api.vsock.put(guest_cid=15, uds_path="vsock.sock")
 
@@ -971,11 +992,12 @@ def test_api_vsock(uvm_nano):
         vm.api.vsock.put(guest_cid=17, uds_path="vsock.sock")
 
 
-def test_api_entropy(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_entropy(uvm):
     """
     Test entropy related API commands.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
 
@@ -992,11 +1014,12 @@ def test_api_entropy(uvm_plain):
         test_microvm.api.entropy.put()
 
 
-def test_api_memory_hotplug(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_memory_hotplug(uvm):
     """
     Test hotplug related API commands.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -1035,11 +1058,12 @@ def test_api_memory_hotplug(uvm_plain):
     assert status["requested_size_mib"] == 512
 
 
-def test_api_balloon(uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_balloon(uvm_configured):
     """
     Test balloon related API commands.
     """
-    test_microvm = uvm_nano
+    test_microvm = uvm_configured
 
     # Updating an inexistent balloon device should give an error.
     with pytest.raises(RuntimeError):
@@ -1098,12 +1122,12 @@ def test_api_balloon(uvm_nano):
         test_microvm.api.balloon.patch(amount_mib=33554432)
 
 
-def test_pmem_api(uvm_plain_any, rootfs):
+def test_pmem_api(uvm, rootfs):
     """
     Test virtio-pmem API commands
     """
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(add_root_device=False)
 
@@ -1150,11 +1174,11 @@ def test_pmem_api(uvm_plain_any, rootfs):
         vm.api.pmem.put(id="pmem")
 
 
-def test_pmem_rate_limiter_api(uvm_plain_any, rootfs):
+def test_pmem_rate_limiter_api(uvm, rootfs):
     """
     Test virtio-pmem rate limiter PUT and PATCH API commands.
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(add_root_device=False)
 
@@ -1245,11 +1269,12 @@ def test_pmem_rate_limiter_api(uvm_plain_any, rootfs):
         )
 
 
-def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_configured):
     """
     Test the configuration of a microVM after restoring from a snapshot.
     """
-    net_iface = uvm_nano.add_net_iface()
+    net_iface = uvm_configured.add_net_iface()
     cpu_vendor = utils_cpuid.get_cpu_vendor()
 
     setup_cfg = {}
@@ -1268,7 +1293,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
     if len(SUPPORTED_CPU_TEMPLATES) != 0:
         setup_cfg["machine-config"]["cpu_template"] = SUPPORTED_CPU_TEMPLATES[0]
 
-    uvm_nano.api.machine_config.patch(**setup_cfg["machine-config"])
+    uvm_configured.api.machine_config.patch(**setup_cfg["machine-config"])
 
     setup_cfg["cpu-config"] = None
 
@@ -1279,23 +1304,23 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
             "is_root_device": True,
             "cache_type": "Unsafe",
             "is_read_only": True,
-            "path_on_host": f"/{uvm_nano.rootfs_file.name}",
+            "path_on_host": f"/{uvm_configured.rootfs_file.name}",
             "rate_limiter": None,
             "io_engine": "Sync",
             "socket": None,
         }
     ]
 
-    uvm_nano.api.pmem.put(
+    uvm_configured.api.pmem.put(
         id="pmem",
-        path_on_host="/" + uvm_nano.rootfs_file.name,
+        path_on_host="/" + uvm_configured.rootfs_file.name,
         root_device=False,
         read_only=False,
     )
     setup_cfg["pmem"] = [
         {
             "id": "pmem",
-            "path_on_host": "/" + uvm_nano.rootfs_file.name,
+            "path_on_host": "/" + uvm_configured.rootfs_file.name,
             "root_device": False,
             "read_only": False,
             "rate_limiter": None,
@@ -1303,7 +1328,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
     ]
 
     # Add a memory balloon device.
-    uvm_nano.api.balloon.put(amount_mib=1, deflate_on_oom=True)
+    uvm_configured.api.balloon.put(amount_mib=1, deflate_on_oom=True)
     setup_cfg["balloon"] = {
         "amount_mib": 1,
         "deflate_on_oom": True,
@@ -1313,7 +1338,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
     }
 
     # Add a vsock device.
-    uvm_nano.api.vsock.put(guest_cid=15, uds_path="vsock.sock")
+    uvm_configured.api.vsock.put(guest_cid=15, uds_path="vsock.sock")
     setup_cfg["vsock"] = {"guest_cid": 15, "uds_path": "vsock.sock"}
 
     setup_cfg["memory-hotplug"] = {
@@ -1321,7 +1346,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
         "block_size_mib": 128,
         "slot_size_mib": 1024,
     }
-    uvm_nano.api.memory_hotplug.put(**setup_cfg["memory-hotplug"])
+    uvm_configured.api.memory_hotplug.put(**setup_cfg["memory-hotplug"])
 
     setup_cfg["logger"] = None
     setup_cfg["metrics"] = None
@@ -1330,10 +1355,10 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
         "network_interfaces": [net_iface.dev_name],
     }
 
-    uvm_nano.api.mmds_config.put(**setup_cfg["mmds-config"])
+    uvm_configured.api.mmds_config.put(**setup_cfg["mmds-config"])
 
     # Start the microvm.
-    uvm_nano.start()
+    uvm_configured.start()
 
     # Add a tx rate limiter to the net device.
     tx_rl = {
@@ -1341,7 +1366,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
         "ops": None,
     }
 
-    response = uvm_nano.api.network.patch(
+    response = uvm_configured.api.network.patch(
         iface_id=net_iface.dev_name, tx_rate_limiter=tx_rl
     )
     setup_cfg["network-interfaces"] = [
@@ -1355,17 +1380,19 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
         }
     ]
 
-    snapshot = uvm_nano.snapshot_full()
+    snapshot = uvm_configured.snapshot_full()
     uvm2 = microvm_factory.build_from_snapshot(snapshot)
     expected_cfg = setup_cfg.copy()
 
     # We expect boot-source to be set with the following values
     expected_cfg["boot-source"] = {
-        "kernel_image_path": uvm_nano.get_jailed_resource(uvm_nano.kernel_file),
+        "kernel_image_path": uvm_configured.get_jailed_resource(
+            uvm_configured.kernel_file
+        ),
         "initrd_path": None,
         "boot_args": "reboot=k panic=1 nomodule swiotlb=noforce console=ttyS0 cryptomgr.notests",
     }
-    if not uvm_nano.pci_enabled:
+    if not uvm_configured.pci_enabled:
         expected_cfg["boot-source"]["boot_args"] += " pci=off"
 
     # no ipv4_address or imds_compat specified during PUT /mmds/config so we expect the default
@@ -1385,11 +1412,12 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_nano):
     assert response == expected_cfg
 
 
-def test_get_full_config(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_get_full_config(uvm):
     """
     Test the reported configuration of a microVM configured with all resources.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     expected_cfg = {}
 
@@ -1520,7 +1548,8 @@ def test_get_full_config(uvm_plain):
     assert response.json() == expected_cfg
 
 
-def test_map_private_seccomp_regression(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_map_private_seccomp_regression(uvm):
     """
     Seccomp mmap MAP_PRIVATE regression test.
 
@@ -1528,7 +1557,7 @@ def test_map_private_seccomp_regression(uvm_plain):
     call mmap with MAP_PRIVATE|MAP_ANONYMOUS. This would result in vmm being
     killed by the seccomp filter before this PR.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.extra_args.update(
         {"http-api-max-payload-size": str(1024 * 1024 * 2)}
     )

--- a/tests/integration_tests/functional/test_api_server.py
+++ b/tests/integration_tests/functional/test_api_server.py
@@ -4,10 +4,12 @@
 
 import socket
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.utils import check_output
 
 
-def test_api_socket_in_use(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_socket_in_use(uvm):
     """
     Test error message when api socket is already in use.
 
@@ -16,7 +18,7 @@ def test_api_socket_in_use(uvm_plain):
     Check that the error message is a fixed one and that it also
     contains the name of the path.
     """
-    microvm = uvm_plain
+    microvm = uvm
 
     cmd = "mkdir {}/run".format(microvm.chroot())
     check_output(cmd)

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -93,11 +93,11 @@ def _test_rss_memory_lower(test_microvm):
 
 
 # pylint: disable=C0103
-def test_rss_memory_lower(uvm_plain_any):
+def test_rss_memory_lower(uvm):
     """
     Test that inflating the balloon makes guest use less rss memory.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -114,11 +114,11 @@ def test_rss_memory_lower(uvm_plain_any):
 
 
 # pylint: disable=C0103
-def test_inflate_reduces_free(uvm_plain_any):
+def test_inflate_reduces_free(uvm):
     """
     Check that the output of free in guest changes with inflate.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -150,7 +150,7 @@ def test_inflate_reduces_free(uvm_plain_any):
 
 # pylint: disable=C0103
 @pytest.mark.parametrize("deflate_on_oom", [True, False])
-def test_deflate_on_oom(uvm_plain_any, deflate_on_oom):
+def test_deflate_on_oom(uvm, deflate_on_oom):
     """
     Verify that setting the `deflate_on_oom` option works correctly.
 
@@ -165,7 +165,7 @@ def test_deflate_on_oom(uvm_plain_any, deflate_on_oom):
       should result in balloon_stats['actual_mib'] remain the same
     """
 
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -215,11 +215,11 @@ def test_deflate_on_oom(uvm_plain_any, deflate_on_oom):
 
 
 # pylint: disable=C0103
-def test_reinflate_balloon(uvm_plain_any):
+def test_reinflate_balloon(uvm):
     """
     Verify that repeatedly inflating and deflating the balloon works.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -280,11 +280,11 @@ def test_reinflate_balloon(uvm_plain_any):
 
 
 # pylint: disable=C0103
-def test_stats(uvm_plain_any):
+def test_stats(uvm):
     """
     Verify that balloon stats work as expected.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -351,11 +351,11 @@ def test_stats(uvm_plain_any):
     check_guest_dmesg_for_stalls(test_microvm.ssh)
 
 
-def test_stats_update(uvm_plain_any):
+def test_stats_update(uvm):
     """
     Verify that balloon stats update correctly.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.add_net_iface()
@@ -403,11 +403,11 @@ def test_stats_update(uvm_plain_any):
     check_guest_dmesg_for_stalls(test_microvm.ssh)
 
 
-def test_balloon_snapshot(uvm_plain_any, microvm_factory):
+def test_balloon_snapshot(uvm, microvm_factory):
     """
     Test that the balloon works after pause/resume.
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     # Free page reporting and hinting fragment guest memory VMAs
     # making it harder to identify them in the memory monitor.
@@ -488,11 +488,11 @@ def test_balloon_snapshot(uvm_plain_any, microvm_factory):
 
 
 @pytest.mark.parametrize("method", ["reporting", "hinting"])
-def test_hinting_reporting_snapshot(uvm_plain_any, microvm_factory, method):
+def test_hinting_reporting_snapshot(uvm, microvm_factory, method):
     """
     Test that the balloon hinting and reporting works after pause/resume.
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     # Free page reporting and hinting fragment guest memory VMAs
     # making it harder to identify them in the memory monitor.
@@ -575,11 +575,11 @@ def test_hinting_reporting_snapshot(uvm_plain_any, microvm_factory, method):
 
 
 @pytest.mark.parametrize("method", ["traditional", "hinting", "reporting"])
-def test_memory_scrub(uvm_plain_any, method):
+def test_memory_scrub(uvm, method):
     """
     Test that the memory is zeroed after deflate.
     """
-    microvm = uvm_plain_any
+    microvm = uvm
     microvm.spawn()
     microvm.basic_config(vcpu_count=2, mem_size_mib=256)
     microvm.add_net_iface()

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -7,11 +7,13 @@ from pathlib import Path
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.utils import check_output
 from host_tools.fcmetrics import validate_fc_metrics
 
 
-def test_describe_snapshot(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_describe_snapshot(uvm):
     """
     Test `--describe-snapshot` correctness for all snapshot versions.
 
@@ -19,7 +21,7 @@ def test_describe_snapshot(uvm_plain):
     snapshot state file.
     """
 
-    vm = uvm_plain
+    vm = uvm
     fc_binary = vm.fc_binary_path
 
     cmd = [fc_binary, "--snapshot-version"]
@@ -38,11 +40,12 @@ def test_describe_snapshot(uvm_plain):
     assert snap_version in stdout
 
 
-def test_cli_metrics_path(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_cli_metrics_path(uvm):
     """
     Test --metrics-path parameter
     """
-    microvm = uvm_plain
+    microvm = uvm
     metrics_path = Path(microvm.path) / "my_metrics.ndjson"
     microvm.spawn(metrics_path=metrics_path)
     microvm.basic_config()
@@ -51,13 +54,14 @@ def test_cli_metrics_path(uvm_plain):
     validate_fc_metrics(metrics)
 
 
-def test_cli_metrics_path_if_metrics_initialized_twice_fail(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_cli_metrics_path_if_metrics_initialized_twice_fail(uvm):
     """
     Given: a running firecracker with metrics configured with the CLI option
     When: Configure metrics via API
     Then: API returns an error
     """
-    microvm = uvm_plain
+    microvm = uvm
 
     # First configure the µvm metrics with --metrics-path
     metrics_path = Path(microvm.path) / "metrics.ndjson"
@@ -75,12 +79,13 @@ def test_cli_metrics_path_if_metrics_initialized_twice_fail(uvm_plain):
         )
 
 
-def test_cli_metrics_if_resume_no_metrics(uvm_plain, microvm_factory):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_cli_metrics_if_resume_no_metrics(uvm, microvm_factory):
     """
     Check that metrics configuration is not part of the snapshot
     """
     # Given: a snapshot of a FC with metrics configured with the CLI option
-    uvm1 = uvm_plain
+    uvm1 = uvm
     metrics_path = Path(uvm1.path) / "metrics.ndjson"
     metrics_path.touch()
     uvm1.spawn(metrics_path=metrics_path)

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -13,6 +13,7 @@ import pytest
 from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.utils import generate_mmds_get_request, generate_mmds_session_token
 from framework.utils_cpu_templates import SUPPORTED_CPU_TEMPLATES
 
@@ -110,12 +111,13 @@ def _get_optional_fields_from_file(vm_config_file):
         return version, ipv4_address, imds_compat
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("vm_config_file", ["framework/vm_config.json"])
-def test_config_start_with_api(uvm_plain, vm_config_file):
+def test_config_start_with_api(uvm, vm_config_file):
     """
     Test if a microvm configured from file boots successfully.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     vm_config = _configure_vm_from_json(test_microvm, vm_config_file)
     test_microvm.spawn(serial_out_path=None)
 
@@ -126,12 +128,13 @@ def test_config_start_with_api(uvm_plain, vm_config_file):
     assert response.json() == vm_config
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("vm_config_file", ["framework/vm_config.json"])
-def test_config_start_no_api(uvm_plain, vm_config_file):
+def test_config_start_no_api(uvm, vm_config_file):
     """
     Test microvm start when API server thread is disabled.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     _configure_vm_from_json(test_microvm, vm_config_file)
     test_microvm.jailer.extra_args.update({"no-api": None})
     test_microvm.spawn(serial_out_path=None)
@@ -155,12 +158,13 @@ def test_config_start_no_api(uvm_plain, vm_config_file):
             )
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("vm_config_file", ["framework/vm_config_network.json"])
-def test_config_start_no_api_exit(uvm_plain, vm_config_file):
+def test_config_start_no_api_exit(uvm, vm_config_file):
     """
     Test microvm exit when API server is disabled.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     _configure_vm_from_json(test_microvm, vm_config_file)
     _configure_network_interface(test_microvm)
     test_microvm.jailer.extra_args.update({"no-api": None})
@@ -175,6 +179,7 @@ def test_config_start_no_api_exit(uvm_plain, vm_config_file):
     assert test_microvm.get_exit_code() == 0
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize(
     "vm_config_file",
     [
@@ -182,11 +187,11 @@ def test_config_start_no_api_exit(uvm_plain, vm_config_file):
         "framework/vm_config_missing_mem_size_mib.json",
     ],
 )
-def test_config_bad_machine_config(uvm_plain, vm_config_file):
+def test_config_bad_machine_config(uvm, vm_config_file):
     """
     Test microvm start when the `machine_config` is invalid.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     _configure_vm_from_json(test_microvm, vm_config_file)
     test_microvm.jailer.extra_args.update({"no-api": None})
     test_microvm.spawn(serial_out_path=None)
@@ -195,6 +200,7 @@ def test_config_bad_machine_config(uvm_plain, vm_config_file):
     test_microvm.mark_killed()
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize(
     "test_config",
     [
@@ -202,11 +208,11 @@ def test_config_bad_machine_config(uvm_plain, vm_config_file):
         ("framework/vm_config_smt_true.json", False, True),
     ],
 )
-def test_config_machine_config_params(uvm_plain, test_config):
+def test_config_machine_config_params(uvm, test_config):
     """
     Test microvm start with optional `machine_config` parameters.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     # Test configuration determines if the file is a valid config or not
     # based on the CPU
@@ -238,12 +244,13 @@ def test_config_machine_config_params(uvm_plain, test_config):
         )
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("vm_config_file", ["framework/vm_config.json"])
-def test_config_start_with_limit(uvm_plain, vm_config_file):
+def test_config_start_with_limit(uvm, vm_config_file):
     """
     Negative test for customised request payload limit.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     _configure_vm_from_json(test_microvm, vm_config_file)
     test_microvm.jailer.extra_args.update({"http-api-max-payload-size": "250"})
@@ -269,12 +276,13 @@ def test_config_start_with_limit(uvm_plain, vm_config_file):
     assert stdout.encode("utf-8") == response.encode("utf-8")
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("vm_config_file", ["framework/vm_config_with_mmdsv2.json"])
-def test_config_with_default_limit(uvm_plain, vm_config_file):
+def test_config_with_default_limit(uvm, vm_config_file):
     """
     Test for request payload limit.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     _configure_vm_from_json(test_microvm, vm_config_file)
     _configure_network_interface(test_microvm)
@@ -304,11 +312,12 @@ def test_config_with_default_limit(uvm_plain, vm_config_file):
     assert stdout.encode("utf-8") == response_err.encode("utf-8")
 
 
-def test_start_with_metadata(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_start_with_metadata(uvm):
     """
     Test if metadata from file is available via MMDS.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     metadata_file = DIR / "metadata.json"
     _add_metadata_file(test_microvm, metadata_file)
 
@@ -324,11 +333,12 @@ def test_start_with_metadata(uvm_plain):
         assert response.json() == json.load(json_file)
 
 
-def test_start_with_metadata_limit(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_start_with_metadata_limit(uvm):
     """
     Test that the metadata size limit is enforced when populating from a file.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.extra_args.update({"mmds-size-limit": "30"})
     metadata_file = DIR / "metadata.json"
     _add_metadata_file(test_microvm, metadata_file)
@@ -342,11 +352,12 @@ def test_start_with_metadata_limit(uvm_plain):
     test_microvm.mark_killed()
 
 
-def test_start_with_metadata_default_limit(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_start_with_metadata_default_limit(uvm):
     """
     Test that the metadata size limit defaults to the api payload limit.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.extra_args.update({"http-api-max-payload-size": "30"})
 
     metadata_file = DIR / "metadata.json"
@@ -362,11 +373,12 @@ def test_start_with_metadata_default_limit(uvm_plain):
     test_microvm.mark_killed()
 
 
-def test_start_with_missing_metadata(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_start_with_missing_metadata(uvm):
     """
     Test if a microvm is configured with a missing metadata file.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     metadata_file = "../resources/tests/metadata_nonexisting.json"
 
     vm_metadata_path = os.path.join(test_microvm.path, os.path.basename(metadata_file))
@@ -385,11 +397,12 @@ def test_start_with_missing_metadata(uvm_plain):
         test_microvm.mark_killed()
 
 
-def test_start_with_invalid_metadata(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_start_with_invalid_metadata(uvm):
     """
     Test if a microvm is configured with a invalid metadata file.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     metadata_file = DIR / "metadata_invalid.json"
     vm_metadata_path = os.path.join(test_microvm.path, os.path.basename(metadata_file))
     shutil.copy(metadata_file, vm_metadata_path)
@@ -406,15 +419,16 @@ def test_start_with_invalid_metadata(uvm_plain):
         test_microvm.mark_killed()
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize(
     "vm_config_file",
     ["framework/vm_config_with_mmdsv1.json", "framework/vm_config_with_mmdsv2.json"],
 )
-def test_config_start_and_mmds_with_api(uvm_plain, vm_config_file):
+def test_config_start_and_mmds_with_api(uvm, vm_config_file):
     """
     Test MMDS behavior when the microvm is configured from file.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     _configure_vm_from_json(test_microvm, vm_config_file)
     _configure_network_interface(test_microvm)
 
@@ -464,19 +478,20 @@ def test_config_start_and_mmds_with_api(uvm_plain, vm_config_file):
     }
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize(
     "vm_config_file",
     ["framework/vm_config_with_mmdsv1.json", "framework/vm_config_with_mmdsv2.json"],
 )
 @pytest.mark.parametrize("metadata_file", [DIR / "metadata.json"])
-def test_with_config_and_metadata_no_api(uvm_plain, vm_config_file, metadata_file):
+def test_with_config_and_metadata_no_api(uvm, vm_config_file, metadata_file):
     """
     Test microvm start when config/mmds and API server thread is disabled.
 
     Ensures the metadata is stored successfully inside the MMDS and
     is available to reach from the guest's side.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     _configure_vm_from_json(test_microvm, vm_config_file)
     _add_metadata_file(test_microvm, metadata_file)
     _configure_network_interface(test_microvm)

--- a/tests/integration_tests/functional/test_concurrency.py
+++ b/tests/integration_tests/functional/test_concurrency.py
@@ -13,12 +13,14 @@ def test_run_concurrency(microvm_factory, guest_kernel, rootfs, pci_enabled):
     """
 
     def launch1():
-        microvm = microvm_factory.build(guest_kernel, rootfs, pci=pci_enabled)
+        microvm = microvm_factory.build_booted(
+            guest_kernel,
+            rootfs,
+            pci=pci_enabled,
+            vcpu_count=1,
+            mem_size_mib=128,
+        )
         microvm.time_api_requests = False  # is flaky because of parallelism
-        microvm.spawn()
-        microvm.basic_config(vcpu_count=1, mem_size_mib=128)
-        microvm.add_net_iface()
-        microvm.start()
 
     with ThreadPoolExecutor(max_workers=NO_OF_MICROVMS) as tpe:
         for _ in range(NO_OF_MICROVMS):

--- a/tests/integration_tests/functional/test_cpu_all.py
+++ b/tests/integration_tests/functional/test_cpu_all.py
@@ -11,6 +11,10 @@ are operating identically, except for the expected differences.
 
 import pytest
 
+from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
+
+pytestmark = [pin_cpu_template(ALL_CPU_TEMPLATES)]
+
 # Use the maximum number of vCPUs supported by Firecracker
 MAX_VCPUS = 32
 

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -5,6 +5,7 @@
 import pytest
 
 from framework.properties import global_props
+from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
 from framework.utils_cpuid import CPU_FEATURES_CMD, CpuModel
 
 pytestmark = pytest.mark.skipif(
@@ -31,6 +32,7 @@ G4_SVE_AND_PAC = set(
 )
 
 
+@pin_cpu_template(ALL_CPU_TEMPLATES)
 def test_guest_cpu_features(uvm_any):
     """Check the CPU features for a microvm with different CPU templates"""
 

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -211,10 +211,10 @@ INTEL_ICELAKE_HOST_ONLY_FEATS_6_18 = INTEL_ICELAKE_HOST_ONLY_FEATS_6_1 - {
 } | {"la57"}
 
 
-def test_host_vs_guest_cpu_features(uvm_plain_any):
+def test_host_vs_guest_cpu_features(uvm):
     """Check CPU features host vs guest"""
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config()
     vm.add_net_iface()

--- a/tests/integration_tests/functional/test_cpu_features_x86_64.py
+++ b/tests/integration_tests/functional/test_cpu_features_x86_64.py
@@ -18,9 +18,18 @@ import pytest
 
 import framework.utils_cpuid as cpuid_utils
 from framework import utils
+from framework.artifacts import (
+    GUEST_KERNEL_DEFAULT,
+    GUEST_KERNELS_6_1,
+    pin_guest_kernel,
+)
 from framework.defs import SUPPORTED_HOST_KERNELS
 from framework.properties import global_props
-from framework.utils_cpu_templates import get_cpu_template_name
+from framework.utils_cpu_templates import (
+    ALL_CPU_TEMPLATES,
+    get_cpu_template_name,
+    pin_cpu_template,
+)
 
 PLATFORM = platform.machine()
 UNSUPPORTED_HOST_KERNEL = (
@@ -105,11 +114,11 @@ def skip_test_based_on_artifacts(snapshot_artifacts_dir):
     "htt",
     [True, False],
 )
-def test_cpuid(uvm_plain_any, num_vcpus, htt):
+def test_cpuid(uvm, num_vcpus, htt):
     """
     Check the CPUID for a microvm with the specified config.
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(vcpu_count=num_vcpus, smt=htt)
     vm.add_net_iface()
@@ -121,11 +130,11 @@ def test_cpuid(uvm_plain_any, num_vcpus, htt):
     cpuid_utils.get_cpu_vendor() != cpuid_utils.CpuVendor.AMD,
     reason="L3 cache info is only present in 0x80000006 for AMD",
 )
-def test_extended_cache_features(uvm_plain_any):
+def test_extended_cache_features(uvm):
     """
     Check extended cache features (leaf 0x80000006).
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config()
     vm.add_net_iface()
@@ -133,7 +142,7 @@ def test_extended_cache_features(uvm_plain_any):
     _check_extended_cache_features(vm)
 
 
-def test_brand_string(uvm_plain_any):
+def test_brand_string(uvm):
     """
     Ensure good formatting for the guest brand string.
 
@@ -148,7 +157,7 @@ def test_brand_string(uvm_plain_any):
     * For other CPUs, the guest brand string should be:
         ""
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     test_microvm.basic_config(vcpu_count=1)
@@ -260,10 +269,11 @@ MSR_SUPPORTED_TEMPLATES = [
 ]
 
 
+@pin_cpu_template(ALL_CPU_TEMPLATES)
 @pytest.mark.timeout(900)
 @pytest.mark.no_block_pr
 def test_cpu_rdmsr(
-    msr_reader_bin, microvm_factory, cpu_template_any, guest_kernel, rootfs, results_dir
+    msr_reader_bin, microvm_factory, cpu_template, guest_kernel, rootfs, results_dir
 ):
     """
     Test MSRs that are available to the guest.
@@ -296,7 +306,7 @@ def test_cpu_rdmsr(
     - All supported guest kernels and rootfs
     - Microvm: 1vCPU with 1024 MB RAM
     """
-    cpu_template_name = get_cpu_template_name(cpu_template_any)
+    cpu_template_name = get_cpu_template_name(cpu_template)
     if cpu_template_name not in MSR_SUPPORTED_TEMPLATES:
         pytest.skip(f"This test does not support {cpu_template_name} template.")
 
@@ -305,7 +315,7 @@ def test_cpu_rdmsr(
     vm.spawn()
     vm.add_net_iface()
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=guest_mem_mib)
-    vm.set_cpu_template(cpu_template_any)
+    vm.set_cpu_template(cpu_template)
     vm.start()
     vm.ssh.scp_put(msr_reader_bin, "/tmp/msr_reader")
     _, stdout, stderr = vm.ssh.run("/tmp/msr_reader")
@@ -363,10 +373,11 @@ def dump_msr_state_to_file(msr_reader_bin, dump_fname, ssh_conn):
     UNSUPPORTED_HOST_KERNEL,
     reason=f"Supported kernels are {SUPPORTED_HOST_KERNELS}",
 )
+@pin_cpu_template(ALL_CPU_TEMPLATES)
 @pytest.mark.timeout(900)
 @pytest.mark.nonci
 def test_cpu_wrmsr_snapshot(
-    msr_reader_bin, microvm_factory, guest_kernel, rootfs, cpu_template_any
+    msr_reader_bin, microvm_factory, guest_kernel, rootfs, cpu_template
 ):
     """
     This is the first part of the test verifying
@@ -384,7 +395,7 @@ def test_cpu_wrmsr_snapshot(
     This part of the test is responsible for taking a snapshot and publishing
     its files along with the `before` MSR dump.
     """
-    cpu_template_name = get_cpu_template_name(cpu_template_any)
+    cpu_template_name = get_cpu_template_name(cpu_template)
     if cpu_template_name not in MSR_SUPPORTED_TEMPLATES:
         pytest.skip(f"This test does not support {cpu_template_name} template.")
 
@@ -400,7 +411,7 @@ def test_cpu_wrmsr_snapshot(
         track_dirty_pages=True,
         boot_args="msr.allow_writes=on",
     )
-    vm.set_cpu_template(cpu_template_any)
+    vm.set_cpu_template(cpu_template)
     vm.start()
 
     # Make MSR modifications
@@ -421,7 +432,7 @@ def test_cpu_wrmsr_snapshot(
     snapshot_artifacts_dir = (
         Path(shared_names["snapshot_artifacts_root_dir_wrmsr"])
         / guest_kernel.name
-        / get_cpu_template_name(cpu_template_any, with_type=True)
+        / get_cpu_template_name(cpu_template, with_type=True)
     )
     clean_and_mkdir(snapshot_artifacts_dir)
 
@@ -466,11 +477,10 @@ def check_msrs_are_equal(before_recs, after_recs):
     UNSUPPORTED_HOST_KERNEL,
     reason=f"Supported kernels are {SUPPORTED_HOST_KERNELS}",
 )
+@pin_cpu_template(ALL_CPU_TEMPLATES)
 @pytest.mark.timeout(900)
 @pytest.mark.nonci
-def test_cpu_wrmsr_restore(
-    msr_reader_bin, microvm_factory, cpu_template_any, guest_kernel
-):
+def test_cpu_wrmsr_restore(msr_reader_bin, microvm_factory, cpu_template, guest_kernel):
     """
     This is the second part of the test verifying
     that MSRs retain their values after restoring from a snapshot.
@@ -484,7 +494,7 @@ def test_cpu_wrmsr_restore(
     This part of the test is responsible for restoring from a snapshot and
     comparing two sets of MSR values.
     """
-    cpu_template_name = get_cpu_template_name(cpu_template_any)
+    cpu_template_name = get_cpu_template_name(cpu_template)
     if cpu_template_name not in MSR_SUPPORTED_TEMPLATES:
         pytest.skip(f"This test does not support {cpu_template_name} template.")
 
@@ -492,7 +502,7 @@ def test_cpu_wrmsr_restore(
     snapshot_artifacts_dir = (
         Path(shared_names["snapshot_artifacts_root_dir_wrmsr"])
         / guest_kernel.name
-        / get_cpu_template_name(cpu_template_any, with_type=True)
+        / get_cpu_template_name(cpu_template, with_type=True)
     )
 
     skip_test_based_on_artifacts(snapshot_artifacts_dir)
@@ -525,9 +535,10 @@ def dump_cpuid_to_file(dump_fname, ssh_conn):
     UNSUPPORTED_HOST_KERNEL,
     reason=f"Supported kernels are {SUPPORTED_HOST_KERNELS}",
 )
+@pin_cpu_template(ALL_CPU_TEMPLATES)
 @pytest.mark.timeout(900)
 @pytest.mark.nonci
-def test_cpu_cpuid_snapshot(microvm_factory, guest_kernel, rootfs, cpu_template_any):
+def test_cpu_cpuid_snapshot(microvm_factory, guest_kernel, rootfs, cpu_template):
     """
     This is the first part of the test verifying
     that CPUID remains the same after restoring from a snapshot.
@@ -539,7 +550,7 @@ def test_cpu_cpuid_snapshot(microvm_factory, guest_kernel, rootfs, cpu_template_
     This part of the test is responsible for taking a snapshot and publishing
     its files along with the `before` CPUID dump.
     """
-    cpu_template_name = get_cpu_template_name(cpu_template_any)
+    cpu_template_name = get_cpu_template_name(cpu_template)
     if cpu_template_name not in MSR_SUPPORTED_TEMPLATES:
         pytest.skip(f"This test does not support {cpu_template_name} template.")
 
@@ -556,14 +567,14 @@ def test_cpu_cpuid_snapshot(microvm_factory, guest_kernel, rootfs, cpu_template_
         mem_size_mib=1024,
         track_dirty_pages=True,
     )
-    vm.set_cpu_template(cpu_template_any)
+    vm.set_cpu_template(cpu_template)
     vm.start()
 
     # Dump CPUID to a file that will be published to S3 for the 2nd part of the test
     snapshot_artifacts_dir = (
         Path(shared_names["snapshot_artifacts_root_dir_cpuid"])
         / guest_kernel.name
-        / get_cpu_template_name(cpu_template_any, with_type=True)
+        / get_cpu_template_name(cpu_template, with_type=True)
     )
     clean_and_mkdir(snapshot_artifacts_dir)
 
@@ -595,9 +606,10 @@ def check_cpuid_is_equal(before_cpuid_fname, after_cpuid_fname):
     UNSUPPORTED_HOST_KERNEL,
     reason=f"Supported kernels are {SUPPORTED_HOST_KERNELS}",
 )
+@pin_cpu_template(ALL_CPU_TEMPLATES)
 @pytest.mark.timeout(900)
 @pytest.mark.nonci
-def test_cpu_cpuid_restore(microvm_factory, guest_kernel, cpu_template_any):
+def test_cpu_cpuid_restore(microvm_factory, guest_kernel, cpu_template):
     """
     This is the second part of the test verifying
     that CPUID remains the same after restoring from a snapshot.
@@ -609,7 +621,7 @@ def test_cpu_cpuid_restore(microvm_factory, guest_kernel, cpu_template_any):
     This part of the test is responsible for restoring from a snapshot and
     comparing two CPUIDs.
     """
-    cpu_template_name = get_cpu_template_name(cpu_template_any)
+    cpu_template_name = get_cpu_template_name(cpu_template)
     if cpu_template_name not in MSR_SUPPORTED_TEMPLATES:
         pytest.skip(f"This test does not support {cpu_template_name} template.")
 
@@ -617,7 +629,7 @@ def test_cpu_cpuid_restore(microvm_factory, guest_kernel, cpu_template_any):
     snapshot_artifacts_dir = (
         Path(shared_names["snapshot_artifacts_root_dir_cpuid"])
         / guest_kernel.name
-        / get_cpu_template_name(cpu_template_any, with_type=True)
+        / get_cpu_template_name(cpu_template, with_type=True)
     )
 
     skip_test_based_on_artifacts(snapshot_artifacts_dir)
@@ -637,7 +649,8 @@ def test_cpu_cpuid_restore(microvm_factory, guest_kernel, cpu_template_any):
     )
 
 
-def test_cpu_template(uvm_plain_any, cpu_template_any, microvm_factory):
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_cpu_template(uvm, cpu_template, microvm_factory):
     """
     Test masked and enabled cpu features against the expected template.
 
@@ -645,7 +658,7 @@ def test_cpu_template(uvm_plain_any, cpu_template_any, microvm_factory):
     guest and that expected enabled features are present for each of the
     supported CPU templates.
     """
-    cpu_template_name = get_cpu_template_name(cpu_template_any)
+    cpu_template_name = get_cpu_template_name(cpu_template)
     if cpu_template_name not in [
         "T2",
         "T2S",
@@ -657,14 +670,14 @@ def test_cpu_template(uvm_plain_any, cpu_template_any, microvm_factory):
     ]:
         pytest.skip(f"This test does not support {cpu_template_name} template.")
 
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
     # Set template as specified in the `cpu_template` parameter.
     test_microvm.basic_config(
         vcpu_count=1,
         mem_size_mib=256,
     )
-    test_microvm.set_cpu_template(cpu_template_any)
+    test_microvm.set_cpu_template(cpu_template)
     test_microvm.add_net_iface()
 
     if cpuid_utils.get_cpu_vendor() != cpuid_utils.CpuVendor.INTEL:
@@ -1256,13 +1269,12 @@ def check_enabled_features(test_microvm, cpu_template):
     or global_props.host_linux_version_tpl < (5, 17),
     reason="Intel AMX is only supported on Intel Sapphire Rapids and kernel v5.17+",
 )
-def test_intel_amx_reported_on_sapphire_rapids(
-    microvm_factory, guest_kernel_default, rootfs
-):
+@pin_guest_kernel(GUEST_KERNELS_6_1)
+def test_intel_amx_reported_on_sapphire_rapids(microvm_factory, guest_kernel, rootfs):
     """
     Verifies that Intel AMX is reported on guest (v5.17+)
     """
-    uvm = microvm_factory.build(guest_kernel_default, rootfs)
+    uvm = microvm_factory.build(guest_kernel, rootfs)
     uvm.spawn()
     uvm.basic_config()
     uvm.add_net_iface()
@@ -1285,12 +1297,13 @@ def test_intel_amx_reported_on_sapphire_rapids(
     )
 
 
-def test_waitpkg_inaccessibility(uvm_nano, waitpkg_bin):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_waitpkg_inaccessibility(uvm_configured, waitpkg_bin):
     """
     Verifies that attempting to use WAITPKG (UMONITOR / UMWAIT instructions)
     generates #UD.
     """
-    vm = uvm_nano
+    vm = uvm_configured
     vm.add_net_iface()
     vm.start()
 

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -11,6 +11,7 @@ import pytest
 from framework import utils
 from framework.defs import SUPPORTED_HOST_KERNELS
 from framework.properties import global_props
+from framework.utils_cpu_templates import CUSTOM_CPU_TEMPLATES, pin_cpu_template
 from framework.utils_cpuid import get_guest_cpuid
 from host_tools import cargo_build
 
@@ -268,7 +269,7 @@ def get_guest_msrs(microvm, msr_index_list):
     ),
 )
 def test_cpu_config_dump_vs_actual(
-    uvm_plain_any,
+    uvm,
     cpu_template_helper,
     tmp_path,
 ):
@@ -282,7 +283,7 @@ def test_cpu_config_dump_vs_actual(
     dump_cpu_config = build_cpu_config_dict(cpu_config_path)
 
     # Retrieve actual CPU config from guest
-    microvm = uvm_plain_any
+    microvm = uvm
     microvm.spawn()
     microvm.basic_config(vcpu_count=1)
     microvm.add_net_iface()
@@ -369,13 +370,14 @@ def test_guest_cpu_config_change(results_dir, cpu_template_helper):
     )
 
 
-def test_json_static_templates(cpu_template_helper, tmp_path, custom_cpu_template):
+@pin_cpu_template(CUSTOM_CPU_TEMPLATES)
+def test_json_static_templates(cpu_template_helper, tmp_path, cpu_template):
     """
     Verify that JSON static CPU templates are applied as intended.
     """
     custom_cpu_template_path = tmp_path / "template.json"
     Path(custom_cpu_template_path).write_text(
-        json.dumps(custom_cpu_template["template"]), encoding="utf-8"
+        json.dumps(cpu_template["template"]), encoding="utf-8"
     )
 
     # Verify the JSON static CPU template.

--- a/tests/integration_tests/functional/test_dirty_pages_in_full_snapshot.py
+++ b/tests/integration_tests/functional/test_dirty_pages_in_full_snapshot.py
@@ -2,14 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Test scenario for reseting dirty pages after making a full snapshot."""
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 
-def test_dirty_pages_after_full_snapshot(uvm_plain):
+
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_dirty_pages_after_full_snapshot(uvm):
     """
     Test if dirty pages are erased after making a full snapshot of a VM
     """
 
     vm_mem_size = 128
-    uvm = uvm_plain
     uvm.spawn()
     uvm.basic_config(mem_size_mib=vm_mem_size, track_dirty_pages=True)
     uvm.add_net_iface()

--- a/tests/integration_tests/functional/test_drive_vhost_user.py
+++ b/tests/integration_tests/functional/test_drive_vhost_user.py
@@ -293,7 +293,7 @@ def test_partuuid_update(uvm_vhost_user_plain_any, rootfs):
     vhost_user_block_metrics.validate(vm)
 
 
-def test_config_change(uvm_plain_any):
+def test_config_change(uvm):
     """
     Verify handling of block device resize.
     We expect that the guest will start reporting the updated size
@@ -304,7 +304,7 @@ def test_config_change(uvm_plain_any):
     new_sizes = [20, 10, 30]  # MB
     mkfs_mount_cmd = "mkfs.ext4 /dev/vdb && mkdir -p /tmp/tmp && mount /dev/vdb /tmp/tmp && umount /tmp/tmp"
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn(log_level="Info")
     vm.basic_config()
     vm.add_net_iface()

--- a/tests/integration_tests/functional/test_drive_virtio.py
+++ b/tests/integration_tests/functional/test_drive_virtio.py
@@ -8,6 +8,7 @@ import pytest
 
 import host_tools.drive as drive_tools
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel, pin_rootfs_mode
 from framework.utils_drive import partuuid_and_disk_path
 
 MB = 1024 * 1024
@@ -23,11 +24,11 @@ def partuuid_and_disk_path_tmpfs(rootfs, tmp_path):
     disk_path.unlink()
 
 
-def test_rescan_file(uvm_plain_any, io_engine):
+def test_rescan_file(uvm, io_engine):
     """
     Verify that rescan works with a file-backed virtio device.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Set up the microVM with 1 vCPUs, 256 MiB of RAM and a root file system
@@ -64,14 +65,14 @@ def test_rescan_file(uvm_plain_any, io_engine):
     _check_block_size(test_microvm.ssh, "/dev/vdb", fs.size())
 
 
-def test_device_ordering(uvm_plain_any, io_engine):
+def test_device_ordering(uvm, io_engine):
     """
     Verify device ordering.
 
     The root device should correspond to /dev/vda in the guest and
     the order of the other devices should match their configuration order.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Add first scratch block device.
@@ -111,11 +112,11 @@ def test_device_ordering(uvm_plain_any, io_engine):
     _check_block_size(ssh_connection, "/dev/vdc", fs2.size())
 
 
-def test_rescan_dev(uvm_plain_any, io_engine):
+def test_rescan_dev(uvm, io_engine):
     """
     Verify that rescan works with a device-backed virtio device.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Set up the microVM with 1 vCPUs, 256 MiB of RAM and a root file system
@@ -151,11 +152,11 @@ def test_rescan_dev(uvm_plain_any, io_engine):
             utils.check_output(["losetup", "--detach", loopback_device])
 
 
-def test_non_partuuid_boot(uvm_plain_any, io_engine):
+def test_non_partuuid_boot(uvm, io_engine):
     """
     Test the output reported by blockdev when booting from /dev/vda.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Sets up the microVM with 1 vCPUs, 256 MiB of RAM and a root file system
@@ -179,7 +180,7 @@ def test_non_partuuid_boot(uvm_plain_any, io_engine):
     _check_drives(test_microvm, assert_dict, assert_dict.keys())
 
 
-def test_partuuid_boot(uvm_plain_any, partuuid_and_disk_path_tmpfs, io_engine):
+def test_partuuid_boot(uvm, partuuid_and_disk_path_tmpfs, io_engine):
     """
     Test the output reported by blockdev when booting with PARTUUID.
     """
@@ -187,7 +188,7 @@ def test_partuuid_boot(uvm_plain_any, partuuid_and_disk_path_tmpfs, io_engine):
     partuuid = partuuid_and_disk_path_tmpfs[0]
     disk_path = partuuid_and_disk_path_tmpfs[1]
 
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Sets up the microVM with 1 vCPUs, 256 MiB of RAM and without root file system
@@ -213,11 +214,11 @@ def test_partuuid_boot(uvm_plain_any, partuuid_and_disk_path_tmpfs, io_engine):
     _check_drives(test_microvm, assert_dict, assert_dict.keys())
 
 
-def test_partuuid_update(uvm_plain_any, io_engine):
+def test_partuuid_update(uvm, io_engine):
     """
     Test successful switching from PARTUUID boot to /dev/vda boot.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Set up the microVM with 1 vCPUs, 256 MiB of RAM
@@ -251,11 +252,11 @@ def test_partuuid_update(uvm_plain_any, io_engine):
     _check_drives(test_microvm, assert_dict, assert_dict.keys())
 
 
-def test_patch_drive(uvm_plain_any, io_engine):
+def test_patch_drive(uvm, io_engine):
     """
     Test replacing the backing filesystem after guest boot works.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Set up the microVM with 1 vCPUs, 256 MiB of RAM and a root file system
@@ -289,11 +290,11 @@ def test_patch_drive(uvm_plain_any, io_engine):
     assert lines[1].strip() == size_bytes_str
 
 
-def test_no_flush(uvm_plain_any, io_engine):
+def test_no_flush(uvm, io_engine):
     """
     Verify default block ignores flush.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
 
     test_microvm.basic_config(vcpu_count=1, add_root_device=False)
@@ -323,11 +324,13 @@ def test_no_flush(uvm_plain_any, io_engine):
     assert fc_metrics["block"]["flush_count"] == 0
 
 
-def test_flush(uvm_plain_rw, io_engine):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+@pin_rootfs_mode("rw")
+def test_flush(uvm, io_engine):
     """
     Verify block with flush actually flushes.
     """
-    test_microvm = uvm_plain_rw
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config(vcpu_count=1, add_root_device=False)
     test_microvm.add_net_iface()

--- a/tests/integration_tests/functional/test_error_code.py
+++ b/tests/integration_tests/functional/test_error_code.py
@@ -6,13 +6,16 @@ import platform
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
+
 
 @pytest.mark.skipif(
     platform.machine() != "aarch64",
     reason="The error code returned on aarch64 will not be returned on x86 "
     "under the same conditions.",
 )
-def test_enosys_error_code(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_enosys_error_code(uvm):
     """
     Test that ENOSYS error is caught and firecracker exits gracefully.
     """
@@ -20,7 +23,7 @@ def test_enosys_error_code(uvm_plain):
     # maps a file into memory and then tries to load the content from an
     # offset in the file bigger than its length into a register asm volatile
     # ("ldr %0, [%1], 4" : "=r" (ret), "+r" (buf));
-    vm = uvm_plain
+    vm = uvm
     vm.spawn()
     vm.memory_monitor = None
     vm.basic_config(

--- a/tests/integration_tests/functional/test_feat_parity.py
+++ b/tests/integration_tests/functional/test_feat_parity.py
@@ -28,11 +28,11 @@ def inst_set_cpu_template_fxt(request):
 
 
 @pytest.fixture(name="vm")
-def vm_fxt(uvm_plain_any, inst_set_cpu_template):
+def vm_fxt(uvm, inst_set_cpu_template):
     """
     Create a VM, using the normal CPU templates
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(vcpu_count=1, mem_size_mib=1024, cpu_template=inst_set_cpu_template)
     vm.add_net_iface()

--- a/tests/integration_tests/functional/test_fuzzing.py
+++ b/tests/integration_tests/functional/test_fuzzing.py
@@ -3,6 +3,7 @@
 """A test that ensures the fuzzing feature warning appears at startup."""
 
 import host_tools.cargo_build
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.microvm import MicroVMFactory
 
 
@@ -25,13 +26,14 @@ def test_fuzzing_warning(guest_kernel, rootfs):
     ), f"Version string missing +fuzzing suffix:\n{uvm.log_data}"
 
 
-def test_no_fuzzing_warning(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_no_fuzzing_warning(uvm):
     """Checks that a standard Firecracker binary does not log the fuzzing warning"""
 
-    uvm_plain.spawn()
-    uvm_plain.basic_config()
-    uvm_plain.start()
+    uvm.spawn()
+    uvm.basic_config()
+    uvm.start()
 
     assert (
-        "built with the `fuzzing` feature enabled" not in uvm_plain.log_data
-    ), f"Fuzzing warning unexpectedly found in logs:\n{uvm_plain.log_data}"
+        "built with the `fuzzing` feature enabled" not in uvm.log_data
+    ), f"Fuzzing warning unexpectedly found in logs:\n{uvm.log_data}"

--- a/tests/integration_tests/functional/test_gdb.py
+++ b/tests/integration_tests/functional/test_gdb.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 import host_tools.cargo_build
+from framework.artifacts import GUEST_KERNEL_DEFAULT_DEBUG, pin_guest_kernel
 from framework.microvm import MicroVMFactory
 
 
@@ -19,13 +20,14 @@ from framework.microvm import MicroVMFactory
     platform.machine() != "x86_64",
     reason="GDB requires a vmlinux but we ship a uImage for ARM in our CI",
 )
-def test_gdb_connects(guest_kernel_default_debug, rootfs):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT_DEBUG)
+def test_gdb_connects(guest_kernel, rootfs):
     """Checks that GDB works in a FC VM"""
 
     bin_dir = host_tools.cargo_build.build_gdb()
 
     vmfcty = MicroVMFactory(bin_dir)
-    uvm = vmfcty.build(guest_kernel_default_debug, rootfs)
+    uvm = vmfcty.build(guest_kernel, rootfs)
     uvm.spawn(validate_api=False)
     uvm.add_net_iface()
     uvm.basic_config()
@@ -54,7 +56,7 @@ def test_gdb_connects(guest_kernel_default_debug, rootfs):
             echo 'waiting for {chroot_gdb_socket}';
             sleep 1;
         done;
-        gdb {guest_kernel_default_debug} -batch -x {gdb_script}
+        gdb {guest_kernel} -batch -x {gdb_script}
         """,
         shell=True,
         stdout=subprocess.PIPE,

--- a/tests/integration_tests/functional/test_hotplug.py
+++ b/tests/integration_tests/functional/test_hotplug.py
@@ -8,6 +8,8 @@ import pytest
 
 import host_tools.drive as drive_tools
 import host_tools.network as net_tools
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel, pin_pci
+from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
 
 VIRTIO_PCI_VENDOR_ID = 0x1AF4
 VIRTIO_PCI_DEVICE_ID_NET = 0x1041
@@ -15,14 +17,17 @@ VIRTIO_PCI_DEVICE_ID_BLOCK = 0x1042
 VIRTIO_PCI_DEVICE_ID_PMEM = 0x105B
 
 
-def test_hotplug_block(uvm_any_with_pci):
+@pin_pci(True)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
+def test_hotplug_block(uvm_any):
     """
     Test hotplugging a block device after VM start.
     Test that the device appears in lspci and is usable.
     Test that invalid hotplug request are rejected.
     Test hot-unplugging the device.
     """
-    vm = uvm_any_with_pci
+    vm = uvm_any
 
     # Snapshot lspci output before hotplug
     _, lspci_before, _ = vm.ssh.check_output("lspci -n")
@@ -120,14 +125,17 @@ def test_hotplug_block(uvm_any_with_pci):
         vm.api.drive.delete("block0")
 
 
-def test_hotplug_pmem(uvm_any_with_pci):
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
+@pin_pci(True)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_hotplug_pmem(uvm_any):
     """
     Test hotplugging a pmem device after VM start.
     Test that the device appears in lspci and is usable.
     Test that invalid hotplug request are rejected.
     Test hot-unplugging the device.
     """
-    vm = uvm_any_with_pci
+    vm = uvm_any
 
     # Snapshot lspci output before hotplug
     _, lspci_before, _ = vm.ssh.check_output("lspci -n")
@@ -221,14 +229,17 @@ def test_hotplug_pmem(uvm_any_with_pci):
         vm.api.pmem.delete("pmem0")
 
 
-def test_hotplug_net(uvm_any_with_pci):
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
+@pin_pci(True)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_hotplug_net(uvm_any):
     """
     Test hotplugging a net device after VM start.
     Test that the device appears in lspci and is usable.
     Test that invalid hotplug request are rejected.
     Test hot-unplugging the device.
     """
-    vm = uvm_any_with_pci
+    vm = uvm_any
 
     # Snapshot lspci output before hotplug
     _, lspci_before, _ = vm.ssh.check_output("lspci -n")
@@ -328,11 +339,12 @@ def test_hotplug_net(uvm_any_with_pci):
         vm.api.network.delete(iface1.dev_name)
 
 
-def test_unplug_root_pmem(microvm_factory, guest_kernel_acpi, rootfs):
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
+def test_unplug_root_pmem(microvm_factory, guest_kernel, rootfs):
     """
     Unplugging the root pmem device must be rejected.
     """
-    vm = microvm_factory.build(guest_kernel_acpi, rootfs, pci=True)
+    vm = microvm_factory.build(guest_kernel, rootfs, pci=True)
     vm.memory_monitor = None
     vm.monitors = []
     vm.spawn()
@@ -345,12 +357,14 @@ def test_unplug_root_pmem(microvm_factory, guest_kernel_acpi, rootfs):
         vm.api.pmem.delete("pmem_root")
 
 
-def test_hotplug_no_pci(uvm_any_without_pci):
+@pin_pci(False)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_hotplug_no_pci(uvm_any):
     """
     Hotplugging and unplugging any device type must be rejected when PCI is not
     enabled.
     """
-    vm = uvm_any_without_pci
+    vm = uvm_any
 
     host_file = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "disk"), size=4)
 
@@ -389,11 +403,14 @@ def test_hotplug_no_pci(uvm_any_without_pci):
         vm.api.network.delete("eth0")
 
 
-def test_hotplug_preserved_after_snapshot(uvm_any_with_pci, microvm_factory):
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
+@pin_pci(True)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_hotplug_preserved_after_snapshot(uvm_any, microvm_factory):
     """
     Test that a hotplugged device survives a full snapshot/restore cycle.
     """
-    vm = uvm_any_with_pci
+    vm = uvm_any
 
     # Snapshot lspci output before hotplug
     _, lspci_before, _ = vm.ssh.check_output("lspci -n")
@@ -438,12 +455,15 @@ def test_hotplug_preserved_after_snapshot(uvm_any_with_pci, microvm_factory):
     assert stdout.strip() == "hotplug_test"
 
 
-def test_hotplug_max_devices(uvm_any_with_pci):
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
+@pin_pci(True)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_hotplug_max_devices(uvm_any):
     """
     Test that hotplugging more devices than available PCI slots is rejected.
     """
     pci_max_slots = 32
-    vm = uvm_any_with_pci
+    vm = uvm_any
 
     # Count how many PCI slots are already in use
     _, lspci_initial, _ = vm.ssh.check_output("lspci -n")

--- a/tests/integration_tests/functional/test_kernel_cmdline.py
+++ b/tests/integration_tests/functional/test_kernel_cmdline.py
@@ -3,16 +3,18 @@
 
 """Test kernel commandline behavior."""
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.microvm import Serial
 
 
-def test_init_params(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_init_params(uvm):
     """Correct propagation of boot args to the kernel's command line.
 
     Test that init's parameters (the ones present after "--") do not get
     altered or misplaced.
     """
-    vm = uvm_plain
+    vm = uvm
     vm.help.enable_console()
     vm.spawn(serial_out_path=None)
     vm.memory_monitor = None

--- a/tests/integration_tests/functional/test_kvm_ptp.py
+++ b/tests/integration_tests/functional/test_kvm_ptp.py
@@ -5,11 +5,14 @@
 
 import pytest
 
+from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
 
-def test_kvm_ptp(uvm_any_booted):
+
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_kvm_ptp(uvm_booted):
     """Test kvm_ptp is usable"""
 
-    vm = uvm_any_booted
+    vm = uvm_booted
     if vm.guest_kernel_version[:2] < (6, 1):
         pytest.skip("Only supported in kernel 6.1 and after")
 

--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -12,6 +12,8 @@ from time import strptime
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
+
 # Array of supported log levels of the current logging system.
 # Do not change order of values inside this array as logic depends on this.
 LOG_LEVELS = ["ERROR", "WARN", "INFO", "DEBUG"]
@@ -71,11 +73,12 @@ def check_log_message_format(log_str, instance_id, level, show_level, show_origi
         assert tag_level_no <= configured_level_no
 
 
-def test_api_requests_logs(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_api_requests_logs(uvm):
     """
     Test that API requests are logged.
     """
-    microvm = uvm_plain
+    microvm = uvm
     microvm.spawn(log_file=None)
     microvm.basic_config()
 
@@ -147,6 +150,7 @@ def test_api_requests_logs(uvm_plain):
     )
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize(
     "log_level,show_level,show_origin",
     [
@@ -158,9 +162,9 @@ def test_api_requests_logs(uvm_plain):
         ("Warning", False, False),
     ],
 )
-def test_log_config(uvm_plain, log_level, show_level, show_origin):
+def test_log_config(uvm, log_level, show_level, show_origin):
     """Exercises different scenarios for testing the logging config."""
-    microvm = uvm_plain
+    microvm = uvm
     microvm.spawn(
         log_level=log_level, log_show_level=show_level, log_show_origin=show_origin
     )

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -6,6 +6,8 @@ import platform
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
+
 
 def max_devices(uvm):
     """
@@ -29,11 +31,11 @@ def max_devices(uvm):
             raise ValueError("Unknown platform")
 
 
-def test_attach_maximum_devices(uvm_plain_any):
+def test_attach_maximum_devices(uvm):
     """
     Test attaching maximum number of devices to the microVM.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.memory_monitor = None
     test_microvm.spawn()
 
@@ -53,11 +55,12 @@ def test_attach_maximum_devices(uvm_plain_any):
         test_microvm.ssh_iface(i).check_output("sync")
 
 
-def test_attach_too_many_devices(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_attach_too_many_devices(uvm):
     """
     Test attaching to a microVM more devices than available IRQs.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.memory_monitor = None
     test_microvm.spawn()
 

--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -5,14 +5,16 @@
 import os
 
 import host_tools.drive as drive_tools
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from host_tools.fcmetrics import FcDeviceMetrics, validate_fc_metrics
 
 
-def test_flush_metrics(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_flush_metrics(uvm):
     """
     Check the `FlushMetrics` vmm action.
     """
-    microvm = uvm_plain
+    microvm = uvm
     microvm.spawn()
     microvm.basic_config()
     microvm.start()
@@ -21,12 +23,13 @@ def test_flush_metrics(uvm_plain):
     validate_fc_metrics(metrics)
 
 
-def test_net_metrics(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_net_metrics(uvm):
     """
     Validate that NetDeviceMetrics doesn't have a breaking change
     and "net" is aggregate of all "net_*" in the json object.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Set up a basic microVM.
@@ -54,12 +57,13 @@ def test_net_metrics(uvm_plain):
         assert exit_code == 0
 
 
-def test_block_metrics(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_block_metrics(uvm):
     """
     Validate that BlockDeviceMetrics doesn't have a breaking change
     and "block" is aggregate of all "block_*" in the json object.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Add first scratch block device.

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.utils import (
     configure_mmds,
     generate_mmds_get_request,
@@ -29,13 +30,14 @@ DEFAULT_IPV4 = "169.254.169.254"
 MMDS_VERSIONS = ["V2", "V1"]
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
 @pytest.mark.parametrize("imds_compat", [True, False])
-def test_mmds_token(uvm_plain, version, imds_compat):
+def test_mmds_token(uvm, version, imds_compat):
     """
     Test MMDS with no token / invalid token / valid token.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     test_microvm.add_net_iface()
@@ -92,12 +94,13 @@ def test_mmds_token(uvm_plain, version, imds_compat):
     assert metrics["mmds"]["rx_no_token"] == 0
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
-def test_custom_ipv4(uvm_plain, version):
+def test_custom_ipv4(uvm, version):
     """
     Test the API for MMDS custom ipv4 support.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     data_store = {
@@ -179,16 +182,17 @@ def test_custom_ipv4(uvm_plain, version):
     run_guest_cmd(ssh_connection, cmd, data_store["latest"]["meta-data"], use_json=True)
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
 @pytest.mark.parametrize("imds_compat", [None, False, True])
 @pytest.mark.parametrize("app_json", [False, True])
-def test_mmds_response(uvm_plain, version, imds_compat, app_json):
+def test_mmds_response(uvm, version, imds_compat, app_json):
     """
     Test MMDS responses to various datastore requests.
     """
     expected_json = not imds_compat and app_json
 
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     test_microvm.add_net_iface()
@@ -280,12 +284,13 @@ def test_mmds_response(uvm_plain, version, imds_compat, app_json):
         )
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
-def test_larger_than_mss_payloads(uvm_plain, version):
+def test_larger_than_mss_payloads(uvm, version):
     """
     Test MMDS content for payloads larger than MSS.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Attach network device.
@@ -348,12 +353,13 @@ def test_larger_than_mss_payloads(uvm_plain, version):
     run_guest_cmd(ssh_connection, cmd, lower_than_mss)
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
-def test_mmds_dummy(uvm_plain, version):
+def test_mmds_dummy(uvm, version):
     """
     Test the API and guest facing features of the microVM MetaData Service.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Attach network device.
@@ -393,12 +399,13 @@ def test_mmds_dummy(uvm_plain, version):
     assert response.json() == dummy_json
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
-def test_guest_mmds_hang(uvm_plain, version):
+def test_guest_mmds_hang(uvm, version):
     """
     Test the MMDS json endpoint when Content-Length larger than actual length.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Attach network device.
@@ -446,12 +453,13 @@ def test_guest_mmds_hang(uvm_plain, version):
         assert "Invalid request" in stdout
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
-def test_mmds_limit_scenario(uvm_plain, version):
+def test_mmds_limit_scenario(uvm, version):
     """
     Test the MMDS json endpoint when data store size reaches the limit.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     # Set a large enough limit for the API so that requests actually reach the
     # MMDS server.
     test_microvm.jailer.extra_args.update(
@@ -514,16 +522,17 @@ def test_mmds_limit_scenario(uvm_plain, version):
     assert len(str(response.json()).replace(" ", "")) == 158
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
 @pytest.mark.parametrize("imds_compat", [None, False, True])
-def test_mmds_snapshot(uvm_nano, microvm_factory, version, imds_compat):
+def test_mmds_snapshot(uvm_configured, microvm_factory, version, imds_compat):
     """
     Test MMDS behavior by restoring a snapshot on current FC versions.
 
     Ensures that the version is persisted or initialised with the default if
     the firecracker version does not support it.
     """
-    basevm = uvm_nano
+    basevm = uvm_configured
     basevm.add_net_iface()
     ipv4_address = "169.254.169.250"
 
@@ -613,11 +622,12 @@ def test_mmds_snapshot(uvm_nano, microvm_factory, version, imds_compat):
     run_guest_cmd(ssh_connection, cmd, expected_response, use_json=not imds_compat)
 
 
-def test_mmds_v2_negative(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_mmds_v2_negative(uvm):
     """
     Test invalid MMDS GET/PUT requests when using V2.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
 
     # Attach network device.
@@ -717,11 +727,12 @@ def test_mmds_v2_negative(uvm_plain):
     )
 
 
-def test_deprecated_mmds_config(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_deprecated_mmds_config(uvm):
     """
     Test deprecated Mmds configs.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
     # Attach network device.
@@ -785,14 +796,15 @@ def _configure_with_aws_credentials(microvm, version, imds_compat):
     return ssh_connection
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
 @pytest.mark.parametrize("imds_compat", [None, False, True])
 @pytest.mark.parametrize("sdk", ["py", "go"])
-def test_aws_credential_provider(uvm_plain, version, imds_compat, sdk):
+def test_aws_credential_provider(uvm, version, imds_compat, sdk):
     """
     Test AWS SDK's credential provider works on MMDS
     """
-    ssh_connection = _configure_with_aws_credentials(uvm_plain, version, imds_compat)
+    ssh_connection = _configure_with_aws_credentials(uvm, version, imds_compat)
 
     match sdk:
         case "py":
@@ -821,11 +833,10 @@ EOF
     assert stdout == "AAA,BBB,CCC\n", stderr
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("version", MMDS_VERSIONS)
 @pytest.mark.parametrize("imds_compat", [None, False, True])
-def test_go_sdk_credential_provider_with_custom_endpoint(
-    uvm_plain, version, imds_compat
-):
+def test_go_sdk_credential_provider_with_custom_endpoint(uvm, version, imds_compat):
     """
     Test AWS SDK's credential provider with custom endpoint.
 
@@ -835,7 +846,7 @@ def test_go_sdk_credential_provider_with_custom_endpoint(
     (i.e. wrapped with doublequotes) with "Content-Type: application/json" but
     AWS SDK for Go expects only the inner JSON object.
     """
-    ssh_connection = _configure_with_aws_credentials(uvm_plain, version, imds_compat)
+    ssh_connection = _configure_with_aws_credentials(uvm, version, imds_compat)
 
     cmd = "/usr/local/bin/go_sdk_cred_provider_with_custom_endpoint"
     ret, stdout, stderr = ssh_connection.run(cmd)

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -10,6 +10,7 @@ from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 import host_tools.network as net_tools
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 
 # The iperf version to run this tests with
 IPERF_BINARY = "iperf3"
@@ -18,11 +19,11 @@ IPERF_BINARY = "iperf3"
 VIRTIO_NET_F_MTU_BIT = 3
 
 
-def test_high_ingress_traffic(uvm_plain_any):
+def test_high_ingress_traffic(uvm):
     """
     Run iperf rx with high UDP traffic.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
 
@@ -57,11 +58,12 @@ def test_high_ingress_traffic(uvm_plain_any):
     test_microvm.ssh.check_output("echo success\n")
 
 
-def test_multi_queue_unsupported(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_multi_queue_unsupported(uvm):
     """
     Creates multi-queue tap device and tries to add it to firecracker.
     """
-    microvm = uvm_plain
+    microvm = uvm
     microvm.spawn()
     microvm.basic_config()
 
@@ -86,12 +88,6 @@ def test_multi_queue_unsupported(uvm_plain):
 
     # clean TAP device
     utils.run_cmd(f"{microvm.netns.cmd_prefix()} ip link del name {tapname}")
-
-
-@pytest.fixture
-def uvm_any(microvm_factory, uvm_ctor, guest_kernel, rootfs, pci_enabled):
-    """Return booted and restored uvm with no CPU templates"""
-    return uvm_ctor(microvm_factory, guest_kernel, rootfs, None, pci_enabled)
 
 
 def test_tap_offload(uvm_any):
@@ -133,14 +129,14 @@ def test_tap_offload(uvm_any):
             assert ret.stdout == message, f"{ret.stdout=} {ret.stderr=}"
 
 
-def test_tap_mtu_advertised_to_guest(uvm_plain_any):
+def test_tap_mtu_advertised_to_guest(uvm):
     """
     Verify that VIRTIO_NET_F_MTU correctly advertises the TAP MTU to the guest.
 
     Configures multiple TAP interfaces with distinct MTU values and checks that
     each guest network interface reports the MTU matching its host TAP.
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config()
 

--- a/tests/integration_tests/functional/test_net_config_space.py
+++ b/tests/integration_tests/functional/test_net_config_space.py
@@ -13,12 +13,12 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 PAYLOAD_DATA_SIZE = 20
 
 
-def test_net_change_mac_address(uvm_plain_any, change_net_config_space_bin):
+def test_net_change_mac_address(uvm, change_net_config_space_bin):
     """
     Test changing the MAC address of the network device.
     """
 
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.help.enable_console()
     test_microvm.spawn()
     test_microvm.basic_config(boot_args="ipv6.disable=1")

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -8,6 +8,8 @@ from subprocess import TimeoutExpired
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
+
 
 def verify_net_emulation_paused(metrics):
     """Verify net emulation is paused based on provided metrics."""
@@ -28,11 +30,12 @@ def verify_net_emulation_paused(metrics):
     print(net_metrics)
 
 
-def test_pause_resume(uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_pause_resume(uvm_configured):
     """
     Test scenario: boot/pause/resume.
     """
-    microvm = uvm_nano
+    microvm = uvm_configured
     microvm.add_net_iface()
 
     # Pausing the microVM before being started is not allowed.
@@ -78,11 +81,12 @@ def test_pause_resume(uvm_nano):
     microvm.kill()
 
 
-def test_describe_instance(uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_describe_instance(uvm_configured):
     """
     Test scenario: DescribeInstance different states.
     """
-    microvm = uvm_nano
+    microvm = uvm_configured
 
     # Check MicroVM state is "Not started"
     response = microvm.api.describe.get()
@@ -112,11 +116,12 @@ def test_describe_instance(uvm_nano):
     microvm.kill()
 
 
-def test_pause_resume_preboot(uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_pause_resume_preboot(uvm_configured):
     """
     Test pause/resume operations are not allowed pre-boot.
     """
-    basevm = uvm_nano
+    basevm = uvm_configured
 
     expected_err = "not supported before starting the microVM"
 
@@ -132,12 +137,12 @@ def test_pause_resume_preboot(uvm_nano):
 @pytest.mark.skipif(
     platform.machine() != "x86_64", reason="Only x86_64 supports pvclocks."
 )
-def test_kvmclock_ctrl(uvm_plain_any):
+def test_kvmclock_ctrl(uvm):
     """
     Test that pausing vCPUs does not trigger a soft lock-up
     """
 
-    microvm = uvm_plain_any
+    microvm = uvm
     microvm.help.enable_console()
     microvm.spawn()
 

--- a/tests/integration_tests/functional/test_pci.py
+++ b/tests/integration_tests/functional/test_pci.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the PCI devices"""
 
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel, pin_pci
+from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
+
 # Virtio PCI common config register offsets
 # https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-1420003
 COMMON_CFG_QUEUE_SELECT = 0x16  # u16
@@ -15,12 +18,15 @@ COMMON_CFG_QUEUE_USED_LO = 0x30  # u32
 COMMON_CFG_QUEUE_USED_HI = 0x34  # u32
 
 
-def test_pci_root_present(uvm_any_with_pci):
+@pin_pci(True)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
+def test_pci_root_present(uvm_any):
     """
     Test that a guest with PCI enabled has a PCI root device.
     """
 
-    vm = uvm_any_with_pci
+    vm = uvm_any
     devices = vm.ssh.run("lspci").stdout.strip().split("\n")
     print(devices)
     assert devices[0].startswith(
@@ -28,12 +34,14 @@ def test_pci_root_present(uvm_any_with_pci):
     ), "PCI root not found in guest"
 
 
-def test_pci_disabled(uvm_any_without_pci):
+@pin_pci(False)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_pci_disabled(uvm_any):
     """
     Test that a guest with PCI disabled does not have a PCI root device but still works.
     """
 
-    vm = uvm_any_without_pci
+    vm = uvm_any
     _, stdout, _ = vm.ssh.run("lspci")
     assert (
         "00:00.0 Host bridge: Intel Corporation Device" not in stdout
@@ -89,7 +97,10 @@ def _devmem_write(vm, tool_path, addr, width, value):
     return int(stdout, 16)
 
 
-def test_queue_config_immutable(uvm_any_with_pci, devmem_bin):
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
+@pin_pci(True)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_queue_config_immutable(uvm_any, devmem_bin):
     """
     Test that queue configuration fields cannot be modified by the guest
     after the device has been activated (DRIVER_OK is set).
@@ -103,7 +114,7 @@ def test_queue_config_immutable(uvm_any_with_pci, devmem_bin):
     MMIO queue fields are write-only (reads return 0), so integration-level
     readback verification via /dev/mem is not possible.
     """
-    vm = uvm_any_with_pci
+    vm = uvm_any
 
     rmt_path = "/tmp/devmem"
     vm.ssh.scp_put(devmem_bin, rmt_path)

--- a/tests/integration_tests/functional/test_pmem.py
+++ b/tests/integration_tests/functional/test_pmem.py
@@ -10,6 +10,7 @@ import pytest
 
 import host_tools.drive as drive_tools
 from framework import utils
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel, pin_rootfs_mode
 
 ALIGNMENT = 2 << 20
 
@@ -49,11 +50,11 @@ def check_pmem_exist(vm, index, root, read_only, size, extension):
     assert False
 
 
-def test_pmem_zero_size_backing_file(uvm_plain_any):
+def test_pmem_zero_size_backing_file(uvm):
     """
     Test that a pmem device with a zero-sized backing file fails at boot time.
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(add_root_device=True)
 
@@ -68,13 +69,13 @@ def test_pmem_zero_size_backing_file(uvm_plain_any):
         vm.start()
 
 
-def test_pmem_add(uvm_plain_any, microvm_factory):
+def test_pmem_add(uvm, microvm_factory):
     """
     Test addition of pmem devices to the VM and
     writes persistance
     """
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(add_root_device=True)
     vm.add_net_iface()
@@ -119,20 +120,21 @@ def test_pmem_add(uvm_plain_any, microvm_factory):
     assert stdout.strip() == test_string
 
 
-def test_pmem_add_as_root_rw(uvm_plain_any, rootfs_rw, microvm_factory):
+@pin_rootfs_mode("rw")
+def test_pmem_add_as_root_rw(uvm, rootfs, microvm_factory):
     """
     Test addition of a single root pmem device in read-write mode
     """
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.memory_monitor = None
     vm.monitors = []
     vm.spawn()
     vm.basic_config(add_root_device=False)
     vm.add_net_iface()
 
-    rootfs_size = os.path.getsize(rootfs_rw)
-    vm.add_pmem("pmem", rootfs_rw, True, False)
+    rootfs_size = os.path.getsize(rootfs)
+    vm.add_pmem("pmem", rootfs, True, False)
     vm.start()
 
     check_pmem_exist(vm, 0, True, False, align(rootfs_size), "ext4")
@@ -142,12 +144,12 @@ def test_pmem_add_as_root_rw(uvm_plain_any, rootfs_rw, microvm_factory):
     check_pmem_exist(restored_vm, 0, True, False, align(rootfs_size), "ext4")
 
 
-def test_pmem_add_as_root_ro(uvm_plain_any, rootfs, microvm_factory):
+def test_pmem_add_as_root_ro(uvm, rootfs, microvm_factory):
     """
     Test addition of a single root pmem device in read-only mode
     """
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.memory_monitor = None
     vm.monitors = []
     vm.spawn()
@@ -180,10 +182,12 @@ def outside_rssanon(vm) -> int:
     return int(stdout.split()[1])
 
 
+@pin_rootfs_mode("rw")
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
 def test_pmem_dax_memory_saving(
     microvm_factory,
-    guest_kernel_acpi,
-    rootfs_rw,
+    guest_kernel,
+    rootfs,
 ):
     """
     Test that booting from pmem with DAX enabled indeed saves memory in the
@@ -191,9 +195,7 @@ def test_pmem_dax_memory_saving(
     """
 
     # Boot from a block device
-    vm = microvm_factory.build(
-        guest_kernel_acpi, rootfs_rw, pci=True, monitor_memory=False
-    )
+    vm = microvm_factory.build(guest_kernel, rootfs, pci=True, monitor_memory=False)
     vm.spawn()
     vm.basic_config()
     vm.add_net_iface()
@@ -203,7 +205,7 @@ def test_pmem_dax_memory_saving(
 
     # Boot from pmem with DAX enabled for root device
     vm_pmem = microvm_factory.build(
-        guest_kernel_acpi, rootfs_rw, pci=True, monitor_memory=False
+        guest_kernel, rootfs, pci=True, monitor_memory=False
     )
     vm_pmem.spawn()
     vm_pmem.basic_config(
@@ -211,7 +213,7 @@ def test_pmem_dax_memory_saving(
         boot_args="reboot=k panic=1 nomodule swiotlb=noforce console=ttyS0 rootflags=dax",
     )
     vm_pmem.add_net_iface()
-    vm_pmem.add_pmem("pmem", rootfs_rw, True, False)
+    vm_pmem.add_pmem("pmem", rootfs, True, False)
     vm_pmem.start()
     pmem_cache_usage = inside_buff_cache(vm_pmem)
     pmem_rss_usage = outside_rssanon(vm_pmem)

--- a/tests/integration_tests/functional/test_pvtime.py
+++ b/tests/integration_tests/functional/test_pvtime.py
@@ -5,17 +5,19 @@
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.properties import global_props
 
 
 @pytest.mark.skipif(
     global_props.cpu_architecture != "aarch64", reason="Only run in aarch64"
 )
-def test_guest_has_pvtime_enabled(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_guest_has_pvtime_enabled(uvm):
     """
     Check that the guest kernel has enabled PV steal time.
     """
-    vm = uvm_plain
+    vm = uvm
     vm.spawn()
     vm.basic_config()
     vm.add_net_iface()

--- a/tests/integration_tests/functional/test_rng.py
+++ b/tests/integration_tests/functional/test_rng.py
@@ -4,14 +4,14 @@
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.utils import check_entropy
 from host_tools.network import SSHConnection
 
 
-def uvm_with_rng_booted(uvm_plain_any, microvm_factory, rate_limiter):
+def uvm_with_rng_booted(uvm, microvm_factory, rate_limiter):
     """Return a booted microvm with virtio-rng configured"""
     # pylint: disable=unused-argument
-    uvm = uvm_plain_any
     uvm.spawn(log_level="INFO")
     uvm.basic_config(vcpu_count=2, mem_size_mib=256)
     uvm.add_net_iface()
@@ -22,9 +22,9 @@ def uvm_with_rng_booted(uvm_plain_any, microvm_factory, rate_limiter):
     return uvm
 
 
-def uvm_with_rng_restored(uvm_plain_any, microvm_factory, rate_limiter):
+def uvm_with_rng_restored(uvm, microvm_factory, rate_limiter):
     """Return a restored uvm with virtio-rng configured"""
-    uvm = uvm_with_rng_booted(uvm_plain_any, microvm_factory, rate_limiter)
+    uvm = uvm_with_rng_booted(uvm, microvm_factory, rate_limiter)
     snapshot = uvm.snapshot_full()
     uvm.kill()
     uvm2 = microvm_factory.build_from_snapshot(snapshot)
@@ -45,9 +45,9 @@ def rate_limiter(request):
 
 
 @pytest.fixture
-def uvm_any(microvm_factory, uvm_ctor, uvm_plain_any, rate_limiter):
+def uvm_any(microvm_factory, uvm_ctor, uvm, rate_limiter):
     """Return booted and restored uvms"""
-    return uvm_ctor(uvm_plain_any, microvm_factory, rate_limiter)
+    return uvm_ctor(uvm, microvm_factory, rate_limiter)
 
 
 def list_rng_available(ssh_connection: SSHConnection) -> list[str]:
@@ -74,13 +74,14 @@ def assert_virtio_rng_is_current_hwrng_device(ssh_connection: SSHConnection):
     ), "virtio_rng device should be the current used by hwrng"
 
 
-def test_rng_not_present(uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_rng_not_present(uvm_configured):
     """
     Test a guest microVM *without* an entropy device and ensure that
     we cannot get data from /dev/hwrng
     """
 
-    vm = uvm_nano
+    vm = uvm_configured
     vm.add_net_iface()
     vm.start()
 

--- a/tests/integration_tests/functional/test_rtc.py
+++ b/tests/integration_tests/functional/test_rtc.py
@@ -15,11 +15,11 @@ DMESG_LOG_REGEX = r"rtc-pl031\s+(\d+).rtc: setting system clock to"
 @pytest.mark.skipif(
     platform.machine() != "aarch64", reason="RTC exists only on aarch64."
 )
-def test_rtc(uvm_plain_any):
+def test_rtc(uvm):
     """
     Test RTC functionality on aarch64.
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.memory_monitor = None
     vm.basic_config()

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -13,16 +13,19 @@ from pathlib import Path
 import pytest
 
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.microvm import Serial
+from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
 
 PLATFORM = platform.machine()
 
 
-def test_serial_after_snapshot(uvm_plain, microvm_factory):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_serial_after_snapshot(uvm, microvm_factory):
     """
     Serial I/O after restoring from a snapshot.
     """
-    microvm = uvm_plain
+    microvm = uvm
     microvm.help.enable_console()
     microvm.spawn(serial_out_path=None)
     microvm.basic_config(
@@ -60,12 +63,13 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
 
 # The VM can become unresponsive in the test due to the interrupt storm .
 @pytest.mark.flaky(reruns=2)
-def test_serial_active_tx_snapshot(uvm_plain, microvm_factory):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_serial_active_tx_snapshot(uvm, microvm_factory):
     """
     Snapshot a guest that is actively transmitting on the serial console and
     test that the transmission continues after snapshot restore.
     """
-    microvm = uvm_plain
+    microvm = uvm
     microvm.help.enable_console()
     microvm.spawn(serial_out_path=None)
     microvm.basic_config(
@@ -109,11 +113,11 @@ def test_serial_active_tx_snapshot(uvm_plain, microvm_factory):
     assert "/root" in res
 
 
-def test_serial_console_login(uvm_plain_any):
+def test_serial_console_login(uvm):
     """
     Test serial console login.
     """
-    microvm = uvm_plain_any
+    microvm = uvm
     microvm.help.enable_console()
     microvm.spawn(serial_out_path=None)
 
@@ -154,11 +158,11 @@ def send_bytes(tty, bytes_count, timeout=60):
             break
 
 
-def test_serial_dos(uvm_plain_any):
+def test_serial_dos(uvm):
     """
     Test serial console behavior under DoS.
     """
-    microvm = uvm_plain_any
+    microvm = uvm
     microvm.help.enable_console()
     microvm.spawn()
 
@@ -186,11 +190,11 @@ def test_serial_dos(uvm_plain_any):
     )
 
 
-def test_serial_block(uvm_plain_any):
+def test_serial_block(uvm):
     """
     Test that writing to stdout never blocks the vCPU thread.
     """
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.help.enable_console()
     test_microvm.spawn(serial_out_path=None)
     # Set up the microVM with 1 vCPU so we make sure the vCPU thread
@@ -231,7 +235,8 @@ def test_serial_block(uvm_plain_any):
 REGISTER_FAILED_WARNING = "Failed to register serial input fd: event_manager: failed to manage epoll file descriptor: Operation not permitted (os error 1)"
 
 
-def test_no_serial_fd_error_when_daemonized(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_no_serial_fd_error_when_daemonized(uvm):
     """
     Tests that when running firecracker daemonized, the serial device
     does not try to register stdin to epoll (which would fail due to stdin no
@@ -240,7 +245,7 @@ def test_no_serial_fd_error_when_daemonized(uvm_plain):
     Regression test for #4037.
     """
 
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.add_net_iface()
     test_microvm.basic_config(
@@ -252,6 +257,7 @@ def test_no_serial_fd_error_when_daemonized(uvm_plain):
     assert REGISTER_FAILED_WARNING not in test_microvm.log_data
 
 
+@pin_cpu_template(ALL_CPU_TEMPLATES)
 def test_serial_file_output(uvm_any):
     """Test that redirecting serial console output to a file works for booted and restored VMs"""
     uvm_any.ssh.check_output("echo 'hello' > /dev/ttyS0")
@@ -259,9 +265,10 @@ def test_serial_file_output(uvm_any):
     assert b"hello" in uvm_any.serial_out_path.read_bytes()
 
 
-def test_serial_rate_limiting(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_serial_rate_limiting(uvm):
     """Test that serial output is rate-limited when a rate limiter is configured."""
-    microvm = uvm_plain
+    microvm = uvm
     microvm.spawn()
     microvm.add_net_iface()
     microvm.basic_config(vcpu_count=1, mem_size_mib=256)

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -9,11 +9,11 @@ from packaging import version
 from framework import utils
 
 
-def test_reboot(uvm_plain_any):
+def test_reboot(uvm):
     """
     Test reboot from guest.
     """
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
 
     # We don't need to monitor the memory for this test because we are

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -10,6 +10,8 @@ from time import sleep
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel, pin_rootfs_mode
+
 signum_str = {
     SIGBUS: "sigbus",
     SIGSEGV: "sigsegv",
@@ -22,14 +24,15 @@ signum_str = {
 }
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize(
     "signum", [SIGBUS, SIGSEGV, SIGXFSZ, SIGXCPU, SIGPIPE, SIGHUP, SIGILL, SIGSYS]
 )
-def test_generic_signal_handler(uvm_plain, signum):
+def test_generic_signal_handler(uvm, signum):
     """
     Test signal handling for all handled signals.
     """
-    microvm = uvm_plain
+    microvm = uvm
     microvm.spawn()
 
     # We don't need to monitor the memory for this test.
@@ -63,11 +66,13 @@ def test_generic_signal_handler(uvm_plain, signum):
         assert metric_line["signals"][signum_str[signum]] == 1
 
 
-def test_sigxfsz_handler(uvm_plain_rw):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+@pin_rootfs_mode("rw")
+def test_sigxfsz_handler(uvm):
     """
     Test intercepting and handling SIGXFSZ.
     """
-    microvm = uvm_plain_rw
+    microvm = uvm
     microvm.spawn()
 
     # We don't need to monitor the memory for this test.
@@ -100,11 +105,12 @@ def test_sigxfsz_handler(uvm_plain_rw):
     assert metric_line["signals"]["sigxfsz"] == 1
 
 
-def test_handled_signals(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_handled_signals(uvm):
     """
     Test that handled signals don't kill the microVM.
     """
-    microvm = uvm_plain
+    microvm = uvm
     microvm.spawn()
 
     # We don't need to monitor the memory for this test.

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -19,8 +19,10 @@ import host_tools.cargo_build as host
 import host_tools.drive as drive_tools
 import host_tools.network as net_tools
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel, pin_rootfs_mode
 from framework.properties import global_props
 from framework.utils import check_filesystem, check_output
+from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
 from framework.utils_vsock import (
     ECHO_SERVER_PORT,
     VSOCK_UDS_PATH,
@@ -56,15 +58,16 @@ def _get_guest_drive_size(ssh_connection, guest_dev_name="/dev/vdb"):
     return lines[1].strip()
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("resume_at_restore", [True, False])
-def test_resume(uvm_nano, microvm_factory, resume_at_restore):
+def test_resume(uvm_configured, microvm_factory, resume_at_restore):
     """Tests snapshot is resumable at or after restoration.
 
     Check that a restored microVM is resumable by either
     a. PUT /snapshot/load with `resume_vm=False`, then calling PATCH /vm resume=True
     b. PUT /snapshot/load with `resume_vm=True`
     """
-    vm = uvm_nano
+    vm = uvm_configured
     vm.add_net_iface()
     vm.start()
     snapshot = vm.snapshot_full()
@@ -78,7 +81,8 @@ def test_resume(uvm_nano, microvm_factory, resume_at_restore):
     restored_vm.ssh.check_output("true")
 
 
-def test_snapshot_current_version(uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_snapshot_current_version(uvm_configured):
     """Tests taking a snapshot at the version specified in Cargo.toml
 
     Check that it is possible to take a snapshot at the version of the upcoming
@@ -87,13 +91,13 @@ def test_snapshot_current_version(uvm_nano):
     only be able to test once the x.y binary has been uploaded to S3, at which
     point it is too late, see also the 1.3 release).
     """
-    vm = uvm_nano
+    vm = uvm_configured
     vm.start()
 
     snapshot = vm.snapshot_full()
 
     # Fetch Firecracker binary for the latest version
-    fc_binary = uvm_nano.fc_binary_path
+    fc_binary = uvm_configured.fc_binary_path
     # Get supported snapshot version from Firecracker binary
     snapshot_version = (
         check_output(f"{fc_binary} --snapshot-version").stdout.strip().splitlines()[0]
@@ -111,15 +115,16 @@ def test_snapshot_current_version(uvm_nano):
 # - Rootfs: Ubuntu 18.04
 # - Microvm: 2vCPU with 512 MB RAM
 # TODO: Multiple microvm sizes must be tested in the async pipeline.
+@pin_cpu_template(ALL_CPU_TEMPLATES)
 @pytest.mark.parametrize("use_snapshot_editor", [False, True])
 def test_cycled_snapshot_restore(
     bin_vsock_path,
     tmp_path,
-    uvm_plain_any,
+    uvm,
     microvm_factory,
     snapshot_type,
     use_snapshot_editor,
-    cpu_template_any,
+    cpu_template,
 ):
     """
     Run a cycle of VM restoration and VM snapshot creation where new VM is
@@ -131,14 +136,14 @@ def test_cycled_snapshot_restore(
 
     logger = logging.getLogger("snapshot_sequence")
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(
         vcpu_count=2,
         mem_size_mib=512,
         track_dirty_pages=snapshot_type.needs_dirty_page_tracking,
     )
-    vm.set_cpu_template(cpu_template_any)
+    vm.set_cpu_template(cpu_template)
     vm.add_net_iface()
     vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path=VSOCK_UDS_PATH)
     vm.start()
@@ -179,14 +184,15 @@ def test_cycled_snapshot_restore(
         check_filesystem(microvm.ssh, "squashfs", "/dev/vda")
 
 
-def test_patch_drive_snapshot(uvm_nano, microvm_factory):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_patch_drive_snapshot(uvm_configured, microvm_factory):
     """
     Test that a patched drive is correctly used by guests loaded from snapshot.
     """
     logger = logging.getLogger("snapshot_sequence")
 
     # Use a predefined vm instance.
-    basevm = uvm_nano
+    basevm = uvm_configured
     basevm.add_net_iface()
 
     # Add a scratch 128MB RW non-root block device.
@@ -217,11 +223,12 @@ def test_patch_drive_snapshot(uvm_nano, microvm_factory):
     assert guest_drive_size == str(scratch_disk2.size())
 
 
-def test_load_snapshot_failure_handling(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_load_snapshot_failure_handling(uvm):
     """
     Test error case of loading empty snapshot files.
     """
-    vm = uvm_plain
+    vm = uvm
     vm.spawn(log_level="Info")
 
     # Create two empty files for snapshot state and snapshot memory
@@ -245,7 +252,7 @@ def test_load_snapshot_failure_handling(uvm_plain):
     vm.mark_killed()
 
 
-def test_cmp_full_and_first_diff_mem(uvm_plain_any):
+def test_cmp_full_and_first_diff_mem(uvm):
     """
     Compare memory of 2 consecutive full and diff snapshots.
 
@@ -256,7 +263,7 @@ def test_cmp_full_and_first_diff_mem(uvm_plain_any):
     """
     logger = logging.getLogger("snapshot_sequence")
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(
         vcpu_count=2,
@@ -278,11 +285,12 @@ def test_cmp_full_and_first_diff_mem(uvm_plain_any):
     assert filecmp.cmp(full_snapshot.mem, diff_snapshot.mem, shallow=False)
 
 
-def test_negative_postload_api(uvm_plain, microvm_factory):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_negative_postload_api(uvm, microvm_factory):
     """
     Test APIs fail after loading from snapshot.
     """
-    basevm = uvm_plain
+    basevm = uvm
     basevm.spawn()
     basevm.basic_config(track_dirty_pages=True)
     basevm.add_net_iface()
@@ -303,11 +311,13 @@ def test_negative_postload_api(uvm_plain, microvm_factory):
         microvm.basic_config()
 
 
-def test_negative_snapshot_permissions(uvm_plain_rw, microvm_factory):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+@pin_rootfs_mode("rw")
+def test_negative_snapshot_permissions(uvm, microvm_factory):
     """
     Test missing permission error scenarios.
     """
-    basevm = uvm_plain_rw
+    basevm = uvm
     basevm.spawn()
     basevm.basic_config()
     basevm.add_net_iface()
@@ -374,11 +384,12 @@ def test_negative_snapshot_permissions(uvm_plain_rw, microvm_factory):
     microvm.mark_killed()
 
 
-def test_negative_snapshot_create(uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_negative_snapshot_create(uvm_configured):
     """
     Test create snapshot before pause.
     """
-    vm = uvm_nano
+    vm = uvm_configured
     vm.start()
 
     with pytest.raises(RuntimeError, match="save/restore unavailable while running"):
@@ -387,7 +398,8 @@ def test_negative_snapshot_create(uvm_nano):
         )
 
 
-def test_create_large_diff_snapshot(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_create_large_diff_snapshot(uvm):
     """
     Create large diff snapshot seccomp regression test.
 
@@ -396,7 +408,7 @@ def test_create_large_diff_snapshot(uvm_plain):
     filter allows it.
     @issue: https://github.com/firecracker-microvm/firecracker/discussions/2811
     """
-    vm = uvm_plain
+    vm = uvm
     vm.spawn()
     vm.basic_config(mem_size_mib=16 * 1024, track_dirty_pages=True)
     vm.start()
@@ -412,12 +424,12 @@ def test_create_large_diff_snapshot(uvm_plain):
 
 
 @pytest.mark.parametrize("mem_size", [256, 4096])
-def test_diff_snapshot_overlay(uvm_plain_any, microvm_factory, mem_size):
+def test_diff_snapshot_overlay(uvm, microvm_factory, mem_size):
     """
     Tests that if we take a diff snapshot and direct firecracker to write it on
     top of an existing snapshot file, it will successfully merge them.
     """
-    basevm = uvm_plain_any
+    basevm = uvm
     basevm.spawn()
     basevm.basic_config(track_dirty_pages=True, mem_size_mib=mem_size)
     basevm.add_net_iface()
@@ -449,7 +461,7 @@ def test_diff_snapshot_overlay(uvm_plain_any, microvm_factory, mem_size):
     # Check that the restored VM works
 
 
-def test_snapshot_overwrite_self(uvm_plain_any, microvm_factory):
+def test_snapshot_overwrite_self(uvm, microvm_factory):
     """Tests that if we try to take a snapshot that would overwrite the
     very file from which the current VM is stored, nothing happens.
 
@@ -457,7 +469,7 @@ def test_snapshot_overwrite_self(uvm_plain_any, microvm_factory):
     of mmap does not specify what should happen if the file is changed after being
     mmap'd (https://man7.org/linux/man-pages/man2/mmap.2.html). It seems that
     these changes can propagate to the mmap'd memory region."""
-    base_vm = uvm_plain_any
+    base_vm = uvm
     base_vm.spawn()
     base_vm.basic_config()
     base_vm.add_net_iface()
@@ -481,11 +493,12 @@ def test_snapshot_overwrite_self(uvm_plain_any, microvm_factory):
     # restored, with a new snapshot of this vm, does not break the VM
 
 
-def test_vmgenid(uvm_plain, microvm_factory, snapshot_type):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_vmgenid(uvm, microvm_factory, snapshot_type):
     """
     Test VMGenID device upon snapshot resume
     """
-    base_vm = uvm_plain
+    base_vm = uvm
     base_vm.spawn()
     base_vm.basic_config(track_dirty_pages=True)
     base_vm.add_net_iface()
@@ -511,7 +524,8 @@ def test_vmgenid(uvm_plain, microvm_factory, snapshot_type):
     ),
     reason="This test requires aarch64 and either kernel 6.4+ or Amazon Linux",
 )
-def test_physical_counter_reset_aarch64(uvm_nano):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_physical_counter_reset_aarch64(uvm_configured):
     """
     Test that the CNTPCT_EL0 register is reset on VM boot.
     We assume the smallest VM will not consume more than
@@ -522,7 +536,7 @@ def test_physical_counter_reset_aarch64(uvm_nano):
     will be a copy of host value. The host value in its turn will be huge because
     it will include host OS boot + CI prep + other CI tests ...
     """
-    vm = uvm_nano
+    vm = uvm_configured
     vm.add_net_iface()
     vm.start()
 
@@ -561,12 +575,13 @@ def test_physical_counter_reset_aarch64(uvm_nano):
         raise RuntimeError("Did not find CNTPCT_EL0 register in snapshot")
 
 
-def test_snapshot_rename_interface(uvm_nano, microvm_factory):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_snapshot_rename_interface(uvm_configured, microvm_factory):
     """
     Test that we can restore a snapshot and point its interface to a
     different host interface.
     """
-    vm = uvm_nano
+    vm = uvm_configured
     base_iface = vm.add_net_iface()
     vm.start()
     snapshot = vm.snapshot_full()
@@ -587,8 +602,9 @@ def test_snapshot_rename_interface(uvm_nano, microvm_factory):
     )
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 def test_snapshot_rename_vsock(
-    uvm_nano,
+    uvm_configured,
     microvm_factory,
 ):
     """
@@ -596,7 +612,7 @@ def test_snapshot_rename_vsock(
     different unix socket.
     """
 
-    vm = uvm_nano
+    vm = uvm_configured
     vm.api.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path="/v.sock1")
     vm.add_net_iface()
     vm.start()
@@ -635,7 +651,7 @@ def read_guest_clocksource(vm):
 @pytest.mark.parametrize("clocksource", CLOCK_SOURCES)
 @pytest.mark.parametrize("clock_realtime", [False, True])
 def test_clocksource_snapshot_restore(
-    uvm_plain_any, microvm_factory, clocksource, clock_realtime
+    uvm, microvm_factory, clocksource, clock_realtime
 ):
     """Measure CLOCK_MONOTONIC before snapshot and after restore to determine
     whether the clocksource jumps forward or resumes from where it left off."""
@@ -650,7 +666,7 @@ def test_clocksource_snapshot_restore(
         f" clocksource={clocksource}"
     )
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(vcpu_count=2, mem_size_mib=256, boot_args=boot_args)
     vm.add_net_iface()

--- a/tests/integration_tests/functional/test_snapshot_editor.py
+++ b/tests/integration_tests/functional/test_snapshot_editor.py
@@ -8,6 +8,7 @@ import pytest
 
 import host_tools.cargo_build as host
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 
 PLATFORM = platform.machine()
 MIDR_EL1 = hex(0x603000000013C000)
@@ -17,14 +18,15 @@ MIDR_EL1 = hex(0x603000000013C000)
     PLATFORM != "aarch64",
     reason="This is aarch64 specific test.",
 )
-def test_remove_regs(uvm_nano, microvm_factory):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_remove_regs(uvm_configured, microvm_factory):
     """
     This test verifies `remove-regs` method of `snapshot-editor`.
     Here we create snapshot and try to romeve MIDR_EL1 register
     from it. Then we try to restore uVM from the snapshot.
     """
 
-    vm = uvm_nano
+    vm = uvm_configured
     vm.add_net_iface()
     vm.start()
 

--- a/tests/integration_tests/functional/test_snapshot_not_losing_dirty_pages.py
+++ b/tests/integration_tests/functional/test_snapshot_not_losing_dirty_pages.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import psutil
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
+
 
 @pytest.fixture
 def mount_tmpfs_small(worker_id):
@@ -24,14 +26,15 @@ def mount_tmpfs_small(worker_id):
         mnt_path.rmdir()
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 def test_diff_snapshot_works_after_error(
-    microvm_factory, guest_kernel_default, rootfs, mount_tmpfs_small
+    microvm_factory, guest_kernel, rootfs, mount_tmpfs_small
 ):
     """
     Test that if a partial snapshot errors it will work after and not lose data
     """
     uvm = microvm_factory.build(
-        guest_kernel_default,
+        guest_kernel,
         rootfs,
         jailer_kwargs={"chroot_base": mount_tmpfs_small},
     )

--- a/tests/integration_tests/functional/test_snapshot_phase1.py
+++ b/tests/integration_tests/functional/test_snapshot_phase1.py
@@ -15,7 +15,13 @@ from framework.utils import (
     generate_mmds_get_request,
     generate_mmds_session_token,
 )
-from framework.utils_cpu_templates import get_cpu_template_name
+from framework.utils_cpu_templates import (
+    ALL_CPU_TEMPLATES,
+    get_cpu_template_name,
+    pin_cpu_template,
+)
+
+pytestmark = pin_cpu_template(ALL_CPU_TEMPLATES)
 
 # Default IPv4 address to route MMDS requests.
 IPV4_ADDRESS = "169.254.169.254"
@@ -24,7 +30,7 @@ NET_IFACE_FOR_MMDS = "eth3"
 
 @pytest.mark.nonci
 def test_snapshot_phase1(
-    microvm_factory, guest_kernel, rootfs, cpu_template_any, results_dir
+    microvm_factory, guest_kernel, rootfs, cpu_template, results_dir
 ):
     """Create a snapshot and save it to disk"""
 
@@ -36,13 +42,12 @@ def test_snapshot_phase1(
         vcpu_count=2,
         mem_size_mib=512,
     )
-    vm.set_cpu_template(cpu_template_any)
+    vm.set_cpu_template(cpu_template)
 
-    guest_kernel_version = re.search("vmlinux-(.*)", vm.kernel_file.name)
-    cpu_template_name = get_cpu_template_name(cpu_template_any, with_type=True)
+    kernel_version = re.search("vmlinux-(.*)", vm.kernel_file.name)
+    cpu_template_name = get_cpu_template_name(cpu_template, with_type=True)
     snapshot_artifacts_dir = (
-        results_dir
-        / f"{guest_kernel_version.group(1)}_{cpu_template_name}_guest_snapshot"
+        results_dir / f"{kernel_version.group(1)}_{cpu_template_name}_guest_snapshot"
     )
 
     # Add 4 network devices

--- a/tests/integration_tests/functional/test_sysgenid.py
+++ b/tests/integration_tests/functional/test_sysgenid.py
@@ -9,9 +9,9 @@ SYSGENID_OUT_PATH = "/tmp/sysgenid.out"
 
 
 @pytest.fixture(scope="function")
-def vm_with_sysgenid(uvm_plain_any, bin_sysgenid_path):
+def vm_with_sysgenid(uvm, bin_sysgenid_path):
     """Create a VM with SysGenID support and the `sysgenid` test binary under `/tmp/sysgenid`"""
-    basevm = uvm_plain_any
+    basevm = uvm
     basevm.spawn()
 
     basevm.basic_config()

--- a/tests/integration_tests/functional/test_topology.py
+++ b/tests/integration_tests/functional/test_topology.py
@@ -194,7 +194,7 @@ def _check_cache_topology_arm(test_microvm, no_cpus, kernel_version_tpl):
 
 @pytest.mark.parametrize("num_vcpus", [1, 2, 16])
 @pytest.mark.parametrize("htt", [True, False], ids=["HTT_ON", "HTT_OFF"])
-def test_cpu_topology(uvm_plain_any, num_vcpus, htt):
+def test_cpu_topology(uvm, num_vcpus, htt):
     """
     Check the CPU topology for a microvm with the specified config.
     """
@@ -206,7 +206,7 @@ def test_cpu_topology(uvm_plain_any, num_vcpus, htt):
     if version.parse(get_kernel_version()) >= version.parse("6.14"):
         pytest.skip("Starting on 6.14 KVM exposes a different CPU cache hierarchy")
 
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(vcpu_count=num_vcpus, smt=htt)
     vm.add_net_iface()
@@ -219,13 +219,13 @@ def test_cpu_topology(uvm_plain_any, num_vcpus, htt):
 
 @pytest.mark.parametrize("num_vcpus", [1, 2, 16])
 @pytest.mark.parametrize("htt", [True, False], ids=["HTT_ON", "HTT_OFF"])
-def test_cache_topology(uvm_plain_any, num_vcpus, htt):
+def test_cache_topology(uvm, num_vcpus, htt):
     """
     Check the cache topology for a microvm with the specified config.
     """
     if htt and PLATFORM == "aarch64":
         pytest.skip("SMT is configurable only on x86.")
-    vm = uvm_plain_any
+    vm = uvm
     vm.spawn()
     vm.basic_config(vcpu_count=num_vcpus, smt=htt)
     vm.add_net_iface()

--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -8,14 +8,15 @@ import re
 import pytest
 import requests
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.utils import Timeout, check_output
 
 
 @pytest.fixture(scope="function", name="snapshot")
-def snapshot_fxt(microvm_factory, guest_kernel_default, rootfs):
+def snapshot_fxt(microvm_factory, guest_kernel, rootfs):
     """Create a snapshot of a microVM."""
 
-    basevm = microvm_factory.build(guest_kernel_default, rootfs)
+    basevm = microvm_factory.build(guest_kernel, rootfs)
     basevm.spawn()
     basevm.basic_config(vcpu_count=2, mem_size_mib=256)
     basevm.add_net_iface()
@@ -34,11 +35,12 @@ def snapshot_fxt(microvm_factory, guest_kernel_default, rootfs):
     yield snapshot
 
 
-def test_bad_socket_path(uvm_plain, snapshot):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_bad_socket_path(uvm, snapshot):
     """
     Test error scenario when socket path does not exist.
     """
-    vm = uvm_plain
+    vm = uvm
     vm.spawn()
     jailed_vmstate = vm.create_jailed_resource(snapshot.vmstate)
 
@@ -56,11 +58,12 @@ def test_bad_socket_path(uvm_plain, snapshot):
     vm.mark_killed()
 
 
-def test_unbinded_socket(uvm_plain, snapshot):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_unbinded_socket(uvm, snapshot):
     """
     Test error scenario when PF handler has not yet called bind on socket.
     """
-    vm = uvm_plain
+    vm = uvm
     vm.spawn()
 
     jailed_vmstate = vm.create_jailed_resource(snapshot.vmstate)
@@ -82,11 +85,12 @@ def test_unbinded_socket(uvm_plain, snapshot):
     vm.mark_killed()
 
 
-def test_valid_handler(uvm_plain, snapshot):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_valid_handler(uvm, snapshot):
     """
     Test valid uffd handler scenario.
     """
-    vm = uvm_plain
+    vm = uvm
     vm.memory_monitor = None
     vm.spawn()
     vm.restore_from_snapshot(snapshot, resume=True, uffd_handler_name="on_demand")
@@ -104,7 +108,8 @@ def test_valid_handler(uvm_plain, snapshot):
     vm.ssh.check_output("true")
 
 
-def test_malicious_handler(uvm_plain, snapshot):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_malicious_handler(uvm, snapshot):
     """
     Test malicious uffd handler scenario.
 
@@ -115,7 +120,7 @@ def test_malicious_handler(uvm_plain, snapshot):
     faults, so that it becomes obvious that something went wrong.
     """
 
-    vm = uvm_plain
+    vm = uvm
     vm.memory_monitor = None
     vm.spawn()
 

--- a/tests/integration_tests/functional/test_vmclock.py
+++ b/tests/integration_tests/functional/test_vmclock.py
@@ -4,11 +4,15 @@
 
 import pytest
 
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel
+
+pytestmark = pin_guest_kernel(ACPI_GUEST_KERNELS)
+
 
 @pytest.fixture(scope="function")
-def vm_with_vmclock(uvm_plain_acpi, bin_vmclock_path):
+def vm_with_vmclock(uvm, bin_vmclock_path):
     """Create a VM with VMclock support and the `vmclock` test binary under `/tmp/vmclock`"""
-    basevm = uvm_plain_acpi
+    basevm = uvm
     basevm.spawn()
 
     basevm.basic_config()

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -21,6 +21,7 @@ from socket import timeout as SocketTimeout
 
 import pytest
 
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel
 from framework.utils_vsock import (
     ECHO_SERVER_PORT,
     VSOCK_UDS_PATH,
@@ -41,12 +42,12 @@ TEST_WORKER_COUNT = 10
 
 
 @pytest.fixture
-def vsock_uvm(uvm_plain_acpi, request):
+def vsock_uvm(uvm, request):
     """Fixture to initialize a microVM with vsock device."""
     vcpus = request.param if hasattr(request, "param") else 1
 
     return boot_vsock_vm(
-        uvm_plain_acpi,
+        uvm,
         vcpu_count=vcpus,
         mem_size_mib=1024,
         log_level="Info",
@@ -56,9 +57,9 @@ def vsock_uvm(uvm_plain_acpi, request):
 
 
 @pytest.fixture
-def vsock_uvm_any(uvm_plain_any):
+def vsock_uvm_any(uvm):
     """Fixture to initialize a kernel-parametrized microVM with vsock device."""
-    return boot_vsock_vm(uvm_plain_any)
+    return boot_vsock_vm(uvm)
 
 
 def test_vsock(vsock_uvm_any, bin_vsock_path, test_fc_session_root_path):
@@ -141,6 +142,7 @@ def test_vsock_epipe(vsock_uvm_any, bin_vsock_path, test_fc_session_root_path):
     validate_fc_metrics(metrics)
 
 
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
 @pytest.mark.parametrize("vsock_uvm", [1, 2], indirect=True, ids=["1vcpu", "2vcpu"])
 def test_vsock_transport_reset_h2g(
     vsock_uvm, microvm_factory, bin_vsock_path, test_fc_session_root_path
@@ -224,6 +226,7 @@ def test_vsock_transport_reset_h2g(
     validate_fc_metrics(metrics)
 
 
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
 @pytest.mark.parametrize("vsock_uvm", [1, 2], indirect=True, ids=["1vcpu", "2vcpu"])
 def test_vsock_transport_reset_g2h(vsock_uvm, microvm_factory):
     """
@@ -290,7 +293,7 @@ def test_vsock_transport_reset_g2h(vsock_uvm, microvm_factory):
 
 
 def test_vsock_after_override(
-    uvm_plain_any, microvm_factory, bin_vsock_path, test_fc_session_root_path
+    uvm, microvm_factory, bin_vsock_path, test_fc_session_root_path
 ):
     """
     Test that the Vsock device works correctly after overriding the host UDS
@@ -299,7 +302,7 @@ def test_vsock_after_override(
     initial_uds_path = VSOCK_UDS_PATH
     overridden_uds_path = f"{VSOCK_UDS_PATH}2"
 
-    test_vm = uvm_plain_any
+    test_vm = uvm
     test_vm.spawn()
     test_vm.basic_config(vcpu_count=2, mem_size_mib=256)
     test_vm.add_net_iface()
@@ -342,14 +345,14 @@ def test_vsock_after_override(
     validate_fc_metrics(metrics)
 
 
-def test_vsock_override_fails_without_device(uvm_plain_any, microvm_factory):
+def test_vsock_override_fails_without_device(uvm, microvm_factory):
     """
     Providing an override should fail if there is no vsock device.
     """
 
     overridden_uds_path = f"{VSOCK_UDS_PATH}2"
 
-    test_vm = uvm_plain_any
+    test_vm = uvm
     test_vm.spawn()
     test_vm.basic_config(vcpu_count=2, mem_size_mib=256)
     test_vm.start()

--- a/tests/integration_tests/performance/test_balloon.py
+++ b/tests/integration_tests/performance/test_balloon.py
@@ -8,11 +8,19 @@ import time
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.microvm import HugePagesConfig
 from framework.utils import (
     get_stable_rss_mem,
     supports_hugetlbfs_discard,
     track_cpu_utilization,
+)
+
+# Every test in this module exercises both huge_pages variants.
+pytestmark = pytest.mark.parametrize(
+    "huge_pages",
+    [HugePagesConfig.NONE, HugePagesConfig.HUGETLBFS_2MB],
+    indirect=True,
 )
 
 NS_IN_MSEC = 1_000_000
@@ -37,11 +45,12 @@ def get_page_fault_duration(vm):
     return duration
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("method", ["reporting", "hinting"])
 @pytest.mark.nonci
 def test_hinting_reporting_cpu(
     microvm_factory,
-    guest_kernel_default,
+    guest_kernel,
     rootfs,
     method,
     metrics,
@@ -51,7 +60,7 @@ def test_hinting_reporting_cpu(
     Measure the CPU usage when running free page reporting and hinting
     """
     test_microvm = microvm_factory.build(
-        guest_kernel_default,
+        guest_kernel,
         rootfs,
         pci=True,
         monitor_memory=False,
@@ -116,11 +125,12 @@ def test_hinting_reporting_cpu(
             metrics.put_metric(f"cpu_utilization_{thread_name}", value, "Percent")
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("sleep_duration", [0, 1, 5])
 @pytest.mark.nonci
 def test_hinting_fault_latency(
     microvm_factory,
-    guest_kernel_default,
+    guest_kernel,
     rootfs,
     metrics,
     sleep_duration,
@@ -135,7 +145,7 @@ def test_hinting_fault_latency(
     """
     runs = 5
     test_microvm = microvm_factory.build(
-        guest_kernel_default,
+        guest_kernel,
         rootfs,
         pci=True,
         monitor_memory=False,
@@ -173,7 +183,7 @@ def test_hinting_fault_latency(
 
 # pylint: disable=C0103
 @pytest.mark.parametrize("method", ["traditional", "hinting", "reporting"])
-def test_size_reduction(uvm_plain_any, method, huge_pages):
+def test_size_reduction(uvm, method, huge_pages):
     """
     Verify that ballooning reduces RSS usage on a newly booted guest.
     """
@@ -188,7 +198,7 @@ def test_size_reduction(uvm_plain_any, method, huge_pages):
         if traditional_balloon:
             pytest.skip("Traditional balloon device won't reduce RSS")
 
-    test_microvm = uvm_plain_any
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config(huge_pages=huge_pages)
     test_microvm.add_net_iface()

--- a/tests/integration_tests/performance/test_block.py
+++ b/tests/integration_tests/performance/test_block.py
@@ -9,7 +9,10 @@ import pytest
 
 import framework.utils_fio as fio
 import host_tools.drive as drive_tools
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel
 from framework.utils import check_output, track_cpu_utilization
+
+pytestmark = pin_guest_kernel(ACPI_GUEST_KERNELS)
 
 # size of the block device used in the test, in MB
 BLOCK_DEVICE_SIZE_MB = 2048
@@ -105,7 +108,7 @@ def emit_fio_metrics(logs_dir, metrics):
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 @pytest.mark.parametrize("fio_engine", [fio.Engine.LIBAIO, fio.Engine.PSYNC])
 def test_block_performance(
-    uvm_plain_acpi,
+    uvm,
     vcpus,
     fio_mode,
     fio_block_size,
@@ -117,7 +120,7 @@ def test_block_performance(
     """
     Execute block device emulation benchmarking scenarios.
     """
-    vm = uvm_plain_acpi
+    vm = uvm
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()
@@ -155,7 +158,7 @@ def test_block_performance(
 @pytest.mark.parametrize("fio_mode", [fio.Mode.RANDREAD])
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_block_vhost_user_performance(
-    uvm_plain_acpi,
+    uvm,
     vcpus,
     fio_mode,
     fio_block_size,
@@ -166,7 +169,7 @@ def test_block_vhost_user_performance(
     Execute block device emulation benchmarking scenarios.
     """
 
-    vm = uvm_plain_acpi
+    vm = uvm
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -8,12 +8,16 @@ import time
 
 import pytest
 
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel, pin_rootfs_mode
+
 # Regex for obtaining boot time from some string.
 
 DEFAULT_BOOT_ARGS = (
     "reboot=k panic=1 nomodule 8250.nr_uarts=0"
     " i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd swiotlb=noforce cryptomgr.notests"
 )
+
+pytestmark = pin_guest_kernel(ACPI_GUEST_KERNELS)
 
 
 def get_boottime_device_info(vm):
@@ -96,8 +100,8 @@ def get_systemd_analyze_times(microvm):
 
 def launch_vm_with_boot_timer(
     microvm_factory,
-    guest_kernel_acpi,
-    rootfs_rw,
+    guest_kernel,
+    rootfs,
     vcpu_count,
     mem_size_mib,
     pci_enabled,
@@ -105,7 +109,7 @@ def launch_vm_with_boot_timer(
 ):
     """Launches a microVM with guest-timer and returns the reported metrics for it"""
     vm = microvm_factory.build(
-        guest_kernel_acpi, rootfs_rw, pci=pci_enabled, monitor_memory=False
+        guest_kernel, rootfs, pci=pci_enabled, monitor_memory=False
     )
     vm.jailer.extra_args.update({"boot-timer": None})
     vm.spawn()
@@ -124,7 +128,7 @@ def launch_vm_with_boot_timer(
             boot_args=DEFAULT_BOOT_ARGS + " init=/usr/local/bin/init rootflags=dax",
             enable_entropy_device=True,
         )
-        vm.add_pmem("pmem", rootfs_rw, True, True)
+        vm.add_pmem("pmem", rootfs, True, True)
 
     vm.add_net_iface()
     vm.start()
@@ -135,10 +139,10 @@ def launch_vm_with_boot_timer(
     return (vm, boot_time_us, cpu_boot_time_us)
 
 
-def test_boot_timer(microvm_factory, guest_kernel_acpi, rootfs, pci_enabled):
+def test_boot_timer(microvm_factory, guest_kernel, rootfs, pci_enabled):
     """Tests that the boot timer device works"""
     launch_vm_with_boot_timer(
-        microvm_factory, guest_kernel_acpi, rootfs, 1, 128, pci_enabled, False
+        microvm_factory, guest_kernel, rootfs, 1, 128, pci_enabled, False
     )
 
 
@@ -146,12 +150,13 @@ def test_boot_timer(microvm_factory, guest_kernel_acpi, rootfs, pci_enabled):
     "vcpu_count,mem_size_mib",
     [(1, 128), (1, 1024), (2, 2048), (4, 4096)],
 )
+@pin_rootfs_mode("rw")
 @pytest.mark.parametrize("boot_from_pmem", [True, False], ids=["PmemBoot", "BlockBoot"])
 @pytest.mark.nonci
 def test_boottime(
     microvm_factory,
-    guest_kernel_acpi,
-    rootfs_rw,
+    guest_kernel,
+    rootfs,
     vcpu_count,
     mem_size_mib,
     boot_from_pmem,
@@ -163,8 +168,8 @@ def test_boottime(
     for i in range(10):
         vm, boot_time_us, cpu_boot_time_us = launch_vm_with_boot_timer(
             microvm_factory,
-            guest_kernel_acpi,
-            rootfs_rw,
+            guest_kernel,
+            rootfs,
             vcpu_count,
             mem_size_mib,
             pci_enabled,

--- a/tests/integration_tests/performance/test_drive_rate_limiter.py
+++ b/tests/integration_tests/performance/test_drive_rate_limiter.py
@@ -7,6 +7,7 @@ import json
 import os
 
 import host_tools.drive as drive_tools
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 
 MB = 2**20
 
@@ -31,11 +32,12 @@ def check_iops_limit(ssh_connection, block_size, count, min_time, max_time):
     assert runtime_ms < max_time * 1000
 
 
-def test_patch_drive_limiter(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_patch_drive_limiter(uvm):
     """
     Test replacing the drive rate-limiter after guest boot works.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     # Set up the microVM with 2 vCPUs, 512 MiB of RAM, 1 network iface, a root
     # file system, and a scratch drive.

--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -11,6 +11,7 @@ run on an ag=1 host due to the use of HugePages.
 import pytest
 from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.guest_stats import MeminfoGuest
 from framework.microvm import HugePagesConfig, SnapshotType
 from framework.properties import global_props
@@ -18,6 +19,8 @@ from framework.utils import get_resident_memory, supports_hugetlbfs_discard
 
 MEMHP_BOOTARGS = "console=ttyS0 reboot=k panic=1 memhp_default_state=online_movable"
 DEFAULT_CONFIG = {"total_size_mib": 1024, "slot_size_mib": 128, "block_size_mib": 2}
+
+pytestmark = pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 
 
 def uvm_booted_memhp(
@@ -65,7 +68,7 @@ def uvm_booted_memhp(
 
 
 def uvm_resumed_memhp(
-    uvm_plain,
+    uvm,
     rootfs,
     microvm_factory,
     vhost_user,
@@ -80,7 +83,7 @@ def uvm_resumed_memhp(
     if huge_pages and huge_pages != HugePagesConfig.NONE and not uffd_handler:
         pytest.skip("Hugepages requires a UFFD handler")
     uvm = uvm_booted_memhp(
-        uvm_plain,
+        uvm,
         rootfs,
         microvm_factory,
         vhost_user,
@@ -136,11 +139,11 @@ def uvm_resumed_memhp(
         "resumed-uffd-huge-pages",
     ],
 )
-def uvm_any_memhp(request, uvm_plain, rootfs, microvm_factory):
+def uvm_any_memhp(request, uvm, rootfs, microvm_factory):
     """Fixture that yields a booted or resumed VM with memory hotplugging"""
     ctor, vhost_user, huge_pages, uffd_handler, snapshot_type = request.param
     yield ctor(
-        uvm_plain,
+        uvm,
         rootfs,
         microvm_factory,
         vhost_user,
@@ -278,11 +281,11 @@ def test_virtio_mem_hotplug_hotunplug(uvm_any_memhp):
     ],
     ids=["all_different", "slot_sized_block", "single_slot", "single_block"],
 )
-def test_virtio_mem_configs(uvm_plain, memhp_config):
+def test_virtio_mem_configs(uvm, memhp_config):
     """
     Check that the virtio mem device is working as expected for different configs
     """
-    uvm = uvm_booted_memhp(uvm_plain, None, None, False, memhp_config, None, None, None)
+    uvm = uvm_booted_memhp(uvm, None, None, False, memhp_config, None, None, None)
     if not uvm.pci_enabled:
         pytest.skip(
             "Skip tests on MMIO transport to save time as we don't expect any difference."
@@ -307,16 +310,16 @@ def test_virtio_mem_configs(uvm_plain, memhp_config):
     validate_metrics(uvm)
 
 
-def test_snapshot_restore_persistence(uvm_plain, microvm_factory, snapshot_type):
+def test_snapshot_restore_persistence(uvm, microvm_factory, snapshot_type):
     """
     Check that hotplugged memory is persisted across snapshot/restore.
     """
-    if not uvm_plain.pci_enabled:
+    if not uvm.pci_enabled:
         pytest.skip(
             "Skip tests on MMIO transport to save time as we don't expect any difference."
         )
     uvm = uvm_booted_memhp(
-        uvm_plain,
+        uvm,
         None,
         microvm_factory,
         False,
@@ -347,17 +350,17 @@ def test_snapshot_restore_persistence(uvm_plain, microvm_factory, snapshot_type)
     validate_metrics(restored_vm)
 
 
-def test_snapshot_restore_incremental(uvm_plain, microvm_factory, snapshot_type):
+def test_snapshot_restore_incremental(uvm, microvm_factory, snapshot_type):
     """
     Check that hotplugged memory is persisted across snapshot/restore.
     """
-    if not uvm_plain.pci_enabled:
+    if not uvm.pci_enabled:
         pytest.skip(
             "Skip tests on MMIO transport to save time as we don't expect any difference."
         )
 
     uvm = uvm_booted_memhp(
-        uvm_plain,
+        uvm,
         None,
         microvm_factory,
         False,
@@ -379,7 +382,7 @@ def test_snapshot_restore_incremental(uvm_plain, microvm_factory, snapshot_type)
     hp_mem_pages_per_cycle = hp_mem_mib_per_cycle * guest_pages_per_mib
 
     checksums = []
-    for i, uvm in enumerate(
+    for i, vm in enumerate(
         microvm_factory.build_n_from_snapshot(
             snapshot,
             hotplug_count + 1,
@@ -387,11 +390,11 @@ def test_snapshot_restore_incremental(uvm_plain, microvm_factory, snapshot_type)
             use_snapshot_editor=True,
         )
     ):
-        uvm.memory_monitor = None
+        vm.memory_monitor = None
 
         # check checksums of previous cycles
         for j in range(i):
-            _, checksum, _ = uvm.ssh.check_output(f"sha256sum /dev/shm/mem_hp_test_{j}")
+            _, checksum, _ = vm.ssh.check_output(f"sha256sum /dev/shm/mem_hp_test_{j}")
             assert checksum == checksums[j], f"Checksums didn't match for i={i} j={j}"
 
         # we run hotplug_count+1 uvms to check all the checksums at the end
@@ -399,18 +402,18 @@ def test_snapshot_restore_incremental(uvm_plain, microvm_factory, snapshot_type)
             continue
 
         total_hp_mem_mib = hp_mem_mib_per_cycle * (i + 1)
-        uvm.hotplug_memory(total_hp_mem_mib)
+        vm.hotplug_memory(total_hp_mem_mib)
 
         # Increase /dev/shm size as it defaults to half of the boot memory
-        uvm.ssh.check_output(
+        vm.ssh.check_output(
             f"mount -o remount,size={total_hp_mem_mib}M -t tmpfs tmpfs /dev/shm"
         )
 
-        uvm.ssh.check_output(
+        vm.ssh.check_output(
             f"dd if=/dev/urandom of=/dev/shm/mem_hp_test_{i} bs=1M count={hp_mem_mib_per_cycle}"
         )
 
-        _, checksum, _ = uvm.ssh.check_output(f"sha256sum /dev/shm/mem_hp_test_{i}")
+        _, checksum, _ = vm.ssh.check_output(f"sha256sum /dev/shm/mem_hp_test_{i}")
         checksums.append(checksum)
 
         # dirty a page in the middle of the hotplugged memory to verify differential snapshots
@@ -418,12 +421,12 @@ def test_snapshot_restore_incremental(uvm_plain, microvm_factory, snapshot_type)
         # one we're going to write to avoid issues like #5696.
         file_to_dirty = i // 2
         page_to_dirty = hp_mem_pages_per_cycle // 2
-        uvm.ssh.check_output(
+        vm.ssh.check_output(
             f"dd if=/dev/shm/mem_hp_test_{file_to_dirty} of=/dev/shm/mem_hp_test_{file_to_dirty} "
             f"bs=4K count=1 skip={page_to_dirty} seek={page_to_dirty} conv=notrunc"
         )
 
-        validate_metrics(uvm)
+        validate_metrics(vm)
 
 
 def timed_memory_hotplug(uvm, size, metrics, metric_prefix, fc_metric_name):
@@ -469,7 +472,7 @@ def timed_memory_hotplug(uvm, size, metrics, metric_prefix, fc_metric_name):
     [HugePagesConfig.NONE, HugePagesConfig.HUGETLBFS_2MB],
 )
 def test_memory_hotplug_latency(
-    microvm_factory, guest_kernel_default, rootfs, hotplug_size, huge_pages, metrics
+    microvm_factory, guest_kernel, rootfs, hotplug_size, huge_pages, metrics
 ):
     """Test the latency of hotplugging memory"""
 
@@ -479,8 +482,8 @@ def test_memory_hotplug_latency(
             "slot_size_mib": 128,
             "block_size_mib": 2,
         }
-        uvm_plain = microvm_factory.build(guest_kernel_default, rootfs, pci=True)
-        uvm = uvm_booted_memhp(uvm_plain, None, None, False, config, None, None, None)
+        uvm = microvm_factory.build(guest_kernel, rootfs, pci=True)
+        uvm = uvm_booted_memhp(uvm, None, None, False, config, None, None, None)
 
         if i == 0:
             metrics.set_dimensions(

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -8,9 +8,12 @@ import time
 import pytest
 
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.microvm import HugePagesConfig
 from framework.properties import global_props
 from framework.utils_ftrace import ftrace_events
+
+pytestmark = pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 
 
 def check_hugetlbfs_in_use(pid: int, allocation_name: str):
@@ -55,21 +58,21 @@ def check_hugetlbfs_in_use(pid: int, allocation_name: str):
     assert kernel_page_size_kib > 4
 
 
-def test_hugetlbfs_boot(uvm_plain):
+def test_hugetlbfs_boot(uvm):
     """Tests booting a microvm with guest memory backed by 2MB hugetlbfs pages"""
 
-    uvm_plain.spawn()
-    uvm_plain.basic_config(huge_pages=HugePagesConfig.HUGETLBFS_2MB, mem_size_mib=128)
-    uvm_plain.add_net_iface()
-    uvm_plain.start()
+    uvm.spawn()
+    uvm.basic_config(huge_pages=HugePagesConfig.HUGETLBFS_2MB, mem_size_mib=128)
+    uvm.add_net_iface()
+    uvm.start()
 
     check_hugetlbfs_in_use(
-        uvm_plain.firecracker_pid,
+        uvm.firecracker_pid,
         "/anon_hugepage",
     )
 
 
-def test_hugetlbfs_snapshot(microvm_factory, uvm_plain, snapshot_type):
+def test_hugetlbfs_snapshot(microvm_factory, uvm, snapshot_type):
     """
     Test hugetlbfs snapshot restore via uffd
 
@@ -78,7 +81,7 @@ def test_hugetlbfs_snapshot(microvm_factory, uvm_plain, snapshot_type):
     """
 
     ### Create Snapshot ###
-    vm = uvm_plain
+    vm = uvm
     vm.memory_monitor = None
     vm.spawn()
     vm.basic_config(
@@ -106,7 +109,7 @@ def test_hugetlbfs_snapshot(microvm_factory, uvm_plain, snapshot_type):
 @pytest.mark.parametrize("huge_pages", HugePagesConfig)
 def test_ept_violation_count(
     microvm_factory,
-    uvm_plain,
+    uvm,
     metrics,
     huge_pages,
 ):
@@ -116,7 +119,7 @@ def test_ept_violation_count(
     """
 
     ### Create Snapshot ###
-    vm = uvm_plain
+    vm = uvm
     vm.memory_monitor = None
     vm.spawn()
     vm.basic_config(huge_pages=huge_pages, mem_size_mib=256)

--- a/tests/integration_tests/performance/test_memory_overhead.py
+++ b/tests/integration_tests/performance/test_memory_overhead.py
@@ -20,6 +20,8 @@ from pathlib import Path
 import psutil
 import pytest
 
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel
+
 # If guest memory is >3072MB, it is split in a 2nd region
 X86_MEMORY_GAP_START = 3072 * 2**20
 
@@ -28,10 +30,11 @@ X86_MEMORY_GAP_START = 3072 * 2**20
     "vcpu_count,mem_size_mib",
     [(1, 128), (1, 1024), (2, 2048), (4, 4096), (32, 4096)],
 )
+@pin_guest_kernel(ACPI_GUEST_KERNELS)
 @pytest.mark.nonci
 def test_memory_overhead(
     microvm_factory,
-    guest_kernel_acpi,
+    guest_kernel,
     rootfs,
     vcpu_count,
     mem_size_mib,
@@ -45,7 +48,7 @@ def test_memory_overhead(
 
     for _ in range(5):
         microvm = microvm_factory.build(
-            guest_kernel_acpi, rootfs, pci=pci_enabled, monitor_memory=False
+            guest_kernel, rootfs, pci=pci_enabled, monitor_memory=False
         )
         microvm.spawn(emit_metrics=True)
         microvm.basic_config(vcpu_count=vcpu_count, mem_size_mib=mem_size_mib)

--- a/tests/integration_tests/performance/test_mmds.py
+++ b/tests/integration_tests/performance/test_mmds.py
@@ -27,9 +27,8 @@ def parse_curl_timing(timing_line):
 
 
 @pytest.fixture
-def mmds_microvm(uvm_plain_any):
+def mmds_microvm(uvm):
     """Creates a microvm with MMDS configured for performance testing."""
-    uvm = uvm_plain_any
     uvm.spawn(log_level="Info")
     uvm.basic_config()
     uvm.add_net_iface()

--- a/tests/integration_tests/performance/test_network.py
+++ b/tests/integration_tests/performance/test_network.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 import pytest
 
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel
 from framework.utils_iperf import IPerf3Test, emit_iperf3_metrics
+
+pytestmark = pin_guest_kernel(ACPI_GUEST_KERNELS)
 
 
 def consume_ping_output(ping_putput):
@@ -38,14 +41,14 @@ def consume_ping_output(ping_putput):
 
 
 @pytest.fixture
-def network_microvm(request, uvm_plain_acpi):
+def network_microvm(request, uvm):
     """Creates a microvm with the networking setup used by the performance tests in this file.
     This fixture receives its vcpu count via indirect parameterization"""
 
     guest_mem_mib = 1024
     guest_vcpus = request.param
 
-    vm = uvm_plain_acpi
+    vm = uvm
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=guest_vcpus, mem_size_mib=guest_mem_mib)
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_pmem.py
+++ b/tests/integration_tests/performance/test_pmem.py
@@ -11,6 +11,7 @@ import pytest
 
 import framework.utils_fio as fio
 import host_tools.drive as drive_tools
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel
 from framework.utils import track_cpu_utilization
 
 PMEM_DEVICE_SIZE_MB = 2048
@@ -18,6 +19,8 @@ PMEM_DEVICE_SIZE_SINGLE_READ_MB = 512
 WARMUP_SEC = 10
 RUNTIME_SEC = 30
 GUEST_MEM_MIB = 1024
+
+pytestmark = pin_guest_kernel(ACPI_GUEST_KERNELS)
 
 
 def run_fio(
@@ -78,7 +81,7 @@ def emit_fio_metrics(logs_dir, metrics):
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 @pytest.mark.parametrize("fio_engine", [fio.Engine.LIBAIO, fio.Engine.PSYNC])
 def test_pmem_performance(
-    uvm_plain_acpi,
+    uvm,
     vcpus,
     fio_mode,
     fio_block_size,
@@ -89,7 +92,7 @@ def test_pmem_performance(
     """
     Measure performance of pmem device
     """
-    vm = uvm_plain_acpi
+    vm = uvm
     vm.memory_monitor = None
     vm.spawn()
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=GUEST_MEM_MIB)
@@ -160,7 +163,7 @@ def emit_fio_single_read_metrics(logs_dir, metrics):
 @pytest.mark.parametrize("fio_block_size", [4096], ids=["bs4096"])
 def test_pmem_first_read(
     microvm_factory,
-    guest_kernel_acpi,
+    guest_kernel,
     rootfs,
     fio_block_size,
     metrics,
@@ -174,9 +177,7 @@ def test_pmem_first_read(
     """
 
     for i in range(10):
-        vm = microvm_factory.build(
-            guest_kernel_acpi, rootfs, pci=True, monitor_memory=False
-        )
+        vm = microvm_factory.build(guest_kernel, rootfs, pci=True, monitor_memory=False)
         vm.spawn()
         vm.basic_config(mem_size_mib=GUEST_MEM_MIB)
         vm.add_net_iface()
@@ -224,9 +225,9 @@ def check_flush_limit(ssh_connection, count, min_time, max_time):
     assert runtime_ms < max_time * 1000
 
 
-def test_pmem_rate_limiter(uvm_plain_acpi):
+def test_pmem_rate_limiter(uvm):
     """Test that the pmem rate limiter throttles flush operations."""
-    vm = uvm_plain_acpi
+    vm = uvm
     vm.memory_monitor = None
     vm.spawn()
     vm.basic_config(vcpu_count=2, mem_size_mib=512)

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -7,45 +7,44 @@ import time
 
 import pytest
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from host_tools.cargo_build import run_seccompiler_bin
 
 ITERATIONS = 100
 
+pytestmark = pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+
 
 @pytest.mark.nonci
-def test_startup_time_new_pid_ns(
-    microvm_factory, guest_kernel_default, rootfs, metrics
-):
+def test_startup_time_new_pid_ns(microvm_factory, guest_kernel, rootfs, metrics):
     """
     Check startup time when jailer is spawned in a new PID namespace.
     """
     for _ in range(ITERATIONS):
-        microvm = microvm_factory.build(guest_kernel_default, rootfs)
+        microvm = microvm_factory.build(guest_kernel, rootfs)
         microvm.jailer.new_pid_ns = True
         _test_startup_time(microvm, metrics, "new_pid_ns")
         microvm.kill()
 
 
 @pytest.mark.nonci
-def test_startup_time_daemonize(microvm_factory, guest_kernel_default, rootfs, metrics):
+def test_startup_time_daemonize(microvm_factory, guest_kernel, rootfs, metrics):
     """
     Check startup time when jailer detaches Firecracker from the controlling terminal.
     """
     for _ in range(ITERATIONS):
-        microvm = microvm_factory.build(guest_kernel_default, rootfs)
+        microvm = microvm_factory.build(guest_kernel, rootfs)
         _test_startup_time(microvm, metrics, "daemonize")
         microvm.kill()
 
 
 @pytest.mark.nonci
-def test_startup_time_custom_seccomp(
-    microvm_factory, guest_kernel_default, rootfs, metrics
-):
+def test_startup_time_custom_seccomp(microvm_factory, guest_kernel, rootfs, metrics):
     """
     Check the startup time when using custom seccomp filters.
     """
     for _ in range(ITERATIONS):
-        microvm = microvm_factory.build(guest_kernel_default, rootfs)
+        microvm = microvm_factory.build(guest_kernel, rootfs)
         _custom_filter_setup(microvm)
         _test_startup_time(microvm, metrics, "custom_seccomp")
         microvm.kill()

--- a/tests/integration_tests/performance/test_rate_limiter.py
+++ b/tests/integration_tests/performance/test_rate_limiter.py
@@ -5,6 +5,7 @@
 import time
 
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from host_tools import cpu_load
 
 # The iperf version to run this tests with
@@ -45,12 +46,14 @@ RATE_LIMITER_WITH_BURST = {
 MAX_RELATIVE_KBPS_CHANGE = 0.1
 MAX_TIME_DIFF = 25
 
+pytestmark = pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 
-def test_tx_rate_limiting(uvm_plain):
+
+def test_tx_rate_limiting(uvm):
     """
     Run iperf tx with and without rate limiting; check limiting effect.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
 
@@ -68,11 +71,11 @@ def test_tx_rate_limiting(uvm_plain):
     _check_tx_rate_limit_patch(test_microvm)
 
 
-def test_rx_rate_limiting(uvm_plain):
+def test_rx_rate_limiting(uvm):
     """
     Run iperf rx with and without rate limiting; check limiting effect.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
 
@@ -91,11 +94,11 @@ def test_rx_rate_limiting(uvm_plain):
     _check_rx_rate_limit_patch(test_microvm)
 
 
-def test_rx_rate_limiting_cpu_load(uvm_plain):
+def test_rx_rate_limiting_cpu_load(uvm):
     """
     Run iperf rx with rate limiting; verify cpu load is below threshold.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
 

--- a/tests/integration_tests/performance/test_snapshot.py
+++ b/tests/integration_tests/performance/test_snapshot.py
@@ -12,11 +12,14 @@ from functools import lru_cache
 import pytest
 
 import host_tools.drive as drive_tools
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.microvm import HugePagesConfig, Microvm, SnapshotType
 
 USEC_IN_MSEC = 1000
 NS_IN_MSEC = 1_000_000
 ITERATIONS = 30
+
+pytestmark = pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 
 
 @lru_cache
@@ -98,7 +101,7 @@ class SnapshotRestoreTest:
     ids=lambda x: x.id,
 )
 def test_restore_latency(
-    microvm_factory, guest_kernel_default, rootfs, pci_enabled, test_setup, metrics
+    microvm_factory, guest_kernel, rootfs, pci_enabled, test_setup, metrics
 ):
     """
     Restores snapshots with vcpu/memory configuration, roughly scaling according to mem = (vcpus - 1) * 2048MB,
@@ -107,7 +110,7 @@ def test_restore_latency(
 
     We only test a single guest kernel, as the guest kernel does not "participate" in snapshot restore.
     """
-    vm = test_setup.boot_vm(microvm_factory, guest_kernel_default, rootfs, pci_enabled)
+    vm = test_setup.boot_vm(microvm_factory, guest_kernel, rootfs, pci_enabled)
 
     metrics.set_dimensions(
         {
@@ -148,7 +151,7 @@ def test_restore_latency(
 def test_post_restore_latency(
     microvm_factory,
     rootfs,
-    guest_kernel_default,
+    guest_kernel,
     pci_enabled,
     metrics,
     uffd_handler,
@@ -159,7 +162,7 @@ def test_post_restore_latency(
         pytest.skip("huge page snapshots can only be restored using uffd")
 
     test_setup = SnapshotRestoreTest(mem=1024, vcpus=2, huge_pages=huge_pages)
-    vm = test_setup.boot_vm(microvm_factory, guest_kernel_default, rootfs, pci_enabled)
+    vm = test_setup.boot_vm(microvm_factory, guest_kernel, rootfs, pci_enabled)
 
     metrics.set_dimensions(
         {
@@ -206,7 +209,7 @@ def test_post_restore_latency(
 def test_population_latency(
     microvm_factory,
     rootfs,
-    guest_kernel_default,
+    guest_kernel,
     pci_enabled,
     metrics,
     huge_pages,
@@ -215,7 +218,7 @@ def test_population_latency(
 ):
     """Collects population latency metrics (e.g. how long it takes UFFD handler to fault in all memory)"""
     test_setup = SnapshotRestoreTest(mem=mem, vcpus=vcpus, huge_pages=huge_pages)
-    vm = test_setup.boot_vm(microvm_factory, guest_kernel_default, rootfs, pci_enabled)
+    vm = test_setup.boot_vm(microvm_factory, guest_kernel, rootfs, pci_enabled)
 
     metrics.set_dimensions(
         {
@@ -259,13 +262,13 @@ def test_population_latency(
 
 @pytest.mark.nonci
 def test_snapshot_create_latency(
-    uvm_plain,
+    uvm,
     metrics,
     snapshot_type,
 ):
     """Measure the latency of creating a Full snapshot"""
 
-    vm = uvm_plain
+    vm = uvm
     vm.spawn()
     vm.basic_config(
         vcpu_count=2,

--- a/tests/integration_tests/performance/test_steal_time.py
+++ b/tests/integration_tests/performance/test_steal_time.py
@@ -5,6 +5,10 @@
 
 import time
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
+
+pytestmark = pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+
 
 def get_steal_time_ms(vm):
     """Returns total steal time of vCPUs in VM in milliseconds"""
@@ -14,11 +18,11 @@ def get_steal_time_ms(vm):
     return steal_time_tck / clk_tck * 1000
 
 
-def test_pvtime_steal_time_increases(uvm_plain):
+def test_pvtime_steal_time_increases(uvm):
     """
     Test that PVTime steal time increases when both vCPUs are contended on the same pCPU.
     """
-    vm = uvm_plain
+    vm = uvm
     vm.spawn()
     vm.basic_config()
     vm.add_net_iface()
@@ -44,12 +48,12 @@ def test_pvtime_steal_time_increases(uvm_plain):
     ), f"Steal time did not increase as expected. Before: {steal_before}, After: {steal_after}"
 
 
-def test_pvtime_snapshot(uvm_plain, microvm_factory):
+def test_pvtime_snapshot(uvm, microvm_factory):
     """
     Test that PVTime steal time is preserved across snapshot/restore
     and continues increasing post-resume.
     """
-    vm = uvm_plain
+    vm = uvm
     vm.spawn()
     vm.basic_config()
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_vhost_user_metrics.py
+++ b/tests/integration_tests/performance/test_vhost_user_metrics.py
@@ -7,10 +7,13 @@ import time
 import pytest
 
 import host_tools.drive as drive_tools
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel
+
+pytestmark = pin_guest_kernel(ACPI_GUEST_KERNELS)
 
 
 @pytest.mark.parametrize("vcpu_count", [1, 2], ids=["1vcpu", "2vcpu"])
-def test_vhost_user_block_metrics(uvm_plain_acpi, vcpu_count, metrics):
+def test_vhost_user_block_metrics(uvm, vcpu_count, metrics):
     """
     This test tries to boot a VM with vhost-user-block
     as a scratch device, resize the vhost-user scratch drive to have
@@ -26,7 +29,7 @@ def test_vhost_user_block_metrics(uvm_plain_acpi, vcpu_count, metrics):
     # low->high->low->high and so the numbers are not in monotonic sequence.
     new_sizes = [20, 10, 30]  # MB
 
-    vm = uvm_plain_acpi
+    vm = uvm
     vm.spawn(log_level="Info")
     vm.basic_config(vcpu_count=vcpu_count)
     vm.add_net_iface()

--- a/tests/integration_tests/performance/test_vsock.py
+++ b/tests/integration_tests/performance/test_vsock.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 
+from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel
 from framework.utils_iperf import IPerf3Test, emit_iperf3_metrics
 from framework.utils_vsock import (
     ECHO_SERVER_PORT,
@@ -20,14 +21,16 @@ from framework.utils_vsock import (
     start_guest_echo_server,
 )
 
+pytestmark = pin_guest_kernel(ACPI_GUEST_KERNELS)
+
 
 @pytest.fixture
-def vsock_uvm(uvm_plain_acpi, request):
+def vsock_uvm(uvm, request):
     """Fixture to initialize a microVM with vsock device for perf tests."""
     vcpus = request.param if hasattr(request, "param") else 1
 
     return boot_vsock_vm(
-        uvm_plain_acpi,
+        uvm,
         vcpu_count=vcpus,
         mem_size_mib=1024,
         log_level="Info",
@@ -116,7 +119,7 @@ def consume_vsock_ping_output(ping_output):
 @pytest.mark.parametrize("payload_length", ["64K", "1024K"], ids=["p64K", "p1024K"])
 @pytest.mark.parametrize("mode", ["g2h", "h2g"])
 def test_vsock_throughput(
-    uvm_plain_acpi,
+    uvm,
     vcpus,
     payload_length,
     mode,
@@ -128,7 +131,7 @@ def test_vsock_throughput(
     """
 
     mem_size_mib = 1024
-    vm = uvm_plain_acpi
+    vm = uvm
     vm.spawn(log_level="Info", emit_metrics=True)
     vm.basic_config(vcpu_count=vcpus, mem_size_mib=mem_size_mib)
     vm.add_net_iface()

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 
 
 def install_filter(microvm, bpf_path):
@@ -15,7 +16,8 @@ def install_filter(microvm, bpf_path):
     microvm.jailer.extra_args.update({"seccomp-filter": bpf_path.name})
 
 
-def test_allow_all(uvm_plain, seccompiler):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_allow_all(uvm, seccompiler):
     """Test --seccomp-filter, allowing all syscalls."""
     seccomp_filter = {
         thread: {"default_action": "allow", "filter_action": "trap", "filter": []}
@@ -23,7 +25,7 @@ def test_allow_all(uvm_plain, seccompiler):
     }
 
     bpf_path = seccompiler.compile(seccomp_filter)
-    test_microvm = uvm_plain
+    test_microvm = uvm
     install_filter(test_microvm, bpf_path)
     test_microvm.spawn()
     test_microvm.basic_config()
@@ -31,7 +33,8 @@ def test_allow_all(uvm_plain, seccompiler):
     utils.assert_seccomp_level(test_microvm.firecracker_pid, "2")
 
 
-def test_working_filter(uvm_plain, seccompiler):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_working_filter(uvm, seccompiler):
     """Test --seccomp-filter, rejecting some dangerous syscalls."""
 
     seccomp_filter = {
@@ -44,7 +47,7 @@ def test_working_filter(uvm_plain, seccompiler):
     }
 
     bpf_path = seccompiler.compile(seccomp_filter)
-    test_microvm = uvm_plain
+    test_microvm = uvm
     install_filter(test_microvm, bpf_path)
     test_microvm.spawn()
     test_microvm.basic_config()
@@ -54,7 +57,8 @@ def test_working_filter(uvm_plain, seccompiler):
     utils.assert_seccomp_level(test_microvm.firecracker_pid, "2")
 
 
-def test_failing_filter(uvm_plain, seccompiler):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_failing_filter(uvm, seccompiler):
     """Test --seccomp-filter, denying some needed syscalls."""
 
     seccomp_filter = {
@@ -68,7 +72,7 @@ def test_failing_filter(uvm_plain, seccompiler):
     }
 
     bpf_path = seccompiler.compile(seccomp_filter)
-    test_microvm = uvm_plain
+    test_microvm = uvm
     install_filter(test_microvm, bpf_path)
     test_microvm.spawn()
     test_microvm.basic_config(vcpu_count=1)
@@ -103,9 +107,10 @@ def test_failing_filter(uvm_plain, seccompiler):
     test_microvm.mark_killed()
 
 
-def test_invalid_bpf(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_invalid_bpf(uvm):
     """Test that FC does not start, given an invalid binary filter."""
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     # Configure VM from JSON. Otherwise, the test will error because
     # the process will be killed before configuring the API socket.

--- a/tests/integration_tests/security/test_fips.py
+++ b/tests/integration_tests/security/test_fips.py
@@ -9,6 +9,42 @@ Tests verify that:
 3. Userspace CSPRNGs are reseeded (diverge across restored VMs)
 """
 
+import pytest
+
+from framework.artifacts import (
+    GUEST_KERNEL_DEFAULT,
+    pin_guest_kernel,
+    pin_pci,
+    pin_rootfs_mode,
+)
+
+pytestmark = [
+    pin_guest_kernel(GUEST_KERNEL_DEFAULT),
+    pin_rootfs_mode("rw"),
+    pin_pci(False),
+]
+
+
+@pytest.fixture
+def uvm_with_fips(uvm):
+    """Boot a microVM with FIPS mode enabled."""
+    uvm.spawn()
+    uvm.basic_config(boot_args="console=ttyS0 reboot=k panic=1 pci=off fips=1")
+    uvm.add_net_iface()
+    uvm.start()
+    return uvm
+
+
+@pytest.fixture
+def fips_snapshot_pair(uvm_with_fips, microvm_factory):
+    """Boot a FIPS VM, snapshot it, restore two VMs from the same snapshot."""
+    snapshot = uvm_with_fips.snapshot_full()
+    uvm_with_fips.kill()
+
+    uvm_a = microvm_factory.build_from_snapshot(snapshot)
+    uvm_b = microvm_factory.build_from_snapshot(snapshot)
+    yield uvm_a, uvm_b
+
 
 def test_fips_enabled(uvm_with_fips):
     """Test that FIPS mode is enabled in the guest kernel."""

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -14,6 +14,7 @@ import pytest
 import requests
 import urllib3
 
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.defs import FC_BINARY_NAME
 from framework.jailer import JailerContext
 
@@ -52,11 +53,12 @@ def check_stats(filepath, stats, uid, gid):
     assert st.st_mode ^ stats == 0
 
 
-def test_empty_jailer_id(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_empty_jailer_id(uvm):
     """
     Test that the jailer ID cannot be empty.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     # Set the jailer ID to None.
     test_microvm.jailer = JailerContext(
@@ -74,11 +76,12 @@ def test_empty_jailer_id(uvm_plain):
         test_microvm.spawn()
 
 
-def test_exec_file_not_exist(uvm_plain, tmp_path):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_exec_file_not_exist(uvm, tmp_path):
     """
     Test the jailer option `--exec-file`
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     # Error case 1: No such file exists
     pseudo_exec_file_path = tmp_path / "pseudo_firecracker_exec_file"
@@ -107,11 +110,12 @@ def test_exec_file_not_exist(uvm_plain, tmp_path):
         test_microvm.spawn()
 
 
-def test_exec_destination_path_is_symlink(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_exec_destination_path_is_symlink(uvm):
     """
     Test the jailer correctly refuses to copy binary into symlink
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     firecracker_root_dir = Path(test_microvm.chroot())
     firecracker_bin_path = firecracker_root_dir / "firecracker"
@@ -126,11 +130,12 @@ def test_exec_destination_path_is_symlink(uvm_plain):
         test_microvm.spawn()
 
 
-def test_exec_destination_path_is_hardlink(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_exec_destination_path_is_hardlink(uvm):
     """
     Test the jailer correctly refuses to copy binary into hardlink
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     firecracker_root_dir = Path(test_microvm.chroot())
     firecracker_bin_path = firecracker_root_dir / "firecracker"
@@ -145,11 +150,12 @@ def test_exec_destination_path_is_hardlink(uvm_plain):
         test_microvm.spawn()
 
 
-def test_default_chroot_hierarchy(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_default_chroot_hierarchy(uvm):
     """
     Test the folder hierarchy created by default by the jailer.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
 
     test_microvm.spawn()
 
@@ -199,11 +205,12 @@ def test_default_chroot_hierarchy(uvm_plain):
     )
 
 
-def test_arbitrary_usocket_location(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_arbitrary_usocket_location(uvm):
     """
     Test arbitrary location scenario for the api socket.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.extra_args = {"api-sock": "api.socket"}
 
     test_microvm.spawn(serial_out_path=None)
@@ -332,11 +339,12 @@ def check_limits(pid, no_file, fsize):
     assert hard == fsize
 
 
-def test_cgroups(uvm_plain, cgroups_info):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_cgroups(uvm, cgroups_info):
     """
     Test the cgroups are correctly set by the jailer.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.cgroup_ver = cgroups_info.version
     if test_microvm.jailer.cgroup_ver == 2:
         test_microvm.jailer.cgroups = ["cpu.weight.nice=10"]
@@ -360,11 +368,12 @@ def test_cgroups(uvm_plain, cgroups_info):
         check_cgroups_v2(test_microvm)
 
 
-def test_cgroups_custom_parent(uvm_plain, cgroups_info):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_cgroups_custom_parent(uvm, cgroups_info):
     """
     Test cgroups when a custom parent cgroup is used.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.cgroup_ver = cgroups_info.version
     test_microvm.jailer.parent_cgroup = "custom_cgroup/group2"
     if test_microvm.jailer.cgroup_ver == 2:
@@ -392,11 +401,12 @@ def test_cgroups_custom_parent(uvm_plain, cgroups_info):
         check_cgroups_v2(test_microvm)
 
 
-def test_node_cgroups(uvm_plain, cgroups_info):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_node_cgroups(uvm, cgroups_info):
     """
     Test the numa node cgroups are correctly set by the jailer.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.cgroup_ver = cgroups_info.version
 
     # Retrieve CPUs from NUMA node 0.
@@ -413,11 +423,12 @@ def test_node_cgroups(uvm_plain, cgroups_info):
         check_cgroups_v2(test_microvm)
 
 
-def test_cgroups_without_numa(uvm_plain, cgroups_info):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_cgroups_without_numa(uvm, cgroups_info):
     """
     Test the cgroups are correctly set by the jailer, without numa assignment.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.cgroup_ver = cgroups_info.version
     if test_microvm.jailer.cgroup_ver == 2:
         test_microvm.jailer.cgroups = ["cpu.weight=2"]
@@ -432,24 +443,26 @@ def test_cgroups_without_numa(uvm_plain, cgroups_info):
         check_cgroups_v2(test_microvm)
 
 
-def test_v1_default_cgroups(uvm_plain, cgroups_info):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_v1_default_cgroups(uvm, cgroups_info):
     """
     Test if the jailer is using cgroup-v1 by default.
     """
     if cgroups_info.version != 1:
         pytest.skip(reason="Requires system with cgroup-v1 enabled.")
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.cgroups = ["cpu.shares=2"]
     test_microvm.spawn()
     check_cgroups_v1(test_microvm.jailer.cgroups, test_microvm.jailer.jailer_id)
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize(
     "parent_exists,domain_controller_in_subtree",
     [(True, False), (True, True), (False, None)],
 )
 def test_cgroups_parent_cgroup_but_no_cgroup(
-    uvm_plain, cgroups_info, parent_exists, domain_controller_in_subtree
+    uvm, cgroups_info, parent_exists, domain_controller_in_subtree
 ):
     """
     Test cgroups when `--parent-cgroup` is used but no `--cgroup` are specified.
@@ -464,7 +477,7 @@ def test_cgroups_parent_cgroup_but_no_cgroup(
     """
     if cgroups_info.version != 2:
         pytest.skip("cgroupsv2 only")
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.cgroup_ver = cgroups_info.version
     # Make it somewhat unique so it doesn't conflict with other test runs
     parent_cgroup = f"custom_cgroup/{test_microvm.id[:8]}"
@@ -510,11 +523,12 @@ def test_cgroups_parent_cgroup_but_no_cgroup(
         assert not cg_parent.exists()
 
 
-def test_args_default_resource_limits(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_args_default_resource_limits(uvm):
     """
     Test the default resource limits are correctly set by the jailer.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     # Get firecracker's PID
     pid = test_microvm.firecracker_pid
@@ -533,11 +547,12 @@ def test_args_default_resource_limits(uvm_plain):
     assert hard == -1
 
 
-def test_args_resource_limits(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_args_resource_limits(uvm):
     """
     Test the resource limits are correctly set by the jailer.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.resource_limits = RESOURCE_LIMITS
     test_microvm.spawn()
     # Get firecracker's PID
@@ -548,7 +563,8 @@ def test_args_resource_limits(uvm_plain):
     check_limits(pid, NOFILE, FSIZE)
 
 
-def test_positive_file_size_limit(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_positive_file_size_limit(uvm):
     """
     Test creating vm succeeds when memory size is under `fsize` limit.
     """
@@ -556,7 +572,7 @@ def test_positive_file_size_limit(uvm_plain):
     vm_mem_size = 128
     jail_limit = (vm_mem_size + 1) << 20
 
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.resource_limits = [f"fsize={jail_limit}"]
     test_microvm.spawn()
     test_microvm.basic_config(mem_size_mib=vm_mem_size)
@@ -565,11 +581,12 @@ def test_positive_file_size_limit(uvm_plain):
     test_microvm.start()
 
 
-def test_negative_file_size_limit(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_negative_file_size_limit(uvm):
     """
     Test creating snapshot file fails when size exceeds `fsize` limit.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     # limit to 1MB, to account for logs and metrics
     test_microvm.jailer.resource_limits = [f"fsize={2**20}"]
     test_microvm.spawn()
@@ -600,11 +617,12 @@ def test_negative_file_size_limit(uvm_plain):
         assert False, "Negative test failed"
 
 
-def test_negative_no_file_limit(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_negative_no_file_limit(uvm):
     """
     Test microVM is killed when exceeding `no-file` limit.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.resource_limits = ["no-file=3"]
 
     # pylint: disable=W0703
@@ -618,11 +636,12 @@ def test_negative_no_file_limit(uvm_plain):
         assert False, "Negative test failed"
 
 
-def test_new_pid_ns_resource_limits(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_new_pid_ns_resource_limits(uvm):
     """
     Test that Firecracker process inherits jailer resource limits.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.resource_limits = RESOURCE_LIMITS
     test_microvm.spawn()
 
@@ -633,11 +652,12 @@ def test_new_pid_ns_resource_limits(uvm_plain):
     check_limits(fc_pid, NOFILE, FSIZE)
 
 
-def test_new_pid_namespace(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_new_pid_namespace(uvm):
     """
     Test that Firecracker is spawned in a new PID namespace if requested.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     # Check that the PID file exists.
     fc_pid = test_microvm.firecracker_pid
@@ -664,6 +684,7 @@ def test_new_pid_namespace(uvm_plain):
     assert int(nstgid_list[0]) == fc_pid
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize(
     "daemonize",
     [True, False],
@@ -672,11 +693,11 @@ def test_new_pid_namespace(uvm_plain):
     "new_pid_ns",
     [True, False],
 )
-def test_firecracker_kill_by_pid(uvm_plain, daemonize, new_pid_ns):
+def test_firecracker_kill_by_pid(uvm, daemonize, new_pid_ns):
     """
     Test that Firecracker is spawned in a new PID namespace if requested.
     """
-    microvm = uvm_plain
+    microvm = uvm
     microvm.jailer.daemonize = daemonize
     microvm.jailer.new_pid_ns = new_pid_ns
     microvm.spawn()
@@ -692,7 +713,8 @@ def test_firecracker_kill_by_pid(uvm_plain, daemonize, new_pid_ns):
     microvm.kill()
 
 
-def test_cgroupsv2_written_only_once(uvm_plain, cgroups_info):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_cgroupsv2_written_only_once(uvm, cgroups_info):
     """
     Test that we only write to cgroup.procs once when using CgroupsV2
 
@@ -702,7 +724,6 @@ def test_cgroupsv2_written_only_once(uvm_plain, cgroups_info):
     if cgroups_info.version != 2:
         pytest.skip(reason="Requires system with cgroup-v2 enabled.")
 
-    uvm = uvm_plain
     strace_output_path = Path(uvm.path, "strace.out")
     strace_cmd = [
         "strace",

--- a/tests/integration_tests/security/test_nv.py
+++ b/tests/integration_tests/security/test_nv.py
@@ -16,7 +16,10 @@ This test is a safety-net to make the test explicit and catch cases where we
 start providing the feature by mistake.
 """
 
+from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
 
-def test_no_nested_virtualization(uvm_any_booted):
+
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_no_nested_virtualization(uvm_booted):
     """Validate that guests don't have Nested Virtualization enabled."""
-    uvm_any_booted.ssh.check_output("[ ! -e /dev/kvm ]")
+    uvm_booted.ssh.check_output("[ ! -e /dev/kvm ]")

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -8,6 +8,7 @@ import platform
 from pathlib import Path
 
 from framework import utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 
 ARCH = platform.machine()
 
@@ -162,11 +163,12 @@ def test_advanced_seccomp(bin_seccomp_paths, seccompiler):
     assert outcome.returncode == -31
 
 
-def test_no_seccomp(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_no_seccomp(uvm):
     """
     Test that Firecracker --no-seccomp installs no filter.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.jailer.extra_args.update({"no-seccomp": None})
     test_microvm.spawn()
     test_microvm.basic_config()
@@ -174,11 +176,12 @@ def test_no_seccomp(uvm_plain):
     utils.assert_seccomp_level(test_microvm.firecracker_pid, "0")
 
 
-def test_default_seccomp_level(uvm_plain):
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_default_seccomp_level(uvm):
     """
     Test that Firecracker installs a seccomp filter by default.
     """
-    test_microvm = uvm_plain
+    test_microvm = uvm
     test_microvm.spawn()
     test_microvm.basic_config()
     test_microvm.start()

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -14,8 +14,10 @@ import requests
 
 from framework import utils
 from framework.ab_test import git_clone
+from framework.artifacts import pin_pci
 from framework.microvm import MicroVMFactory
 from framework.properties import global_props
+from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
 
 # Pinned due to issues introduced in https://github.com/speed47/spectre-meltdown-checker/pull/527
 CHECKER_URL = "https://raw.githubusercontent.com/speed47/spectre-meltdown-checker/3a822fdcf291ebb8bfbcb77aa216ac342c6b2f12/spectre-meltdown-checker.sh"
@@ -204,18 +206,32 @@ def microvm_factory_a(record_property):
 
 
 @pytest.fixture
-def uvm_any_a(microvm_factory_a, uvm_ctor, guest_kernel, rootfs, cpu_template_any):
-    """Return uvm with revision A firecracker
+def uvm_any_a(
+    microvm_factory_a,
+    uvm_lifecycle,
+    guest_kernel,
+    rootfs,
+    pci_enabled,
+    cpu_template,
+):
+    """Return uvm with revision A firecracker, matching uvm_any's lifecycle.
 
-    Since pytest caches fixtures, this guarantees uvm_any_a will match a vm from uvm_any.
-    See https://docs.pytest.org/en/stable/how-to/fixtures.html#fixtures-can-be-requested-more-than-once-per-test-return-values-are-cached
+    Both `uvm_any` and `uvm_any_a` depend on `uvm_lifecycle`, which guarantees
+    they pick the same booted/restored state per test run.
     """
-    return uvm_ctor(microvm_factory_a, guest_kernel, rootfs, cpu_template_any, False)
+    builder = (
+        microvm_factory_a.build_booted
+        if uvm_lifecycle == "booted"
+        else microvm_factory_a.build_restored
+    )
+    return builder(guest_kernel, rootfs, pci=pci_enabled, cpu_template=cpu_template)
 
 
-def test_check_vulnerability_files_ab(request, uvm_any_without_pci):
+@pin_pci(False)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
+def test_check_vulnerability_files_ab(request, uvm_any):
     """Test vulnerability files on guests"""
-    res_b = check_vulnerabilities_files_on_guest(uvm_any_without_pci)
+    res_b = check_vulnerabilities_files_on_guest(uvm_any)
     if global_props.buildkite_pr:
         # we only get the uvm_any_a fixtures if we need it
         uvm_a = request.getfixturevalue("uvm_any_a")
@@ -225,13 +241,15 @@ def test_check_vulnerability_files_ab(request, uvm_any_without_pci):
         assert not [x for x in res_b if "Vulnerable" in x["stdout"]]
 
 
+@pin_pci(False)
+@pin_cpu_template(ALL_CPU_TEMPLATES)
 def test_spectre_meltdown_checker_on_guest(
     request,
-    uvm_any_without_pci,
+    uvm_any,
     spectre_meltdown_checker,
 ):
     """Test with the spectre / meltdown checker on any supported guest."""
-    res_b = spectre_meltdown_checker.get_report_for_guest(uvm_any_without_pci)
+    res_b = spectre_meltdown_checker.get_report_for_guest(uvm_any)
     if global_props.buildkite_pr:
         # we only get the uvm_any_a fixtures if we need it
         uvm_a = request.getfixturevalue("uvm_any_a")
@@ -239,5 +257,5 @@ def test_spectre_meltdown_checker_on_guest(
         assert res_b <= res_a
     else:
         assert res_b == spectre_meltdown_checker.expected_vulnerabilities(
-            uvm_any_without_pci.cpu_template_name
+            uvm_any.cpu_template_name
         )


### PR DESCRIPTION
## Changes

- Refactor test fixtures to centre around a single `uvm` fixture. 
- Update all tests to use new fixtures (NB: this PR does not try to alter the restrictions on test cases that run, it should be a 1:1 mapping from old to new)
- Updated `tests/README.md` to reflect the new fixtures

## Reason

Fixtures had become rather fragmented and unwieldy. With our current system, new test dimensions (e.g. PCI most recently) encourage new fixtures to be created to isolate values of the dimension. 

With this PR, we take the approach of parameterizing the single `uvm` fixture. The fixture is open by default (tests all dimension values), so restrictions must be applied to limit the cases tested where necessary. This can be done either via module-level `pytestmark` assignments, or on individual tests using annotations. Some helpers have been defined to simplify the syntax for this (e.g. `pin_guest_kernel()`). This approach has the additional benefit of forcing developers to think about the restrictions they need to enforce on the test cases, rather than just picking the nearest fixture.

Primarily, this centralisation makes it easier to add new dimensions to existing tests, with the trade-off being that we must annotate functions where the new dimension is not to be tested.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
