### PR TITLE
fix: don't panic when MSI-X interrupt drop fails

### DIFF
--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -194,8 +194,16 @@ impl Drop for MsixVectorGroup {
             .lock()
             .expect("Poisoned lock");
         for vector in &self.vectors {
-            // SAFETY: we allocated gsi from this allocator.
-            allocator.gsi_msi_allocator.free_id(vector.gsi).unwrap();
+            // Under correct operation, an error should never be returned here. GSIs are allocated
+            // by the same allocator, so freeing them should always work. This error is only
+            // reachable via a corrupted VM snapshot where either a device's serialized GSI list
+            // contains unallocated interrupts, or the allocator's state has been corrupted, and the
+            // next_id / freed_ids fields are incorrect.
+            // As part of Firecracker's threat model, snapshot files are assumed to be trusted,
+            // so the device and allocator states should always agree under compliant operation.
+            if let Err(e) = allocator.gsi_msi_allocator.free_id(vector.gsi) {
+                error!("Failed to free GSI {}: {e}", vector.gsi);
+            }
         }
     }
 }

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -1105,6 +1105,29 @@ pub(crate) mod tests {
         assert_eq!(gsis_before, gsis_after);
     }
 
+    #[test]
+    fn test_msi_vector_group_drop_does_not_panic_on_unallocated_gsi() {
+        // Regression test: A corrupted snapshot can produce a `MsixVectorGroup` holding
+        // a GSI that the allocator never handed out. Dropping such a group must not panic when it
+        // tries to free that GSI.
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
+        enable_irqchip(&mut vm);
+        let vm = Arc::new(vm);
+
+        // `GSI_MSI_END` is in range but, against a fresh allocator whose watermark still sits at
+        // `GSI_MSI_START`, it was never allocated. Restoring a group with it mimics a corrupted
+        // snapshot.
+        let group = MsixVectorGroup::restore(vm.clone(), &vec![crate::arch::GSI_MSI_END]).unwrap();
+
+        // Dropping must not panic even though the GSI cannot be freed.
+        drop(group);
+
+        // The allocator was untouched by the rejected free, so it still hands out GSIs from the
+        // start of the range.
+        let gsi = vm.resource_allocator().allocate_gsi_msi(1).unwrap();
+        assert_eq!(gsi, vec![crate::arch::GSI_MSI_START]);
+    }
+
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_restore_state_resource_allocator() {


### PR DESCRIPTION
## Changes

- Instead of panicking, log an error if freeing an MSI-X interrupt fails
- Add a regression unit test to ensure that panics don't occur in this case

## Reason

**There can only be mismatched interrupts if a VM is restored from a tampered snapshot state file**
This panic was identified by the fuzzer mutating the snapshot state to have a mismatch between interrupts allocated to a device and the interrupt allocator state. Under Firecracker's threat model, snapshot files are assumed trusted and untampered, so this condition should never be encountered under correct operation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
