### PR TITLE
chore: increase Cargo network retries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,7 @@ rustflags = [
 
 [net]
 git-fetch-with-cli = true
+retry = 10
 
 [env]
 AWS_LC_SYS_NO_JITTER_ENTROPY = "1"


### PR DESCRIPTION

## Changes

Quite often (at least 7 times today), tests fail because cargo fails to download a package.
This commit sets the retries to 10 (up to the default of 3).

Reference: https://doc.rust-lang.org/cargo/reference/config.html#netretry

Example of failures:
- https://buildkite.com/firecracker/firecracker-pr-optional/builds/16886/list?sid=019ebca3-0f27-4506-9ba7-45502ced3cd1&tab=output
- https://buildkite.com/firecracker/firecracker-pr-optional/builds/16890/list?sid=019ebcb9-c946-4ed4-9db2-e27081d7e522&tab=output
- https://buildkite.com/firecracker/firecracker-pr-optional/builds/16894/list?sid=019ebcc0-db95-498d-8b2b-ea09e9669722&tab=output
- https://buildkite.com/firecracker/firecracker-pr/builds/17520/list?jid=019ebc92-42fa-4d5e-b439-c5e74e894331&tab=output
- https://buildkite.com/firecracker/firecracker-pr/builds/17520/list?jid=019ebc92-4352-4d66-b158-db5336d95d1d&tab=output
- https://buildkite.com/firecracker/firecracker-pr/builds/17520/list?jid=019ebc92-435a-44b4-8a16-a48754a4db35&tab=output
- https://buildkite.com/firecracker/firecracker-pr/builds/17528/list?sid=019ebcc0-e087-43d9-a562-90b6ca8e4053&tab=output



## Reason

Reduce false positives.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
