### PR TITLE
docs: add Marco Marangoni to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@ Firecracker is maintained by a dedicated team within Amazon:
 - Jack Thomson <jackabt@amazon.com>
 - James Curtis <jxcurtis@amazon.com>
 - Jay Chung <jaehoc@amazon.com>
+- Marco Marangoni <mamarang@amazon.com>
 - Michael Zoumboulakis <zoumboul@amazon.com>
 - Riccardo Mancini <mancio@amazon.com>
 - Takahiro Itazuri <itazur@amazon.com>


### PR DESCRIPTION
## Changes

Add Marco Marangoni to `MAINTAINERS.md`.

## Reason

New team member of `compute-capsule` team.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
  - It actually fails with `tests/framework/microvm.py:6:0: C0302: Too many lines in module (1491/1000) (too-many-lines)`, but seems unrelated to this PR
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
