### PR TITLE
Sync to newest APF Patches

### DIFF
--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -745,7 +745,19 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 1075883734,
-                        "comment": "KVM_ASYNC_PF (accept/ready/sync_complete)"
+                        "comment": "KVM_ASYNC_PF (accept/ready)"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1075883737,
+                        "comment": "KVM_SET_APF_EVENTFD"
                     }
                 ]
             }
@@ -1516,7 +1528,7 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 1075883734,
-                        "comment": "KVM_ASYNC_PF (accept/ready/sync_complete)"
+                        "comment": "KVM_ASYNC_PF (accept/ready)"
                     }
                 ]
             }

--- a/src/firecracker/examples/uffd/fault_all_handler.rs
+++ b/src/firecracker/examples/uffd/fault_all_handler.rs
@@ -64,7 +64,7 @@ fn main() {
                 }
             }
         },
-        |_uffd_handler: &mut UffdHandler, _offset: usize| {},
+        |_uffd_handler: &mut UffdHandler, _offset: usize, _len: usize| {},
     );
 }
 

--- a/src/firecracker/examples/uffd/malicious_handler.rs
+++ b/src/firecracker/examples/uffd/malicious_handler.rs
@@ -39,6 +39,6 @@ fn main() {
                 panic!("Fear me! I am the malicious page fault handler.")
             }
         },
-        |_uffd_handler: &mut UffdHandler, _offset: usize| {},
+        |_uffd_handler: &mut UffdHandler, _offset: usize, _len: usize| {},
     );
 }

--- a/src/firecracker/examples/uffd/on_demand_handler.rs
+++ b/src/firecracker/examples/uffd/on_demand_handler.rs
@@ -154,16 +154,14 @@ fn main() {
                 }
             }
         },
-        |uffd_handler: &mut UffdHandler, offset: usize| {
-            let bytes_written = uffd_handler.populate_via_write(offset, uffd_handler.page_size);
+        |uffd_handler: &mut UffdHandler, offset: usize, len: usize| {
+            let bytes_written = uffd_handler.populate_via_write(offset, len);
 
-            if bytes_written == 0 {
+            if bytes_written != len {
                 println!(
-                    "got a vcpu fault for an already populated page at offset {}",
-                    offset
+                    "got a vcpu fault range with already populated pages at offset {}: wrote {} of {} bytes",
+                    offset, bytes_written, len
                 );
-            } else {
-                assert_eq!(bytes_written, uffd_handler.page_size);
             }
         },
     );

--- a/src/firecracker/examples/uffd/uffd_utils.rs
+++ b/src/firecracker/examples/uffd/uffd_utils.rs
@@ -18,10 +18,11 @@ use std::ffi::c_void;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::num::NonZero;
+use std::os::fd::OwnedFd;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::ptr;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering, fence};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -31,7 +32,20 @@ use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 use crate::uffd_utils::userfault_bitmap::UserfaultBitmap;
 
 // Exitless APF support — must match kernel UAPI definitions
