### PR TITLE
tests: wait for screen on test teardown

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Optional
 
 import psutil
-from tenacity import Retrying, retry, stop_after_attempt, wait_fixed
+from tenacity import Retrying, retry, stop_after_attempt, stop_after_delay, wait_fixed
 
 import host_tools.cargo_build as build_tools
 import host_tools.network as net_tools
@@ -343,6 +343,11 @@ class Microvm:
                 continue
             try:
                 os.kill(pid_to_kill, signal.SIGKILL)
+                try:
+                    utils.wait_process_termination(pid_to_kill)
+                except TimeoutError:
+                    utils.dump_proc_state(pid_to_kill)
+                    raise
             except ProcessLookupError:
                 pass
             except OSError:
@@ -355,37 +360,32 @@ class Microvm:
                     self._dump_debug_information(msg)
                     raise
 
-        if self._spawned and self.firecracker_pid:
-            try:
-                utils.wait_process_termination(self.firecracker_pid)
-            except TimeoutError:
-                utils.dump_proc_state(self.firecracker_pid)
-                raise
-
         # if microvm was spawned then check if it gets killed
         if self._spawned:
             # The following logic guards us against the case where `firecracker_pid` for some
             # reason is the wrong PID, e.g. this is a regression test for
             # https://github.com/firecracker-microvm/firecracker/pull/4442/commits/d63eb7a65ffaaae0409d15ed55d99ecbd29bc572
+            # Note: we have to retry a bit because /proc might show killed processes for a brief amount of time.
+            for attempt in Retrying(
+                wait=wait_fixed(0.1), stop=stop_after_delay(1.0), reraise=True
+            ):
+                with attempt:
+                    # filter ps results for the jailer's unique id
+                    _, stdout, _ = utils.check_output(
+                        "ps ax --no-headers -o pid,cmd -ww"
+                    )
 
-            # filter ps results for the jailer's unique id
-            _, stdout, stderr = utils.run_cmd(
-                f"ps ax -o pid,cmd -ww | grep {self.jailer.jailer_id}"
-            )
+                    offenders = []
+                    for proc in stdout.splitlines():
+                        _, cmd = proc.lower().split(maxsplit=1)
+                        if self.jailer.jailer_id in cmd and "firecracker" in cmd:
+                            offenders.append(proc)
 
-            assert not stderr, f"error querying processes using `ps`: {stderr}"
-
-            offenders = []
-            for proc in stdout.splitlines():
-                _, cmd = proc.lower().split(maxsplit=1)
-                if "firecracker" in proc and not cmd.startswith("screen"):
-                    offenders.append(proc)
-
-            # make sure firecracker was killed
-            assert not offenders, (
-                f"Firecracker reported its pid {self.firecracker_pid}, which was killed, but there still exist processes using the supposedly dead Firecracker's jailer_id: \n"
-                + "\n".join(offenders)
-            )
+                    # make sure firecracker was killed
+                    assert not offenders, (
+                        f"Firecracker reported its pid {self.firecracker_pid}, which was killed, but there still exist processes using the supposedly dead Firecracker's jailer_id: \n"
+                        + "\n".join(offenders)
+                    )
 
         if self.uffd_handler and self.uffd_handler.is_running():
             self.uffd_handler.kill()


### PR DESCRIPTION
## Changes

When launching Firecracker/jailer in a screen session, we don't wait for
 it to actually exit, which might result in sporadic test failures
 during test teardown.

This commit waits for screen after killing it.

## Reason

Test failed on https://buildkite.com/firecracker/firecracker-pr/builds/17585/list?jid=019ed00c-7bf7-49c7-a98e-7bb098197f2f&tab=output

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
