### PR TITLE
vmm: Deassign ioeventfds on PCI device hot-unplug

### DIFF
--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -599,6 +599,10 @@ impl DeviceManager {
         let pci_device_arc = self.pci_devices.virtio_devices.remove(&device_id).unwrap();
         let pci_device = pci_device_arc.lock().expect("Poisoned lock");
 
+        pci_device
+            .unregister_notification_ioevents(&vm)
+            .map_err(PciManagerError::Kvm)?;
+
         vm.common
             .mmio_bus
             .remove(pci_device.config_bar_addr(), CAPABILITY_BAR_SIZE)

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -130,7 +130,7 @@ impl PciDevices {
         Self::register_bars_with_bus(vm, &virtio_device)?;
 
         let mut device = virtio_device.lock().expect("Poisoned lock");
-        device.register_notification_ioevent(vm)?;
+        device.register_notification_ioevents(vm)?;
 
         let sub_id = event_manager.add_subscriber(device.virtio_device());
         device.sub_id = Some(sub_id);

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -620,8 +620,7 @@ impl VirtioPciDevice {
         !self.device_activated.load(Ordering::SeqCst) && self.is_driver_ready()
     }
 
-    /// Register the IoEvent notification for a VirtIO device
-    pub fn register_notification_ioevent(&self, vm: &KvmVm) -> Result<(), errno::Error> {
+    fn set_notification_ioevents(&self, vm: &KvmVm, assign: bool) -> Result<(), errno::Error> {
         let bar_addr = self.config_bar_addr();
         for (i, queue_evt) in self
             .device
@@ -634,9 +633,24 @@ impl VirtioPciDevice {
             let notify_base = bar_addr + u64::from(NOTIFICATION_BAR_OFFSET);
             let io_addr =
                 IoEventAddress::Mmio(notify_base + i as u64 * u64::from(NOTIFY_OFF_MULTIPLIER));
-            vm.fd().register_ioevent(queue_evt, &io_addr, NoDatamatch)?;
+            if assign {
+                vm.fd().register_ioevent(queue_evt, &io_addr, NoDatamatch)?;
+            } else {
+                vm.fd()
+                    .unregister_ioevent(queue_evt, &io_addr, NoDatamatch)?;
+            }
         }
         Ok(())
+    }
+
+    /// Register the IoEvent notifications for a VirtIO device.
+    pub fn register_notification_ioevents(&self, vm: &KvmVm) -> Result<(), errno::Error> {
+        self.set_notification_ioevents(vm, true)
+    }
+
+    /// Unregister the IoEvent notifications for a VirtIO device.
+    pub fn unregister_notification_ioevents(&self, vm: &KvmVm) -> Result<(), errno::Error> {
+        self.set_notification_ioevents(vm, false)
     }
 
     pub fn state(&self) -> VirtioPciDeviceState {


### PR DESCRIPTION
Closing the eventfds registered with KVM_IOEVENTFD is not sufficient, KVM holds its own references. We need to explicitly assign them by calling KVM_IOEVENTFD again with the KVM_IOEVENTFD_FLAG_DEASSIGN flag. Do that in hot_unplug_device().

Add VirtioPciDevice::unregister_notification_ioevents() as the counterpart to register_notification_ioevent() and move the common logic into a private helper. Since we are here rename
register_notification_ioevent() to register_notification_ioevents() since it's used to register multiple events.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
