### PR TITLE
guest-configs: enable Landlock LSM in 6.1 kernel configs

### DIFF
--- a/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config
+++ b/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config
@@ -3004,13 +3004,12 @@ CONFIG_SECURITY_SELINUX_SID2STR_CACHE_SIZE=256
 # CONFIG_SECURITY_YAMA is not set
 # CONFIG_SECURITY_SAFESETID is not set
 # CONFIG_SECURITY_LOCKDOWN_LSM is not set
-# CONFIG_SECURITY_LANDLOCK is not set
+CONFIG_SECURITY_LANDLOCK=y
 # CONFIG_INTEGRITY is not set
 # CONFIG_IMA_SECURE_AND_OR_TRUSTED_BOOT is not set
 CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
-
+CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
 #
 # Kernel hardening options
 #

--- a/resources/guest_configs/microvm-kernel-ci-x86_64-6.1.config
+++ b/resources/guest_configs/microvm-kernel-ci-x86_64-6.1.config
@@ -2933,11 +2933,11 @@ CONFIG_SECURITY_SELINUX_SID2STR_CACHE_SIZE=256
 # CONFIG_SECURITY_YAMA is not set
 # CONFIG_SECURITY_SAFESETID is not set
 # CONFIG_SECURITY_LOCKDOWN_LSM is not set
-# CONFIG_SECURITY_LANDLOCK is not set
+CONFIG_SECURITY_LANDLOCK=y
 # CONFIG_INTEGRITY is not set
 CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
+CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
 
 #
 # Kernel hardening options


### PR DESCRIPTION
Enable CONFIG_SECURITY_LANDLOCK=y and prepend "landlock," to CONFIG_LSM in the 6.1 guest kernel configs for both x86_64 and aarch64 architectures.

Landlock is an unprivileged access control mechanism merged into mainline Linux in 5.13. It allows processes to restrict their own filesystem access without requiring privileges, complementing Firecracker's guest/host isolation boundary with fine-grained in-guest per-process sandboxing.

Landlock is not available in the 5.10 kernel configs (predates 5.13) so those are left unchanged.

The LSM ordering follows upstream Linux defaults, with "landlock" placed first in the initialization list.

Resolves #5997

## Changes

Enable `CONFIG_SECURITY_LANDLOCK=y` and prepend `"landlock,"` to
`CONFIG_LSM` in the 6.1 guest kernel configs for both x86_64 and
aarch64 architectures.

Landlock is an unprivileged access control mechanism merged into
mainline Linux in 5.13. It allows processes to restrict their own
filesystem access without requiring privileges, complementing
Firecracker's guest/host isolation boundary with fine-grained
in-guest per-process sandboxing. Workloads running inside the
microVM can use Landlock to enforce least-privilege filesystem
access on individual processes — for example agent runtimes,
build systems, or semi-trusted code — without requiring root,
containers, or additional host configuration.

The 5.10 kernel configs are intentionally left unchanged since
Landlock was not available until kernel 5.13.

The LSM ordering follows upstream Linux defaults, with "landlock"
placed first in the initialization list per the kernel's own
`security/Kconfig` defaults.

## Testing

This change modifies kernel config files only. The actual kernel
build and validation requires Firecracker's devtool build
environment with `resources/rebuild.sh`. I have verified:
- `CONFIG_SECURITY=y` is present in both 6.1 configs (the only
  dependency for `CONFIG_SECURITY_LANDLOCK`)
- Landlock is not available in 5.10 (introduced in 5.13), so
  the 5.10 configs are correctly left unchanged
- The LSM string format matches existing conventions in the config

Resolves #5997

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [X] I have read and understand [CONTRIBUTING.md][3].
- [X] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [X] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [X] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [X] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [X] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [X] If a specific issue led to this PR, this PR closes the issue.
- [X] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [X] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [X] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
