### PR TITLE
fix(buildkite): build helper binaries for release QA pipeline

### DIFF
--- a/.buildkite/pipeline_release_qa.py
+++ b/.buildkite/pipeline_release_qa.py
@@ -8,6 +8,13 @@ Buildkite pipeline for release QA
 
 from common import BKPipeline
 
+HELPER_BINARIES = [
+    "snapshot-editor",
+    "seccompiler-bin",
+    "cpu-template-helper",
+    "rebase-snap",
+]
+
 pipeline = BKPipeline(with_build_step=False)
 
 # NOTE: we need to escape $ using $$ otherwise buildkite tries to replace it instead of the shell
@@ -38,6 +45,30 @@ pipeline.build_group_per_arch(
             "for f in $$RELEASE_DIR/*-$$(uname -m); do"
             "  mv $$f $$OUT_DIR/$$(basename $$f $$RELEASE_SUFFIX);"
             "  mv $$f.debug $$OUT_DIR/$$(basename $$f $$RELEASE_SUFFIX).debug;"
+            "done"
+        ),
+        'buildkite-agent artifact upload "release-$$VERSION/**/*"',
+    ],
+    depends_on_build=False,
+)
+
+# The S3 release contains only firecracker and jailer, but some tests resolve
+# helper binaries from the same --binary-dir. Build only those helpers on the
+# agent and stage them next to the downloaded release binaries. The dev path's
+# make_release already produces these.
+pipeline.build_group_per_arch(
+    "build-helpers",
+    **{"if": 'build.env("VERSION") != "dev"'},
+    command=[
+        "CARGO_TARGET=$$(uname -m)-unknown-linux-musl",
+        (
+            "./tools/devtool -y sh cargo build --target $$CARGO_TARGET --release "
+            + " ".join(f"--bin {binary}" for binary in HELPER_BINARIES)
+        ),
+        "mkdir -p release-$$VERSION/$$(uname -m)/",
+        (
+            "for f in " + " ".join(HELPER_BINARIES) + "; do"
+            "  cp build/cargo_target/$$CARGO_TARGET/release/$$f release-$$VERSION/$$(uname -m)/;"
             "done"
         ),
         'buildkite-agent artifact upload "release-$$VERSION/**/*"',


### PR DESCRIPTION

## Changes

Add a new step `build-helpers` to the release QA pipeline, only run when `VERSION` env variable is set. This step explicitly builds helper binaries (e.g. snapshot-editor) and uploads them to be used in the custom binary dir

## Reason

PR #5736 fixed an issue where the `snapshot-editor` binary was being pulled from the default binary directory, even when a custom `--binary-dir` was specified. The release QA pipeline erroneously relied on this behaviour — when the `VERSION` env variable is set, a custom `--binary-dir`  only populated with the Firecracker and Jailer bins is used. It then relied on the snapshot-editor being present in the default location, despite the custom dir being supplied. 

To fix this, we just ensure that we push the helper binaries to the custom dir.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
