### PR TITLE
test: allow BuildKite jobs to be split across multiple pipelines

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -246,6 +246,13 @@ COMMON_PARSER.add_argument(
     default=1,
     type=int,
 )
+COMMON_PARSER.add_argument(
+    "--max-jobs",
+    help="Max leaf jobs per pipeline chunk. If set, to_json() returns a JSON array of pipelines.",
+    required=False,
+    default=None,
+    type=int,
+)
 
 
 def random_str(k: int):
@@ -420,13 +427,59 @@ class BKPipeline:
                 )
         return self.add_step(grp, depends_on_build=depends_on_build)
 
+    def _chunk_steps(self, max_jobs: int):
+        """Split steps into chunks of at most max_jobs leaf jobs each.
+
+        Groups that exceed the remaining space are split to fill each chunk.
+        """
+        chunks = []
+        current_chunk = []
+        current_count = 0
+
+        for step in self.steps:
+            if isinstance(step, dict) and "group" in step:
+                remaining_steps = step["steps"]
+                while remaining_steps:
+                    available = max_jobs - current_count
+                    if available <= 0:
+                        chunks.append(current_chunk)
+                        current_chunk = []
+                        current_count = 0
+                        available = max_jobs
+                    take = remaining_steps[:available]
+                    remaining_steps = remaining_steps[available:]
+                    current_chunk.append({**step, "steps": take})
+                    current_count += len(take)
+            else:
+                if current_chunk and current_count + 1 > max_jobs:
+                    chunks.append(current_chunk)
+                    current_chunk = []
+                    current_count = 0
+                current_chunk.append(step)
+                current_count += 1
+
+        if current_chunk:
+            chunks.append(current_chunk)
+        return chunks
+
     def to_dict(self):
         """Render the pipeline as a dictionary."""
         return {"steps": self.steps}
 
     def to_json(self):
-        """Serialize the pipeline to JSON"""
-        return json.dumps(self.to_dict(), indent=4, sort_keys=True, ensure_ascii=False)
+        """Serialize the pipeline to JSON.
+
+        If --max-jobs is set, returns a JSON array of pipeline objects,
+        each with at most max_jobs leaf jobs. Otherwise, returns a single
+        pipeline object (legacy behavior).
+        """
+        max_jobs = self.args.max_jobs
+        if max_jobs is None:
+            to_serialize = self.to_dict()
+        else:
+            chunks = self._chunk_steps(max_jobs)
+            to_serialize = [{"steps": chunk} for chunk in chunks]
+        return json.dumps(to_serialize, indent=4, sort_keys=True, ensure_ascii=False)
 
     def devtool_download_artifacts(self, artifacts):
         """Generate a `devtool download_ci_artifacts` command"""

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -62,12 +62,6 @@ perf_test = {
         "tests": "integration_tests/performance/test_snapshot.py::test_population_latency",
         "devtool_opts": "-c 1-12 -m 0",
     },
-    "misc": {
-        "label": "misc",
-        "tests": "integration_tests/performance/test_memory_overhead.py integration_tests/performance/test_boottime.py::test_boottime integration_tests/performance/test_process_startup_time.py integration_tests/performance/test_jailer.py integration_tests/performance/test_mmds.py",
-        "devtool_opts": "-c 1-10 -m 0",
-        "ab_opts": "--noise-threshold startup=0.1",
-    },
     "memory-overhead": {
         "label": "memory-overhead",
         "tests": "integration_tests/performance/test_memory_overhead.py",
@@ -95,16 +89,6 @@ perf_test = {
         "devtool_opts": "-c 1-10 -m 0",
     },
 }
-
-# These can only be selected by manually providing `--tests` argument otherwise
-# the number of unique tasks we would create is too big for BK to handle
-only_manually_selected_tests = [
-    "memory-overhead",
-    "boottime",
-    "process-startup",
-    "jailer",
-    "mmds",
-]
 
 REVISION_A = os.environ.get("REVISION_A")
 REVISION_B = os.environ.get("REVISION_B")
@@ -142,10 +126,7 @@ pipeline = BKPipeline(
 if pipeline.args.test:
     tests = [perf_test[test] for test in pipeline.args.test]
 else:
-    tests = []
-    for test_name, test_description in perf_test.items():
-        if test_name not in only_manually_selected_tests:
-            tests.append(test_description)
+    tests = perf_test.values()
 
 for test in tests:
     devtool_opts = test.pop("devtool_opts")

--- a/.buildkite/pipeline_upload.sh
+++ b/.buildkite/pipeline_upload.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Proxy script that handles chunked pipeline upload.
+# Usage: .buildkite/pipeline_pr.py --max-jobs 500 | .buildkite/pipeline_upload.sh
+#
+# If the input is a JSON array (chunked), uploads each element separately.
+# If it's a single object, uploads it directly (backwards compatible).
+
+set -euo pipefail
+
+pipeline_json=$(cat)
+
+if echo "$pipeline_json" | jq -e 'type == "array"' > /dev/null 2>&1; then
+    count=$(echo "$pipeline_json" | jq 'length')
+    for ((i = 0; i < count; i++)); do
+        echo "$pipeline_json" | jq ".[$i]" | buildkite-agent pipeline upload
+    done
+else
+    echo "$pipeline_json" | buildkite-agent pipeline upload
+fi


### PR DESCRIPTION
## Changes

BuildKite has a limit of 500 jobs per pipeline upload. 
With this commit, we can enqueue more steps by splitting the upload in multiple chunks with a new `--max-jobs` option.

Without the option, the previous behavior is preserved, so existing pipelines won't break.
Pipelines that need more than 500 jobs can be updated to call for example:

```
.buildkite/pipeline_perf.py --max-jobs 500 | .buildkite/pipeline_upload.sh
```

## Reason

Enable better scaling for our CI; remove the misc test group.

An example of a pipeline execution with this new model: https://buildkite.com/firecracker/mamarang-test-500-job-limit/builds/8/summary?sid=019edf68-b56b-45d0-81e4-061d7f40b3d3&tab=output

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
