### PR TITLE
ci: unify some performance tests into single group

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -32,9 +32,24 @@ perf_test = {
         "devtool_opts": "-c 1-10 -m 0",
         "ab_opts": "--noise-threshold 0.1",
     },
+    "pmem": {
+        "label": "pmem",
+        "tests": "integration_tests/performance/test_pmem.py",
+        "devtool_opts": "-c 1-10 -m 0",
+    },
     "network": {
         "label": "network",
         "tests": "integration_tests/performance/test_network.py",
+        "devtool_opts": "-c 1-10 -m 0",
+    },
+    "vsock-throughput": {
+        "label": "vsock-throughput",
+        "tests": "integration_tests/performance/test_vsock.py",
+        "devtool_opts": "-c 1-10 -m 0",
+    },
+    "memory-hotplug": {
+        "label": "memory-hotplug",
+        "tests": "integration_tests/performance/test_hotplug_memory.py",
         "devtool_opts": "-c 1-10 -m 0",
     },
     "snapshot-latency": {
@@ -47,9 +62,9 @@ perf_test = {
         "tests": "integration_tests/performance/test_snapshot.py::test_population_latency",
         "devtool_opts": "-c 1-12 -m 0",
     },
-    "vsock-throughput": {
-        "label": "vsock-throughput",
-        "tests": "integration_tests/performance/test_vsock.py",
+    "misc": {
+        "label": "misc",
+        "tests": "integration_tests/performance/test_memory_overhead.py integration_tests/performance/test_boottime.py::test_boottime integration_tests/performance/test_process_startup_time.py integration_tests/performance/test_jailer.py integration_tests/performance/test_mmds.py",
         "devtool_opts": "-c 1-10 -m 0",
     },
     "memory-overhead": {
@@ -72,22 +87,22 @@ perf_test = {
         "tests": "integration_tests/performance/test_jailer.py",
         "devtool_opts": "-c 1-10 -m 0",
     },
-    "pmem": {
-        "label": "pmem",
-        "tests": "integration_tests/performance/test_pmem.py",
-        "devtool_opts": "-c 1-10 -m 0",
-    },
     "mmds": {
         "label": "mmds",
         "tests": "integration_tests/performance/test_mmds.py",
         "devtool_opts": "-c 1-10 -m 0",
     },
-    "memory-hotplug": {
-        "label": "memory-hotplug",
-        "tests": "integration_tests/performance/test_hotplug_memory.py",
-        "devtool_opts": "-c 1-10 -m 0",
-    },
 }
+
+# These can only be selected by manually providing `--tests` argument otherwise
+# the number of unique tasks we would create is too big for BK to handle
+only_manually_selected_tests = [
+    "memory-overhead",
+    "boottime",
+    "process-startup",
+    "jailer",
+    "mmds",
+]
 
 REVISION_A = os.environ.get("REVISION_A")
 REVISION_B = os.environ.get("REVISION_B")
@@ -131,7 +146,14 @@ pipeline = BKPipeline(
     env={"FC_TEST_DUMP_ON_FAILURE": "1"},
 )
 
-tests = [perf_test[test] for test in pipeline.args.test or perf_test.keys()]
+if pipeline.args.test:
+    tests = [perf_test[test] for test in pipeline.args.test]
+else:
+    tests = []
+    for test_name, test_description in perf_test.items():
+        if test_name not in only_manually_selected_tests:
+            tests.append(test_description)
+
 for test in tests:
     devtool_opts = test.pop("devtool_opts")
     test_selector = test.pop("tests")


### PR DESCRIPTION
## Changes
With addition of 6.18 host kernel, we now run
12 (instance types) * 3 (host kernels) * 14 (test groups) = 504 jobs The BuildKite has a limit of 500 jobs.

To fix this unite small test groups into a single one. The total runtime of them should be approximately same as the runtime of longer test like block/net etc.
This cuts the number of jobs to 12 * 3 * 10 = 360 which is just a more than what it was before introduction of 3rd host kernel.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
