### PR TITLE
sh: filter on DMR capability not guest_memfd 

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -69,12 +69,11 @@ use crate::vstate::memory::{
 use crate::vstate::resources::ResourceAllocator;
 use crate::vstate::vcpu::{SharedApfStream, VcpuError};
 use crate::vstate::vm::{
-    GUEST_MEMFD_FLAG_INIT_SHARED, GUEST_MEMFD_FLAG_MMAP, GUEST_MEMFD_FLAG_NO_DIRECT_MAP,
-    GUEST_MEMFD_FLAG_WRITE, KvmVm, Vm, VmError,
+    KVM_CAP_GUEST_MEMFD_FLAGS, KvmVm, SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS,
+    SECRET_FREE_RESTORE_GUEST_MEMFD_FLAGS, Vm, VmError, ensure_guest_memfd_flags,
 };
 use crate::{EventManager, UffdMessageBroker, Vmm, VmmError};
 
-const KVM_CAP_GUEST_MEMFD_FLAGS: u32 = 244;
 const KVM_CAP_ASYNC_PF_USERFAULT: u32 = 246;
 
 pub(crate) fn pipe2(flags: libc::c_int) -> io::Result<(RawFd, RawFd)> {
@@ -204,6 +203,9 @@ pub fn build_microvm_for_boot(
     }
 
     let kvm = Kvm::new(kvm_capabilities)?;
+    if secret_free {
+        ensure_guest_memfd_flags(&kvm, SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS)?;
+    }
     // Set up KVM VM and register memory regions.
     // Build custom CPU config if a custom template is provided.
     let mut vm = KvmVm::new(kvm, secret_free)?;
@@ -226,9 +228,7 @@ pub fn build_microvm_for_boot(
         true => Some(Arc::new(
             vm.create_guest_memfd(
                 vm_resources.dram_memory_size() + vm_resources.hotplug_memory_size(),
-                GUEST_MEMFD_FLAG_MMAP
-                    | GUEST_MEMFD_FLAG_INIT_SHARED
-                    | GUEST_MEMFD_FLAG_NO_DIRECT_MAP,
+                SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS,
             )
             .map_err(VmmError::KvmVm)?,
         )),
@@ -639,6 +639,10 @@ pub fn build_microvm_from_snapshot(
         .ok();
 
     let kvm = Kvm::new(kvm_capabilities).map_err(StartMicrovmError::Kvm)?;
+    if secret_free {
+        ensure_guest_memfd_flags(&kvm, SECRET_FREE_RESTORE_GUEST_MEMFD_FLAGS)
+            .map_err(StartMicrovmError::KvmVm)?;
+    }
 
     // Check APF capability at runtime — don't require it
     let apf_supported = apf_stream.is_some()
@@ -677,10 +681,7 @@ pub fn build_microvm_from_snapshot(
         true => Some(
             vm.create_guest_memfd(
                 memory_size_from_mem_state(&microvm_state.vm_state.memory),
-                GUEST_MEMFD_FLAG_MMAP
-                    | GUEST_MEMFD_FLAG_INIT_SHARED
-                    | GUEST_MEMFD_FLAG_NO_DIRECT_MAP
-                    | GUEST_MEMFD_FLAG_WRITE,
+                SECRET_FREE_RESTORE_GUEST_MEMFD_FLAGS,
             )
             .map_err(VmmError::KvmVm)?,
         ),

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -55,9 +55,34 @@ pub enum StartVcpusError {
 
 pub(crate) const GUEST_MEMFD_FLAG_MMAP: u64 = 1;
 pub(crate) const GUEST_MEMFD_FLAG_INIT_SHARED: u64 = 2;
-#[allow(dead_code)]
 pub(crate) const GUEST_MEMFD_FLAG_NO_DIRECT_MAP: u64 = 4;
 pub(crate) const GUEST_MEMFD_FLAG_WRITE: u64 = 8;
+pub(crate) const KVM_CAP_GUEST_MEMFD_FLAGS: u32 = 244;
+
+pub(crate) const SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS: u64 =
+    GUEST_MEMFD_FLAG_MMAP | GUEST_MEMFD_FLAG_INIT_SHARED | GUEST_MEMFD_FLAG_NO_DIRECT_MAP;
+pub(crate) const SECRET_FREE_RESTORE_GUEST_MEMFD_FLAGS: u64 =
+    SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS | GUEST_MEMFD_FLAG_WRITE;
+
+pub(crate) fn guest_memfd_flags_supported(supported_flags: u64, required_flags: u64) -> bool {
+    supported_flags & required_flags == required_flags
+}
+
+pub(crate) fn ensure_guest_memfd_flags(kvm: &Kvm, required_flags: u64) -> Result<(), VmError> {
+    let supported_flags = kvm
+        .fd
+        .check_extension_raw(u64::from(KVM_CAP_GUEST_MEMFD_FLAGS));
+    let supported_flags = u64::try_from(supported_flags).unwrap_or_default();
+
+    if guest_memfd_flags_supported(supported_flags, required_flags) {
+        Ok(())
+    } else {
+        Err(VmError::GuestMemfdFlagsNotSupported(
+            required_flags,
+            supported_flags,
+        ))
+    }
+}
 
 /// KVM userfault information
 #[derive(Copy, Clone, Default, Eq, PartialEq, Debug)]
@@ -132,6 +157,8 @@ pub enum VmError {
     MemoryError(#[from] MemoryError),
     /// Failure to create guest_memfd: {0}
     GuestMemfd(kvm_ioctls::Error),
+    /// guest_memfd flags requested by Firecracker are not supported on this host kernel: requested {0:#x}, supported {1:#x}.
+    GuestMemfdFlagsNotSupported(u64, u64),
     /// guest_memfd is not supported on this host kernel.
     GuestMemfdNotSupported,
     /// UserMemory2 is not supported on this host kernel.
@@ -976,6 +1003,32 @@ pub(crate) mod tests {
 
         KvmVm::new(kvm, true)
             .expect("should be able to create secret free VMs if guest_memfd is supported");
+    }
+
+    #[test]
+    fn test_secret_free_boot_guest_memfd_flags() {
+        let upstream_flags = GUEST_MEMFD_FLAG_MMAP | GUEST_MEMFD_FLAG_INIT_SHARED;
+
+        assert!(!guest_memfd_flags_supported(
+            upstream_flags,
+            SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS,
+        ));
+        assert!(guest_memfd_flags_supported(
+            SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS,
+            SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS,
+        ));
+    }
+
+    #[test]
+    fn test_secret_free_restore_guest_memfd_flags() {
+        assert!(!guest_memfd_flags_supported(
+            SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS,
+            SECRET_FREE_RESTORE_GUEST_MEMFD_FLAGS,
+        ));
+        assert!(guest_memfd_flags_supported(
+            SECRET_FREE_RESTORE_GUEST_MEMFD_FLAGS,
+            SECRET_FREE_RESTORE_GUEST_MEMFD_FLAGS,
+        ));
     }
 
     #[test]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -528,10 +528,7 @@ def snapshot_type(request):
 
 
 secret_free_test_cases = [False]
-if (
-    global_props.host_linux_version_metrics == "next"
-    and global_props.instance != "m6g.metal"
-):
+if global_props.secret_free_restore_supported and global_props.instance != "m6g.metal":
     secret_free_test_cases.append(True)
 
 
@@ -546,7 +543,7 @@ secret_free_ids = {
     ids=list(map(lambda v: secret_free_ids[v], secret_free_test_cases)),
 )
 def secret_free(request):
-    """Supported secret hiding configuration, based on hardware"""
+    """Supported secret hiding configuration, based on host KVM capabilities."""
     return request.param
 
 

--- a/tests/framework/kvm.py
+++ b/tests/framework/kvm.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for probing host KVM capabilities used by tests."""
+
+import fcntl
+import os
+from dataclasses import dataclass
+
+KVMIO = 0xAE
+KVM_CHECK_EXTENSION = (KVMIO << 8) | 0x03
+
+KVM_CAP_USER_MEMORY2 = 231
+KVM_CAP_GUEST_MEMFD = 234
+KVM_CAP_GUEST_MEMFD_FLAGS = 244
+KVM_CAP_USERFAULT = 245
+
+GUEST_MEMFD_FLAG_MMAP = 1 << 0
+GUEST_MEMFD_FLAG_INIT_SHARED = 1 << 1
+GUEST_MEMFD_FLAG_NO_DIRECT_MAP = 1 << 2
+GUEST_MEMFD_FLAG_WRITE = 1 << 3
+
+SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS = (
+    GUEST_MEMFD_FLAG_MMAP
+    | GUEST_MEMFD_FLAG_INIT_SHARED
+    | GUEST_MEMFD_FLAG_NO_DIRECT_MAP
+)
+SECRET_FREE_RESTORE_GUEST_MEMFD_FLAGS = (
+    SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS | GUEST_MEMFD_FLAG_WRITE
+)
+
+
+@dataclass(frozen=True)
+class KvmCapabilities:
+    """Host KVM capabilities needed by secret_free tests."""
+
+    user_memory2: int = 0
+    guest_memfd: int = 0
+    guest_memfd_flags: int = 0
+    userfault: int = 0
+
+
+def _supports_guest_memfd_flags(supported_flags: int, required_flags: int) -> bool:
+    """Return True if all guest_memfd flags required by Firecracker are present."""
+    return supported_flags & required_flags == required_flags
+
+
+def _check_kvm_extension(kvm_fd: int, capability: int) -> int:
+    """Query a single KVM capability via KVM_CHECK_EXTENSION."""
+    return int(fcntl.ioctl(kvm_fd, KVM_CHECK_EXTENSION, capability))
+
+
+def get_kvm_capabilities() -> KvmCapabilities:
+    """Probe the host KVM capabilities needed by secret_free tests."""
+    try:
+        kvm_fd = os.open("/dev/kvm", os.O_RDWR | os.O_CLOEXEC)
+    except OSError:
+        return KvmCapabilities()
+
+    try:
+        return KvmCapabilities(
+            user_memory2=_check_kvm_extension(kvm_fd, KVM_CAP_USER_MEMORY2),
+            guest_memfd=_check_kvm_extension(kvm_fd, KVM_CAP_GUEST_MEMFD),
+            guest_memfd_flags=_check_kvm_extension(kvm_fd, KVM_CAP_GUEST_MEMFD_FLAGS),
+            userfault=_check_kvm_extension(kvm_fd, KVM_CAP_USERFAULT),
+        )
+    except OSError:
+        return KvmCapabilities()
+    finally:
+        os.close(kvm_fd)
+
+
+def supports_secret_free_boot(kvm_capabilities: KvmCapabilities) -> bool:
+    """Return True if the host can boot secret_free microVMs."""
+    return (
+        kvm_capabilities.user_memory2 != 0
+        and kvm_capabilities.guest_memfd != 0
+        and _supports_guest_memfd_flags(
+            kvm_capabilities.guest_memfd_flags,
+            SECRET_FREE_BOOT_GUEST_MEMFD_FLAGS,
+        )
+    )
+
+
+def supports_secret_free_restore(kvm_capabilities: KvmCapabilities) -> bool:
+    """Return True if the host can restore secret_free snapshots via UFFD."""
+    return (
+        supports_secret_free_boot(kvm_capabilities)
+        and kvm_capabilities.userfault != 0
+        and _supports_guest_memfd_flags(
+            kvm_capabilities.guest_memfd_flags,
+            SECRET_FREE_RESTORE_GUEST_MEMFD_FLAGS,
+        )
+    )

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -11,8 +11,15 @@ import os
 import platform
 import re
 import subprocess
+from dataclasses import asdict
 from pathlib import Path
 
+from framework.kvm import (
+    KvmCapabilities,
+    get_kvm_capabilities,
+    supports_secret_free_boot,
+    supports_secret_free_restore,
+)
 from framework.utils import get_kernel_version
 from framework.utils_cpuid import get_cpu_codename, get_cpu_model_name, get_cpu_vendor
 from framework.utils_imdsv2 import imdsv2_get
@@ -82,6 +89,7 @@ class GlobalProps:
         self.buildkite_revision_a = os.environ.get("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
         # Development environment detection
         self.is_dev_env = os.environ.get("FC_TEST_DEVELOPMENT_ENVIRONMENT") == "1"
+        self.kvm_capabilities = asdict(get_kvm_capabilities())
 
         if self._in_git_repo():
             self.git_commit_id = run_cmd("git rev-parse HEAD")
@@ -115,6 +123,16 @@ class GlobalProps:
         return (
             "next" if self.host_linux_version_tpl > (6, 12) else self.host_linux_version
         )
+
+    @property
+    def secret_free_boot_supported(self):
+        """Whether the host KVM supports booting secret_free microVMs."""
+        return supports_secret_free_boot(KvmCapabilities(**self.kvm_capabilities))
+
+    @property
+    def secret_free_restore_supported(self):
+        """Whether the host KVM supports restoring secret_free snapshots."""
+        return supports_secret_free_restore(KvmCapabilities(**self.kvm_capabilities))
 
     @property
     def is_ec2(self):

--- a/tests/integration_tests/functional/test_apf.py
+++ b/tests/integration_tests/functional/test_apf.py
@@ -113,7 +113,7 @@ def _assert_vm_healthy(microvm):
 
 
 @pytest.fixture
-def apf_vm(microvm_factory, guest_kernel_linux_5_10, rootfs, secret_free):
+def apf_vm(microvm_factory, guest_kernel, rootfs, secret_free):
     """Provide a factory function for booting + snapshotting VMs.
 
     APF requires secret_free (KVM_MEM_USERFAULT + userfault bitmap).
@@ -124,7 +124,7 @@ def apf_vm(microvm_factory, guest_kernel_linux_5_10, rootfs, secret_free):
 
     def _make(vcpus=2, mem_mib=512):
         vm = microvm_factory.build(
-            guest_kernel_linux_5_10,
+            guest_kernel,
             rootfs,
             monitor_memory=False,
         )

--- a/tests/integration_tests/functional/test_secret_freedom.py
+++ b/tests/integration_tests/functional/test_secret_freedom.py
@@ -11,8 +11,8 @@ from integration_tests.performance.test_initrd import INITRD_FILESYSTEM
 
 pytestmark = [
     pytest.mark.skipif(
-        global_props.host_linux_version_metrics != "next",
-        reason="Secret Freedom is only supported on the in-dev upstream kernels for now",
+        not global_props.secret_free_boot_supported,
+        reason="Secret Freedom boot is not supported by this host KVM",
     ),
     pytest.mark.skipif(
         global_props.instance == "m6g.metal",

--- a/tests/integration_tests/performance/test_apf.py
+++ b/tests/integration_tests/performance/test_apf.py
@@ -40,7 +40,7 @@ while true; do i=$((i+1)); done
 )
 def test_apf_latency(
     microvm_factory,
-    guest_kernel_linux_5_10,
+    guest_kernel,
     rootfs,
     secret_free,
     metrics,
@@ -69,7 +69,7 @@ def test_apf_latency(
     no_exitless_env = apf_variant == "fallback"
 
     vm = microvm_factory.build(
-        guest_kernel_linux_5_10,
+        guest_kernel,
         rootfs,
         monitor_memory=False,
     )

--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -177,8 +177,8 @@ def uvm_any_memhp(request, uvm, rootfs, microvm_factory):
         request.param
     )
 
-    if secret_free is True and global_props.host_linux_version_metrics != "next":
-        pytest.skip("Secret Freedom isn't supported by this host kernel")
+    if secret_free is True and not global_props.secret_free_restore_supported:
+        pytest.skip("Secret Freedom restore isn't supported by this host KVM")
 
     if secret_free is True and global_props.instance == "m6g.metal":
         pytest.skip("Secret Freedom isn't supported on Graviton2")


### PR DESCRIPTION


## Changes

The original gate which depended on the guest_memfd means that 6.18 hosts will attempt to run the DMR tests.

Update the gate to check for specifically for the DMR feature bits we require.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
Collect the KVM capability probing needed by Secret Freedom
coverage in a dedicated framework helper.

This keeps the ioctl details out of GlobalProps and gives later
test gating a single place to extend.

Add focused unit coverage for the helper boot and restore checks so
follow-up consumers can reuse it safely.

Signed-off-by: Jack Thomson <jackabt@amazon.com>