### PR TITLE
test: better retries for test_vsock_transport_reset_g2h

### DIFF
--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from socket import timeout as SocketTimeout
 
 import pytest
+from tenacity import Retrying, stop_after_delay, wait_fixed
 
 from framework.artifacts import (
     ACPI_GUEST_KERNELS,
@@ -276,9 +277,13 @@ def test_vsock_transport_reset_g2h(vsock_uvm, microvm_factory):
         )
 
         try:
-            # Give some time for host socat to create socket
-            time.sleep(0.5)
-            assert Path(host_socket_path).exists()
+            # Waiting for the host socat to create socket
+            for attempt in Retrying(
+                wait=wait_fixed(0.1), stop=stop_after_delay(1.0), reraise=True
+            ):
+                with attempt:
+                    assert Path(host_socket_path).exists()
+
             new_vm.create_jailed_resource(host_socket_path)
 
             # Create a socat process in the guest which will connect to the host socat
@@ -295,12 +300,14 @@ def test_vsock_transport_reset_g2h(vsock_uvm, microvm_factory):
             snapshot = new_vm.snapshot_full()
             new_vm.resume()
 
-            # Give some time for guest socat to detect closed socket
-            time.sleep(0.1)
-
-            # After `create_snapshot` + 'resume' calls, connection should be dropped
-            code, _, _ = new_vm.ssh.run("pidof socat")
-            assert code == 1
+            # Note: it might take some time for guest socat to detect closed socket
+            for attempt in Retrying(
+                wait=wait_fixed(0.1), stop=stop_after_delay(1.0), reraise=True
+            ):
+                with attempt:
+                    # After `create_snapshot` + 'resume' calls, connection should be dropped
+                    code, _, _ = new_vm.ssh.run("pidof socat")
+                    assert code == 1
         finally:
             # Kill host socat as it is not useful anymore. Done in `finally`
             # so that an assertion failure earlier in the iteration does not


### PR DESCRIPTION
## Changes

Instead of fixed wait time, this commit adds flexible retries that improve test reliability in slow execution environments (e.g. nested virtualization).

## Reason

Improve reliability of `test_vsock_transport_reset_g2h`.

Example of a failure: https://buildkite.com/firecracker/mamarang-nested/builds/102/list?sid=019ed681-662c-4459-891f-4fa1dc527255&tab=output

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
