### PR TITLE
fix(test): generate RSA SSH key in docker-popular build

### DIFF
--- a/tools/test-popular-containers/build_rootfs.sh
+++ b/tools/test-popular-containers/build_rootfs.sh
@@ -22,7 +22,7 @@ IMAGES=(amazonlinux:2023 alpine:latest ubuntu:22.04 ubuntu:24.04 ubuntu:25.04 ub
 
 # Generate SSH key for access from host
 if [ ! -s id_rsa ]; then
-  ssh-keygen -f id_rsa -N ""
+  ssh-keygen -t rsa -b 2048 -f id_rsa -N ""
 fi
 
 # install rootfs dependencies


### PR DESCRIPTION
## Summary

`build_rootfs.sh` generates an SSH key without specifying a type, defaulting to ED25519 on modern OpenSSH. However, the SSH connection options added in ab6841c4a2 require RSA keys (`PubkeyAcceptedAlgorithms=rsa-sha2-512`, `HostKeyAlgorithms=rsa-sha2-512`). This mismatch caused all docker-popular jobs to fail with `Permission denied (publickey)`.

## Fix

Align `build_rootfs.sh` with `setup-ci-artifacts.sh` by explicitly generating RSA-2048 keys.

## Testing

Ran the full docker-popular test locally — all 6 rootfs images pass:
```
>>>> Testing ubuntu-latest.squashfs       ✓
>>>> Testing ubuntu-25.04.squashfs        ✓
>>>> Testing amazonlinux-2023.squashfs    ✓
>>>> Testing ubuntu-24.04.squashfs        ✓
>>>> Testing ubuntu-22.04.squashfs        ✓
>>>> Testing alpine-latest.squashfs       ✓
```