### PR TITLE
[Backport 1.16] Fix vsock guest-to-host timeout after snapshot restore (#5958)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to
 - [#5959](https://github.com/firecracker-microvm/firecracker/pull/5959):
   Reverted the use of `O_NOFOLLOW` for the jailer's cgroup and network namespace
   file operations, so symlinks are again allowed in these paths.
+- [#5958](https://github.com/firecracker-microvm/firecracker/pull/5958): Fixed a
+  bug that caused vsock guest-to-host connections to time out after snapshot
+  restore, triggered by taking a snapshot with a TX descriptor in-flight. On
+  restore the device now replays the TX queue notification so in-flight TX
+  descriptors are re-processed and notification suppression is re-armed.
 
 ## [1.16.0]
 

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -290,8 +290,9 @@ where
     /// using them to manage the internal connection state.
     ///
     /// Returns:
-    /// always `Ok(())`: the packet has been consumed;
-    fn send_pkt(&mut self, pkt: &VsockPacketTx) -> Result<(), VsockError> {
+    /// The packet is always consumed: host-side back-pressure is buffered and unrecoverable
+    /// stream errors terminate the connection.
+    fn send_pkt(&mut self, pkt: &VsockPacketTx) {
         // Update the peer credit information.
         self.peer_buf_alloc = pkt.hdr.buf_alloc();
         self.peer_fwd_cnt = Wrapping(pkt.hdr.fwd_cnt());
@@ -309,7 +310,7 @@ where
                         "vsock: dropping empty data packet from guest (lp={}, pp={}",
                         self.local_port, self.peer_port
                     );
-                    return Ok(());
+                    return;
                 }
 
                 // Unwrapping here is safe, since we just checked `pkt.buf()` above.
@@ -321,7 +322,7 @@ where
                         self.local_port, self.peer_port, err
                     );
                     self.kill();
-                    return Ok(());
+                    return;
                 }
 
                 // We might've just consumed some data. If that's the case, we might need to
@@ -394,8 +395,6 @@ where
                 );
             }
         };
-
-        Ok(())
     }
 
     /// Check if the connection has any pending packet addressed to the peer.
@@ -922,7 +921,7 @@ mod tests {
         }
 
         fn send(&mut self) {
-            self.conn.send_pkt(&self.tx_pkt).unwrap();
+            self.conn.send_pkt(&self.tx_pkt);
         }
 
         fn recv(&mut self) {

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -242,10 +242,7 @@ where
                 }
             };
 
