### PR TITLE
Misc CI fixes

### DIFF
--- a/.buildkite/pipeline_cross.py
+++ b/.buildkite/pipeline_cross.py
@@ -31,7 +31,10 @@ if __name__ == "__main__":
     restore_only_platforms = [("al2023", "linux_6.18")]
     x86_64_platforms = DEFAULT_PLATFORMS + restore_only_platforms
     commands = [
-        "./tools/devtool -y test --no-build --no-archive -- -m nonci -n4 integration_tests/functional/test_snapshot_phase1.py",
+        *pipeline.devtool_test(
+            devtool_opts="--no-archive",
+            pytest_opts="-m nonci -n4 integration_tests/functional/test_snapshot_phase1.py",
+        ),
         # punch holes in mem snapshot tiles and tar them so they are preserved in S3
         "find test_results/test_snapshot_phase1 -type f -name mem |xargs -P4 -t -n1 fallocate -d",
         "mv -v test_results/test_snapshot_phase1 snapshot_artifacts",

--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -495,7 +495,7 @@ def test_memory_hotplug_latency(
             "block_size_mib": 2,
         }
         uvm = microvm_factory.build(guest_kernel, rootfs, pci=True)
-        uvm = uvm_booted_memhp(uvm, None, None, False, config, None, None, None)
+        uvm = uvm_booted_memhp(uvm, None, None, False, config, huge_pages, None, None)
 
         if i == 0:
             metrics.set_dimensions(


### PR DESCRIPTION
## Changes

### pipeline_cross.py
* Replace the hardcoded devtool command string with the `pipeline.devtool_test()` helper

### test_memory_hotplug_latency
* The test was passing `None` instead of the huge_pages fixture value when constructing the `uvm_booted_memhp` 

## Reason

### pipeline_cross.py
* Align the cross-snapshot pipeline with the approach used in other pipelines.

### test_memory_hotplug_latency
* The test always ignored the guest-side huge pages configuration since its introduction (https://github.com/firecracker-microvm/firecracker/commit/ba535fb8931fd091feb94858750a6a741b925b55).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
