### PR TITLE
test(jailer): regression test for chroot bind-mount propagation

### DIFF
--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -223,6 +223,63 @@ def test_arbitrary_usocket_location(uvm):
     )
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_jailer_bind_mount_propagation(uvm):
+    """
+    Test that host bind-mounts inside the chroot propagate into the jail.
+
+    Mounts that exist before the jailer starts, covering the recursive
+    self-bind fix (MS_BIND -> MS_BIND | MS_REC).
+
+    Regression test for #1089.
+    """
+    test_microvm = uvm
+    chroot = Path(test_microvm.chroot())
+
+    kernel_jail_name = "vmlinux.bin"
+    rootfs_jail_name = "rootfs.img"
+    kernel_mount_point = chroot / kernel_jail_name
+    rootfs_mount_point = chroot / rootfs_jail_name
+    kernel_mount_point.touch()
+    rootfs_mount_point.touch()
+    try:
+        subprocess.check_call(
+            ["mount", "--bind", str(test_microvm.kernel_file), str(kernel_mount_point)]
+        )
+        subprocess.check_call(
+            ["mount", "--bind", str(test_microvm.rootfs_file), str(rootfs_mount_point)]
+        )
+        test_microvm.spawn()
+
+        # Drive the API directly: basic_config() would hardlink over our
+        # bind-mount points and mask what we are testing.
+        test_microvm.api.machine_config.put(vcpu_count=2, mem_size_mib=256)
+        test_microvm.boot_args = (
+            "reboot=k panic=1 nomodule swiotlb=noforce console=ttyS0 cryptomgr.notests"
+        )
+        if not test_microvm.pci_enabled:
+            test_microvm.boot_args += " pci=off"
+        test_microvm.api.boot.put(
+            kernel_image_path=f"/{kernel_jail_name}",
+            boot_args=test_microvm.boot_args,
+        )
+        test_microvm.api.drive.put(
+            drive_id="rootfs",
+            path_on_host=f"/{rootfs_jail_name}",
+            is_root_device=True,
+            is_read_only=True,
+        )
+        test_microvm.add_net_iface()
+        test_microvm.start()
+        test_microvm.ssh.check_output("true")
+    finally:
+        # Unmount before the framework's chroot rmtree so it never
+        # recurses into the bind-mount sources.
+        test_microvm.kill()
+        for mp in (rootfs_mount_point, kernel_mount_point):
+            subprocess.run(["umount", str(mp)], check=False)
+
+
 class Cgroups:
     """Helper class to work with cgroups"""
 


### PR DESCRIPTION
## Changes

Bind mounts established on the host inside the chroot before jailer start must propagate into the jailer's mount namespace. The test bind-mounts kernel and rootfs onto empty placeholders in the chroot and drives the API directly (bypassing basic_config to avoid create_jailed_resource hardlinking over the mounts), then asserts a clean SSH boot.

## Tests

### Successful run

> w/ the fix applied

```sh
$ sudo ./tools/devtool test -- integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation

...
integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_ON-ro-vmlinux-6.1.172] PASSED [ 50%]
integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_OFF-ro-vmlinux-6.1.172] PASSED [100%]

--------------------------------- JSON report ----------------------------------
report saved to: ../test_results/test-report.json
============================= slowest 10 durations =============================
1.99s call     integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_ON-ro-vmlinux-6.1.172]
1.74s call     integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_OFF-ro-vmlinux-6.1.172]
0.01s setup    integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_OFF-ro-vmlinux-6.1.172]
0.01s teardown integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_OFF-ro-vmlinux-6.1.172]
0.00s setup    integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_ON-ro-vmlinux-6.1.172]
0.00s teardown integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_ON-ro-vmlinux-6.1.172]
============================== 2 passed in 3.80s ===============================
[Firecracker devtool] Finished test run ...
```

### Reproduce #1089

> regression check to confirm the test catches the original bug

Step 1. Revert the fix locally to restore the buggy behavior

