### PR TITLE
feat: enable THP for guest memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
   emits the microVM instance id under a top-level `id` field, and `properties`
   emits operator-defined key-value pairs under a top-level `properties` field.
   Each is opt-in and independent. See [metrics documentation](docs/metrics.md).
+- [#6003](https://github.com/firecracker-microvm/firecracker/pull/6003): Added a
+  new option `Transparent` for the `huge_pages` setting. If set, Firecracker
+  will use transparent huge pages for the guest memory via
+  `madvise(MADV_HUGEPAGE)`. Guest memory must be a multiple of 2MB when using
+  this option.
 
 ### Changed
 

--- a/docs/hugepages.md
+++ b/docs/hugepages.md
@@ -1,14 +1,49 @@
 # Backing Guest Memory by Huge Pages
 
-Firecracker supports backing the guest memory of a VM by 2MB hugetlbfs pages.
-This can be enabled by setting the `huge_pages` field of `PUT` or `PATCH`
-requests to the `/machine-config` endpoint to `2M`.
+Firecracker supports three modes for the `huge_pages` field of `PUT` or `PATCH`
+requests to the `/machine-config` endpoint:
 
-Backing guest memory by huge pages can bring performance improvements for
-specific workloads, due to less TLB contention and less overhead during
-virtual->physical address resolution. It can also help reduce the number of
-KVM_EXITS required to rebuild extended page tables post snapshot restore, as
-well as improve boot times (by up to 50% as measured by Firecracker's
+- `None` (default): Uses the host's default page size (typically 4K) with no
+  huge page behavior.
+- `Transparent`: Uses `madvise(MADV_HUGEPAGE)` to request transparent huge pages
+  for guest memory. Guest memory size must be a multiple of 2MB.
+- `2M`: Backs guest memory by 2MB hugetlbfs pages.
+
+## Transparent Huge Pages (THP)
+
+Setting `huge_pages` to `Transparent` enables transparent huge pages for guest
+memory via `madvise(MADV_HUGEPAGE)`. This allows the kernel to opportunistically
+back guest memory with huge pages without requiring a pre-allocated hugetlbfs
+pool.
+
+Note that while traditional THP uses PMD-sized pages (2MB on x86_64), the actual
+THP size depends on the CPU architecture. Modern kernels also support
+"multi-size THP" (mTHP), which can allocate pages in various power-of-2 sizes
+between the base page size and PMD size (e.g. 16K, 32K, 64K). Firecracker
+requires guest memory size to be a multiple of 2MB regardless of the THP size
+used by the host kernel.
+
+Limitations:
+
+- When vhost-user-blk devices are in use, guest memory is memfd-backed (shared
+  memory). THP for shared/shmem memory is controlled separately from anonymous
+  memory via `/sys/kernel/mm/transparent_hugepage/shmem_enabled` and may not be
+  enabled by default. Refer to the
+  [Linux Documentation on shmem THP][thp_shmem_docs] for details on how to
+  configure it.
+- THP does not integrate with UFFD; no transparent huge pages will be allocated
+  during userfault-handling while resuming from a snapshot.
+
+Please refer to the [Linux Documentation][thp_docs] for more information.
+
+## Hugetlbfs (2M)
+
+Setting `huge_pages` to `2M` backs guest memory by 2MB hugetlbfs pages. This can
+bring performance improvements for specific workloads, due to less TLB
+contention and less overhead during virtual->physical address resolution. It can
+also help reduce the number of KVM_EXITS required to rebuild extended page
+tables post snapshot restore, as well as improve boot times (by up to 50% as
+measured by Firecracker's
 [boot time performance tests](../tests/integration_tests/performance/test_boottime.py))
 
 Using hugetlbfs requires the host running Firecracker to have a pre-allocated
@@ -19,7 +54,7 @@ not try to reserve sufficient hugetlbfs pages at the time of the `mmap` call,
 trying to claim them from the pool on-demand. For details on how to manage this
 pool, please refer to the [Linux Documentation][hugetlbfs_docs].
 
-## Huge Pages and Snapshotting
+### Huge Pages and Snapshotting
 
 Restoring a Firecracker snapshot of a microVM backed by huge pages will also use
 huge pages to back the restored guest. There is no option to flip between
@@ -43,15 +78,6 @@ the device is unable to reclaim the hugepage backing of the guest and drop RSS.
 However, the balloon can still be inflated and used to restrict memory usage in
 the guest.
 
-## FAQ
-
-### Why does Firecracker not offer a transparent huge pages (THP) setting?
-
-Firecracker's guest memory can be memfd based. Linux (as of 6.1) does not offer
-a way to dynamically enable THP for such memory regions. Additionally, UFFD does
-not integrate with THP (no transparent huge pages will be allocated during
-userfaulting). Please refer to the [Linux Documentation][thp_docs] for more
-information.
-
 [hugetlbfs_docs]: https://docs.kernel.org/admin-guide/mm/hugetlbpage.html
 [thp_docs]: https://www.kernel.org/doc/html/next/admin-guide/mm/transhuge.html#hugepages-in-tmpfs-shmem
+[thp_shmem_docs]: https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#shmem-internal-tmpfs

--- a/src/firecracker/src/api_server/request/machine_configuration.rs
+++ b/src/firecracker/src/api_server/request/machine_configuration.rs
@@ -104,6 +104,7 @@ mod tests {
 
         let huge_pages_cases = [
             ("None", HugePageConfig::None),
+            ("Transparent", HugePageConfig::Transparent),
             ("2M", HugePageConfig::Hugetlbfs2M),
         ];
 

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1442,8 +1442,13 @@ definitions:
         type: string
         enum:
           - None
+          - Transparent
           - 2M
-        description: Which huge pages configuration (if any) should be used to back guest memory.
+        default: None
+        description: >-
+          Which huge pages configuration should be used to back guest memory.
+          "None" uses regular 4K pages. "Transparent" enables THP via
+          madvise(MADV_HUGEPAGE). "2M" uses explicit hugetlbfs 2MB pages.
 
   MemoryBackend:
     type: object

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -31,12 +31,12 @@ use crate::initrd::InitrdConfig;
 use zerocopy::IntoBytes;
 
 use crate::logger::warn;
-use crate::utils::{align_up, u64_to_usize, usize_to_u64};
+use crate::utils::{u64_to_usize, usize_to_u64};
 use crate::vmm_config::machine_config::MachineConfig;
 use crate::vstate::memory::{Address, Bytes, GuestAddress, GuestMemoryMmap, GuestRegionType};
 use crate::vstate::vcpu::KvmVcpuError;
 use crate::vstate::vm::KvmVm;
-use crate::{DeviceManager, Kvm, Vcpu, VcpuConfig, logger};
+use crate::{DeviceManager, Kvm, Vcpu, VcpuConfig, align_up, logger};
 
 /// Errors thrown while configuring aarch64 system.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -222,9 +222,9 @@ pub fn get_kernel_start() -> u64 {
 
 /// Returns the memory address where the initrd could be loaded.
 pub fn initrd_load_addr(guest_mem: &GuestMemoryMmap, initrd_size: usize) -> Option<u64> {
-    let rounded_size = align_up(
+    let rounded_size = align_up!(
         usize_to_u64(initrd_size),
-        usize_to_u64(super::GUEST_PAGE_SIZE),
+        usize_to_u64(super::GUEST_PAGE_SIZE)
     );
     GuestAddress(get_fdt_addr(guest_mem))
         .checked_sub(rounded_size)

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -42,14 +42,14 @@ use crate::cpu_config::x86_64::CpuConfiguration;
 use crate::device_manager::DeviceManager;
 use crate::initrd::InitrdConfig;
 use crate::logger::debug;
-use crate::utils::{align_down, u64_to_usize, usize_to_u64};
+use crate::utils::{u64_to_usize, usize_to_u64};
 use crate::vmm_config::machine_config::MachineConfig;
 use crate::vstate::memory::{
     Address, GuestAddress, GuestMemoryMmap, GuestMemoryRegion, GuestRegionType,
 };
 use crate::vstate::vcpu::KvmVcpuConfigureError;
 use crate::vstate::vm::KvmVm;
-use crate::{Vcpu, VcpuConfig, logger};
+use crate::{Vcpu, VcpuConfig, align_down, logger};
 use kvm::Kvm;
 use layout::{
     CMDLINE_START, MMIO32_MEM_SIZE, MMIO32_MEM_START, MMIO64_MEM_SIZE, MMIO64_MEM_START,
@@ -166,9 +166,9 @@ pub fn initrd_load_addr(guest_mem: &GuestMemoryMmap, initrd_size: usize) -> Opti
         return None;
     }
 
-    Some(align_down(
+    Some(align_down!(
         usize_to_u64(lowmem_size - initrd_size),
-        usize_to_u64(super::GUEST_PAGE_SIZE),
+        usize_to_u64(super::GUEST_PAGE_SIZE)
     ))
 }
 

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -1017,7 +1017,6 @@ pub(crate) mod tests {
     use super::super::BALLOON_CONFIG_SPACE_SIZE;
     use super::*;
     use crate::arch::host_page_size;
-    use crate::check_metric_after_block;
     use crate::devices::virtio::balloon::report_balloon_event_fail;
     use crate::devices::virtio::balloon::test_utils::{
         check_request_completion, invoke_handler_for_queue_event, set_request,
@@ -1028,8 +1027,8 @@ pub(crate) mod tests {
     };
     use crate::devices::virtio::test_utils::{VirtQueue, default_interrupt, default_mem};
     use crate::test_utils::single_region_mem;
-    use crate::utils::align_up;
     use crate::vstate::memory::GuestAddress;
+    use crate::{align_up, check_metric_after_block};
 
     impl VirtioTestDevice for Balloon {
         fn set_queues(&mut self, queues: Vec<Queue>) {
@@ -1589,7 +1588,7 @@ pub(crate) mod tests {
         let page_size_chain = page_size as u32;
         let reporting_idx = th.device().free_page_reporting_idx();
 
-        let safe_addr = align_up(th.data_address(), page_size);
+        let safe_addr = align_up!(th.data_address(), page_size);
 
         th.add_scatter_gather(reporting_idx, 0, &[(0, safe_addr, page_size_chain, 0)]);
         check_metric_after_block!(
@@ -1644,7 +1643,7 @@ pub(crate) mod tests {
 
             let page_size = host_page_size() as u64;
             let hinting_idx = th.device().free_page_hinting_idx();
-            let safe_addr = align_up(th.data_address(), page_size);
+            let safe_addr = align_up!(th.data_address(), page_size);
 
             // Ack the config set on start
             th.device()

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -25,7 +25,7 @@ use crate::rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 use crate::utils::u64_to_usize;
 use crate::vmm_config::RateLimiterConfig;
 use crate::vmm_config::pmem::PmemConfig;
-use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap, GuestMmapRegion};
+use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap};
 use crate::vstate::vm::{KvmVm, VmError};
 use crate::{align_up, impl_device_type};
 

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -20,14 +20,14 @@ use crate::devices::virtio::pmem::PMEM_QUEUE_SIZE;
 use crate::devices::virtio::pmem::metrics::{PmemMetrics, PmemMetricsPerDevice};
 use crate::devices::virtio::queue::{DescriptorChain, InvalidAvailIdx, Queue, QueueError};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
-use crate::impl_device_type;
 use crate::logger::{IncMetric, error, info, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter, TokenType};
-use crate::utils::{align_up, u64_to_usize};
+use crate::utils::u64_to_usize;
 use crate::vmm_config::RateLimiterConfig;
 use crate::vmm_config::pmem::PmemConfig;
 use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap, GuestMmapRegion};
 use crate::vstate::vm::{KvmVm, VmError};
+use crate::{align_up, impl_device_type};
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum PmemError {
@@ -196,7 +196,7 @@ impl PmemMmap {
             prot |= libc::PROT_WRITE;
         }
 
-        let mmap_len = align_up(file_len, Self::ALIGNMENT);
+        let mmap_len = align_up!(file_len, Self::ALIGNMENT);
         let mmap_ptr = if (mmap_len == file_len) {
             // SAFETY: We are calling the system call with valid arguments and checking the returned
             // value

--- a/src/vmm/src/devices/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/test_utils.rs
@@ -9,11 +9,12 @@ use std::mem;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use crate::align_up;
 use crate::devices::virtio::queue::Queue;
 use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::devices::virtio::transport::mmio::IrqTrigger;
 use crate::test_utils::single_region_mem;
-use crate::utils::{align_up, u64_to_usize};
+use crate::utils::u64_to_usize;
 use crate::vstate::memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
 
 #[macro_export]
@@ -258,7 +259,7 @@ impl<'a> VirtQueue<'a> {
         const USED_ALIGN: u64 = 4;
 
         let mut x = avail.end().0;
-        x = align_up(x, USED_ALIGN);
+        x = align_up!(x, USED_ALIGN);
 
         let used = VirtqUsed::new(GuestAddress(x), mem, qsize, u64_to_usize(USED_ALIGN));
 

--- a/src/vmm/src/devices/virtio/vhost_user.rs
+++ b/src/vmm/src/devices/virtio/vhost_user.rs
@@ -487,6 +487,7 @@ pub(crate) mod tests {
                 libc::MAP_PRIVATE,
                 Some(file),
                 false,
+                libc::MADV_NORMAL,
             )
             .unwrap()
             .into_iter()

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -449,8 +449,13 @@ pub fn restore_from_snapshot(
                 .into());
             }
             (
-                guest_memory_from_file(mem_backend_path, mem_state, track_dirty_pages)
-                    .map_err(RestoreFromSnapshotGuestMemoryError::File)?,
+                guest_memory_from_file(
+                    mem_backend_path,
+                    mem_state,
+                    track_dirty_pages,
+                    vm_resources.machine_config.huge_pages,
+                )
+                .map_err(RestoreFromSnapshotGuestMemoryError::File)?,
                 None,
             )
         }
@@ -512,9 +517,11 @@ fn guest_memory_from_file(
     mem_file_path: &Path,
     mem_state: &GuestMemoryState,
     track_dirty_pages: bool,
+    huge_pages: HugePageConfig,
 ) -> Result<Vec<GuestRegionMmap>, GuestMemoryFromFileError> {
     let mem_file = File::open(mem_file_path)?;
-    let guest_mem = memory::snapshot_file(mem_file, mem_state.regions(), track_dirty_pages)?;
+    let guest_mem =
+        memory::snapshot_file(mem_file, mem_state.regions(), track_dirty_pages, huge_pages)?;
     Ok(guest_mem)
 }
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -580,6 +580,7 @@ mod tests {
     use crate::vmm_config::RateLimiterConfig;
     use crate::vmm_config::boot_source::{BootConfig, BootSource, BootSourceConfig};
     use crate::vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
+    use crate::vmm_config::machine_config::HugePageConfig::{Hugetlbfs2M, Transparent};
     use crate::vmm_config::machine_config::{HugePageConfig, MachineConfig, MachineConfigError};
     use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
     use crate::vmm_config::vsock::tests::default_config;
@@ -1474,6 +1475,26 @@ mod tests {
         assert_eq!(
             vm_resources.update_machine_config(&aux_vm_config),
             Err(MachineConfigError::InvalidMemorySize)
+        );
+
+        // Odd memory size - not supported by THP/Hugetlbfs
+        aux_vm_config.mem_size_mib = Some(1025);
+        aux_vm_config.huge_pages = Some(Transparent);
+        assert_eq!(
+            vm_resources.update_machine_config(&aux_vm_config),
+            Err(MachineConfigError::InvalidMemorySize)
+        );
+        aux_vm_config.huge_pages = Some(Hugetlbfs2M);
+        assert_eq!(
+            vm_resources.update_machine_config(&aux_vm_config),
+            Err(MachineConfigError::InvalidMemorySize)
+        );
+        // Odd size supported by HugePageConfig::None
+        aux_vm_config.huge_pages = Some(HugePageConfig::None);
+        vm_resources.update_machine_config(&aux_vm_config).unwrap();
+        assert_eq!(
+            MachineConfigUpdate::from(vm_resources.machine_config.clone()),
+            aux_vm_config
         );
 
         // Incompatible mem_size_mib with balloon size.

--- a/src/vmm/src/utils/mod.rs
+++ b/src/vmm/src/utils/mod.rs
@@ -54,16 +54,28 @@ pub const fn bytes_to_mib(bytes: usize) -> usize {
     bytes >> MIB_TO_BYTES_SHIFT
 }
 
-/// Align address up to the aligment.
-pub const fn align_up(addr: u64, align: u64) -> u64 {
-    debug_assert!(align != 0);
-    (addr + align - 1) & !(align - 1)
+/// Align address up to the alignment.
+///
+/// Works with any integer type (`u64`, `usize`, etc.).
+/// `$align` must be a power of two.
+#[macro_export]
+macro_rules! align_up {
+    ($addr:expr, $align:expr) => {{
+        debug_assert!($align != 0);
+        ($addr.wrapping_add($align - 1)) & !($align - 1)
+    }};
 }
 
-/// Align address down to the aligment.
-pub const fn align_down(addr: u64, align: u64) -> u64 {
-    debug_assert!(align != 0);
-    addr & !(align - 1)
+/// Align address down to the alignment.
+///
+/// Works with any integer type (`u64`, `usize`, etc.).
+/// `$align` must be a power of two.
+#[macro_export]
+macro_rules! align_down {
+    ($addr:expr, $align:expr) => {{
+        debug_assert!($align != 0);
+        $addr & !($align - 1)
+    }};
 }
 
 /// Create and open a file for both reading and writing to it with a O_NONBLOCK flag.
@@ -78,4 +90,118 @@ pub fn open_file_nonblock(path: &Path) -> Result<File, std::io::Error> {
         .read(true)
         .write(true)
         .open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_align_up_already_aligned() {
+        assert_eq!(align_up!(0u64, 4096u64), 0);
+        assert_eq!(align_up!(4096u64, 4096u64), 4096);
+        assert_eq!(align_up!(8192u64, 4096u64), 8192);
+        assert_eq!(align_up!(0x20_0000u64, 0x20_0000u64), 0x20_0000); // 2 MiB
+    }
+
+    #[test]
+    fn test_align_up_rounds_up() {
+        assert_eq!(align_up!(1u64, 4096u64), 4096);
+        assert_eq!(align_up!(4095u64, 4096u64), 4096);
+        assert_eq!(align_up!(4097u64, 4096u64), 8192);
+        assert_eq!(align_up!(0x10_0001u64, 0x20_0000u64), 0x20_0000); // 1 MiB + 1 -> 2 MiB
+    }
+
+    #[test]
+    fn test_align_up_power_of_two_alignments() {
+        for shift in 1..20 {
+            let align = 1u64 << shift;
+            // One byte before alignment boundary rounds up.
+            assert_eq!(align_up!(align - 1, align), align);
+            // Exact boundary stays.
+            assert_eq!(align_up!(align, align), align);
+            // One byte after boundary rounds to next.
+            assert_eq!(align_up!(align + 1, align), align * 2);
+        }
+    }
+
+    #[test]
+    fn test_align_up_alignment_of_one() {
+        // Alignment of 1 is a no-op: every address is 1-aligned.
+        assert_eq!(align_up!(0u64, 1u64), 0);
+        assert_eq!(align_up!(1u64, 1u64), 1);
+        assert_eq!(align_up!(123u64, 1u64), 123);
+    }
+
+    #[test]
+    fn test_align_up_works_with_usize() {
+        let test_cases: &[(usize, usize)] = &[
+            (0, 4096),
+            (1, 4096),
+            (4095, 4096),
+            (4096, 4096),
+            (4097, 4096),
+            (0x1F_FFFF, 0x20_0000),
+            (0x20_0000, 0x20_0000),
+            (0x20_0001, 0x20_0000),
+        ];
+        for &(addr, align) in test_cases {
+            assert_eq!(
+                align_up!(addr, align),
+                u64_to_usize(align_up!(usize_to_u64(addr), usize_to_u64(align))),
+                "mismatch for addr={addr:#x} align={align:#x}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_align_down_already_aligned() {
+        assert_eq!(align_down!(0u64, 4096u64), 0);
+        assert_eq!(align_down!(4096u64, 4096u64), 4096);
+        assert_eq!(align_down!(8192u64, 4096u64), 8192);
+        assert_eq!(align_down!(0x20_0000u64, 0x20_0000u64), 0x20_0000); // 2 MiB
+    }
+
+    #[test]
+    fn test_align_down_rounds_down() {
+        assert_eq!(align_down!(1u64, 4096u64), 0);
+        assert_eq!(align_down!(4095u64, 4096u64), 0);
+        assert_eq!(align_down!(4097u64, 4096u64), 4096);
+        assert_eq!(align_down!(0x2F_FFFF_u64, 0x20_0000u64), 0x20_0000); // 3 MiB - 1 -> 2 MiB
+    }
+
+    #[test]
+    fn test_align_down_power_of_two_alignments() {
+        for shift in 1..20 {
+            let align = 1u64 << shift;
+            // One byte before alignment boundary rounds down.
+            assert_eq!(align_down!(align - 1, align), 0);
+            // Exact boundary stays.
+            assert_eq!(align_down!(align, align), align);
+            // One byte after boundary stays at boundary.
+            assert_eq!(align_down!(align + 1, align), align);
+        }
+    }
+
+    #[test]
+    fn test_align_down_alignment_of_one() {
+        // Alignment of 1 is a no-op: every address is 1-aligned.
+        assert_eq!(align_down!(0u64, 1u64), 0);
+        assert_eq!(align_down!(1u64, 1u64), 1);
+        assert_eq!(align_down!(123u64, 1u64), 123);
+    }
+
+    #[test]
+    fn test_align_up_and_down_relationship() {
+        // For any aligned address, both functions are identity.
+        // For non-aligned addresses, align_down < addr < align_up.
+        for shift in [12, 16, 21] {
+            let align = 1u64 << shift;
+            for offset in [1u64, align / 2, align - 1] {
+                let addr = align + offset;
+                assert_eq!(align_down!(addr, align), align);
+                assert_eq!(align_up!(addr, align), align * 2);
+            }
+        }
+    }
 }

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -34,9 +34,11 @@ pub enum MachineConfigError {
 /// Describes the possible (huge)page configurations for a microVM's memory.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HugePageConfig {
-    /// Do not use hugepages, e.g. back guest memory by 4K
+    /// Back guest memory by 4K pages, no hugepage behavior
     #[default]
     None,
+    /// Use madvise(MADV_HUGEPAGE) for transparent huge pages
+    Transparent,
     /// Back guest memory by 2MB hugetlbfs pages
     #[serde(rename = "2M")]
     Hugetlbfs2M,
@@ -49,6 +51,10 @@ impl HugePageConfig {
         let divisor = match self {
             // Any integer memory size expressed in MiB will be a multiple of 4096KiB.
             HugePageConfig::None => 1,
+            // Note: THP technically supports memory not multiple of 2MB, however that disables some optimizations done
+            // by the kernel (e.g. automatic memory alignment on Linux 6.4+).
+            // To avoid performance/fragmentation surprises, having a memory multiple of 2MB is wiser.
+            HugePageConfig::Transparent => 2,
             HugePageConfig::Hugetlbfs2M => 2,
         };
 
@@ -59,8 +65,17 @@ impl HugePageConfig {
     /// create a mapping backed by huge pages as described by this [`HugePageConfig`].
     pub fn mmap_flags(&self) -> libc::c_int {
         match self {
-            HugePageConfig::None => 0,
+            HugePageConfig::None | HugePageConfig::Transparent => 0,
             HugePageConfig::Hugetlbfs2M => libc::MAP_HUGETLB | libc::MAP_HUGE_2MB,
+        }
+    }
+
+    /// Returns the flags required to pass to [libc::madvise], after allocating anonymous guest memory.
+    /// Note: returning [libc::MADV_NORMAL] might skip the call to `madvise` entirely.
+    pub fn madvise_flags(&self) -> libc::c_int {
+        match self {
+            HugePageConfig::Transparent => libc::MADV_HUGEPAGE,
+            HugePageConfig::None | HugePageConfig::Hugetlbfs2M => libc::MADV_NORMAL,
         }
     }
 
@@ -72,7 +87,7 @@ impl HugePageConfig {
     /// Gets the page size in bytes of this [`HugePageConfig`].
     pub fn page_size(&self) -> usize {
         match self {
-            HugePageConfig::None => 4096,
+            HugePageConfig::None | HugePageConfig::Transparent => 4096,
             HugePageConfig::Hugetlbfs2M => 2 * 1024 * 1024,
         }
     }
@@ -81,7 +96,7 @@ impl HugePageConfig {
 impl From<HugePageConfig> for Option<memfd::HugetlbSize> {
     fn from(value: HugePageConfig) -> Self {
         match value {
-            HugePageConfig::None => None,
+            HugePageConfig::None | HugePageConfig::Transparent => None,
             HugePageConfig::Hugetlbfs2M => Some(memfd::HugetlbSize::Huge2MB),
         }
     }

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -5,10 +5,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+use std::ffi::c_void;
 use std::fs::File;
 use std::io;
 use std::io::SeekFrom;
 use std::ops::Deref;
+use std::os::fd::AsRawFd;
 use std::sync::{Arc, Mutex};
 
 use bitvec::vec::BitVec;
@@ -27,17 +29,17 @@ use vm_memory::{
 
 use crate::arch::host_page_size;
 use crate::logger::error;
-use crate::utils::u64_to_usize;
+use crate::utils::{mib_to_bytes, u64_to_usize};
 use crate::vmm_config::machine_config::HugePageConfig;
 use crate::vstate::vm::{KvmVm, VmError};
-use crate::{DirtyBitmap, warn_unrestricted};
+use crate::{DirtyBitmap, align_up, warn_unrestricted};
 
-/// Type of GuestRegionMmap.
-pub type GuestRegionMmap = vm_memory::GuestRegionMmap<Option<AtomicBitmap>>;
 /// Type of GuestMemoryMmap.
 pub type GuestMemoryMmap = vm_memory::GuestRegionCollection<GuestRegionMmapExt>;
-/// Type of GuestMmapRegion.
-pub type GuestMmapRegion = vm_memory::MmapRegion<Option<AtomicBitmap>>;
+
+/// The alignment used to allocate guest memory.
+/// Chosen to enable optimizations on host kernel, e.g. allow huge pages at the beginning of the memory space.
+const GUEST_MEMORY_ALIGNMENT: usize = mib_to_bytes(2);
 
 /// Errors associated with dumping guest memory to file.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -56,6 +58,8 @@ pub enum MemoryError {
     OffsetTooLarge,
     /// Cannot retrieve snapshot file metadata: {0}
     FileMetadata(std::io::Error),
+    /// Memory region has zero size
+    ZeroSize,
     /// Memory region has zero slots
     ZeroSlots,
     /// Memory region of {region_size} bytes is not evenly divisible into {slot_count} slots
@@ -96,6 +100,262 @@ pub enum GuestRegionType {
     Dram,
     /// Hotpluggable memory
     Hotpluggable,
+}
+
+/// A region of guest memory. Unmapped on drop.
+/// This struct doesn't provide any facility to access the memory or read its properties, see [GuestRegionMmap].
+#[derive(Debug)]
+struct RawGuestRegionMmap {
+    mmap_address: *mut u8,
+    mmap_size: usize,
+}
+
+impl RawGuestRegionMmap {
+    /// Allocates a `PROT_NONE` region of memory, aligned to [`GUEST_MEMORY_ALIGNMENT`] (2 MiB).
+    ///
+    /// To actually use the memory, callers must either re-map it (e.g. with `MAP_FIXED`) or use
+    /// [`Self::allocate`] which does this automatically.
+    ///
+    /// # Size rounding
+    ///
+    /// The returned `mmap_size` may be **larger** than `requested_size`: it is rounded up to the
+    /// nearest multiple of the host page size (typically 4 KiB). This is because `mmap`/`munmap`
+    /// operate at page granularity — the kernel cannot map or protect a partial page. For example,
+    /// requesting 5000 bytes on a 4 KiB-page host yields an `mmap_size` of 8192 bytes (2 pages).
+    ///
+    /// The invariant is: `mmap_size == align_up!(requested_size, page_size)`.
+    fn allocate_protected(requested_size: usize) -> Result<Self, MemoryError> {
+        // Strategy: over-allocate by 2 MiB, then trim the unaligned head and tail via munmap,
+        // leaving a 2 MiB-aligned region of `size_page_multiple` bytes.
+        //
+        //         ptr                          ptr + alloc_size
+        //          |                                  |
+        //          v                                  v
+        //          +------+------------------+--------+
+        //          | head |   guest memory   |  tail  |
+        //          +------+------------------+--------+
+        //                 ^                  ^
+        //                 |                  |
+        //           aligned_ptr       aligned_ptr + size_page_multiple
+        //          (2 MiB-aligned)
+        //
+        //  1. Round requested_size up to page size -> `size_page_multiple`.
+        //  2. mmap(`size_page_multiple + 2 MiB`) -> `ptr` (page-aligned, not necessarily 2 MiB-aligned).
+        //  3. Compute `aligned_ptr` = first 2 MiB boundary ≥ `ptr`.
+        //  4. munmap the head (`ptr..aligned_ptr`) and tail (`aligned_ptr + size_page_multiple..end`).
+        //  5. Return the 2 MiB-aligned region of `size_page_multiple` bytes.
+        if requested_size == 0 {
+            return Err(MemoryError::ZeroSize);
+        }
+        let page_size = host_page_size();
+        let size_page_multiple = align_up!(requested_size, page_size);
+
+        // Over-allocate to guarantee we can find a 2 MiB-aligned sub-region of the desired size.
+        let alloc_size = size_page_multiple + GUEST_MEMORY_ALIGNMENT;
+
+        // SAFETY: anonymous private mapping with no fd; does not alias existing memory.
+        // The returned region is PROT_NONE (inaccessible) until the caller re-maps it.
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                alloc_size,
+                libc::PROT_NONE,
+                libc::MAP_PRIVATE | libc::MAP_NORESERVE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            return Err(MemoryError::MmapRegionError(MmapRegionError::Mmap(
+                std::io::Error::last_os_error(),
+            )));
+        }
+
+        // Find the first 2 MiB-aligned address within the allocation.
+        let aligned_ptr = align_up!(ptr as usize, GUEST_MEMORY_ALIGNMENT);
+
+        // Compute head/tail sizes to trim. Both are guaranteed to be page-aligned because
+        // `ptr` is page-aligned (from mmap), `aligned_ptr` is 2 MiB-aligned (a multiple of
+        // page size), and `size_page_multiple` is a page multiple by construction.
+        let head_size = aligned_ptr - ptr as usize;
+        let tail_size = alloc_size - head_size - size_page_multiple;
+
+        // Sanity checks: the three parts must exactly partition the allocation.
+        assert_eq!(
+            head_size + size_page_multiple + tail_size,
+            alloc_size,
+            "Allocated memory is not fully partitioned"
+        );
+        assert_eq!(
+            ptr as usize + head_size,
+            aligned_ptr,
+            "Head and aligned portion aren't adjacent"
+        );
+        assert_eq!(
+            aligned_ptr + size_page_multiple,
+            ptr as usize + alloc_size - tail_size,
+            "Tail and aligned portion aren't adjacent"
+        );
+        assert_eq!(
+            head_size % page_size,
+            0,
+            "head size is not a multiple of page-size"
+        );
+        assert_eq!(
+            tail_size % page_size,
+            0,
+            "tail size is not a multiple of page-size"
+        );
+
+        // Unmap the head and tail to release them back to the kernel.
+        // Failures are non-critical (at worst we leak a `PROT_NONE` VMA slot), so we only print a warning.
+        if head_size > 0 {
+            // SAFETY: `ptr` is page-aligned and `head_size` is a page multiple within our mapping.
+            let ret = unsafe { libc::munmap(ptr, head_size) };
+            if ret != 0 {
+                warn_unrestricted!("munmap failed: {}", std::io::Error::last_os_error(),);
+            }
+        }
+        if tail_size > 0 {
+            // SAFETY: address is page-aligned and `tail_size` is a page multiple within our mapping.
+            let ret = unsafe {
+                libc::munmap((aligned_ptr + size_page_multiple) as *mut c_void, tail_size)
+            };
+            if ret != 0 {
+                warn_unrestricted!("munmap failed: {}", std::io::Error::last_os_error(),);
+            }
+        }
+
+        Ok(Self {
+            mmap_address: aligned_ptr as *mut u8,
+            mmap_size: size_page_multiple,
+        })
+    }
+
+    /// Allocates a region of memory of the given size, aligned with [GUEST_MEMORY_ALIGNMENT].
+    ///
+    /// Note: the returned region of memory might be bigger than the requested size, as it is aligned to page-size.
+    fn allocate(
+        size: usize,
+        prot: libc::c_int,
+        flags: libc::c_int,
+        fd: libc::c_int,
+        offset: libc::off_t,
+    ) -> Result<Self, MemoryError> {
+        // This function works by doing a mmap fixed over a GuestMmapRegion allocated with PROT_NONE.
+        let ret = Self::allocate_protected(size)?;
+
+        // SAFETY: this mmap is performed over the same memory region we just allocated, so it's
+        // guarantee it's not in use elsewhere.
+        let addr = unsafe {
+            libc::mmap(
+                ret.mmap_address.cast::<c_void>(),
+                ret.mmap_size,
+                prot,
+                flags | libc::MAP_FIXED,
+                fd,
+                offset,
+            )
+        };
+        if addr == libc::MAP_FAILED {
+            return Err(MemoryError::MmapRegionError(MmapRegionError::Mmap(
+                std::io::Error::last_os_error(),
+            )));
+        }
+        assert_eq!(
+            addr.cast::<u8>(),
+            ret.mmap_address,
+            "mmap fixed returned a different address"
+        );
+
+        Ok(ret)
+    }
+}
+
+impl Drop for RawGuestRegionMmap {
+    fn drop(&mut self) {
+        // SAFETY: All memory access is done via GuestRegionMmap, and at this point there are no references to that.
+        let ret = unsafe { libc::munmap(self.mmap_address.cast::<c_void>(), self.mmap_size) };
+        // Panicking if unmapping failed: otherwise the guest memory might still be accessible after drop!
+        assert_eq!(ret, 0, "munmap of guest region failed");
+    }
+}
+
+/// SAFETY: Send and Sync aren't automatically inherited for the raw address pointer.
+/// RawGuestRegionMmap exclusively owns the memory region and doesn't expose the raw pointer for concurrent mutation.
+unsafe impl Send for RawGuestRegionMmap {}
+/// SAFETY: See comment above.
+unsafe impl Sync for RawGuestRegionMmap {}
+
+/// A region of guest memory. Unmapped on drop.
+/// Note: this implements automatic defer for vm_memory::GuestRegionMmap, so it can be used in its place.
+#[derive(Debug)]
+pub struct GuestRegionMmap {
+    /// Held for its `Drop` impl which unmaps the guest memory region.
+    _region: RawGuestRegionMmap,
+    proxy: vm_memory::GuestRegionMmap<Option<AtomicBitmap>>,
+}
+
+impl Deref for GuestRegionMmap {
+    type Target = vm_memory::GuestRegionMmap<Option<AtomicBitmap>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.proxy
+    }
+}
+
+impl GuestRegionMmap {
+    /// Creates a new [GuestRegionMmap], by actually allocating the guest memory with the given properties.
+    fn allocate(
+        guest_base: GuestAddress,
+        size: usize,
+        prot: libc::c_int,
+        flags: libc::c_int,
+        file_offset: Option<FileOffset>,
+        track_dirty_pages: bool,
+    ) -> Result<Self, MemoryError> {
+        let (fd, offset) = if let Some(ref f_off) = file_offset {
+            let fd = f_off.file().as_raw_fd();
+            let offset = f_off
+                .start()
+                .try_into()
+                .map_err(|_| MemoryError::OffsetTooLarge)?;
+            (fd, offset)
+        } else {
+            (-1, 0)
+        };
+        let region = RawGuestRegionMmap::allocate(size, prot, flags, fd, offset)?;
+
+        let mut builder = MmapRegionBuilder::new_with_bitmap(
+            size,
+            track_dirty_pages.then(|| AtomicBitmap::with_len(size)),
+        )
+        .with_mmap_prot(prot)
+        .with_mmap_flags(flags);
+
+        if let Some(file_offset) = file_offset {
+            builder = builder.with_file_offset(file_offset);
+        }
+
+        // SAFETY: the memory mapping is valid, and has the same flags passed to builder.
+        unsafe {
+            builder = builder.with_raw_mmap_pointer(region.mmap_address);
+        }
+
+        let mmap_region = builder.build().map_err(MemoryError::MmapRegionError)?;
+        // The memory cannot be double-owned: OwnedRegionMmap should be responsible for deallocation
+        assert!(!mmap_region.owned());
+        // `region` and `mapping` need to point to the same address.
+        assert_eq!(region.mmap_address, mmap_region.as_ptr());
+        // Size might differ, as region.mmap_size is page-aligned. But it for sure cannot be smaller.
+        assert!(region.mmap_size >= mmap_region.size());
+
+        Ok(GuestRegionMmap {
+            _region: region,
+            proxy: vm_memory::GuestRegionMmap::new(mmap_region, guest_base)
+                .ok_or(MemoryError::VmMemoryError)?,
+        })
+    }
 }
 
 /// An extension to GuestMemoryRegion that can be split into multiple KVM slots of
@@ -539,43 +799,32 @@ pub fn create(
     let file = file.map(Arc::new);
     regions
         .map(|(start, size)| {
-            let mut builder = MmapRegionBuilder::new_with_bitmap(
-                size,
-                track_dirty_pages.then(|| AtomicBitmap::with_len(size)),
-            )
-            .with_mmap_prot(libc::PROT_READ | libc::PROT_WRITE)
-            .with_mmap_flags(libc::MAP_NORESERVE | mmap_flags);
-
-            if let Some(ref file) = file {
-                let file_offset = FileOffset::from_arc(Arc::clone(file), offset);
-
-                builder = builder.with_file_offset(file_offset);
-            }
-
-            offset = match offset.checked_add(size as u64) {
-                None => return Err(MemoryError::OffsetTooLarge),
-                Some(new_off) if new_off >= i64::MAX as u64 => {
-                    return Err(MemoryError::OffsetTooLarge);
-                }
-                Some(new_off) => new_off,
-            };
-
-            GuestRegionMmap::new(
-                builder.build().map_err(MemoryError::MmapRegionError)?,
+            let guest_memory = GuestRegionMmap::allocate(
                 start,
-            )
-            .ok_or(MemoryError::VmMemoryError)
-            .inspect(|region| {
-                if madvise_flags != libc::MADV_NORMAL {
-                    // SAFETY: The referenced memory was just mapped.
-                    let ret = unsafe {
-                        libc::madvise(region.as_ptr().cast(), region.size(), madvise_flags)
-                    };
-                    if ret != 0 {
-                        return Err(MemoryError::Madvise(io::Error::last_os_error()));
-                    }
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_NORESERVE | mmap_flags,
+                file.as_ref()
+                    .map(|file| FileOffset::from_arc(Arc::clone(file), offset)),
+                track_dirty_pages,
+            )?;
+            offset = offset
+                .checked_add(size as u64)
+                .ok_or(MemoryError::OffsetTooLarge)?;
+            if madvise_flags != libc::MADV_NORMAL {
+                // SAFETY: The referenced memory was just mapped.
+                let ret = unsafe {
+                    libc::madvise(
+                        guest_memory.as_ptr().cast(),
+                        guest_memory.size(),
+                        madvise_flags,
+                    )
+                };
+                if ret != 0 {
+                    return Err(MemoryError::Madvise(io::Error::last_os_error()));
                 }
-            })
+            }
+            Ok(guest_memory)
         })
         .collect::<Result<Vec<_>, _>>()
 }

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -6,6 +6,7 @@
 // found in the THIRD-PARTY file.
 
 use std::fs::File;
+use std::io;
 use std::io::SeekFrom;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
@@ -24,12 +25,12 @@ use vm_memory::{
     GuestMemoryBackend, GuestMemoryError, GuestMemoryRegionBytes, VolatileSlice, WriteVolatile,
 };
 
-use crate::DirtyBitmap;
 use crate::arch::host_page_size;
 use crate::logger::error;
 use crate::utils::u64_to_usize;
 use crate::vmm_config::machine_config::HugePageConfig;
 use crate::vstate::vm::{KvmVm, VmError};
+use crate::{DirtyBitmap, warn_unrestricted};
 
 /// Type of GuestRegionMmap.
 pub type GuestRegionMmap = vm_memory::GuestRegionMmap<Option<AtomicBitmap>>;
@@ -66,6 +67,8 @@ pub enum MemoryError {
     },
     /// Error protecting memory slot: {0}
     Mprotect(std::io::Error),
+    /// Error calling madvise: {0}
+    Madvise(std::io::Error),
     /// Size too large for i64 conversion
     SlotSizeTooLarge,
     /// Dirty bitmap not found for memory slot {0}
@@ -530,6 +533,7 @@ pub fn create(
     mmap_flags: libc::c_int,
     file: Option<File>,
     track_dirty_pages: bool,
+    madvise_flags: libc::c_int,
 ) -> Result<Vec<GuestRegionMmap>, MemoryError> {
     let mut offset = 0;
     let file = file.map(Arc::new);
@@ -561,6 +565,17 @@ pub fn create(
                 start,
             )
             .ok_or(MemoryError::VmMemoryError)
+            .inspect(|region| {
+                if madvise_flags != libc::MADV_NORMAL {
+                    // SAFETY: The referenced memory was just mapped.
+                    let ret = unsafe {
+                        libc::madvise(region.as_ptr().cast(), region.size(), madvise_flags)
+                    };
+                    if ret != 0 {
+                        return Err(MemoryError::Madvise(io::Error::last_os_error()));
+                    }
+                }
+            })
         })
         .collect::<Result<Vec<_>, _>>()
 }
@@ -579,6 +594,7 @@ pub fn memfd_backed(
         libc::MAP_SHARED | huge_pages.mmap_flags(),
         Some(memfd_file),
         track_dirty_pages,
+        huge_pages.madvise_flags(),
     )
 }
 
@@ -593,6 +609,7 @@ pub fn anonymous(
         libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | huge_pages.mmap_flags(),
         None,
         track_dirty_pages,
+        huge_pages.madvise_flags(),
     )
 }
 
@@ -602,6 +619,7 @@ pub fn snapshot_file(
     file: File,
     regions: impl Iterator<Item = (GuestAddress, usize)>,
     track_dirty_pages: bool,
+    huge_pages: HugePageConfig,
 ) -> Result<Vec<GuestRegionMmap>, MemoryError> {
     let regions: Vec<_> = regions.collect();
     let memory_size = regions
@@ -621,6 +639,7 @@ pub fn snapshot_file(
         libc::MAP_PRIVATE,
         Some(file),
         track_dirty_pages,
+        huge_pages.madvise_flags(),
     )
 }
 
@@ -953,8 +972,13 @@ mod tests {
             file.write_all(&vec![0x42u8; page_size]).unwrap();
 
             let regions = vec![(GuestAddress(0), page_size)];
-            let guest_regions =
-                snapshot_file(file, regions.into_iter(), dirty_page_tracking).unwrap();
+            let guest_regions = snapshot_file(
+                file,
+                regions.into_iter(),
+                dirty_page_tracking,
+                HugePageConfig::None,
+            )
+            .unwrap();
             assert_eq!(guest_regions.len(), 1);
             guest_regions.iter().for_each(|region| {
                 assert_eq!(region.bitmap().is_some(), dirty_page_tracking);
@@ -975,7 +999,8 @@ mod tests {
             (GuestAddress(0x10000), page_size),
             (GuestAddress(0x20000), page_size),
         ];
-        let guest_regions = snapshot_file(file, regions.into_iter(), false).unwrap();
+        let guest_regions =
+            snapshot_file(file, regions.into_iter(), false, HugePageConfig::None).unwrap();
         assert_eq!(guest_regions.len(), 3);
     }
 
@@ -987,7 +1012,7 @@ mod tests {
         file.write_all(&vec![0x42u8; page_size]).unwrap();
 
         let regions = vec![(GuestAddress(0), 2 * page_size)];
-        let result = snapshot_file(file, regions.into_iter(), false);
+        let result = snapshot_file(file, regions.into_iter(), false, HugePageConfig::None);
         assert!(matches!(result.unwrap_err(), MemoryError::OffsetTooLarge));
     }
 
@@ -1177,8 +1202,15 @@ mod tests {
         let mut memory_file = TempFile::new().unwrap().into_file();
         guest_memory.dump(&mut memory_file).unwrap();
 
-        let restored_guest_memory =
-            into_region_ext(snapshot_file(memory_file, memory_state.regions(), false).unwrap());
+        let restored_guest_memory = into_region_ext(
+            snapshot_file(
+                memory_file,
+                memory_state.regions(),
+                false,
+                HugePageConfig::None,
+            )
+            .unwrap(),
+        );
 
         // Check that the region contents are the same.
         let mut restored_region = vec![0u8; page_size * 2];
@@ -1242,8 +1274,9 @@ mod tests {
             .unwrap();
 
         // We can restore from this because this is the first dirty dump.
-        let restored_guest_memory =
-            into_region_ext(snapshot_file(file, memory_state.regions(), false).unwrap());
+        let restored_guest_memory = into_region_ext(
+            snapshot_file(file, memory_state.regions(), false, HugePageConfig::None).unwrap(),
+        );
 
         // Check that the region contents are the same.
         let mut restored_region = vec![0u8; region_size];
@@ -1467,6 +1500,7 @@ mod tests {
                 memory_file,
                 std::iter::once((GuestAddress(0), 2 * page_size)),
                 false,
+                HugePageConfig::None,
             )
             .unwrap(),
         );

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -2175,4 +2175,108 @@ mod tests {
         ext.check_range_plugged(MemoryRegionAddress(0x2000), 0)
             .unwrap();
     }
+
+    /// Returns the (start, end) of the VMA containing `addr` in `/proc/self/maps`, if any.
+    fn find_vma_containing(addr: usize) -> Option<(usize, usize)> {
+        use std::io::BufRead;
+        let maps = std::fs::File::open("/proc/self/maps").unwrap();
+        for line in std::io::BufReader::new(maps).lines() {
+            let line = line.unwrap();
+            let range = line.split_whitespace().next().unwrap_or("");
+            let mut parts = range.split('-');
+            let start = usize::from_str_radix(parts.next().unwrap_or("0"), 16).unwrap_or(0);
+            let end = usize::from_str_radix(parts.next().unwrap_or("0"), 16).unwrap_or(0);
+            if addr >= start && addr < end {
+                return Some((start, end));
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_guest_region_errors_when_empty_size() {
+        assert!(matches!(
+            RawGuestRegionMmap::allocate_protected(0),
+            Err(MemoryError::ZeroSize)
+        ));
+    }
+
+    #[test]
+    fn test_guest_region_alignment_and_size() {
+        let page_size = host_page_size();
+        let huge_page_size = GUEST_MEMORY_ALIGNMENT;
+
+        // Base sizes: powers of two from 1 KiB to 16 MiB.
+        let base_sizes: Vec<usize> = (10..=24).map(|shift| 1usize << shift).collect();
+
+        // Offsets to apply to each base size.
+        // The idea is to test memory allocation for sizes that aren't necessarily page multiples.
+        let offsets: &[isize] = &[-1, 0, 1, 1023, 1024, 1025];
+
+        for base in base_sizes {
+            for offset in offsets {
+                let size = base.checked_add_signed(*offset).unwrap();
+
+                let region = RawGuestRegionMmap::allocate_protected(size).unwrap();
+                let addr = region.mmap_address as usize;
+
+                // Returned address is 2MB-aligned.
+                assert_eq!(
+                    addr % huge_page_size,
+                    0,
+                    "Address not 2MB-aligned for base={base:#x} offset={offset}"
+                );
+
+                // Returned size is the requested size rounded up to page alignment.
+                assert!(
+                    region.mmap_size >= size && region.mmap_size < size + page_size,
+                    "mmap_size {mmap_size} unexpected for size={size} (base={base:#x} \
+                     offset={offset})",
+                    mmap_size = region.mmap_size
+                );
+                assert_eq!(
+                    region.mmap_size % page_size,
+                    0,
+                    "mmap_size not page-aligned for base={base:#x} offset={offset}"
+                );
+
+                // Verify the VMA spans exactly the page-aligned size (head/tail unmapped).
+                let (vma_start, vma_end) = find_vma_containing(addr).unwrap_or_else(|| {
+                    panic!(
+                        "Aligned region not in /proc/self/maps for base={base:#x} offset={offset}"
+                    )
+                });
+                let vma_size = vma_end - vma_start;
+                // Note: the kernel might merge our VMA with a neighbor, we can only check that our region is
+                // contained within the (larger) merged VMA.
+                assert!(
+                    vma_start <= addr,
+                    "VMA start mismatch for base={base:#x} offset={offset}"
+                );
+                assert!(
+                    vma_size >= region.mmap_size,
+                    "VMA size mismatch for base={base:#x} offset={offset}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_guest_region_drop_reclaims_memory() {
+        let size = mib_to_bytes(4);
+        let region = RawGuestRegionMmap::allocate_protected(size).unwrap();
+        let addr = region.mmap_address as usize;
+
+        // The region should be mapped before drop.
+        assert!(find_vma_containing(addr).is_some());
+
+        // Drop the region.
+        drop(region);
+
+        // After drop, the memory should no longer be mapped.
+        assert!(
+            find_vma_containing(addr).is_none(),
+            "Memory was not reclaimed after drop"
+        );
+    }
 }

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -766,7 +766,6 @@ pub(crate) mod tests {
     use std::sync::atomic::Ordering;
 
     use vm_memory::GuestAddress;
-    use vm_memory::mmap::MmapRegionBuilder;
 
     use super::*;
     use crate::arch;
@@ -774,8 +773,9 @@ pub(crate) mod tests {
     use crate::snapshot::Persist;
     use crate::test_utils::single_region_mem_raw;
     use crate::utils::mib_to_bytes;
+    use crate::vmm_config::machine_config::HugePageConfig;
     use crate::vstate::kvm::Kvm;
-    use crate::vstate::memory::GuestRegionMmap;
+    use crate::vstate::memory::anonymous;
 
     // Auxiliary function being used throughout the tests.
     pub(crate) fn setup_vm() -> KvmVm {
@@ -821,33 +821,16 @@ pub(crate) mod tests {
         let mut vm = setup_vm();
         let max_nr_regions = vm.kvm().max_nr_memslots();
 
-        // SAFETY: valid mmap parameters
-        let ptr = unsafe {
-            libc::mmap(
-                std::ptr::null_mut(),
-                0x1000,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
-                -1,
-                0,
-            )
-        };
-
-        assert_ne!(ptr, libc::MAP_FAILED);
-
         for i in 0..=max_nr_regions {
-            // SAFETY: we assert above that the ptr is valid, and the size matches what we passed to
-            // mmap
-            let region = unsafe {
-                MmapRegionBuilder::new(0x1000)
-                    .with_raw_mmap_pointer(ptr.cast())
-                    .build()
-                    .unwrap()
-            };
+            let regions = anonymous(
+                vec![(GuestAddress(i as u64 * 0x1000), 0x1000)].into_iter(),
+                false,
+                HugePageConfig::None,
+            )
+            .unwrap();
+            assert_eq!(regions.len(), 1);
 
-            let region = GuestRegionMmap::new(region, GuestAddress(i as u64 * 0x1000)).unwrap();
-
-            let res = vm.register_dram_memory_regions(vec![region]);
+            let res = vm.register_dram_memory_regions(regions);
 
             if max_nr_regions <= i {
                 assert!(

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -187,6 +187,7 @@ class HugePagesConfig(str, Enum):
     """Enum describing the huge pages configurations supported Firecracker"""
 
     NONE = "None"
+    TRANSPARENT = "Transparent"
     HUGETLBFS_2MB = "2M"
 
 
@@ -274,6 +275,7 @@ class Microvm:
         self.iface = {}
         self.disks = {}
         self.disks_vhost_user = {}
+        self.huge_pages = HugePagesConfig.NONE
         self.vcpus_count = None
         self.mem_size_bytes = None
         self.cpu_template_name = "None"
@@ -816,7 +818,7 @@ class Microvm:
         boot_args: str = None,
         use_initrd: bool = False,
         track_dirty_pages: bool = False,
-        huge_pages: HugePagesConfig = None,
+        huge_pages: HugePagesConfig = HugePagesConfig.NONE,
         rootfs_io_engine=None,
         cpu_template: Optional[str] = None,
         enable_entropy_device=False,
@@ -844,6 +846,7 @@ class Microvm:
             track_dirty_pages=track_dirty_pages,
             huge_pages=huge_pages,
         )
+        self.huge_pages = huge_pages
         self.vcpus_count = vcpu_count
         self.mem_size_bytes = mem_size_mib * 2**20
 

--- a/tests/framework/static_analysis.py
+++ b/tests/framework/static_analysis.py
@@ -566,7 +566,11 @@ def load_seccomp_rules(seccomp_path: Path):
     """Loads seccomp rules from the given file, and presents them as a dictionary
     mapping syscalls to a list of individual filters. Each individual filter
     describes some restriction of the arguments that are allowed to be passed
-    to the syscall."""
+    to the syscall.
+
+    Each filter is a dict mapping arg_index to (val, mask) tuples.
+    For plain 'eq' comparisons, mask is None.
+    For 'masked_eq' comparisons, mask is the bitmask value."""
     filters = json.loads(seccomp_path.read_text("utf-8"))
 
     all_filters = (
@@ -577,9 +581,21 @@ def load_seccomp_rules(seccomp_path: Path):
     for seccomp_filter in all_filters:
         syscall_name = seccomp_filter["syscall"]
 
-        allowlist[syscall_name].append(
-            {arg["index"]: arg["val"] for arg in seccomp_filter.get("args", [])}
-        )
+        arg_constraints = {}
+        for arg in seccomp_filter.get("args", []):
+            op = arg["op"]
+            if isinstance(op, dict) and "masked_eq" in op:
+                mask = op["masked_eq"]
+            elif op == "eq":
+                mask = None
+            else:
+                raise ValueError(
+                    f"Unknown seccomp op '{op}' for syscall '{syscall_name}' arg {arg['index']}. "
+                    f"Please add support for this op in load_seccomp_rules and _arg_matches."
+                )
+            arg_constraints[arg["index"]] = (arg["val"], mask)
+
+        allowlist[syscall_name].append(arg_constraints)
 
     return allowlist
 
@@ -617,8 +633,8 @@ def determine_unneeded_seccomp_rules(seccomp_rules, found_syscalls):
             rule_not_needed = all(
                 any(
                     actual_invocations[arg_index] is not None
-                    and actual_invocations[arg_index] != allowed_arg
-                    for arg_index, allowed_arg in allowed_arguments.items()
+                    and not _arg_matches(actual_invocations[arg_index], val, mask)
+                    for arg_index, (val, mask) in allowed_arguments.items()
                 )
                 for actual_invocations in found_syscalls.get(syscall, [])
             )
@@ -627,3 +643,14 @@ def determine_unneeded_seccomp_rules(seccomp_rules, found_syscalls):
                 redundant_rules.append((syscall, allowed_arguments))
 
     return redundant_rules
+
+
+def _arg_matches(actual, val, mask):
+    """Check whether an actual argument value matches a seccomp rule constraint.
+
+    For plain 'eq' (mask is None): actual == val
+    For 'masked_eq': (actual & mask) == val
+    """
+    if mask is None:
+        return actual == val
+    return (actual & mask) == val

--- a/tests/integration_tests/functional/test_huge_pages.py
+++ b/tests/integration_tests/functional/test_huge_pages.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests that transparent huge pages are used (or not) based on configuration."""
+
+import re
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from framework import utils
+from framework.microvm import HugePagesConfig
+
+THP_ENABLED_PATH = Path("/sys/kernel/mm/transparent_hugepage/enabled")
+
+
+def get_host_thp_setting() -> Optional[str]:
+    """Get the current host THP setting (always, madvise, or never).
+
+    Returns `None` if the sysfs path does not exist or cannot be parsed.
+    """
+    if not THP_ENABLED_PATH.exists():
+        return None
+    content = THP_ENABLED_PATH.read_text(encoding="utf-8").strip()
+    # Format: "always [madvise] never" — the active option is in brackets
+    match = re.search(r"\[(\w+)]", content)
+    return match.group(1) if match else None
+
+
+def get_anon_huge_pages_kb(pid: int) -> int:
+    """Get total AnonHugePages in kB for a process from /proc/<pid>/smaps."""
+    cmd = f"awk '/AnonHugePages/{{sum += $2}} END{{print sum}}' /proc/{pid}/smaps"
+    _, stdout, _ = utils.check_output(cmd)
+    return int(stdout.strip())
+
+
+@pytest.mark.parametrize(
+    "huge_pages", [HugePagesConfig.NONE, HugePagesConfig.TRANSPARENT]
+)
+def test_transparent_huge_pages_allocation(uvm, huge_pages):
+    """
+    Test that allocating memory in the guest causes transparent huge pages
+    to appear on the host when configured, and not when disabled.
+    """
+    host_thp = get_host_thp_setting()
+
+    if huge_pages == HugePagesConfig.TRANSPARENT and host_thp not in {
+        "madvise",
+        "always",
+    }:
+        raise RuntimeError(
+            f"THP cannot be tested in this host. THP support must be enabled. "
+            f"/sys/kernel/mm/transparent_hugepage/enabled reports {host_thp}; madvise or always required"
+        )
+
+    vm = uvm
+    vm.spawn()
+    vm.basic_config(vcpu_count=2, mem_size_mib=256, huge_pages=huge_pages)
+    vm.add_net_iface()
+    vm.start()
+
+    # Allocate and touch anonymous memory inside the guest to trigger host-side
+    # page faults on the guest memory region (which is what THP backs).
+    vm.ssh.check_output("python3 -c 'x = bytearray(128 * 1024 * 1024)'")
+
+    anon_huge_kb = get_anon_huge_pages_kb(vm.firecracker_pid)
+
+    if huge_pages == HugePagesConfig.TRANSPARENT:
+        # With THP enabled, the kernel should have promoted some pages (let's say 64 MiB out of 128MiB)
+        assert (
+            anon_huge_kb > 64 * 1024
+        ), f"Expected AnonHugePages > 0 with Transparent huge pages, got {anon_huge_kb} kB"
+    else:
+        # With huge pages disabled, no anonymous huge pages should be present
+        assert (
+            anon_huge_kb == 0
+        ), f"Expected AnonHugePages == 0 with huge pages None, got {anon_huge_kb} kB"

--- a/tests/integration_tests/functional/test_pmem.py
+++ b/tests/integration_tests/functional/test_pmem.py
@@ -12,6 +12,11 @@ from tenacity import Retrying, stop_after_delay, wait_fixed
 import host_tools.drive as drive_tools
 from framework import utils
 from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel, pin_rootfs_mode
+from framework.microvm import HugePagesConfig
+
+pytestmark = pytest.mark.parametrize(
+    "huge_pages", [HugePagesConfig.NONE, HugePagesConfig.TRANSPARENT]
+)
 
 ALIGNMENT = 2 << 20
 
@@ -51,13 +56,13 @@ def check_pmem_exist(vm, index, root, read_only, size, extension):
     assert False
 
 
-def test_pmem_zero_size_backing_file(uvm):
+def test_pmem_zero_size_backing_file(uvm, huge_pages):
     """
     Test that a pmem device with a zero-sized backing file fails at boot time.
     """
     vm = uvm
     vm.spawn()
-    vm.basic_config(add_root_device=True)
+    vm.basic_config(add_root_device=True, huge_pages=huge_pages)
 
     zero_size_path = os.path.join(vm.fsfiles, "zero_scratch")
     utils.check_output(f"touch {zero_size_path}")
@@ -70,7 +75,7 @@ def test_pmem_zero_size_backing_file(uvm):
         vm.start()
 
 
-def test_pmem_add(uvm, microvm_factory):
+def test_pmem_add(uvm, huge_pages, microvm_factory):
     """
     Test addition of pmem devices to the VM and
     writes persistance
@@ -78,7 +83,7 @@ def test_pmem_add(uvm, microvm_factory):
 
     vm = uvm
     vm.spawn()
-    vm.basic_config(add_root_device=True)
+    vm.basic_config(add_root_device=True, huge_pages=huge_pages)
     vm.add_net_iface()
 
     # Pmem should work with non 2MB aligned files as well
@@ -122,7 +127,7 @@ def test_pmem_add(uvm, microvm_factory):
 
 
 @pin_rootfs_mode("rw")
-def test_pmem_add_as_root_rw(uvm, rootfs, microvm_factory):
+def test_pmem_add_as_root_rw(uvm, huge_pages, rootfs, microvm_factory):
     """
     Test addition of a single root pmem device in read-write mode
     """
@@ -131,7 +136,7 @@ def test_pmem_add_as_root_rw(uvm, rootfs, microvm_factory):
     vm.memory_monitor = None
     vm.monitors = []
     vm.spawn()
-    vm.basic_config(add_root_device=False)
+    vm.basic_config(add_root_device=False, huge_pages=huge_pages)
     vm.add_net_iface()
 
     rootfs_size = os.path.getsize(rootfs)
@@ -145,7 +150,7 @@ def test_pmem_add_as_root_rw(uvm, rootfs, microvm_factory):
     check_pmem_exist(restored_vm, 0, True, False, align(rootfs_size), "ext4")
 
 
-def test_pmem_add_as_root_ro(uvm, rootfs, microvm_factory):
+def test_pmem_add_as_root_ro(uvm, huge_pages, rootfs, microvm_factory):
     """
     Test addition of a single root pmem device in read-only mode
     """
@@ -154,7 +159,7 @@ def test_pmem_add_as_root_ro(uvm, rootfs, microvm_factory):
     vm.memory_monitor = None
     vm.monitors = []
     vm.spawn()
-    vm.basic_config(add_root_device=False)
+    vm.basic_config(add_root_device=False, huge_pages=huge_pages)
     vm.add_net_iface()
 
     rootfs_size = os.path.getsize(rootfs)
@@ -189,6 +194,7 @@ def test_pmem_dax_memory_saving(
     microvm_factory,
     guest_kernel,
     rootfs,
+    huge_pages,
 ):
     """
     Test that booting from pmem with DAX enabled indeed saves memory in the
@@ -198,7 +204,7 @@ def test_pmem_dax_memory_saving(
     # Boot from a block device
     vm = microvm_factory.build(guest_kernel, rootfs, pci=True, monitor_memory=False)
     vm.spawn()
-    vm.basic_config()
+    vm.basic_config(huge_pages=huge_pages)
     vm.add_net_iface()
     vm.start()
     block_cache_usage = inside_buff_cache(vm)
@@ -212,6 +218,7 @@ def test_pmem_dax_memory_saving(
     vm_pmem.basic_config(
         add_root_device=False,
         boot_args="reboot=k panic=1 nomodule swiotlb=noforce console=ttyS0 rootflags=dax",
+        huge_pages=huge_pages,
     )
     vm_pmem.add_net_iface()
     vm_pmem.add_pmem("pmem", rootfs, True, False)
@@ -231,13 +238,13 @@ def test_pmem_dax_memory_saving(
     ), f"{block_cache_usage} <= {pmem_cache_usage}"
 
 
-def test_device_reset(uvm):
+def test_device_reset(uvm, huge_pages):
     """
     Test that virtio-pmem device reset works.
     """
     vm = uvm
     vm.spawn()
-    vm.basic_config(add_root_device=True)
+    vm.basic_config(add_root_device=True, huge_pages=huge_pages)
     vm.add_net_iface()
 
     fs = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "scratch"), size=2)

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -4,12 +4,17 @@
 
 import platform
 
+import pytest
 from packaging import version
 
 from framework import utils
+from framework.microvm import HugePagesConfig
 
 
-def test_reboot(uvm):
+@pytest.mark.parametrize(
+    "huge_pages", [HugePagesConfig.NONE, HugePagesConfig.TRANSPARENT]
+)
+def test_reboot(uvm, huge_pages):
     """
     Test reboot from guest.
     """
@@ -23,7 +28,7 @@ def test_reboot(uvm):
     # Set up the microVM with 4 vCPUs, 256 MiB of RAM, 0 network ifaces, and
     # a root file system with the rw permission. The network interfaces is
     # added after we get a unique MAC and IP.
-    vm.basic_config(vcpu_count=4)
+    vm.basic_config(vcpu_count=4, huge_pages=huge_pages)
     vm.add_net_iface()
     vm.start()
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -20,6 +20,7 @@ import host_tools.drive as drive_tools
 import host_tools.network as net_tools
 from framework import utils
 from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel, pin_rootfs_mode
+from framework.microvm import HugePagesConfig
 from framework.properties import global_props
 from framework.utils import check_filesystem, check_output
 from framework.utils_cpu_templates import ALL_CPU_TEMPLATES, pin_cpu_template
@@ -60,7 +61,12 @@ def _get_guest_drive_size(ssh_connection, guest_dev_name="/dev/vdb"):
 
 @pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 @pytest.mark.parametrize("resume_at_restore", [True, False])
-def test_resume(uvm_configured, microvm_factory, resume_at_restore):
+@pytest.mark.parametrize(
+    "huge_pages",
+    [HugePagesConfig.NONE, HugePagesConfig.TRANSPARENT],
+    indirect=True,
+)
+def test_resume(uvm_configured, microvm_factory, resume_at_restore, huge_pages):
     """Tests snapshot is resumable at or after restoration.
 
     Check that a restored microVM is resumable by either
@@ -68,6 +74,7 @@ def test_resume(uvm_configured, microvm_factory, resume_at_restore):
     b. PUT /snapshot/load with `resume_vm=True`
     """
     vm = uvm_configured
+    assert vm.huge_pages == huge_pages
     vm.add_net_iface()
     vm.start()
     snapshot = vm.snapshot_full()

--- a/tests/integration_tests/performance/test_balloon.py
+++ b/tests/integration_tests/performance/test_balloon.py
@@ -16,10 +16,10 @@ from framework.utils import (
     track_cpu_utilization,
 )
 
-# Every test in this module exercises both huge_pages variants.
+# Every test in this module exercises all huge_pages variants.
 pytestmark = pytest.mark.parametrize(
     "huge_pages",
-    [HugePagesConfig.NONE, HugePagesConfig.HUGETLBFS_2MB],
+    HugePagesConfig,
     indirect=True,
 )
 

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -9,6 +9,7 @@ import time
 import pytest
 
 from framework.artifacts import ACPI_GUEST_KERNELS, pin_guest_kernel, pin_rootfs_mode
+from framework.microvm import HugePagesConfig
 
 # Regex for obtaining boot time from some string.
 
@@ -106,6 +107,7 @@ def launch_vm_with_boot_timer(
     mem_size_mib,
     pci_enabled,
     boot_from_pmem,
+    huge_pages=HugePagesConfig.NONE,
 ):
     """Launches a microVM with guest-timer and returns the reported metrics for it"""
     vm = microvm_factory.build(
@@ -119,6 +121,7 @@ def launch_vm_with_boot_timer(
             mem_size_mib=mem_size_mib,
             boot_args=DEFAULT_BOOT_ARGS + " init=/usr/local/bin/init",
             enable_entropy_device=True,
+            huge_pages=huge_pages,
         )
     else:
         vm.basic_config(
@@ -127,6 +130,7 @@ def launch_vm_with_boot_timer(
             mem_size_mib=mem_size_mib,
             boot_args=DEFAULT_BOOT_ARGS + " init=/usr/local/bin/init rootflags=dax",
             enable_entropy_device=True,
+            huge_pages=huge_pages,
         )
         vm.add_pmem("pmem", rootfs, True, True)
 
@@ -152,6 +156,9 @@ def test_boot_timer(microvm_factory, guest_kernel, rootfs, pci_enabled):
 )
 @pin_rootfs_mode("rw")
 @pytest.mark.parametrize("boot_from_pmem", [True, False], ids=["PmemBoot", "BlockBoot"])
+@pytest.mark.parametrize(
+    "huge_pages", [HugePagesConfig.NONE, HugePagesConfig.TRANSPARENT], indirect=True
+)
 @pytest.mark.nonci
 def test_boottime(
     microvm_factory,
@@ -161,6 +168,7 @@ def test_boottime(
     mem_size_mib,
     boot_from_pmem,
     pci_enabled,
+    huge_pages,
     metrics,
 ):
     """Test boot time with different guest configurations"""
@@ -174,6 +182,7 @@ def test_boottime(
             mem_size_mib,
             pci_enabled,
             boot_from_pmem,
+            huge_pages,
         )
 
         if i == 0:
@@ -181,6 +190,7 @@ def test_boottime(
                 {
                     "performance_test": "test_boottime",
                     "boot_from_pmem": str(boot_from_pmem),
+                    "huge_pages": str(huge_pages),
                     **vm.dimensions,
                 }
             )

--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -82,7 +82,7 @@ def uvm_resumed_memhp(
     """Restores a VM with the given memory hotplugging config after booting and snapshotting"""
     if vhost_user:
         pytest.skip("vhost-user doesn't support snapshot/restore")
-    if huge_pages and huge_pages != HugePagesConfig.NONE and not uffd_handler:
+    if huge_pages == HugePagesConfig.HUGETLBFS_2MB and not uffd_handler:
         pytest.skip("Hugepages requires a UFFD handler")
     uvm = uvm_booted_memhp(
         uvm,
@@ -104,6 +104,7 @@ def uvm_resumed_memhp(
 @pytest.fixture(
     params=[
         (uvm_booted_memhp, False, HugePagesConfig.NONE, None, None),
+        (uvm_booted_memhp, False, HugePagesConfig.TRANSPARENT, None, None),
         (uvm_booted_memhp, False, HugePagesConfig.HUGETLBFS_2MB, None, None),
         (uvm_booted_memhp, True, HugePagesConfig.NONE, None, None),
         (uvm_resumed_memhp, False, HugePagesConfig.NONE, None, SnapshotType.FULL),
@@ -114,6 +115,13 @@ def uvm_resumed_memhp(
             HugePagesConfig.NONE,
             None,
             SnapshotType.DIFF_MINCORE,
+        ),
+        (
+            uvm_resumed_memhp,
+            False,
+            HugePagesConfig.TRANSPARENT,
+            None,
+            SnapshotType.FULL,
         ),
         (
             uvm_resumed_memhp,
@@ -132,11 +140,13 @@ def uvm_resumed_memhp(
     ],
     ids=[
         "booted",
+        "booted-thp",
         "booted-huge-pages",
         "booted-vhost-user",
         "resumed",
         "resumed-diff",
         "resumed-mincore",
+        "resumed-thp",
         "resumed-uffd",
         "resumed-uffd-huge-pages",
     ],
@@ -481,7 +491,7 @@ def timed_memory_hotplug(uvm, size, metrics, metric_prefix, fc_metric_name):
 )
 @pytest.mark.parametrize(
     "huge_pages",
-    [HugePagesConfig.NONE, HugePagesConfig.HUGETLBFS_2MB],
+    HugePagesConfig,
 )
 def test_memory_hotplug_latency(
     microvm_factory, guest_kernel, rootfs, hotplug_size, huge_pages, metrics


### PR DESCRIPTION
## Changes

This PR adds THP for the guest memory, with a new value for the huge_pages option.

Additionally, guest memory is also now 2MiB aligned, to better facilitate the promotion to huge pages for head/tail guest memory. 

### Boot time improvements
#### Relative

  | Environment | systemd_kernel | guest_cpu_boot_time | guest_boot_time | systemd_total |
  |---|---|---|---|---|
  | m8i.16xlarge, AL2, 5.10 | **-47.6%** (-72.8% to -22.3%) | **-57.2%** (-64.9% to -43.9%) | **-46.7%** (-68.5% to -25.5%) | **-29.1%** (-43.6% to -19.1%) |
  | m8i.16xlarge, AL2023, 6.1 | **-54.0%** (-76.1% to -31.6%) | **-64.5%** (-72.3% to -54.2%) | **-54.5%** (-73.3% to -35.8%) | **-33.8%** (-48.6% to -24.1%) |
  | m8i.16xlarge, AL2023, 6.18 | **-54.5%** (-76.5% to -31.6%) | **-65.4%** (-73.3% to -55.3%) | **-50.8%** (-71.4% to -34.1%) | **-34.0%** (-49.1% to -23.4%) |
  | m8i.metal-48xl, AL2, 5.10 | **-24.7%** (-47.9% to -8.5%) | **-29.2%** (-34.5% to -21.8%) | **-21.6%** (-36.5% to -9.7%) | **-12.4%** (-22.5% to -8.2%) |
  | m8i.metal-48xl, AL2023, 6.1 | **-23.5%** (-44.4% to -7.9%) | **-32.8%** (-38.8% to -24.7%) | **-22.8%** (-39.4% to -9.2%) | **-12.4%** (-22.2% to -7.4%) |
  | m8i.metal-48xl, AL2023, 6.18 | **-24.9%** (-45.0% to -9.3%) | **-34.1%** (-38.5% to -25.7%) | **-19.3%** (-33.9% to -9.8%) | **-13.0%** (-21.7% to -8.1%) |

#### Absolute

  | Environment | systemd_kernel | guest_cpu_boot_time | guest_boot_time | systemd_total |
  |---|---|---|---|---|
  | m8i.16xlarge, AL2, 5.10 | **236ms → 131ms** (88–472 → 34–297) | **257ms → 108ms** (137–431 → 62–184) | **280ms → 155ms** (133–513 → 59–325) | **710ms → 501ms**  (462–1001 → 290–676) |
  | m8i.16xlarge, AL2023, 6.1 | **279ms → 136ms** (101–546 → 34–316) | **321ms → 113ms** (164–561 → 62–214) | **334ms → 159ms** (163–595 → 60–342) | **800ms → 528ms**  (510–1088 → 294–675) |
  | m8i.16xlarge, AL2023, 6.18 | **281ms → 136ms** (102–552 → 34–315) | **325ms → 112ms** (164–572 → 59–216) | **362ms → 183ms** (181–625 → 73–356) | **803ms →  529ms** (523–1092 → 301–679) |
  | m8i.metal-48xl, AL2, 5.10 | **132ms → 108ms** (38–298 → 24–263) | **122ms → 86ms** (74–210 → 52–158) | **163ms → 134ms** (72–324 → 51–281) | **500ms → 439ms**  (296–712 → 242–616) |
  | m8i.metal-48xl, AL2023, 6.1 | **130ms → 108ms** (37–298 → 24–272) | **107ms → 72ms** (67–174 → 48–118) | **157ms → 128ms** (66–321 → 48–289) | **497ms → 436ms**  (299–688 → 232–592) |
  | m8i.metal-48xl, AL2023, 6.18 | **130ms → 107ms** (37–300 → 24–262) | **110ms → 72ms** (68–180 → 48–119) | **188ms → 157ms** (86–351 → 65–311) | **497ms → 433ms**  (292–680 → 233–592) |

Source: https://buildkite.com/firecracker/mamarang-nested-a-b/builds/119/list.

## Design choices

 - require guest memory to be multiple of 2MB: this is technically not required, but I think it will reduce surprises by end-users when some VM configuration have some pages that cannot be merged
 - not enabled by default: THP has some impact on the host, and feedback from internal customers was that they want to enable THP under their terms. We can re-evaluate changing the default in future Firecracker versions
 - requested optimistically: there's no guarantee that huge-pages will actually be used by the host: 
    - `madvise` is called even for memfd, even though it is ignored (`/sys/kernel/mm/transparent_hugepage/shmem_enabled` is `never` in most distros, see https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#shmem-internal-tmpfs)
    - `madivise` is also called in case of snapshot restore, even though it won't have effect on memory pages registered with UFFD, or backed by file systems without large folios support
  - guest memory is always 2MiB aligned, regardless of whether THP is enabled or not. This is to avoid unnecessary modalities, and enable the performance benefit when THP is enforced by the host (e.g. `/sys/kernel/mm/transparent_hugepage/enabled` = `always`).

## Reason

Reduce page fault frequency, reduce TLB usage.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
