### PR TITLE
test: skip flaky hotplug tests on 5.10 hosts

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,4 +15,9 @@ ignore = [
     #   the `thread_rng` feature, so the affected functions are not compiled in.
     # See https://rustsec.org/advisories/RUSTSEC-2026-0097.html
     "RUSTSEC-2026-0097",
+
+    # `anyhow` is not directly used by any of our crates. It is a transitive
+    # dependency of build-time WASM tooling (wit-bindgen).
+    # See https://rustsec.org/advisories/RUSTSEC-2026-0190.html
+    "RUSTSEC-2026-0190",
 ]

--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -8,6 +8,8 @@ This file also contains functional tests for virtio-mem because they need to be
 run on an ag=1 host due to the use of HugePages.
 """
 
+import platform
+
 import pytest
 from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
@@ -252,6 +254,11 @@ def check_hotunplug(uvm, requested_size_mib):
         assert rss_after < rss_before, "RSS didn't decrease"
 
 
+# TODO: remove this once the hotplug latency on 5.10 hosts is fixed
+@pytest.mark.skipif(
+    platform.machine() == "x86_64" and global_props.host_linux_version_tpl == (5, 10),
+    reason="GET /hotplug/memory intermittently exceeds the duration threshold on x86_64 5.10 hosts",
+)
 def test_virtio_mem_hotplug_hotunplug(uvm_any_memhp):
     """
     Check that memory can be hotplugged into the VM.
@@ -456,6 +463,11 @@ def timed_memory_hotplug(uvm, size, metrics, metric_prefix, fc_metric_name):
     )
 
 
+# TODO: remove this once the hotplug latency on 5.10 hosts is fixed
+@pytest.mark.skipif(
+    platform.machine() == "x86_64" and global_props.host_linux_version_tpl == (5, 10),
+    reason="GET /hotplug/memory intermittently exceeds the duration threshold on x86_64 5.10 hosts",
+)
 @pytest.mark.nonci
 @pytest.mark.parametrize(
     "hotplug_size",


### PR DESCRIPTION
## Changes
- Skip `test_virtio_mem_hotplug_hotunplug` and `test_memory_hotplug_latency` on 5.10 hosts.
- Add `RUSTSEC-2026-0190` to `.cargo/audit.toml` ignore list.

## Reason
Both tests intermittently fail on 5.10 hosts, where the `GET /hotplug/memory` API call exceeds the maximum duration assertion (the unplug request gets queued behind the VMM thread and the API call waits). Skip until the RC is investigated.

The cargo-audit ignore is bundled here to unblock the merge queue: RUSTSEC-2026-0190 (anyhow) was published and is failing `test_cargo_audit` on all PRs. anyhow is not a direct dependency of any Firecracker crate; it is only pulled in transitively by build-time WASM tooling (wit-bindgen).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
