### PR TITLE
Re-enable most performance A/B tests

### DIFF
--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -115,62 +115,13 @@ def format_with_reduced_unit(value, unit):
     return f"{reduced_value:.2f}{formatted_unit}"
 
 
-# Performance tests that are known to be unstable and exhibit variances of up to 60% of the mean
+# Performance tests that we don't want to alarm on.
 IGNORED = [
-    # Network throughput on m6a.metal
-    {"instance": "m6a.metal", "performance_test": "test_network_tcp_throughput"},
-    # Network throughput on m7a.metal
-    {"instance": "m7a.metal-48xl", "performance_test": "test_network_tcp_throughput"},
-    # vsock throughput on m7a.metal
-    {
-        "instance": "m7a.metal-48xl",
-        "performance_test": "test_vsock_throughput",
-        "mode": "g2h",
-    },
-    # Network latency on m6a.metal / m7a.metal
-    *[
-        {"instance": instance, "performance_test": "test_network_latency"}
-        for instance in ["m6a.metal", "m7a.metal-48xl"]
-    ],
-    # Network latencies on m8i.metal-{48,96}xl w/ 5.10 host
-    *[
-        {
-            "instance": instance,
-            "performance_test": "test_network_latency",
-            "host_kernel": "linux-5.10",
-        }
-        for instance in ["m8i.metal-48xl", "m8i.metal-96xl"]
-    ],
-    # Network latencies on m5n.metal w/ al2 host
-    {
-        "instance": "m5n.metal",
-        "performance_test": "test_network_latency",
-        "host_kernel": "linux-5.10",
-    },
-    # Network latencies on m8g
-    *[
-        {"instance": instance, "performance_test": "test_network_latency"}
-        for instance in ["m8g.metal-24xl", "m8g.metal-48xl"]
-    ],
-    # MMDS metrics on m8i, m7g and m8g
-    *[
-        {"instance": instance, "performance_test": "test_mmds_performance"}
-        for instance in [
-            "m8i.metal-48xl",
-            "m8i.metal-96xl",
-            "m7g.metal",
-            "m8g.metal-24xl",
-            "m8g.metal-48xl",
-        ]
-    ],
     # block latencies if guest uses async request submission
     {"fio_engine": "libaio", "metric": "clat_read"},
     {"fio_engine": "libaio", "metric": "clat_write"},
     # boot time metrics
     {"performance_test": "test_boottime", "metric": "resume_time"},
-    # block throughput on m8g
-    {"fio_engine": "libaio", "vcpus": "2", "instance": "m8g.metal-24xl"},
-    {"fio_engine": "libaio", "vcpus": "2", "instance": "m8g.metal-48xl"},
     # memory hotplug metrics: ignore api_time and fc_time metrics, keeping only total_time.
     *[
         {


### PR DESCRIPTION
## Changes

With #5955 merged, there should be less false positives in the A/B performance tests.
This commits re-enables most performance tests, and only leaves ignored tests for which we don't want to receive tickets at all.

## Reason

Ignored tests prevent us from spotting real performance regressions.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
