### PR TITLE
Refactor VMM construction path for extensibility

### DIFF
--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -33,6 +33,10 @@ pub enum ApiServerError {
     FailedToBindAndRunHttpServer(ServerError),
     /// Failed to build MicroVM from Json: {0}
     BuildFromJson(crate::BuildFromJsonError),
+    /// Missing vmm seccomp filter
+    MissingSeccompFilter,
+    /// Failed to install vmm seccomp filter: {0}
+    SeccompFilter(vmm::seccomp::InstallationError),
 }
 
 #[derive(Debug)]
@@ -243,7 +247,16 @@ pub(crate) fn run_with_api(
         .map_err(ApiServerError::BuildMicroVmError),
     };
 
+    // INVARIANT: seccomp must be applied before entering the event loop.
+    // No guest-facing operations may occur between builder return and filter installation.
     let result = build_result.and_then(|vmm| {
+        vmm::seccomp::apply_filter(
+            seccomp_filters
+                .get("vmm")
+                .ok_or(ApiServerError::MissingSeccompFilter)?,
+        )
+        .map_err(ApiServerError::SeccompFilter)?;
+
         firecracker_metrics
             .lock()
             .expect("Poisoned lock")

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -616,6 +616,10 @@ enum RunWithoutApiError {
     Shutdown(FcExitCode),
     /// Failed to build MicroVM from Json: {0}
     BuildMicroVMFromJson(BuildFromJsonError),
+    /// Missing vmm seccomp filter
+    MissingSeccompFilter,
+    /// Failed to install vmm seccomp filter: {0}
+    SeccompFilter(vmm::seccomp::InstallationError),
 }
 
 fn run_without_api(
@@ -646,6 +650,14 @@ fn run_without_api(
         metadata_json,
     )
     .map_err(RunWithoutApiError::BuildMicroVMFromJson)?;
+
+    // INVARIANT: seccomp must be applied before entering the event loop.
+    vmm::seccomp::apply_filter(
+        seccomp_filters
+            .get("vmm")
+            .ok_or(RunWithoutApiError::MissingSeccompFilter)?,
+    )
+    .map_err(RunWithoutApiError::SeccompFilter)?;
 
     // Start the metrics.
     firecracker_metrics

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -359,17 +359,6 @@ pub fn build_microvm_for_boot(
         debug!("No GDB socket provided not starting gdb server.");
     }
 
-    // Load seccomp filters for the VMM thread.
-    // Execution panics if filters cannot be loaded, use --no-seccomp if skipping filters
-    // altogether is the desired behaviour.
-    // Keep this as the last step before resuming vcpus.
-    crate::seccomp::apply_filter(
-        seccomp_filters
-            .get("vmm")
-            .ok_or_else(|| StartMicrovmError::MissingSeccompFilters("vmm".to_string()))?,
-    )
-    .map_err(VmmError::SeccompFilters)?;
-
     event_manager.add_subscriber(vmm.clone());
 
     Ok(vmm)
@@ -425,10 +414,6 @@ pub enum BuildMicrovmFromSnapshotError {
     StartVcpus(#[from] crate::StartVcpusError),
     /// Failed to restore vCPUs: {0}
     RestoreVcpus(#[from] VcpuError),
-    /// Failed to apply VMM secccomp filter as none found.
-    MissingVmmSeccompFilters,
-    /// Failed to apply VMM secccomp filter: {0}
-    SeccompFiltersInternal(#[from] crate::seccomp::InstallationError),
     /// Failed to restore devices: {0}
     RestoreDevices(#[from] DeviceManagerPersistError),
     /// clock_realtime is not supported on aarch64.
@@ -548,13 +533,6 @@ pub fn build_microvm_from_snapshot(
     vmm.lock().unwrap().instance_info.state = VmState::Paused;
     event_manager.add_subscriber(vmm.clone());
 
-    // Load seccomp filters for the VMM thread.
-    // Keep this as the last step of the building process.
-    crate::seccomp::apply_filter(
-        seccomp_filters
-            .get("vmm")
-            .ok_or(BuildMicrovmFromSnapshotError::MissingVmmSeccompFilters)?,
-    )?;
     debug!("event_end: build microvm from snapshot");
 
     Ok(vmm)

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -48,6 +48,7 @@ use crate::resources::VmResources;
 use crate::seccomp::BpfThreadMap;
 use crate::snapshot::Persist;
 use crate::utils::mib_to_bytes;
+use crate::vmm_config::boot_source::{DEFAULT_KERNEL_CMDLINE, build_cmdline};
 use crate::vmm_config::instance_info::{InstanceInfo, VmState};
 use crate::vmm_config::machine_config::MachineConfigError;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
@@ -162,8 +163,12 @@ pub fn build_microvm_for_boot(
         .map_err(StartMicrovmError::GuestMemory)?;
 
     // Clone the command-line so that a failed boot doesn't pollute the original.
+    // If the user didn't provide boot_args, use the KVM-specific default.
     #[allow(unused_mut)]
-    let mut boot_cmdline = boot_config.cmdline.clone();
+    let mut boot_cmdline = match boot_config.cmdline.clone() {
+        Some(cmdline) => cmdline,
+        None => build_cmdline(DEFAULT_KERNEL_CMDLINE)?,
+    };
 
     let cpu_template = vm_resources
         .machine_config
@@ -797,7 +802,7 @@ pub(crate) mod tests {
     use crate::mmds::ns::MmdsNetworkStack;
     use crate::utils::mib_to_bytes;
     use crate::vmm_config::balloon::{BALLOON_DEV_ID, BalloonBuilder, BalloonDeviceConfig};
-    use crate::vmm_config::boot_source::{BootSourceConfig, DEFAULT_KERNEL_CMDLINE};
+    use crate::vmm_config::boot_source::BootSourceConfig;
     use crate::vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
     use crate::vmm_config::entropy::{EntropyDeviceBuilder, EntropyDeviceConfig};
     use crate::vmm_config::machine_config::MachineConfig;
@@ -854,11 +859,7 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn default_kernel_cmdline() -> Cmdline {
-        linux_loader::cmdline::Cmdline::try_from(
-            DEFAULT_KERNEL_CMDLINE,
-            crate::arch::CMDLINE_MAX_SIZE,
-        )
-        .unwrap()
+        build_cmdline(DEFAULT_KERNEL_CMDLINE).unwrap()
     }
 
     pub(crate) fn default_vmm() -> Vmm {

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -112,14 +112,14 @@ pub enum FindDeviceError {
     DeviceNotFound,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 /// A manager of all peripheral devices of Firecracker
 pub struct DeviceManager {
     /// MMIO devices
     pub mmio_devices: MMIODeviceManager,
     #[cfg(target_arch = "x86_64")]
-    /// Legacy devices
-    pub legacy_devices: PortIODeviceManager,
+    /// Legacy devices (`None` if not initialized)
+    pub legacy_devices: Option<PortIODeviceManager>,
     /// ACPI devices
     pub acpi_devices: ACPIDeviceManager,
     /// PCIe devices
@@ -183,15 +183,15 @@ impl DeviceManager {
 
         #[cfg(target_arch = "x86_64")]
         {
-            Some(
-                self.legacy_devices
+            self.legacy_devices.as_ref().map(|legacy| {
+                legacy
                     .stdio_serial
                     .lock()
                     .expect("Poisoned lock")
                     .serial
                     .state()
-                    .into(),
-            )
+                    .into()
+            })
         }
     }
 
@@ -247,7 +247,7 @@ impl DeviceManager {
         Ok(DeviceManager {
             mmio_devices: MMIODeviceManager::new(),
             #[cfg(target_arch = "x86_64")]
-            legacy_devices,
+            legacy_devices: Some(legacy_devices),
             acpi_devices: ACPIDeviceManager::default(),
             pci_devices: PciDevices::new(),
         })
@@ -772,7 +772,7 @@ impl<'a> Persist<'a> for DeviceManager {
         Ok(DeviceManager {
             mmio_devices,
             #[cfg(target_arch = "x86_64")]
-            legacy_devices,
+            legacy_devices: Some(legacy_devices),
             acpi_devices,
             pci_devices,
         })
@@ -819,7 +819,7 @@ pub(crate) mod tests {
         DeviceManager {
             mmio_devices,
             #[cfg(target_arch = "x86_64")]
-            legacy_devices,
+            legacy_devices: Some(legacy_devices),
             acpi_devices,
             pci_devices,
         }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -268,6 +268,8 @@ pub enum VmmError {
     Block(#[from] BlockError),
     /// Balloon: {0}
     Balloon(#[from] BalloonError),
+    /// Operation not supported on this VM type
+    NotSupported,
     /// Failed to create memory hotplug device: {0}
     VirtioMem(#[from] VirtioMemError),
 }
@@ -486,6 +488,8 @@ impl Vmm {
     pub fn send_ctrl_alt_del(&mut self) -> Result<(), VmmError> {
         self.device_manager
             .legacy_devices
+            .as_ref()
+            .ok_or(VmmError::NotSupported)?
             .i8042
             .lock()
             .expect("i8042 lock was poisoned")

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -234,8 +234,6 @@ pub enum VmmError {
     Metrics(MetricsError),
     /// Cannot add a device to the MMIO Bus. {0}
     RegisterMMIODevice(device_manager::mmio::MmioError),
-    /// Cannot install seccomp filters: {0}
-    SeccompFilters(seccomp::InstallationError),
     /// Error writing to the serial console: {0}
     Serial(io::Error),
     /// Error creating the vcpu: {0}

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -578,9 +578,7 @@ mod tests {
     use crate::resources::VmResources;
     use crate::utils::net::mac::MacAddr;
     use crate::vmm_config::RateLimiterConfig;
-    use crate::vmm_config::boot_source::{
-        BootConfig, BootSource, BootSourceConfig, DEFAULT_KERNEL_CMDLINE,
-    };
+    use crate::vmm_config::boot_source::{BootConfig, BootSource, BootSourceConfig};
     use crate::vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
     use crate::vmm_config::machine_config::{HugePageConfig, MachineConfig, MachineConfigError};
     use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
@@ -639,13 +637,11 @@ mod tests {
     }
 
     fn default_boot_cfg() -> BootSource {
-        let kernel_cmdline =
-            linux_loader::cmdline::Cmdline::try_from(DEFAULT_KERNEL_CMDLINE, 4096).unwrap();
         let tmp_file = TempFile::new().unwrap();
         BootSource {
             config: BootSourceConfig::default(),
             builder: Some(BootConfig {
-                cmdline: kernel_cmdline,
+                cmdline: None,
                 kernel_file: File::open(tmp_file.as_path()).unwrap(),
                 initrd_file: Some(File::open(tmp_file.as_path()).unwrap()),
             }),
@@ -1584,12 +1580,12 @@ mod tests {
         let tmp_ino = tmp_file.as_file().metadata().unwrap().st_ino();
 
         assert_ne!(
-            boot_builder
-                .cmdline
+            boot_builder.cmdline.as_ref().map(|c| c
                 .as_cstring()
                 .unwrap()
-                .as_bytes_with_nul(),
-            [cmdline.as_bytes(), b"\0"].concat()
+                .as_bytes_with_nul()
+                .to_vec()),
+            Some([cmdline.as_bytes(), b"\0"].concat())
         );
         assert_ne!(
             boot_builder.kernel_file.metadata().unwrap().st_ino(),
@@ -1611,6 +1607,8 @@ mod tests {
         assert_eq!(
             boot_source_builder
                 .cmdline
+                .as_ref()
+                .unwrap()
                 .as_cstring()
                 .unwrap()
                 .as_bytes_with_nul(),

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -4,6 +4,7 @@
 use std::fs::File;
 use std::io;
 
+use linux_loader::cmdline;
 use serde::{Deserialize, Serialize};
 
 /// Default guest kernel command line:
@@ -56,12 +57,18 @@ pub struct BootSource {
 /// Holds the kernel builder (created and validates based on BootSourceConfig).
 #[derive(Debug)]
 pub struct BootConfig {
-    /// The commandline validated against correctness.
-    pub cmdline: linux_loader::cmdline::Cmdline,
+    /// The commandline, if explicitly provided by the user. `None` means the
+    /// consumer should apply its own default (e.g. [`DEFAULT_KERNEL_CMDLINE`]).
+    pub cmdline: Option<cmdline::Cmdline>,
     /// The descriptor to the kernel file.
     pub kernel_file: File,
     /// The descriptor to the initrd file, if there is one.
     pub initrd_file: Option<File>,
+}
+
+/// Build a [`Cmdline`](cmdline::Cmdline) from a string.
+pub fn build_cmdline(s: &str) -> Result<cmdline::Cmdline, cmdline::Error> {
+    cmdline::Cmdline::try_from(s, crate::arch::CMDLINE_MAX_SIZE)
 }
 
 impl BootConfig {
@@ -78,13 +85,12 @@ impl BootConfig {
             None => None,
         };
 
-        let cmdline_str = match cfg.boot_args.as_ref() {
-            None => DEFAULT_KERNEL_CMDLINE,
-            Some(str) => str.as_str(),
+        let cmdline = match cfg.boot_args.as_ref() {
+            None => None,
+            Some(s) => {
+                Some(build_cmdline(s).map_err(|err| InvalidKernelCommandLine(err.to_string()))?)
+            }
         };
-        let cmdline =
-            linux_loader::cmdline::Cmdline::try_from(cmdline_str, crate::arch::CMDLINE_MAX_SIZE)
-                .map_err(|err| InvalidKernelCommandLine(err.to_string()))?;
 
         Ok(BootConfig {
             cmdline,
@@ -114,10 +120,7 @@ pub(crate) mod tests {
 
         let boot_cfg = BootConfig::new(&boot_src_cfg).unwrap();
         assert!(boot_cfg.initrd_file.is_none());
-        assert_eq!(
-            boot_cfg.cmdline.as_cstring().unwrap().as_bytes_with_nul(),
-            [DEFAULT_KERNEL_CMDLINE.as_bytes(), b"\0"].concat()
-        );
+        assert!(boot_cfg.cmdline.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Changes

Three small, self-contained refactorings to the VMM construction path. Each makes a piece of the builder more flexible so alternative VM construction flows can reuse the existing machinery, without changing behavior for the current KVM path.

**`device_manager: make legacy_devices optional`**
`DeviceManager::legacy_devices` was an unconditional `PortIODeviceManager` (x86_64). It is now `Option<PortIODeviceManager>`, and `DeviceManager` derives `Default`. This lets construction paths that don't need port-mapped I/O devices skip legacy device initialization, while the KVM path continues to populate it exactly as before.

**`vmm: make boot_args resolution lazy in BootConfig`**
`BootConfig::new()` previously baked `DEFAULT_KERNEL_CMDLINE` into `self.cmdline` whenever the user didn't supply `boot_args`. `BootConfig.cmdline` becomes `Option<Cmdline>`: `None` means "the user did not specify a command line", and each consumer resolves its own default. The KVM builder resolves `None` to `DEFAULT_KERNEL_CMDLINE` via a new `build_cmdline()` helper in `boot_source.rs`, preserving today's behavior.

**`vmm: hoist vmm-thread seccomp filter to event-loop call sites`**
The VMM-thread seccomp filter was applied inside each builder function as its last step. Since all device setup, file I/O, and thread spawning happen inside the builder — and the only post-builder syscalls (`epoll_ctl`, `epoll_wait`, `timerfd_settime`) are already in the `vmm` profile — the filter is now applied once at the call site, just before entering the event loop. This keeps filter application in a single, obvious place.

## Reason

These are foundational refactorings that decouple VMM construction from assumptions baked into the KVM path (mandatory legacy devices, a single global default command line, per-builder seccomp application), making the builder reusable by future VM construction flows. They are pure refactors and preserve current behavior.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
