### PR TITLE
Fix tests on non-metal instance

### DIFF
--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -97,10 +97,12 @@ class GlobalProps:
             self.instance = imdsv2_get("/meta-data/instance-type")
             self.instance_id = imdsv2_get("/meta-data/instance-id")
             self.ami = imdsv2_get("/meta-data/ami-id")
+            self.is_ec2_virt = "metal" not in self.instance
         else:
             self.instance = "NA"
             self.instance_id = "NA"
             self.ami = "NA"
+            self.is_ec2_virt = False
 
     @property
     def host_linux_version_tpl(self):

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -26,6 +26,7 @@ from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
+    stop_after_delay,
     wait_fixed,
 )
 
@@ -738,3 +739,44 @@ class Timeout:
 def pvh_supported() -> bool:
     """Checks if PVH boot is supported"""
     return platform.architecture() == "x86_64"
+
+
+def wait_for_tcp_port_on_host(network_prefix, port, timeout=5.0):
+    """Poll until a TCP port is accepting connections on localhost."""
+    for attempt in Retrying(
+        wait=wait_fixed(0.1), stop=stop_after_delay(timeout), reraise=True
+    ):
+        with attempt:
+            exit_code, _, _ = run_cmd(f"{network_prefix} ss -tln | grep -q ':{port} '")
+            assert exit_code == 0, f"Port {port} not open on host"
+
+
+def wait_for_tcp_port_on_guest(vm, port, timeout=5.0):
+    """Poll via SSH until a TCP port is listening inside the guest."""
+    for attempt in Retrying(
+        wait=wait_fixed(0.1), stop=stop_after_delay(timeout), reraise=True
+    ):
+        with attempt:
+            exit_code, _, _ = vm.ssh.run(f"ss -tln | grep -q ':{port} '")
+            assert exit_code == 0, f"Port {port} not open on guest"
+
+
+def kill_and_wait_on_host(process_name, timeout=5.0):
+    """Kills the given process on the host, and waits for its termination via waitpid"""
+    exit_code, pid, _ = run_cmd(["pgrep", process_name])
+    if exit_code == 0:
+        # Note: process might be spawned as a child, I need to explicitly
+        # wait for it, otherwise it might remain a zombie
+        run_cmd(f"kill {pid}")
+        wait_process_termination(int(pid), timeout)
+
+
+def kill_and_wait_on_guest(vm, process_name, timeout=5.0):
+    """Kills the given process on the guest"""
+    vm.ssh.run(f"pkill {process_name}")
+    for attempt in Retrying(
+        wait=wait_fixed(0.1), stop=stop_after_delay(timeout), reraise=True
+    ):
+        with attempt:
+            exit_code, _, _ = vm.ssh.run(f"pgrep {process_name}")
+            assert exit_code == 1, f"{process_name} is still running on guest"

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -210,6 +210,53 @@ INTEL_ICELAKE_HOST_ONLY_FEATS_6_18 = INTEL_ICELAKE_HOST_ONLY_FEATS_6_1 - {
     "flush_l1d",
 } | {"la57"}
 
+# CPU features not available when running in a non-metal EC2 C8i, M8i, and R8i instance
+EC2_CMR8i_VIRT_UNAVAILABLE = {
+    "acpi",
+    "arch_lbr",
+    "art",
+    "bts",
+    "cat_l2",
+    "cat_l3",
+    "cdp_l2",
+    "cdp_l3",
+    "cqm",
+    "cqm_llc",
+    "cqm_mbm_local",
+    "cqm_mbm_total",
+    "cqm_occup_llc",
+    "dca",
+    "ds_cpl",
+    "dtes64",
+    "dtherm",
+    "dts",
+    "enqcmd",
+    "epb",
+    "est",
+    "hwp",
+    "hwp_act_window",
+    "hwp_epp",
+    "hwp_pkg_req",
+    "ibpb_exit_to_user",
+    "ibt",
+    "intel_ppin",
+    "intel_pt",
+    "la57",
+    "mba",
+    "pbe",
+    "pconfig",
+    "pebs",
+    "pln",
+    "pts",
+    "rdt_a",
+    "sdbg",
+    "smx",
+    "split_lock_detect",
+    "tm",
+    "tm2",
+    "xtpr",
+}
+
 
 def test_host_vs_guest_cpu_features(uvm):
     """Check CPU features host vs guest"""
@@ -456,6 +503,12 @@ def test_host_vs_guest_cpu_features(uvm):
                     # Granite Rapids host kernel 6.18 enables split lock detection (a
                     # host-only synthesized bit; the guest can't read MSR 0x33).
                     expected_host_minus_guest |= {"split_lock_detect"}
+
+            if global_props.is_ec2_virt:
+                # These features aren't available in the host
+                expected_host_minus_guest -= EC2_CMR8i_VIRT_UNAVAILABLE
+                # Both host and guest run under an hypervisor
+                expected_guest_minus_host -= {"hypervisor"}
 
             assert host_feats - guest_feats == expected_host_minus_guest
             assert guest_feats - host_feats == expected_guest_minus_host

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -290,7 +290,10 @@ def test_vsock_transport_reset_g2h(vsock_uvm, microvm_factory):
             snapshot = new_vm.snapshot_full()
             new_vm.resume()
 
-            # After `create_snapshot` + 'restore' calls, connection should be dropped
+            # Give some time for guest socat to detect closed socket
+            time.sleep(0.1)
+
+            # After `create_snapshot` + 'resume' calls, connection should be dropped
             code, _, _ = new_vm.ssh.run("pidof socat")
             assert code == 1
         finally:

