### PR TITLE
Add guest kernel 6.18 build artifacts

### DIFF
--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -102,17 +102,17 @@ function clone_amazon_linux_repo {
 # prints the git tag corresponding to the newest and best matching the provided kernel version $1
 # this means that if a microvm kernel exists, the tag returned will be of the form
 #
-#    microvm-kernel-$1.<patch number>.amzn2[023]
+#    microvm-kernel.*$1.<patch number>.amzn2[023]
 #
 # otherwise choose the newest tag matching
 #
-#    kernel-$1.<patch number>.amzn2[023]
+#    kernel.*$1.<patch number>.amzn2[023]
 function get_tag {
     local KERNEL_VERSION=$1
 
     # list all tags from newest to oldest
-    (git --no-pager tag -l --sort=-v:refname | grep "microvm-kernel-$1\..*\.amzn2" \
-        || git --no-pager tag -l --sort=-v:refname | grep "kernel-$1\..*\.amzn2") | head -n1
+    (git --no-pager tag -l --sort=-v:refname | grep "microvm-kernel.*$KERNEL_VERSION\..*\.amzn2" \
+        || git --no-pager tag -l --sort=-v:refname | grep "kernel.*$KERNEL_VERSION\..*\.amzn2") | head -n1
 }
 
 function build_al_kernel {

--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -217,7 +217,7 @@ function build_al_kernels {
         die "Too many arguments in '$(basename $0) kernels' command. Please use \`$0 help\` for help."
     else
         KERNEL_VERSION=$1
-        if [[ "$KERNEL_VERSION" != @(5.10|5.10-no-acpi|6.1) ]]; then
+        if [[ "$KERNEL_VERSION" != @(5.10|5.10-no-acpi|6.1|6.18) ]]; then
             die "Unsupported kernel version: '$KERNEL_VERSION'. Please use \`$0 help\` for help."
         fi
     fi
@@ -235,6 +235,9 @@ function build_al_kernels {
     if [[ "$KERNEL_VERSION" == @(all|6.1) ]]; then
         build_al_kernel $PWD/guest_configs/microvm-kernel-ci-$ARCH-6.1.config "$CI_CONFIG"
     fi
+    if [[ "$KERNEL_VERSION" == @(all|6.18) ]]; then
+        build_al_kernel $PWD/guest_configs/microvm-kernel-ci-$ARCH-6.18.config "$CI_CONFIG"
+    fi
 
     # Build debug kernels
     FTRACE_CONFIG="$PWD/guest_configs/ftrace.config"
@@ -248,6 +251,10 @@ function build_al_kernels {
     if [[ "$KERNEL_VERSION" == @(all|6.1) ]]; then
         build_al_kernel "$PWD/guest_configs/microvm-kernel-ci-$ARCH-6.1.config" "$CI_CONFIG" "$FTRACE_CONFIG" "$DEBUG_CONFIG"
         vmlinux_split_debuginfo $OUTPUT_DIR/vmlinux-6.1.*
+    fi
+    if [[ "$KERNEL_VERSION" == @(all|6.18) ]]; then
+        build_al_kernel "$PWD/guest_configs/microvm-kernel-ci-$ARCH-6.18.config" "$CI_CONFIG" "$FTRACE_CONFIG" "$DEBUG_CONFIG"
+        vmlinux_split_debuginfo $OUTPUT_DIR/vmlinux-6.18.*
     fi
 }
 
@@ -273,7 +280,7 @@ Available commands:
         Builds our the currently supported CI kernels.
 
         version: Optionally choose a kernel version to build. Supported
-                 versions are: 5.10, 5.10-no-acpi or 6.1.
+                 versions are: 5.10, 5.10-no-acpi, 6.1 or 6.18.
 
     help
         Displays the help message and exits.


### PR DESCRIPTION
## Changes

* Broaden the `get_tag` grep pattern to match with tag `kernel$version` as well
* Add kernel version 6.18 to the supported versions list

## Reason

* Amazon Linux changed its kernel tag format (e.g., `kernel-6.18.x` → `kernel6.18-6.18.x`). The existing rigid grep patterns in get_tag would fail to locate the correct source tag for the 6.18 kernel. T
* This PR enables us to produce guest kernel artifacts with version 6.18 as a supported build target so CI can produce guest.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
