### PR TITLE
[RFC] Allow MAP_SHARED for snapshot-restore mem_backend (cooperative-snapshot tooling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ### Added
 
+- [#XXXX](https://github.com/firecracker-microvm/firecracker/pull/XXXX): Added
+  an optional `shared` boolean to the `mem_backend` config of `PUT
+  /snapshot/load` (default `false`). When `true` with the `File` backend, the
+  guest memory file is mapped `MAP_SHARED` instead of `MAP_PRIVATE`, letting
+  cooperative-snapshot tooling that holds the same backing file observe guest
+  writes. Existing behavior is unchanged when the field is absent.
 - [#5786](https://github.com/firecracker-microvm/firecracker/pull/5786): Added
   developer preview support for hotplugging and hot-unplugging PCI virtio
   devices (block, pmem, net) on a running microVM. The guest must manually

--- a/src/firecracker/src/api_server/request/snapshot.rs
+++ b/src/firecracker/src/api_server/request/snapshot.rs
@@ -98,6 +98,7 @@ fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, RequestError> {
                 // either `mem_file_path` or `mem_backend` field is always specified.
                 backend_path: snapshot_config.mem_file_path.unwrap(),
                 backend_type: MemBackendType::File,
+                shared: false,
             }
         }
     };
@@ -185,6 +186,7 @@ mod tests {
             mem_backend: MemBackendConfig {
                 backend_path: PathBuf::from("bar"),
                 backend_type: MemBackendType::File,
+                shared: false,
             },
             track_dirty_pages: false,
             resume_vm: false,
@@ -217,6 +219,7 @@ mod tests {
             mem_backend: MemBackendConfig {
                 backend_path: PathBuf::from("bar"),
                 backend_type: MemBackendType::File,
+                shared: false,
             },
             track_dirty_pages: true,
             resume_vm: false,
@@ -249,6 +252,7 @@ mod tests {
             mem_backend: MemBackendConfig {
                 backend_path: PathBuf::from("bar"),
                 backend_type: MemBackendType::Uffd,
+                shared: false,
             },
             track_dirty_pages: false,
             resume_vm: true,
@@ -287,6 +291,7 @@ mod tests {
             mem_backend: MemBackendConfig {
                 backend_path: PathBuf::from("bar"),
                 backend_type: MemBackendType::Uffd,
+                shared: false,
             },
             track_dirty_pages: false,
             resume_vm: true,
@@ -319,6 +324,7 @@ mod tests {
             mem_backend: MemBackendConfig {
                 backend_path: PathBuf::from("bar"),
                 backend_type: MemBackendType::File,
+                shared: false,
             },
             track_dirty_pages: false,
             resume_vm: true,

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1463,6 +1463,16 @@ definitions:
           2) Path to the UDS where a process is listening for a UFFD initialization
           control payload and open file descriptor that it can use to serve this
           process's guest memory page faults
+      shared:
+        type: boolean
+        default: false
+        description:
+          Only used when 'backend_type' is 'File'. When true, the guest
+          memory file is mapped MAP_SHARED instead of MAP_PRIVATE, so an
+          external process holding the same backing file (e.g. a memfd
+          shared over a unix socket) can observe guest writes through its
+          own mapping. Defaults to false (copy-on-write, unchanged
+          behavior). Ignored for the 'Uffd' backend.
 
   Metrics:
     type: object

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -449,8 +449,13 @@ pub fn restore_from_snapshot(
                 .into());
             }
             (
-                guest_memory_from_file(mem_backend_path, mem_state, track_dirty_pages)
-                    .map_err(RestoreFromSnapshotGuestMemoryError::File)?,
+                guest_memory_from_file(
+                    mem_backend_path,
+                    mem_state,
+                    track_dirty_pages,
+                    params.mem_backend.shared,
+                )
+                .map_err(RestoreFromSnapshotGuestMemoryError::File)?,
                 None,
             )
         }
@@ -512,9 +517,11 @@ fn guest_memory_from_file(
     mem_file_path: &Path,
     mem_state: &GuestMemoryState,
     track_dirty_pages: bool,
+    shared: bool,
 ) -> Result<Vec<GuestRegionMmap>, GuestMemoryFromFileError> {
     let mem_file = File::open(mem_file_path)?;
-    let guest_mem = memory::snapshot_file(mem_file, mem_state.regions(), track_dirty_pages)?;
+    let guest_mem =
+        memory::snapshot_file(mem_file, mem_state.regions(), track_dirty_pages, shared)?;
     Ok(guest_mem)
 }
 

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1325,6 +1325,7 @@ mod tests {
                 mem_backend: MemBackendConfig {
                     backend_type: MemBackendType::File,
                     backend_path: PathBuf::new(),
+                    shared: false,
                 },
                 track_dirty_pages: false,
                 resume_vm: false,

--- a/src/vmm/src/vmm_config/snapshot.rs
+++ b/src/vmm/src/vmm_config/snapshot.rs
@@ -130,6 +130,16 @@ pub struct MemBackendConfig {
     pub backend_path: PathBuf,
     /// Specifies the guest memory backend type.
     pub backend_type: MemBackendType,
+    /// If `true` and `backend_type == File`, mmap the backing file with
+    /// `MAP_SHARED` instead of the default `MAP_PRIVATE`. Enables
+    /// cooperative-snapshot tooling: an external process that holds
+    /// the backing memfd open via `/proc/<pid>/fd/<N>` can observe
+    /// guest writes through its own mmap of the same fd.
+    ///
+    /// Defaults to `false` (unchanged behavior). Ignored for the
+    /// `Uffd` backend.
+    #[serde(default)]
+    pub shared: bool,
 }
 
 /// The microVM state options.

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -575,10 +575,17 @@ pub fn anonymous(
 
 /// Creates a GuestMemoryMmap given a `file` containing the data
 /// and a `state` containing mapping information.
+///
+/// When `shared` is `true`, the file is mapped with `MAP_SHARED`
+/// instead of the default `MAP_PRIVATE`. This is opt-in for
+/// cooperative-snapshot tooling that needs an external process
+/// (holding the same backing fd open) to observe guest writes.
+/// Existing callers pass `shared=false` and get unchanged behavior.
 pub fn snapshot_file(
     file: File,
     regions: impl Iterator<Item = (GuestAddress, usize)>,
     track_dirty_pages: bool,
+    shared: bool,
 ) -> Result<Vec<GuestRegionMmap>, MemoryError> {
     let regions: Vec<_> = regions.collect();
     let memory_size = regions
@@ -593,9 +600,14 @@ pub fn snapshot_file(
         return Err(MemoryError::OffsetTooLarge);
     }
 
+    let mmap_flags = if shared {
+        libc::MAP_SHARED
+    } else {
+        libc::MAP_PRIVATE
+    };
     create(
         regions.into_iter(),
-        libc::MAP_PRIVATE,
+        mmap_flags,
         Some(file),
         track_dirty_pages,
     )
@@ -921,7 +933,7 @@ mod tests {
 
             let regions = vec![(GuestAddress(0), page_size)];
             let guest_regions =
-                snapshot_file(file, regions.into_iter(), dirty_page_tracking).unwrap();
+                snapshot_file(file, regions.into_iter(), dirty_page_tracking, false).unwrap();
             assert_eq!(guest_regions.len(), 1);
             guest_regions.iter().for_each(|region| {
                 assert_eq!(region.bitmap().is_some(), dirty_page_tracking);
@@ -942,7 +954,7 @@ mod tests {
             (GuestAddress(0x10000), page_size),
             (GuestAddress(0x20000), page_size),
         ];
-        let guest_regions = snapshot_file(file, regions.into_iter(), false).unwrap();
+        let guest_regions = snapshot_file(file, regions.into_iter(), false, false).unwrap();
         assert_eq!(guest_regions.len(), 3);
     }
 
@@ -954,7 +966,7 @@ mod tests {
         file.write_all(&vec![0x42u8; page_size]).unwrap();
 
         let regions = vec![(GuestAddress(0), 2 * page_size)];
-        let result = snapshot_file(file, regions.into_iter(), false);
+        let result = snapshot_file(file, regions.into_iter(), false, false);
         assert!(matches!(result.unwrap_err(), MemoryError::OffsetTooLarge));
     }
 
@@ -1144,8 +1156,9 @@ mod tests {
         let mut memory_file = TempFile::new().unwrap().into_file();
         guest_memory.dump(&mut memory_file).unwrap();
 
-        let restored_guest_memory =
-            into_region_ext(snapshot_file(memory_file, memory_state.regions(), false).unwrap());
+        let restored_guest_memory = into_region_ext(
+            snapshot_file(memory_file, memory_state.regions(), false, false).unwrap(),
+        );
 
         // Check that the region contents are the same.
         let mut restored_region = vec![0u8; page_size * 2];
@@ -1210,7 +1223,7 @@ mod tests {
 
         // We can restore from this because this is the first dirty dump.
         let restored_guest_memory =
-            into_region_ext(snapshot_file(file, memory_state.regions(), false).unwrap());
+            into_region_ext(snapshot_file(file, memory_state.regions(), false, false).unwrap());
 
         // Check that the region contents are the same.
         let mut restored_region = vec![0u8; region_size];
@@ -1433,6 +1446,7 @@ mod tests {
             snapshot_file(
                 memory_file,
                 std::iter::once((GuestAddress(0), 2 * page_size)),
+                false,
                 false,
             )
             .unwrap(),

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -889,7 +889,7 @@ mod tests {
 
     use std::collections::HashMap;
     use std::io::{Read, Seek, Write};
-    use std::os::unix::fs::MetadataExt;
+    use std::os::unix::fs::{FileExt, MetadataExt};
 
     use vmm_sys_util::tempfile::TempFile;
 
@@ -938,6 +938,37 @@ mod tests {
             guest_regions.iter().for_each(|region| {
                 assert_eq!(region.bitmap().is_some(), dirty_page_tracking);
             });
+        }
+    }
+
+    /// `shared = true` must map the backing file `MAP_SHARED`: a write
+    /// through guest memory becomes visible to any other reader of the
+    /// same file. `shared = false` (the default) must keep `MAP_PRIVATE`
+    /// CoW semantics: guest writes never reach the backing file.
+    #[test]
+    fn test_snapshot_file_shared_mapping_visibility() {
+        let page_size = host_page_size();
+        for (shared, expect_visible) in [(true, true), (false, false)] {
+            let mut file = TempFile::new().unwrap().into_file();
+            file.set_len(page_size as u64).unwrap();
+            file.write_all(&vec![0u8; page_size]).unwrap();
+            let reader = file.try_clone().unwrap();
+
+            let regions = vec![(GuestAddress(0), page_size)];
+            let guest_regions =
+                into_region_ext(snapshot_file(file, regions.into_iter(), false, shared).unwrap());
+
+            // Write through the guest mapping...
+            guest_regions.write(&[0x42u8; 16], GuestAddress(0)).unwrap();
+
+            // ...and check whether the backing file observed it.
+            let mut observed = [0u8; 16];
+            reader.read_exact_at(&mut observed, 0).unwrap();
+            if expect_visible {
+                assert_eq!(observed, [0x42u8; 16], "MAP_SHARED write not visible");
+            } else {
+                assert_eq!(observed, [0u8; 16], "MAP_PRIVATE write leaked to file");
+            }
         }
     }
 

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -311,6 +311,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
             mem_backend: MemBackendConfig {
                 backend_path: memory_file.as_path().to_path_buf(),
                 backend_type: MemBackendType::File,
+                shared: false,
             },
             track_dirty_pages: false,
             resume_vm: true,
@@ -397,6 +398,7 @@ fn verify_load_snap_disallowed_after_boot_resources(res: VmmAction, res_name: &s
         mem_backend: MemBackendConfig {
             backend_path: memory_file.as_path().to_path_buf(),
             backend_type: MemBackendType::File,
+            shared: false,
         },
         track_dirty_pages: false,
         resume_vm: false,


### PR DESCRIPTION
## Changes

Adds an optional `shared: bool` field (default `false`) to the `mem_backend` config of `PUT /snapshot/load`. When `true` with the `File` backend, guest memory is mapped `MAP_SHARED` instead of `MAP_PRIVATE`. Three commits:

1. **api** — the field + serde default + swagger + CHANGELOG; all existing initializers updated, existing API clients unaffected
2. **vmm** — thread the flag into `vstate::memory::snapshot_file`, which picks `MAP_SHARED` over `MAP_PRIVATE` when requested; every existing caller passes `false` and keeps CoW semantics bit-for-bit
3. **test** — behavioral unit test: `shared=true` ⇒ a guest-memory write is visible to another reader of the backing file; `shared=false` ⇒ it is not (the historical behavior)

~30 lines of non-test change; no `unsafe`, no new dependencies, default path untouched.

## Reason

Context issue: #5912.

Cooperative-snapshot tooling — managers that pass Firecracker a memfd as the restore backend (via `/proc/<pid>/fd/<N>`) — currently can't observe guest writes through their own mapping of the same fd, because the VMM maps the file `MAP_PRIVATE` and all guest dirty state lives in private CoW pages. `shared: true` makes the obvious opt-in available: the manager's mapping and the guest's mapping become coherent views of the same pages.

Concrete user: [forkd](https://github.com/deeplethe/forkd) (open-source fork-on-write sandbox manager, ~1.9k stars) uses exactly this to take incremental snapshots of a *running* microVM: with a shared memfd backing plus `userfaultfd` write-protect armed on it, the source VM's pause window during a snapshot drops from **202 ms p50 (pause-and-dump on a 1.5 GiB guest) to 56 ms p50**, with the memory copy streamed in the background after resume ([bench data](https://github.com/deeplethe/forkd/blob/main/bench/live-fork-pause-window/RESULTS-v0.4.md)). Today that requires shipping a patched Firecracker, which is the single biggest install burden for users — and version drift between the patched binary and stock snapshots is a recurring failure mode.

We suspect other snapshot-orchestration tools (warm-pool managers, live migration experiments, CRIU-style tooling) hit the same wall.

### Design notes

- **Opt-in, default unchanged.** Absent field ⇒ `MAP_PRIVATE`, exactly as today.
- **`Uffd` backend ignores it** — that path already hands page-serving to an external process.
- **No dirty-tracking interaction**: `track_dirty_pages` composes with either mapping flag (covered by the existing `snapshot_file` tests which now run against the 4-arg signature).
- **Security posture**: `MAP_SHARED` of a caller-supplied file does mean guest writes reach that file. That's the point — and the caller already controls the file; no privilege boundary changes.

## Testing

- New behavioral unit test (`test_snapshot_file_shared_mapping_visibility`) asserts observable write-visibility semantics for both flag values rather than inspecting mmap flags.
- `cargo test -p vmm --lib vstate::memory`: 17/17 on x86_64 Linux 6.14.
- `cargo clippy --all-targets` on `vmm` + `firecracker`: clean; `cargo fmt --check`: clean; each commit compiles standalone.
- Happy to add an integration test under `tests/integration_tests/functional/test_snapshot_basic.py` (restore with `shared: true`, observe a guest write through a second mapping) if maintainers think this direction is worth pursuing — flagging as RFC first to get directional feedback before investing in the full harness.

- [x] This functionality cannot be added in [`firecracker-containerd`](https://github.com/firecracker-microvm/firecracker-containerd), [`firectl`](https://github.com/firecracker-microvm/firectl) or [`firecracker-go-sdk`](https://github.com/firecracker-microvm/firecracker-go-sdk) — it changes how the VMM itself maps guest memory.
- [x] I have read and understand [CONTRIBUTING.md](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md).
- [x] All commits are signed off (DCO) with my real name.
- [x] No `unsafe` code added; default behavior is bit-for-bit unchanged.