### PR TITLE
fix: interrupts: replay legacy GSI allocations on restore

### DIFF
--- a/src/vmm/src/device_manager/acpi.rs
+++ b/src/vmm/src/device_manager/acpi.rs
@@ -17,6 +17,8 @@ pub enum ACPIDeviceError {
     VmClock(#[from] VmClockError),
     /// Could not register IRQ with KVM: {0}
     RegisterIrq(#[from] kvm_ioctls::Error),
+    /// Resource allocator error: {0}
+    ResourceAllocator(#[from] vm_allocator::Error),
 }
 
 // Although both VMGenID and VMClock devices are always present, they should be instantiated when
@@ -65,6 +67,17 @@ impl ACPIDeviceManager {
     pub fn activate_vmclock(&self, vm: &KvmVm) -> Result<(), ACPIDeviceError> {
         vm.register_irq(&self.vmclock().interrupt_evt, self.vmclock().gsi)?;
         self.vmclock().activate(vm.guest_memory())?;
+        Ok(())
+    }
+
+    pub fn replay_gsi_allocations(&self, vm: &KvmVm) -> Result<(), ACPIDeviceError> {
+        let mut resource_allocator = vm.resource_allocator();
+        resource_allocator
+            .gsi_legacy_allocator
+            .allocate_id_at(self.vmgenid().gsi)?;
+        resource_allocator
+            .gsi_legacy_allocator
+            .allocate_id_at(self.vmclock().gsi)?;
         Ok(())
     }
 

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -282,6 +282,9 @@ impl MMIODeviceManager {
         // Create a new MMIODeviceInfo object on boot path or unwrap the
         // existing object on restore path.
         let device_info = if let Some(device_info) = device_info_opt {
+            vm.resource_allocator()
+                .gsi_legacy_allocator
+                .allocate_id_at(device_info.gsi.ok_or(MmioError::InvalidIrqConfig)?)?;
             device_info
         } else {
             let gsi = vm.resource_allocator().allocate_gsi_legacy(1)?;
@@ -342,6 +345,9 @@ impl MMIODeviceManager {
         // Create a new MMIODeviceInfo object on boot path or unwrap the
         // existing object on restore path.
         let device_info = if let Some(device_info) = device_info_opt {
+            vm.resource_allocator()
+                .gsi_legacy_allocator
+                .allocate_id_at(device_info.gsi.ok_or(MmioError::InvalidIrqConfig)?)?;
             device_info
         } else {
             let gsi = vm.resource_allocator().allocate_gsi_legacy(1)?;

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -678,6 +678,8 @@ pub enum DevicePersistError {
     VirtioMem(#[from] VirtioMemPersistError),
     /// Could not activate device: {0}
     DeviceActivation(#[from] ActivateError),
+    /// Resource allocator error: {0}
+    ResourceAllocator(#[from] vm_allocator::Error),
 }
 
 /// Errors for (de)serialization of the device manager.

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -193,6 +193,8 @@ impl<'a> Persist<'a> for ACPIDeviceManager {
             VmClock::restore((), &state.vmclock).unwrap(),
         );
 
+        acpi_devices.replay_gsi_allocations(vm)?;
+
         acpi_devices.activate_vmgenid(vm)?;
         acpi_devices.do_post_restore_vmgenid()?;
 
@@ -401,6 +403,10 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                 MmioTransport::restore(restore_args, state)
                     .map_err(|()| DevicePersistError::MmioTransport)?,
             ));
+
+            vm.resource_allocator()
+                .gsi_legacy_allocator
+                .allocate_id_at(device_info.gsi.ok_or(MmioError::InvalidIrqConfig)?)?;
 
             dev_manager.register_mmio_virtio(
                 vm,

--- a/src/vmm/src/vstate/resources.rs
+++ b/src/vmm/src/vstate/resources.rs
@@ -110,10 +110,11 @@ impl ResourceAllocator {
 }
 
 /// Serializable state for the resource allocator.
+///
+/// GSI allocators are reconstructed empty and repopulated from restored device state so malformed
+/// snapshots cannot provide allocator state that disagrees with the devices.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResourceAllocatorState {
-    /// Allocator for legacy device interrupt lines
-    pub gsi_legacy_allocator: IdAllocator,
     /// Allocator for memory in the 32-bit MMIO address space
     pub mmio32_memory: AddressAllocator,
     /// Allocator for memory in the 64-bit MMIO address space
@@ -137,7 +138,6 @@ impl<'a> Persist<'a> for ResourceAllocator {
 
     fn save(&self) -> Self::State {
         ResourceAllocatorState {
-            gsi_legacy_allocator: self.gsi_legacy_allocator.clone(),
             mmio32_memory: self.mmio32_memory.clone(),
             mmio64_memory: self.mmio64_memory.clone(),
             past_mmio64_memory: self.past_mmio64_memory.clone(),
@@ -150,7 +150,7 @@ impl<'a> Persist<'a> for ResourceAllocator {
         state: &Self::State,
     ) -> Result<Self, Self::Error> {
         Ok(ResourceAllocator {
-            gsi_legacy_allocator: state.gsi_legacy_allocator.clone(),
+            gsi_legacy_allocator: IdAllocator::new(arch::GSI_LEGACY_START, arch::GSI_LEGACY_END)?,
             gsi_msi_allocator: IdAllocator::new(arch::GSI_MSI_START, arch::GSI_MSI_END)?,
             mmio32_memory: state.mmio32_memory.clone(),
             mmio64_memory: state.mmio64_memory.clone(),
@@ -161,7 +161,7 @@ impl<'a> Persist<'a> for ResourceAllocator {
 }
 
 /// An unique ID allocator that allows management of IDs in a given interval.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IdAllocator {
     // Beginning of the range of IDs that we want to manage.
     range_base: u32,
@@ -356,7 +356,7 @@ mod tests {
         }
 
         #[test]
-        fn test_persist_omits_msi_gsi_allocator() {
+        fn test_persist_omits_gsi_allocators() {
             let mut allocator = ResourceAllocator::new();
 
             let legacy_gsi = allocator.allocate_gsi_legacy(1).unwrap()[0];
@@ -369,16 +369,16 @@ mod tests {
             let state = allocator.save();
             let mut restored = ResourceAllocator::restore((), &state).unwrap();
 
-            // Legacy GSIs and MMIO ranges are serialized, so their allocations survive restore.
-            assert_eq!(restored.allocate_gsi_legacy(1).unwrap()[0], legacy_gsi + 1);
+            // GSI allocators are intentionally omitted from ResourceAllocatorState and replayed by
+            // the restored devices, so they start empty after restore.
+            assert_eq!(restored.allocate_gsi_legacy(1).unwrap()[0], legacy_gsi);
+            assert_eq!(restored.allocate_gsi_msi(1).unwrap()[0], msi_gsi);
+
+            // Memory allocators are still serialized directly.
             restored
                 .mmio32_memory
                 .allocate(1024, 1024, AllocPolicy::ExactMatch(mmio_range.start()))
                 .unwrap_err();
-
-            // MSI GSIs are intentionally omitted from ResourceAllocatorState and replayed by the
-            // restored PCI devices, so the allocator starts empty after restore.
-            assert_eq!(restored.allocate_gsi_msi(1).unwrap()[0], msi_gsi);
         }
     }
 


### PR DESCRIPTION

## Changes

- Remove `legacy_gsi_allocator` from `ResourceAllocatorState`
- Replay legacy GSI allocations on restore

## Reason

This is a follow-up from PR #5952, where we replayed MSI-X GSI allocations on snapshot restore, to ensure all of the handed out GSIs are valid at restore time. As part of that PR, we changed the `IdAllocator` struct to use a bitmap, backed by the `BitVec` struct from `bitvec` crate.

`bitvec`'s implementation of serde deserialization doesn't handle malformed input gracefully, panicking instead of returning an error. Under normal conditions, where a well-formed snapshot is provided, such panics would never occur, but we would like to avoid a panic even under such conditions.

This also matches behaviour again across both the `IdAllocator`s used by Firecracker

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
