### PR TITLE
Provide initial randomness for aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to
   Advertise MTU to the guest via `VIRTIO_NET_F_MTU` using a new optional `mtu`
   field in the `network-interfaces` API. When set, a compatible guest driver
   will configure the interface with the specified MTU.
+- [#5906](https://github.com/firecracker-microvm/firecracker/pull/5906): Add
+  `rng-seed` FDT node for aarch64 guests which provides an initial random seed
+  for the guest to use. This helps older aarch64 machines which do not have
+  hardware random generators.
 
 ### Changed
 

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -8,6 +8,7 @@
 use std::ffi::CString;
 use std::fmt::Debug;
 
+use aws_lc_rs::rand;
 use vm_fdt::{Error as VmFdtError, FdtWriter, FdtWriterNode};
 use vm_memory::{GuestMemoryError, GuestMemoryRegion};
 
@@ -275,6 +276,10 @@ fn create_chosen_node(
     // Prevent the kernel from reassigning PCI BAR addresses.
     // https://elixir.bootlin.com/linux/v6.19.8/source/drivers/pci/of.c#L255
     fdt.property_u32("linux,pci-probe-only", 1)?;
+
+    let mut rng_seed = [0u8; 64];
+    rand::fill(&mut rng_seed).expect("could not generate rng-seed");
+    fdt.property("rng-seed", &rng_seed)?;
 
     fdt.end_node(chosen)?;
 


### PR DESCRIPTION
## Changes
Add `rng-seed` node to the FDT on aarch64 to help VMs booted on the older hosts which do not have hardware rng device to get initial randomness.

## Reason
Help older instances to run VMs with good initial entropy.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
