### PR TITLE
refactor(gdb): use cfg_select! for arch-specific gdbstub imports

### DIFF
--- a/src/vmm/src/gdb/target.rs
+++ b/src/vmm/src/gdb/target.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cfg_select;
 use std::collections::HashMap;
 use std::sync::mpsc::{Receiver, RecvError};
 use std::sync::{Arc, Mutex, PoisonError};
@@ -19,14 +20,16 @@ use gdbstub::target::ext::breakpoints::{
 };
 use gdbstub::target::ext::thread_extra_info::{ThreadExtraInfo, ThreadExtraInfoOps};
 use gdbstub::target::{Target, TargetError, TargetResult};
-#[cfg(target_arch = "aarch64")]
-use gdbstub_arch::aarch64::AArch64 as GdbArch;
-#[cfg(target_arch = "aarch64")]
-use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
-#[cfg(target_arch = "x86_64")]
-use gdbstub_arch::x86::X86_64_SSE as GdbArch;
-#[cfg(target_arch = "x86_64")]
-use gdbstub_arch::x86::reg::X86_64CoreRegs as CoreRegs;
+cfg_select! {
+    target_arch = "aarch64" => {
+        use gdbstub_arch::aarch64::AArch64 as GdbArch;
+        use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
+    }
+    target_arch = "x86_64" => {
+        use gdbstub_arch::x86::X86_64_SSE as GdbArch;
+        use gdbstub_arch::x86::reg::X86_64CoreRegs as CoreRegs;
+    }
+}
 use vm_memory::{Bytes, GuestAddress, GuestMemoryError};
 
 use super::arch;


### PR DESCRIPTION
## Changes
Replace the four stacked `#[cfg(target_arch = "...")]` attributes that import the  architecture-specific gdbstub register types (`GdbArch` and `CoreRegs`) in   `src/vmm/src/gdb/target.rs` with a single `cfg_select!` block, and add the required `use std::cfg_select;` import.

## Reason
`cfg_select!` was stabilized in Rust 1.95.0 (the pinned toolchain). Grouping the per-architecture `GdbArch`/`CoreRegs` selection into one `cfg_select!` block reads  clearer than four separate `#[cfg]` attributes. No functional change.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
