### PR TITLE
fix(pmem): validate mmap size matches config space size on restore

### DIFF
--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -41,6 +41,8 @@ pub enum PmemError {
     BackingFile(std::io::Error),
     /// Error backing file size is 0
     BackingFileZeroSize,
+    /// Restored pmem size {0} does not match backing file mapping size {1}
+    RestoredSizeMismatch(u64, u64),
     /// Error with EventFd: {0}
     EventFd(std::io::Error),
     /// Unexpected read-only descriptor
@@ -314,7 +316,12 @@ impl Pmem {
         let mmap = PmemMmap::new(&config.path_on_host, config.read_only)?;
 
         let guest_region = match config_space {
-            Some(cs) => GuestPmemRegion::from_state(vm.clone(), cs),
+            Some(cs) => {
+                if cs.size != mmap.mmap_len {
+                    return Err(PmemError::RestoredSizeMismatch(cs.size, mmap.mmap_len));
+                }
+                GuestPmemRegion::from_state(vm.clone(), cs)
+            }
             None => GuestPmemRegion::new(vm.clone(), mmap.mmap_len)?,
         };
 

--- a/src/vmm/src/devices/virtio/pmem/persist.rs
+++ b/src/vmm/src/devices/virtio/pmem/persist.rs
@@ -84,6 +84,7 @@ impl<'a> Persist<'a> for Pmem {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
@@ -136,5 +137,40 @@ mod tests {
         );
         assert!(!restored_pmem.is_activated());
         assert_eq!(restored_pmem.config, pmem_state.config);
+    }
+
+    #[test]
+    fn test_restore_rejects_mismatched_config_space_size() {
+        let dummy_file = TempFile::new().unwrap();
+        dummy_file.as_file().set_len(0x20_0000);
+        let dummy_path = dummy_file.as_path().to_str().unwrap().to_string();
+        let config = PmemConfig {
+            id: "1".into(),
+            path_on_host: dummy_path,
+            root_device: true,
+            read_only: false,
+            ..Default::default()
+        };
+        let guest_mem = default_mem();
+        let vm = Arc::new(setup_vm());
+        let pmem = Pmem::new(vm.clone(), config).unwrap();
+
+        let mut pmem_state = pmem.save();
+        drop(pmem);
+
+        pmem_state.config_space.size += Pmem::ALIGNMENT;
+
+        let err = Pmem::restore(
+            PmemConstructorArgs {
+                mem: &guest_mem,
+                vm: vm.clone(),
+            },
+            &pmem_state,
+        )
+        .unwrap_err();
+        assert_matches!(
+            err,
+            PmemPersistError::Pmem(PmemError::RestoredSizeMismatch(_, _))
+        );
     }
 }


### PR DESCRIPTION
## Changes

- Validate that the mmapped region size (derived from the file) matches the region size stored in the serialized config space
- Add a regression test that checks that mismatching sizes are rejected

## Reason

Defense-in-depth improvement

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
