### PR TITLE
fix(jailer): harden aarch64 cache-info file ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to
   restore, triggered by taking a snapshot with a TX descriptor in-flight. On
   restore the device now replays the TX queue notification so in-flight TX
   descriptors are re-processed and notification suppression is re-armed.
+- [#5956](https://github.com/firecracker-microvm/firecracker/pull/5956): Fixed a
+  TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
+  `MIDR_EL1` information files copied into the chroot.
 
 ## [1.16.0]
 

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -133,6 +133,28 @@ pub struct Env {
     uffd_dev_minor: Option<u32>,
 }
 
+/// Creates a new file owned by the given uid/gid at `dst` and writes `line`
+/// into it, plus a trailing newline.
+#[cfg(target_arch = "aarch64")]
+fn create_owned_file_with_data(
+    dst: &Path,
+    line: String,
+    uid: u32,
+    gid: u32,
+) -> Result<(), JailerError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        // `create_new` maps to `O_CREAT | O_EXCL`: fail if `dst` already exists.
+        .create_new(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(dst)
+        .map_err(|err| JailerError::Write(dst.to_path_buf(), err))?;
+    file.write_all(format!("{}\n", line).as_bytes())
+        .map_err(|err| JailerError::Write(dst.to_path_buf(), err))?;
+    fchown(&file, Some(uid), Some(gid))
+        .map_err(|err| JailerError::ChangeFileOwner(dst.to_path_buf(), err))
+}
+
 impl Env {
     pub fn new(
         arguments: &arg_parser::Arguments,
@@ -548,7 +570,7 @@ impl Env {
 
     #[cfg(target_arch = "aarch64")]
     fn copy_cache_info(&self) -> Result<(), JailerError> {
-        use crate::{readln_special, to_cstring, writeln_special};
+        use crate::readln_special;
 
         const HOST_CACHE_INFO: &str = "/sys/devices/system/cpu/cpu0/cache";
         // Based on https://elixir.free-electrons.com/linux/v4.9.62/source/arch/arm64/kernel/cacheinfo.c#L29.
@@ -592,18 +614,7 @@ impl Env {
                 let jailer_cache_file = jailer_path.join(entry);
 
                 if let Ok(line) = readln_special(&host_cache_file) {
-                    writeln_special(&jailer_cache_file, line)?;
-
-                    // We now change the permissions.
-                    let dest_path_cstr = to_cstring(&jailer_cache_file)?;
-                    // SAFETY: Safe because dest_path_cstr is null-terminated.
-                    SyscallReturnCode(unsafe {
-                        libc::chown(dest_path_cstr.as_ptr(), self.uid(), self.gid())
-                    })
-                    .into_empty_result()
-                    .map_err(|err| {
-                        JailerError::ChangeFileOwner(jailer_cache_file.to_owned(), err)
-                    })?;
+                    create_owned_file_with_data(&jailer_cache_file, line, self.uid(), self.gid())?;
                 }
             }
         }
@@ -612,7 +623,7 @@ impl Env {
 
     #[cfg(target_arch = "aarch64")]
     fn copy_midr_el1_info(&self) -> Result<(), JailerError> {
-        use crate::{readln_special, to_cstring, writeln_special};
+        use crate::readln_special;
 
         const HOST_MIDR_EL1_INFO: &str = "/sys/devices/system/cpu/cpu0/regs/identification";
 
@@ -624,16 +635,10 @@ impl Env {
         let host_midr_el1_file = PathBuf::from(format!("{}/midr_el1", HOST_MIDR_EL1_INFO));
         let jailer_midr_el1_file = jailer_midr_el1_directory.join("midr_el1");
 
-        // Read and copy the MIDR_EL1 file to Jailer
+        // Read the host MIDR_EL1 value and write it into the jail, owned by
+        // the jailed uid:gid.
         let line = readln_special(&host_midr_el1_file)?;
-        writeln_special(&jailer_midr_el1_file, line)?;
-
-        // Change the permissions.
-        let dest_path_cstr = to_cstring(&jailer_midr_el1_file)?;
-        // SAFETY: Safe because `dest_path_cstr` is null-terminated.
-        SyscallReturnCode(unsafe { libc::chown(dest_path_cstr.as_ptr(), self.uid(), self.gid()) })
-            .into_empty_result()
-            .map_err(|err| JailerError::ChangeFileOwner(jailer_midr_el1_file.to_owned(), err))?;
+        create_owned_file_with_data(&jailer_midr_el1_file, line, self.uid(), self.gid())?;
 
         Ok(())
     }
@@ -1427,6 +1432,10 @@ mod tests {
         mock_cgroups.add_v1_mounts().unwrap();
 
         let env = create_env(&mock_cgroups.proc_mounts_path);
+
+        // Clear any leftovers from a previous run of this test, as
+        // `copy_cache_info` expects to be creating these files.
+        let _ = fs::remove_dir_all(env.chroot_dir());
 
         // Create the required chroot dir hierarchy.
         fs::create_dir_all(env.chroot_dir()).expect("Could not create dir hierarchy.");


### PR DESCRIPTION
## Changes

On aarch64, the jailer's `copy_cache_info` and `copy_midr_el1_info` wrote each
CPU cache / `MIDR_EL1` information file into the chroot and then set its
ownership with a separate, path-based `chown`. Setting ownership by path after
the write leaves a TOCTOU window between the two operations.

This change introduces a small helper that:

- creates the destination file exclusively (`O_CREAT | O_EXCL`, with
  `O_NOFOLLOW`), so the operation only ever targets a freshly created regular
  file, and
- sets ownership via `fchown` on that file descriptor, so it always applies to
  the file that was just created.

Both `copy_cache_info` and `copy_midr_el1_info` now use this helper.

## Reason

Make the jailer's ownership changes for the aarch64 cache-info files robust by
operating on a single file descriptor instead of a write-then-chown-by-path
sequence.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this
  PR.
- [x] API changes follow the [Runbook](https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md) (N/A).
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.