### PR TITLE
Fix build paper-cuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tags
 /resources/linux
 /resources/x86_64
 /resources/aarch64
+redundant_seccomp_rules_build

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint:disable=too-many-lines
 
 """Classes for working with microVMs.
 
@@ -8,8 +9,6 @@ destroy microvms.
 
 - Use the Firecracker Open API spec to populate Microvm API resource URLs.
 """
-
-# pylint:disable=too-many-lines
 
 import json
 import logging


### PR DESCRIPTION
## Changes

This PR fixes some paper-cuts related to building Firecracker. 

Specifically:
 - Add `redundant_seccomp_rules_build` to `.gitignore`. The file is created by `test_seccomp_no_redundant_rules.py`
 - Move pylint:disable immediately after docstring. This was causing `./tools/devtool checkstyle` to not pass for me

## Reason

Streamlining the development experience.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
