### PR TITLE
fix: fips: remove invalid test_fips_reseeded_userspace_csprng test 

### DIFF
--- a/tests/integration_tests/security/test_fips.py
+++ b/tests/integration_tests/security/test_fips.py
@@ -78,16 +78,3 @@ def test_fips_reseeded_kernel_csprng(fips_snapshot_pair):
     assert (
         seq_a != seq_b
     ), "Kernel CSPRNG produced identical output on two VMs restored from the same snapshot"
-
-
-def test_fips_reseeded_userspace_csprng(fips_snapshot_pair):
-    """Test that userspace CSPRNG diverges across VMs restored from the same snapshot."""
-    uvm_a, uvm_b = fips_snapshot_pair
-    cmd = 'python3 -c "import secrets, base64; print(base64.b64encode(secrets.token_bytes(32)).decode())"'
-
-    seq_a = _get_random_sequence(uvm_a, cmd)
-    seq_b = _get_random_sequence(uvm_b, cmd)
-
-    assert (
-        seq_a != seq_b
-    ), "Userspace CSPRNG produced identical output on two VMs restored from the same snapshot"


### PR DESCRIPTION
## Changes
The test_fips_reseeded_user space_csprng was attempting to test the user
space re-seeding mechanism based on the vmgenid notification, but it
incorrectly used python to get some random numbers from the kernel
instead. Since vmgenid notification testing is already performed in the
`functional/test_vmgenid.py`, we know that the user space does receive
the notification. There is no reason to duplicate this test for FIPS
enabled VMs, since these features are orthogonal.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