-pub const KVM_APF_RING_SIZE: usize = 32;
+pub const KVM_APF_SHARED_VERSION: u32 = 1;
+pub const KVM_APF_RING_SIZE: usize = 64;
+pub const KVM_APF_SHARED_FLAG_NOTIFY_ARMED: u32 = 1;
+const KVM_APF_PAGE_OFFSET: libc::off_t = 3;
+const KVM_APF_RING_MASK: u32 = (KVM_APF_RING_SIZE as u32) - 1;
+
+#[repr(C)]
+pub struct KvmApfSharedHeader {
+    pub version: u32,
+    pub ring_size: u32,
+    pub entry_size: u32,
+    pub flags: AtomicU32,
+    pub reserved: [u64; 6],
+}
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy)]
@@ -43,29 +57,96 @@ pub struct KvmApfRingEntry {
 #[repr(C)]
 pub struct KvmApfRing {
     pub head: AtomicU32,
+    pub _pad_head: [u32; 15],
     pub tail: AtomicU32,
-    pub reserved: u32,
-    pub padding: u32,
+    pub _pad_tail: [u32; 15],
     pub entries: [KvmApfRingEntry; KVM_APF_RING_SIZE],
 }
 
 #[repr(C)]
 pub struct KvmApfSharedPage {
+    pub header: KvmApfSharedHeader,
     pub notify: KvmApfRing,
     pub complete: KvmApfRing,
 }
 
 impl KvmApfRing {
+    pub fn has_entries(&self) -> bool {
+        let head = self.head.load(Ordering::Acquire);
+        let tail = self.tail.load(Ordering::Relaxed);
+
+        head != tail
+    }
+
     pub fn pop(&self) -> Option<KvmApfRingEntry> {
         let head = self.head.load(Ordering::Acquire);
         let tail = self.tail.load(Ordering::Relaxed);
         if head == tail {
             return None;
         }
-        let entry = self.entries[tail as usize];
-        self.tail
-            .store((tail + 1) % KVM_APF_RING_SIZE as u32, Ordering::Release);
+        let entry = self.entries[(tail & KVM_APF_RING_MASK) as usize];
+        self.tail.store(tail.wrapping_add(1), Ordering::Release);
         Some(entry)
+    }
+
+    pub fn drain_into(&self, out: &mut [KvmApfRingEntry]) -> usize {
+        let head = self.head.load(Ordering::Acquire);
+        let mut tail = self.tail.load(Ordering::Relaxed);
+        let mut count = 0;
+        let limit = head
+            .wrapping_sub(tail)
+            .min(KVM_APF_RING_SIZE as u32)
+            .min(out.len() as u32);
+
+        while count < limit as usize {
+            out[count] = self.entries[(tail & KVM_APF_RING_MASK) as usize];
+            tail = tail.wrapping_add(1);
+            count += 1;
+        }
+        if count > 0 {
+            self.tail.store(tail, Ordering::Release);
+        }
+        count
+    }
+}
+
+impl KvmApfSharedPage {
+    fn validate(&self) -> std::io::Result<()> {
+        if self.header.version != KVM_APF_SHARED_VERSION
+            || self.header.ring_size != KVM_APF_RING_SIZE as u32
+            || self.header.entry_size != std::mem::size_of::<KvmApfRingEntry>() as u32
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "unsupported APF shared page: version={} ring_size={} entry_size={}",
+                    self.header.version, self.header.ring_size, self.header.entry_size
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn arm_notify_if_empty(&self) -> bool {
+        if self.notify.has_entries() {
+            return false;
+        }
+
+        self.header
+            .flags
+            .fetch_or(KVM_APF_SHARED_FLAG_NOTIFY_ARMED, Ordering::Release);
+        // Paired with KVM's full barrier after publishing notify.head.
+        fence(Ordering::SeqCst);
+
+        if self.notify.has_entries() {
+            self.header
+                .flags
+                .fetch_and(!KVM_APF_SHARED_FLAG_NOTIFY_ARMED, Ordering::AcqRel);
+            return false;
+        }
+
+        true
     }
 }
 
@@ -80,26 +161,36 @@ impl ExitlessApfVcpu {
     pub fn from_fds(
         eventfd: RawFd,
         complete_eventfd: RawFd,
-        shared_page_memfd: RawFd,
+        shared_page_vcpu_fd: RawFd,
     ) -> std::io::Result<Self> {
+        // SAFETY: these fds were just received via SCM_RIGHTS and ownership is transferred here.
+        let eventfd = unsafe { OwnedFd::from_raw_fd(eventfd) };
+        // SAFETY: these fds were just received via SCM_RIGHTS and ownership is transferred here.
+        let complete_eventfd = unsafe { OwnedFd::from_raw_fd(complete_eventfd) };
+        // SAFETY: these fds were just received via SCM_RIGHTS and ownership is transferred here.
+        let shared_page_vcpu_fd = unsafe { OwnedFd::from_raw_fd(shared_page_vcpu_fd) };
         let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
+        let offset = KVM_APF_PAGE_OFFSET * page_size as libc::off_t;
         let ptr = unsafe {
             libc::mmap(
                 ptr::null_mut(),
                 page_size,
                 libc::PROT_READ | libc::PROT_WRITE,
                 libc::MAP_SHARED,
-                shared_page_memfd,
-                0,
+                shared_page_vcpu_fd.as_raw_fd(),
+                offset,
             )
         };
         if ptr == libc::MAP_FAILED {
             return Err(std::io::Error::last_os_error());
         }
-        unsafe { libc::close(shared_page_memfd) };
+        if let Err(err) = unsafe { &*(ptr as *const KvmApfSharedPage) }.validate() {
+            unsafe { libc::munmap(ptr, page_size) };
+            return Err(err);
+        }
         Ok(Self {
-            eventfd,
-            complete_eventfd,
+            eventfd: eventfd.into_raw_fd(),
+            complete_eventfd: complete_eventfd.into_raw_fd(),
             shared_page: ptr as *mut KvmApfSharedPage,
             buff: [0; 8],
         })
@@ -112,47 +203,74 @@ impl ExitlessApfVcpu {
         unsafe { &(*self.shared_page).complete }
     }
 
+    pub fn arm_notify_if_empty(&self) -> bool {
+        unsafe { &*self.shared_page }.arm_notify_if_empty()
+    }
+
     pub fn drain_eventfd(&mut self) {
         unsafe { libc::read(self.eventfd, self.buff.as_mut_ptr() as *mut c_void, 8) };
     }
 
+    fn signal_complete_eventfd(&self) {
+        let val: u64 = 1;
+        unsafe {
+            libc::write(
+                self.complete_eventfd,
+                &val as *const u64 as *const c_void,
+                8,
+            )
+        };
+    }
+
     pub fn signal_ready(&self, gpa: u64) {
-        let ring = self.complete_ring();
         let entry = KvmApfRingEntry { gpa, flags: 0 };
-        for attempt in 0u32.. {
-            let head = ring.head.load(Ordering::Relaxed);
-            let tail = ring.tail.load(Ordering::Acquire);
-            let next = (head + 1) % KVM_APF_RING_SIZE as u32;
-            if next != tail {
-                unsafe {
-                    let slot = &raw const ring.entries[head as usize] as *mut KvmApfRingEntry;
-                    ptr::write(slot, entry);
+        self.signal_ready_batch(std::slice::from_ref(&entry));
+    }
+
+    pub fn signal_ready_batch(&self, entries: &[KvmApfRingEntry]) {
+        let ring = self.complete_ring();
+        let mut needs_signal = false;
+
+        for entry in entries {
+            let entry = KvmApfRingEntry {
+                gpa: entry.gpa,
+                flags: 0,
+            };
+            let mut attempt = 0u32;
+            loop {
+                let head = ring.head.load(Ordering::Relaxed);
+                let tail = ring.tail.load(Ordering::Acquire);
+                if head.wrapping_sub(tail) < KVM_APF_RING_SIZE as u32 {
+                    unsafe {
+                        let slot = &raw const ring.entries[(head & KVM_APF_RING_MASK) as usize]
+                            as *mut KvmApfRingEntry;
+                        ptr::write(slot, entry);
+                    }
+                    ring.head.store(head.wrapping_add(1), Ordering::Release);
+                    needs_signal = true;
+                    break;
                 }
-                ring.head.store(next, Ordering::Release);
-                let val: u64 = 1;
-                unsafe {
-                    libc::write(
-                        self.complete_eventfd,
-                        &val as *const u64 as *const c_void,
-                        8,
-                    )
-                };
-                return;
+
+                // If we filled the completion ring with this batch, kick the kernel so it can
+                // drain entries.  If it was already full, keep the old behavior and kick once on
+                // the first spin in case a previous notification was lost/coalesced.
+                if needs_signal || attempt == 0 {
+                    self.signal_complete_eventfd();
+                    needs_signal = false;
+                }
+                if attempt == 10_000 {
+                    eprintln!(
+                        "WARN: APF completion ring full after {attempt} spins for gpa {:#x}",
+                        entry.gpa
+                    );
+                }
+                attempt = attempt.wrapping_add(1);
+                std::hint::spin_loop();
             }
-            if attempt == 0 {
-                let val: u64 = 1;
-                unsafe {
-                    libc::write(
-                        self.complete_eventfd,
-                        &val as *const u64 as *const c_void,
-                        8,
-                    )
-                };
-            }
-            if attempt >= 10_000 {
-                eprintln!("WARN: APF completion ring full after {attempt} spins for gpa {gpa:#x}");
-            }
-            std::hint::spin_loop();
+        }
+
+        if needs_signal {
+            self.signal_complete_eventfd();
         }
     }
 }
@@ -177,13 +295,13 @@ fn signal_apf_ready(shared_page: SendableSharedPage, complete_eventfd: RawFd, gp
     for attempt in 0u32.. {
         let head = ring.head.load(Ordering::Relaxed);
         let tail = ring.tail.load(Ordering::Acquire);
-        let next = (head + 1) % KVM_APF_RING_SIZE as u32;
-        if next != tail {
+        if head.wrapping_sub(tail) < KVM_APF_RING_SIZE as u32 {
             unsafe {
-                let slot = &raw const ring.entries[head as usize] as *mut KvmApfRingEntry;
+                let slot = &raw const ring.entries[(head & KVM_APF_RING_MASK) as usize]
+                    as *mut KvmApfRingEntry;
                 ptr::write(slot, entry);
             }
-            ring.head.store(next, Ordering::Release);
+            ring.head.store(head.wrapping_add(1), Ordering::Release);
             let val: u64 = 1;
             unsafe { libc::write(complete_eventfd, &val as *const u64 as *const c_void, 8) };
             return;
@@ -294,6 +412,7 @@ impl GuestRegionUffdMapping {
 pub struct UffdHandler {
     pub mem_regions: Vec<GuestRegionUffdMapping>,
     pub page_size: usize,
+    total_size: usize,
     backing_buffer: *const u8,
     pub uffd: Uffd,
     pub guest_memfd: Option<File>,
@@ -399,6 +518,7 @@ impl UffdHandler {
                 Self {
                     mem_regions: mappings,
                     page_size,
+                    total_size: memsize,
                     backing_buffer,
                     uffd,
                     guest_memfd,
@@ -409,6 +529,7 @@ impl UffdHandler {
             (None, None) => Self {
                 mem_regions: mappings,
                 page_size,
+                total_size: memsize,
                 backing_buffer,
                 uffd,
                 guest_memfd: None,
@@ -426,6 +547,11 @@ impl UffdHandler {
     /// Convert a guest physical address to an offset in the backing memory file.
     #[inline]
     pub fn gpa_to_offset(&self, gpa: u64) -> Option<usize> {
+        if let [region] = self.mem_regions.as_slice() {
+            return (region.gpa_start <= gpa && gpa < region.gpa_start + region.size as u64)
+                .then_some((gpa - region.gpa_start + region.offset) as usize);
+        }
+
         for region in &self.mem_regions {
             if region.gpa_start <= gpa && gpa < region.gpa_start + region.size as u64 {
                 return Some((gpa - region.gpa_start + region.offset) as usize);
@@ -453,6 +579,12 @@ impl UffdHandler {
 
     pub fn addr_to_offset(&self, addr: *mut u8) -> u64 {
         let addr = addr as u64;
+        if let [region] = self.mem_regions.as_slice()
+            && region.contains(addr)
+        {
+            return addr - region.base_host_virt_addr + region.offset;
+        }
+
         for region in &self.mem_regions {
             if region.contains(addr) {
                 return addr - region.base_host_virt_addr + region.offset;
@@ -470,6 +602,14 @@ impl UffdHandler {
         let dst = (addr as usize & !(self.page_size - 1)) as *mut libc::c_void;
         let fault_page_addr = dst as u64;
 
+        if let [region] = self.mem_regions.as_slice()
+            && region.contains(fault_page_addr)
+        {
+            let offset = (region.offset + fault_page_addr - region.base_host_virt_addr) as usize;
+            let src = unsafe { self.backing_buffer.add(offset) };
+            return self.populate_via_uffdio_copy(src, fault_page_addr, len);
+        }
+
         for region in self.mem_regions.iter() {
             if region.contains(fault_page_addr) {
                 let offset =
@@ -486,7 +626,7 @@ impl UffdHandler {
     }
 
     pub fn size(&self) -> usize {
-        self.mem_regions.iter().map(|r| r.size).sum()
+        self.total_size
     }
 
     pub fn populate_via_write(&mut self, offset: usize, len: usize) -> usize {
@@ -506,60 +646,58 @@ impl UffdHandler {
             self.size()
         );
 
+        let guest_memfd = self.guest_memfd.as_ref().unwrap().as_raw_fd();
+        let userfault_bitmap = self.userfault_bitmap.as_ref().unwrap();
         let mut total_written = 0;
         let mut pos = 0;
 
         while pos < len {
-            let src = unsafe { self.backing_buffer.add(offset + pos) };
+            let write_offset = offset + pos;
+            let src = unsafe { self.backing_buffer.add(write_offset) };
             let len_to_write = (len - pos).min(MAX_WRITE_LEN);
             let bytes_written = unsafe {
                 libc::pwrite64(
-                    self.guest_memfd.as_ref().unwrap().as_raw_fd(),
+                    guest_memfd,
                     src.cast(),
                     len_to_write,
-                    (offset + pos) as libc::off64_t,
+                    write_offset as libc::off64_t,
                 )
             };
 
-            let bytes_written = match bytes_written {
+            match bytes_written {
                 -1 if vmm_sys_util::errno::Error::last().errno() == libc::EEXIST => {
                     // write() syscall returns -1 with EEXIST when the direct map PTE for the page
                     // has already been removed, indicating the page has been populated. Reset the
                     // corresponding bit in the userfault bitmap to suppress further KVM userfaults
                     // for that page and skip the page.
-                    self.userfault_bitmap
-                        .as_mut()
-                        .unwrap()
-                        .reset_addr_range(offset + pos, self.page_size);
-                    pos += self.page_size;
-                    0
+                    let skip_len = self.page_size.min(len - pos);
+                    userfault_bitmap.reset_addr_range(write_offset, skip_len);
+                    pos += skip_len;
                 }
                 written @ 0.. => {
-                    if (written as usize) < len_to_write {
+                    let bytes_written = written as usize;
+                    assert!(bytes_written <= len_to_write);
+
+                    if bytes_written > 0 {
+                        userfault_bitmap.reset_addr_range(write_offset, bytes_written);
+                        total_written += bytes_written;
+                        pos += bytes_written;
+                    }
+
+                    if bytes_written < len_to_write {
                         // write() syscall wrote less bytes than we requested when the direct map
                         // PTE for the page has already been removed,
                         // indicating a page has been populated. Reset the
                         // corresponding bit in the userfault bitmap to
                         // suppress further KVM userfaults for that page and
                         // skip the page.
-                        self.userfault_bitmap.as_mut().unwrap().reset_addr_range(
-                            offset + pos + bytes_written as usize,
-                            self.page_size,
-                        );
-                        pos += self.page_size;
+                        let skip_len = self.page_size.min(len - pos);
+                        userfault_bitmap.reset_addr_range(offset + pos, skip_len);
+                        pos += skip_len;
                     }
-                    written as usize
                 }
                 _ => panic!("{:?}", std::io::Error::last_os_error()),
-            };
-
-            self.userfault_bitmap
-                .as_mut()
-                .unwrap()
-                .reset_addr_range(offset + pos, bytes_written);
-
-            total_written += bytes_written;
-            pos += bytes_written;
+            }
         }
 
         total_written
@@ -622,20 +760,38 @@ impl Iterator for UffdMsgIterBitcode {
     type Item = FaultRequest;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.can_decode() {
+            return self.decode_next();
+        }
+
         match self.stream.read(&mut self.buffer[self.current_pos..]) {
             Ok(bytes_read) => self.current_pos += bytes_read,
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
             Err(e) => panic!("Failed to read from stream: {e}"),
         }
 
-        if self.current_pos < 4 {
+        if !self.can_decode() {
             return None;
         }
 
-        let size = u32::from_le_bytes(self.buffer[..4].try_into().unwrap()) as usize;
-        if self.current_pos < 4 + size {
-            return None;
+        self.decode_next()
+    }
+}
+
+impl UffdMsgIterBitcode {
+    fn can_decode(&self) -> bool {
+        if self.current_pos < 4 {
+            return false;
         }
+
+        let size = u32::from_le_bytes(self.buffer[..4].try_into().unwrap()) as usize;
+        self.current_pos >= 4 + size
+    }
+
+    fn decode_next(&mut self) -> Option<FaultRequest> {
+        debug_assert!(self.can_decode());
+
+        let size = u32::from_le_bytes(self.buffer[..4].try_into().unwrap()) as usize;
 
         let decoded: FaultRequest = bitcode::decode(&self.buffer[4..4 + size])
             .unwrap_or_else(|e| panic!("Failed to decode bitcode message: {e}"));
@@ -663,6 +819,8 @@ pub struct Runtime {
     handler: UffdHandler,
     apf_stream: UnixStream,
     exitless_vcpus: HashMap<RawFd, ExitlessApfVcpu>,
+    encode_buffer: bitcode::Buffer,
+    write_buffer: [u8; 4096],
 }
 
 impl Runtime {
@@ -697,6 +855,8 @@ impl Runtime {
             handler,
             apf_stream,
             exitless_vcpus: HashMap::new(),
+            encode_buffer: bitcode::Buffer::new(),
+            write_buffer: [0; 4096],
         }
     }
 
@@ -737,18 +897,31 @@ impl Runtime {
         }));
     }
 
+    fn encode_fault_reply(&mut self, fault_reply: &FaultReply) -> usize {
+        let encoded = self.encode_buffer.encode(fault_reply);
+        let len = encoded.len();
+        let size = u32::try_from(len).expect("encoded message exceeds u32::MAX");
+        assert!(
+            4 + len <= self.write_buffer.len(),
+            "encoded APF reply exceeds write buffer"
+        );
+        self.write_buffer[..4].copy_from_slice(&size.to_le_bytes());
+        self.write_buffer[4..4 + len].copy_from_slice(encoded);
+        4 + len
+    }
+
     pub fn send_fault_reply(&mut self, fault_reply: FaultReply) {
-        let encoded = bitcode::encode(&fault_reply);
-        let size = (encoded.len() as u32).to_le_bytes();
-        self.stream.write_all(&size).unwrap();
-        self.stream.write_all(&encoded).unwrap();
+        let frame_len = self.encode_fault_reply(&fault_reply);
+        self.stream
+            .write_all(&self.write_buffer[..frame_len])
+            .unwrap();
     }
 
     pub fn send_apf_fault_reply(&mut self, fault_reply: FaultReply) {
-        let encoded = bitcode::encode(&fault_reply);
-        let size = (encoded.len() as u32).to_le_bytes();
-        self.apf_stream.write_all(&size).unwrap();
-        self.apf_stream.write_all(&encoded).unwrap();
+        let frame_len = self.encode_fault_reply(&fault_reply);
+        self.apf_stream
+            .write_all(&self.write_buffer[..frame_len])
+            .unwrap();
     }
 
     pub fn construct_handler(
@@ -789,8 +962,11 @@ impl Runtime {
     }
 
     pub fn try_receive_exitless_apf(&mut self) -> std::io::Result<bool> {
+        const MAX_EXITLESS_APF_VCPUS: usize = 32;
+        const MAX_EXITLESS_APF_FDS: usize = MAX_EXITLESS_APF_VCPUS * 3;
+
         let mut msg_buf = [0u8; 256];
-        let mut fds = [0i32; 64];
+        let mut fds = [0i32; MAX_EXITLESS_APF_FDS];
         // Firecracker sends exitless APF fds over the UFFD socket (self.stream),
         // not the APF socket. Block until we receive the message.
         self.stream.set_nonblocking(false).expect("set nonblocking");
@@ -808,17 +984,26 @@ impl Runtime {
             }
         };
         self.stream.set_nonblocking(true).expect("set nonblocking");
-        if bytes_read > 0 && fds_read == 0 {
-            let msg = std::str::from_utf8(&msg_buf[..bytes_read]).unwrap_or("");
-            if msg.starts_with("no_exitless_apf") {
-                println!("Exitless APF: not supported by kernel, disabled");
-                return Ok(false);
-            }
+        let msg = std::str::from_utf8(&msg_buf[..bytes_read]).unwrap_or("");
+        if bytes_read > 0 && fds_read == 0 && msg.starts_with("no_exitless_apf") {
+            println!("Exitless APF: not supported by kernel, disabled");
+            return Ok(false);
         }
         if fds_read == 0 || fds_read % 3 != 0 {
             return Ok(false);
         }
+        let expected_vcpus = msg
+            .strip_prefix("exitless_apf:")
+            .and_then(|count| count.parse::<usize>().ok());
         let num_vcpus = fds_read / 3;
+        if expected_vcpus != Some(num_vcpus) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "exitless APF fd count mismatch: message={expected_vcpus:?} fds={fds_read}"
+                ),
+            ));
+        }
         for i in 0..num_vcpus {
             let base = i * 3;
             let ctx = ExitlessApfVcpu::from_fds(fds[base], fds[base + 1], fds[base + 2])?;
@@ -829,6 +1014,61 @@ impl Runtime {
         Ok(!self.exitless_vcpus.is_empty())
     }
 
+    fn process_exitless_apf_batch(
+        handler: &mut UffdHandler,
+        ctx: &mut ExitlessApfVcpu,
+        pf_vcpu_event_dispatch: &impl Fn(&mut UffdHandler, usize, usize),
+    ) -> bool {
+        let page_size = handler.page_size;
+        let mut entries = [KvmApfRingEntry::default(); KVM_APF_RING_SIZE];
+        let mut processed = false;
+
+        loop {
+            let count = ctx.notify_ring().drain_into(&mut entries);
+            if count == 0 {
+                break;
+            }
+            processed = true;
+
+            let batch = &entries[..count];
+            let mut range_start = None;
+            let mut range_len = 0usize;
+
+            for entry in batch {
+                let Some(offset) = handler.gpa_to_offset(entry.gpa) else {
+                    if let Some(start) = range_start.take() {
+                        pf_vcpu_event_dispatch(handler, start, range_len);
+                    }
+                    continue;
+                };
+                assert!(
+                    offset < handler.size(),
+                    "received bogus offset from exitless APF ring"
+                );
+
+                if let Some(start) = range_start {
+                    if start.checked_add(range_len) == Some(offset) {
+                        range_len += page_size;
+                        continue;
+                    }
+
+                    pf_vcpu_event_dispatch(handler, start, range_len);
+                }
+
+                range_start = Some(offset);
+                range_len = page_size;
+            }
+
+            if let Some(start) = range_start {
+                pf_vcpu_event_dispatch(handler, start, range_len);
+            }
+
+            ctx.signal_ready_batch(batch);
+        }
+
+        processed
+    }
+
     /// Polls the `UnixStream` and UFFD fds in a loop.
     /// When stream is polled, new uffd is retrieved.
     /// When uffd is polled, page fault is handled by
@@ -837,7 +1077,7 @@ impl Runtime {
     pub fn run(
         &mut self,
         pf_event_dispatch: impl Fn(&mut UffdHandler),
-        pf_vcpu_event_dispatch: impl Fn(&mut UffdHandler, usize),
+        pf_vcpu_event_dispatch: impl Fn(&mut UffdHandler, usize, usize),
     ) {
         let stream_fd = self.stream.as_raw_fd();
         let apf_stream_fd = self.apf_stream.as_raw_fd();
@@ -882,6 +1122,32 @@ impl Runtime {
         );
 
         loop {
+            if !self.exitless_vcpus.is_empty() {
+                let mut made_progress = false;
+                {
+                    let handler = &mut self.handler;
+                    let exitless_vcpus = &mut self.exitless_vcpus;
+
+                    for ctx in exitless_vcpus.values_mut() {
+                        made_progress |=
+                            Self::process_exitless_apf_batch(handler, ctx, &pf_vcpu_event_dispatch);
+                    }
+                }
+                if made_progress {
+                    continue;
+                }
+
+                let mut need_immediate_drain = false;
+                for ctx in self.exitless_vcpus.values() {
+                    if !ctx.arm_notify_if_empty() {
+                        need_immediate_drain = true;
+                    }
+                }
+                if need_immediate_drain {
+                    continue;
+                }
+            }
+
             let pollfd_ptr = pollfds.as_mut_ptr();
             let pollfd_size = pollfds.len() as u64;
 
@@ -910,7 +1176,7 @@ impl Runtime {
                                 offset < self.handler.size(),
                                 "received bogus offset from firecracker"
                             );
-                            pf_vcpu_event_dispatch(&mut self.handler, offset);
+                            pf_vcpu_event_dispatch(&mut self.handler, offset, page_size);
                             self.send_fault_reply(fault_request.into_reply(page_size as u64));
                         }
                     } else if fd.fd == apf_stream_fd {
@@ -925,18 +1191,17 @@ impl Runtime {
                                 offset < self.handler.size(),
                                 "received bogus offset from APF handler"
                             );
-                            pf_vcpu_event_dispatch(&mut self.handler, offset);
+                            pf_vcpu_event_dispatch(&mut self.handler, offset, page_size);
                             self.send_apf_fault_reply(fault_request.into_reply(page_size as u64));
                         }
                     } else if let Some(ctx) = self.exitless_vcpus.get_mut(&fd.fd) {
                         // Exitless APF: drain notify ring and resolve pages
                         ctx.drain_eventfd();
-                        while let Some(entry) = ctx.notify_ring().pop() {
-                            if let Some(offset) = self.handler.gpa_to_offset(entry.gpa) {
-                                pf_vcpu_event_dispatch(&mut self.handler, offset);
-                            }
-                            ctx.signal_ready(entry.gpa);
-                        }
+                        let _ = Self::process_exitless_apf_batch(
+                            &mut self.handler,
+                            ctx,
+                            &pf_vcpu_event_dispatch,
+                        );
                     } else {
                         // Handle one of uffd page faults
                         pf_event_dispatch(&mut self.handler);
@@ -993,7 +1258,10 @@ mod tests {
                 .expect("Cannot set APF stream non-blocking");
             // Update runtime with actual runtime
             let runtime = uninit_runtime.write(Runtime::new(stream, file, apf_stream));
-            runtime.run(|_: &mut UffdHandler| {}, |_: &mut UffdHandler, _: usize| {});
+            runtime.run(
+                |_: &mut UffdHandler| {},
+                |_: &mut UffdHandler, _: usize, _: usize| {},
+            );
         });
 
         // wait for runtime thread to initialize itself

--- a/src/firecracker/examples/uffd/uffd_utils/userfault_bitmap.rs
+++ b/src/firecracker/examples/uffd/uffd_utils/userfault_bitmap.rs
@@ -63,16 +63,46 @@ impl UserfaultBitmap {
             return;
         }
 
-        let first_bit = start_addr / self.page_size;
-        let last_bit = start_addr.saturating_add(len - 1) / self.page_size;
+        let first_bit = start_addr / self.page_size.get();
+        if first_bit >= self.size {
+            return;
+        }
 
-        for n in first_bit..=last_bit {
-            if n >= self.size {
-                break;
-            }
+        let last_bit =
+            (start_addr.saturating_add(len - 1) / self.page_size.get()).min(self.size - 1);
+        let first_word = first_bit >> 6;
+        let last_word = last_bit >> 6;
+
+        for word in first_word..=last_word {
+            let start = if word == first_word {
+                first_bit & 63
+            } else {
+                0
+            };
+            let end = if word == last_word { last_bit & 63 } else { 63 };
+            let width = end - start + 1;
+            let mask = if width == u64::BITS as usize {
+                u64::MAX
+            } else {
+                ((1u64 << width) - 1) << start
+            };
+
             unsafe {
-                let map_entry = &*self.map.add(n >> 6);
-                map_entry.fetch_and(!(1 << (n & 63)), Ordering::SeqCst);
+                let map_entry = &*self.map.add(word);
+                // Clearing a bit tells KVM to stop intercepting faults for this page. KVM reads
+                // the bitmap with a plain copy_from_user() (no acquire), so ordering is NOT
+                // established by an acquire/release pair on the bitmap itself. It is established
+                // by the full barriers that always bracket this clear:
+                //   * the page contents are published by the preceding populate syscall
+                //     (pwrite64 to guest_memfd / UFFDIO_COPY ioctl), and
+                //   * the clear becomes visible to KVM only after a later release store on the
+                //     completion-ring head (exitless APF) or a socket round-trip (sync fault),
+                //     each of which orders this store ahead of the kernel's re-read.
+                // Release keeps populate-before-clear self-contained without SeqCst's full
+                // barrier (which is pointless on weaker ISAs and identical on x86, where this
+                // locked RMW is already a full barrier). The real win is clearing a whole word
+                // of pages per RMW instead of one RMW per page.
+                map_entry.fetch_and(!mask, Ordering::Release);
             }
         }
     }
@@ -159,6 +189,27 @@ mod tests {
         // Check adjacent bits are still set
         assert!(bitmap.is_bit_set(62));
         assert!(bitmap.is_bit_set(65));
+    }
+
+    #[test]
+    fn test_reset_addr_range_full_word_width() {
+        // page_size = 1 byte so that bit N maps to byte N, making it easy to clear
+        // exactly 64 contiguous bits (a whole word). This exercises the `width == 64`
+        // branch in `reset_addr_range`, which must use `u64::MAX` to avoid the
+        // `1u64 << 64` shift overflow.
+        let page_size = NonZeroUsize::new(1).unwrap();
+        let (memory, bitmap) = setup_test_bitmap(128, page_size); // 128 pages, 2 words
+        memory[0].store(u64::MAX, Ordering::SeqCst);
+        memory[1].store(u64::MAX, Ordering::SeqCst);
+
+        // Clear exactly word 0 (bits 0..=63); word 1 must be untouched.
+        bitmap.reset_addr_range(0, 64);
+        assert_eq!(memory[0].load(Ordering::SeqCst), 0);
+        assert_eq!(memory[1].load(Ordering::SeqCst), u64::MAX);
+
+        // Clear the remaining full word (bits 64..=127), spanning a whole second word.
+        bitmap.reset_addr_range(64, 64);
+        assert_eq!(memory[1].load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -75,6 +75,7 @@ use crate::vstate::vm::{
 use crate::{EventManager, UffdMessageBroker, Vmm, VmmError};
 
 const KVM_CAP_ASYNC_PF_USERFAULT: u32 = 246;
+const KVM_CAP_ASYNC_PF_USERFAULT_EVENTFD: u32 = 247;
 
 pub(crate) fn pipe2(flags: libc::c_int) -> io::Result<(RawFd, RawFd)> {
     let mut fds = [0, 0];
@@ -653,6 +654,11 @@ pub fn build_microvm_from_snapshot(
     if apf_stream.is_some() && !apf_supported {
         warn!("KVM_CAP_ASYNC_PF_USERFAULT not supported by kernel, APF disabled");
     }
+    let exitless_apf_supported = apf_supported
+        && kvm
+            .fd
+            .check_extension_raw(u64::from(KVM_CAP_ASYNC_PF_USERFAULT_EVENTFD))
+            != 0;
 
     // Set up KVM VM and register memory regions.
     // Build custom CPU config if a custom template is provided.
@@ -768,29 +774,35 @@ pub fn build_microvm_from_snapshot(
         use vmm_sys_util::sock_ctrl_msg::ScmSocket;
         if let Some(uff_socket) = uffd_socket {
             let broker = UffdMessageBroker::new(uff_socket);
-            let apf_exitless = apf_supported
+            let apf_exitless = exitless_apf_supported
                 && std::env::var("FC_APF_NO_EXITLESS").is_err()
                 && !std::path::Path::new("/apf_no_exitless").exists();
             let (contexts, done) = if apf_exitless {
                 let mut contexts = Vec::new();
                 let mut handler_fds = Vec::new();
+                let mut setup_failed = false;
                 for &vcpu_fd in &vcpu_fds {
                     match crate::vstate::exitless_apf::ExitlessApfContext::new(vcpu_fd) {
                         Ok(ctx) => {
-                            let (n, c, m) = ctx.fds_for_handler();
-                            handler_fds.push(n);
-                            handler_fds.push(c);
-                            handler_fds.push(m);
+                            let (notify_fd, complete_fd, vcpu_mmap_fd) = ctx.fds_for_handler();
+                            handler_fds.push(notify_fd);
+                            handler_fds.push(complete_fd);
+                            handler_fds.push(vcpu_mmap_fd);
                             contexts.push(ctx);
                         }
                         Err(e) => {
                             warn!("Exitless APF context creation failed: {e}");
+                            setup_failed = true;
                             break;
                         }
                     }
                 }
-                if !contexts.is_empty() {
-                    let msg = format!("exitless_apf:{}", vcpu_fds.len());
+                if setup_failed || contexts.len() != vcpu_fds.len() {
+                    let msg = b"no_exitless_apf";
+                    let _ = broker.stream().send_with_fds(&[&msg[..]], &[]);
+                    contexts.clear();
+                } else if !contexts.is_empty() {
+                    let msg = format!("exitless_apf:{}", contexts.len());
                     match broker
                         .stream()
                         .send_with_fds(&[msg.as_bytes()], &handler_fds)

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -178,6 +178,8 @@ pub use crate::vstate::vm::{StartVcpusError, Vm};
 /// Shorthand type for the EventManager flavour used by Firecracker.
 pub type EventManager = BaseEventManager<Arc<Mutex<dyn MutEventSubscriber>>>;
 
+const KVM_CAP_ASYNC_PF_USERFAULT_EVENTFD: u32 = 247;
+
 // Since the exit code names e.g. `SIGBUS` are most appropriate yet trigger a test error with the
 // clippy lint `upper_case_acronyms` we have disabled this lint for this enum.
 /// Vmm exit-code type.
@@ -727,7 +729,7 @@ impl Vmm {
     }
 
     /// Set up exitless APF - creates contexts in Firecracker (where the KVM ioctl works)
-    /// and sends eventfds + shared page memfds to the handler.
+    /// and sends eventfds + vCPU fds for shared-page mmap to the handler.
     pub fn setup_exitless_apf(&mut self) -> Result<(), VmmError> {
         use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
@@ -735,7 +737,16 @@ impl Vmm {
             return Ok(());
         }
 
-        if !self.apf_supported {
+        let exitless_supported = self.apf_supported
+            && self.vm.as_kvm().is_some_and(|vm| {
+                vm.common
+                    .kvm
+                    .fd
+                    .check_extension_raw(u64::from(KVM_CAP_ASYNC_PF_USERFAULT_EVENTFD))
+                    != 0
+            });
+
+        if !exitless_supported {
             // Tell the handler that exitless APF is not available
             if let Some(ref uffd_socket) = self.uffd_socket {
                 let msg = b"no_exitless_apf";
@@ -751,21 +762,29 @@ impl Vmm {
         let mut contexts = Vec::new();
         let mut handler_fds = Vec::new();
         for &vcpu_fd in &self.vcpu_fds {
-            let ctx = vstate::exitless_apf::ExitlessApfContext::new(vcpu_fd).map_err(|e| {
-                VmmError::ExitlessApfSetup(format!(
-                    "Failed to create context for vcpu fd {vcpu_fd}: {e}"
-                ))
-            })?;
-            let (notify_fd, complete_fd, memfd) = ctx.fds_for_handler();
+            let ctx = match vstate::exitless_apf::ExitlessApfContext::new(vcpu_fd) {
+                Ok(ctx) => ctx,
+                Err(e) => {
+                    if let Some(ref uffd_socket) = self.uffd_socket {
+                        let msg = b"no_exitless_apf";
+                        let _ = uffd_socket.stream().send_with_fds(&[&msg[..]], &[]);
+                    }
+                    self.exitless_apf_setup_done = true;
+                    return Err(VmmError::ExitlessApfSetup(format!(
+                        "Failed to create context for vcpu fd {vcpu_fd}: {e}"
+                    )));
+                }
+            };
+            let (notify_fd, complete_fd, vcpu_mmap_fd) = ctx.fds_for_handler();
             handler_fds.push(notify_fd);
             handler_fds.push(complete_fd);
-            handler_fds.push(memfd);
+            handler_fds.push(vcpu_mmap_fd);
             contexts.push(ctx);
         }
 
         // Send the fds to the handler: 3 fds per vCPU
         if let Some(ref uffd_socket) = self.uffd_socket {
-            let msg = format!("exitless_apf:{}", self.vcpu_fds.len());
+            let msg = format!("exitless_apf:{}", contexts.len());
             let n = uffd_socket
                 .stream()
                 .send_with_fds(&[msg.as_bytes()], &handler_fds)
@@ -789,7 +808,7 @@ impl Vmm {
             vcpu,
             offset: 0,
             flags: userfault_data.flags,
-            gpa: Some(userfault_data.gpa),
+            gpa: Some(userfault_data.page_gpa()),
         };
 
         self.uffd_socket
@@ -833,6 +852,7 @@ impl Vmm {
     }
 
     fn apf_ready_ioctl(&self, vcpu: usize, gpa: u64) {
+        let gpa = gpa & !((crate::arch::GUEST_PAGE_SIZE as u64) - 1);
         let apf_message = KvmAPFReq {
             gpa,
             op: KVM_APF_OP_READY,

--- a/src/vmm/src/uffd_broker.rs
+++ b/src/vmm/src/uffd_broker.rs
@@ -102,6 +102,10 @@ impl Iterator for UffdMessageBroker {
     type Item = FaultReply;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.can_decode() {
+            return self.decode_next();
+        }
+
         match self.stream.read(&mut self.read_buffer[self.current_pos..]) {
             Ok(bytes_read) => self.current_pos += bytes_read,
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
@@ -116,6 +120,14 @@ impl Iterator for UffdMessageBroker {
         if !self.can_decode() {
             return None;
         }
+
+        self.decode_next()
+    }
+}
+
+impl UffdMessageBroker {
+    fn decode_next(&mut self) -> Option<FaultReply> {
+        debug_assert!(self.can_decode());
 
         // Safe: `can_decode()` returned true, so `expected_size()` is `Some`.
         let size = self.expected_size().unwrap() as usize;

--- a/src/vmm/src/vstate/exitless_apf.rs
+++ b/src/vmm/src/vstate/exitless_apf.rs
@@ -3,19 +3,22 @@
 
 //! Exitless Async Page Fault context for the VMM side.
 //!
-//! Creates the memfd-backed shared page, eventfds, and issues the
-//! `KVM_SET_APF_EVENTFD` ioctl. The ring buffer types and all read/write
+//! Creates eventfds, issues the `KVM_SET_APF_EVENTFD` ioctl, and mmaps the
+//! kernel-allocated APF shared page. The ring buffer types and all read/write
 //! logic live exclusively in the UFFD handler (`uffd_utils.rs`).
 
 use std::io;
-use std::os::fd::{AsRawFd, FromRawFd, RawFd};
-use std::os::unix::io::OwnedFd;
+use std::os::fd::{AsRawFd, RawFd};
 
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::ioctl_with_ref;
 use vmm_sys_util::ioctl_iow_nr;
 
 const KVMIO: u32 = 0xAE;
+const KVM_APF_PAGE_OFFSET: libc::off_t = 3;
+const KVM_APF_SHARED_VERSION: u32 = 1;
+const KVM_APF_RING_SIZE: u32 = 64;
+const KVM_APF_RING_ENTRY_SIZE: u32 = 16;
 
 /// `KVM_SET_APF_EVENTFD` ioctl — registers eventfds for exitless APF.
 mod apf_eventfd_ioctl {
@@ -32,24 +35,22 @@ pub struct KvmApfEventfd {
     pub fd: i32,
     /// Completion eventfd: userspace signals this after resolving a page.
     pub complete_fd: i32,
-    /// Userspace address of the shared page containing notify/completion rings.
-    pub page_addr: u64,
     /// Flags (reserved, must be 0). Set `fd = -1` to deregister.
     pub flags: u32,
     /// Padding for alignment.
     pub padding: u32,
+    /// Reserved for future use.
+    pub reserved: [u64; 2],
 }
 
 /// Exitless APF context for a single vCPU.
 ///
-/// Creates a memfd-backed shared page that the kernel, VMM, and UFFD handler
-/// all mmap. The VMM treats the page as opaque — only the kernel and handler
-/// read/write the ring buffers it contains.
+/// Maps the kernel-allocated shared page for a vCPU. The VMM treats the page as
+/// opaque — only the kernel and handler read/write the ring buffers it contains.
 pub struct ExitlessApfContext {
     eventfd: EventFd,
     complete_eventfd: EventFd,
-    memfd: OwnedFd,
-    /// Opaque mmap of the shared page (ring layout managed by handler)
+    /// Opaque mmap of the shared page (ring layout managed by handler).
     shared_page: *mut libc::c_void,
     vcpu_fd: RawFd,
 }
@@ -62,13 +63,12 @@ impl std::fmt::Debug for ExitlessApfContext {
     }
 }
 
-// SAFETY: `ExitlessApfContext` holds a raw pointer (`shared_page`) to a memfd-backed mmap.
+// SAFETY: `ExitlessApfContext` holds a raw pointer (`shared_page`) to a vCPU-fd mmap.
 // Sending across threads is safe because:
-// - The mmap remains valid for the struct's lifetime: the backing `OwnedFd` (memfd) is owned
-//   by this struct, so the mapping cannot be freed while the struct exists.
+// - The mmap remains valid for the struct's lifetime and is explicitly unmapped in Drop.
 // - The VMM never reads or writes the shared page contents after setup — only the kernel
-//   and UFFD handler access the ring buffers via their own independent mmaps of the same memfd.
-// - The eventfds and memfd are plain file descriptors, which are Send.
+//   and UFFD handler access the ring buffers via independent mmaps of the vCPU fd.
+// - The eventfds and vCPU fd are plain file descriptors, which are Send.
 unsafe impl Send for ExitlessApfContext {}
 
 // SAFETY: Shared references are safe because:
@@ -78,6 +78,31 @@ unsafe impl Send for ExitlessApfContext {}
 //   and the handler writes the completion ring, synchronized by volatile head/tail indices.
 // - No `&self` method on this struct reads or writes through `shared_page`.
 unsafe impl Sync for ExitlessApfContext {}
+
+fn validate_shared_page(ptr: *mut libc::c_void) -> io::Result<()> {
+    // SAFETY: caller passes a valid shared-page mapping.
+    let header = ptr.cast::<u32>();
+    // SAFETY: the header starts with version, ring_size, entry_size.
+    let version = unsafe { std::ptr::read_volatile(header) };
+    // SAFETY: the header starts with version, ring_size, entry_size.
+    let ring_size = unsafe { std::ptr::read_volatile(header.add(1)) };
+    // SAFETY: the header starts with version, ring_size, entry_size.
+    let entry_size = unsafe { std::ptr::read_volatile(header.add(2)) };
+
+    if version != KVM_APF_SHARED_VERSION
+        || ring_size != KVM_APF_RING_SIZE
+        || entry_size != KVM_APF_RING_ENTRY_SIZE
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported APF shared page: version={version} ring_size={ring_size} entry_size={entry_size}"
+            ),
+        ));
+    }
+
+    Ok(())
+}
 
 impl ExitlessApfContext {
     /// Create a new exitless APF context for the given vCPU fd.
@@ -89,58 +114,66 @@ impl ExitlessApfContext {
         let page_size =
             usize::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) }).unwrap_or(4096);
 
-        // SAFETY: memfd_create with a valid C string and MFD_CLOEXEC is safe.
-        let raw_memfd = unsafe { libc::memfd_create(c"apf_shared".as_ptr(), libc::MFD_CLOEXEC) };
-        if raw_memfd < 0 {
+        let apf_eventfd = KvmApfEventfd {
+            fd: eventfd.as_raw_fd(),
+            complete_fd: complete_eventfd.as_raw_fd(),
+            flags: 0,
+            padding: 0,
+            reserved: [0; 2],
+        };
+
+        // SAFETY: ioctl on a valid vCPU fd with a properly initialized KvmApfEventfd struct.
+        let ret = unsafe { ioctl_with_ref(&vcpu_fd, KVM_SET_APF_EVENTFD(), &apf_eventfd) };
+        if ret < 0 {
             return Err(io::Error::last_os_error());
         }
-        // SAFETY: raw_memfd is a valid fd (checked >= 0 above) and we take sole ownership.
-        let memfd = unsafe { OwnedFd::from_raw_fd(raw_memfd) };
 
-        // SAFETY: ftruncate on a valid memfd with a small positive size is safe.
-        #[allow(clippy::cast_possible_wrap)]
-        if unsafe { libc::ftruncate(memfd.as_raw_fd(), page_size as libc::off_t) } < 0 {
-            return Err(io::Error::last_os_error());
-        }
-
-        // SAFETY: mmap with MAP_SHARED on a valid memfd, page-aligned size, is safe.
+        let page_offset = libc::off_t::try_from(page_size)
+            .map_err(|_| io::Error::from_raw_os_error(libc::EOVERFLOW))?;
+        let offset = KVM_APF_PAGE_OFFSET * page_offset;
+        // SAFETY: mmap with MAP_SHARED on a valid vCPU fd and APF page offset is safe.
         let ptr = unsafe {
             libc::mmap(
                 std::ptr::null_mut(),
                 page_size,
                 libc::PROT_READ | libc::PROT_WRITE,
                 libc::MAP_SHARED,
-                memfd.as_raw_fd(),
-                0,
+                vcpu_fd,
+                offset,
             )
         };
         if ptr == libc::MAP_FAILED {
-            return Err(io::Error::last_os_error());
-        }
-        // SAFETY: ptr is a valid mmap'd region of page_size bytes (checked != MAP_FAILED above).
-        unsafe { std::ptr::write_bytes(ptr.cast::<u8>(), 0, page_size) };
-
-        let apf_eventfd = KvmApfEventfd {
-            fd: eventfd.as_raw_fd(),
-            complete_fd: complete_eventfd.as_raw_fd(),
-            page_addr: ptr as u64,
-            flags: 0,
-            padding: 0,
-        };
-
-        // SAFETY: ioctl on a valid vCPU fd with a properly initialized KvmApfEventfd struct.
-        let ret = unsafe { ioctl_with_ref(&vcpu_fd, KVM_SET_APF_EVENTFD(), &apf_eventfd) };
-        if ret < 0 {
             let err = io::Error::last_os_error();
+            let dereg = KvmApfEventfd {
+                fd: -1,
+                complete_fd: -1,
+                flags: 0,
+                padding: 0,
+                reserved: [0; 2],
+            };
+            // SAFETY: best-effort deregistration on the vCPU fd.
+            unsafe { ioctl_with_ref(&vcpu_fd, KVM_SET_APF_EVENTFD(), &dereg) };
+            return Err(err);
+        }
+
+        if let Err(err) = validate_shared_page(ptr) {
             // SAFETY: ptr/page_size are from a successful mmap above.
             unsafe { libc::munmap(ptr, page_size) };
+            let dereg = KvmApfEventfd {
+                fd: -1,
+                complete_fd: -1,
+                flags: 0,
+                padding: 0,
+                reserved: [0; 2],
+            };
+            // SAFETY: best-effort deregistration on the vCPU fd.
+            unsafe { ioctl_with_ref(&vcpu_fd, KVM_SET_APF_EVENTFD(), &dereg) };
             return Err(err);
         }
 
         Ok(Self {
             eventfd,
             complete_eventfd,
-            memfd,
             shared_page: ptr,
             vcpu_fd,
         })
@@ -152,12 +185,12 @@ impl ExitlessApfContext {
     }
 
     /// Returns fds to send to the UFFD handler:
-    /// (notify_eventfd, complete_eventfd, shared_page_memfd)
+    /// (notify_eventfd, complete_eventfd, vcpu_fd_for_shared_page_mmap)
     pub fn fds_for_handler(&self) -> (RawFd, RawFd, RawFd) {
         (
             self.eventfd.as_raw_fd(),
             self.complete_eventfd.as_raw_fd(),
-            self.memfd.as_raw_fd(),
+            self.vcpu_fd,
         )
     }
 }
@@ -167,9 +200,9 @@ impl Drop for ExitlessApfContext {
         let dereg = KvmApfEventfd {
             fd: -1,
             complete_fd: -1,
-            page_addr: 0,
             flags: 0,
             padding: 0,
+            reserved: [0; 2],
         };
         // SAFETY: ioctl on a valid vCPU fd to deregister the eventfd (fd = -1).
         unsafe {

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -99,7 +99,7 @@ impl From<vm_memory::VolatileMemoryError> for MemoryError {
 pub struct KvmAPFReq {
     /// Guest physical address of the faulting page.
     pub gpa: u64,
-    /// Operation code (ready, accept, or sync-complete).
+    /// Operation code (accept or ready).
     pub op: u32,
     /// Flags (currently unused, must be 0).
     pub flags: u32,
@@ -107,13 +107,10 @@ pub struct KvmAPFReq {
     pub reserved: [u64; 2],
 }
 
-/// Mark an async page fault as ready (page is now available).
-pub const KVM_APF_OP_READY: u32 = 0;
 /// Accept an async page fault (vCPU acknowledges the APF).
 pub const KVM_APF_OP_ACCEPT: u32 = 1;
-/// Signal synchronous completion of an async page fault.
-#[allow(dead_code)]
-pub const KVM_APF_OP_SYNC_COMPLETE: u32 = 2;
+/// Mark an async page fault as ready (page is now available).
+pub const KVM_APF_OP_READY: u32 = 2;
 
 /// `KVM_ASYNC_PF` ioctl — manages async page faults on a vCPU.
 #[allow(missing_docs)]

--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -436,6 +436,7 @@ impl Vcpu {
         userfaultfd_data: UserfaultData,
     ) -> Result<VcpuEmulation, VcpuError> {
         let is_async_pf = userfaultfd_data.flags & KVM_MEMORY_EXIT_FLAG_APF != 0;
+        let gpa = userfaultfd_data.page_gpa();
 
         if is_async_pf {
             // Exitless ring was full — kernel fell back to a vCPU exit.
@@ -446,7 +447,7 @@ impl Vcpu {
                     vcpu: self.kvm_vcpu.index as u32,
                     offset: 0,
                     flags: userfaultfd_data.flags,
-                    gpa: Some(userfaultfd_data.gpa),
+                    gpa: Some(gpa),
                 };
                 if let Err(e) = stream
                     .lock()
@@ -458,7 +459,7 @@ impl Vcpu {
             }
 
             let req = crate::vstate::memory::KvmAPFReq {
-                gpa: userfaultfd_data.gpa,
+                gpa,
                 op: crate::vstate::memory::KVM_APF_OP_ACCEPT,
                 flags: 0,
                 reserved: [0; 2],

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -27,7 +27,7 @@ use vmm_sys_util::ioctl::ioctl_with_ref;
 use vmm_sys_util::terminal::Terminal;
 use vmm_sys_util::{errno, ioctl_iow_nr};
 
-use crate::arch::{GSI_MSI_END, host_page_size};
+use crate::arch::{GSI_MSI_END, GUEST_PAGE_SIZE, host_page_size};
 pub use crate::arch::{KvmVm, KvmVmError, VmState};
 use crate::logger::{debug, info};
 use crate::persist::CreateSnapshotError;
@@ -93,6 +93,13 @@ pub struct UserfaultData {
     pub gpa: u64,
     /// Size
     pub size: u64,
+}
+
+impl UserfaultData {
+    /// Return the guest page containing the fault address.
+    pub fn page_gpa(&self) -> u64 {
+        self.gpa & !((GUEST_PAGE_SIZE as u64) - 1)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Changes

Update to newest APF patches (CI tests will likely fail as we'll need a kernel rebuild)

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
Track the revised kernel ABI for exitless async page faults. Gate
exitless setup on KVM_CAP_ASYNC_PF_USERFAULT_EVENTFD, mmap the
kernel-owned shared page from the vCPU fd, and pass the vCPU fd to the
UFFD handler instead of a memfd.

Update the APF ioctl constants and seccomp comments for the
accept/ready-only ABI.

Signed-off-by: Jack Thomson <jackabt@amazon.com>