### PR TITLE
feat(metrics): add optional id and properties fields to metrics output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ### Added
 
+- [#5983](https://github.com/firecracker-microvm/firecracker/pull/5983): Add two
+  optional metrics fields, set via `PUT /metrics` or a config file: `emit_id`
+  emits the microVM instance id under a top-level `id` field, and `properties`
+  emits operator-defined key-value pairs under a top-level `properties` field.
+  Each is opt-in and independent. See [metrics documentation](docs/metrics.md).
+
 ### Changed
 
 ### Deprecated

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -56,6 +56,13 @@ the `metrics` block of a configuration file; the `--metrics-path` CLI option
 configures only the path. Like the rest of the metrics configuration, they are
 set once before boot and fixed for the lifetime of the microVM.
 
+### `id`
+
+Set `emit_id` to `true` to emit the microVM instance id (the value passed to
+`--id`, defaulting to `anonymous-instance`) under a top-level `id` field. This
+lets lines collected from multiple microVMs into one destination be attributed
+to their source.
+
 ### `properties`
 
 Set `properties` to a map of operator-defined key-value pairs to emit them under
@@ -72,6 +79,7 @@ curl --unix-socket /tmp/firecracker.socket -i \
     -H "Content-Type: application/json" \
     -d "{
              \"metrics_path\": \"metrics.fifo\",
+             \"emit_id\": true,
              \"properties\": {
                  \"customer_id\": \"1234\",
                  \"bundle_id\": \"fn-abc\"
@@ -86,6 +94,7 @@ passed via `--config-file`:
 {
     "metrics": {
         "metrics_path": "metrics.fifo",
+        "emit_id": true,
         "properties": {
             "customer_id": "1234",
             "bundle_id": "fn-abc"
@@ -94,16 +103,17 @@ passed via `--config-file`:
 }
 ```
 
-With no properties configured, a line carries only the default keys:
+With neither field configured, a line carries only the default keys:
 
 ```json
 {"utc_timestamp_ms": 1739000000000, "api_server": {"...": 0}}
 ```
 
-With the properties above, the same line also carries them:
+With both fields configured as above, the same line also carries the instance id
+and the properties:
 
 ```json
-{"utc_timestamp_ms": 1739000000000, "properties": {"bundle_id": "fn-abc", "customer_id": "1234"}, "api_server": {"...": 0}}
+{"utc_timestamp_ms": 1739000000000, "id": "my-instance", "properties": {"bundle_id": "fn-abc", "customer_id": "1234"}, "api_server": {"...": 0}}
 ```
 
 ## Flushing the metrics

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -47,6 +47,65 @@ Details about this configuration can be found in the
 
 The metrics are written to the `metrics_path` in JSON format.
 
+## Optional metrics fields
+
+Firecracker can emit additional top-level fields on every metrics line. Each is
+opt-in and off by default, so the default output is unchanged. They are
+configured alongside `metrics_path`, through the `PUT /metrics` API request or
+the `metrics` block of a configuration file; the `--metrics-path` CLI option
+configures only the path. Like the rest of the metrics configuration, they are
+set once before boot and fixed for the lifetime of the microVM.
+
+### `properties`
+
+Set `properties` to a map of operator-defined key-value pairs to emit them under
+a top-level `properties` field.
+
+### Examples
+
+Configure the fields via the API by adding them to the request body:
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i \
+    -X PUT "http://localhost/metrics" \
+    -H "accept: application/json" \
+    -H "Content-Type: application/json" \
+    -d "{
+             \"metrics_path\": \"metrics.fifo\",
+             \"properties\": {
+                 \"customer_id\": \"1234\",
+                 \"bundle_id\": \"fn-abc\"
+             }
+    }"
+```
+
+The same fields can be provided in the `metrics` block of a configuration file
+passed via `--config-file`:
+
+```json
+{
+    "metrics": {
+        "metrics_path": "metrics.fifo",
+        "properties": {
+            "customer_id": "1234",
+            "bundle_id": "fn-abc"
+        }
+    }
+}
+```
+
+With no properties configured, a line carries only the default keys:
+
+```json
+{"utc_timestamp_ms": 1739000000000, "api_server": {"...": 0}}
+```
+
+With the properties above, the same line also carries them:
+
+```json
+{"utc_timestamp_ms": 1739000000000, "properties": {"bundle_id": "fn-abc", "customer_id": "1234"}, "api_server": {"...": 0}}
+```
+
 ## Flushing the metrics
 
 The metrics get flushed in two ways:

--- a/src/firecracker/src/api_server/request/metrics.rs
+++ b/src/firecracker/src/api_server/request/metrics.rs
@@ -31,6 +31,7 @@ mod tests {
         }"#;
         let expected_config = MetricsConfig {
             metrics_path: PathBuf::from("metrics"),
+            emit_id: false,
             properties: None,
         };
         assert_eq!(
@@ -42,6 +43,23 @@ mod tests {
             "invalid_field": "metrics"
         }"#;
         parse_put_metrics(&Body::new(invalid_body)).unwrap_err();
+    }
+
+    #[test]
+    fn test_parse_put_metrics_request_with_emit_id() {
+        let body = r#"{
+            "metrics_path": "metrics",
+            "emit_id": true
+        }"#;
+        let expected_config = MetricsConfig {
+            metrics_path: PathBuf::from("metrics"),
+            emit_id: true,
+            properties: None,
+        };
+        assert_eq!(
+            vmm_action_from_request(parse_put_metrics(&Body::new(body)).unwrap()),
+            VmmAction::ConfigureMetrics(expected_config)
+        );
     }
 
     #[test]
@@ -58,6 +76,7 @@ mod tests {
         properties.insert("bundle_id".to_string(), "fn-abc".to_string());
         let expected_config = MetricsConfig {
             metrics_path: PathBuf::from("metrics"),
+            emit_id: false,
             properties: Some(properties),
         };
         assert_eq!(

--- a/src/firecracker/src/api_server/request/metrics.rs
+++ b/src/firecracker/src/api_server/request/metrics.rs
@@ -31,6 +31,7 @@ mod tests {
         }"#;
         let expected_config = MetricsConfig {
             metrics_path: PathBuf::from("metrics"),
+            properties: None,
         };
         assert_eq!(
             vmm_action_from_request(parse_put_metrics(&Body::new(body)).unwrap()),
@@ -41,5 +42,27 @@ mod tests {
             "invalid_field": "metrics"
         }"#;
         parse_put_metrics(&Body::new(invalid_body)).unwrap_err();
+    }
+
+    #[test]
+    fn test_parse_put_metrics_request_with_properties() {
+        let body = r#"{
+            "metrics_path": "metrics",
+            "properties": {
+                "customer_id": "1234",
+                "bundle_id": "fn-abc"
+            }
+        }"#;
+        let mut properties = std::collections::BTreeMap::new();
+        properties.insert("customer_id".to_string(), "1234".to_string());
+        properties.insert("bundle_id".to_string(), "fn-abc".to_string());
+        let expected_config = MetricsConfig {
+            metrics_path: PathBuf::from("metrics"),
+            properties: Some(properties),
+        };
+        assert_eq!(
+            vmm_action_from_request(parse_put_metrics(&Body::new(body)).unwrap()),
+            VmmAction::ConfigureMetrics(expected_config)
+        );
     }
 }

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -371,6 +371,7 @@ fn main_exec() -> Result<(), MainError> {
     if let Some(metrics_path) = arguments.single_value("metrics-path") {
         let metrics_config = MetricsConfig {
             metrics_path: PathBuf::from(metrics_path),
+            properties: None,
         };
         init_metrics(metrics_config).map_err(MainError::MetricsInitialization)?;
     }

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -371,6 +371,7 @@ fn main_exec() -> Result<(), MainError> {
     if let Some(metrics_path) = arguments.single_value("metrics-path") {
         let metrics_config = MetricsConfig {
             metrics_path: PathBuf::from(metrics_path),
+            emit_id: false,
             properties: None,
         };
         init_metrics(metrics_config).map_err(MainError::MetricsInitialization)?;

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1474,6 +1474,12 @@ definitions:
       metrics_path:
         type: string
         description: Path to the named pipe or file where the JSON-formatted metrics are flushed.
+      emit_id:
+        type: boolean
+        description:
+          Whether to emit the microVM instance id (the value passed to the
+          jailer "--id") as a top-level "id" field on each metrics line.
+        default: false
       properties:
         type: object
         description:

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1474,6 +1474,13 @@ definitions:
       metrics_path:
         type: string
         description: Path to the named pipe or file where the JSON-formatted metrics are flushed.
+      properties:
+        type: object
+        description:
+          Operator-defined key-value pairs emitted under a top-level
+          "properties" field on each metrics line.
+        additionalProperties:
+          type: string
 
   MmdsConfig:
     type: object

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -61,6 +61,7 @@
 //! If if turns out this approach is not really what we want, it's pretty easy to resort to
 //! something else, while working behind the same interface.
 
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::io::Write;
 use std::ops::Deref;
@@ -331,6 +332,42 @@ impl ProcessTimeReporter {
 // The following structs are used to define a certain organization for the set of metrics we
 // are interested in. Whenever the name of a field differs from its ideal textual representation
 // in the serialized form, we can use the #[serde(rename = "name")] attribute to, well, rename it.
+
+/// Operator-supplied key-value pairs emitted alongside the metrics.
+#[derive(Debug, Default)]
+pub struct MetricsProperties {
+    /// The properties, set once at metrics configuration time.
+    inner: OnceLock<BTreeMap<String, String>>,
+}
+
+impl Serialize for MetricsProperties {
+    /// Serializes as a `properties` map flattened into the parent metrics object,
+    /// or as nothing when unset.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(None)?;
+        if let Some(props) = self.inner.get() {
+            map.serialize_entry("properties", props)?;
+        }
+        map.end()
+    }
+}
+
+impl MetricsProperties {
+    /// Const default construction.
+    pub const fn new() -> Self {
+        Self {
+            inner: OnceLock::new(),
+        }
+    }
+
+    /// Sets the properties once. Returns an error if already set.
+    pub fn set(&self, properties: BTreeMap<String, String>) -> Result<(), MetricsError> {
+        self.inner
+            .set(properties)
+            .map_err(|_| MetricsError::AlreadyInitialized)
+    }
+}
 
 /// Metrics related to the internal API server.
 #[derive(Debug, Default, Serialize)]
@@ -907,6 +944,9 @@ create_serialize_proxy!(MemoryHotplugSerializeProxy, virtio_mem_metrics);
 #[derive(Debug, Default, Serialize)]
 pub struct FirecrackerMetrics {
     utc_timestamp_ms: SerializeToUtcTimestampMs,
+    #[serde(flatten)]
+    /// Operator-supplied custom properties.
+    pub properties: MetricsProperties,
     /// API Server related metrics.
     pub api_server: ApiServerMetrics,
     #[serde(flatten)]
@@ -966,6 +1006,7 @@ impl FirecrackerMetrics {
     pub const fn new() -> Self {
         Self {
             utc_timestamp_ms: SerializeToUtcTimestampMs::new(),
+            properties: MetricsProperties::new(),
             api_server: ApiServerMetrics::new(),
             balloon_ser: BalloonMetricsSerializeProxy {},
             block_ser: BlockMetricsSerializeProxy {},
@@ -1026,6 +1067,33 @@ mod tests {
         let f = TempFile::new().expect("Failed to create temporary metrics file");
 
         m.init(LineWriter::new(f.into_file())).unwrap_err();
+    }
+
+    #[test]
+    fn test_metrics_properties_serialize_unset() {
+        let props = MetricsProperties::new();
+        assert_eq!(serde_json::to_string(&props).unwrap(), "{}");
+    }
+
+    #[test]
+    fn test_metrics_properties_serialize_set() {
+        let props = MetricsProperties::new();
+        let mut map = BTreeMap::new();
+        map.insert("customer_id".to_string(), "1234".to_string());
+        map.insert("bundle_id".to_string(), "fn-abc".to_string());
+        props.set(map).unwrap();
+
+        assert_eq!(
+            serde_json::to_string(&props).unwrap(),
+            r#"{"properties":{"bundle_id":"fn-abc","customer_id":"1234"}}"#
+        );
+    }
+
+    #[test]
+    fn test_metrics_properties_set_once() {
+        let props = MetricsProperties::new();
+        props.set(BTreeMap::new()).unwrap();
+        props.set(BTreeMap::new()).unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/logger/metrics.rs
+++ b/src/vmm/src/logger/metrics.rs
@@ -31,6 +31,11 @@
 //! named `block` which is in turn a serializable child structure collecting metrics for
 //! the block device such as `activate_fails`, `cfg_fails`, etc.
 //!
+//! Besides the per-component metrics, two top-level fields can be emitted, controlled
+//! independently via the metrics API or config file: `id`, the microVM instance id (the jailer
+//! `--id`), enabled by `emit_id`; and `properties`, a map of operator-defined key-value pairs.
+//! See the `InstanceIdField` and `MetricsProperties` structs.
+//!
 //! # Limitations
 //! Metrics are only written to buffers.
 //!
@@ -65,13 +70,14 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::io::Write;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
+use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 use utils::time::{ClockType, get_time_ns, get_time_us};
 
-use super::FcLineWriter;
+use super::{DEFAULT_INSTANCE_ID, FcLineWriter, INSTANCE_ID};
 use crate::devices::legacy;
 use crate::devices::virtio::balloon::metrics as balloon_metrics;
 use crate::devices::virtio::block::virtio::metrics as block_metrics;
@@ -341,10 +347,8 @@ pub struct MetricsProperties {
 }
 
 impl Serialize for MetricsProperties {
-    /// Serializes as a `properties` map flattened into the parent metrics object,
-    /// or as nothing when unset.
+    /// Serializes as a flattened `properties` field when set, or as nothing when unset.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeMap;
         let mut map = serializer.serialize_map(None)?;
         if let Some(props) = self.inner.get() {
             map.serialize_entry("properties", props)?;
@@ -910,6 +914,45 @@ impl Serialize for SerializeToUtcTimestampMs {
     }
 }
 
+/// The microVM instance id emitted alongside the metrics.
+#[derive(Debug, Default)]
+pub struct InstanceIdField {
+    /// Whether the `id` field should be emitted. Flipped once at metrics configuration time.
+    enabled: AtomicBool,
+}
+
+impl Serialize for InstanceIdField {
+    /// Serializes as a flattened `id` field (the jailer `--id`) when enabled, or as nothing when
+    /// disabled.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        if self.enabled.load(Ordering::Relaxed) {
+            map.serialize_entry(
+                "id",
+                INSTANCE_ID
+                    .get()
+                    .map(String::as_str)
+                    .unwrap_or(DEFAULT_INSTANCE_ID),
+            )?;
+        }
+        map.end()
+    }
+}
+
+impl InstanceIdField {
+    /// Const default construction.
+    pub const fn new() -> Self {
+        Self {
+            enabled: AtomicBool::new(false),
+        }
+    }
+
+    /// Enables emission of the `id` field.
+    pub fn enable(&self) {
+        self.enabled.store(true, Ordering::Relaxed);
+    }
+}
+
 macro_rules! create_serialize_proxy {
     // By using the below structure in FirecrackerMetrics it is easy
     // to serialise Firecracker app_metrics as a single json object which
@@ -944,6 +987,9 @@ create_serialize_proxy!(MemoryHotplugSerializeProxy, virtio_mem_metrics);
 #[derive(Debug, Default, Serialize)]
 pub struct FirecrackerMetrics {
     utc_timestamp_ms: SerializeToUtcTimestampMs,
+    #[serde(flatten)]
+    /// The microVM instance id (jailer `--id`), emitted when enabled.
+    pub id: InstanceIdField,
     #[serde(flatten)]
     /// Operator-supplied custom properties.
     pub properties: MetricsProperties,
@@ -1006,6 +1052,7 @@ impl FirecrackerMetrics {
     pub const fn new() -> Self {
         Self {
             utc_timestamp_ms: SerializeToUtcTimestampMs::new(),
+            id: InstanceIdField::new(),
             properties: MetricsProperties::new(),
             api_server: ApiServerMetrics::new(),
             balloon_ser: BalloonMetricsSerializeProxy {},
@@ -1067,6 +1114,20 @@ mod tests {
         let f = TempFile::new().expect("Failed to create temporary metrics file");
 
         m.init(LineWriter::new(f.into_file())).unwrap_err();
+    }
+
+    #[test]
+    fn test_instance_id_serialize_disabled() {
+        let id = InstanceIdField::new();
+        assert_eq!(serde_json::to_string(&id).unwrap(), "{}");
+    }
+
+    #[test]
+    fn test_instance_id_serialize_enabled() {
+        let id = InstanceIdField::new();
+        id.enable();
+        let out = serde_json::to_string(&id).unwrap();
+        assert!(out.contains(r#""id":"#));
     }
 
     #[test]

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1289,6 +1289,7 @@ mod tests {
         check_unsupported(runtime_request(VmmAction::ConfigureMetrics(
             MetricsConfig {
                 metrics_path: PathBuf::new(),
+                properties: None,
             },
         )));
         check_unsupported(runtime_request(VmmAction::SetVsockDevice(

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1289,6 +1289,7 @@ mod tests {
         check_unsupported(runtime_request(VmmAction::ConfigureMetrics(
             MetricsConfig {
                 metrics_path: PathBuf::new(),
+                emit_id: false,
                 properties: None,
             },
         )));

--- a/src/vmm/src/vmm_config/metrics.rs
+++ b/src/vmm/src/vmm_config/metrics.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Auxiliary module for configuring the metrics system.
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,9 @@ use crate::utils::open_file_nonblock;
 pub struct MetricsConfig {
     /// Named pipe or file used as output for metrics.
     pub metrics_path: PathBuf,
+    /// Optional operator-defined key-value properties emitted on every metrics line.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub properties: Option<BTreeMap<String, String>>,
 }
 
 /// Errors associated with actions on the `MetricsConfig`.
@@ -31,7 +35,16 @@ pub fn init_metrics(metrics_cfg: MetricsConfig) -> Result<(), MetricsConfigError
     );
     METRICS
         .init(writer)
-        .map_err(|err| MetricsConfigError::InitializationFailure(err.to_string()))
+        .map_err(|err| MetricsConfigError::InitializationFailure(err.to_string()))?;
+
+    if let Some(properties) = metrics_cfg.properties {
+        METRICS
+            .properties
+            .set(properties)
+            .map_err(|err| MetricsConfigError::InitializationFailure(err.to_string()))?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -46,6 +59,7 @@ mod tests {
         let metrics_file = TempFile::new().unwrap();
         let desc = MetricsConfig {
             metrics_path: metrics_file.as_path().to_path_buf(),
+            properties: None,
         };
 
         init_metrics(desc.clone()).unwrap();

--- a/src/vmm/src/vmm_config/metrics.rs
+++ b/src/vmm/src/vmm_config/metrics.rs
@@ -15,7 +15,10 @@ use crate::utils::open_file_nonblock;
 pub struct MetricsConfig {
     /// Named pipe or file used as output for metrics.
     pub metrics_path: PathBuf,
-    /// Optional operator-defined key-value properties emitted on every metrics line.
+    /// Whether to emit the microVM instance id as a top-level `id` field on every metrics line.
+    #[serde(default)]
+    pub emit_id: bool,
+    /// Operator-defined key-value properties emitted on every metrics line.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub properties: Option<BTreeMap<String, String>>,
 }
@@ -37,6 +40,10 @@ pub fn init_metrics(metrics_cfg: MetricsConfig) -> Result<(), MetricsConfigError
         .init(writer)
         .map_err(|err| MetricsConfigError::InitializationFailure(err.to_string()))?;
 
+    if metrics_cfg.emit_id {
+        METRICS.id.enable();
+    }
+
     if let Some(properties) = metrics_cfg.properties {
         METRICS
             .properties
@@ -55,14 +62,30 @@ mod tests {
 
     #[test]
     fn test_init_metrics() {
-        // Initializing metrics with valid pipe is ok.
+        // Initializing metrics with a valid pipe is ok. Enable both optional
+        // fields so their configuration paths are exercised.
         let metrics_file = TempFile::new().unwrap();
+        let mut properties = BTreeMap::new();
+        properties.insert("customer_id".to_string(), "1234".to_string());
         let desc = MetricsConfig {
             metrics_path: metrics_file.as_path().to_path_buf(),
-            properties: None,
+            emit_id: true,
+            properties: Some(properties),
         };
 
         init_metrics(desc.clone()).unwrap();
+        // Metrics can only be initialized once.
         init_metrics(desc).unwrap_err();
+    }
+
+    #[test]
+    fn test_emit_id_defaults_to_false() {
+        let cfg: MetricsConfig = serde_json::from_str(r#"{"metrics_path": "metrics"}"#).unwrap();
+        assert!(!cfg.emit_id);
+        assert_eq!(cfg.properties, None);
+
+        let cfg: MetricsConfig =
+            serde_json::from_str(r#"{"metrics_path": "metrics", "emit_id": true}"#).unwrap();
+        assert!(cfg.emit_id);
     }
 }

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -376,6 +376,14 @@ def validate_fc_metrics(metrics):
 
     firecracker_metrics_schema = create_metrics_schema_objects(firecracker_metrics)
 
+    # "properties" is an optional operator-defined string map (see
+    # MetricsConfig.properties), not a metric: allow it when present, never
+    # require it, and keep every real metric strictly validated.
+    firecracker_metrics_schema["properties"]["properties"] = {
+        "type": "object",
+        "additionalProperties": {"type": "string"},
+    }
+
     jsonschema.validate(instance=metrics, schema=firecracker_metrics_schema)
 
     def validate_missing_metrics(metrics):

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -376,9 +376,11 @@ def validate_fc_metrics(metrics):
 
     firecracker_metrics_schema = create_metrics_schema_objects(firecracker_metrics)
 
-    # "properties" is an optional operator-defined string map (see
-    # MetricsConfig.properties), not a metric: allow it when present, never
-    # require it, and keep every real metric strictly validated.
+    # "id" and "properties" are optional non-metric fields (see
+    # MetricsConfig.emit_id and MetricsConfig.properties): allow them when
+    # present, never require them, and keep every real metric strictly
+    # validated.
+    firecracker_metrics_schema["properties"]["id"] = {"type": "string"}
     firecracker_metrics_schema["properties"]["properties"] = {
         "type": "object",
         "additionalProperties": {"type": "string"},

--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -3,6 +3,7 @@
 """Tests the metrics system."""
 
 import os
+from pathlib import Path
 
 import host_tools.drive as drive_tools
 from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
@@ -21,6 +22,83 @@ def test_flush_metrics(uvm):
 
     metrics = microvm.flush_metrics()
     validate_fc_metrics(metrics)
+
+
+def _configure_metrics_via_api(microvm, **kwargs):
+    """Configure metrics through the API rather than the `--metrics-path` CLI
+    option (the two ways of initializing metrics are mutually exclusive), and
+    wire up the host-side metrics file so the line can be read back."""
+    microvm.spawn(metrics_path=None)
+    microvm.basic_config()
+
+    metrics_path = Path(microvm.path) / "metrics.ndjson"
+    metrics_path.touch()
+    microvm.metrics_file = metrics_path
+
+    microvm.api.metrics.put(
+        metrics_path=microvm.create_jailed_resource(metrics_path), **kwargs
+    )
+    microvm.start()
+
+
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_metrics_default_shape(uvm):
+    """
+    Check that no `id` or `properties` field is emitted by default.
+    """
+    microvm = uvm
+    microvm.spawn()
+    microvm.basic_config()
+    microvm.start()
+
+    metrics = microvm.flush_metrics()
+    validate_fc_metrics(metrics)
+    assert "id" not in metrics
+    assert "properties" not in metrics
+
+
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_metrics_emit_id(uvm):
+    """
+    Check that `emit_id` emits the instance id, independently of `properties`.
+    """
+    microvm = uvm
+    _configure_metrics_via_api(microvm, emit_id=True)
+
+    metrics = microvm.flush_metrics()
+    validate_fc_metrics(metrics)
+    assert metrics["id"] == microvm.id
+    assert "properties" not in metrics
+
+
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_metrics_with_properties(uvm):
+    """
+    Check that `properties` is emitted, independently of `emit_id`.
+    """
+    microvm = uvm
+    properties = {"customer_id": "1234", "bundle_id": "fn-abc"}
+    _configure_metrics_via_api(microvm, properties=properties)
+
+    metrics = microvm.flush_metrics()
+    validate_fc_metrics(metrics)
+    assert metrics["properties"] == properties
+    assert "id" not in metrics
+
+
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+def test_metrics_emit_id_and_properties(uvm):
+    """
+    Check that `emit_id` and `properties` can be enabled together.
+    """
+    microvm = uvm
+    properties = {"customer_id": "1234", "bundle_id": "fn-abc"}
+    _configure_metrics_via_api(microvm, emit_id=True, properties=properties)
+
+    metrics = microvm.flush_metrics()
+    validate_fc_metrics(metrics)
+    assert metrics["id"] == microvm.id
+    assert metrics["properties"] == properties
 
 
 @pin_guest_kernel(GUEST_KERNEL_DEFAULT)


### PR DESCRIPTION
## Changes

Add two optional, independent fields to the metrics configuration (`PUT /metrics` and the `metrics` block of a config file), each emitted as a top-level key on every metrics line and each off by default:

  - `emit_id` (boolean): emits the microVM instance id (the value passed to the jailer `--id`) under a top-level `id` field.
  - `properties` (map of string to string): emits operator-defined key-value pairs under a top-level `properties` field.

When neither is configured, the metrics line is byte-for-byte unchanged, so existing consumers are unaffected.

Example line with both enabled:
  ```json
  {"utc_timestamp_ms": 1739000000000, "id": "my-instance",
  "properties": {"bundle_id": "fn-abc", "customer_id": "1234"},
  "api_server": {"...": 0}}
```

## Reason
Operators that collect metrics from many microVMs into a single destination (for example, a log agent that globs every VM's metrics file into one log stream) cannot tell which microVM a given line came from, because the lines carry no identifier. The original feature request asked for arbitrary key-value tagging to attribute lines to a VM; subsequent discussion clarified that the primary need is simply a stable, authoritative identifier, with operator tags as an enrichment.


## Design decisions

- id as a separate top-level field, not a key inside properties. An earlier idea was to auto-populate the instance id inside the properties map. A separate id field was chosen instead, for several reasons:

  - The instance id is owned and known by Firecracker; the properties are arbitrary data supplied by operators. Keeping them separate preserves the distinction and avoids a reserved-key collision if an operator also wants a key named id.
  - An operator can want only the id, only custom tags, or both.
  - Consumers querying by VM identity get a top-level field.


- Two independent opt-in switches: Both default to off so the default line shape is unchanged (backwards compatibility). emit_id is a boolean toggle modeled on the existing LoggerConfig show_level / show_log_origin toggles.

- No CLI flag for properties: Structured data is supplied through the API or a config file, not the command line. This matches convention that CLI arguments are scalars, paths, and booleans, with structured input provided by file (as MMDS content already does). --metrics-path continues to configure only the path.

- Omitted when unset, not emitted empty: When a field is not configured its key is absent entirely.

- Snapshot behavior unchanged: Metrics configuration is not part of the snapshot and is reconfigured on a restored microVM; this change adds nothing to the snapshot surface.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
