### PR TITLE
test(vsock): raise host echo server accept backlog

### DIFF
--- a/tests/framework/utils_vsock.py
+++ b/tests/framework/utils_vsock.py
@@ -185,8 +185,19 @@ def host_echo_server(vm, server_port_path):
     service's `pids.max` so guest workers can fork freely. Yields the socket
     path and tears the server down on exit.
     """
+    # The backlog must be >= the number of concurrent guest connections
+    # (`TEST_CONNECTION_COUNT`). Firecracker's vsock muxer establishes the
+    # host-side connection with a *blocking* `connect()` on its event-loop
+    # thread; if the listener's accept backlog is saturated (e.g. the whole
+    # worker burst reconnecting at once right after a snapshot restore), that
+    # `connect()` stalls the VMM, delaying `OP_RESPONSE`s past the guest's 2s
+    # vsock connect timeout and causing spurious `connect(): timed out`.
     echo_server = Popen(
-        ["socat", f"UNIX-LISTEN:{server_port_path},fork,backlog=5", "exec:'/bin/cat'"]
+        [
+            "socat",
+            f"UNIX-LISTEN:{server_port_path},fork,backlog={SERVER_ACCEPT_BACKLOG}",
+            "exec:'/bin/cat'",
+        ]
     )
     try:
         # Give socat a bit of time to create the socket


### PR DESCRIPTION
## Changes

Use the existing SERVER_ACCEPT_BACKLOG (128) so the backlog comfortably exceeds the concurrent connection count, matching the guest-side listener.

## Reason

check_guest_connections fires TEST_CONNECTION_COUNT (50) concurrent guest->host connects, but host_echo_server listened with backlog=5. The vsock muxer establishes the host-side connection with a blocking connect() on the VMM event-loop thread; when the backlog saturates (the whole worker burst reconnecting at once after a snapshot restore), that connect() stalls the VMM and delays OP_RESPONSEs past the guest's 2s vsock connect timeout, causing intermittent "connect(): timed out" failures in test_cycled_snapshot_restore.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
