### PR TITLE
virtio-blk: add async discard support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - [#5908](https://github.com/firecracker-microvm/firecracker/pull/5908): Add
   opt-in virtio-blk discard support for writable `Sync` IO engine drives through
   the `discard` drive configuration field.
+- [#5935](https://github.com/firecracker-microvm/firecracker/pull/5935): Add
+  virtio-blk discard support for writable `Async` IO engine drives using regular
+  backing files or block-device backing stores on host kernels that support
+  `BLOCK_URING_CMD_DISCARD`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 ### Added
 
+- [#5908](https://github.com/firecracker-microvm/firecracker/pull/5908): Add
+  opt-in virtio-blk discard support for writable `Sync` IO engine drives through
+  the `discard` drive configuration field.
+
 ### Changed
 
 ### Deprecated

--- a/docs/api_requests/block-discard.md
+++ b/docs/api_requests/block-discard.md
@@ -1,0 +1,43 @@
+# Block device discard
+
+Firecracker can expose virtio-blk discard support to Linux guests. When enabled,
+the guest can issue discard/TRIM requests, for example through `fstrim`, and
+Firecracker forwards those requests to the backing storage.
+
+Discard is configured per virtio-block device through the `discard` field in the
+`PUT /drives/{drive_id}` request. It is disabled by default.
+
+## Supported configuration
+
+Discard is currently supported only for writable virtio-block devices using the
+`Sync` IO engine. It is not supported for:
+
+- read-only drives;
+- `Async` IO engine drives;
+- vhost-user block devices.
+
+For regular backing files, Firecracker uses hole punching. For block-device
+backends, Firecracker uses `BLKDISCARD`.
+
+## Example configuration
+
+```bash
+curl --unix-socket ${socket} -i \
+     -X PUT "http://localhost/drives/rootfs" \
+     -H "accept: application/json" \
+     -H "Content-Type: application/json" \
+     -d "{
+             \"drive_id\": \"rootfs\",
+             \"path_on_host\": \"${drive_path}\",
+             \"is_root_device\": true,
+             \"is_read_only\": false,
+             \"io_engine\": \"Sync\",
+             \"discard\": true
+         }"
+```
+
+After the guest boots, Linux guests can usually issue discard requests with:
+
+```bash
+fstrim -av
+```

--- a/docs/api_requests/block-discard.md
+++ b/docs/api_requests/block-discard.md
@@ -9,15 +9,20 @@ Discard is configured per virtio-block device through the `discard` field in the
 
 ## Supported configuration
 
-Discard is currently supported only for writable virtio-block devices using the
-`Sync` IO engine. It is not supported for:
+Discard is currently supported only for writable virtio-block devices. It is not
+supported for:
 
 - read-only drives;
-- `Async` IO engine drives;
 - vhost-user block devices.
 
 For regular backing files, Firecracker uses hole punching. For block-device
-backends, Firecracker uses `BLKDISCARD`.
+backends, Firecracker uses `BLKDISCARD` with the `Sync` IO engine and
+`BLOCK_URING_CMD_DISCARD` with the `Async` IO engine.
+
+When discard is enabled with the `Async` IO engine, regular backing files
+require host support for `IORING_OP_FALLOCATE`. Block-device backing stores
+additionally require host support for `BLOCK_URING_CMD_DISCARD`, which is
+available starting with Linux 6.12.
 
 ## Example configuration
 
@@ -31,7 +36,7 @@ curl --unix-socket ${socket} -i \
              \"path_on_host\": \"${drive_path}\",
              \"is_root_device\": true,
              \"is_read_only\": false,
-             \"io_engine\": \"Sync\",
+             \"io_engine\": \"Async\",
              \"discard\": true
          }"
 ```

--- a/docs/api_requests/block-io-engine.md
+++ b/docs/api_requests/block-io-engine.md
@@ -59,6 +59,12 @@ If a block device is configured with the `Async` io_engine on a host kernel
 older than 5.10.51, the API call will return a 400 Bad Request, with a
 suggestive error message.
 
+When the `discard` block option is enabled with the `Async` IO engine,
+Firecracker uses `IORING_OP_FALLOCATE` for regular backing files. For block
+device backing stores, async discard requires the kernel block uring discard
+command (`BLOCK_URING_CMD_DISCARD`), which is available starting with Linux
+6.12.
+
 ## Performance considerations
 
 The performance is strictly tied to the host kernel version. The gathered data

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -43,6 +43,19 @@
                 "syscall": "fsync"
             },
             {
+                "syscall": "fallocate",
+                "comment": "Used by the VirtIO block device to punch holes for discard on regular backing files",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE"
+                    }
+                ]
+            },
+            {
                 "syscall": "close"
             },
             {
@@ -516,6 +529,19 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 0
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Used by the VirtIO block device to pass discard through to block-device backing files",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4727,
+                        "comment": "BLKDISCARD"
                     }
                 ]
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -43,6 +43,19 @@
                 "syscall": "fsync"
             },
             {
+                "syscall": "fallocate",
+                "comment": "Used by the VirtIO block device to punch holes for discard on regular backing files",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 3,
+                        "comment": "FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE"
+                    }
+                ]
+            },
+            {
                 "syscall": "close"
             },
             {
@@ -568,6 +581,19 @@
                         "op": "eq",
                         "val": 21506,
                         "comment": "TCSETS"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Used by the VirtIO block device to pass discard through to block-device backing files",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4727,
+                        "comment": "BLKDISCARD"
                     }
                 ]
             },

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1238,6 +1238,14 @@ definitions:
         description:
           Is block read only.
           This field is required for virtio-block config and should be omitted for vhost-user-block configuration.
+      discard:
+        type: boolean
+        description:
+          Enables virtio-blk discard support. When enabled, the guest can issue
+          discard/TRIM requests for this drive. Only supported for writable
+          virtio-block devices using the Sync IO engine.
+          This field is optional for virtio-block config and should be omitted for vhost-user-block configuration.
+        default: false
       path_on_host:
         type: string
         description:

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1243,7 +1243,9 @@ definitions:
         description:
           Enables virtio-blk discard support. When enabled, the guest can issue
           discard/TRIM requests for this drive. Only supported for writable
-          virtio-block devices using the Sync IO engine.
+          virtio-block devices. Async IO engine block-device backends require
+          host support for BLOCK_URING_CMD_DISCARD, available starting with
+          Linux 6.12.
           This field is optional for virtio-block config and should be omitted for vhost-user-block configuration.
         default: false
       path_on_host:

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -894,6 +894,7 @@ pub(crate) mod tests {
                 cache_type: custom_block_cfg.cache_type,
 
                 is_read_only: Some(custom_block_cfg.is_read_only),
+                discard: None,
                 path_on_host: Some(
                     block_files
                         .last()

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -886,6 +886,7 @@ pub(crate) mod tests {
             is_root_device: is_root,
             cache_type: CacheType::Unsafe,
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(f.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: None,

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -67,9 +67,10 @@ impl TryFrom<&BlockDeviceConfig> for VhostUserBlockConfig {
     type Error = VhostUserBlockError;
 
     fn try_from(value: &BlockDeviceConfig) -> Result<Self, Self::Error> {
-        if let (Some(socket), None, None, None, None) = (
+        if let (Some(socket), None, None, None, None, None) = (
             &value.socket,
             &value.is_read_only,
+            &value.discard,
             &value.path_on_host,
             &value.rate_limiter,
             &value.file_engine_type,
@@ -97,6 +98,7 @@ impl From<VhostUserBlockConfig> for BlockDeviceConfig {
             cache_type: value.cache_type,
 
             is_read_only: None,
+            discard: None,
             path_on_host: None,
             rate_limiter: None,
             file_engine_type: None,
@@ -409,6 +411,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: None,
+            discard: None,
             path_on_host: None,
             rate_limiter: None,
             file_engine_type: None,
@@ -424,6 +427,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            discard: None,
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
@@ -439,6 +443,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            discard: None,
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -30,7 +30,7 @@ use crate::devices::virtio::block::CacheType;
 use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, BlockMetricsPerDevice};
 use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::{
-    VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES,
+    VIRTIO_BLK_F_DISCARD, VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES,
 };
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
@@ -220,6 +220,8 @@ pub struct VirtioBlockConfig {
     /// If set to true, the drive is opened in read-only mode. Otherwise, the
     /// drive is opened as read-write.
     pub is_read_only: bool,
+    /// If set to true, the device advertises discard support to the guest.
+    pub discard: bool,
     /// Path of the backing file on the host
     pub path_on_host: String,
     /// Rate Limiter for I/O operations.
@@ -242,6 +244,7 @@ impl TryFrom<&BlockDeviceConfig> for VirtioBlockConfig {
                 cache_type: value.cache_type,
 
                 is_read_only: value.is_read_only.unwrap_or(false),
+                discard: value.discard.unwrap_or(false),
                 path_on_host: path_on_host.clone(),
                 rate_limiter: value.rate_limiter,
                 file_engine_type: value.file_engine_type.unwrap_or_default(),
@@ -261,6 +264,7 @@ impl From<VirtioBlockConfig> for BlockDeviceConfig {
             cache_type: value.cache_type,
 
             is_read_only: Some(value.is_read_only),
+            discard: Some(value.discard),
             path_on_host: Some(value.path_on_host),
             rate_limiter: value.rate_limiter,
             file_engine_type: Some(value.file_engine_type),
@@ -315,6 +319,10 @@ impl VirtioBlock {
     ///
     /// The given file must be seekable and sizable.
     pub fn new(config: VirtioBlockConfig) -> Result<VirtioBlock, VirtioBlockError> {
+        if config.discard && config.file_engine_type == FileEngineType::Async {
+            return Err(VirtioBlockError::DiscardAsyncUnsupported);
+        }
+
         let disk_properties = DiskProperties::new(
             config.path_on_host,
             config.is_read_only,
@@ -336,6 +344,8 @@ impl VirtioBlock {
 
         if config.is_read_only {
             avail_features |= 1u64 << VIRTIO_BLK_F_RO;
+        } else if config.discard {
+            avail_features |= 1u64 << VIRTIO_BLK_F_DISCARD;
         };
 
         let queue_evts = [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?];
@@ -376,6 +386,7 @@ impl VirtioBlock {
             is_root_device: self.root_device,
             partuuid: self.partuuid.clone(),
             is_read_only: self.read_only,
+            discard: self.avail_features & (1u64 << VIRTIO_BLK_F_DISCARD) != 0,
             cache_type: self.cache_type,
             rate_limiter: rl.into_option(),
             file_engine_type: self.file_engine_type(),
@@ -752,6 +763,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            discard: None,
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Default::default(),
@@ -767,6 +779,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: None,
+            discard: None,
             path_on_host: None,
             rate_limiter: None,
             file_engine_type: Default::default(),
@@ -782,6 +795,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            discard: None,
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Default::default(),
@@ -841,6 +855,46 @@ mod tests {
             }
             assert_eq!(block.acked_features, features);
         }
+    }
+
+    #[test]
+    fn test_discard_feature() {
+        let f = TempFile::new().unwrap();
+        f.as_file().set_len(0x1000).unwrap();
+        let path = f.as_path().to_str().unwrap().to_string();
+        let config = VirtioBlockConfig {
+            drive_id: "test".to_string(),
+            path_on_host: path.clone(),
+            is_root_device: false,
+            partuuid: None,
+            is_read_only: false,
+            discard: true,
+            cache_type: CacheType::Unsafe,
+            rate_limiter: None,
+            file_engine_type: FileEngineType::Sync,
+        };
+
+        let block = VirtioBlock::new(config).unwrap();
+        assert_eq!(
+            block.avail_features & (1u64 << VIRTIO_BLK_F_DISCARD),
+            1u64 << VIRTIO_BLK_F_DISCARD
+        );
+
+        let async_config = VirtioBlockConfig {
+            drive_id: "test".to_string(),
+            path_on_host: path,
+            is_root_device: false,
+            partuuid: None,
+            is_read_only: false,
+            discard: true,
+            cache_type: CacheType::Unsafe,
+            rate_limiter: None,
+            file_engine_type: FileEngineType::Async,
+        };
+        assert!(matches!(
+            VirtioBlock::new(async_config),
+            Err(VirtioBlockError::DiscardAsyncUnsupported)
+        ));
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -97,6 +97,7 @@ impl DiskProperties {
         disk_image_path: String,
         is_disk_read_only: bool,
         file_engine_type: FileEngineType,
+        discard: bool,
     ) -> Result<Self, VirtioBlockError> {
         let mut disk_image = Self::open_file(&disk_image_path, is_disk_read_only)?;
         let disk_size = Self::file_size(&disk_image_path, &mut disk_image)?;
@@ -104,7 +105,7 @@ impl DiskProperties {
 
         Ok(Self {
             file_path: disk_image_path,
-            file_engine: FileEngine::from_file(disk_image, file_engine_type)
+            file_engine: FileEngine::from_file(disk_image, file_engine_type, discard)
                 .map_err(VirtioBlockError::FileEngine)?,
             nsectors: disk_size >> SECTOR_SHIFT,
             image_id,
@@ -319,14 +320,11 @@ impl VirtioBlock {
     ///
     /// The given file must be seekable and sizable.
     pub fn new(config: VirtioBlockConfig) -> Result<VirtioBlock, VirtioBlockError> {
-        if config.discard && config.file_engine_type == FileEngineType::Async {
-            return Err(VirtioBlockError::DiscardAsyncUnsupported);
-        }
-
         let disk_properties = DiskProperties::new(
             config.path_on_host,
             config.is_read_only,
             config.file_engine_type,
+            config.discard,
         )?;
 
         let rate_limiter = config
@@ -451,6 +449,7 @@ impl VirtioBlock {
                             head.index,
                             &active_state.mem,
                             &self.metrics,
+                            self.acked_features & (1u64 << VIRTIO_BLK_F_DISCARD) != 0,
                         )
                     }
                     Err(err) => {
@@ -745,9 +744,9 @@ mod tests {
     use crate::check_metric_after_block;
     use crate::devices::virtio::block::virtio::IO_URING_NUM_ENTRIES;
     use crate::devices::virtio::block::virtio::test_utils::{
-        default_block, read_blk_req_descriptors, set_queue, set_rate_limiter,
-        simulate_async_completion_event, simulate_queue_and_async_completion_events,
-        simulate_queue_event,
+        RequestDescriptorChain, default_block, read_blk_req_descriptors, set_queue,
+        set_rate_limiter, simulate_async_completion_event,
+        simulate_queue_and_async_completion_events, simulate_queue_event,
     };
     use crate::devices::virtio::queue::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
     use crate::devices::virtio::test_utils::{VirtQueue, default_interrupt, default_mem};
@@ -813,16 +812,20 @@ mod tests {
         f.as_file().set_len(size).unwrap();
 
         for engine in [FileEngineType::Sync, FileEngineType::Async] {
-            let disk_properties =
-                DiskProperties::new(String::from(f.as_path().to_str().unwrap()), true, engine)
-                    .unwrap();
+            let disk_properties = DiskProperties::new(
+                String::from(f.as_path().to_str().unwrap()),
+                true,
+                engine,
+                false,
+            )
+            .unwrap();
 
             assert_eq!(size, u64::from(SECTOR_SIZE) * num_sectors);
             assert_eq!(disk_properties.nsectors, num_sectors);
             // Testing `backing_file.virtio_block_disk_image_id()` implies
             // duplicating that logic in tests, so skipping it.
 
-            let res = DiskProperties::new("invalid-disk-path".to_string(), true, engine);
+            let res = DiskProperties::new("invalid-disk-path".to_string(), true, engine, false);
             assert!(
                 matches!(res, Err(VirtioBlockError::BackingFile(_, _))),
                 "{:?}",
@@ -891,10 +894,59 @@ mod tests {
             rate_limiter: None,
             file_engine_type: FileEngineType::Async,
         };
-        assert!(matches!(
-            VirtioBlock::new(async_config),
-            Err(VirtioBlockError::DiscardAsyncUnsupported)
-        ));
+        let block = VirtioBlock::new(async_config).unwrap();
+        assert_eq!(
+            block.avail_features & (1u64 << VIRTIO_BLK_F_DISCARD),
+            1u64 << VIRTIO_BLK_F_DISCARD
+        );
+    }
+
+    #[test]
+    fn test_discard_requires_negotiated_feature() {
+        for engine in [FileEngineType::Sync, FileEngineType::Async] {
+            let f = TempFile::new().unwrap();
+            f.as_file().set_len(0x1000).unwrap();
+            let config = VirtioBlockConfig {
+                drive_id: "test".to_string(),
+                path_on_host: f.as_path().to_str().unwrap().to_string(),
+                is_root_device: false,
+                partuuid: None,
+                is_read_only: false,
+                discard: true,
+                cache_type: CacheType::Unsafe,
+                rate_limiter: None,
+                file_engine_type: engine,
+            };
+            let mut block = VirtioBlock::new(config).unwrap();
+            let mem = default_mem();
+            let interrupt = default_interrupt();
+            let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
+            set_queue(&mut block, 0, vq.create_queue());
+            block.activate(mem.clone(), interrupt).unwrap();
+
+            let chain = RequestDescriptorChain::new(&vq);
+            chain.set_header(RequestHeader::new(VIRTIO_BLK_T_DISCARD, 0));
+            chain.data_desc.flags.set(VIRTQ_DESC_F_NEXT);
+            chain.data_desc.len.set(16);
+
+            let mut discard_range = [0u8; 16];
+            discard_range[8..12].copy_from_slice(&1_u32.to_le_bytes());
+            mem.write_slice(&discard_range, GuestAddress(chain.data_desc.addr.get()))
+                .unwrap();
+
+            simulate_queue_event(&mut block, Some(true));
+
+            assert_eq!(vq.used.idx.get(), 1);
+            assert_eq!(vq.used.ring[0].get().id, 0);
+            assert_eq!(vq.used.ring[0].get().len, 1);
+            assert_eq!(
+                u32::from(
+                    mem.read_obj::<u8>(GuestAddress(chain.status_desc.addr.get()))
+                        .unwrap()
+                ),
+                VIRTIO_BLK_S_UNSUPP
+            );
+        }
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -21,7 +21,10 @@ use vmm_sys_util::eventfd::EventFd;
 
 use super::io::async_io;
 use super::request::*;
-use super::{BLOCK_QUEUE_SIZES, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError, io as block_io};
+use super::{
+    BLOCK_QUEUE_SIZES, DISCARD_SECTOR_ALIGNMENT, MAX_DISCARD_SECTORS, MAX_DISCARD_SEG,
+    SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError, io as block_io,
+};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::block::CacheType;
 use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, BlockMetricsPerDevice};
@@ -163,10 +166,38 @@ impl DiskProperties {
 #[repr(C)]
 pub struct ConfigSpace {
     pub capacity: u64,
+    pub size_max: u32,
+    pub seg_max: u32,
+    pub cylinders: u16,
+    pub heads: u8,
+    pub sectors: u8,
+    pub blk_size: u32,
+    pub physical_block_exp: u8,
+    pub alignment_offset: u8,
+    pub min_io_size: u16,
+    pub opt_io_size: u32,
+    pub wce: u8,
+    pub unused: u8,
+    pub num_queues: u16,
+    pub max_discard_sectors: u32,
+    pub max_discard_seg: u32,
+    pub discard_sector_alignment: u32,
 }
 
 // SAFETY: `ConfigSpace` contains only PODs in `repr(C)` or `repr(transparent)`, without padding.
 unsafe impl ByteValued for ConfigSpace {}
+
+impl ConfigSpace {
+    pub(crate) fn new(capacity_sectors: u64) -> Self {
+        Self {
+            capacity: capacity_sectors,
+            max_discard_sectors: MAX_DISCARD_SECTORS,
+            max_discard_seg: MAX_DISCARD_SEG,
+            discard_sector_alignment: DISCARD_SECTOR_ALIGNMENT,
+            ..Default::default()
+        }
+    }
+}
 
 /// Use this structure to set up the Block Device before booting the kernel.
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -311,9 +342,7 @@ impl VirtioBlock {
 
         let queues = BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect();
 
-        let config_space = ConfigSpace {
-            capacity: disk_properties.nsectors.to_le(),
-        };
+        let config_space = ConfigSpace::new(disk_properties.nsectors);
 
         Ok(VirtioBlock {
             avail_features,
@@ -536,7 +565,7 @@ impl VirtioBlock {
     /// Update the backing file and the config space of the block device.
     pub fn update_disk_image(&mut self, disk_image_path: String) -> Result<(), VirtioBlockError> {
         self.disk.update(disk_image_path, self.read_only)?;
-        self.config_space.capacity = self.disk.nsectors.to_le(); // virtio_block_config_space();
+        self.config_space = ConfigSpace::new(self.disk.nsectors);
 
         // Kick the driver to pick up the changes. (But only if the device is already activated).
         if self.is_activated() {
@@ -824,11 +853,14 @@ mod tests {
             // This will read the number of sectors.
             // The block's backing file size is 0x1000, so there are 8 (4096/512) sectors.
             // The config space is little endian.
-            let expected_config_space = ConfigSpace { capacity: 8 };
+            let expected_config_space = ConfigSpace::new(8);
             assert_eq!(actual_config_space, expected_config_space);
 
             // Invalid read.
-            let expected_config_space = ConfigSpace { capacity: 696969 };
+            let expected_config_space = ConfigSpace {
+                capacity: 696969,
+                ..Default::default()
+            };
             actual_config_space = expected_config_space;
             block.read_config(
                 std::mem::size_of::<ConfigSpace>() as u64 + 1,
@@ -845,7 +877,10 @@ mod tests {
         for engine in [FileEngineType::Sync, FileEngineType::Async] {
             let mut block = default_block(engine);
 
-            let expected_config_space = ConfigSpace { capacity: 696969 };
+            let expected_config_space = ConfigSpace {
+                capacity: 696969,
+                ..Default::default()
+            };
             block.write_config(0, expected_config_space.as_slice());
 
             let mut actual_config_space = ConfigSpace::default();
@@ -855,6 +890,7 @@ mod tests {
             // If privileged user writes to `/dev/mem`, in block config space - byte by byte.
             let expected_config_space = ConfigSpace {
                 capacity: 0x1122334455667788,
+                ..Default::default()
             };
             let expected_config_space_slice = expected_config_space.as_slice();
             for (i, b) in expected_config_space_slice.iter().enumerate() {
@@ -866,6 +902,7 @@ mod tests {
             // Invalid write.
             let new_config_space = ConfigSpace {
                 capacity: 0xDEADBEEF,
+                ..Default::default()
             };
             block.write_config(5, new_config_space.as_slice());
             // Make sure nothing got written.

--- a/src/vmm/src/devices/virtio/block/virtio/io/async_io.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/async_io.rs
@@ -1,9 +1,11 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ffi::CStr;
 use std::fmt::Debug;
 use std::fs::File;
 use std::os::fd::RawFd;
+use std::os::unix::fs::FileTypeExt;
 use std::os::unix::io::AsRawFd;
 
 use vm_memory::GuestMemoryError;
@@ -21,6 +23,8 @@ use crate::vstate::memory::{GuestAddress, GuestMemory, GuestMemoryExtension, Gue
 pub enum AsyncIoError {
     /// Not implemented
     NotImplemented,
+    /// Discard is not supported with this async backend on the host kernel.
+    DiscardUnsupported,
     /// IO: {0}
     IO(std::io::Error),
     /// IoUring: {0}
@@ -40,6 +44,13 @@ pub struct AsyncFileEngine {
     file: File,
     ring: IoUring<WrappedRequest>,
     completion_evt: EventFd,
+    discard_op: Option<AsyncDiscardOp>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AsyncDiscardOp {
+    BlockUringCmd,
+    Fallocate,
 }
 
 #[derive(Debug)]
@@ -70,46 +81,133 @@ impl WrappedRequest {
 }
 
 impl AsyncFileEngine {
+    const BLOCK_URING_CMD_DISCARD: u32 = 0x1200;
+    const FALLOC_FL_KEEP_SIZE: u32 = 0x01;
+    const FALLOC_FL_PUNCH_HOLE: u32 = 0x02;
+    const MIN_BLOCK_URING_DISCARD_KERNEL: (u32, u32) = (6, 12);
+
     fn new_ring(
         file: &File,
         completion_fd: RawFd,
+        discard_op: Option<AsyncDiscardOp>,
     ) -> Result<IoUring<WrappedRequest>, IoUringError> {
-        IoUring::new(
+        let mut restrictions = vec![
+            // Make sure we only allow operations on pre-registered fds.
+            Restriction::RequireFixedFds,
+            // Allowlist of opcodes.
+            Restriction::AllowOpCode(OpCode::Read),
+            Restriction::AllowOpCode(OpCode::Write),
+            Restriction::AllowOpCode(OpCode::Fsync),
+        ];
+        let mut required_ops = vec![OpCode::Read, OpCode::Write, OpCode::Fsync];
+        match discard_op {
+            Some(AsyncDiscardOp::Fallocate) => {
+                restrictions.push(Restriction::AllowOpCode(OpCode::Fallocate));
+                required_ops.push(OpCode::Fallocate);
+            }
+            Some(AsyncDiscardOp::BlockUringCmd) => {
+                restrictions.push(Restriction::AllowOpCode(OpCode::UringCmd));
+                required_ops.push(OpCode::UringCmd);
+            }
+            None => {}
+        }
+
+        IoUring::new_with_required_ops(
             u32::from(IO_URING_NUM_ENTRIES),
             vec![file],
-            vec![
-                // Make sure we only allow operations on pre-registered fds.
-                Restriction::RequireFixedFds,
-                // Allowlist of opcodes.
-                Restriction::AllowOpCode(OpCode::Read),
-                Restriction::AllowOpCode(OpCode::Write),
-                Restriction::AllowOpCode(OpCode::Fsync),
-            ],
+            restrictions,
             Some(completion_fd),
+            &required_ops,
         )
     }
 
-    pub fn from_file(file: File) -> Result<AsyncFileEngine, AsyncIoError> {
+    pub fn from_file(file: File, discard: bool) -> Result<AsyncFileEngine, AsyncIoError> {
         log_dev_preview_warning("Async file IO", Option::None);
 
         let completion_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(AsyncIoError::EventFd)?;
-        let ring =
-            Self::new_ring(&file, completion_evt.as_raw_fd()).map_err(AsyncIoError::IoUring)?;
+        let discard_op = Self::discard_op(&file, discard)?;
+        let ring = Self::new_ring(&file, completion_evt.as_raw_fd(), discard_op)
+            .map_err(AsyncIoError::IoUring)?;
 
         Ok(AsyncFileEngine {
             file,
             ring,
             completion_evt,
+            discard_op,
         })
     }
 
     pub fn update_file(&mut self, file: File) -> Result<(), AsyncIoError> {
-        let ring = Self::new_ring(&file, self.completion_evt.as_raw_fd())
+        let discard_op = Self::discard_op(&file, self.discard_op.is_some())?;
+        let ring = Self::new_ring(&file, self.completion_evt.as_raw_fd(), discard_op)
             .map_err(AsyncIoError::IoUring)?;
 
-        self.file = file;
         self.ring = ring;
+        self.file = file;
+        self.discard_op = discard_op;
         Ok(())
+    }
+
+    fn discard_op(file: &File, discard: bool) -> Result<Option<AsyncDiscardOp>, AsyncIoError> {
+        if !discard {
+            return Ok(None);
+        }
+
+        if file
+            .metadata()
+            .map_err(AsyncIoError::IO)?
+            .file_type()
+            .is_block_device()
+        {
+            // BLOCK_URING_CMD_DISCARD is introduced for block devices in Linux 6.12.
+            // IORING_OP_URING_CMD probing alone is not enough because older kernels can
+            // support uring commands for other file operations.
+            if !Self::host_kernel_at_least(Self::MIN_BLOCK_URING_DISCARD_KERNEL)
+                .map_err(AsyncIoError::IO)?
+            {
+                return Err(AsyncIoError::DiscardUnsupported);
+            }
+            Ok(Some(AsyncDiscardOp::BlockUringCmd))
+        } else {
+            Ok(Some(AsyncDiscardOp::Fallocate))
+        }
+    }
+
+    fn host_kernel_at_least((major, minor): (u32, u32)) -> Result<bool, std::io::Error> {
+        // SAFETY: An all-zeroed value for `libc::utsname` is valid.
+        let mut name: libc::utsname = unsafe { std::mem::zeroed() };
+        // SAFETY: The passed arg is a valid mutable reference of `libc::utsname`.
+        let ret = unsafe { libc::uname(&mut name) };
+        if ret != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        // SAFETY: The fields of `libc::utsname` are terminated by a null byte.
+        let release = unsafe { CStr::from_ptr(name.release.as_ptr()) }
+            .to_string_lossy()
+            .into_owned();
+        Self::kernel_release_at_least(&release, (major, minor)).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid kernel release")
+        })
+    }
+
+    fn parse_kernel_release(release: &str) -> Option<(u32, u32)> {
+        let mut parts = release
+            .split(|ch: char| !ch.is_ascii_digit() && ch != '.')
+            .next()
+            .unwrap_or("")
+            .split('.');
+
+        let host_major = parts.next()?.parse::<u32>().ok()?;
+        let host_minor = parts.next()?.parse::<u32>().ok()?;
+
+        Some((host_major, host_minor))
+    }
+
+    fn kernel_release_at_least(release: &str, (major, minor): (u32, u32)) -> Option<bool> {
+        let (host_major, host_minor) = Self::parse_kernel_release(release)?;
+
+        Some(host_major > major || (host_major == major && host_minor >= minor))
     }
 
     #[cfg(test)]
@@ -200,8 +298,42 @@ impl AsyncFileEngine {
             })
     }
 
-    pub fn discard(&mut self, _range: (u64, u64)) -> Result<u32, AsyncIoError> {
-        Err(AsyncIoError::NotImplemented)
+    pub fn push_discard(
+        &mut self,
+        range: (u64, u64),
+        req: PendingRequest,
+    ) -> Result<(), RequestError<AsyncIoError>> {
+        let wrapped_user_data = WrappedRequest::new(req);
+        let (offset, len) = range;
+        let operation = match self.discard_op {
+            Some(AsyncDiscardOp::Fallocate) => Operation::fallocate(
+                0,
+                Self::FALLOC_FL_KEEP_SIZE | Self::FALLOC_FL_PUNCH_HOLE,
+                offset,
+                len,
+                wrapped_user_data,
+            ),
+            Some(AsyncDiscardOp::BlockUringCmd) => Operation::block_discard(
+                0,
+                Self::BLOCK_URING_CMD_DISCARD,
+                offset,
+                len,
+                wrapped_user_data,
+            ),
+            None => {
+                return Err(RequestError {
+                    req: wrapped_user_data.req,
+                    error: AsyncIoError::NotImplemented,
+                });
+            }
+        };
+
+        self.ring
+            .push(operation)
+            .map_err(|(io_uring_error, data)| RequestError {
+                req: data.req,
+                error: AsyncIoError::IoUring(io_uring_error),
+            })
     }
 
     pub fn kick_submission_queue(&mut self) -> Result<(), AsyncIoError> {
@@ -252,5 +384,44 @@ impl AsyncFileEngine {
         });
 
         Ok(cqe)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    #[test]
+    fn test_kernel_release_at_least() {
+        assert_eq!(
+            AsyncFileEngine::kernel_release_at_least("6.11.0-1018-aws", (6, 12)),
+            Some(false)
+        );
+        assert_eq!(
+            AsyncFileEngine::kernel_release_at_least("6.12.0-1020-aws", (6, 12)),
+            Some(true)
+        );
+        assert_eq!(
+            AsyncFileEngine::kernel_release_at_least("6.17.0-29-generic", (6, 12)),
+            Some(true)
+        );
+        assert_eq!(
+            AsyncFileEngine::kernel_release_at_least("7.0.2-6-pve", (6, 12)),
+            Some(true)
+        );
+        assert_eq!(
+            AsyncFileEngine::kernel_release_at_least("not-a-kernel", (6, 12)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_discard_regular_file_uses_fallocate() {
+        let file = TempFile::new().unwrap().into_file();
+        let engine = AsyncFileEngine::from_file(file, true).unwrap();
+
+        assert_eq!(engine.discard_op, Some(AsyncDiscardOp::Fallocate));
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/io/async_io.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/async_io.rs
@@ -19,6 +19,8 @@ use crate::vstate::memory::{GuestAddress, GuestMemory, GuestMemoryExtension, Gue
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum AsyncIoError {
+    /// Not implemented
+    NotImplemented,
     /// IO: {0}
     IO(std::io::Error),
     /// IoUring: {0}
@@ -196,6 +198,10 @@ impl AsyncFileEngine {
                 req: data.req,
                 error: AsyncIoError::IoUring(io_uring_error),
             })
+    }
+
+    pub fn discard(&mut self, _range: (u64, u64)) -> Result<u32, AsyncIoError> {
+        Err(AsyncIoError::NotImplemented)
     }
 
     pub fn kick_submission_queue(&mut self) -> Result<(), AsyncIoError> {

--- a/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
@@ -57,10 +57,14 @@ pub enum FileEngine {
 }
 
 impl FileEngine {
-    pub fn from_file(file: File, engine_type: FileEngineType) -> Result<FileEngine, BlockIoError> {
+    pub fn from_file(
+        file: File,
+        engine_type: FileEngineType,
+        discard: bool,
+    ) -> Result<FileEngine, BlockIoError> {
         match engine_type {
             FileEngineType::Async => Ok(FileEngine::Async(
-                AsyncFileEngine::from_file(file).map_err(BlockIoError::Async)?,
+                AsyncFileEngine::from_file(file, discard).map_err(BlockIoError::Async)?,
             )),
             FileEngineType::Sync => Ok(FileEngine::Sync(SyncFileEngine::from_file(file))),
         }
@@ -163,11 +167,11 @@ impl FileEngine {
         req: PendingRequest,
     ) -> Result<FileEngineOk, RequestError<BlockIoError>> {
         match self {
-            FileEngine::Async(engine) => match engine.discard(range) {
-                Ok(count) => Ok(FileEngineOk::Executed(RequestOk { req, count })),
+            FileEngine::Async(engine) => match engine.push_discard(range, req) {
+                Ok(_) => Ok(FileEngineOk::Submitted),
                 Err(err) => Err(RequestError {
-                    req,
-                    error: BlockIoError::Async(err),
+                    req: err.req,
+                    error: BlockIoError::Async(err.error),
                 }),
             },
             FileEngine::Sync(engine) => match engine.discard(range) {
@@ -278,7 +282,7 @@ pub mod tests {
         let mem = create_mem();
         // Create backing file.
         let file = TempFile::new().unwrap().into_file();
-        let mut engine = FileEngine::from_file(file, FileEngineType::Sync).unwrap();
+        let mut engine = FileEngine::from_file(file, FileEngineType::Sync, false).unwrap();
 
         let data = vmm_sys_util::rand::rand_alphanumerics(FILE_LEN as usize)
             .as_bytes()
@@ -362,7 +366,7 @@ pub mod tests {
     fn test_async() {
         // Create backing file.
         let file = TempFile::new().unwrap().into_file();
-        let mut engine = FileEngine::from_file(file, FileEngineType::Async).unwrap();
+        let mut engine = FileEngine::from_file(file, FileEngineType::Async, false).unwrap();
 
         let data = vmm_sys_util::rand::rand_alphanumerics(FILE_LEN as usize)
             .as_bytes()

--- a/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
@@ -157,6 +157,29 @@ impl FileEngine {
         }
     }
 
+    pub fn discard(
+        &mut self,
+        range: (u64, u64),
+        req: PendingRequest,
+    ) -> Result<FileEngineOk, RequestError<BlockIoError>> {
+        match self {
+            FileEngine::Async(engine) => match engine.discard(range) {
+                Ok(count) => Ok(FileEngineOk::Executed(RequestOk { req, count })),
+                Err(err) => Err(RequestError {
+                    req,
+                    error: BlockIoError::Async(err),
+                }),
+            },
+            FileEngine::Sync(engine) => match engine.discard(range) {
+                Ok(count) => Ok(FileEngineOk::Executed(RequestOk { req, count })),
+                Err(err) => Err(RequestError {
+                    req,
+                    error: BlockIoError::Sync(err),
+                }),
+            },
+        }
+    }
+
     pub fn drain(&mut self, discard: bool) -> Result<(), BlockIoError> {
         match self {
             FileEngine::Async(engine) => engine.drain(discard).map_err(BlockIoError::Async),

--- a/src/vmm/src/devices/virtio/block/virtio/io/sync_io.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/sync_io.rs
@@ -3,6 +3,8 @@
 
 use std::fs::File;
 use std::io::{Seek, SeekFrom, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::FileTypeExt;
 
 use vm_memory::{GuestMemoryError, ReadVolatile, WriteVolatile};
 
@@ -10,6 +12,8 @@ use crate::vstate::memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum SyncIoError {
+    /// Discard: {0}
+    Discard(std::io::Error),
     /// Flush: {0}
     Flush(std::io::Error),
     /// Seek: {0}
@@ -27,6 +31,50 @@ pub struct SyncFileEngine {
 
 // SAFETY: `File` is send and ultimately a POD.
 unsafe impl Send for SyncFileEngine {}
+
+const BLKDISCARD: libc::Ioctl = 0x1277;
+const FALLOC_FL_KEEP_SIZE: libc::c_int = 0x01;
+const FALLOC_FL_PUNCH_HOLE: libc::c_int = 0x02;
+
+pub(super) fn discard_file(file: &File, range: (u64, u64)) -> Result<u32, std::io::Error> {
+    let file_type = file.metadata()?.file_type();
+    let (offset, len) = range;
+
+    if len == 0 {
+        return Ok(0);
+    }
+
+    if file_type.is_block_device() {
+        let mut range = [offset, len];
+        // SAFETY: file is a valid fd, BLKDISCARD expects a pointer to two u64 values
+        // representing byte offset and byte length.
+        let ret = unsafe { libc::ioctl(file.as_raw_fd(), BLKDISCARD, range.as_mut_ptr()) };
+        if ret < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    } else {
+        let off = libc::off_t::try_from(offset).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "discard offset overflow")
+        })?;
+        let len = libc::off_t::try_from(len).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "discard length overflow")
+        })?;
+        // SAFETY: file is a valid fd and fallocate does not retain the passed values.
+        let ret = unsafe {
+            libc::fallocate(
+                file.as_raw_fd(),
+                FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE,
+                off,
+                len,
+            )
+        };
+        if ret < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+
+    Ok(u32::try_from(len).unwrap_or(u32::MAX))
+}
 
 impl SyncFileEngine {
     pub fn from_file(file: File) -> SyncFileEngine {
@@ -80,5 +128,47 @@ impl SyncFileEngine {
         self.file.flush().map_err(SyncIoError::Flush)?;
         // Sync data out to physical media on host.
         self.file.sync_all().map_err(SyncIoError::SyncAll)
+    }
+
+    pub fn discard(&mut self, range: (u64, u64)) -> Result<u32, SyncIoError> {
+        discard_file(&self.file, range).map_err(SyncIoError::Discard)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::discard_file;
+
+    #[test]
+    fn test_discard_regular_file() {
+        let mut file = TempFile::new().unwrap().into_file();
+        file.write_all(&vec![0x5a; 4096]).unwrap();
+
+        match discard_file(&file, (1024, 2048)) {
+            Ok(discarded) => assert_eq!(discarded, 2048),
+            // Some filesystems do not support hole punching; that is a host/filesystem
+            // capability limitation, not a test failure for the regular discard path.
+            Err(err)
+                if matches!(
+                    err.raw_os_error(),
+                    Some(libc::EOPNOTSUPP) | Some(libc::ENOSYS)
+                ) =>
+            {
+                return;
+            }
+            Err(err) => panic!("discard failed: {err}"),
+        }
+
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let mut data = vec![0u8; 4096];
+        file.read_exact(&mut data).unwrap();
+
+        assert_eq!(&data[..1024], vec![0x5a; 1024].as_slice());
+        assert_eq!(&data[1024..3072], vec![0; 2048].as_slice());
+        assert_eq!(&data[3072..], vec![0x5a; 1024].as_slice());
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/io/sync_io.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/sync_io.rs
@@ -43,6 +43,9 @@ pub(super) fn discard_file(file: &File, range: (u64, u64)) -> Result<u32, std::i
     if len == 0 {
         return Ok(0);
     }
+    let discarded = u32::try_from(len).map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "discard length overflow")
+    })?;
 
     if file_type.is_block_device() {
         let mut range = [offset, len];
@@ -73,7 +76,7 @@ pub(super) fn discard_file(file: &File, range: (u64, u64)) -> Result<u32, std::i
         }
     }
 
-    Ok(u32::try_from(len).unwrap_or(u32::MAX))
+    Ok(discarded)
 }
 
 impl SyncFileEngine {

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -56,6 +56,8 @@ pub enum VirtioBlockError {
     InvalidDataLength,
     /// The requested operation would cause a seek beyond disk end.
     InvalidOffset,
+    /// Discard is not supported with the async IO engine.
+    DiscardAsyncUnsupported,
     /// Guest gave us a read only descriptor that protocol says to write to.
     UnexpectedReadOnlyDescriptor,
     /// Guest gave us a write only descriptor that protocol says to read from.

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -22,6 +22,15 @@ use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
 pub const SECTOR_SHIFT: u8 = 9;
 /// Size of block sector.
 pub const SECTOR_SIZE: u32 = (0x01_u32) << SECTOR_SHIFT;
+/// Maximum sectors accepted in a single discard range.
+///
+/// Keep this bounded so guest fstrim is split into predictable chunks instead
+/// of letting one large discard ioctl block the VMM thread for too long.
+pub const MAX_DISCARD_SECTORS: u32 = (128_u32 << 20) / SECTOR_SIZE;
+/// Maximum number of segments accepted in a single discard request.
+pub const MAX_DISCARD_SEG: u32 = 1;
+/// Discard alignment, expressed in 512-byte sectors.
+pub const DISCARD_SECTOR_ALIGNMENT: u32 = 1;
 /// The number of queues of block device.
 pub const BLOCK_NUM_QUEUES: usize = 1;
 pub const BLOCK_QUEUE_SIZES: [u16; BLOCK_NUM_QUEUES] = [FIRECRACKER_MAX_QUEUE_SIZE];

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -56,8 +56,6 @@ pub enum VirtioBlockError {
     InvalidDataLength,
     /// The requested operation would cause a seek beyond disk end.
     InvalidOffset,
-    /// Discard is not supported with the async IO engine.
-    DiscardAsyncUnsupported,
     /// Guest gave us a read only descriptor that protocol says to write to.
     UnexpectedReadOnlyDescriptor,
     /// Guest gave us a write only descriptor that protocol says to read from.

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -110,9 +110,7 @@ impl Persist<'_> for VirtioBlock {
         let avail_features = state.virtio_state.avail_features;
         let acked_features = state.virtio_state.acked_features;
 
-        let config_space = ConfigSpace {
-            capacity: disk_properties.nsectors.to_le(),
-        };
+        let config_space = ConfigSpace::new(disk_properties.nsectors);
 
         Ok(VirtioBlock {
             avail_features,
@@ -159,6 +157,7 @@ mod tests {
             is_root_device: false,
             partuuid: None,
             is_read_only: false,
+            discard: false,
             cache_type: CacheType::Writeback,
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
@@ -200,6 +199,7 @@ mod tests {
             is_root_device: false,
             partuuid: None,
             is_read_only: false,
+            discard: false,
             cache_type: CacheType::Unsafe,
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -13,7 +13,7 @@ use crate::devices::virtio::block::persist::BlockConstructorArgs;
 use crate::devices::virtio::block::virtio::device::FileEngineType;
 use crate::devices::virtio::block::virtio::metrics::BlockMetricsPerDevice;
 use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDeviceType};
-use crate::devices::virtio::generated::virtio_blk::VIRTIO_BLK_F_RO;
+use crate::devices::virtio::generated::virtio_blk::{VIRTIO_BLK_F_DISCARD, VIRTIO_BLK_F_RO};
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::rate_limiter::RateLimiter;
 use crate::rate_limiter::persist::RateLimiterState;
@@ -86,6 +86,7 @@ impl Persist<'_> for VirtioBlock {
         state: &Self::State,
     ) -> Result<Self, Self::Error> {
         let is_read_only = state.virtio_state.avail_features & (1u64 << VIRTIO_BLK_F_RO) != 0;
+        let discard = state.virtio_state.avail_features & (1u64 << VIRTIO_BLK_F_DISCARD) != 0;
         let rate_limiter = RateLimiter::restore((), &state.rate_limiter_state)
             .map_err(VirtioBlockError::RateLimiter)?;
 
@@ -93,6 +94,7 @@ impl Persist<'_> for VirtioBlock {
             state.disk_path.clone(),
             is_read_only,
             state.file_engine_type.into(),
+            discard,
         )?;
 
         let queue_evts = [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?];

--- a/src/vmm/src/devices/virtio/block/virtio/request.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/request.rs
@@ -263,7 +263,6 @@ pub struct Request {
     pub status_addr: GuestAddress,
     sector: u64,
     data_addr: GuestAddress,
-    discard_range: Option<(u64, u64)>,
 }
 
 impl Request {
@@ -282,7 +281,6 @@ impl Request {
             r#type: RequestType::from(request_header.request_type),
             sector: request_header.sector,
             data_addr: GuestAddress(0),
-            discard_range: None,
             data_len: 0,
             status_addr: GuestAddress(0),
         };
@@ -390,7 +388,10 @@ impl Request {
         let byte_len = u64::from(range.num_sectors)
             .checked_mul(u64::from(SECTOR_SIZE))
             .ok_or(VirtioBlockError::InvalidDataLength)?;
-        self.discard_range = Some((byte_offset, byte_len));
+        let byte_len = u32::try_from(byte_len).map_err(|_| VirtioBlockError::InvalidDataLength)?;
+
+        self.sector = byte_offset;
+        self.data_len = byte_len;
 
         Ok(())
     }
@@ -457,11 +458,8 @@ impl Request {
                     ));
                 }
 
-                disk.file_engine.discard(
-                    self.discard_range
-                        .expect("discard request missing validated range"),
-                    pending,
-                )
+                disk.file_engine
+                    .discard((self.sector, u64::from(self.data_len)), pending)
             }
             RequestType::Flush => disk.file_engine.flush(pending),
             RequestType::GetDeviceID => {
@@ -586,9 +584,17 @@ mod tests {
                 request.r#type,
                 RequestType::from(expected_header.request_type)
             );
-            assert_eq!(request.sector, expected_header.sector);
+            if request.r#type == RequestType::Discard {
+                let range: DiscardWriteZeroes = memory
+                    .read_obj(GuestAddress(self.data_desc.addr.get()))
+                    .unwrap();
+                assert_eq!(request.sector, range.sector * u64::from(SECTOR_SIZE));
+                assert_eq!(request.data_len, range.num_sectors * SECTOR_SIZE);
+            } else {
+                assert_eq!(request.sector, expected_header.sector);
+            }
 
-            if check_data {
+            if check_data && request.r#type != RequestType::Discard {
                 assert_eq!(request.data_addr.raw_value(), self.data_desc.addr.get());
                 assert_eq!(request.data_len, self.data_desc.len.get());
             }
@@ -999,7 +1005,6 @@ mod tests {
             status_addr,
             sector: sector & (NUM_DISK_SECTORS - sectors_len),
             data_addr,
-            discard_range: None,
         };
         let mut request_header = RequestHeader::new(virtio_request_id, request.sector);
 
@@ -1031,10 +1036,8 @@ mod tests {
                     request.data_addr,
                 )
                 .unwrap();
-                request.discard_range = Some((
-                    discard_sector * u64::from(SECTOR_SIZE),
-                    u64::from(SECTOR_SIZE),
-                ));
+                request.sector = discard_sector * u64::from(SECTOR_SIZE);
+                request.data_len = SECTOR_SIZE;
             }
         }
 

--- a/src/vmm/src/devices/virtio/block/virtio/request.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/request.rs
@@ -6,24 +6,27 @@
 // found in the THIRD-PARTY file.
 
 use std::convert::From;
+use std::mem::size_of;
 
 use vm_memory::GuestMemoryError;
 
-use super::{SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError, io as block_io};
+use super::{MAX_DISCARD_SECTORS, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError, io as block_io};
 use crate::devices::virtio::block::virtio::device::DiskProperties;
 use crate::devices::virtio::block::virtio::metrics::BlockDeviceMetrics;
 pub use crate::devices::virtio::generated::virtio_blk::{
     VIRTIO_BLK_ID_BYTES, VIRTIO_BLK_S_IOERR, VIRTIO_BLK_S_OK, VIRTIO_BLK_S_UNSUPP,
-    VIRTIO_BLK_T_FLUSH, VIRTIO_BLK_T_GET_ID, VIRTIO_BLK_T_IN, VIRTIO_BLK_T_OUT,
+    VIRTIO_BLK_T_DISCARD, VIRTIO_BLK_T_FLUSH, VIRTIO_BLK_T_GET_ID, VIRTIO_BLK_T_IN,
+    VIRTIO_BLK_T_OUT,
 };
 use crate::devices::virtio::queue::DescriptorChain;
 use crate::logger::{IncMetric, error};
 use crate::rate_limiter::{RateLimiter, TokenType};
-use crate::vstate::memory::{ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
+use crate::vstate::memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug)]
 pub enum IoErr {
     GetId(GuestMemoryError),
+    UnsupportedRequest(u32),
     PartialTransfer { completed: u32, expected: u32 },
     FileEngine(block_io::BlockIoError),
 }
@@ -32,6 +35,7 @@ pub enum IoErr {
 pub enum RequestType {
     In,
     Out,
+    Discard,
     Flush,
     GetDeviceID,
     Unsupported(u32),
@@ -42,6 +46,7 @@ impl From<u32> for RequestType {
         match value {
             VIRTIO_BLK_T_IN => RequestType::In,
             VIRTIO_BLK_T_OUT => RequestType::Out,
+            VIRTIO_BLK_T_DISCARD => RequestType::Discard,
             VIRTIO_BLK_T_FLUSH => RequestType::Flush,
             VIRTIO_BLK_T_GET_ID => RequestType::GetDeviceID,
             t => RequestType::Unsupported(t),
@@ -167,6 +172,9 @@ impl PendingRequest {
                 }
                 status
             }
+            (Ok(_), RequestType::Discard) => Status::Ok {
+                num_bytes_to_mem: 0,
+            },
             (Ok(_), RequestType::Flush) => {
                 block_metrics.flush_count.inc();
                 Status::Ok {
@@ -176,7 +184,9 @@ impl PendingRequest {
             (Ok(transferred_data_len), RequestType::GetDeviceID) => {
                 Status::from_data(self.data_len, transferred_data_len, true)
             }
-            (_, RequestType::Unsupported(op)) => Status::Unsupported { op },
+            (Err(IoErr::UnsupportedRequest(op)), _) | (_, RequestType::Unsupported(op)) => {
+                Status::Unsupported { op }
+            }
             (Err(err), _) => Status::IoErr {
                 num_bytes_to_mem: 0,
                 err,
@@ -206,6 +216,21 @@ pub struct RequestHeader {
 
 // SAFETY: Safe because RequestHeader only contains plain data.
 unsafe impl ByteValued for RequestHeader {}
+
+#[derive(Debug, Copy, Clone, Default)]
+#[repr(C)]
+pub struct DiscardWriteZeroes {
+    sector: u64,
+    num_sectors: u32,
+    flags: u32,
+}
+
+// SAFETY: Safe because DiscardWriteZeroes only contains plain data and has no padding.
+unsafe impl ByteValued for DiscardWriteZeroes {}
+
+fn discard_range_size() -> u32 {
+    u32::try_from(size_of::<DiscardWriteZeroes>()).expect("discard range size fits in u32")
+}
 
 impl RequestHeader {
     pub fn new(request_type: u32, sector: u64) -> RequestHeader {
@@ -238,6 +263,7 @@ pub struct Request {
     pub status_addr: GuestAddress,
     sector: u64,
     data_addr: GuestAddress,
+    discard_range: Option<(u64, u64)>,
 }
 
 impl Request {
@@ -256,6 +282,7 @@ impl Request {
             r#type: RequestType::from(request_header.request_type),
             sector: request_header.sector,
             data_addr: GuestAddress(0),
+            discard_range: None,
             data_len: 0,
             status_addr: GuestAddress(0),
         };
@@ -278,7 +305,9 @@ impl Request {
                 .next_descriptor()
                 .ok_or(VirtioBlockError::DescriptorChainTooShort)?;
 
-            if data_desc.is_write_only() && req.r#type == RequestType::Out {
+            if data_desc.is_write_only()
+                && (req.r#type == RequestType::Out || req.r#type == RequestType::Discard)
+            {
                 return Err(VirtioBlockError::UnexpectedWriteOnlyDescriptor);
             }
             if !data_desc.is_write_only() && req.r#type == RequestType::In {
@@ -311,6 +340,9 @@ impl Request {
             RequestType::GetDeviceID if req.data_len < VIRTIO_BLK_ID_BYTES => {
                 return Err(VirtioBlockError::InvalidDataLength);
             }
+            RequestType::Discard => {
+                req.validate_discard_ranges(mem, num_disk_sectors)?;
+            }
             _ => {}
         }
 
@@ -326,6 +358,41 @@ impl Request {
         req.status_addr = status_desc.addr;
 
         Ok(req)
+    }
+
+    fn validate_discard_ranges(
+        &mut self,
+        mem: &GuestMemoryMmap,
+        num_disk_sectors: u64,
+    ) -> Result<(), VirtioBlockError> {
+        if self.data_len != discard_range_size() {
+            return Err(VirtioBlockError::InvalidDataLength);
+        }
+
+        let range: DiscardWriteZeroes = mem
+            .read_obj(self.data_addr)
+            .map_err(VirtioBlockError::GuestMemory)?;
+        if range.num_sectors == 0 || range.num_sectors > MAX_DISCARD_SECTORS || range.flags != 0 {
+            return Err(VirtioBlockError::InvalidDataLength);
+        }
+        let top_sector = range
+            .sector
+            .checked_add(u64::from(range.num_sectors))
+            .ok_or(VirtioBlockError::InvalidOffset)?;
+        if top_sector > num_disk_sectors {
+            return Err(VirtioBlockError::InvalidOffset);
+        }
+
+        let byte_offset = range
+            .sector
+            .checked_mul(u64::from(SECTOR_SIZE))
+            .ok_or(VirtioBlockError::InvalidOffset)?;
+        let byte_len = u64::from(range.num_sectors)
+            .checked_mul(u64::from(SECTOR_SIZE))
+            .ok_or(VirtioBlockError::InvalidDataLength)?;
+        self.discard_range = Some((byte_offset, byte_len));
+
+        Ok(())
     }
 
     pub(crate) fn rate_limit(&self, rate_limiter: &mut RateLimiter) -> bool {
@@ -380,6 +447,11 @@ impl Request {
                 disk.file_engine
                     .write(self.offset(), mem, self.data_addr, self.data_len, pending)
             }
+            RequestType::Discard => disk.file_engine.discard(
+                self.discard_range
+                    .expect("discard request missing validated range"),
+                pending,
+            ),
             RequestType::Flush => disk.file_engine.flush(pending),
             RequestType::GetDeviceID => {
                 let res = mem
@@ -445,6 +517,7 @@ mod tests {
         let supported_request_types = vec![
             VIRTIO_BLK_T_IN,
             VIRTIO_BLK_T_OUT,
+            VIRTIO_BLK_T_DISCARD,
             VIRTIO_BLK_T_FLUSH,
             VIRTIO_BLK_T_GET_ID,
         ];
@@ -468,6 +541,10 @@ mod tests {
     fn test_request_type_from() {
         assert_eq!(RequestType::from(VIRTIO_BLK_T_IN), RequestType::In);
         assert_eq!(RequestType::from(VIRTIO_BLK_T_OUT), RequestType::Out);
+        assert_eq!(
+            RequestType::from(VIRTIO_BLK_T_DISCARD),
+            RequestType::Discard
+        );
         assert_eq!(RequestType::from(VIRTIO_BLK_T_FLUSH), RequestType::Flush);
         assert_eq!(
             RequestType::from(VIRTIO_BLK_T_GET_ID),
@@ -644,6 +721,74 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_discard() {
+        let mem = &default_mem();
+        let queue = VirtQueue::new(GuestAddress(0), mem, 16);
+        let chain = RequestDescriptorChain::new(&queue);
+
+        let request_header = RequestHeader::new(VIRTIO_BLK_T_DISCARD, 0);
+        chain.set_header(request_header);
+
+        // Write only data descriptor for Discard.
+        chain
+            .data_desc
+            .flags
+            .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+        chain.check_parse_err(VirtioBlockError::UnexpectedWriteOnlyDescriptor);
+
+        chain.data_desc.flags.set(VIRTQ_DESC_F_NEXT);
+        chain.data_desc.len.set(15);
+        chain.check_parse_err(VirtioBlockError::InvalidDataLength);
+
+        let range = DiscardWriteZeroes {
+            sector: 0,
+            num_sectors: 0,
+            flags: 0,
+        };
+        chain.data_desc.len.set(discard_range_size());
+        mem.write_obj(range, GuestAddress(chain.data_desc.addr.get()))
+            .unwrap();
+        chain.check_parse_err(VirtioBlockError::InvalidDataLength);
+
+        let range = DiscardWriteZeroes {
+            sector: 0,
+            num_sectors: 1,
+            flags: 1,
+        };
+        mem.write_obj(range, GuestAddress(chain.data_desc.addr.get()))
+            .unwrap();
+        chain.check_parse_err(VirtioBlockError::InvalidDataLength);
+
+        let range = DiscardWriteZeroes {
+            sector: 0,
+            num_sectors: MAX_DISCARD_SECTORS + 1,
+            flags: 0,
+        };
+        mem.write_obj(range, GuestAddress(chain.data_desc.addr.get()))
+            .unwrap();
+        chain.check_parse_err(VirtioBlockError::InvalidDataLength);
+
+        let range = DiscardWriteZeroes {
+            sector: NUM_DISK_SECTORS - 1,
+            num_sectors: 2,
+            flags: 0,
+        };
+        chain.data_desc.len.set(discard_range_size());
+        mem.write_obj(range, GuestAddress(chain.data_desc.addr.get()))
+            .unwrap();
+        chain.check_parse_err(VirtioBlockError::InvalidOffset);
+
+        let range = DiscardWriteZeroes {
+            sector: NUM_DISK_SECTORS - 1,
+            num_sectors: 1,
+            flags: 0,
+        };
+        mem.write_obj(range, GuestAddress(chain.data_desc.addr.get()))
+            .unwrap();
+        chain.check_parse(true);
+    }
+
+    #[test]
     fn test_parse_get_id() {
         let mem = &default_mem();
         let queue = VirtQueue::new(GuestAddress(0), mem, 16);
@@ -695,6 +840,7 @@ mod tests {
             (u32, std::sync::Arc<fn() -> Self>),
             (u32, std::sync::Arc<fn() -> Self>),
             (u32, std::sync::Arc<fn() -> Self>),
+            (u32, std::sync::Arc<fn() -> Self>),
             (
                 u32,
                 std::sync::Arc<Map<<u32 as Arbitrary>::Strategy, fn(u32) -> Self>>,
@@ -702,20 +848,25 @@ mod tests {
         )>;
 
         fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            const FIRST_UNSUPPORTED_REQUEST_ID: u32 = VIRTIO_BLK_T_DISCARD + 1;
+
             // All strategies have the same weight, there is no reson currently to skew
             // the rations to increase the odds of a specific request type.
             TupleUnion::new((
                 (1u32, std::sync::Arc::new(|| RequestType::In {})),
                 (1u32, std::sync::Arc::new(|| RequestType::Out {})),
+                (1u32, std::sync::Arc::new(|| RequestType::Discard {})),
                 (1u32, std::sync::Arc::new(|| RequestType::Flush {})),
                 (1u32, std::sync::Arc::new(|| RequestType::GetDeviceID {})),
                 (
                     1u32,
                     std::sync::Arc::new(Strategy::prop_map(any::<u32>(), |id| {
-                        // Random unsupported requests for our implementation start at
-                        // VIRTIO_BLK_T_GET_ID + 1 = 9.
-                        // This can be further refined to include unsupported requests ids < 9.
-                        RequestType::Unsupported(id.checked_add(9).unwrap_or(9))
+                        // Random unsupported requests for our implementation start above the
+                        // highest request id we support.
+                        RequestType::Unsupported(
+                            id.checked_add(FIRST_UNSUPPORTED_REQUEST_ID)
+                                .unwrap_or(FIRST_UNSUPPORTED_REQUEST_ID),
+                        )
                     })),
                 ),
             ))
@@ -727,6 +878,7 @@ mod tests {
             match request_type {
                 RequestType::In => VIRTIO_BLK_T_IN,
                 RequestType::Out => VIRTIO_BLK_T_OUT,
+                RequestType::Discard => VIRTIO_BLK_T_DISCARD,
                 RequestType::Flush => VIRTIO_BLK_T_FLUSH,
                 RequestType::GetDeviceID => VIRTIO_BLK_T_GET_ID,
                 RequestType::Unsupported(id) => id,
@@ -738,7 +890,7 @@ mod tests {
     fn request_type_flags(request_type: RequestType) -> u16 {
         match request_type {
             RequestType::In => VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE,
-            RequestType::Out => VIRTQ_DESC_F_NEXT,
+            RequestType::Out | RequestType::Discard => VIRTQ_DESC_F_NEXT,
             RequestType::Flush => VIRTQ_DESC_F_NEXT,
             RequestType::GetDeviceID => VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE,
             RequestType::Unsupported(_) => VIRTQ_DESC_F_NEXT,
@@ -823,7 +975,11 @@ mod tests {
 
         // Make sure that data_len is a multiple of 512
         // and that 512 <= data_len <= (4096 + 512).
-        let valid_data_len = ((data_len & 4096) | (SECTOR_SIZE - 1)) + 1;
+        let valid_data_len = if request_type == RequestType::Discard {
+            discard_range_size()
+        } else {
+            ((data_len & 4096) | (SECTOR_SIZE - 1)) + 1
+        };
         let sectors_len = u64::from(valid_data_len / SECTOR_SIZE);
         // Craft a random request with the randomized parameters.
         let mut request = Request {
@@ -832,6 +988,7 @@ mod tests {
             status_addr,
             sector: sector & (NUM_DISK_SECTORS - sectors_len),
             data_addr,
+            discard_range: None,
         };
         let mut request_header = RequestHeader::new(virtio_request_id, request.sector);
 
@@ -851,6 +1008,23 @@ mod tests {
                 request_type_flags(request.r#type),
                 2,
             );
+
+            if request.r#type == RequestType::Discard {
+                let discard_sector = sector % NUM_DISK_SECTORS;
+                mem.write_obj(
+                    DiscardWriteZeroes {
+                        sector: discard_sector,
+                        num_sectors: 1,
+                        flags: 0,
+                    },
+                    request.data_addr,
+                )
+                .unwrap();
+                request.discard_range = Some((
+                    discard_sector * u64::from(SECTOR_SIZE),
+                    u64::from(SECTOR_SIZE),
+                ));
+            }
         }
 
         chain
@@ -889,7 +1063,7 @@ mod tests {
         if *coins.next().unwrap() {
             match request.r#type {
                 // Readonly buffer is writable.
-                RequestType::Out => {
+                RequestType::Out | RequestType::Discard => {
                     data_desc_flags.set(data_desc_flags.get() | VIRTQ_DESC_F_WRITE);
                     return (Err(VirtioBlockError::UnexpectedWriteOnlyDescriptor), mem, q);
                 }
@@ -913,6 +1087,11 @@ mod tests {
                         .set(valid_data_len + (data_len % 511) + 1);
                     return (Err(VirtioBlockError::InvalidDataLength), mem, q);
                 }
+                RequestType::Discard => {
+                    // data_len is not a multiple of discard range size.
+                    chain.data_desc.len.set(valid_data_len + 1);
+                    return (Err(VirtioBlockError::InvalidDataLength), mem, q);
+                }
                 RequestType::GetDeviceID => {
                     // data_len is < VIRTIO_BLK_ID_BYTES
                     chain
@@ -931,6 +1110,18 @@ mod tests {
                 RequestType::In | RequestType::Out => {
                     request_header.sector = (sector | NUM_DISK_SECTORS) + 1;
                     chain.set_header(request_header);
+                    return (Err(VirtioBlockError::InvalidOffset), mem, q);
+                }
+                RequestType::Discard => {
+                    mem.write_obj(
+                        DiscardWriteZeroes {
+                            sector: NUM_DISK_SECTORS,
+                            num_sectors: 1,
+                            flags: 0,
+                        },
+                        request.data_addr,
+                    )
+                    .unwrap();
                     return (Err(VirtioBlockError::InvalidOffset), mem, q);
                 }
                 _ => {}

--- a/src/vmm/src/devices/virtio/block/virtio/request.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/request.rs
@@ -434,6 +434,7 @@ impl Request {
         desc_idx: u16,
         mem: &GuestMemoryMmap,
         block_metrics: &BlockDeviceMetrics,
+        discard_supported: bool,
     ) -> ProcessingResult {
         let pending = self.to_pending_request(desc_idx);
         let res = match self.r#type {
@@ -447,11 +448,21 @@ impl Request {
                 disk.file_engine
                     .write(self.offset(), mem, self.data_addr, self.data_len, pending)
             }
-            RequestType::Discard => disk.file_engine.discard(
-                self.discard_range
-                    .expect("discard request missing validated range"),
-                pending,
-            ),
+            RequestType::Discard => {
+                if !discard_supported {
+                    return ProcessingResult::Executed(pending.finish(
+                        mem,
+                        Err(IoErr::UnsupportedRequest(VIRTIO_BLK_T_DISCARD)),
+                        block_metrics,
+                    ));
+                }
+
+                disk.file_engine.discard(
+                    self.discard_range
+                        .expect("discard request missing validated range"),
+                    pending,
+                )
+            }
             RequestType::Flush => disk.file_engine.flush(pending),
             RequestType::GetDeviceID => {
                 let res = mem

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -43,6 +43,7 @@ pub fn default_block_with_path(path: String, file_engine_type: FileEngineType) -
         is_root_device: false,
         partuuid: None,
         is_read_only: false,
+        discard: false,
         cache_type: CacheType::Unsafe,
         // Rate limiting is enabled but with a high operation rate (10 million ops/s).
         rate_limiter: Some(RateLimiterConfig {

--- a/src/vmm/src/io_uring/mod.rs
+++ b/src/vmm/src/io_uring/mod.rs
@@ -109,6 +109,17 @@ impl<T: Debug> IoUring<T> {
         restrictions: Vec<Restriction>,
         eventfd: Option<RawFd>,
     ) -> Result<Self, IoUringError> {
+        Self::new_with_required_ops(num_entries, files, restrictions, eventfd, &REQUIRED_OPS)
+    }
+
+    /// Create a new instance, checking an explicit set of required operations.
+    pub fn new_with_required_ops(
+        num_entries: u32,
+        files: Vec<&File>,
+        restrictions: Vec<Restriction>,
+        eventfd: Option<RawFd>,
+        required_ops: &[OpCode],
+    ) -> Result<Self, IoUringError> {
         let mut params = io_uring_params {
             // Create the ring as disabled, so that we may register restrictions.
             flags: generated::IORING_SETUP_R_DISABLED,
@@ -148,7 +159,7 @@ impl<T: Debug> IoUring<T> {
             slab,
         };
 
-        instance.check_operations()?;
+        instance.check_operations(required_ops)?;
 
         if let Some(eventfd) = eventfd {
             instance.register_eventfd(eventfd)?;
@@ -345,7 +356,7 @@ impl<T: Debug> IoUring<T> {
         Ok(())
     }
 
-    fn check_operations(&self) -> Result<(), IoUringError> {
+    fn check_operations(&self, required_ops: &[OpCode]) -> Result<(), IoUringError> {
         let mut probes = ProbeWrapper::new(PROBE_LEN).map_err(IoUringError::Fam)?;
 
         // SAFETY: Safe because values are valid and we check the return value.
@@ -368,7 +379,7 @@ impl<T: Debug> IoUring<T> {
             .map(|op| op.op)
             .collect();
 
-        for opcode in REQUIRED_OPS.iter() {
+        for opcode in required_ops.iter() {
             if !supported_opcodes.contains(&(*opcode as u8)) {
                 return Err(IoUringError::UnsupportedOperation((*opcode).into()));
             }

--- a/src/vmm/src/io_uring/operation/mod.rs
+++ b/src/vmm/src/io_uring/operation/mod.rs
@@ -29,6 +29,10 @@ pub enum OpCode {
     Write = io_uring_op::IORING_OP_WRITE as u8,
     /// Fsync operation.
     Fsync = io_uring_op::IORING_OP_FSYNC as u8,
+    /// Fallocate operation.
+    Fallocate = io_uring_op::IORING_OP_FALLOCATE as u8,
+    /// Uring command operation.
+    UringCmd = io_uring_op::IORING_OP_URING_CMD as u8,
 }
 
 // Useful for outputting errors.
@@ -38,6 +42,8 @@ impl From<OpCode> for &'static str {
             OpCode::Read => "read",
             OpCode::Write => "write",
             OpCode::Fsync => "fsync",
+            OpCode::Fallocate => "fallocate",
+            OpCode::UringCmd => "uring_cmd",
         }
     }
 }
@@ -49,8 +55,10 @@ pub struct Operation<T> {
     pub(crate) opcode: OpCode,
     pub(crate) addr: Option<usize>,
     pub(crate) len: Option<u32>,
+    pub(crate) cmd_op: Option<u32>,
     flags: u8,
     pub(crate) offset: Option<u64>,
+    pub(crate) addr3: Option<u64>,
     pub(crate) user_data: T,
 }
 
@@ -64,10 +72,12 @@ impl<T> fmt::Debug for Operation<T> {
                 opcode: {:?},
                 addr: {:?},
                 len: {:?},
+                cmd_op: {:?},
                 offset: {:?},
+                addr3: {:?},
             }}
         ",
-            self.opcode, self.addr, self.len, self.offset
+            self.opcode, self.addr, self.len, self.cmd_op, self.offset, self.addr3
         )
     }
 }
@@ -81,8 +91,10 @@ impl<T: Debug> Operation<T> {
             opcode: OpCode::Read,
             addr: Some(addr),
             len: Some(len),
+            cmd_op: None,
             flags: 0,
             offset: Some(offset),
+            addr3: None,
             user_data,
         }
     }
@@ -94,8 +106,10 @@ impl<T: Debug> Operation<T> {
             opcode: OpCode::Write,
             addr: Some(addr),
             len: Some(len),
+            cmd_op: None,
             flags: 0,
             offset: Some(offset),
+            addr3: None,
             user_data,
         }
     }
@@ -107,8 +121,40 @@ impl<T: Debug> Operation<T> {
             opcode: OpCode::Fsync,
             addr: None,
             len: None,
+            cmd_op: None,
             flags: 0,
             offset: None,
+            addr3: None,
+            user_data,
+        }
+    }
+
+    /// Construct a fallocate operation.
+    pub fn fallocate(fd: FixedFd, mode: u32, offset: u64, len: u64, user_data: T) -> Self {
+        Self {
+            fd,
+            opcode: OpCode::Fallocate,
+            addr: Some(usize::try_from(len).unwrap()),
+            len: Some(mode),
+            cmd_op: None,
+            flags: 0,
+            offset: Some(offset),
+            addr3: None,
+            user_data,
+        }
+    }
+
+    /// Construct a block uring command operation.
+    pub fn block_discard(fd: FixedFd, cmd_op: u32, offset: u64, len: u64, user_data: T) -> Self {
+        Self {
+            fd,
+            opcode: OpCode::UringCmd,
+            addr: Some(usize::try_from(offset).unwrap()),
+            len: None,
+            cmd_op: Some(cmd_op),
+            flags: 0,
+            offset: None,
+            addr3: Some(len),
             user_data,
         }
     }
@@ -143,11 +189,76 @@ impl<T: Debug> Operation<T> {
             inner.len = len;
         }
 
+        if let Some(cmd_op) = self.cmd_op {
+            inner.__bindgen_anon_1.__bindgen_anon_1.cmd_op = cmd_op;
+        }
+
         if let Some(offset) = self.offset {
             inner.__bindgen_anon_1.off = offset;
+        }
+
+        if let Some(addr3) = self.addr3 {
+            // SAFETY: `__bindgen_anon_1` is the `addr3` view of this SQE union and
+            // we are only writing plain integer fields before the SQE is submitted.
+            unsafe {
+                inner.__bindgen_anon_6.__bindgen_anon_1.as_mut().addr3 = addr3;
+            }
         }
         inner.user_data = slab.insert(self.user_data) as u64;
 
         Sqe::new(inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io_uring::generated::io_uring_op;
+
+    #[test]
+    fn test_fallocate_sqe_layout() {
+        let mut slab = slab::Slab::new();
+        let sqe = Operation::fallocate(0, 3, 4096, 8192, 7u8)
+            .into_sqe(&mut slab)
+            .0;
+
+        assert_eq!(
+            sqe.opcode,
+            u8::try_from(io_uring_op::IORING_OP_FALLOCATE).unwrap()
+        );
+        assert_eq!(sqe.fd, 0);
+        assert_eq!(sqe.len, 3);
+        // SAFETY: These are the SQE union fields populated by fallocate().
+        let offset = unsafe { sqe.__bindgen_anon_1.off };
+        // SAFETY: This is the SQE union field populated by fallocate().
+        let len = unsafe { sqe.__bindgen_anon_2.addr };
+        assert_eq!(offset, 4096);
+        assert_eq!(len, 8192);
+    }
+
+    #[test]
+    fn test_block_discard_sqe_layout() {
+        const BLOCK_URING_CMD_DISCARD: u32 = 0x1200;
+
+        let mut slab = slab::Slab::new();
+        let sqe = Operation::block_discard(0, BLOCK_URING_CMD_DISCARD, 4096, 8192, 7u8)
+            .into_sqe(&mut slab)
+            .0;
+
+        assert_eq!(
+            sqe.opcode,
+            u8::try_from(io_uring_op::IORING_OP_URING_CMD).unwrap()
+        );
+        assert_eq!(sqe.fd, 0);
+        assert_eq!(sqe.len, 0);
+        // SAFETY: These are the SQE union fields populated by block_discard().
+        let cmd_op = unsafe { sqe.__bindgen_anon_1.__bindgen_anon_1.cmd_op };
+        // SAFETY: This is the SQE union field populated by block_discard().
+        let offset = unsafe { sqe.__bindgen_anon_2.addr };
+        // SAFETY: `__bindgen_anon_1` is the `addr3` view populated by block_discard().
+        let len = unsafe { sqe.__bindgen_anon_6.__bindgen_anon_1.as_ref().addr3 };
+        assert_eq!(cmd_op, BLOCK_URING_CMD_DISCARD);
+        assert_eq!(offset, 4096);
+        assert_eq!(len, 8192);
     }
 }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -621,6 +621,7 @@ mod tests {
                 cache_type: CacheType::Unsafe,
 
                 is_read_only: Some(false),
+                discard: None,
                 path_on_host: Some(tmp_file.as_path().to_str().unwrap().to_string()),
                 rate_limiter: Some(RateLimiterConfig::default()),
                 file_engine_type: None,

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -51,6 +51,8 @@ pub struct BlockDeviceConfig {
     /// If set to true, the drive is opened in read-only mode. Otherwise, the
     /// drive is opened as read-write.
     pub is_read_only: Option<bool>,
+    /// If set to true, the drive advertises discard support to the guest.
+    pub discard: Option<bool>,
     /// Path of the drive.
     pub path_on_host: Option<String>,
     /// Rate Limiter for I/O operations.
@@ -208,6 +210,7 @@ mod tests {
                 partuuid: self.partuuid.clone(),
                 is_root_device: self.is_root_device,
                 is_read_only: self.is_read_only,
+                discard: self.discard,
                 cache_type: self.cache_type,
 
                 path_on_host: self.path_on_host.clone(),
@@ -237,6 +240,7 @@ mod tests {
             cache_type: CacheType::Writeback,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path),
             rate_limiter: None,
             file_engine_type: None,
@@ -271,6 +275,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            discard: None,
             path_on_host: Some(dummy_path),
             rate_limiter: None,
             file_engine_type: None,
@@ -303,6 +308,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            discard: None,
             path_on_host: Some(dummy_path),
             rate_limiter: None,
             file_engine_type: None,
@@ -332,6 +338,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
@@ -348,6 +355,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
@@ -375,6 +383,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
@@ -391,6 +400,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
@@ -407,6 +417,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_3),
             rate_limiter: None,
             file_engine_type: None,
@@ -448,6 +459,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
@@ -464,6 +476,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
@@ -480,6 +493,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_3),
             rate_limiter: None,
             file_engine_type: None,
@@ -522,6 +536,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_1.clone()),
             rate_limiter: None,
             file_engine_type: None,
@@ -538,6 +553,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_2.clone()),
             rate_limiter: None,
             file_engine_type: None,
@@ -610,6 +626,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
@@ -626,6 +643,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            discard: None,
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
@@ -652,6 +670,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            discard: None,
             path_on_host: Some(dummy_file.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
@@ -682,6 +701,7 @@ mod tests {
             cache_type: CacheType::default(),
 
             is_read_only: Some(true),
+            discard: None,
             path_on_host: Some(backing_file.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: None,

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -433,6 +433,7 @@ fn test_preboot_load_snap_disallowed_after_boot_resources() {
         cache_type: CacheType::Unsafe,
 
         is_read_only: Some(false),
+        discard: None,
         path_on_host: Some(tmp_file),
         rate_limiter: None,
         file_engine_type: None,


### PR DESCRIPTION
## Changes

- Build on top of #5908 to add `discard=true` support for writable `Async` IO engine virtio-block drives.
- Use `IORING_OP_FALLOCATE` for regular backing files.
- Use `BLOCK_URING_CMD_DISCARD` for block-device backing stores on host kernels that support it.
- Reject async discard for block-device backends on host kernels older than Linux 6.12.
- Include the required io_uring opcode probing so unsupported hosts fail during configuration instead of later at request execution time.
- Keep discard gated by negotiated `VIRTIO_BLK_F_DISCARD`, so guests that did not negotiate the feature receive an unsupported status.
- Update API schema, block discard docs, block IO engine docs, changelog, and tests for the async support matrix.

This PR intentionally depends on #5908. If #5908 is merged first, this branch should be rebased so the final diff only contains the async follow-up.

## Reason

#5908 keeps the initial discard implementation focused on the `Sync` IO engine. This follow-up adds the io_uring path so deployments using the `Async` IO engine can still expose guest `fstrim`/discard where the host kernel and backing storage support it.

## Validation

- Ran `tools/devtool checkstyle` locally after the latest update: passed (`20 passed, 4 skipped`).
- Earlier local validation covered `tools/devtool checkbuild --all` while resolving the `libc::Ioctl` review thread.
- Added/kept unit and integration coverage for discard feature negotiation, unsupported requests, API configuration, and functional discard behavior inherited from #5908.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
