### PR TITLE
Improve reliability of mem hotplug and network_latency tests

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -51,6 +51,9 @@ perf_test = {
         "label": "memory-hotplug",
         "tests": "integration_tests/performance/test_hotplug_memory.py",
         "devtool_opts": "-c 1-10 -m 0",
+        # The test require polling (5 ms), so any change smaller than that is not significant.
+        # Additionally, unplugging memory is dependent on how exactly it's being used, so some volatility is expected.
+        "ab_opts": "--absolute-strength 0.005 --noise-threshold hotunplug_total_time=0.1",
     },
     "snapshot-latency": {
         "label": "snapshot-latency",

--- a/tests/integration_tests/performance/test_network.py
+++ b/tests/integration_tests/performance/test_network.py
@@ -65,8 +65,7 @@ def test_network_latency(network_microvm, metrics):
     Test network latency by sending pings from the guest to the host.
     """
 
-    rounds = 15
-    request_per_round = 30
+    target_datapoints = 500
     delay = 0.0
 
     metrics.set_dimensions(
@@ -76,18 +75,18 @@ def test_network_latency(network_microvm, metrics):
         }
     )
 
-    samples = []
     host_ip = network_microvm.iface["eth0"]["iface"].host_ip
 
-    for _ in range(rounds):
+    # ping might return less than the requested datapoints, so we need to iterate multiple times.
+    # Note: we're okay with _more_ datapoints than the target
+    collected_datapoints = 0
+    while collected_datapoints < target_datapoints:
         _, ping_output, _ = network_microvm.ssh.check_output(
-            f"ping -c {request_per_round} -i {delay} {host_ip}"
+            f"ping -c {target_datapoints} -i {delay} {host_ip}"
         )
-
-        samples.extend(consume_ping_output(ping_output))
-
-    for sample in samples:
-        metrics.put_metric("ping_latency", sample, "Milliseconds")
+        for sample in consume_ping_output(ping_output):
+            collected_datapoints += 1
+            metrics.put_metric("ping_latency", sample, "Milliseconds")
 
 
 @pytest.mark.nonci

--- a/tools/ab_plot.py
+++ b/tools/ab_plot.py
@@ -51,7 +51,10 @@ def load_data(data_path: Path):
     Recursively collects `metrics.json` files in provided path
     """
     data = []
-    for name in glob.glob(f"{data_path}/**/metrics.json", recursive=True):
+    # Track cumulative index per (test, metric, dimensions) so that
+    # subsequent iterations are plotted consecutively.
+    offsets = {}
+    for name in sorted(glob.glob(f"{data_path}/**/metrics.json", recursive=True)):
         with open(name, encoding="utf-8") as f:
             j = json.load(f)
 
@@ -78,10 +81,12 @@ def load_data(data_path: Path):
             mm = metrics[m]
             unit = mm["unit"]
             values = mm["values"]
+            key = (perf_test, m, dimensions)
+            offset = offsets.get(key, 0)
             for i, v in enumerate(values):
                 data.append(
                     {
-                        "index": i,
+                        "index": offset + i,
                         "test": perf_test,
                         "metric": m,
                         "value": v,
@@ -89,6 +94,7 @@ def load_data(data_path: Path):
                         "dimensions": dimensions,
                     }
                 )
+            offsets[key] = offset + len(values)
 
     return data
 


### PR DESCRIPTION
## Changes

See the commits for details, but tl;dr:
 - improve the plotting script so subsequent test iterations are plot one after the other (rather than overlapping)
 - tuned A/B test parameters of the mem hotplug test, to account for polling frequency and guest unpredictable behavior on unplug
 - changed how we call ping, so the first call latency penalty is reduced, and we check that all datapoints get collected

## Reason

Improve A/B test reliability.

Report that shows not all datapoints are collected:
 - [test_network_latency_4.pdf](https://github.com/user-attachments/files/29102876/test_network_latency_4.pdf)

Memory hotplug report
 (note: only the "*_total_time" is used for A/B test):
 - [test_memory_hotplug_latency.pdf](https://github.com/user-attachments/files/29102929/test_memory_hotplug_latency.pdf)


A/B test run that succeeded when running this code: https://buildkite.com/firecracker/mamarang-generic/builds/55/list

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
