### PR TITLE
virtio: fix: enforce device activation from an inactive state

### DIFF
--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -956,6 +956,8 @@ impl VirtioDevice for Balloon {
         mem: GuestMemoryMmap,
         interrupt: Arc<dyn VirtioInterrupt>,
     ) -> Result<(), ActivateError> {
+        assert!(!self.is_activated());
+
         for q in self.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -349,6 +349,8 @@ where
         mem: GuestMemoryMmap,
         interrupt: Arc<dyn VirtioInterrupt>,
     ) -> Result<(), ActivateError> {
+        assert!(!self.is_activated());
+
         for q in self.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -651,6 +651,8 @@ impl VirtioDevice for VirtioBlock {
         mem: GuestMemoryMmap,
         interrupt: Arc<dyn VirtioInterrupt>,
     ) -> Result<(), ActivateError> {
+        assert!(!self.is_activated());
+
         for q in self.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -1386,6 +1386,8 @@ mod tests {
 
             // Read at valid address, with an overflowing length.
             {
+                let mut block = default_block(engine);
+
                 // Default mem size is 0x10000
                 let mem = default_mem();
                 let interrupt = default_interrupt();

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -664,6 +664,8 @@ impl VirtioDevice for VirtioMem {
         mem: GuestMemoryMmap,
         interrupt: Arc<dyn VirtioInterrupt>,
     ) -> Result<(), ActivateError> {
+        assert!(!self.is_activated());
+
         if (self.acked_features & (1 << VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE)) == 0 {
             error!(
                 "virtio-mem: VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE feature not acknowledged by guest"

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -1045,6 +1045,8 @@ impl VirtioDevice for Net {
         mem: GuestMemoryMmap,
         interrupt: Arc<dyn VirtioInterrupt>,
     ) -> Result<(), ActivateError> {
+        assert!(!self.is_activated());
+
         for q in self.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -571,6 +571,8 @@ impl VirtioDevice for Pmem {
         mem: GuestMemoryMmap,
         interrupt: Arc<dyn VirtioInterrupt>,
     ) -> Result<(), ActivateError> {
+        assert!(!self.is_activated());
+
         for q in self.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -312,6 +312,8 @@ impl VirtioDevice for Entropy {
         mem: GuestMemoryMmap,
         interrupt: Arc<dyn VirtioInterrupt>,
     ) -> Result<(), ActivateError> {
+        assert!(!self.is_activated());
+
         for q in self.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -369,6 +369,8 @@ where
         mem: GuestMemoryMmap,
         interrupt: Arc<dyn VirtioInterrupt>,
     ) -> Result<(), ActivateError> {
+        assert!(!self.is_activated());
+
         for q in self.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;


### PR DESCRIPTION
Virtio devices must be activated from an inactive state. Until now `activate()` could be called on an already-active device and would overwrite the previous device_state (swap memory and interrupt). Adding `assert!(!self.is_activated())` in `activate()` enforces that virtio devices are only activated from an inactive state. 

This is not a production behavior change since the transport layer already gates activation behind an `is_activated()`/`needs_activation()` check. The assert makes that existing invariant explicit and catches any future misuse.

This surfaced from the block device's test_read_write, which relied on the overwrite from re-activating an already-active device. The test has been fixed by creating a dedicated device for that case.

## Changes

1. Added `assert!(!self.is_activated());` at the beginning of all `activate()` functions of virtio devices.
2. Added `let mut block = default_block(engine);` in the `test_read_write()` test of block device.

## Reason

Enforce the Inactive to Active activation flow and make the invariant explicit, so accidental re-activation panic instead of silently changing device state.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [X] I have read and understand [CONTRIBUTING.md][3].
- [X] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [X] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [X] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [X] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [X] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
