### PR TITLE
Fix all tests when running on a c5.metal dev-desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tags
 /resources/x86_64
 /resources/aarch64
 redundant_seccomp_rules_build
+test_instrumented_firecracker_build

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,10 +17,20 @@ excluding tests marked with `pytest.mark.nonci`):
 tools/devtool -y test
 ```
 
+Note: some performance tests require host performance tuning (e.g. dedicating
+some memory for `hugetlbfs`). For those tests, the `--performance` flag is also
+required:
+
+```sh
+tools/devtool -y test --performance
+```
+
 To run only tests from specific directories and/or files:
 
 ```sh
 tools/devtool -y test -- integration_tests/performance/test_boottime.py
+# Or
+tools/devtool -y test --performance -- integration_tests/performance/test_huge_pages.py
 ```
 
 To run a single specific test from a file:

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,6 +72,9 @@ dev container automatically, so setting them on the host before invoking
   at the uVM chroot root. The cheap artifacts (`host-dmesg.log` and the guest
   serial console) are always collected. Default off. The nightly performance
   pipeline sets this.
+- `FC_TEST_DEVELOPMENT_ENVIRONMENT=1` — skip tests that depend on specific host
+  configurations that don't add any value when running on a development
+  environment.
 
 ### Output
 

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -80,6 +80,8 @@ class GlobalProps:
         self.buildkite_build_number = os.environ.get("BUILDKITE_BUILD_NUMBER")
         self.buildkite_pr = os.environ.get("BUILDKITE_PULL_REQUEST", "false") != "false"
         self.buildkite_revision_a = os.environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
+        # Development environment detection
+        self.is_dev_env = os.environ.get("FC_TEST_DEVELOPMENT_ENVIRONMENT") == "1"
 
         if self._in_git_repo():
             self.git_commit_id = run_cmd("git rev-parse HEAD")

--- a/tests/framework/utils_cpuid.py
+++ b/tests/framework/utils_cpuid.py
@@ -38,6 +38,7 @@ class CpuModel(str, Enum):
 CPU_DICT = {
     CpuVendor.INTEL: {
         "Intel(R) Xeon(R) Platinum 8259CL CPU": "INTEL_CASCADELAKE",
+        "Intel(R) Xeon(R) Platinum 8275CL CPU": "INTEL_CASCADELAKE",
         "Intel(R) Xeon(R) Platinum 8375C CPU": "INTEL_ICELAKE",
         "Intel(R) Xeon(R) Platinum 8488C": "INTEL_SAPPHIRE_RAPIDS",
         "Intel(R) Xeon(R) 6975P-C": "INTEL_GRANITE_RAPIDS",

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -110,7 +110,7 @@ def download_spectre_meltdown_checker(tmp_path_factory):
 
 # Nothing can be sensibly tested in a PR context here
 @pytest.mark.skipif(
-    global_props.buildkite_pr,
+    global_props.buildkite_pr or global_props.is_dev_env,
     reason="Test depends solely on factors external to GitHub repository",
 )
 def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
@@ -121,7 +121,7 @@ def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
 
 # Nothing can be sensibly tested here in a PR context
 @pytest.mark.skipif(
-    global_props.buildkite_pr,
+    global_props.buildkite_pr or global_props.is_dev_env,
     reason="Test depends solely on factors external to GitHub repository",
 )
 def test_vulnerabilities_on_host():


### PR DESCRIPTION
## Changes

This PR contains several commit that make all test pass locally on a c5.metal dev-desktop.

Changes include:
 - Skipping some test on `test_vulnerabilities.py` when `FC_TEST_DEVELOPMENT_ENVIRONMENT=1` env var is detected
 - Add support for Intel 8275CL CPU
 - Update instructions for `hugetlbfs`

## Reason

With this commit, all tests should pass on metal dev-desktops (with the new `FC_TEST_DEVELOPMENT_ENVIRONMENT=1` env var set).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
