### PR TITLE
chore: make style checks work with git worktrees

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -335,6 +335,21 @@ run_devctr() {
         fi
     done
 
+    # Linked worktrees have a .git file that points to the common git directory,
+    # which can live outside FC_ROOT_DIR. Mount it at the same path in the
+    # container so git commands keep working after FC_ROOT_DIR is mounted at
+    # /firecracker.
+    git_common_dir=$(git -C "$FC_ROOT_DIR" rev-parse --git-common-dir 2>/dev/null || true)
+    if [[ -n "$git_common_dir" ]]; then
+        [[ "$git_common_dir" = /* ]] || git_common_dir="$FC_ROOT_DIR/$git_common_dir"
+        git_common_dir=$(cd "$git_common_dir" && pwd)
+        case "$git_common_dir/" in
+            "$FC_ROOT_DIR"/*) ;;
+            # If the common .git directory is outside FC_ROOT_DIR, bind-mount it as a separate volume
+            *) docker_args+=("--volume") && docker_args+=("$git_common_dir:$git_common_dir:ro,z") ;;
+        esac
+    fi
+
     # Finally, run the dev container
     # Use 'z' on the --volume parameter for docker to automatically relabel the
     # content and allow sharing between containers.


### PR DESCRIPTION
## Changes

Bind mount the `.git` dir (as **read only**) from the main worktree to the devctr if an auxiliary worktree is being used.

## Reason

Git worktrees all share a single .git directory under the main worktree. Auxiliary worktrees instead contain .git files which link back to the main worktree's .git dir. When running the devctr from a worktree, we therefore only have access to the .git file, not the full dir. 

The helper function `utils_repo.git_repo_files` calls `git ls-files`, which fails with `not a git repository` if the `.git` dir is not available. This PR makes the `.git` dir available at the location pointed to by the auxiliary worktree's `.git` file.

No behavioural change if worktrees are not being used.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
