### PR TITLE
ci: validate CI artifact build on PR

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -128,6 +128,47 @@ def run_all_tests(changed_files):
     )
 
 
+def ci_artifacts_change_mode(changed_files):
+    """
+    Determine whether a PR touches the source files that define the CI guest
+    artifacts (guest kernels and rootfs), and which half is affected.
+
+    Returns one of:
+    - "all":     resources/rebuild.sh changed (it builds both halves), or both
+                 the rootfs and the kernel sources changed
+    - "rootfs":  only rootfs sources changed
+    - "kernels": only guest-kernel sources changed (guest_configs or patches)
+    - None:      no CI-artifact source files changed
+    """
+    rootfs_changed = False
+    kernel_changed = False
+    rebuild_all = False
+    for f in changed_files:
+        parts = f.parts
+        if f.name == "rebuild.sh" and parts[0] == "resources":
+            # rebuild.sh drives both the rootfs and the kernel builds.
+            rebuild_all = True
+        elif len(parts) >= 2 and parts[0] == "resources" and parts[1] == "rootfs":
+            rootfs_changed = True
+        elif (
+            len(parts) >= 2
+            and parts[0] == "resources"
+            and parts[1] in ("guest_configs", "patches")
+        ):
+            # guest_configs holds the kernel .config and config patches;
+            # resources/patches holds downstream kernel patchsets (rebuild.sh
+            # applies them to the kernel tree). Both drive the kernel build.
+            kernel_changed = True
+
+    if rebuild_all or (rootfs_changed and kernel_changed):
+        return "all"
+    if rootfs_changed:
+        return "rootfs"
+    if kernel_changed:
+        return "kernels"
+    return None
+
+
 class DictAction(argparse.Action):
     """An argparse action that can receive a nested dictionary
 

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -4,7 +4,12 @@
 
 """Generate Buildkite pipelines dynamically"""
 
-from common import BKPipeline, get_changed_files, run_all_tests
+from common import (
+    BKPipeline,
+    ci_artifacts_change_mode,
+    get_changed_files,
+    run_all_tests,
+)
 
 # Buildkite default job priority is 0. Setting this to 1 prioritizes PRs over
 # scheduled jobs and other batch jobs.
@@ -37,6 +42,19 @@ if any(x.parent.name == "devctr" for x in changed_files):
     pipeline.build_group_per_arch(
         "dev-container-sanity-build",
         "./tools/devtool -y build_devctr && DEVCTR_IMAGE_TAG=latest ./tools/devtool test --no-build -- integration_tests/functional/test_api.py",
+    )
+
+# run sanity build of the CI guest artifacts (kernels/rootfs) if any of their
+# source files changed. Rebuild only the affected half when possible, pulling
+# the unchanged half from S3 so a guest can still boot.
+artifacts_mode = ci_artifacts_change_mode(changed_files)
+if artifacts_mode is not None:
+    pipeline.build_group_per_arch(
+        "ci-artifacts-sanity-build",
+        f"./tools/devtool -y build_ci_artifacts {artifacts_mode} && "
+        f"./tools/devtool -y stage_ci_artifacts {artifacts_mode} && "
+        "./tools/devtool -y test --no-build -- integration_tests/functional/test_api.py",
+        timeout_in_minutes=75,
     )
 
 if any(

--- a/tools/devtool
+++ b/tools/devtool
@@ -453,6 +453,12 @@ cmd_help() {
     echo "        Builds the rootfs and guest kernel artifacts we use for our CI."
     echo "        Run './tools/devtool build_ci_artifacts help' for more details about the available commands."
     echo ""
+    echo "    stage_ci_artifacts [all|rootfs|kernels]"
+    echo "        Post-processes the CI artifacts already built in resources/\$(uname -m) (inject SSH key,"
+    echo "        build ext4 images, decompress debuginfo) and points the test framework at them via"
+    echo "        $LOCAL_ARTIFACTS_CURRENT_DIR_FILE. For a partial set ('rootfs' or 'kernels') the missing"
+    echo "        half is downloaded from S3 so a guest can boot."
+    echo ""
     echo "    download_ci_artifacts [--force] [s3_uri_1, s3_uri_2 ...]"
     echo "        Downloads artifacts from provided S3 URI (like s3://spec.ccfc.min/firecracker-ci/my_artifacts)"
     echo "        and runs ./tools/setup-ci-artifacts.sh. for each of them."
@@ -1390,6 +1396,62 @@ cmd_build_ci_artifacts() {
         ./resources/rebuild.sh "$@"
 
     cmd_fix_perms
+}
+
+# Download only one "half" (rootfs or kernels) of the newest CI artifacts from
+# S3 into the local CI artifacts dir, to complement a partial local build.
+# Args: one `aws s3 sync` --include glob per argument, e.g. "vmlinux-*" "debug/*".
+download_complementary_artifacts() {
+    local s3_base=$(get_newest_s3_artifacts)
+    local s3_arch="$s3_base/$(uname -m)"
+    local dest="resources/$(uname -m)"
+
+    local include_args=()
+    local glob
+    for glob in "$@"; do
+        include_args+=(--include "$glob")
+    done
+
+    say "Fetching complementary artifacts from S3: $s3_arch -> $dest"
+    mkdir -pv "$dest"
+    aws s3 sync --no-sign-request "$s3_arch" "$dest" --exclude "*" "${include_args[@]}"
+    ok_or_die "Failed to download complementary artifacts using awscli!"
+}
+
+cmd_stage_ci_artifacts() {
+    local mode="${1:-all}"
+    local local_artifacts_path="resources/$(uname -m)"
+
+    # For a partial build, fetch the unchanged half from S3 so the artifacts
+    # directory holds both a kernel and a rootfs (a guest boot needs both).
+    case "$mode" in
+        rootfs)
+            # Fetch the matching guest kernels.
+            download_complementary_artifacts "vmlinux-*" "debug/*"
+            ;;
+        kernels)
+            # Fetch the matching rootfs.
+            download_complementary_artifacts "*.squashfs" "initramfs*"
+            ;;
+        all)
+            ;;
+        *)
+            die "Unknown mode: '$mode'. Please use one of: all|rootfs|kernels."
+            ;;
+    esac
+
+    [ -d "$local_artifacts_path" ] || \
+        die "No built artifacts at $local_artifacts_path. Run 'build_ci_artifacts $mode' first."
+
+    # Post-process the raw artifacts (inject SSH key, build ext4 images,
+    # decompress debuginfo) inside the dev container.
+    cmd_sh "./tools/setup-ci-artifacts.sh $local_artifacts_path"
+    ok_or_die "Failed to setup artifacts!"
+    cmd_fix_perms
+
+    # Point the test framework at the freshly built artifacts.
+    echo "$local_artifacts_path" > "$LOCAL_ARTIFACTS_CURRENT_DIR_FILE"
+    say "Current artifacts path: $local_artifacts_path"
 }
 
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -1394,8 +1394,9 @@ cmd_build_ci_artifacts() {
         --workdir "$CTR_FC_ROOT_DIR" \
         -- \
         ./resources/rebuild.sh "$@"
-
+    local ret=$?
     cmd_fix_perms
+    return $ret
 }
 
 # Download only one "half" (rootfs or kernels) of the newest CI artifacts from


### PR DESCRIPTION
## Changes

- Add a `ci-artifacts-sanity-build` step to `.buildkite/pipeline_pr.py` that runs when a PR changes CI artifact sources (`resources/rootfs/**`, `resources/guest_configs/**`, or `resources/rebuild.sh`). It rebuilds only the affected half (`rootfs`, `kernels`, or `all` when `rebuild.sh` changed) and runs `integration_tests/functional/test_api.py` against the result.
- Add `ci_artifacts_change_mode()` to `.buildkite/common.py` to classify a PR's changed files into `rootfs` / `kernels` / `all` / none.
- Add a `stage_ci_artifacts` devtool command: post-process locally built artifacts with `setup-ci-artifacts.sh`, download the unchanged half from S3 for partial builds (a guest boot needs both a kernel and a rootfs), and point the test framework at them via `build/current_artifacts`.
- Make `build_ci_artifacts` fail when `rebuild.sh` fails. `devtool` does not run under `set -e`, so the trailing `cmd_fix_perms` previously masked a non-zero build exit.


After adding a simple no-op commit for rootfs, verified below that the CI steps were triggered, rebuilding rootfs while downloading the kernel remotely.

<img width="1439" height="1132" alt="Screenshot 2026-06-16 at 12 04 05" src="https://github.com/user-attachments/assets/c359af21-f87a-4452-b878-8a301cb31fab" />


## Reason

CI tests always download prebuilt guest artifacts from S3, so PRs that change the guest kernel configs or the rootfs build recipe are never exercised against an actual rebuild. This allows a bug to pass CI, only to be surfaced
later during a manual rebuild (e.g. #5545). This change closes that gap, mirroring the existing dev-container sanity build, which, when a source changes on a PR, rebuilds the affected artifacts and smoke-tests them.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
