### PR TITLE
buildkite: remove hotunplug_total_time override

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -53,7 +53,7 @@ perf_test = {
         "devtool_opts": "-c 1-10 -m 0",
         # The test require polling (5 ms), so any change smaller than that is not significant.
         # Additionally, unplugging memory is dependent on how exactly it's being used, so some volatility is expected.
-        "ab_opts": "--absolute-strength 0.005 --noise-threshold hotunplug_total_time=0.1",
+        "ab_opts": "--absolute-strength 0.005",
     },
     "snapshot-latency": {
         "label": "snapshot-latency",


### PR DESCRIPTION
## Changes
In the commit ac7510c ("test: skip flaky hotplug tests on x86_64 5.10 hosts") we disabled `test_memory_hotplug_latency` and `test_virtio_mem_hotplug_hotunplug` for x86_64/5.10 instances and that broke the A/B script since we pass the `hotunplug_total_time` override. So remove this override at least until we figured out what is happening with x86_64/5.10.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
