### PR TITLE
[v1.16] chore(docs): update RELEASE_POLICY with v1.16.1

### DIFF
--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -90,7 +90,7 @@ v3.1 will be patched since were the last two Firecracker releases and less than
 
 | Release | Release Date | Latest Patch | Min. end of support | Official end of Support         |
 | ------: | -----------: | -----------: | ------------------: | :------------------------------ |
-|   v1.16 |   2026-06-03 |      v1.16.0 |          2026-12-03 | Supported                       |
+|   v1.16 |   2026-06-03 |      v1.16.1 |          2026-12-03 | Supported                       |
 |   v1.15 |   2026-03-09 |      v1.15.1 |          2026-09-09 | Supported                       |
 |   v1.14 |   2025-12-17 |      v1.14.4 |          2026-06-17 | 2026-06-03 (v1.16 released)     |
 |   v1.13 |   2025-08-28 |      v1.13.2 |          2026-02-28 | 2026-03-09 (v1.15 released)     |


### PR DESCRIPTION
## Changes

Bumping the v1.16 entry to v1.16.1 in the release status table, in preparation for the v1.16.1 patch release.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