-            if self.backend.send_pkt(&self.tx_packet).is_err() {
-                queue.undo_pop();
-                break;
-            }
+            self.backend.send_pkt(&self.tx_packet);
 
             have_used = true;
             queue.add_used(index, 0).unwrap_or_else(|err| {

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -406,21 +406,47 @@ where
     }
 
     fn kick(&mut self) {
-        // Vsock has complicated protocol that isn't resilient to any packet loss,
-        // so for Vsock we don't support connection persistence through snapshot.
-        // Any in-flight packets or events are simply lost.
-        // Vsock is restored 'empty'.
-        // The only reason we still `kick` it is to make guest process
-        // `TRANSPORT_RESET_EVENT` event we sent during snapshot creation.
         if self.is_activated() {
             self.pending_event_ack = true;
 
+            // Vsock has a complicated protocol that isn't resilient to any packet loss,
+            // so for Vsock we don't support connection persistence through snapshot. Any
+            // in-flight packets or events are simply lost and Vsock is restored 'empty'.
+            // We signal the event queue to make the guest process the
+            // `TRANSPORT_RESET_EVENT` event we sent during snapshot creation. (We signal
+            // it host->guest rather than writing its eventfd, which would invoke the
+            // guest's reset-ack path and clear `pending_event_ack` prematurely.)
             info!(
                 "[{:?}:{}] signaling event queue",
                 self.device_type(),
                 self.id()
             );
             self.signal_used_queue(EVQ_INDEX).unwrap();
+
+            // Replay the TX queue notification, like the default `VirtioDevice::kick`
+            // does for its data queues, so the device re-processes any TX descriptor
+            // that was in-flight at snapshot time and re-arms `avail_event`.
+            //
+            // Without this, `avail_idx` stays ahead of the `avail_event` we published.
+            // Under EVENT_IDX the guest only notifies us when `avail_idx` crosses
+            // `avail_event`; since it is already past, the guest considers itself to
+            // have notified us and stays silent, so we never process the queue and
+            // guest-to-host connections hang. RX needs no replay: it is gated by
+            // `pending_event_ack` until the guest acks the reset, and the host pulls
+            // from the backend rather than waiting on a guest RX notification.
+            info!(
+                "[{:?}:{}] notifying tx queue",
+                self.device_type(),
+                self.id()
+            );
+            if let Err(err) = self.queue_events[TXQ_INDEX].write(1) {
+                error!(
+                    "[{:?}:{}] error notifying tx queue: {}",
+                    self.device_type(),
+                    self.id(),
+                    err
+                );
+            }
         }
     }
 
@@ -616,6 +642,26 @@ mod tests {
         let progressed = ctx.device.process_rx().unwrap();
         assert!(!progressed);
         assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
+    }
+
+    #[test]
+    fn test_kick_replays_tx_notification_only() {
+        // On restore, kick() must replay only the TX data queue (to re-process in-flight
+        // TX and re-arm avail_event). RX is gated by pending_event_ack so it needs no
+        // replay, and the event queue's data eventfd must not be notified -- that is the
+        // guest's TRANSPORT_RESET ack path; the event queue is signaled host->guest.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        ctx.device.kick();
+
+        // TX queue eventfd was replayed for re-processing.
+        assert_eq!(ctx.device.queue_events[TXQ_INDEX].read().unwrap(), 1);
+        // RX and the event queue's data eventfd must not be signaled by kick()
+        // (non-blocking read returns an error when the eventfd has no pending count).
+        ctx.device.queue_events[RXQ_INDEX].read().unwrap_err();
+        ctx.device.queue_events[EVQ_INDEX].read().unwrap_err();
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -123,11 +123,8 @@ where
     pub fn notify_backend(&mut self, evset: EventSet) -> Result<Vec<u16>, InvalidAvailIdx> {
         let mut used_queues = Vec::new();
         self.backend.notify(evset);
-        // After the backend has been kicked, it might've freed up some resources, so we
-        // can attempt to send it more data to process.
-        // In particular, if `self.backend.send_pkt()` halted the TX queue processing (by
-        // returning an error) at some point in the past, now is the time to try walking the
-        // TX queue again.
+        // After the backend has been kicked it may have freed up resources, so walk the TX
+        // queue again in case there are packets waiting to be forwarded to it.
         if self.process_tx()? {
             used_queues.push(TXQ_INDEX.try_into().unwrap());
         }
@@ -283,23 +280,6 @@ mod tests {
             // Both available RX and TX descriptors should have been used.
             assert_eq!(ctx.guest_txvq.used.idx.get(), 1);
             assert_eq!(ctx.guest_rxvq.used.idx.get(), 1);
-        }
-
-        // Test case:
-        // - the driver has something to send (there's data in the TX queue); and
-        // - the backend errors out and cannot process the TX queue.
-        {
-            let test_ctx = TestContext::new();
-            let mut ctx = test_ctx.create_event_handler_context();
-            ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
-
-            ctx.device.backend.set_pending_rx(false);
-            ctx.device.backend.set_tx_err(Some(VsockError::NoData));
-            ctx.signal_txq_event();
-
-            // Both RX and TX queues should be untouched.
-            assert_eq!(ctx.guest_txvq.used.idx.get(), 0);
-            assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
         }
 
         // Test case:

--- a/src/vmm/src/devices/virtio/vsock/mod.rs
+++ b/src/vmm/src/devices/virtio/vsock/mod.rs
@@ -169,7 +169,11 @@ pub trait VsockChannel {
     fn recv_pkt(&mut self, pkt: &mut VsockPacketRx) -> Result<(), VsockError>;
 
     /// Write/send a packet through the channel.
-    fn send_pkt(&mut self, pkt: &VsockPacketTx) -> Result<(), VsockError>;
+    ///
+    /// The packet is always consumed (its virtio TX buffers can be returned to the guest):
+    /// host-side back-pressure is absorbed by buffering, and unrecoverable errors terminate
+    /// the offending connection rather than halting queue processing.
+    fn send_pkt(&mut self, pkt: &VsockPacketTx);
 
     /// Checks whether there is pending incoming data inside the channel, meaning that a subsequent
     /// call to `recv_pkt()` won't fail.

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -27,7 +27,6 @@ use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
 pub struct TestBackend {
     pub evfd: EventFd,
     pub rx_err: Option<VsockError>,
-    pub tx_err: Option<VsockError>,
     pub pending_rx: bool,
     pub rx_ok_cnt: usize,
     pub tx_ok_cnt: usize,
@@ -39,7 +38,6 @@ impl TestBackend {
         Self {
             evfd: EventFd::new(libc::EFD_NONBLOCK).unwrap(),
             rx_err: None,
-            tx_err: None,
             pending_rx: false,
             rx_ok_cnt: 0,
             tx_ok_cnt: 0,
@@ -49,9 +47,6 @@ impl TestBackend {
 
     pub fn set_rx_err(&mut self, err: Option<VsockError>) {
         self.rx_err = err;
-    }
-    pub fn set_tx_err(&mut self, err: Option<VsockError>) {
-        self.tx_err = err;
     }
     pub fn set_pending_rx(&mut self, prx: bool) {
         self.pending_rx = prx;
@@ -84,14 +79,8 @@ impl VsockChannel for TestBackend {
         }
     }
 
-    fn send_pkt(&mut self, _pkt: &VsockPacketTx) -> Result<(), VsockError> {
-        match self.tx_err.take() {
-            None => {
-                self.tx_ok_cnt += 1;
-                Ok(())
-            }
-            Some(err) => Err(err),
-        }
+    fn send_pkt(&mut self, _pkt: &VsockPacketTx) {
+        self.tx_ok_cnt += 1;
     }
 
     fn has_pending_rx(&self) -> bool {

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -193,10 +193,9 @@ impl VsockChannel for VsockMuxer {
     /// This absorbs unexpected packets, handles RSTs (by dropping connections), and forwards
     /// all the rest to their owning `MuxerConnection`.
     ///
-    /// Returns:
-    /// always `Ok(())` - the packet has been consumed, and its virtio TX buffers can be
-    /// returned to the guest vsock driver.
-    fn send_pkt(&mut self, pkt: &VsockPacketTx) -> Result<(), VsockError> {
+    /// The packet is always consumed, and its virtio TX buffers can be returned to the guest
+    /// vsock driver.
+    fn send_pkt(&mut self, pkt: &VsockPacketTx) {
         let conn_key = ConnMapKey {
             local_port: pkt.hdr.dst_port(),
             peer_port: pkt.hdr.src_port(),
@@ -212,7 +211,7 @@ impl VsockChannel for VsockMuxer {
         //
         if pkt.hdr.type_() != uapi::VSOCK_TYPE_STREAM {
             self.enq_rst(pkt.hdr.dst_port(), pkt.hdr.src_port());
-            return Ok(());
+            return;
         }
 
         // We don't know how to handle packets addressed to other CIDs. We only handle the host
@@ -222,7 +221,7 @@ impl VsockChannel for VsockMuxer {
                 "vsock: dropping guest packet for unknown CID: {:?}",
                 pkt.hdr
             );
-            return Ok(());
+            return;
         }
 
         if !self.conn_map.contains_key(&conn_key) {
@@ -236,7 +235,7 @@ impl VsockChannel for VsockMuxer {
                 // Send back an RST, to let the drive know we weren't expecting this packet.
                 self.enq_rst(pkt.hdr.dst_port(), pkt.hdr.src_port());
             }
-            return Ok(());
+            return;
         }
 
         // Right, we know where to send this packet, then (to `conn_key`).
@@ -244,16 +243,13 @@ impl VsockChannel for VsockMuxer {
         // there's no point in forwarding it the packet.
         if pkt.hdr.op() == uapi::VSOCK_OP_RST {
             self.remove_connection(conn_key);
-            return Ok(());
+            return;
         }
 
         // Alright, everything looks in order - forward this packet to its owning connection.
-        let mut res: Result<(), VsockError> = Ok(());
         self.apply_conn_mutation(conn_key, |conn| {
-            res = conn.send_pkt(pkt);
+            conn.send_pkt(pkt);
         });
-
-        res
     }
 
     /// Check if the muxer has any pending RX data, with which to fill a guest-provided RX
@@ -895,7 +891,7 @@ mod tests {
         }
 
         fn send(&mut self) {
-            self.muxer.send_pkt(&self.tx_pkt).unwrap();
+            self.muxer.send_pkt(&self.tx_pkt);
         }
 
         fn recv(&mut self) {

--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -6,7 +6,7 @@ import hashlib
 import os.path
 import re
 import time
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from socket import AF_UNIX, SOCK_STREAM, socket
 from subprocess import Popen
@@ -176,18 +176,18 @@ def check_host_connections(uds_path, blob_path, blob_hash):
             assert wrk.hash == blob_hash
 
 
-def check_guest_connections(vm, server_port_path, blob_path, blob_hash):
-    """Test guest-initiated connections.
+@contextmanager
+def host_echo_server(vm, server_port_path):
+    """Run a host-side echo server reachable by the guest over vsock.
 
-    This will start an echo server on the host (in its own thread), then
-    start `TEST_CONNECTION_COUNT` workers inside the guest VM, all
-    communicating with the echo server.
+    Starts `socat` listening on the Unix socket `server_port_path`, links it
+    into the VM's jail so Firecracker can reach it, and raises the ssh
+    service's `pids.max` so guest workers can fork freely. Yields the socket
+    path and tears the server down on exit.
     """
-
     echo_server = Popen(
         ["socat", f"UNIX-LISTEN:{server_port_path},fork,backlog=5", "exec:'/bin/cat'"]
     )
-
     try:
         # Give socat a bit of time to create the socket
         for attempt in Retrying(
@@ -210,6 +210,23 @@ def check_guest_connections(vm, server_port_path, blob_path, blob_hash):
             f"echo 1024 > /sys/fs/cgroup/system.slice/{vm.distro.ssh_service}/pids.max"
         )
 
+        yield server_port_path
+    finally:
+        echo_server.terminate()
+        rc = echo_server.wait()
+        # socat exits with 128 + 15 (SIGTERM)
+        assert rc == 143
+
+
+def check_guest_connections(vm, server_port_path, blob_path, blob_hash):
+    """Test guest-initiated connections.
+
+    This will start an echo server on the host (in its own thread), then
+    start `TEST_CONNECTION_COUNT` workers inside the guest VM, all
+    communicating with the echo server.
+    """
+
+    with host_echo_server(vm, server_port_path):
         # Build the guest worker sub-command.
         # `vsock_helper` will read the blob file from STDIN and send the echo
         # server response to STDOUT. This response is then hashed, and the
@@ -234,11 +251,6 @@ def check_guest_connections(vm, server_port_path, blob_path, blob_hash):
         cmd += "for w in $workers; do wait $w || (wait; exit 1); done"
 
         vm.ssh.check_output(cmd)
-    finally:
-        echo_server.terminate()
-        rc = echo_server.wait()
-        # socat exits with 128 + 15 (SIGTERM)
-        assert rc == 143
 
 
 def make_host_port_path(uds_path, port):

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -34,6 +34,7 @@ from framework.utils_vsock import (
     check_guest_connections,
     check_host_connections,
     check_vsock_device,
+    host_echo_server,
     make_blob,
     make_host_port_path,
     start_guest_echo_server,
@@ -474,3 +475,48 @@ def test_vsock_post_restore_connect_storm(
                 validate_fc_metrics(metrics)
         finally:
             vm.kill()
+
+
+def test_snapshot_restore_with_inflight_vsock_tx(
+    vsock_uvm, bin_vsock_path, tmp_path, microvm_factory
+):
+    """
+    Guest-initiated vsock connections must still work after a snapshot taken
+    while the guest is actively transmitting.
+
+    If a guest TX descriptor is un-consumed when the snapshot is created, the
+    restored TX queue has avail_idx ahead of avail_event; with EVENT_IDX the
+    guest then suppresses all TX notifications and guest-initiated connections
+    hang. Unlike test_cycled_snapshot_restore (which snapshots after traffic has
+    drained, so it only hits this by chance), this test snapshots while a guest
+    worker is streaming, making the in-flight condition reliable.
+    """
+    vm = vsock_uvm
+
+    vm_blob_path = "/tmp/vsock/test.blob"
+    blob_path, blob_hash = make_blob(tmp_path)
+    _copy_vsock_data_to_guest(vm.ssh, blob_path, vm_blob_path, bin_vsock_path)
+
+    server_port_path = os.path.join(
+        vm.path, make_host_port_path(VSOCK_UDS_PATH, ECHO_SERVER_PORT)
+    )
+    with host_echo_server(vm, server_port_path):
+        # Continuously stream guest->host so the TX queue is non-empty when the
+        # snapshot is taken.
+        vm.ssh.check_output(
+            "nohup sh -c 'while true; do "
+            f"cat {vm_blob_path} | /tmp/vsock_helper echo 2 {ECHO_SERVER_PORT} "
+            ">/dev/null 2>&1; done' >/dev/null 2>&1 &"
+        )
+        # Let the stream ramp up so traffic is genuinely in-flight.
+        time.sleep(2)
+        snapshot = vm.snapshot_full()
+    vm.kill()
+
+    # Restore and verify a *fresh* guest-initiated connection works -- this is
+    # what hangs when a TX descriptor was in-flight at snapshot time.
+    new_vm = microvm_factory.build_from_snapshot(snapshot)
+    path = os.path.join(
+        new_vm.path, make_host_port_path(VSOCK_UDS_PATH, ECHO_SERVER_PORT)
+    )
+    check_guest_connections(new_vm, path, vm_blob_path, blob_hash)


### PR DESCRIPTION
## Changes
Backport PR for #5958 onto firecracker-v1.16, for the v1.16.1 patch release.


Note: dropped the @pin_guest_kernel(GUEST_KERNEL_DEFAULT) decorator from the backported test, that helper was added to framework.artifacts by an unrelated test-fixture refactor (#5902) that isn't on v1.16. On this branch the test's kernel is already constrained via the vsock_uvm -> uvm_plain_acpi fixture, so the test runs across ACPI guest kernels instead of a single pinned one. Backporting the refactor itself would rewrite fixtures across ~59 test files, out of scope for the patch.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
