### PR TITLE
fix: validate allocated MSI-X interrupts on restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "vm-allocator"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040a65b0c29f298d71ca45dd52d02b0d0ddc15b9b97d95dfeebe67d6fdd42a28"
+checksum = "a2feb549d049009150155ab6e1b0c8c0db9ea6805ba5bdc57a27a3b7466e80f5"
 dependencies = [
  "libc",
  "serde",

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -50,7 +50,7 @@ userfaultfd = "0.9.0"
 utils = { path = "../utils" }
 uuid = "1.23.2"
 vhost = { version = "0.15.0", features = ["vhost-user-frontend"] }
-vm-allocator = { version = "0.1.3", features = ["serde"] }
+vm-allocator = { version = "0.1.4", features = ["serde"] }
 vm-memory = { version = "0.17.1", features = [
   "backend-mmap",
   "backend-bitmap",

--- a/src/vmm/src/arch/aarch64/vm.rs
+++ b/src/vmm/src/arch/aarch64/vm.rs
@@ -7,8 +7,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::Kvm;
 use crate::arch::aarch64::gic::GicState;
+use crate::snapshot::Persist;
 use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryState};
-use crate::vstate::resources::ResourceAllocator;
+use crate::vstate::resources::{ResourceAllocator, ResourceAllocatorState};
 use crate::vstate::vm::{VmCommon, VmError};
 
 /// Structure representing the current architecture's understand of what a "virtual machine" is.
@@ -29,6 +30,8 @@ pub enum KvmVmError {
     SaveGic(crate::arch::aarch64::gic::GicError),
     /// Failed to restore the VM's GIC state: {0}
     RestoreGic(crate::arch::aarch64::gic::GicError),
+    /// Failed to restore resource allocator: {0}
+    ResourceAllocator(#[from] vm_allocator::Error),
 }
 
 impl KvmVm {
@@ -77,7 +80,7 @@ impl KvmVm {
                 .get_irqchip()
                 .save_device(mpidrs)
                 .map_err(KvmVmError::SaveGic)?,
-            resource_allocator: self.resource_allocator().clone(),
+            resource_allocator: self.resource_allocator().save(),
         })
     }
 
@@ -90,7 +93,8 @@ impl KvmVm {
         self.get_irqchip()
             .restore_device(mpidrs, &state.gic)
             .map_err(KvmVmError::RestoreGic)?;
-        self.common.resource_allocator = Mutex::new(state.resource_allocator.clone());
+        self.common.resource_allocator =
+            Mutex::new(ResourceAllocator::restore((), &state.resource_allocator)?);
 
         Ok(())
     }
@@ -104,5 +108,5 @@ pub struct VmState {
     /// GIC state.
     pub gic: GicState,
     /// resource allocator
-    pub resource_allocator: ResourceAllocator,
+    pub resource_allocator: ResourceAllocatorState,
 }

--- a/src/vmm/src/arch/x86_64/vm.rs
+++ b/src/vmm/src/arch/x86_64/vm.rs
@@ -17,7 +17,7 @@ use crate::utils::u64_to_usize;
 use crate::vstate::bus::Bus;
 use crate::vstate::kvm::Kvm;
 use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryState};
-use crate::vstate::resources::ResourceAllocator;
+use crate::vstate::resources::{ResourceAllocator, ResourceAllocatorState};
 use crate::vstate::vm::{VmCommon, VmError};
 
 /// Error type for [`KvmVm::restore_state`]
@@ -51,6 +51,8 @@ pub enum KvmVmError {
     GetMsrsToSave(MsrError),
     /// Failed during KVM_SET_TSS_ADDRESS: {0}
     SetTssAddress(kvm_ioctls::Error),
+    /// Failed to restore resource allocator: {0}
+    ResourceAllocator(#[from] vm_allocator::Error),
 }
 
 /// Structure representing the current architecture's understand of what a "virtual machine" is.
@@ -160,7 +162,8 @@ impl KvmVm {
         self.fd()
             .set_irqchip(&state.ioapic)
             .map_err(KvmVmError::SetIrqChipIoAPIC)?;
-        self.common.resource_allocator = Mutex::new(state.resource_allocator.clone());
+        self.common.resource_allocator =
+            Mutex::new(ResourceAllocator::restore((), &state.resource_allocator)?);
         Ok(())
     }
 
@@ -238,7 +241,7 @@ pub struct VmState {
     /// guest memory state
     pub memory: GuestMemoryState,
     /// resource allocator
-    pub resource_allocator: ResourceAllocator,
+    pub resource_allocator: ResourceAllocatorState,
     pitstate: kvm_pit_state2,
     clock: kvm_clock_data,
     // TODO: rename this field to adopt inclusive language once Linux updates it, too.

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -636,6 +636,7 @@ mod tests {
     use crate::vmm_config::net::NetworkInterfaceConfig;
     use crate::vmm_config::pmem::PmemConfig;
     use crate::vmm_config::vsock::VsockDeviceConfig;
+    use crate::vstate::resources::ResourceAllocator;
 
     #[test]
     fn test_device_manager_persistence() {
@@ -729,7 +730,7 @@ mod tests {
 
             let device_state = vmm.device_manager.save();
             serialized_data = bitcode::serialize(&device_state).unwrap();
-            saved_allocator = vmm.vm.as_kvm().unwrap().resource_allocator().clone()
+            saved_allocator = vmm.vm.as_kvm().unwrap().resource_allocator().save()
         }
 
         tmp_sock_file.remove().unwrap();
@@ -742,7 +743,8 @@ mod tests {
         let vmm = default_vmm();
         // Restore the source allocator's state so the restored devices' GSIs match what their
         // `MsixVectorGroup::Drop` will try to free at end-of-test.
-        *vmm.vm.as_kvm().unwrap().resource_allocator() = saved_allocator;
+        *vmm.vm.as_kvm().unwrap().resource_allocator() =
+            ResourceAllocator::restore((), &saved_allocator).unwrap();
 
         let device_manager_state: device_manager::DevicesState =
             bitcode::deserialize(&serialized_data).unwrap();

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -45,7 +45,6 @@ use crate::snapshot::Persist;
 use crate::vstate::bus::BusDevice;
 use crate::vstate::interrupts::{InterruptError, MsixVectorGroup};
 use crate::vstate::memory::GuestMemoryMmap;
-use crate::vstate::resources::ResourceAllocator;
 use crate::vstate::vm::KvmVm;
 
 /// Vector value used to disable MSI for a queue.
@@ -1056,6 +1055,8 @@ mod tests {
     use crate::pci::msix::MsixCap;
     use crate::pci::{PciCapabilityId, PciClassCode, PciDevice};
     use crate::rate_limiter::RateLimiter;
+    use crate::snapshot::Persist;
+    use crate::vstate::resources::ResourceAllocator;
 
     fn create_vmm_with_virtio_pci_device() -> Vmm {
         let mut vmm = default_vmm();
@@ -1740,12 +1741,13 @@ mod tests {
         // copy reuses the same MSI-X GSIs, so the two `MsixVectorGroup` instances must never
         // exist concurrently. This is how it will happen in real scenario anyway.
         let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
-        let saved_allocator = kvm_vm.resource_allocator().clone();
+        let saved_allocator = kvm_vm.resource_allocator().save();
         drop(device);
         drop(vmm);
-        // Restore the allocator state so the restored group's GSIs are marked allocated and
-        // its `MsixVectorGroup::drop` will succeed when the test ends.
-        *kvm_vm.resource_allocator() = saved_allocator;
+        // Restore allocator state through `ResourceAllocator::restore`, matching the VM restore
+        // path. This resets the MSI GSI allocator before the restored device replays its saved GSI
+        // allocations.
+        *kvm_vm.resource_allocator() = ResourceAllocator::restore((), &saved_allocator).unwrap();
 
         let new_entropy = Arc::new(Mutex::new(Entropy::new(RateLimiter::default()).unwrap()));
         let restored =

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -160,7 +160,7 @@ pub enum CreateSnapshotError {
 }
 
 /// Snapshot version
-pub const SNAPSHOT_VERSION: Version = Version::new(10, 0, 0);
+pub const SNAPSHOT_VERSION: Version = Version::new(11, 0, 0);
 
 /// Creates a Microvm snapshot.
 pub fn create_snapshot(

--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -218,8 +218,14 @@ impl<'a> Persist<'a> for MsixVectorGroup {
     ) -> Result<Self, Self::Error> {
         let mut vectors = Vec::with_capacity(state.len());
 
-        for gsi in state {
-            vectors.push(MsixVector::new(*gsi, false)?);
+        {
+            // Replay the GSI allocations rather than trusting the serialized allocator state.
+            // This validates the snapshot is not malformed, containing doubly allocated GSI IDs
+            let mut resource_allocator = constructor_args.resource_allocator();
+            for gsi in state {
+                resource_allocator.gsi_msi_allocator.allocate_id_at(*gsi)?;
+                vectors.push(MsixVector::new(*gsi, false)?);
+            }
         }
 
         Ok(MsixVectorGroup {

--- a/src/vmm/src/vstate/resources.rs
+++ b/src/vmm/src/vstate/resources.rs
@@ -1,12 +1,10 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::Infallible;
-
 use bitvec::vec::BitVec;
 use serde::{Deserialize, Serialize};
+use vm_allocator::AddressAllocator;
 pub use vm_allocator::AllocPolicy;
-use vm_allocator::{AddressAllocator, IdAllocator};
 
 use crate::arch;
 use crate::snapshot::Persist;
@@ -41,7 +39,7 @@ fn allocate_many_ids(
 /// * GSIs for legacy x86_64 devices
 /// * GSIs for MMIO devicecs
 /// * Memory allocations in the MMIO address space
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ResourceAllocator {
     /// Allocator for legacy device interrupt lines
     pub gsi_legacy_allocator: IdAllocator,
@@ -111,20 +109,57 @@ impl ResourceAllocator {
     }
 }
 
+/// Serializable state for the resource allocator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceAllocatorState {
+    /// Allocator for legacy device interrupt lines
+    pub gsi_legacy_allocator: IdAllocator,
+    /// Allocator for memory in the 32-bit MMIO address space
+    pub mmio32_memory: AddressAllocator,
+    /// Allocator for memory in the 64-bit MMIO address space
+    pub mmio64_memory: AddressAllocator,
+    /// Allocator for memory after the 64-bit MMIO address space
+    pub past_mmio64_memory: AddressAllocator,
+    /// Memory allocator for system data
+    pub system_memory: AddressAllocator,
+}
+
+impl Default for ResourceAllocatorState {
+    fn default() -> Self {
+        ResourceAllocator::new().save()
+    }
+}
+
 impl<'a> Persist<'a> for ResourceAllocator {
-    type State = ResourceAllocator;
+    type State = ResourceAllocatorState;
     type ConstructorArgs = ();
-    type Error = Infallible;
+    type Error = vm_allocator::Error;
 
     fn save(&self) -> Self::State {
-        self.clone()
+        ResourceAllocatorState {
+            gsi_legacy_allocator: self.gsi_legacy_allocator.clone(),
+            mmio32_memory: self.mmio32_memory.clone(),
+            mmio64_memory: self.mmio64_memory.clone(),
+            past_mmio64_memory: self.past_mmio64_memory.clone(),
+            system_memory: self.system_memory.clone(),
+        }
     }
 
     fn restore(
         _constructor_args: Self::ConstructorArgs,
         state: &Self::State,
     ) -> Result<Self, Self::Error> {
-        Ok(state.clone())
+        Ok(ResourceAllocator {
+            gsi_legacy_allocator: state.gsi_legacy_allocator.clone(),
+            gsi_msi_allocator: IdAllocator::new(arch::GSI_MSI_START, arch::GSI_MSI_END)?,
+            mmio32_memory: state.mmio32_memory.clone(),
+            mmio64_memory: state.mmio64_memory.clone(),
+            past_mmio64_memory: state.past_mmio64_memory.clone(),
+            system_memory: state.system_memory.clone(),
+        })
+    }
+}
+
 /// An unique ID allocator that allows management of IDs in a given interval.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdAllocator {
@@ -229,8 +264,9 @@ impl IdAllocator {
 #[cfg(test)]
 mod tests {
     mod resource_allocator {
-        use super::super::ResourceAllocator;
+        use super::super::{AllocPolicy, ResourceAllocator};
         use crate::arch::{self, GSI_LEGACY_NUM, GSI_MSI_NUM};
+        use crate::snapshot::Persist;
 
         #[test]
         fn test_allocate_irq() {
@@ -318,6 +354,32 @@ mod tests {
                 assert_eq!(allocator.allocate_gsi_msi(1), Ok(vec![i]));
             }
         }
+
+        #[test]
+        fn test_persist_omits_msi_gsi_allocator() {
+            let mut allocator = ResourceAllocator::new();
+
+            let legacy_gsi = allocator.allocate_gsi_legacy(1).unwrap()[0];
+            let msi_gsi = allocator.allocate_gsi_msi(1).unwrap()[0];
+            let mmio_range = allocator
+                .mmio32_memory
+                .allocate(1024, 1024, AllocPolicy::FirstMatch)
+                .unwrap();
+
+            let state = allocator.save();
+            let mut restored = ResourceAllocator::restore((), &state).unwrap();
+
+            // Legacy GSIs and MMIO ranges are serialized, so their allocations survive restore.
+            assert_eq!(restored.allocate_gsi_legacy(1).unwrap()[0], legacy_gsi + 1);
+            restored
+                .mmio32_memory
+                .allocate(1024, 1024, AllocPolicy::ExactMatch(mmio_range.start()))
+                .unwrap_err();
+
+            // MSI GSIs are intentionally omitted from ResourceAllocatorState and replayed by the
+            // restored PCI devices, so the allocator starts empty after restore.
+            assert_eq!(restored.allocate_gsi_msi(1).unwrap()[0], msi_gsi);
+        }
     }
 
     mod id_allocator {
@@ -339,7 +401,7 @@ mod tests {
             assert_eq!(legacy_irq_allocator.allocate_id().unwrap(), 6);
 
             for _ in 2..19 {
-                assert!(legacy_irq_allocator.allocate_id().is_ok());
+                legacy_irq_allocator.allocate_id().unwrap();
             }
 
             assert_eq!(
@@ -354,7 +416,6 @@ mod tests {
             assert_eq!(allocator.allocate_id().unwrap(), u32::MAX - 1);
             assert_eq!(allocator.allocate_id().unwrap(), u32::MAX);
             let res = allocator.allocate_id();
-            assert!(res.is_err());
             assert_eq!(res.unwrap_err(), Error::ResourceNotAvailable);
         }
 

--- a/src/vmm/src/vstate/resources.rs
+++ b/src/vmm/src/vstate/resources.rs
@@ -3,6 +3,7 @@
 
 use std::convert::Infallible;
 
+use bitvec::vec::BitVec;
 use serde::{Deserialize, Serialize};
 pub use vm_allocator::AllocPolicy;
 use vm_allocator::{AddressAllocator, IdAllocator};
@@ -124,98 +125,375 @@ impl<'a> Persist<'a> for ResourceAllocator {
         state: &Self::State,
     ) -> Result<Self, Self::Error> {
         Ok(state.clone())
+/// An unique ID allocator that allows management of IDs in a given interval.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdAllocator {
+    // Beginning of the range of IDs that we want to manage.
+    range_base: u32,
+    // One bit per id in the managed range. A set bit means the corresponding
+    // id is currently allocated.
+    allocated: BitVec,
+}
+
+impl IdAllocator {
+    /// Create a new IdAllocator with IDs in [`range_base`, `range_end`].
+    pub fn new(range_base: u32, range_end: u32) -> Result<Self, vm_allocator::Error> {
+        if range_end < range_base {
+            return Err(vm_allocator::Error::InvalidRange(
+                range_base.into(),
+                range_end.into(),
+            ));
+        }
+
+        let num_ids = u64::from(range_end) - u64::from(range_base) + 1;
+        let num_ids = usize::try_from(num_ids).map_err(|_| vm_allocator::Error::Overflow)?;
+        let mut allocated = BitVec::with_capacity(num_ids);
+        allocated.resize(num_ids, false);
+
+        Ok(IdAllocator {
+            range_base,
+            allocated,
+        })
+    }
+
+    /// Map `id` to its corresponding index in the bitmap.
+    fn index_for(&self, id: u32) -> Result<usize, vm_allocator::Error> {
+        let offset = id
+            .checked_sub(self.range_base)
+            .ok_or(vm_allocator::Error::OutOfRange(id))?;
+        let index = offset as usize;
+        self.allocated
+            .get(index)
+            .map(|_| index)
+            .ok_or(vm_allocator::Error::OutOfRange(id))
+    }
+
+    // Given `index` into the bitmap, return the `id` in that position
+    // Returns `vm_allocator::Error::Overflow` if the index would map to an overflowed id.
+    fn id_for_index(&self, index: usize) -> Result<u32, vm_allocator::Error> {
+        let offset = u32::try_from(index).map_err(|_| vm_allocator::Error::Overflow)?;
+        self.range_base
+            .checked_add(offset)
+            .ok_or(vm_allocator::Error::Overflow)
+    }
+
+    /// Allocate an ID from the managed range.Returns the first available id
+    /// from the managed range, or `ResourceNotAvailable` if every id has been
+    /// handed out.
+    pub fn allocate_id(&mut self) -> Result<u32, vm_allocator::Error> {
+        if let Some(index) = self.allocated.first_zero() {
+            self.allocated.set(index, true);
+            let id = self.id_for_index(index)?;
+            Ok(id)
+        } else {
+            Err(vm_allocator::Error::ResourceNotAvailable)
+        }
+    }
+
+    /// Allocate the specified ID from the managed range.
+    ///
+    /// Returns `id` on success, `OutOfRange` if `id` is outside the managed
+    /// range, or `ResourceNotAvailable` if `id` has already been allocated.
+    pub fn allocate_id_at(&mut self, id: u32) -> Result<u32, vm_allocator::Error> {
+        let index = self.index_for(id)?;
+        if !self.allocated[index] {
+            self.allocated.set(index, true);
+            Ok(id)
+        } else {
+            Err(vm_allocator::Error::ResourceNotAvailable)
+        }
+    }
+
+    /// Returns `true` if `id` is currently allocated from the managed range.
+    ///
+    /// Ids outside the managed range are considered never allocated, so return false.
+    pub fn is_allocated(&self, id: u32) -> bool {
+        match self.index_for(id) {
+            Ok(index) => self.allocated[index],
+            Err(_) => false,
+        }
+    }
+
+    /// Frees an id from the managed range.
+    pub fn free_id(&mut self, id: u32) -> Result<u32, vm_allocator::Error> {
+        let index = self.index_for(id)?;
+        if self.allocated[index] {
+            self.allocated.set(index, false);
+            Ok(id)
+        } else {
+            Err(vm_allocator::Error::NeverAllocated(id))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ResourceAllocator;
-    use crate::arch::{self, GSI_LEGACY_NUM, GSI_MSI_NUM};
+    mod resource_allocator {
+        use super::super::ResourceAllocator;
+        use crate::arch::{self, GSI_LEGACY_NUM, GSI_MSI_NUM};
 
-    #[test]
-    fn test_allocate_irq() {
-        let mut allocator = ResourceAllocator::new();
-        // asking for 0 IRQs should return us an empty vector
-        assert_eq!(allocator.allocate_gsi_legacy(0), Ok(vec![]));
-        // We cannot allocate more GSIs than available
-        assert_eq!(
-            allocator.allocate_gsi_legacy(GSI_LEGACY_NUM + 1),
-            Err(vm_allocator::Error::ResourceNotAvailable)
-        );
-        // But allocating all of them at once should work
-        assert_eq!(
-            allocator.allocate_gsi_legacy(GSI_LEGACY_NUM),
-            Ok((arch::GSI_LEGACY_START..=arch::GSI_LEGACY_END).collect::<Vec<_>>())
-        );
-        // And now we ran out of GSIs
-        assert_eq!(
-            allocator.allocate_gsi_legacy(1),
-            Err(vm_allocator::Error::ResourceNotAvailable)
-        );
-        // But we should be able to ask for 0 GSIs
-        assert_eq!(allocator.allocate_gsi_legacy(0), Ok(vec![]));
+        #[test]
+        fn test_allocate_irq() {
+            let mut allocator = ResourceAllocator::new();
+            // asking for 0 IRQs should return us an empty vector
+            assert_eq!(allocator.allocate_gsi_legacy(0), Ok(vec![]));
+            // We cannot allocate more GSIs than available
+            assert_eq!(
+                allocator.allocate_gsi_legacy(GSI_LEGACY_NUM + 1),
+                Err(vm_allocator::Error::ResourceNotAvailable)
+            );
+            // But allocating all of them at once should work
+            assert_eq!(
+                allocator.allocate_gsi_legacy(GSI_LEGACY_NUM),
+                Ok((arch::GSI_LEGACY_START..=arch::GSI_LEGACY_END).collect::<Vec<_>>())
+            );
+            // And now we ran out of GSIs
+            assert_eq!(
+                allocator.allocate_gsi_legacy(1),
+                Err(vm_allocator::Error::ResourceNotAvailable)
+            );
+            // But we should be able to ask for 0 GSIs
+            assert_eq!(allocator.allocate_gsi_legacy(0), Ok(vec![]));
 
-        let mut allocator = ResourceAllocator::new();
-        // We should be able to allocate 1 GSI
-        assert_eq!(
-            allocator.allocate_gsi_legacy(1),
-            Ok(vec![arch::GSI_LEGACY_START])
-        );
-        // We can't allocate MAX_IRQS any more
-        assert_eq!(
-            allocator.allocate_gsi_legacy(GSI_LEGACY_NUM),
-            Err(vm_allocator::Error::ResourceNotAvailable)
-        );
-        // We can allocate another one and it should be the second available
-        assert_eq!(
-            allocator.allocate_gsi_legacy(1),
-            Ok(vec![arch::GSI_LEGACY_START + 1])
-        );
-        // Let's allocate the rest in a loop
-        for i in arch::GSI_LEGACY_START + 2..=arch::GSI_LEGACY_END {
-            assert_eq!(allocator.allocate_gsi_legacy(1), Ok(vec![i]));
+            let mut allocator = ResourceAllocator::new();
+            // We should be able to allocate 1 GSI
+            assert_eq!(
+                allocator.allocate_gsi_legacy(1),
+                Ok(vec![arch::GSI_LEGACY_START])
+            );
+            // We can't allocate MAX_IRQS any more
+            assert_eq!(
+                allocator.allocate_gsi_legacy(GSI_LEGACY_NUM),
+                Err(vm_allocator::Error::ResourceNotAvailable)
+            );
+            // We can allocate another one and it should be the second available
+            assert_eq!(
+                allocator.allocate_gsi_legacy(1),
+                Ok(vec![arch::GSI_LEGACY_START + 1])
+            );
+            // Let's allocate the rest in a loop
+            for i in arch::GSI_LEGACY_START + 2..=arch::GSI_LEGACY_END {
+                assert_eq!(allocator.allocate_gsi_legacy(1), Ok(vec![i]));
+            }
+        }
+
+        #[test]
+        fn test_allocate_gsi() {
+            let mut allocator = ResourceAllocator::new();
+            // asking for 0 IRQs should return us an empty vector
+            assert_eq!(allocator.allocate_gsi_msi(0), Ok(vec![]));
+            // We cannot allocate more GSIs than available
+            assert_eq!(
+                allocator.allocate_gsi_msi(GSI_MSI_NUM + 1),
+                Err(vm_allocator::Error::ResourceNotAvailable)
+            );
+            // But allocating all of them at once should work
+            assert_eq!(
+                allocator.allocate_gsi_msi(GSI_MSI_NUM),
+                Ok((arch::GSI_MSI_START..=arch::GSI_MSI_END).collect::<Vec<_>>())
+            );
+            // And now we ran out of GSIs
+            assert_eq!(
+                allocator.allocate_gsi_msi(1),
+                Err(vm_allocator::Error::ResourceNotAvailable)
+            );
+            // But we should be able to ask for 0 GSIs
+            assert_eq!(allocator.allocate_gsi_msi(0), Ok(vec![]));
+
+            let mut allocator = ResourceAllocator::new();
+            // We should be able to allocate 1 GSI
+            assert_eq!(allocator.allocate_gsi_msi(1), Ok(vec![arch::GSI_MSI_START]));
+            // We can't allocate MAX_IRQS any more
+            assert_eq!(
+                allocator.allocate_gsi_msi(GSI_MSI_NUM),
+                Err(vm_allocator::Error::ResourceNotAvailable)
+            );
+            // We can allocate another one and it should be the second available
+            assert_eq!(
+                allocator.allocate_gsi_msi(1),
+                Ok(vec![arch::GSI_MSI_START + 1])
+            );
+            // Let's allocate the rest in a loop
+            for i in arch::GSI_MSI_START + 2..=arch::GSI_MSI_END {
+                assert_eq!(allocator.allocate_gsi_msi(1), Ok(vec![i]));
+            }
         }
     }
 
-    #[test]
-    fn test_allocate_gsi() {
-        let mut allocator = ResourceAllocator::new();
-        // asking for 0 IRQs should return us an empty vector
-        assert_eq!(allocator.allocate_gsi_msi(0), Ok(vec![]));
-        // We cannot allocate more GSIs than available
-        assert_eq!(
-            allocator.allocate_gsi_msi(GSI_MSI_NUM + 1),
-            Err(vm_allocator::Error::ResourceNotAvailable)
-        );
-        // But allocating all of them at once should work
-        assert_eq!(
-            allocator.allocate_gsi_msi(GSI_MSI_NUM),
-            Ok((arch::GSI_MSI_START..=arch::GSI_MSI_END).collect::<Vec<_>>())
-        );
-        // And now we ran out of GSIs
-        assert_eq!(
-            allocator.allocate_gsi_msi(1),
-            Err(vm_allocator::Error::ResourceNotAvailable)
-        );
-        // But we should be able to ask for 0 GSIs
-        assert_eq!(allocator.allocate_gsi_msi(0), Ok(vec![]));
+    mod id_allocator {
 
-        let mut allocator = ResourceAllocator::new();
-        // We should be able to allocate 1 GSI
-        assert_eq!(allocator.allocate_gsi_msi(1), Ok(vec![arch::GSI_MSI_START]));
-        // We can't allocate MAX_IRQS any more
-        assert_eq!(
-            allocator.allocate_gsi_msi(GSI_MSI_NUM),
-            Err(vm_allocator::Error::ResourceNotAvailable)
-        );
-        // We can allocate another one and it should be the second available
-        assert_eq!(
-            allocator.allocate_gsi_msi(1),
-            Ok(vec![arch::GSI_MSI_START + 1])
-        );
-        // Let's allocate the rest in a loop
-        for i in arch::GSI_MSI_START + 2..=arch::GSI_MSI_END {
-            assert_eq!(allocator.allocate_gsi_msi(1), Ok(vec![i]));
+        use super::super::IdAllocator;
+        use vm_allocator::Error;
+
+        #[test]
+        fn test_slot_id_allocation() {
+            let faulty_allocator = IdAllocator::new(23, 5);
+            assert_eq!(faulty_allocator.unwrap_err(), Error::InvalidRange(23, 5));
+            let mut legacy_irq_allocator = IdAllocator::new(5, 23).unwrap();
+            assert_eq!(legacy_irq_allocator.range_base, 5);
+            assert_eq!(legacy_irq_allocator.allocated.len(), 19);
+
+            let id = legacy_irq_allocator.allocate_id().unwrap();
+            assert_eq!(id, 5);
+            assert!(legacy_irq_allocator.is_allocated(id));
+            assert_eq!(legacy_irq_allocator.allocate_id().unwrap(), 6);
+
+            for _ in 2..19 {
+                assert!(legacy_irq_allocator.allocate_id().is_ok());
+            }
+
+            assert_eq!(
+                legacy_irq_allocator.allocate_id().unwrap_err(),
+                Error::ResourceNotAvailable
+            );
+        }
+
+        #[test]
+        fn test_u32_max_exhaustion() {
+            let mut allocator = IdAllocator::new(u32::MAX - 1, u32::MAX).unwrap();
+            assert_eq!(allocator.allocate_id().unwrap(), u32::MAX - 1);
+            assert_eq!(allocator.allocate_id().unwrap(), u32::MAX);
+            let res = allocator.allocate_id();
+            assert!(res.is_err());
+            assert_eq!(res.unwrap_err(), Error::ResourceNotAvailable);
+        }
+
+        #[test]
+        fn test_slot_id_free() {
+            let mut legacy_irq_allocator = IdAllocator::new(5, 23).unwrap();
+            assert_eq!(
+                legacy_irq_allocator.free_id(3).unwrap_err(),
+                Error::OutOfRange(3)
+            );
+
+            for _ in 1..10 {
+                let _id = legacy_irq_allocator.allocate_id().unwrap();
+            }
+
+            let irq = 10;
+            legacy_irq_allocator.free_id(irq).unwrap();
+            assert!(!legacy_irq_allocator.is_allocated(irq));
+            assert_eq!(
+                legacy_irq_allocator.free_id(10).unwrap_err(),
+                Error::NeverAllocated(10)
+            );
+            let irq = 9;
+            legacy_irq_allocator.free_id(irq).unwrap();
+            assert!(!legacy_irq_allocator.is_allocated(irq));
+
+            let irq = legacy_irq_allocator.allocate_id().unwrap();
+            assert_eq!(irq, 9);
+            assert!(legacy_irq_allocator.is_allocated(irq));
+            assert!(!legacy_irq_allocator.is_allocated(10));
+            assert_eq!(
+                legacy_irq_allocator.free_id(21).unwrap_err(),
+                Error::NeverAllocated(21)
+            );
+        }
+
+        #[test]
+        fn test_free_id_never_allocated_boundary() {
+            let mut allocator = IdAllocator::new(5, 23).unwrap();
+
+            assert_eq!(allocator.free_id(5).unwrap_err(), Error::NeverAllocated(5));
+
+            for _ in 0..3 {
+                allocator.allocate_id().unwrap();
+            }
+            assert!(allocator.is_allocated(7));
+            assert!(!allocator.is_allocated(8));
+            assert_eq!(allocator.free_id(8).unwrap_err(), Error::NeverAllocated(8));
+        }
+
+        #[test]
+        fn test_is_allocated() {
+            let mut allocator = IdAllocator::new(5, 23).unwrap();
+
+            assert!(!allocator.is_allocated(4));
+            assert!(!allocator.is_allocated(24));
+
+            assert!(!allocator.is_allocated(10));
+
+            let id = allocator.allocate_id().unwrap();
+            assert_eq!(id, 5);
+            assert!(allocator.is_allocated(5));
+            assert!(!allocator.is_allocated(6));
+
+            allocator.free_id(5).unwrap();
+            assert!(!allocator.is_allocated(5));
+
+            let id = allocator.allocate_id().unwrap();
+            assert_eq!(id, 5);
+            assert!(allocator.is_allocated(5));
+        }
+
+        #[test]
+        fn test_is_allocated_full_range() {
+            let mut allocator = IdAllocator::new(u32::MAX - 1, u32::MAX).unwrap();
+
+            assert!(!allocator.is_allocated(u32::MAX - 1));
+            assert!(!allocator.is_allocated(u32::MAX));
+
+            assert_eq!(allocator.allocate_id().unwrap(), u32::MAX - 1);
+            assert!(allocator.is_allocated(u32::MAX - 1));
+            assert!(!allocator.is_allocated(u32::MAX));
+
+            assert_eq!(allocator.allocate_id().unwrap(), u32::MAX);
+            assert!(allocator.is_allocated(u32::MAX));
+
+            allocator.free_id(u32::MAX).unwrap();
+            assert!(!allocator.is_allocated(u32::MAX));
+            assert!(allocator.is_allocated(u32::MAX - 1));
+        }
+
+        #[test]
+        fn test_is_allocated_with_freed() {
+            let mut allocator = IdAllocator::new(5, 23).unwrap();
+            allocator.allocate_id().unwrap();
+            allocator.allocate_id().unwrap();
+
+            assert!(allocator.is_allocated(6));
+            assert!(!allocator.is_allocated(7));
+
+            allocator.free_id(5).unwrap();
+            assert!(!allocator.is_allocated(5));
+            assert!(allocator.is_allocated(6));
+            assert!(!allocator.is_allocated(7));
+        }
+
+        #[test]
+        fn test_allocate_id_at() {
+            let mut allocator = IdAllocator::new(5, 8).unwrap();
+
+            assert_eq!(allocator.allocate_id_at(7).unwrap(), 7);
+            assert!(allocator.is_allocated(7));
+            assert_eq!(
+                allocator.allocate_id_at(7).unwrap_err(),
+                Error::ResourceNotAvailable
+            );
+            assert_eq!(
+                allocator.allocate_id_at(4).unwrap_err(),
+                Error::OutOfRange(4)
+            );
+            assert_eq!(
+                allocator.allocate_id_at(9).unwrap_err(),
+                Error::OutOfRange(9)
+            );
+            assert_eq!(allocator.allocate_id().unwrap(), 5);
+            assert_eq!(allocator.allocate_id().unwrap(), 6);
+            assert_eq!(allocator.allocate_id().unwrap(), 8);
+            assert_eq!(
+                allocator.allocate_id().unwrap_err(),
+                Error::ResourceNotAvailable
+            );
+        }
+
+        #[test]
+        fn test_out_of_range_checks() {
+            let legacy_irq_allocator = IdAllocator::new(5, 23).unwrap();
+
+            assert!(!legacy_irq_allocator.is_allocated(4));
+            assert!(!legacy_irq_allocator.is_allocated(25));
         }
     }
 }

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -771,6 +771,7 @@ pub(crate) mod tests {
     use vm_memory::mmap::MmapRegionBuilder;
 
     use super::*;
+    use crate::arch;
     use crate::pci::PciSBDF;
     use crate::snapshot::Persist;
     use crate::test_utils::single_region_mem_raw;
@@ -1053,6 +1054,11 @@ pub(crate) mod tests {
 
         msix_group.enable().unwrap();
         let state = msix_group.save();
+
+        // On the real restore path the allocator state omits MSI GSIs before devices replay
+        // their allocations. Mimic that here so `restore` can re-claim the saved GSIs.
+        let allocator_state = vm.resource_allocator().save();
+        *vm.resource_allocator() = ResourceAllocator::restore((), &allocator_state).unwrap();
         let restored_group = MsixVectorGroup::restore(vm.clone(), &state).unwrap();
 
         assert_eq!(msix_group.num_vectors(), restored_group.num_vectors());
@@ -1068,6 +1074,18 @@ pub(crate) mod tests {
         // Both groups own the same GSIs in this test so dropping both will result in panic. Resolve
         // this by simply forgetting about the restored version.
         std::mem::forget(restored_group);
+    }
+
+    #[test]
+    fn test_msi_vector_group_restore_rejects_out_of_range_gsi() {
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
+        enable_irqchip(&mut vm);
+        let vm = Arc::new(vm);
+
+        // A snapshot with a GSI outside the managed MSI range must be rejected rather than panic
+        // when the GSI is later freed on drop.
+        let tampered_state = vec![arch::GSI_MSI_END + 1];
+        MsixVectorGroup::restore(vm.clone(), &tampered_state).unwrap_err();
     }
 
     #[test]
@@ -1113,7 +1131,7 @@ pub(crate) mod tests {
         let mut vm = setup_vm_with_memory(0x1000);
         vm.setup_irqchip().unwrap();
 
-        // Allocate a GSI and some memory and make sure they are still allocated after restore
+        // Allocate a GSI and some memory.
         let (gsi, range) = {
             let mut resource_allocator = vm.resource_allocator();
 
@@ -1132,9 +1150,14 @@ pub(crate) mod tests {
         vm.restore_state(&restored_state, false).unwrap();
 
         let mut resource_allocator = vm.resource_allocator();
-        let gsi_new = resource_allocator.allocate_gsi_msi(1).unwrap()[0];
-        assert_eq!(gsi + 1, gsi_new);
 
+        // The MSI GSI allocator is reset on restore (its allocations are replayed by the devices),
+        // so the previously allocated GSI is free again and is the first one handed out.
+        let gsi_new = resource_allocator.allocate_gsi_msi(1).unwrap()[0];
+        assert_eq!(gsi, gsi_new);
+
+        // Memory allocations, on the other hand, are restored from the serialized state, so the
+        // range allocated before the snapshot is still reserved.
         resource_allocator
             .mmio32_memory
             .allocate(1024, 1024, AllocPolicy::ExactMatch(range))


### PR DESCRIPTION
## Changes

- Bump vm-allocator to v0.1.4
- Vendor `IdAllocator` from vm-allocator, now backed by a bitmap rather than high water mark
- Validate that serialized MSI-X interrupts are globally unique at restore-time

## Reason

A malformed snapshot with unexpected MSI-X IDs could previously cause panics on device hotunplug, due to the IDs only being validated at drop time. Fill the gap by validating that GSIs are unique across all devices at restore time.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
