### PR TITLE
vmm: extract shared root= cmdline helper

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -48,7 +48,9 @@ use crate::resources::VmResources;
 use crate::seccomp::BpfThreadMap;
 use crate::snapshot::Persist;
 use crate::utils::mib_to_bytes;
-use crate::vmm_config::boot_source::{DEFAULT_KERNEL_CMDLINE, build_cmdline};
+use crate::vmm_config::boot_source::{
+    DEFAULT_KERNEL_CMDLINE, append_root_device_cmdline, build_cmdline,
+};
 use crate::vmm_config::instance_info::{InstanceInfo, VmState};
 use crate::vmm_config::machine_config::MachineConfigError;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
@@ -668,14 +670,11 @@ fn attach_block_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Block>>> + Debug>(
         let (id, is_vhost_user) = {
             let locked = block.lock().expect("Poisoned lock");
             if locked.root_device() {
-                match locked.partuuid() {
-                    Some(partuuid) => cmdline.insert_str(format!("root=PARTUUID={}", partuuid))?,
-                    None => cmdline.insert_str("root=/dev/vda")?,
-                }
-                match locked.read_only() {
-                    true => cmdline.insert_str("ro")?,
-                    false => cmdline.insert_str("rw")?,
-                }
+                append_root_device_cmdline(
+                    cmdline,
+                    locked.partuuid().as_deref(),
+                    locked.read_only(),
+                )?;
             }
             (locked.id().to_string(), locked.is_vhost_user())
         };

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -71,6 +71,22 @@ pub fn build_cmdline(s: &str) -> Result<cmdline::Cmdline, cmdline::Error> {
     cmdline::Cmdline::try_from(s, crate::arch::CMDLINE_MAX_SIZE)
 }
 
+/// Append the `root=` (and `ro`/`rw`) arguments derived from a root block
+/// device to `cmdline`. Uses `root=PARTUUID=<uuid>` when a partuuid is
+/// available, otherwise `root=/dev/vda`.
+pub fn append_root_device_cmdline(
+    cmdline: &mut cmdline::Cmdline,
+    partuuid: Option<&str>,
+    read_only: bool,
+) -> Result<(), cmdline::Error> {
+    match partuuid {
+        Some(uuid) => cmdline.insert_str(format!("root=PARTUUID={uuid}"))?,
+        None => cmdline.insert_str("root=/dev/vda")?,
+    }
+    cmdline.insert_str(if read_only { "ro" } else { "rw" })?;
+    Ok(())
+}
+
 impl BootConfig {
     /// Creates the BootConfig based on a given configuration.
     pub fn new(cfg: &BootSourceConfig) -> Result<Self, BootSourceConfigError> {


### PR DESCRIPTION
## Changes

Factor the root-device kernel-cmdline derivation out of `attach_block_devices`
into a reusable helper:

- Add `append_root_device_cmdline(cmdline, partuuid, read_only)` to
  `vmm_config::boot_source`. It appends `root=PARTUUID=<uuid>` when a partuuid
  is available, otherwise `root=/dev/vda`, followed by `ro` or `rw`.
- `attach_block_devices` (`builder.rs`) now calls the helper instead of
  open-coding the `root=` / `ro|rw` `insert_str` sequence inline.

## Reason

The `root=`/`ro|rw` derivation was inline in `attach_block_devices`. Extracting
it into `boot_source` gives a single, named, reusable entry point for building
the root-device portion of a kernel command line. This is a pure refactor with
no behavioral change: the resulting cmdline is byte-for-byte identical for the
existing path.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
