### PR TITLE
chore: release v1.16.1

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -189,6 +189,7 @@ Contributors to the Firecracker repository:
 - Manohar Castelino <manohar.r.castelino@intel.com>
 - Marc Brooker <mbrooker@amazon.com>
 - Marco Cali <xmarcalx@amazon.co.uk>
+- Marco Marangoni <mamarang@amazon.com>
 - Marco Vedovati <mvedovati@suse.com>
 - Markus Ziller <web+github@markusziller.de>
 - Masatoshi Higuchi <matt9ucci@gmail.com>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "cpu-template-helper"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "clap",
  "displaydoc",
@@ -576,7 +576,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firecracker"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "cargo_toml",
  "displaydoc",
@@ -791,7 +791,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jailer"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "libc",
  "log-instrument",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "rebase-snap"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "displaydoc",
  "libc",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "seccompiler"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "bitcode",
  "clap",
@@ -1360,7 +1360,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "snapshot-editor"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "clap",
  "clap-num",

--- a/src/cpu-template-helper/Cargo.toml
+++ b/src/cpu-template-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpu-template-helper"
-version = "1.16.0"
+version = "1.16.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "1.16.0"
+version = "1.16.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2024"
 build = "build.rs"

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 1.16.0
+  version: 1.16.1
   termsOfService: ""
   contact:
     email: "firecracker-maintainers@amazon.com"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "1.16.0"
+version = "1.16.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2024"
 description = "Process for starting Firecracker in production scenarios; applies a cgroup/namespace isolation barrier and then drops privileges."

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rebase-snap"
-version = "1.16.0"
+version = "1.16.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seccompiler"
-version = "1.16.0"
+version = "1.16.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2024"
 description = "Program that compiles multi-threaded seccomp-bpf filters expressed as JSON into raw BPF programs, serializing them and outputting them to a file."

--- a/src/snapshot-editor/Cargo.toml
+++ b/src/snapshot-editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapshot-editor"
-version = "1.16.0"
+version = "1.16.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
Update version number / CHANGELOG / CREDITS

## Changes

Release commit for v1.16.1 (patch), generated by `./tools/release-prepare.sh 1.16.1`:
  - Version bump 1.16.0 → 1.16.1 (firecracker, jailer, rebase-snap, seccompiler,
    cpu-template-helper, snapshot-editor, swagger spec) + Cargo.lock
  - CHANGELOG: `[1.16.1]` section (O_NOFOLLOW revert #5959, vsock g2h fix #5958)
  - CREDITS regenerated

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
