### PR TITLE
sh: test: GNR misreported old microcode

### DIFF
--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -126,7 +126,7 @@ def test_spectre_meltdown_checker_on_host(spectre_meltdown_checker):
     reason="Test depends solely on factors external to GitHub repository",
 )
 @pytest.mark.skipif(
-    cpuid_utils.get_cpu_codename() == "INTEL_SAPPHIRE_RAPIDS",
+    cpuid_utils.get_cpu_codename() in ("INTEL_SAPPHIRE_RAPIDS", "INTEL_GRANITE_RAPIDS"),
     reason="Reporting old microcode for unknown reason",
 )
 def test_vulnerabilities_on_host():


### PR DESCRIPTION
Currently our nightly tests are failing due to an issue with parsing the CPU microcode version. This has been patched in new kernel versions but hasn't in our base commit.

Ignore this until we rebase our patches

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