--- a/tests/integration_tests/performance/test_rate_limiter.py
+++ b/tests/integration_tests/performance/test_rate_limiter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests that fail if network throughput does not obey rate limits."""
 
-import time
-
 from framework import utils
 from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from host_tools import cpu_load
@@ -19,6 +17,9 @@ IPERF_TRANSMIT_TIME = 4
 
 # Use a fixed-size TCP window so we get constant flow
 IPERF_TCP_WINDOW = "256K"
+
+# The port that iperf will use
+IPERF_PORT = 5201
 
 # The rate limiting value
 RATE_LIMIT_BYTES = 10485760
@@ -39,7 +40,6 @@ RATE_LIMITER_WITH_BURST = {
         "refill_time": REFILL_TIME_MS,
     }
 }
-
 
 # Deltas that are accepted between expected values and achieved
 # values throughout the tests
@@ -114,11 +114,12 @@ def test_rx_rate_limiting_cpu_load(uvm):
     _start_iperf_server_on_guest(test_microvm)
 
     # Run iperf client sending UDP traffic.
-    iperf_cmd = "{} {} -u -c {} -b 1000000000 -t{} -f KBytes".format(
+    iperf_cmd = "{} {} -u -c {} -b 1000000000 -t{} -f KBytes -p {}".format(
         test_microvm.netns.cmd_prefix(),
         IPERF_BINARY,
         iface.guest_ip,
         IPERF_TRANSMIT_TIME * 5,
+        IPERF_PORT,
     )
 
     # Enable monitor that checks if the cpu load is over the threshold.
@@ -214,12 +215,13 @@ def _check_rx_rate_limiting(test_microvm):
     print("Run guest RX iperf for rate limiting with burst")
     # Use iperf to obtain the bandwidth when there is burst to consume from,
     # send exactly BURST_SIZE packets.
-    iperf_cmd = "{} {} -c {} -n {} -f KBytes -w {} -N".format(
+    iperf_cmd = "{} {} -c {} -n {} -f KBytes -w {} -N -p {}".format(
         test_microvm.netns.cmd_prefix(),
         IPERF_BINARY,
         eth2.guest_ip,
         BURST_SIZE,
         IPERF_TCP_WINDOW,
+        IPERF_PORT,
     )
     iperf_out = _run_iperf_on_host(iperf_cmd, test_microvm)
     _, burst_kbps = _process_iperf_output(iperf_out)
@@ -305,12 +307,13 @@ def _get_rx_bandwidth(test_microvm, guest_ip):
 
     _start_iperf_server_on_guest(test_microvm)
 
-    iperf_cmd = "{} {} -c {} -t {} -f KBytes -w {} -N".format(
+    iperf_cmd = "{} {} -c {} -t {} -f KBytes -w {} -N -p {}".format(
         test_microvm.netns.cmd_prefix(),
         IPERF_BINARY,
         guest_ip,
         IPERF_TRANSMIT_TIME,
         IPERF_TCP_WINDOW,
+        IPERF_PORT,
     )
     iperf_out = _run_iperf_on_host(iperf_cmd, test_microvm)
     _, observed_kbps = _process_iperf_output(iperf_out)
@@ -336,14 +339,13 @@ def _patch_iface_bw(test_microvm, iface_id, rx_or_tx, new_bucket_size, new_refil
 
 def _start_iperf_server_on_guest(test_microvm):
     """Start iperf in server mode through an SSH connection."""
-    kill_cmd = f"pkill {IPERF_BINARY}"
-    test_microvm.ssh.run(kill_cmd)
+    utils.kill_and_wait_on_guest(test_microvm, IPERF_BINARY)
 
     iperf_cmd = f"{IPERF_BINARY} -sD -f KBytes --logfile {GUEST_IPERF_SERVER_LOG}"
     test_microvm.ssh.run(iperf_cmd)
 
-    # Wait for the iperf to start.
-    time.sleep(1)
+    # Wait for the iperf server to start listening
+    utils.wait_for_tcp_port_on_guest(test_microvm, IPERF_PORT)
 
 
 def _run_iperf_on_guest(test_microvm, iperf_cmd):
@@ -353,14 +355,15 @@ def _run_iperf_on_guest(test_microvm, iperf_cmd):
 
 def _start_iperf_server_on_host(netns_cmd_prefix):
     """Start iperf in server mode after killing any leftover iperf daemon."""
-    kill_cmd = f"pkill {IPERF_BINARY}"
-    utils.run_cmd(kill_cmd)
+    utils.kill_and_wait_on_host(IPERF_BINARY)
 
-    iperf_cmd = "{} {} -sD -f KBytes\n".format(netns_cmd_prefix, IPERF_BINARY)
+    iperf_cmd = "{} {} -sD -f KBytes -p {}\n".format(
+        netns_cmd_prefix, IPERF_BINARY, IPERF_PORT
+    )
     utils.check_output(iperf_cmd)
 
-    # Wait for the iperf daemon to start.
-    time.sleep(1)
+    # Wait for the iperf server to start listening
+    utils.wait_for_tcp_port_on_host(netns_cmd_prefix, IPERF_PORT)
 
 
 def _run_iperf_on_host(iperf_cmd, test_microvm):


### PR DESCRIPTION
## Changes

This PR carries fixes to tests when running on a non-metal instance (specifically, this has been tested on a `m8i.16xlarge`).

Note: some tests still fail, but this is a step towards that goal.

Specific changes:
 - updated expectations on CPU features available on host & guest
 - better process management of iperf3 (it is started/stopped asynchronously, and different timing on nested made the tests fail)
 -  added a small delay after closing the vsock for `socat` to exit (again related to different performances on nested)

## Reason

We want to improve support for nested virtualization.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
