### PR TITLE
docs: update MAINTAINERS.md with pbertho

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,5 +9,6 @@ Firecracker is maintained by a dedicated team within Amazon:
 - Jay Chung <jaehoc@amazon.com>
 - Marco Marangoni <mamarang@amazon.com>
 - Michael Zoumboulakis <zoumboul@amazon.com>
+- Pierre Bertholom <pbertho@amazon.com>
 - Riccardo Mancini <mancio@amazon.com>
 - Takahiro Itazuri <itazur@amazon.com>


### PR DESCRIPTION
## Changes

Add Pierre Bertholom to `MAINTAINERS.md`

## Reason

New member of the team

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [X] I have read and understand [CONTRIBUTING.md][3].
- [X] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [X] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [X] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [X] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
