### PR TITLE
fix hangs in CI due to unbounded wait in Vmm:drop() caused by undelivered signals due to resource leak

### DIFF
--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -7,8 +7,9 @@
 
 use std::os::fd::AsRawFd;
 use std::sync::atomic::{Ordering, fence};
-use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, TryRecvError, channel};
 use std::sync::{Arc, Barrier};
+use std::time::Duration;
 use std::{fmt, io, thread};
 
 use kvm_bindings::{KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN};
@@ -31,6 +32,9 @@ use crate::vstate::vm::KvmVm;
 
 /// Signal number (SIGRTMIN) used to kick Vcpus.
 pub const VCPU_RTSIG_OFFSET: i32 = 0;
+
+/// Maximum time to wait for a vCPU thread to exit when dropping its handle.
+const VCPU_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Errors associated with the wrappers over KVM ioctls.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -624,14 +628,28 @@ impl VcpuHandle {
 // Wait for the Vcpu thread to finish execution
 impl Drop for VcpuHandle {
     fn drop(&mut self) {
-        // We assume that by the time a VcpuHandle is dropped, other code has run to
-        // get the state machine loop to finish so the thread is ready to join.
-        // The strategy of avoiding more complex messaging protocols during the Drop
-        // helps avoid cycles which were preventing a truly clean shutdown.
-        //
-        // If the code hangs at this point, that means that a Finish event was not
-        // sent by Vmm.
-        self.vcpu_thread.take().unwrap().join().unwrap();
+        // The vCPU thread owns the response sender, so the channel disconnects
+        // once it exits. Wait for that disconnect (draining any stale responses)
+        // with a timeout rather than joining unconditionally, so a thread that
+        // never finished (e.g. a missed Finish event) fails fast instead of
+        // hanging teardown forever.
+        let thread = self.vcpu_thread.take().unwrap();
+        loop {
+            match self.response_receiver.recv_timeout(VCPU_JOIN_TIMEOUT) {
+                // Sender dropped: the thread has exited.
+                Err(RecvTimeoutError::Disconnected) => break,
+                Err(RecvTimeoutError::Timeout) => {
+                    let name = thread.thread().name().unwrap_or("<unnamed>");
+                    panic!("Timed out waiting for vCPU thread '{name}' to exit")
+                }
+                // Unexpected: a response was still queued at teardown. Discard
+                // it and keep waiting for the thread to exit.
+                Ok(response) => {
+                    warn!("Discarding unexpected vCPU response during teardown: {response:?}");
+                }
+            }
+        }
+        thread.join().unwrap();
     }
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,23 @@ if _libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
     raise OSError(ctypes.get_errno(), "prctl(PR_SET_CHILD_SUBREAPER) failed")
 
 
+def reap_orphaned_children():
+    """Reap descendants that have reparented to this subreaper session.
+
+    Non-blocking; safe to call repeatedly. Returns the number reaped.
+    """
+    reaped = 0
+    while True:
+        try:
+            pid, _status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            break
+        if pid == 0:
+            break
+        reaped += 1
+    return reaped
+
+
 METRICS = get_metrics_logger()
 PHASE_REPORT_KEY = pytest.StashKey[dict[str, pytest.CollectReport]]()
 
@@ -124,6 +141,17 @@ def record_props(request, record_property):
     # Extract attributes from the docstrings
     function_docstring = inspect.getdoc(request.function)
     record_property("description", function_docstring)
+
+
+@pytest.fixture(scope="function")
+def reap_orphans():
+    """Reap orphaned descendants after each test.
+
+    Teardown runs after the microVM is killed because `microvm_factory`
+    depends on this fixture (fixtures finalize in reverse setup order).
+    """
+    yield
+    reap_orphaned_children()
 
 
 def pytest_runtest_logreport(report):
@@ -374,8 +402,14 @@ def netns_factory(worker_id):
 
 
 @pytest.fixture()
-def microvm_factory(request, record_property, results_dir, netns_factory):
-    """Fixture to create microvms simply."""
+# pylint: disable=unused-argument
+def microvm_factory(request, record_property, results_dir, netns_factory, reap_orphans):
+    """Fixture to create microvms simply.
+
+    `reap_orphans` is requested only for teardown ordering (reaping runs
+    after the VMs are killed), so it is intentionally not referenced in
+    the body.
+    """
 
     binary_dir = request.config.getoption("--binary-dir") or DEFAULT_BINARY_DIR
     if isinstance(binary_dir, str):

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -27,6 +27,7 @@ def cargo(
     env: dict = None,
     cwd: str = None,
     nightly: bool = False,
+    timeout: int = None,
 ):
     """Executes the specified cargo subcommand"""
     toolchain = f"+{nightly_toolchain()}" if nightly else ""
@@ -35,7 +36,7 @@ def cargo(
     cmd = (
         f"{env_string} cargo {toolchain} {subcommand} {cargo_args} -- {subcommand_args}"
     )
-    return utils.check_output(cmd, cwd=cwd)
+    return utils.check_output(cmd, cwd=cwd, timeout=timeout)
 
 
 def get_rustflags():
@@ -50,10 +51,18 @@ def cargo_test(path, extra_args=""):
     env = {
         "CARGO_TARGET_DIR": os.path.join(path, "unit-tests"),
         "RUST_TEST_THREADS": 1,
-        "RUST_BACKTRACE": 1,
+        "RUST_BACKTRACE": "1",
         "RUSTFLAGS": get_rustflags(),
     }
-    cargo("test", extra_args + " --all --no-fail-fast", env=env)
+    cargo(
+        "test",
+        extra_args + " --all --no-fail-fast",
+        subcommand_args="--nocapture",
+        env=env,
+        # Kill cargo test 60s before pytest's 600s timeout, so pytest can report
+        # the failure and upload artifacts cleanly instead of being killed itself.
+        timeout=540,
+    )
 
 
 def get_binary(name, *, binary_dir=DEFAULT_BINARY_DIR, example=None):


### PR DESCRIPTION
## Problem

`test_unittests` was intermittently hanging in CI, hitting the 600s pytest timeout — most often during `test_build_and_boot_microvm`. Retrying usually passed, and it was worse on `m5n.metal` and on nightly.

## Root cause

The hang is caused by exhaustion of the per-`RLIMIT_SIGPENDING` queued-signal pool:

- `conftest.py` sets `PR_SET_CHILD_SUBREAPER`, so daemonized descendants (firecracker after the jailer double-fork, plus helpers like `screen`, `ssh`, vhost-user backends, and the `cat` processes `socat` forks in the vsock tests) reparent to the pytest session.
- The framework only `waitpid()`s the firecracker PID, so every other descendant lingers as a **zombie**. A zombie's pending signals are not freed until it is reaped (`release_task`), so each one keeps its queued signal (e.g. the `SIGTERM` from teardown) charged against the `RLIMIT_SIGPENDING` pool.
- As zombies accumulate, the pool saturates. Once it is full, the kernel silently drops further real-time signal sends — including the `SIGRTMIN` kick Firecracker uses to interrupt a vCPU thread. The vCPU never sees its `Finish` event, and `VcpuHandle::drop` blocked forever on `join()`, hanging teardown until the outer timeout.

This was confirmed on an affected agent: thousands of zombie `cat`/`jailer`/`ssh` processes, `SigQ` near the `RLIMIT_SIGPENDING` limit, and (via drgn) each zombie holding one queued signal.

## Changes

- **`tests/conftest.py`**: reap orphaned descendants on teardown after each test, so zombies can't accumulate and saturate the signal pool. Ordered to run after the microVM is killed (via a `microvm_factory` dependency).
- **`src/vmm/src/vstate/vcpu.rs`**: bound the wait in `VcpuHandle::drop`. The vCPU thread owns the response-channel sender, so the channel disconnects when it exits; Drop waits for that disconnect with a 1s timeout (draining any stale responses) and panics if exceeded, so a thread that never observed its `Finish` event makes teardown fail fast instead of hanging. The wait is a futex, so no seccomp changes are needed.
- **`tests/host_tools/cargo_build.py`** (original diagnostic change, kept as it's independently useful): `RUST_BACKTRACE=1`, `--nocapture`, and a 540s cargo-test timeout so failures are reported cleanly before pytest's 600s timeout.

The earlier debug-only instrumentation commits (KVM_RUN/per-event logging, watchdog thread dump) have been dropped now that the root cause is understood.
