### PR TITLE
virtio: add config_as_bytes() to VirtioDevice, default read_config()

### DIFF
--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -566,9 +566,8 @@ pub(crate) mod tests {
             let _ = value;
         }
 
-        fn read_config(&self, offset: u64, data: &mut [u8]) {
-            let _ = offset;
-            let _ = data;
+        fn config_as_bytes(&self) -> &[u8] {
+            &[]
         }
 
         fn write_config(&mut self, offset: u64, data: &[u8]) {

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -927,13 +927,8 @@ impl VirtioDevice for Balloon {
             .deref()
     }
 
-    fn read_config(&self, offset: u64, data: &mut [u8]) {
-        if let Some(config_space_bytes) = self.config_space.as_slice().get(u64_to_usize(offset)..) {
-            let len = config_space_bytes.len().min(data.len());
-            data[..len].copy_from_slice(&config_space_bytes[..len]);
-        } else {
-            error!("Failed to read config space");
-        }
+    fn config_as_bytes(&self) -> &[u8] {
+        self.config_space.as_slice()
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {
@@ -1181,7 +1176,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_virtio_read_config() {
+    fn test_config_as_bytes() {
         let balloon = Balloon::new(0x10, true, 0, false, false).unwrap();
 
         let cfg = BalloonConfig {
@@ -1193,29 +1188,14 @@ pub(crate) mod tests {
         };
         assert_eq!(balloon.config(), cfg);
 
-        let mut actual_config_space = [0u8; BALLOON_CONFIG_SPACE_SIZE];
-        balloon.read_config(0, &mut actual_config_space);
-        // The first 4 bytes are num_pages, the last 4 bytes are actual_pages.
-        // The config space is little endian.
-        // 0x10 MB in the constructor corresponds to 0x1000 pages in the
-        // config space.
-        let expected_config_space: [u8; BALLOON_CONFIG_SPACE_SIZE] = [
+        let config = balloon.config_as_bytes();
+        assert_eq!(config.len(), BALLOON_CONFIG_SPACE_SIZE);
+        // The first 4 bytes are num_pages (LE), the last 4 bytes are actual_pages.
+        // 0x10 MB = 0x1000 pages.
+        let expected: [u8; BALLOON_CONFIG_SPACE_SIZE] = [
             0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
-        assert_eq!(actual_config_space, expected_config_space);
-
-        // Invalid read.
-        let expected_config_space: [u8; BALLOON_CONFIG_SPACE_SIZE] = [
-            0xd, 0xe, 0xa, 0xd, 0xb, 0xe, 0xe, 0xf, 0x00, 0x00, 0x00, 0x00,
-        ];
-        actual_config_space = expected_config_space;
-        balloon.read_config(
-            BALLOON_CONFIG_SPACE_SIZE as u64 + 1,
-            &mut actual_config_space,
-        );
-
-        // Validate read failed (the config space was not updated).
-        assert_eq!(actual_config_space, expected_config_space);
+        assert_eq!(config, expected);
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -175,10 +175,10 @@ impl VirtioDevice for Block {
         }
     }
 
-    fn read_config(&self, offset: u64, data: &mut [u8]) {
+    fn config_as_bytes(&self) -> &[u8] {
         match self {
-            Self::Virtio(b) => b.read_config(offset, data),
-            Self::VhostUser(b) => b.read_config(offset, data),
+            Self::Virtio(b) => b.config_as_bytes(),
+            Self::VhostUser(b) => b.config_as_bytes(),
         }
     }
 

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -328,14 +328,8 @@ where
             .deref()
     }
 
-    fn read_config(&self, offset: u64, data: &mut [u8]) {
-        if let Some(config_space_bytes) = self.config_space.as_slice().get(u64_to_usize(offset)..) {
-            let len = config_space_bytes.len().min(data.len());
-            data[..len].copy_from_slice(&config_space_bytes[..len]);
-        } else {
-            error!("Failed to read config space");
-            self.metrics.cfg_fails.inc();
-        }
+    fn config_as_bytes(&self) -> &[u8] {
+        self.config_space.as_slice()
     }
 
     fn write_config(&mut self, _offset: u64, _data: &[u8]) {

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -620,14 +620,8 @@ impl VirtioDevice for VirtioBlock {
             .deref()
     }
 
-    fn read_config(&self, offset: u64, data: &mut [u8]) {
-        if let Some(config_space_bytes) = self.config_space.as_slice().get(u64_to_usize(offset)..) {
-            let len = config_space_bytes.len().min(data.len());
-            data[..len].copy_from_slice(&config_space_bytes[..len]);
-        } else {
-            error!("Failed to read config space");
-            self.metrics.cfg_fails.inc();
-        }
+    fn config_as_bytes(&self) -> &[u8] {
+        self.config_space.as_slice()
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {
@@ -815,28 +809,14 @@ mod tests {
     }
 
     #[test]
-    fn test_virtio_read_config() {
+    fn test_config_as_bytes() {
         for engine in [FileEngineType::Sync, FileEngineType::Async] {
             let block = default_block(engine);
 
-            let mut actual_config_space = ConfigSpace::default();
-            block.read_config(0, actual_config_space.as_mut_slice());
-            // This will read the number of sectors.
+            let config = block.config_as_bytes();
             // The block's backing file size is 0x1000, so there are 8 (4096/512) sectors.
-            // The config space is little endian.
             let expected_config_space = ConfigSpace { capacity: 8 };
-            assert_eq!(actual_config_space, expected_config_space);
-
-            // Invalid read.
-            let expected_config_space = ConfigSpace { capacity: 696969 };
-            actual_config_space = expected_config_space;
-            block.read_config(
-                std::mem::size_of::<ConfigSpace>() as u64 + 1,
-                actual_config_space.as_mut_slice(),
-            );
-
-            // Validate read failed (the config space was not updated).
-            assert_eq!(actual_config_space, expected_config_space);
+            assert_eq!(config, expected_config_space.as_slice());
         }
     }
 

--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -19,6 +19,7 @@ use crate::MutEventSubscriber;
 use crate::devices::virtio::AsAny;
 use crate::devices::virtio::generated::virtio_ids;
 use crate::logger::{error, info, warn};
+use crate::utils::u64_to_usize;
 use crate::vstate::memory::GuestMemoryMmap;
 
 /// State of an active VirtIO device
@@ -162,8 +163,23 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
         self.set_acked_features(self.acked_features() | v);
     }
 
+    /// Returns the full device-specific configuration as a byte slice.
+    ///
+    /// Each device returns its live config struct bytes here.
+    fn config_as_bytes(&self) -> &[u8];
+
     /// Reads this device configuration space at `offset`.
-    fn read_config(&self, offset: u64, data: &mut [u8]);
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        let config = self.config_as_bytes();
+        let offset = u64_to_usize(offset);
+        if let Some(config_from_offset) = config.get(offset..) {
+            let len = config_from_offset.len().min(data.len());
+            data[..len].copy_from_slice(&config_from_offset[..len]);
+            data[len..].fill(0);
+        } else {
+            data.fill(0);
+        }
+    }
 
     /// Writes to this device configuration space at `offset`.
     fn write_config(&mut self, offset: u64, data: &[u8]);
@@ -249,6 +265,7 @@ pub(crate) mod tests {
     struct MockVirtioDevice {
         avail_features: u64,
         acked_features: u64,
+        config: Vec<u8>,
     }
 
     impl MutEventSubscriber for MockVirtioDevice {
@@ -291,8 +308,8 @@ pub(crate) mod tests {
             todo!()
         }
 
-        fn read_config(&self, _offset: u64, _data: &mut [u8]) {
-            todo!()
+        fn config_as_bytes(&self) -> &[u8] {
+            &self.config
         }
 
         fn write_config(&mut self, _offset: u64, _data: &[u8]) {
@@ -317,6 +334,7 @@ pub(crate) mod tests {
         let mut device = MockVirtioDevice {
             avail_features: 0,
             acked_features: 0,
+            config: vec![],
         };
 
         let mock_feature_1 = 1u64;
@@ -338,6 +356,7 @@ pub(crate) mod tests {
         let mut device = MockVirtioDevice {
             avail_features: features,
             acked_features: 0,
+            config: vec![],
         };
 
         assert_eq!(
@@ -354,5 +373,49 @@ pub(crate) mod tests {
         }
 
         assert_eq!(device.acked_features, features);
+    }
+
+    #[test]
+    fn test_read_config_default() {
+        let device = MockVirtioDevice {
+            avail_features: 0,
+            acked_features: 0,
+            config: vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22],
+        };
+
+        // Exact read within bounds.
+        let mut buf = [0xFF; 8];
+        device.read_config(0, &mut buf);
+        assert_eq!(buf, [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22]);
+
+        // Partial read at valid offset (offset+len exceeds config size).
+        let mut buf = [0xFF; 8];
+        device.read_config(4, &mut buf);
+        assert_eq!(buf, [0xEE, 0xFF, 0x11, 0x22, 0, 0, 0, 0]);
+
+        // Fully out-of-bounds (offset == config size).
+        let mut buf = [0xFF; 4];
+        device.read_config(8, &mut buf);
+        assert_eq!(buf, [0, 0, 0, 0]);
+
+        // Fully out-of-bounds (offset > config size).
+        let mut buf = [0xFF; 4];
+        device.read_config(100, &mut buf);
+        assert_eq!(buf, [0, 0, 0, 0]);
+
+        // Sub-range read within bounds.
+        let mut buf = [0xFF; 2];
+        device.read_config(2, &mut buf);
+        assert_eq!(buf, [0xCC, 0xDD]);
+
+        // Empty config: any read returns zeros.
+        let empty_device = MockVirtioDevice {
+            avail_features: 0,
+            acked_features: 0,
+            config: vec![],
+        };
+        let mut buf = [0xFF; 4];
+        empty_device.read_config(0, &mut buf);
+        assert_eq!(buf, [0, 0, 0, 0]);
     }
 }

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -637,18 +637,8 @@ impl VirtioDevice for VirtioMem {
         self.acked_features = acked_features;
     }
 
-    fn read_config(&self, offset: u64, data: &mut [u8]) {
-        let offset = u64_to_usize(offset);
-        self.config
-            .as_slice()
-            .get(offset..offset + data.len())
-            .map(|s| data.copy_from_slice(s))
-            .unwrap_or_else(|| {
-                error!(
-                    "virtio-mem: Config read offset+length {offset}+{} out of bounds",
-                    data.len()
-                )
-            })
+    fn config_as_bytes(&self) -> &[u8] {
+        self.config.as_slice()
     }
 
     fn write_config(&mut self, offset: u64, _data: &[u8]) {
@@ -810,38 +800,23 @@ mod tests {
     }
 
     #[test]
-    fn test_read_config() {
+    fn test_config_as_bytes() {
         let mem = default_virtio_mem();
-        let mut data = [0u8; 8];
+        let config = mem.config_as_bytes();
 
-        mem.read_config(0, &mut data);
+        assert_eq!(config.len(), std::mem::size_of::<virtio_mem_config>());
         assert_eq!(
-            u64::from_le_bytes(data),
+            u64::from_le_bytes(config[0..8].try_into().unwrap()),
             mib_to_bytes(mem.block_size_mib()) as u64
         );
-
-        mem.read_config(16, &mut data);
-        assert_eq!(u64::from_le_bytes(data), 512 << 30);
-
-        mem.read_config(24, &mut data);
         assert_eq!(
-            u64::from_le_bytes(data),
+            u64::from_le_bytes(config[16..24].try_into().unwrap()),
+            512 << 30
+        );
+        assert_eq!(
+            u64::from_le_bytes(config[24..32].try_into().unwrap()),
             mib_to_bytes(mem.total_size_mib()) as u64
         );
-    }
-
-    #[test]
-    fn test_read_config_out_of_bounds() {
-        let mem = default_virtio_mem();
-
-        let mut data = [0u8; 8];
-        let config_size = std::mem::size_of::<virtio_mem_config>();
-        mem.read_config(config_size as u64, &mut data);
-        assert_eq!(data, [0u8; 8]); // Should remain unchanged
-
-        let mut data = vec![0u8; config_size];
-        mem.read_config(8, &mut data);
-        assert_eq!(data, vec![0u8; config_size]); // Should remain unchanged
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -1021,14 +1021,8 @@ impl VirtioDevice for Net {
             .deref()
     }
 
-    fn read_config(&self, offset: u64, data: &mut [u8]) {
-        if let Some(config_space_bytes) = self.config_space.as_slice().get(u64_to_usize(offset)..) {
-            let len = config_space_bytes.len().min(data.len());
-            data[..len].copy_from_slice(&config_space_bytes[..len]);
-        } else {
-            error!("Failed to read config space");
-            self.metrics.cfg_fails.inc();
-        }
+    fn config_as_bytes(&self) -> &[u8] {
+        self.config_space.as_slice()
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {
@@ -1266,20 +1260,14 @@ pub mod tests {
     }
 
     #[test]
-    fn test_virtio_device_read_config() {
+    fn test_config_as_bytes() {
         let mut net = default_net();
         set_mac(&mut net, MacAddr::from_str("11:22:33:44:55:66").unwrap());
 
-        // Test `read_config()`. This also validates the MAC was properly configured.
+        // Validate config_as_bytes returns the MAC address.
         let mac = MacAddr::from_str("11:22:33:44:55:66").unwrap();
-        let mut config_mac = [0u8; MAC_ADDR_LEN as usize];
-        net.read_config(0, &mut config_mac);
-        assert_eq!(&config_mac, mac.get_bytes());
-
-        // Invalid read.
-        config_mac = [0u8; MAC_ADDR_LEN as usize];
-        net.read_config(u64::from(MAC_ADDR_LEN), &mut config_mac);
-        assert_eq!(config_mac, [0u8, 0u8, 0u8, 0u8, 0u8, 0u8]);
+        let config = net.config_as_bytes();
+        assert_eq!(&config[..MAC_ADDR_LEN as usize], mac.get_bytes());
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -549,19 +549,8 @@ impl VirtioDevice for Pmem {
             .deref()
     }
 
-    fn read_config(&self, offset: u64, data: &mut [u8]) {
-        if let Some(config_space_bytes) = self
-            .guest_region
-            .config_space
-            .as_slice()
-            .get(u64_to_usize(offset)..)
-        {
-            let len = config_space_bytes.len().min(data.len());
-            data[..len].copy_from_slice(&config_space_bytes[..len]);
-        } else {
-            error!("Failed to read config space");
-            self.metrics.cfg_fails.inc();
-        }
+    fn config_as_bytes(&self) -> &[u8] {
+        self.guest_region.config_space.as_slice()
     }
 
     fn write_config(&mut self, _offset: u64, _data: &[u8]) {}

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -299,7 +299,9 @@ impl VirtioDevice for Entropy {
         self.acked_features = acked_features;
     }
 
-    fn read_config(&self, _offset: u64, mut _data: &mut [u8]) {}
+    fn config_as_bytes(&self) -> &[u8] {
+        &[]
+    }
 
     fn write_config(&mut self, _offset: u64, _data: &[u8]) {}
 
@@ -374,21 +376,9 @@ mod tests {
     }
 
     #[test]
-    fn test_read_config() {
+    fn test_config_as_bytes() {
         let entropy_dev = default_entropy();
-        let mut config = vec![0; 10];
-
-        entropy_dev.read_config(0, &mut config);
-        assert_eq!(config, vec![0; 10]);
-
-        entropy_dev.read_config(1, &mut config);
-        assert_eq!(config, vec![0; 10]);
-
-        entropy_dev.read_config(2, &mut config);
-        assert_eq!(config, vec![0; 10]);
-
-        entropy_dev.read_config(1024, &mut config);
-        assert_eq!(config, vec![0; 10]);
+        assert!(entropy_dev.config_as_bytes().is_empty());
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/transport/mmio.rs
+++ b/src/vmm/src/devices/virtio/transport/mmio.rs
@@ -573,8 +573,8 @@ pub(crate) mod tests {
                 .deref()
         }
 
-        fn read_config(&self, offset: u64, data: &mut [u8]) {
-            data.copy_from_slice(&self.config_bytes[u64_to_usize(offset)..]);
+        fn config_as_bytes(&self) -> &[u8] {
+            &self.config_bytes
         }
 
         fn write_config(&mut self, offset: u64, data: &[u8]) {

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -41,7 +41,7 @@ use crate::devices::virtio::vsock::metrics::METRICS;
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, info, warn};
 use crate::utils::byte_order;
-use crate::vstate::memory::{Bytes, GuestMemoryMmap};
+use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap};
 
 pub(crate) const RXQ_INDEX: usize = 0;
 pub(crate) const TXQ_INDEX: usize = 1;
@@ -335,24 +335,16 @@ where
             .deref()
     }
 
-    fn read_config(&self, offset: u64, data: &mut [u8]) {
-        match offset {
-            0 if data.len() == 8 => byte_order::write_le_u64(data, self.cid()),
-            0 if data.len() == 4 => {
-                byte_order::write_le_u32(data, (self.cid() & 0xffff_ffff) as u32)
-            }
-            4 if data.len() == 4 => {
-                byte_order::write_le_u32(data, ((self.cid() >> 32) & 0xffff_ffff) as u32)
-            }
-            _ => {
-                METRICS.cfg_fails.inc();
-                warn!(
-                    "vsock: virtio-vsock received invalid read request of {} bytes at offset {}",
-                    data.len(),
-                    offset
-                )
-            }
-        }
+    fn config_as_bytes(&self) -> &[u8] {
+        // ByteValued::as_slice() gives native-endian bytes. Firecracker only
+        // targets little-endian platforms, matching virtio's LE config space;
+        // the static assert below makes a big-endian target a compile error
+        // rather than a silent mis-serialization.
+        const _: () = assert!(
+            cfg!(target_endian = "little"),
+            "virtio config requires a little-endian target"
+        );
+        self.cid.as_slice()
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {
@@ -511,32 +503,14 @@ mod tests {
         // as the device features.
         assert_eq!(ctx.device.acked_features, device_features & driver_features);
 
-        // Test reading 32-bit chunks.
-        let mut data = [0u8; 8];
-        ctx.device.read_config(0, &mut data[..4]);
-        assert_eq!(
-            u64::from(byte_order::read_le_u32(&data[..])),
-            ctx.cid & 0xffff_ffff
-        );
-        ctx.device.read_config(4, &mut data[4..]);
-        assert_eq!(
-            u64::from(byte_order::read_le_u32(&data[4..])),
-            (ctx.cid >> 32) & 0xffff_ffff
-        );
-
-        // Test reading 64-bit.
-        let mut data = [0u8; 8];
-        ctx.device.read_config(0, &mut data);
-        assert_eq!(byte_order::read_le_u64(&data), ctx.cid);
-
-        // Check that out-of-bounds reading doesn't mutate the destination buffer.
-        let mut data = [0u8, 1, 2, 3, 4, 5, 6, 7];
-        ctx.device.read_config(2, &mut data);
-        assert_eq!(data, [0u8, 1, 2, 3, 4, 5, 6, 7]);
+        // Validate config_as_bytes returns the CID in little-endian.
+        let config = ctx.device.config_as_bytes();
+        assert_eq!(config.len(), 8);
+        assert_eq!(byte_order::read_le_u64(config), ctx.cid);
 
         // Just covering lines here, since the vsock device has no writable config.
         // A warning is, however, logged, if the guest driver attempts to write any config data.
-        ctx.device.write_config(0, &data[..4]);
+        ctx.device.write_config(0, &[0u8; 4]);
 
         // Test a bad activation.
         // let bad_activate = ctx.device.activate(

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -196,27 +196,9 @@ pub(crate) mod tests {
             device_features & driver_features
         );
 
-        // Test reading 32-bit chunks.
-        let mut data = [0u8; 8];
-        restored_device.read_config(0, &mut data[..4]);
-        assert_eq!(
-            u64::from(byte_order::read_le_u32(&data[..])),
-            ctx.cid & 0xffff_ffff
-        );
-        restored_device.read_config(4, &mut data[4..]);
-        assert_eq!(
-            u64::from(byte_order::read_le_u32(&data[4..])),
-            (ctx.cid >> 32) & 0xffff_ffff
-        );
-
-        // Test reading 64-bit.
-        let mut data = [0u8; 8];
-        restored_device.read_config(0, &mut data);
-        assert_eq!(byte_order::read_le_u64(&data), ctx.cid);
-
-        // Check that out-of-bounds reading doesn't mutate the destination buffer.
-        let mut data = [0u8, 1, 2, 3, 4, 5, 6, 7];
-        restored_device.read_config(2, &mut data);
-        assert_eq!(data, [0u8, 1, 2, 3, 4, 5, 6, 7]);
+        // Validate config_as_bytes returns the CID in little-endian.
+        let config = restored_device.config_as_bytes();
+        assert_eq!(config.len(), 8);
+        assert_eq!(byte_order::read_le_u64(config), ctx.cid);
     }
 }


### PR DESCRIPTION
## Changes

Refactor the `VirtioDevice` config-read path to remove duplicated
`read_config()` boilerplate across the virtio devices:

- Add a `config_as_bytes(&self) -> &[u8]` method to the `VirtioDevice` trait,
  returning the device's raw config-space bytes.
- Provide a default `read_config()` on the trait that slices
  `config_as_bytes()` at the requested offset, so devices no longer each carry
  their own copy of that logic.
- Remove the now-redundant per-device `read_config()` implementations.

Each device returns its config bytes directly:

- Block / Net / Balloon / Pmem / VirtioMem: `self.config_space.as_slice()`
- Vsock: the stored CID little-endian bytes (`cid_config`)
- Entropy (rng): empty slice (no config)

## Reason

The per-device `read_config()` bodies were near-identical offset/copy logic.
Centralizing the slice-at-offset behavior in one default trait method removes
the duplication (net −86 lines) and makes the config-read contract a single,
testable implementation. This is a pure refactor: there is no change to the
bytes any device reports over its config space.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
