### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,16 @@
-# All markdown files
-*.md @kalyazin @Manciukic @micz010
+# Cover all "*policy*.md" documents
+**/*policy*.md @Manciukic @micz010 @marco-marangoni
+**/*POLICY*.md @Manciukic @micz010 @marco-marangoni
 
-# But not the ones in docs/
-docs/*.md
+# Cover these files in the repository root
+CODE_OF_CONDUCT.md @Manciukic @micz010 @marco-marangoni
+DEPRECATED.md @Manciukic @micz010 @marco-marangoni
+LICENSE @Manciukic @micz010 @marco-marangoni
+NOTICE @Manciukic @micz010 @marco-marangoni
+PGP-KEY.asc @Manciukic @micz010 @marco-marangoni
+SECURITY.md @Manciukic @micz010 @marco-marangoni
+SPECIFICATION.md @Manciukic @micz010 @marco-marangoni
+THIRD-PARTY @Manciukic @micz010 @marco-marangoni
 
-# Except these specific ones
-docs/getting-started.md @kalyazin @Manciukic @micz010
-docs/prod-host-setup.md @kalyazin @Manciukic @micz010
-
-# Also cover all "*policy*.md" documents
-**/*policy*.md @kalyazin @Manciukic @micz010
-**/*POLICY*.md @kalyazin @Manciukic @micz010
-
-# Also these non-md files in the repository root
-THIRD-PARTY @kalyazin @Manciukic @micz010
-LICENSE @kalyazin @Manciukic @micz010
-NOTICE @kalyazin @Manciukic @micz010
-PGP-KEY.asc @kalyazin @Manciukic @micz010
+# Cover files related to audit/security
+.cargo/audit.toml @Manciukic @micz010 @marco-marangoni


### PR DESCRIPTION
## Changes

Updated `.github/CODEOWNERS`.

## Reason

As agreed, I'm limiting the scope of extra reviewers only to files that directly relate to security, policies or explicit customer commitments.

I'm also updating the list of reviewers to the current L6+ members.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
