### PR TITLE
test: fix API timing false positives in test_population_latency

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -252,7 +252,7 @@ class Microvm:
 
         self._screen_pid = None
 
-        self.time_api_requests = global_props.host_linux_version != "6.1"
+        self.time_api_requests = True
         # disable the HTTP API timings as they cause a lot of false positives
         if int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", 1)) > 1:
             self.time_api_requests = False

--- a/tests/integration_tests/performance/test_snapshot.py
+++ b/tests/integration_tests/performance/test_snapshot.py
@@ -239,6 +239,9 @@ def test_population_latency(
     for microvm in microvm_factory.build_n_from_snapshot(
         snapshot, ITERATIONS, uffd_handler_name="fault_all"
     ):
+        # API response times are unreliable while the uffd handler is
+        # faulting in all pages — skip the timing validation.
+        microvm.time_api_requests = False
         # do _something_ to trigger a pagefault, which will then cause the UFFD handler to fault in _everything_
         microvm.ssh.check_output("true")
 


### PR DESCRIPTION
## Problem

`test_population_latency` fails on host kernel 6.18 (and previously on 6.1) with:
```
AssertionError: Get /machine-config API call exceeded maximum duration: 884 ms
```

The test uses the `fault_all` uffd handler which eagerly faults in all guest memory after snapshot restore. During this window, any API call (like `Get /machine-config`) competes with the faulting activity, causing response times to exceed the `MAX_API_CALL_DURATION_MS` threshold.

This was previously worked around by blanket-disabling `time_api_requests` on host kernel 6.1 (commit 03eb60cf2), but the same issue appeared on 6.18 after it was added to CI.

## Fix

- **Revert** the kernel-version-based exclusion (`!= "6.1"`) back to unconditional `True` — re-enables the check on 6.1 for all other tests.
- **Disable** `time_api_requests` only for restored VMs in `test_population_latency`, where slow API responses during uffd faulting are expected by design.

## Why this is correct

- `_validate_api_response_times()` is called at VM teardown (`kill()`), which happens after `yield` returns from `build_n_from_snapshot`
- Setting `microvm.time_api_requests = False` inside the loop body (before any test logic) ensures the flag is already set when `kill()` eventually checks it
- No `memory_monitor` is attached (`monitor_memory=False`), so `Get /machine-config` is not called during restore itself

## Testing

- `./tools/devtool checkstyle` passes (20 passed, 4 skipped)