### PR TITLE
Revert "jailer: Use O_NOFOLLOW for cgroup and netns file operations"

### DIFF
--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -519,11 +519,8 @@ impl Env {
 
     fn join_netns(path: &str) -> Result<(), JailerError> {
         // The fd backing the file will be automatically dropped at the end of the scope
-        let netns = OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_NOFOLLOW)
-            .open(path)
-            .map_err(|err| JailerError::FileOpen(PathBuf::from(path), err))?;
+        let netns =
+            File::open(path).map_err(|err| JailerError::FileOpen(PathBuf::from(path), err))?;
 
         // SAFETY: Safe because we are passing valid parameters.
         SyscallReturnCode(unsafe { libc::setns(netns.as_raw_fd(), libc::CLONE_NEWNET) })

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -3,9 +3,6 @@
 
 use std::ffi::{CString, NulError, OsString};
 use std::fmt::{Debug, Display};
-use std::fs::OpenOptions;
-use std::io::Read;
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::{env as p_env, fs, io};
 
@@ -243,25 +240,12 @@ where
     T: AsRef<Path> + Debug,
     V: Display + Debug,
 {
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(file_path.as_ref())
-        .map_err(|err| JailerError::Write(PathBuf::from(file_path.as_ref()), err))?;
-    io::Write::write_all(&mut file, format!("{}\n", value).as_bytes())
+    fs::write(file_path, format!("{}\n", value))
         .map_err(|err| JailerError::Write(PathBuf::from(file_path.as_ref()), err))
 }
 
 pub fn readln_special<T: AsRef<Path> + Debug>(file_path: &T) -> Result<String, JailerError> {
-    let mut file = OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(file_path.as_ref())
-        .map_err(|err| JailerError::ReadToString(PathBuf::from(file_path.as_ref()), err))?;
-    let mut line = String::new();
-    file.read_to_string(&mut line)
+    let mut line = fs::read_to_string(file_path)
         .map_err(|err| JailerError::ReadToString(PathBuf::from(file_path.as_ref()), err))?;
 
     // Remove the newline character at the end (if any).


### PR DESCRIPTION
This reverts commit ce2a467895c188c438cba94bd964a9d1ca2b92c4.

It turns out users do want to legitimately use symlinks in these paths. Commit 72340caae33 ("docs: Clarify that all jailer inputs must be trusted") updated documentation to make it clear that all jailer inputs are always considered trusted anyway, so this revert is not a regression.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
