### PR TITLE
ci: trigger `no_dirty_cargo_locks_check` on merge_group

### DIFF
--- a/.github/workflows/dco_merge_group.yml
+++ b/.github/workflows/dco_merge_group.yml
@@ -1,0 +1,18 @@
+# We configure DCO (https://github.com/dcoapp) as a required approval on every PR.
+# The same requirement also apply to merge queues.
+# However, DCO doesn't run on merge queues (https://github.com/dcoapp/app/issues/199), so this is
+# a workaround to make the check pass.
+# Note: for a PR to be added on the merge queue, the real DCO check was already performed.
+name: DCO
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Mock DCO check that runs in the merge queue, see https://github.com/dcoapp/app/issues/199"

--- a/.github/workflows/deny_dirty_cargo_locks.yml
+++ b/.github/workflows/deny_dirty_cargo_locks.yml
@@ -1,7 +1,8 @@
 name: Check no Cargo.lock files are dirty
 
-on: pull_request
-
+on:
+  pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Changes

Start `no_dirty_cargo_locks_check` on a merge group event

## Reason

With merge queues, we need to trigger certain GitHub workflows (especially mandatory ones) on a merge group event.
Otherwise, the merge queue will be waiting for a signal that will never arrive.

More doc on https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
