### PR TITLE
[BACKPORT 1.16]  IA32_XSS to preserve supervisor XSTATE

### DIFF
--- a/src/vmm/src/arch/x86_64/msr.rs
+++ b/src/vmm/src/arch/x86_64/msr.rs
@@ -225,6 +225,9 @@ static SERIALIZABLE_MSR_RANGES: &[MsrRange] = &[
     MSR_RANGE!(MSR_MISC_FEATURES_ENABLES),
     MSR_RANGE!(MSR_K7_HWCR),
     MSR_RANGE!(MSR_IA32_TSX_CTRL),
+    // IA32_XSS controls which supervisor XSTATE components are enabled. Without it, the guest
+    // kernel's XRSTORS of process FPU state containing CET/PT supervisor components triggers #GP.
+    MSR_RANGE!(MSR_IA32_XSS),
     MSR_RANGE!(
         MSR_KVM_RANGE_START,
         MSR_KVM_RANGE_END - MSR_KVM_RANGE_START + 1


### PR DESCRIPTION
Backporting PR: https://github.com/firecracker-microvm/firecracker/pull/5972 to v1.16

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
