### PR TITLE
A/B testing + Guest kernel patching small fixes

### DIFF
--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -133,7 +133,7 @@ function build_al_kernel {
 
     # Apply any patchset we have for our kernels
     for patchset in ../patches/*; do
-        [ -d "$patchset" ] || continue
+        [ -d "$patchset/$KERNEL_VERSION" ] || continue
         echo "Applying patchset ${patchset}/${KERNEL_VERSION}"
         git apply ${patchset}/${KERNEL_VERSION}/*.patch
     done

--- a/tools/ab_plot.py
+++ b/tools/ab_plot.py
@@ -4,8 +4,8 @@
 """
 Script for creating visualizations for A/B runs.
 
-Usage:
-ab_plot.py path_to_run_a path_to_run_b path_to_run_c ... --output_type pdf/table
+See usage:
+ab_plot.py -h
 """
 
 import argparse
@@ -54,7 +54,8 @@ def load_data(data_path: Path):
     # Track cumulative index per (test, metric, dimensions) so that
     # subsequent iterations are plotted consecutively.
     offsets = {}
-    for name in sorted(glob.glob(f"{data_path}/**/metrics.json", recursive=True)):
+    pattern = f"{glob.escape(str(data_path))}/**/metrics.json"
+    for name in sorted(glob.glob(pattern, recursive=True)):
         with open(name, encoding="utf-8") as f:
             j = json.load(f)
 
@@ -274,7 +275,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "paths",
         nargs="+",
-        help="Paths to directories with test runs",
+        help="Paths to directories with test runs' metrics.json file",
         type=Path,
     )
     parser.add_argument(
@@ -285,7 +286,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--output_type",
-        default=["pdf"],
+        default="pdf",
         help="Type of the output to generate",
     )
     args = parser.parse_args()

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -10,9 +10,9 @@ test using binaries compiled from each revision, and runs a regression test
 comparing resulting metrics between runs.
 
 It performs the A/B-test as follows:
-For both A and B runs, collect all `metrics.json` files and read all dimentions
-from them. Script assumes all dimentions are unique within single run and both
-A and B runs result in the same dimentions. After collection is done, perform
+For both A and B runs, collect all `metrics.json` files and read all dimensions
+from them. Script assumes all dimensions are unique within single run and both
+A and B runs result in the same dimensions. After collection is done, perform
 statistical regression test across all the list-valued properties collected.
 """
 
@@ -149,14 +149,15 @@ def is_ignored(dimensions) -> bool:
 def load_data_series(data_path: Path):
     """Recursively collects `metrics.json` files in provided path"""
     data = {}
-    for name in glob.glob(f"{data_path}/**/metrics.json", recursive=True):
+    pattern = f"{glob.escape(str(data_path))}/**/metrics.json"
+    for name in glob.glob(pattern, recursive=True):
         with open(name, encoding="utf-8") as f:
             j = json.load(f)
 
         metrics = j["metrics"]
-        dimentions = frozenset(j["dimensions"].items())
+        dimensions = frozenset(j["dimensions"].items())
 
-        data[dimentions] = {}
+        data[dimensions] = {}
         for m in metrics:
             # Ignore certain metrics as we know them to be volatile
             if "cpu_utilization" in m:
@@ -164,7 +165,7 @@ def load_data_series(data_path: Path):
             mm = metrics[m]
             unit = mm["unit"]
             values = mm["values"]
-            data[dimentions][m] = (values, unit)
+            data[dimensions][m] = (values, unit)
 
     return data
 
@@ -527,16 +528,16 @@ def main():
     )
     analyze_parser = subparsers.add_parser(
         "analyze",
-        help="Analyze the results of two manually ran tests based on their test-report.json files",
+        help="Analyze the results of two manually ran tests based on their metrics.json files",
     )
     analyze_parser.add_argument(
         "path_a",
-        help="The path to the directory with A run",
+        help="The path to the directory with run A's metrics.json file",
         type=Path,
     )
     analyze_parser.add_argument(
         "path_b",
-        help="The path to the directory with B run",
+        help="The path to the directory with run B's metrics.json file",
         type=Path,
     )
     parser.add_argument(


### PR DESCRIPTION
## Changes

### A/B Testing
  - Escape glob special characters in data paths so that the scripts work with directories containing `[` and `]` characters (such as the folder paths for CI test results)
  - Fix `--output_type` default in `ab_plot.py` from a list (`["pdf"]`) to a string (`"pdf"`)
  - Fix "dimentions" typos → "dimensions" in `ab_test.py`
  - Clarify help messages for positional arguments

### Kernel build script:
Fix the patching logic so that only patchsets containing a directory for the target kernel version are applied.

## Reason

### A/B testing
Just a few small fixes to improve Quality-of-Experience

### Kernel build script
Previously, the loop iterated over all directories under `patches/` and attempted to apply patches targeting unrelated kernel versions, causing build failures.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
