### PR TITLE
ci: disable test_virtio_mem_hotplug_hotunplug on x86/5.10

### DIFF
--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -8,6 +8,8 @@ This file also contains functional tests for virtio-mem because they need to be
 run on an ag=1 host due to the use of HugePages.
 """
 
+import platform
+
 import pytest
 from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
@@ -252,6 +254,11 @@ def check_hotunplug(uvm, requested_size_mib):
         assert rss_after < rss_before, "RSS didn't decrease"
 
 
+# TODO remove this once fixed
+@pytest.mark.skipif(
+    platform.machine() == "x86_64" and global_props.host_linux_version_tpl == (5, 10),
+    reason="This test is timing out on x86_64 5.10 kernels and blocks all pipelines",
+)
 def test_virtio_mem_hotplug_hotunplug(uvm_any_memhp):
     """
     Check that memory can be hotplugged into the VM.


### PR DESCRIPTION
## Changes
The test is failing all the time and blocks all pipelines. Disabling until the fix/rootcause is found.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