```diff
diff --git a/src/jailer/src/chroot.rs b/src/jailer/src/chroot.rs
index 56335c03a..488c00436 100644
--- a/src/jailer/src/chroot.rs
+++ b/src/jailer/src/chroot.rs
@@ -32,12 +32,12 @@ pub fn chroot(path: &Path) -> Result<(), JailerError> {
             null(),
             ROOT_DIR.as_ptr(),
             null(),
-            libc::MS_SLAVE | libc::MS_REC,
+            libc::MS_PRIVATE | libc::MS_REC,
             null(),
         )
     })
     .into_empty_result()
-    .map_err(JailerError::MountPropagationSlave)?;
+    .map_err(JailerError::MountPropagationPrivate)?;
 
     // We need a CString for the following mount call.
     let chroot_dir = to_cstring(path)?;
@@ -51,7 +51,7 @@ pub fn chroot(path: &Path) -> Result<(), JailerError> {
             chroot_dir.as_ptr(),
             chroot_dir.as_ptr(),
             null(),
-            libc::MS_BIND | libc::MS_REC,
+            libc::MS_BIND,
             null(),
         )
     })
diff --git a/src/jailer/src/main.rs b/src/jailer/src/main.rs
index 4f87f2563..5951209b7 100644
--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -108,7 +108,7 @@ pub enum JailerError {
     #[error("Failed to bind mount the jail root directory: {0}")]
     MountBind(io::Error),
     #[error("Failed to change the propagation type to slave: {0}")]
-    MountPropagationSlave(io::Error),
+    MountPropagationPrivate(io::Error),
     #[error("{}", format!("{:?} is not a file", .0).replace('\"', ""))]
     NotAFile(PathBuf),
     #[error("{}", format!("{:?} is not a directory", .0).replace('\"', ""))]
```

Step 2. Run the test

```sh
$ sudo ./tools/devtool test -- integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation

...
--------------------------------- JSON report ----------------------------------
report saved to: ../test_results/test-report.json
============================= slowest 10 durations =============================
0.43s call     integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_ON-ro-vmlinux-6.1.172]
0.31s call     integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_OFF-ro-vmlinux-6.1.172]
0.01s teardown integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_OFF-ro-vmlinux-6.1.172]
0.01s teardown integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_ON-ro-vmlinux-6.1.172]
0.01s setup    integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_ON-ro-vmlinux-6.1.172]
0.00s setup    integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_OFF-ro-vmlinux-6.1.172]
=========================== short test summary info ============================
FAILED integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_ON-ro-vmlinux-6.1.172] - RuntimeError: ('Start microvm error: System configuration error: Cannot load kernel due to invalid memory configuration or invalid kernel image: Kernel Loader: failed to load ELF kernel image: Kernel Loader: Unable to read elf header', {'fault_message': 'Start microvm error: System configuration error: Cannot load kernel due to invalid memory configuration or invalid kernel image: Kernel Loader: failed to load ELF kernel image: Kernel Loader: Unable to read elf header'}, <Response [400]>)
FAILED integration_tests/security/test_jail.py::test_jailer_bind_mount_propagation[PCI_OFF-ro-vmlinux-6.1.172] - RuntimeError: ('Start microvm error: System configuration error: Cannot load kernel due to invalid memory configuration or invalid kernel image: Kernel Loader: failed to load ELF kernel image: Kernel Loader: Unable to read elf header', {'fault_message': 'Start microvm error: System configuration error: Cannot load kernel due to invalid memory configuration or invalid kernel image: Kernel Loader: failed to load ELF kernel image: Kernel Loader: Unable to read elf header'}, <Response [400]>)
============================== 2 failed in 0.90s ===============================
[Firecracker devtool] Finished test run ...
```

The 400 response and "Unable to read elf header" message match https://github.com/firecracker-microvm/firecracker/issues/1089#issuecomment-491955003 , confirming the test reproduces the original bug when the fix is reverted.

## Reason

Closes #1099 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
