### PR TITLE
fix(vsock): stop busy-spinning the event thread on guest RX starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to
 - [#5956](https://github.com/firecracker-microvm/firecracker/pull/5956): Fixed a
   TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
   `MIDR_EL1` information files copied into the chroot.
+- [#6031](https://github.com/firecracker-microvm/firecracker/pull/6031): Fixed
+  the vsock device re-arming its host-stream `EPOLLIN` interest while received
+  data was still awaiting a guest RX buffer, which could busy-spin the event
+  thread until the guest posted buffers.
 
 ## [1.16.1]
 

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -438,6 +438,12 @@ where
         match self.state {
             ConnState::Killed | ConnState::LocalClosed | ConnState::PeerClosed(true, _) => (),
             _ if self.need_credit_update_from_peer() => (),
+            // An `Rw` indication means the host stream is readable and its data is waiting to
+            // be delivered to the guest by `recv_pkt`, which needs a guest RX buffer. While
+            // that data is undeliverable, re-arming IN would just busy-spin the event thread
+            // on the level-triggered muxer epoll fd. IN is re-armed once `recv_pkt` clears
+            // the `Rw` (on RX-queue refill).
+            _ if self.pending_rx.contains(PendingRx::Rw) => (),
             _ => evset.insert(EventSet::IN),
         }
         evset
@@ -1033,6 +1039,44 @@ mod tests {
         ctx.notify_epollin();
         ctx.recv();
         assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RST);
+    }
+
+    #[test]
+    fn test_polled_evset_drops_in_while_rw_pending() {
+        // Regression test for the guest-RX-starvation busy-spin.
+        // An Established connection with an undeliverable RW indication (host wrote data,
+        // guest has not provided RX buffers) must NOT keep advertising EPOLLIN, or the
+        // level-triggered muxer epoll fd busy-spins the event thread. IN must be re-armed
+        // once the guest posts an RX buffer and the pending packet is delivered.
+        let mut ctx = CsmTestContext::new_established();
+        // Fresh Established connection is interested in IN.
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
+
+        ctx.set_stream(TestStream::new_with_read_buf(&[1, 2, 3, 4]));
+        ctx.notify_epollin(); // sets PendingRx::Rw
+        // With an undeliverable Rw queued, IN must be suppressed.
+        assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
+
+        // Draining the pending packet (guest posted an RX buffer) clears Rw and re-arms IN.
+        ctx.recv();
+        assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert!(!ctx.conn.has_pending_rx());
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
+    }
+
+    #[test]
+    fn test_polled_evset_drops_in_on_host_eof() {
+        // Same as `test_polled_evset_drops_in_while_rw_pending`, but the host closed its
+        // end (EOF) instead of writing data. The resulting undeliverable RW indication must
+        // still suppress EPOLLIN so the muxer epoll fd does not busy-spin the event thread.
+        let mut ctx = CsmTestContext::new_established();
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
+
+        let mut stream = TestStream::new();
+        stream.read_state = StreamState::Closed;
+        ctx.set_stream(stream);
+        ctx.notify_epollin(); // sets PendingRx::Rw
+        assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -83,11 +83,6 @@ pub struct Vsock<B> {
     pub(crate) pending_event_ack: bool,
 }
 
-// TODO: Detect / handle queue deadlock:
-// 1. If the driver halts RX queue processing, we'll need to notify `self.backend`, so that it can
-//    unregister any EPOLLIN listeners, since otherwise it will keep spinning, unable to consume its
-//    EPOLLIN events.
-
 impl<B> Vsock<B>
 where
     B: VsockBackend + Debug,

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -1198,6 +1198,69 @@ mod tests {
     }
 
     #[test]
+    fn test_starvation_drops_and_rearms_epoll_listener() {
+        // End-to-end regression test for the guest-RX-starvation busy-spin at the muxer
+        // layer. When a connection has host data pending but the guest provides no RX
+        // buffer to drain it, the muxer must drop the connection's epoll listener (so the
+        // nested epoll fd goes quiet instead of re-firing IN forever), and re-arm it once
+        // the pending packet is delivered on RX-queue refill.
+        let mut ctx = MuxerTestContext::new("starvation_data");
+        let peer_port = 1025;
+        let (mut stream, local_port) = ctx.local_connect(peer_port);
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        let conn_fd = ctx.muxer.conn_map.get(&key).unwrap().as_raw_fd();
+
+        // Established connection is registered with an epoll listener.
+        assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 1);
+
+        // Host writes data; drive the muxer without providing a guest RX buffer.
+        stream.write_all(&[1, 2, 3, 4]).unwrap();
+        ctx.notify_muxer();
+
+        // The connection now has an undeliverable pending RX, so its epoll listener
+        // must have been dropped - the nested epoll fd goes quiet.
+        assert!(ctx.muxer.has_pending_rx());
+        assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 0);
+
+        // The guest posts an RX buffer: recv drains the packet, clearing the pending RX
+        // and re-arming the epoll listener.
+        ctx.recv();
+        assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 1);
+    }
+
+    #[test]
+    fn test_starvation_drops_epoll_listener_on_host_eof() {
+        // Same as `test_starvation_drops_and_rearms_epoll_listener`, but the host closes
+        // its end (EOF) instead of writing data. No host-side entity can break the loop,
+        // so dropping the listener is what makes the nested epoll fd quiet.
+        let mut ctx = MuxerTestContext::new("starvation_eof");
+        let peer_port = 1025;
+        let (stream, local_port) = ctx.local_connect(peer_port);
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        let conn_fd = ctx.muxer.conn_map.get(&key).unwrap().as_raw_fd();
+        assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
+
+        // Close the host end and drive the muxer without a guest RX buffer.
+        drop(stream);
+        ctx.notify_muxer();
+
+        // The pending EOF (SHUTDOWN) is undeliverable, so the listener must be dropped.
+        assert!(ctx.muxer.has_pending_rx());
+        assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 0);
+    }
+
+    #[test]
     fn test_local_close() {
         let peer_port = 1025;
         let mut ctx = MuxerTestContext::new("local_close");


### PR DESCRIPTION
## Changes

Stop the vsock device from re-arming its host-stream `EPOLLIN` interest while a
received-data (`Rw`) indication is still pending delivery to the guest.
`VsockConnection::get_polled_evset` now withholds `EventSet::IN` while
`pending_rx` already holds an `Rw`, and re-arms it once `recv_pkt` delivers the
pending packet on the next RX-queue refill.

Also removes a stale `TODO` in `device.rs` that described this exact scenario,
and adds a unit test covering both the data-available and host-EOF variants.

## Reason

An `Established` connection kept advertising level-triggered `EPOLLIN` even when
it already had an undeliverable `Rw` queued. If a host-side application wrote
data (or closed its end) and the guest stopped posting virtio RX buffers, the
muxer's nested epoll fd stayed readable, so the single-threaded event manager
woke on every `epoll_wait`, made no progress, and busy-spun the event thread
until the guest posted buffers. Because the event manager is single-threaded,
this also delayed servicing of the API socket, metrics, and other device
backends.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
