### PR TITLE
tests: reap uffd handler processes after kill

### DIFF
--- a/tests/framework/utils_uffd.py
+++ b/tests/framework/utils_uffd.py
@@ -82,6 +82,8 @@ class UffdHandler:
         assert self.is_running()
 
         self.proc.kill()
+        self.proc.wait(timeout=5)
+        self._proc = None
 
     def mark_killed(self, timeout=10):
         """Wait for the uffd handler to exit on its own, and mark it dead.

--- a/tests/framework/utils_uffd.py
+++ b/tests/framework/utils_uffd.py
@@ -83,9 +83,21 @@ class UffdHandler:
 
         self.proc.kill()
 
-    def mark_killed(self):
-        """Marks the uffd handler as already dead"""
-        assert not self.is_running()
+    def mark_killed(self, timeout=10):
+        """Wait for the uffd handler to exit on its own, and mark it dead.
+
+        Used when the handler is expected to die by itself (e.g. the malicious
+        handler panics on the first page fault). Process exit after a panic is
+        not instantaneous, so wait for a given timeout duration before raising.
+        """
+        if self._proc is not None:
+            try:
+                self._proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                raise AssertionError(
+                    f"UFFD handler '{self._handler_name}' still running "
+                    f"{timeout}s after it should have died. Logs:\n{self.log_data}"
+                ) from None
 
         self._proc = None
 


### PR DESCRIPTION
## Changes

- After the UFFD handler process is killed by `UffdHandler.kill()`, `wait` to reap the process.
- If the UFFD handler is expected to die by itself, (i.e., malicious handler that panics), also `wait` in `UffdHandler.mark_killed()`

## Reason

In `test_uffd.py::test_malicious_handler`, there existed a race condition where the UffdHandler process and the test framework would race. The rust process essentially had to panic before the test framework checked whether it had been killed (via `assert not proc.is_running()`. In rare cases under load, this may not occur. The process would also be left as a zombie, as the parent would not wait to receive the exit code. 

Now, wait for 5s when checking whether the process has died or not. This should remove the race and clean up the process, preventing spurious test failures.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
