### PR TITLE
vmm: fix panic on ACPI device restore when EventFd creation fails

### DIFF
--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -187,10 +187,8 @@ impl<'a> Persist<'a> for ACPIDeviceManager {
 
     fn restore(vm: Self::ConstructorArgs, state: &Self::State) -> Result<Self, Self::Error> {
         let mut acpi_devices = ACPIDeviceManager::new(
-            // Safe to unwrap() here, this will never return an error.
-            VmGenId::restore((), &state.vmgenid).unwrap(),
-            // Safe to unwrap() here, this will never return an error.
-            VmClock::restore((), &state.vmclock).unwrap(),
+            VmGenId::restore((), &state.vmgenid)?,
+            VmClock::restore((), &state.vmclock)?,
         );
 
         acpi_devices.replay_gsi_allocations(vm)?;


### PR DESCRIPTION
ACPIDeviceManager::restore() called .unwrap() on VmGenId::restore()
and VmClock::restore(), both annotated with a comment claiming they
can never fail. This is incorrect: both call EventFd::new(), which
can fail (e.g. EMFILE) when the process is near its file descriptor
limit, a realistic condition during snapshot-restore when many
devices are being reconstructed. A failure here would panic and
crash Firecracker instead of returning a graceful error.

ACPIDeviceError already has #[from] conversions for VmGenIdError and
VmClockError, so this replaces the two unwrap() calls with ? and
removes the incorrect comments.

Tested with ./tools/devtool checkbuild -m aarch64 and
./tools/devtool checkstyle (rustfmt, clippy for aarch64-musl/gnu,
style/lint suite) — all passed. KVM-dependent unit/integration tests
could not be run locally (no /dev/kvm available).

Signed-off-by: RyanJHamby <ryanhamby22@gmail.com>
