### PR TITLE
Update rust and libseccomp dependencies

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -11,7 +11,7 @@
 # allowlisted using a toolchain that requires it, causing the A/B-test to
 # always fail.
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.0"
 targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]
 profile = "minimal"
 

--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -392,13 +392,13 @@ impl CgroupV2 {
         let parent = match path.as_ref().parent() {
             Some(p) => p,
             None => {
-                writeln_special(&cg_subtree_ctrl, format!("+{}", &controller))?;
+                writeln_special(&cg_subtree_ctrl, format!("+{}", controller))?;
                 return Ok(());
             }
         };
 
         Self::write_all_subtree_control(parent, controller)?;
-        writeln_special(&cg_subtree_ctrl, format!("+{}", &controller))
+        writeln_special(&cg_subtree_ctrl, format!("+{}", controller))
     }
 
     // Returns controllers that can be enabled from the cgroup path specified

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -382,7 +382,7 @@ mod tests {
 
         let mut fds = Vec::new();
         for i in 0..n {
-            let maybe_file = File::create(format!("{}/{}", &tmp_dir_path, i));
+            let maybe_file = File::create(format!("{}/{}", tmp_dir_path, i));
             fds.push(maybe_file.unwrap().into_raw_fd());
         }
 

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -434,7 +434,7 @@ impl MMIODeviceManager {
     #[cfg(target_arch = "aarch64")]
     pub fn virtio_device_info(&self) -> Vec<&MMIODeviceInfo> {
         let mut device_info = Vec::new();
-        for (_, dev) in self.virtio_devices.iter() {
+        for dev in self.virtio_devices.values() {
             device_info.push(&dev.resources);
         }
         device_info

--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -54,6 +54,6 @@ def test_cargo_audit():
     toml_file = FC_WORKSPACE_DIR / "Cargo.toml"
 
     git_ab_test_host_command_if_pr(
-        f"cargo deny --manifest-path {toml_file} -f json check advisories",
+        f"RUSTUP_LOG=warn cargo deny --manifest-path {toml_file} -f json check advisories",
         comparator=set_did_not_grow_comparator(set_of_vulnerabilities),
     )

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update \
 # Builder: static libseccomp (musl)
 # ============================================================
 FROM base-image AS libseccomp-builder
-ENV LIBSECCOMP_VER="v2.6.0"
+ENV LIBSECCOMP_VER="v2.6.1"
 
 # Install static version of libseccomp
 # We need to compile from source because

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -204,7 +204,7 @@ RUN cp /usr/lib/python3/dist-packages/seccomp.cpython-312-"$ARCH"-linux-gnu.so "
 # Base: Rust toolchain (current version)
 # ============================================================
 FROM python-deps AS rust-toolchain
-ARG RUST_TOOLCHAIN="1.96.0"
+ARG RUST_TOOLCHAIN="1.97.0"
 ENV CARGO_HOME=/usr/local/rust
 ENV RUSTUP_HOME=/usr/local/rust
 ENV PATH="$PATH:$CARGO_HOME/bin"

--- a/tools/devtool
+++ b/tools/devtool
@@ -68,7 +68,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v91}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v92}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
## Changes

- Update libseccomp from v2.6.0 to v2.6.1 in the development container.
- Update the Rust toolchain from 1.96.0 to 1.97.0.
- Fix the Clippy warnings introduced by Rust 1.97.0.
- Update the default development container image from v91 to v92.
- Suppress rustup informational logs when the cargo-deny A/B test installs the baseline toolchain on demand.

## Reason

Closes #6012 
Closes #6027 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [na] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [na] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [na] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [na] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
