### PR TITLE
fix(tests): make serial reads more resilient after snapshot

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -1469,3 +1469,23 @@ class Serial:
                 assert False
 
         return rx_str
+
+    def drain_until_idle(self, idle_seconds=1):
+        """Read and discard serial output until the console is idle.
+
+        Returns once no new output has arrived for idle_seconds.
+        Used after snapshot restore to let kernel messages (e.g. crng reseeded)
+        finish before sending input, avoiding the input being swallowed while
+        the kernel holds the console lock.
+        """
+        last_activity = time.time()
+        start = time.time()
+        while True:
+            now = time.time()
+            if (now - start) >= self.RX_TIMEOUT_S:
+                break
+            ch = self.rx_char()
+            if ch:
+                last_activity = now
+            elif now - last_activity >= idle_seconds:
+                break

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -48,11 +48,10 @@ def test_serial_after_snapshot(uvm_plain, microvm_factory):
     vm.restore_from_snapshot(snapshot, resume=True)
     serial = Serial(vm)
     serial.open()
-    # We need to send a newline to signal the serial to flush
-    # the login content.
+    # After restore, the kernel may emit messages (e.g. crng reseeded on 6.1)
+    # that hold the console lock. Wait for those to finish before sending input.
+    serial.drain_until_idle()
     serial.tx("")
-
-    # looking for the # prompt at the end
     serial.rx(vm.distro.shell_prompt)
     serial.tx("pwd")
     res = serial.rx("#")


### PR DESCRIPTION
## Changes

- Add `drain_until_idle` method to `Serial` class in integ test framework
- Call `drain_until_idle` as part of `test_serial_after_snapshot`

## Reason

PR #5732 made `test_serial_after_snapshot` flaky. The reason seems to be that, after snapshot restore on 6.1, the guest kernel emits `crng reseeded after virtual machine fork` ([link](https://github.com/amazonlinux/linux/blob/e7ae89a0c97ce2b68b0983cd01eda67cf373517d/drivers/char/random.c#L983)). This log and the shell prompt were racing, which occasionally led to the `Serial::rx` method reading the log message instead of the shell prompt / `pwd` output. 

By introducing the `drain_until_idle` method, we keep reading until nothing new is emitted for 1s. After that point we can start checking for the shell prompt + `pwd` output.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
