### PR TITLE
[Backport 1.16] CI: allow BuildKite jobs to be split across multiple pipelines (#5982, #5985)

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -399,16 +399,18 @@ class BKPipeline:
             if isinstance(step, dict) and "group" in step:
                 remaining_steps = step["steps"]
                 while remaining_steps:
-                    available = max_jobs - current_count
+                    # -1 to reserve a slot for the group step itself
+                    available = max_jobs - current_count - 1
                     if available <= 0:
                         chunks.append(current_chunk)
                         current_chunk = []
                         current_count = 0
-                        available = max_jobs
+                        available = max_jobs - 1
                     take = remaining_steps[:available]
                     remaining_steps = remaining_steps[available:]
                     current_chunk.append({**step, "steps": take})
-                    current_count += len(take)
+                    # +1 for the group step itself
+                    current_count += len(take) + 1
             else:
                 if current_chunk and current_count + 1 > max_jobs:
                     chunks.append(current_chunk)

--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -205,6 +205,13 @@ COMMON_PARSER.add_argument(
     default=1,
     type=int,
 )
+COMMON_PARSER.add_argument(
+    "--max-jobs",
+    help="Max leaf jobs per pipeline chunk. If set, to_json() returns a JSON array of pipelines.",
+    required=False,
+    default=None,
+    type=int,
+)
 
 
 def random_str(k: int):
@@ -379,13 +386,59 @@ class BKPipeline:
                 )
         return self.add_step(grp, depends_on_build=depends_on_build)
 
+    def _chunk_steps(self, max_jobs: int):
+        """Split steps into chunks of at most max_jobs leaf jobs each.
+
+        Groups that exceed the remaining space are split to fill each chunk.
+        """
+        chunks = []
+        current_chunk = []
+        current_count = 0
+
+        for step in self.steps:
+            if isinstance(step, dict) and "group" in step:
+                remaining_steps = step["steps"]
+                while remaining_steps:
+                    available = max_jobs - current_count
+                    if available <= 0:
+                        chunks.append(current_chunk)
+                        current_chunk = []
+                        current_count = 0
+                        available = max_jobs
+                    take = remaining_steps[:available]
+                    remaining_steps = remaining_steps[available:]
+                    current_chunk.append({**step, "steps": take})
+                    current_count += len(take)
+            else:
+                if current_chunk and current_count + 1 > max_jobs:
+                    chunks.append(current_chunk)
+                    current_chunk = []
+                    current_count = 0
+                current_chunk.append(step)
+                current_count += 1
+
+        if current_chunk:
+            chunks.append(current_chunk)
+        return chunks
+
     def to_dict(self):
         """Render the pipeline as a dictionary."""
         return {"steps": self.steps}
 
     def to_json(self):
-        """Serialize the pipeline to JSON"""
-        return json.dumps(self.to_dict(), indent=4, sort_keys=True, ensure_ascii=False)
+        """Serialize the pipeline to JSON.
+
+        If --max-jobs is set, returns a JSON array of pipeline objects,
+        each with at most max_jobs leaf jobs. Otherwise, returns a single
+        pipeline object (legacy behavior).
+        """
+        max_jobs = self.args.max_jobs
+        if max_jobs is None:
+            to_serialize = self.to_dict()
+        else:
+            chunks = self._chunk_steps(max_jobs)
+            to_serialize = [{"steps": chunk} for chunk in chunks]
+        return json.dumps(to_serialize, indent=4, sort_keys=True, ensure_ascii=False)
 
     def devtool_download_artifacts(self, artifacts):
         """Generate a `devtool download_ci_artifacts` command"""

--- a/.buildkite/pipeline_upload.sh
+++ b/.buildkite/pipeline_upload.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Proxy script that handles chunked pipeline upload.
+# Usage: .buildkite/pipeline_pr.py --max-jobs 500 | .buildkite/pipeline_upload.sh
+#
+# If the input is a JSON array (chunked), uploads each element separately.
+# If it's a single object, uploads it directly (backwards compatible).
+
+set -euo pipefail
+
+pipeline_json=$(cat)
+
+if echo "$pipeline_json" | jq -e 'type == "array"' > /dev/null 2>&1; then
+    count=$(echo "$pipeline_json" | jq 'length')
+    for ((i = 0; i < count; i++)); do
+        echo "$pipeline_json" | jq ".[$i]" | buildkite-agent pipeline upload
+    done
+else
+    echo "$pipeline_json" | buildkite-agent pipeline upload
+fi


### PR DESCRIPTION
## Changes

Backport PR for #5982 and #5985 onto firecracker-v1.16, for the v1.16.1 patch release.

## Reason

PR CI on firecracker-v1.16 fails because the shared firecracker-pr Buildkite bootstrap runs `pipeline_pr.py --max-jobs 500 | pipeline_upload.sh`, but `--max-jobs` and `pipeline_upload.sh` were added to main after the v1.16 release (#5982, #5985) and aren't on this branch. This backports those two commits so the release branch's CI tooling matches what the bootstrap expects; future release branches inherit it from main, so it's a one-time fix for v1.16.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
