### PR TITLE
New retry strategy for A/B tests

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -108,6 +108,7 @@ REVISION_A = os.environ.get("REVISION_A")
 REVISION_B = os.environ.get("REVISION_B")
 REVISION_A_ARTIFACTS = os.environ.get("REVISION_A_ARTIFACTS")
 REVISION_B_ARTIFACTS = os.environ.get("REVISION_B_ARTIFACTS")
+A_B_TEST_MAX_ITERATIONS = 4
 
 # Either both are specified or neither. Only doing either is a bug. If you want to
 # run performance tests _on_ a specific commit, specify neither and put your commit
@@ -125,21 +126,11 @@ BKPipeline.parser.add_argument(
     action="append",
 )
 
-retry = {}
-if REVISION_A:
-    # Enable automatic retry and disable manual retries to suppress spurious issues.
-    retry["automatic"] = [
-        {"exit_status": -1, "limit": 1},
-        {"exit_status": 1, "limit": 1},
-    ]
-    retry["manual"] = False
-
 pipeline = BKPipeline(
     # Boost priority from 1 to 2 so these jobs are preferred by ag=1 agents
     priority=2,
     # use ag=1 instances to make sure no two performance tests are scheduled on the same instance
     agents={"ag": 1},
-    retry=retry,
     # Heavy post-failure dumps (full snapshot + chroot copy) are useful
     # for triaging performance flakes that are hard to reproduce locally.
     # Cheap dumps are always on; this flag turns the heavy block on.
@@ -163,7 +154,7 @@ for test in tests:
     artifacts = []
     if REVISION_A:
         devtool_opts += " --ab"
-        test_script_opts = f'{ab_opts} run --binaries-a build/{REVISION_A}/ --binaries-b build/{REVISION_B} --pytest-opts "{test_selector}"'
+        test_script_opts = f'{ab_opts} run --binaries-a build/{REVISION_A}/ --binaries-b build/{REVISION_B} --max-iterations={A_B_TEST_MAX_ITERATIONS} --pytest-opts "{test_selector}"'
         if REVISION_A_ARTIFACTS:
             artifacts.append(REVISION_A_ARTIFACTS)
             artifacts.append(REVISION_B_ARTIFACTS)

--- a/tests/README.md
+++ b/tests/README.md
@@ -242,7 +242,7 @@ compare boottime of microVMs between Firecracker binaries compiled from the
 ```sh
 tools/devtool -y build --rev main --release
 tools/devtool -y build --rev HEAD --release
-tools/devtool -y test --no-build --ab -- run build/main build/HEAD --pytest-opts integration_tests/performance/test_boottime.py::test_boottime
+tools/devtool -y test --no-build --ab -- run --binaries-a build/main --binaries-b build/HEAD --pytest-opts integration_tests/performance/test_boottime.py::test_boottime
 ```
 
 To download custom artifacts use

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -22,6 +22,7 @@ import json
 import os
 import statistics
 import subprocess
+import time
 from collections import defaultdict
 from pathlib import Path
 from typing import Callable, List, Optional, TypeVar
@@ -49,7 +50,6 @@ UNIT_REDUCTIONS = {
     "Gigabits/Second": "Terabits/Second",
 }
 INV_UNIT_REDUCTIONS = {v: k for k, v in UNIT_REDUCTIONS.items()}
-
 
 UNIT_SHORTHANDS = {
     "Seconds": "s",
@@ -318,6 +318,7 @@ def analyze_data(
 
     results = {}
 
+    t0 = time.perf_counter()
     for dimension_set in data_a:
         metrics_a = data_a[dimension_set]
         metrics_b = data_b[dimension_set]
@@ -331,6 +332,8 @@ def analyze_data(
                 values_a, metrics_b[metric][0], n_resamples=n_resamples
             )
             results[dimension_set, metric] = (result, unit)
+
+    print(f"Regression tests took {time.perf_counter() - t0:.2f}s")
 
     # We sort our A/B-Testing results keyed by metric here. The resulting lists of values
     # will be approximately normal distributed, and we will use this property as a means of error correction.
@@ -550,6 +553,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.command == "run":
+        t0 = time.perf_counter()
         ab_performance_test(
             args.binaries_a,
             args.binaries_b,
@@ -560,10 +564,15 @@ if __name__ == "__main__":
             args.absolute_strength,
             args.noise_threshold,
         )
+        print(f"Total A/B test took {time.perf_counter() - t0:.2f}s")
     else:
+        t0 = time.perf_counter()
         data_a = load_data_series(args.path_a)
         data_b = load_data_series(args.path_b)
+        t_load = time.perf_counter() - t0
+        print(f"Data loading took {t_load:.2f}s")
 
+        t0 = time.perf_counter()
         analyze_data(
             data_a,
             data_b,
@@ -571,3 +580,5 @@ if __name__ == "__main__":
             args.absolute_strength,
             args.noise_threshold,
         )
+        t_analyze = time.perf_counter() - t0
+        print(f"Analysis took {t_analyze:.2f}s")

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -20,11 +20,12 @@ import argparse
 import glob
 import json
 import os
+import shutil
 import subprocess
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Callable, List, Optional, TypeVar
+from typing import List, Optional
 
 import numpy
 import scipy
@@ -254,6 +255,9 @@ def collect_data(
     test_path = f"test_results/{tag}"
     test_report_path = f"{test_path}/test-report.json"
 
+    # Cleaning the report directory, to ensure we start from a clean state.
+    shutil.rmtree(test_path, ignore_errors=True)
+
     # It is not possible to just download them here this script is usually run inside docker
     # and artifacts downloading does not work inside it.
     if artifacts:
@@ -309,7 +313,7 @@ def analyze_data(
     Analyzes the A/B-test data produced by `collect_data`, by performing regression tests
     as described this script's doc-comment.
 
-    Returns a mapping of dimensions and properties/metrics to the result of their regression test.
+    Returns the list of error messages (empty if the test passes).
     """
     assert set(data_a.keys()) == set(
         data_b.keys()
@@ -390,7 +394,7 @@ def analyze_data(
                 result.statistic / baseline_mean
             )
 
-    messages = []
+    error_messages = []
     do_not_print_list = uninteresting_dimensions(data_a)
     for dimension_set, metric, result, unit in failures:
         # Sanity check as described above
@@ -415,33 +419,21 @@ def analyze_data(
                 f"characteristics did not change across the tested commits, has a probability of {result.pvalue:.2%}. "
                 f"Tested Dimensions:\n{json.dumps({k: v for k, v in dimension_set if k not in do_not_print_list}, indent=2, sort_keys=True)}"
             )
-            messages.append(msg)
+            error_messages.append(msg)
 
-    assert not messages, "\n" + "\n".join(messages)
-    print("No regressions detected!")
-
-
-T = TypeVar("T")
-U = TypeVar("U")
+    return error_messages
 
 
-def binary_ab_test(
-    test_runner: Callable[[Path, Optional[Path], bool], T],
-    comparator: Callable[[T, T], U],
-    *,
-    a_directory: Path,
-    b_directory: Path,
-    a_artifacts: Optional[Path],
-    b_artifacts: Optional[Path],
-):
-    """
-    Similar to `git_ab_test`, but instead of locally checking out different revisions, it operates on
-    directories containing firecracker/jailer binaries
-    """
-    result_a = test_runner(a_directory, a_artifacts, True)
-    result_b = test_runner(b_directory, b_artifacts, False)
-
-    return result_a, result_b, comparator(result_a, result_b)
+def merge_data(accumulated, new_data):
+    """Merge new_data into accumulated by appending values lists for each metric."""
+    for dimension_set, metrics in new_data.items():
+        if dimension_set not in accumulated:
+            accumulated[dimension_set] = {}
+        for metric, (values, unit) in metrics.items():
+            if metric in accumulated[dimension_set]:
+                accumulated[dimension_set][metric][0].extend(values)
+            else:
+                accumulated[dimension_set][metric] = (list(values), unit)
 
 
 def ab_performance_test(
@@ -453,29 +445,52 @@ def ab_performance_test(
     p_thresh,
     strength_abs_thresh,
     noise_threshold,
+    max_iterations=1,
 ):
-    """Does an A/B-test of the specified test with the given firecracker/jailer binaries"""
+    """Does an A/B-test of the specified test with the given firecracker/jailer binaries.
 
-    return binary_ab_test(
-        lambda bin_dir, art_dir, is_a: collect_data(
-            is_a and "A" or "B", bin_dir, art_dir, pytest_opts
-        ),
-        lambda ah, be: analyze_data(
-            ah,
-            be,
+    Retries up to max_iterations times, accumulating data only for dimensions
+    that are still failing, to reduce noise-induced false positives."""
+
+    data_a = {}
+    data_b = {}
+    error_messages = []
+
+    for i in range(max_iterations):
+        print(f"\n=== Iteration {i + 1}/{max_iterations} ===")
+        # Changing the order or A and B executions across iterations, to avoid fluctuations caused by execution order
+        if i % 2 == 0:
+            new_a = collect_data("A", a_directory, a_artifacts, pytest_opts)
+            new_b = collect_data("B", b_directory, b_artifacts, pytest_opts)
+        else:
+            new_b = collect_data("B", b_directory, b_artifacts, pytest_opts)
+            new_a = collect_data("A", a_directory, a_artifacts, pytest_opts)
+        merge_data(data_a, new_a)
+        merge_data(data_b, new_b)
+
+        error_messages = analyze_data(
+            data_a,
+            data_b,
             p_thresh,
             strength_abs_thresh,
             noise_threshold,
             n_resamples=int(100 / p_thresh),
-        ),
-        a_directory=a_directory,
-        b_directory=b_directory,
-        a_artifacts=a_artifacts,
-        b_artifacts=b_artifacts,
-    )
+        )
+
+        if not error_messages:
+            print("No regressions detected!")
+            return
+
+        if i < max_iterations - 1:
+            print(
+                f"{len(error_messages)} regression(s) detected, retrying to collect more data..."
+            )
+
+    assert not error_messages, "\n" + "\n".join(error_messages)
 
 
-if __name__ == "__main__":
+def main():
+    """The main function when invoking the script"""
     parser = argparse.ArgumentParser(
         description="Executes Firecracker's A/B testsuite across the specified commits"
     )
@@ -516,6 +531,12 @@ if __name__ == "__main__":
         "--pytest-opts",
         help="Parameters to pass through to pytest, for example for test selection",
         required=True,
+    )
+    run_parser.add_argument(
+        "--max-iterations",
+        help="Maximum number of A/B iterations. Retries only if regressions are detected, accumulating more data to reduce false positives.",
+        type=int,
+        default=1,
     )
     analyze_parser = subparsers.add_parser(
         "analyze",
@@ -562,6 +583,7 @@ if __name__ == "__main__":
             args.significance,
             args.absolute_strength,
             args.noise_threshold,
+            max_iterations=args.max_iterations,
         )
         print(f"Total A/B test took {time.perf_counter() - t0:.2f}s")
     else:
@@ -572,7 +594,7 @@ if __name__ == "__main__":
         print(f"Data loading took {t_load:.2f}s")
 
         t0 = time.perf_counter()
-        analyze_data(
+        error_messages = analyze_data(
             data_a,
             data_b,
             args.significance,
@@ -581,3 +603,9 @@ if __name__ == "__main__":
         )
         t_analyze = time.perf_counter() - t0
         print(f"Analysis took {t_analyze:.2f}s")
+        assert not error_messages, "\n" + "\n".join(error_messages)
+        print("No regressions detected!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -20,13 +20,13 @@ import argparse
 import glob
 import json
 import os
-import statistics
 import subprocess
 import time
 from collections import defaultdict
 from pathlib import Path
 from typing import Callable, List, Optional, TypeVar
 
+import numpy
 import scipy
 
 UNIT_REDUCTIONS = {
@@ -291,8 +291,7 @@ def check_regression(
     return scipy.stats.permutation_test(
         (a_samples, b_samples),
         # Compute the difference of means, such that a positive different indicates potential for regression.
-        lambda x, y: statistics.mean(y) - statistics.mean(x),
-        vectorized=False,
+        lambda x, y, axis: numpy.mean(y, axis=axis) - numpy.mean(x, axis=axis),
         n_resamples=n_resamples,
     )
 
@@ -380,7 +379,7 @@ def analyze_data(
         print(f"Doing A/B-test for dimensions {dimension_set} and property {metric}")
 
         values_a = data_a[dimension_set][metric][0]
-        baseline_mean = statistics.mean(values_a)
+        baseline_mean = numpy.mean(values_a)
 
         relative_changes_by_metric[metric].append(result.statistic / baseline_mean)
 
@@ -395,7 +394,7 @@ def analyze_data(
     do_not_print_list = uninteresting_dimensions(data_a)
     for dimension_set, metric, result, unit in failures:
         # Sanity check as described above
-        if abs(statistics.mean(relative_changes_by_metric[metric])) <= noise_threshold:
+        if abs(numpy.mean(relative_changes_by_metric[metric])) <= noise_threshold:
             continue
 
         # No data points for this metric were deemed significant
@@ -403,9 +402,9 @@ def analyze_data(
             continue
 
         # The significant data points themselves are above the noise threshold
-        if abs(statistics.mean(relative_changes_significant[metric])) > noise_threshold:
-            old_mean = statistics.mean(data_a[dimension_set][metric][0])
-            new_mean = statistics.mean(data_b[dimension_set][metric][0])
+        if abs(numpy.mean(relative_changes_significant[metric])) > noise_threshold:
+            old_mean = numpy.mean(data_a[dimension_set][metric][0])
+            new_mean = numpy.mean(data_b[dimension_set][metric][0])
 
             msg = (
                 f"\033[0;32m[Firecracker A/B-Test Runner]\033[0m A/B-testing shows a change of "

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -590,8 +590,7 @@ def main():
         t0 = time.perf_counter()
         data_a = load_data_series(args.path_a)
         data_b = load_data_series(args.path_b)
-        t_load = time.perf_counter() - t0
-        print(f"Data loading took {t_load:.2f}s")
+        print(f"Data loading took {time.perf_counter() - t0:.2f}s")
 
         t0 = time.perf_counter()
         error_messages = analyze_data(
@@ -601,8 +600,7 @@ def main():
             args.absolute_strength,
             args.noise_threshold,
         )
-        t_analyze = time.perf_counter() - t0
-        print(f"Analysis took {t_analyze:.2f}s")
+        print(f"Analysis took {time.perf_counter() - t0:.2f}s")
         assert not error_messages, "\n" + "\n".join(error_messages)
         print("No regressions detected!")
 


### PR DESCRIPTION
## Changes

This PR introduces several improvements to the A/B test script:
 - improved performance by using numpy (this enables vectorization and hardware acceleration, and up to 18x speedup on my machine)
 - a new retry mechanism handled directly from the A/B test rather than BuildKite

I'm introducing a new `--max-iterations` option for the A/B test. With this option, the data collection for A and B is repeated up to max-iterations times (only if an error is detected).

Unlike the current BuildKite retries, datapoints are remembered across iterations, so we're not losing information across tries.  
So if in one run a A is slower, and in the second B is slower, this might cancel out and pass the test. Additionally, increasing the number of iterations won't reduce the true positive rate, because the more datapoints we analyze, the smaller the allowed deviation becomes.

Note that this is different than simply collecting more datapoints from the actual performance test, because tests are interleaved and flipped (e.g. with 3 iterations, we run `A`, `B`, `analyze_data`, `B`, `A`, `analyze_data`, `A`, `B`, `analyze_data`, and so on).  
This allows for the test execution to absorb noise that has a period longer than the test themselves (e.g. power states variations), and fluctuations cased by execution order (e.g. running `B` after `A` might be slightly faster than running `A` cold or after `analyze_data`).

Finally, I'm also changing the configuration for the performance pipeline to use this new option (set to 4 max iterations) instead of retries.

## Reason

Reduce A/B test false positives without impacting true positive significantly.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
