### PR TITLE
device_manager: centralise virtio devices under single `VirtioDeviceManager` enum 

### DIFF
--- a/src/vmm/src/acpi/mod.rs
+++ b/src/vmm/src/acpi/mod.rs
@@ -87,7 +87,7 @@ impl AcpiTableWriter<'_> {
         let mut dsdt_data = Vec::new();
 
         // Virtio-devices DSDT data
-        dsdt_data.extend_from_slice(&device_manager.mmio_devices.dsdt_data);
+        dsdt_data.extend_from_slice(&device_manager.mmio_virtio_devices.dsdt_data);
 
         // Add GED and VMGenID AML data.
         device_manager

--- a/src/vmm/src/acpi/mod.rs
+++ b/src/vmm/src/acpi/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use acpi_tables::fadt::{FADT_F_HW_REDUCED_ACPI, FADT_F_PWR_BUTTON, FADT_F_SLP_BUTTON};
-use acpi_tables::{Aml, Dsdt, Fadt, Madt, Mcfg, Rsdp, Sdt, Xsdt, aml};
+use acpi_tables::{Dsdt, Fadt, Madt, Mcfg, Rsdp, Sdt, Xsdt, aml};
 use vm_allocator::AllocPolicy;
 
 use crate::Vcpu;
@@ -86,17 +86,8 @@ impl AcpiTableWriter<'_> {
     ) -> Result<u64, AcpiError> {
         let mut dsdt_data = Vec::new();
 
-        // Virtio-devices DSDT data
-        dsdt_data.extend_from_slice(&device_manager.mmio_virtio_devices.dsdt_data);
-
-        // Add GED and VMGenID AML data.
-        device_manager
-            .acpi_devices
-            .append_aml_bytes(&mut dsdt_data)?;
-
-        if let Some(pci_segment) = &device_manager.pci_devices.pci_segment {
-            pci_segment.append_aml_bytes(&mut dsdt_data)?;
-        }
+        // Device DSDT data.
+        device_manager.append_aml_bytes(&mut dsdt_data)?;
 
         // Architecture specific DSDT data
         setup_arch_dsdt(&mut dsdt_data)?;

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -20,9 +20,9 @@ use crate::arch::{
 };
 use crate::device_manager::DeviceManager;
 use crate::device_manager::mmio::MMIODeviceInfo;
-use crate::device_manager::pci_mngr::PciDevices;
 use crate::devices::acpi::vmclock::{VMCLOCK_SIZE, VmClock};
 use crate::devices::acpi::vmgenid::{VMGENID_MEM_SIZE, VmGenId};
+use crate::devices::pci::PciSegment;
 use crate::initrd::InitrdConfig;
 use crate::vstate::memory::{Address, GuestMemoryMmap, GuestRegionType};
 
@@ -101,7 +101,7 @@ pub fn create_fdt(
     create_vmgenid_node(&mut fdt_writer, device_manager.acpi_devices.vmgenid())?;
     create_vmclock_node(&mut fdt_writer, device_manager.acpi_devices.vmclock())?;
     if let Some(pci_devices) = device_manager.pci_devices() {
-        create_pci_nodes(&mut fdt_writer, pci_devices)?;
+        create_pci_nodes(&mut fdt_writer, pci_devices.pci_segment())?;
     }
 
     // End Header node.
@@ -484,14 +484,7 @@ fn create_devices_node(
     Ok(())
 }
 
-fn create_pci_nodes(fdt: &mut FdtWriter, pci_devices: &PciDevices) -> Result<(), FdtError> {
-    if pci_devices.pci_segment.is_none() {
-        return Ok(());
-    }
-
-    // Fine to unwrap here, we just checked it's not `None`.
-    let segment = pci_devices.pci_segment.as_ref().unwrap();
-
+fn create_pci_nodes(fdt: &mut FdtWriter, segment: &PciSegment) -> Result<(), FdtError> {
     let pci_node_name = format!("pci@{:x}", segment.mmio_config_address);
     // Each range here is a thruple of `(PCI address, CPU address, PCI size)`.
     //

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -461,11 +461,11 @@ fn create_devices_node(
     fdt: &mut FdtWriter,
     device_manager: &DeviceManager,
 ) -> Result<(), FdtError> {
-    if let Some(rtc_info) = device_manager.mmio_devices.rtc_device_info() {
+    if let Some(rtc_info) = device_manager.mmio_platform_devices.rtc_device_info() {
         create_rtc_node(fdt, rtc_info)?;
     }
 
-    if let Some(serial_info) = device_manager.mmio_devices.serial_device_info() {
+    if let Some(serial_info) = device_manager.mmio_platform_devices.serial_device_info() {
         create_serial_node(fdt, serial_info)?;
     }
 

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -469,7 +469,7 @@ fn create_devices_node(
         create_serial_node(fdt, serial_info)?;
     }
 
-    let mut virtio_mmio = device_manager.mmio_devices.virtio_device_info();
+    let mut virtio_mmio = device_manager.mmio_virtio_devices.virtio_device_info();
 
     // Sort out virtio devices by address from low to high and insert them into fdt table.
     virtio_mmio.sort_by_key(|a| a.addr);
@@ -591,7 +591,7 @@ mod tests {
             .unwrap();
         let dummy = Arc::new(Mutex::new(DummyDevice::new()));
         device_manager
-            .mmio_devices
+            .mmio_virtio_devices
             .register_virtio_test_device(
                 &vm,
                 mem.clone(),

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -100,7 +100,9 @@ pub fn create_fdt(
     create_devices_node(&mut fdt_writer, device_manager)?;
     create_vmgenid_node(&mut fdt_writer, device_manager.acpi_devices.vmgenid())?;
     create_vmclock_node(&mut fdt_writer, device_manager.acpi_devices.vmclock())?;
-    create_pci_nodes(&mut fdt_writer, &device_manager.pci_devices)?;
+    if let Some(pci_devices) = device_manager.pci_devices() {
+        create_pci_nodes(&mut fdt_writer, pci_devices)?;
+    }
 
     // End Header node.
     fdt_writer.end_node(root)?;
@@ -469,12 +471,14 @@ fn create_devices_node(
         create_serial_node(fdt, serial_info)?;
     }
 
-    let mut virtio_mmio = device_manager.mmio_virtio_devices.virtio_device_info();
+    if let Some(mmio_virtio_devices) = device_manager.mmio_virtio_devices() {
+        let mut virtio_mmio = mmio_virtio_devices.virtio_device_info();
 
-    // Sort out virtio devices by address from low to high and insert them into fdt table.
-    virtio_mmio.sort_by_key(|a| a.addr);
-    for ordered_device_info in virtio_mmio.drain(..) {
-        create_virtio_node(fdt, ordered_device_info)?;
+        // Sort out virtio devices by address from low to high and insert them into fdt table.
+        virtio_mmio.sort_by_key(|a| a.addr);
+        for device_info in virtio_mmio {
+            create_virtio_node(fdt, device_info)?;
+        }
     }
 
     Ok(())
@@ -565,7 +569,7 @@ mod tests {
     use crate::arch::aarch64::gic::create_gic;
     use crate::arch::{FDT_MAX_SIZE, KvmVm};
     use crate::device_manager::mmio::tests::DummyDevice;
-    use crate::device_manager::tests::default_device_manager;
+    use crate::device_manager::tests::{default_device_manager, mmio_devices_mut};
     use crate::test_utils::arch_mem;
     use crate::vstate::memory::GuestAddress;
     use crate::{EventManager, Kvm};
@@ -590,8 +594,7 @@ mod tests {
             .attach_legacy_devices_aarch64(&vm, &mut event_manager, &mut cmdline, None, None)
             .unwrap();
         let dummy = Arc::new(Mutex::new(DummyDevice::new()));
-        device_manager
-            .mmio_virtio_devices
+        mmio_devices_mut(&mut device_manager)
             .register_virtio_test_device(
                 &vm,
                 mem.clone(),

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -771,7 +771,7 @@ pub(crate) mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::device_manager::tests::default_device_manager;
+    use crate::device_manager::tests::{default_device_manager, default_device_manager_with_pci};
     use crate::devices::virtio::block::CacheType;
     use crate::devices::virtio::device::VirtioDeviceType;
     use crate::devices::virtio::rng::device::ENTROPY_DEV_ID;
@@ -861,8 +861,7 @@ pub(crate) mod tests {
         let _ = vm.create_vcpus(1).unwrap();
 
         let vm = Arc::new(vm);
-        let mut device_manager = default_device_manager();
-        device_manager.pci_devices.attach_pci_segment(&vm).unwrap();
+        let device_manager = default_device_manager_with_pci(&vm);
 
         Vmm {
             instance_info: InstanceInfo::default(),

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -596,7 +596,7 @@ fn attach_entropy_device(
         .id()
         .to_string();
 
-    device_manager.attach_virtio_device(
+    device_manager.attach_boot_virtio_device(
         vm,
         id,
         entropy_device.clone(),
@@ -646,7 +646,7 @@ fn attach_virtio_mem_device(
     ));
 
     let id = virtio_mem.lock().expect("Poisoned lock").id().to_string();
-    device_manager.attach_virtio_device(
+    device_manager.attach_boot_virtio_device(
         vm,
         id,
         virtio_mem.clone(),
@@ -677,7 +677,7 @@ fn attach_block_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Block>>> + Debug>(
             (locked.id().to_string(), locked.is_vhost_user())
         };
         // The device mutex mustn't be locked here otherwise it will deadlock.
-        device_manager.attach_virtio_device(
+        device_manager.attach_boot_virtio_device(
             vm,
             id,
             block.clone(),
@@ -699,7 +699,7 @@ fn attach_net_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Net>>> + Debug>(
     for net_device in net_devices {
         let id = net_device.lock().expect("Poisoned lock").id().to_string();
         // The device mutex mustn't be locked here otherwise it will deadlock.
-        device_manager.attach_virtio_device(
+        device_manager.attach_boot_virtio_device(
             vm,
             id,
             net_device.clone(),
@@ -731,7 +731,7 @@ fn attach_pmem_devices(
         let pmem = Pmem::new(kvm_vm.clone(), config.clone())?;
         let device = Arc::new(Mutex::new(pmem));
 
-        device_manager.attach_virtio_device(vm, id, device, cmdline, event_manager, false)?;
+        device_manager.attach_boot_virtio_device(vm, id, device, cmdline, event_manager, false)?;
     }
     Ok(())
 }
@@ -745,7 +745,14 @@ fn attach_unixsock_vsock_device(
 ) -> Result<(), AttachDeviceError> {
     let id = String::from(unix_vsock.lock().expect("Poisoned lock").id());
     // The device mutex mustn't be locked here otherwise it will deadlock.
-    device_manager.attach_virtio_device(vm, id, unix_vsock.clone(), cmdline, event_manager, false)
+    device_manager.attach_boot_virtio_device(
+        vm,
+        id,
+        unix_vsock.clone(),
+        cmdline,
+        event_manager,
+        false,
+    )
 }
 
 fn attach_balloon_device(
@@ -758,7 +765,7 @@ fn attach_balloon_device(
     let _kvm_vm = vm.as_kvm().ok_or(AttachDeviceError::NotSupported)?;
     let id = String::from(balloon.lock().expect("Poisoned lock").id());
     // The device mutex mustn't be locked here otherwise it will deadlock.
-    device_manager.attach_virtio_device(vm, id, balloon.clone(), cmdline, event_manager, false)
+    device_manager.attach_boot_virtio_device(vm, id, balloon.clone(), cmdline, event_manager, false)
 }
 
 #[cfg(test)]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1312,7 +1312,12 @@ pub(crate) mod tests {
             .device_manager
             .attach_boot_timer_device(vmm.vm.as_kvm().unwrap(), request_ts);
         res.unwrap();
-        assert!(vmm.device_manager.mmio_devices.boot_timer.is_some());
+        assert!(
+            vmm.device_manager
+                .mmio_platform_devices
+                .boot_timer
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -24,7 +24,6 @@ use crate::construct_kvm_mpidrs;
 use crate::cpu_config::templates::{GetCpuTemplate, GetCpuTemplateError, GuestConfigError};
 #[cfg(target_arch = "x86_64")]
 use crate::device_manager;
-use crate::device_manager::pci_mngr::PciManagerError;
 use crate::device_manager::{
     AttachDeviceError, DeviceManager, DeviceManagerCreateError, DeviceManagerPersistError,
     DeviceRestoreArgs,
@@ -83,8 +82,6 @@ pub enum StartMicrovmError {
     /// Error creating legacy device: {0}
     #[cfg(target_arch = "x86_64")]
     CreateLegacyDevice(device_manager::legacy::LegacyDeviceError),
-    /// Error enabling PCIe support: {0}
-    EnablePciDevices(#[from] PciManagerError),
     /// Error enabling pvtime on vcpu: {0}
     #[cfg(target_arch = "aarch64")]
     EnablePVTime(crate::arch::VcpuArchError),
@@ -207,15 +204,14 @@ pub fn build_microvm_for_boot(
         &kvm_vm,
         vm_resources.serial_out_path.as_ref(),
         vm_resources.serial_rate_limiter(),
+        vm_resources.pci_enabled,
     )?;
 
     let guest_memory = kvm_vm.guest_memory();
     let entry_point = load_kernel(&boot_config.kernel_file, guest_memory)?;
     let initrd = InitrdConfig::from_config(boot_config, guest_memory)?;
 
-    if vm_resources.pci_enabled {
-        device_manager.enable_pci(&kvm_vm)?;
-    } else {
+    if !vm_resources.pci_enabled {
         boot_cmdline.insert("pci", "off")?;
     }
 
@@ -856,6 +852,25 @@ pub(crate) mod tests {
             shutdown_exit_code: None,
             vm: Vm::Kvm(Arc::new(vm)),
             device_manager: default_device_manager(),
+        }
+    }
+
+    pub(crate) fn default_vmm_with_pci() -> Vmm {
+        let mut vm = setup_vm_with_memory(mib_to_bytes(128));
+
+        let _ = vm.create_vcpus(1).unwrap();
+
+        let vm = Arc::new(vm);
+        let mut device_manager = default_device_manager();
+        device_manager.pci_devices.attach_pci_segment(&vm).unwrap();
+
+        Vmm {
+            instance_info: InstanceInfo::default(),
+            machine_config: MachineConfig::default(),
+            boot_source_config: BootSourceConfig::default(),
+            shutdown_exit_code: None,
+            vm: Vm::Kvm(vm),
+            device_manager,
         }
     }
 

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -124,14 +124,6 @@ pub struct MMIODevice<T> {
 pub struct MMIODeviceManager {
     /// VirtIO devices using an MMIO transport layer
     pub(crate) virtio_devices: HashMap<VirtioDeviceId, MMIODevice<MmioTransport>>,
-    /// Boot timer device
-    pub(crate) boot_timer: Option<MMIODevice<BootTimer>>,
-    #[cfg(target_arch = "aarch64")]
-    /// Real-Time clock on Aarch64 platforms
-    pub(crate) rtc: Option<MMIODevice<RTCDevice>>,
-    #[cfg(target_arch = "aarch64")]
-    /// Serial device on Aarch64 platforms
-    pub(crate) serial: Option<MMIODevice<SerialDevice>>,
     #[cfg(target_arch = "x86_64")]
     // We create the AML byte code for every VirtIO device in the order we build
     // it, so that we ensure the root block device is appears first in the DSDT.
@@ -144,7 +136,7 @@ pub struct MMIODeviceManager {
 }
 
 impl MMIODeviceManager {
-    /// Create a new DeviceManager handling mmio devices (virtio net, block).
+    /// Create a new manager for virtio devices using the MMIO transport.
     pub fn new() -> MMIODeviceManager {
         Default::default()
     }
@@ -270,6 +262,92 @@ impl MMIODeviceManager {
         Ok(())
     }
 
+    /// Gets the specified device.
+    pub fn get_virtio_device(
+        &self,
+        device_type: VirtioDeviceType,
+        device_id: &str,
+    ) -> Option<&MMIODevice<MmioTransport>> {
+        self.virtio_devices
+            .get(&(device_type, device_id.to_string()))
+    }
+
+    /// Run fn for each registered virtio device.
+    pub fn for_each_virtio_mmio_device<F, E: Debug>(&self, mut f: F) -> Result<(), E>
+    where
+        F: FnMut(&VirtioDeviceType, &String, &MMIODevice<MmioTransport>) -> Result<(), E>,
+    {
+        for ((device_type, device_id), mmio_device) in &self.virtio_devices {
+            f(device_type, device_id, mmio_device)?;
+        }
+        Ok(())
+    }
+
+    pub fn for_each_virtio_device(&self, mut f: impl FnMut(VirtioDeviceType, &dyn VirtioDevice)) {
+        for ((device_type, _), virtio_device) in &self.virtio_devices {
+            let device_arc = virtio_device.inner.lock().expect("Poisoned lock").device();
+            let virtio_device = device_arc.lock().expect("Poisoned lock");
+            f(*device_type, &*virtio_device);
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub fn virtio_device_info(&self) -> Vec<&MMIODeviceInfo> {
+        let mut device_info = Vec::new();
+        for dev in self.virtio_devices.values() {
+            device_info.push(&dev.resources);
+        }
+        device_info
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct MMIOPlatformDevices {
+    /// Boot timer device
+    pub(crate) boot_timer: Option<MMIODevice<BootTimer>>,
+    #[cfg(target_arch = "aarch64")]
+    /// Real-Time clock on Aarch64 platforms
+    pub(crate) rtc: Option<MMIODevice<RTCDevice>>,
+    #[cfg(target_arch = "aarch64")]
+    /// Serial device on Aarch64 platforms
+    pub(crate) serial: Option<MMIODevice<SerialDevice>>,
+}
+
+impl MMIOPlatformDevices {
+    /// Create a new manager for MMIO platform devices.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Register a boot timer device.
+    pub fn register_mmio_boot_timer(
+        &mut self,
+        mmio_bus: &Bus,
+        boot_timer: Arc<Mutex<BootTimer>>,
+    ) -> Result<(), MmioError> {
+        // Attach a new boot timer device.
+        let device_info = MMIODeviceInfo {
+            addr: BOOT_DEVICE_MEM_START,
+            len: MMIO_LEN,
+            gsi: None,
+        };
+
+        let device = MMIODevice {
+            resources: device_info,
+            inner: boot_timer,
+            sub_id: None,
+        };
+
+        mmio_bus.insert(
+            device.inner.clone(),
+            device.resources.addr,
+            device.resources.len,
+        )?;
+        self.boot_timer = Some(device);
+
+        Ok(())
+    }
+
     #[cfg(target_arch = "aarch64")]
     /// Register an early console at the specified MMIO configuration if given as parameter,
     /// otherwise allocate a new MMIO resources for it.
@@ -371,73 +449,6 @@ impl MMIODeviceManager {
         )?;
         self.rtc = Some(device);
         Ok(())
-    }
-
-    /// Register a boot timer device.
-    pub fn register_mmio_boot_timer(
-        &mut self,
-        mmio_bus: &Bus,
-        boot_timer: Arc<Mutex<BootTimer>>,
-    ) -> Result<(), MmioError> {
-        // Attach a new boot timer device.
-        let device_info = MMIODeviceInfo {
-            addr: BOOT_DEVICE_MEM_START,
-            len: MMIO_LEN,
-            gsi: None,
-        };
-
-        let device = MMIODevice {
-            resources: device_info,
-            inner: boot_timer,
-            sub_id: None,
-        };
-
-        mmio_bus.insert(
-            device.inner.clone(),
-            device.resources.addr,
-            device.resources.len,
-        )?;
-        self.boot_timer = Some(device);
-
-        Ok(())
-    }
-
-    /// Gets the specified device.
-    pub fn get_virtio_device(
-        &self,
-        device_type: VirtioDeviceType,
-        device_id: &str,
-    ) -> Option<&MMIODevice<MmioTransport>> {
-        self.virtio_devices
-            .get(&(device_type, device_id.to_string()))
-    }
-
-    /// Run fn for each registered virtio device.
-    pub fn for_each_virtio_mmio_device<F, E: Debug>(&self, mut f: F) -> Result<(), E>
-    where
-        F: FnMut(&VirtioDeviceType, &String, &MMIODevice<MmioTransport>) -> Result<(), E>,
-    {
-        for ((device_type, device_id), mmio_device) in &self.virtio_devices {
-            f(device_type, device_id, mmio_device)?;
-        }
-        Ok(())
-    }
-
-    pub fn for_each_virtio_device(&self, mut f: impl FnMut(VirtioDeviceType, &dyn VirtioDevice)) {
-        for ((device_type, _), virtio_device) in &self.virtio_devices {
-            let device_arc = virtio_device.inner.lock().expect("Poisoned lock").device();
-            let virtio_device = device_arc.lock().expect("Poisoned lock");
-            f(*device_type, &*virtio_device);
-        }
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    pub fn virtio_device_info(&self) -> Vec<&MMIODeviceInfo> {
-        let mut device_info = Vec::new();
-        for dev in self.virtio_devices.values() {
-            device_info.push(&dev.resources);
-        }
-        device_info
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -121,7 +121,7 @@ pub struct MMIODevice<T> {
 
 /// Manages the complexities of registering a MMIO device.
 #[derive(Debug, Default)]
-pub struct MMIODeviceManager {
+pub struct MMIOVirtioDevices {
     /// VirtIO devices using an MMIO transport layer
     pub(crate) virtio_devices: HashMap<VirtioDeviceId, MMIODevice<MmioTransport>>,
     #[cfg(target_arch = "x86_64")]
@@ -135,9 +135,9 @@ pub struct MMIODeviceManager {
     pub(crate) dsdt_data: Vec<u8>,
 }
 
-impl MMIODeviceManager {
+impl MMIOVirtioDevices {
     /// Create a new manager for virtio devices using the MMIO transport.
-    pub fn new() -> MMIODeviceManager {
+    pub fn new() -> MMIOVirtioDevices {
         Default::default()
     }
 
@@ -484,7 +484,7 @@ pub(crate) mod tests {
 
     const QUEUE_SIZES: &[u16] = &[64];
 
-    impl MMIODeviceManager {
+    impl MMIOVirtioDevices {
         pub(crate) fn register_virtio_test_device(
             &mut self,
             vm: &KvmVm,
@@ -620,7 +620,7 @@ pub(crate) mod tests {
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = KvmVm::new(kvm).unwrap();
         vm.register_dram_memory_regions(guest_mem).unwrap();
-        let mut device_manager = MMIODeviceManager::new();
+        let mut device_manager = MMIOVirtioDevices::new();
 
         let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         let dummy = Arc::new(Mutex::new(DummyDevice::new()));
@@ -674,7 +674,7 @@ pub(crate) mod tests {
         let kvm = Kvm::new(vec![]).expect("Cannot create Kvm");
         let mut vm = KvmVm::new(kvm).unwrap();
         vm.register_dram_memory_regions(guest_mem).unwrap();
-        let mut device_manager = MMIODeviceManager::new();
+        let mut device_manager = MMIOVirtioDevices::new();
 
         let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         #[cfg(target_arch = "x86_64")]
@@ -736,7 +736,7 @@ pub(crate) mod tests {
         #[cfg(target_arch = "aarch64")]
         vm.setup_irqchip(1).unwrap();
 
-        let mut device_manager = MMIODeviceManager::new();
+        let mut device_manager = MMIOVirtioDevices::new();
         let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         let dummy = Arc::new(Mutex::new(DummyDevice::new()));
 
@@ -802,7 +802,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_no_irq_allocation() {
-        let mut device_manager = MMIODeviceManager::new();
+        let mut device_manager = MMIOVirtioDevices::new();
         let mut resource_allocator = ResourceAllocator::new();
 
         let device_info = device_manager
@@ -813,7 +813,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_irq_allocation() {
-        let mut device_manager = MMIODeviceManager::new();
+        let mut device_manager = MMIOVirtioDevices::new();
         let mut resource_allocator = ResourceAllocator::new();
 
         let device_info = device_manager
@@ -824,7 +824,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_allocation_failure() {
-        let mut device_manager = MMIODeviceManager::new();
+        let mut device_manager = MMIOVirtioDevices::new();
         let mut resource_allocator = ResourceAllocator::new();
         assert_eq!(
             format!(

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -25,7 +25,7 @@ use crate::arch::{RTC_MEM_START, SERIAL_MEM_START};
 use crate::devices::legacy::{RTCDevice, SerialDevice};
 use crate::devices::pseudo::BootTimer;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceId, VirtioDeviceType};
-use crate::devices::virtio::transport::mmio::MmioTransport;
+use crate::devices::virtio::transport::mmio::{IrqTrigger, MmioTransport};
 #[cfg(target_arch = "x86_64")]
 use crate::logger::debug;
 use crate::vstate::bus::{Bus, BusError};
@@ -139,6 +139,25 @@ impl MMIOVirtioDevices {
     /// Create a new manager for virtio devices using the MMIO transport.
     pub fn new() -> MMIOVirtioDevices {
         Default::default()
+    }
+
+    /// Attach a VirtioDevice using the MMIO transport.
+    pub(crate) fn attach_mmio_virtio_device(
+        &mut self,
+        vm: &KvmVm,
+        id: String,
+        device: Arc<Mutex<dyn VirtioDevice>>,
+        cmdline: &mut kernel_cmdline::Cmdline,
+        event_manager: &mut EventManager,
+        is_vhost_user: bool,
+    ) -> Result<(), MmioError> {
+        let interrupt = Arc::new(IrqTrigger::new());
+        // The device mutex mustn't be locked here otherwise it will deadlock.
+        let device =
+            MmioTransport::new(vm.guest_memory().clone(), interrupt, device, is_vhost_user);
+        self.register_mmio_virtio_for_boot(vm, id, device, event_manager, cmdline)?;
+
+        Ok(())
     }
 
     /// Allocates resources for a new device to be added.
@@ -272,6 +291,15 @@ impl MMIOVirtioDevices {
             .get(&(device_type, device_id.to_string()))
     }
 
+    pub(crate) fn get_device(
+        &self,
+        device_type: VirtioDeviceType,
+        device_id: &str,
+    ) -> Option<Arc<Mutex<dyn VirtioDevice>>> {
+        self.get_virtio_device(device_type, device_id)
+            .map(|device| device.inner.lock().expect("Poisoned lock").device())
+    }
+
     /// Run fn for each registered virtio device.
     pub fn for_each_virtio_mmio_device<F, E: Debug>(&self, mut f: F) -> Result<(), E>
     where
@@ -289,6 +317,23 @@ impl MMIOVirtioDevices {
             let virtio_device = device_arc.lock().expect("Poisoned lock");
             f(*device_type, &*virtio_device);
         }
+    }
+
+    pub(crate) fn for_each_virtio_device_mut(
+        &self,
+        mut f: impl FnMut(VirtioDeviceType, &mut dyn VirtioDevice),
+    ) {
+        for ((device_type, _), virtio_device) in &self.virtio_devices {
+            let device_arc = virtio_device.inner.lock().expect("Poisoned lock").device();
+            let mut virtio_device = device_arc.lock().expect("Poisoned lock");
+            f(*device_type, &mut *virtio_device);
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) fn append_aml_bytes(&self, dsdt_data: &mut Vec<u8>) -> Result<(), aml::AmlError> {
+        dsdt_data.extend_from_slice(&self.dsdt_data);
+        Ok(())
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -285,8 +285,10 @@ impl DeviceManager {
         Ok(())
     }
 
-    /// Attaches a VirtioDevice device to the device manager and event manager.
-    pub(crate) fn attach_virtio_device<T: 'static + VirtioDevice + MutEventSubscriber + Debug>(
+    /// Attaches a boot-time VirtioDevice device to the device manager and event manager.
+    pub(crate) fn attach_boot_virtio_device<
+        T: 'static + VirtioDevice + MutEventSubscriber + Debug,
+    >(
         &mut self,
         vm: &Vm,
         id: String,

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -15,7 +15,7 @@ use event_manager::{MutEventSubscriber, SubscriberOps};
 #[cfg(target_arch = "x86_64")]
 use legacy::{LegacyDeviceError, PortIODeviceManager};
 use linux_loader::loader::Cmdline;
-use mmio::{MMIODeviceManager, MMIOPlatformDevices, MmioError};
+use mmio::{MMIOPlatformDevices, MMIOVirtioDevices, MmioError};
 use pci_mngr::{PciDevices, PciDevicesConstructorArgs, PciManagerError};
 use persist::{
     MMIODevManagerConstructorArgs, MMIOPlatformDevicesConstructorArgs, MMIOPlatformDevicesState,
@@ -120,7 +120,7 @@ pub struct DeviceManager {
     /// MMIO Platform devices (non-virtio)
     pub mmio_platform_devices: MMIOPlatformDevices,
     /// Virtio devices using an MMIO transport.
-    pub mmio_devices: MMIODeviceManager,
+    pub mmio_virtio_devices: MMIOVirtioDevices,
     #[cfg(target_arch = "x86_64")]
     /// Legacy devices (`None` if not initialized)
     pub legacy_devices: Option<PortIODeviceManager>,
@@ -250,7 +250,7 @@ impl DeviceManager {
 
         Ok(DeviceManager {
             mmio_platform_devices: MMIOPlatformDevices::new(),
-            mmio_devices: MMIODeviceManager::new(),
+            mmio_virtio_devices: MMIOVirtioDevices::new(),
             #[cfg(target_arch = "x86_64")]
             legacy_devices: Some(legacy_devices),
             acpi_devices: ACPIDeviceManager::default(),
@@ -274,8 +274,13 @@ impl DeviceManager {
         // The device mutex mustn't be locked here otherwise it will deadlock.
         let device =
             MmioTransport::new(vm.guest_memory().clone(), interrupt, device, is_vhost_user);
-        self.mmio_devices
-            .register_mmio_virtio_for_boot(vm, id, device, event_manager, cmdline)?;
+        self.mmio_virtio_devices.register_mmio_virtio_for_boot(
+            vm,
+            id,
+            device,
+            event_manager,
+            cmdline,
+        )?;
 
         Ok(())
     }
@@ -383,7 +388,7 @@ impl DeviceManager {
         info!("Artificially kick devices");
         // Go through MMIO VirtIO devices
         let _: Result<(), MmioError> =
-            self.mmio_devices
+            self.mmio_virtio_devices
                 .for_each_virtio_mmio_device(|_, _, device| {
                     let mmio_transport_locked = device.inner.lock().expect("Poisoned lock");
                     mmio_transport_locked
@@ -422,7 +427,7 @@ impl DeviceManager {
     pub fn mark_virtio_queue_memory_dirty(&self, mem: &GuestMemoryMmap) {
         // Go through MMIO VirtIO devices
         let _: Result<(), Infallible> =
-            self.mmio_devices
+            self.mmio_virtio_devices
                 .for_each_virtio_mmio_device(|_, _, device| {
                     let mmio_transport_locked = device.inner.lock().expect("Poisoned locked");
                     Self::do_mark_virtio_queue_memory_dirty(mmio_transport_locked.device(), mem);
@@ -453,7 +458,7 @@ impl DeviceManager {
             )
         } else {
             let mmio_device = self
-                .mmio_devices
+                .mmio_virtio_devices
                 .get_virtio_device(device_type, device_id)?;
             Some(
                 mmio_device
@@ -488,7 +493,7 @@ impl DeviceManager {
         if self.is_pci_enabled() {
             self.pci_devices.for_each_virtio_device(&mut f);
         } else {
-            self.mmio_devices.for_each_virtio_device(&mut f);
+            self.mmio_virtio_devices.for_each_virtio_device(&mut f);
         }
     }
 
@@ -734,7 +739,7 @@ impl<'a> Persist<'a> for DeviceManager {
 
     fn save(&self) -> Self::State {
         DevicesState {
-            mmio_state: self.mmio_devices.save(),
+            mmio_state: self.mmio_virtio_devices.save(),
             mmio_platform_state: self.mmio_platform_devices.save(),
             acpi_state: self.acpi_devices.save(),
             pci_state: self.pci_devices.save(),
@@ -779,7 +784,7 @@ impl<'a> Persist<'a> for DeviceManager {
             vm_resources: constructor_args.vm_resources,
             instance_id: constructor_args.instance_id,
         };
-        let mmio_devices = MMIODeviceManager::restore(mmio_ctor_args, &state.mmio_state)
+        let mmio_virtio_devices = MMIOVirtioDevices::restore(mmio_ctor_args, &state.mmio_state)
             .map_err(DeviceManagerPersistError::MmioRestore)?;
 
         // Restore ACPI devices
@@ -798,7 +803,7 @@ impl<'a> Persist<'a> for DeviceManager {
 
         Ok(DeviceManager {
             mmio_platform_devices,
-            mmio_devices,
+            mmio_virtio_devices,
             #[cfg(target_arch = "x86_64")]
             legacy_devices: Some(legacy_devices),
             acpi_devices,
@@ -828,7 +833,7 @@ pub(crate) mod tests {
     pub(crate) fn default_device_manager() -> DeviceManager {
         let mut resource_allocator = ResourceAllocator::new();
         let mmio_platform_devices = MMIOPlatformDevices::new();
-        let mmio_devices = MMIODeviceManager::new();
+        let mmio_virtio_devices = MMIOVirtioDevices::new();
         let acpi_devices = ACPIDeviceManager::new(
             VmGenId::new(&mut resource_allocator).unwrap(),
             VmClock::new(&mut resource_allocator).unwrap(),
@@ -847,7 +852,7 @@ pub(crate) mod tests {
 
         DeviceManager {
             mmio_platform_devices,
-            mmio_devices,
+            mmio_virtio_devices,
             #[cfg(target_arch = "x86_64")]
             legacy_devices: Some(legacy_devices),
             acpi_devices,

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -15,9 +15,11 @@ use event_manager::{MutEventSubscriber, SubscriberOps};
 #[cfg(target_arch = "x86_64")]
 use legacy::{LegacyDeviceError, PortIODeviceManager};
 use linux_loader::loader::Cmdline;
-use mmio::{MMIODeviceManager, MmioError};
+use mmio::{MMIODeviceManager, MMIOPlatformDevices, MmioError};
 use pci_mngr::{PciDevices, PciDevicesConstructorArgs, PciManagerError};
-use persist::MMIODevManagerConstructorArgs;
+use persist::{
+    MMIODevManagerConstructorArgs, MMIOPlatformDevicesConstructorArgs, MMIOPlatformDevicesState,
+};
 use serde::{Deserialize, Serialize};
 use utils::time::TimestampUs;
 use vm_superio::serial;
@@ -115,7 +117,9 @@ pub enum FindDeviceError {
 #[derive(Debug, Default)]
 /// A manager of all peripheral devices of Firecracker
 pub struct DeviceManager {
-    /// MMIO devices
+    /// MMIO Platform devices (non-virtio)
+    pub mmio_platform_devices: MMIOPlatformDevices,
+    /// Virtio devices using an MMIO transport.
     pub mmio_devices: MMIODeviceManager,
     #[cfg(target_arch = "x86_64")]
     /// Legacy devices (`None` if not initialized)
@@ -175,7 +179,7 @@ impl DeviceManager {
     fn serial_state(&self) -> Option<persist::SerialState> {
         #[cfg(target_arch = "aarch64")]
         {
-            self.mmio_devices.serial.as_ref().map(|device| {
+            self.mmio_platform_devices.serial.as_ref().map(|device| {
                 let locked = device.inner.lock().expect("Poisoned lock");
                 locked.serial.state().into()
             })
@@ -245,6 +249,7 @@ impl DeviceManager {
         )?;
 
         Ok(DeviceManager {
+            mmio_platform_devices: MMIOPlatformDevices::new(),
             mmio_devices: MMIODeviceManager::new(),
             #[cfg(target_arch = "x86_64")]
             legacy_devices: Some(legacy_devices),
@@ -314,7 +319,7 @@ impl DeviceManager {
     ) -> Result<(), AttachDeviceError> {
         let boot_timer = Arc::new(Mutex::new(BootTimer::new(request_ts)));
 
-        self.mmio_devices
+        self.mmio_platform_devices
             .register_mmio_boot_timer(&vm.common.mmio_bus, boot_timer)?;
 
         Ok(())
@@ -356,12 +361,15 @@ impl DeviceManager {
                 None,
                 serial_rate_limiter,
             )?;
-            self.mmio_devices.register_mmio_serial(vm, serial, None)?;
-            self.mmio_devices.add_mmio_serial_to_cmdline(cmdline)?;
+            self.mmio_platform_devices
+                .register_mmio_serial(vm, serial, None)?;
+            self.mmio_platform_devices
+                .add_mmio_serial_to_cmdline(cmdline)?;
         }
 
         let rtc = Arc::new(Mutex::new(RTCDevice::new()));
-        self.mmio_devices.register_mmio_rtc(vm, rtc, None)?;
+        self.mmio_platform_devices
+            .register_mmio_rtc(vm, rtc, None)?;
         Ok(())
     }
 
@@ -634,8 +642,10 @@ impl DeviceManager {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 /// State of devices in the system
 pub struct DevicesState {
-    /// MMIO devices state
+    /// MMIO virtio devices state
     pub mmio_state: persist::DeviceStates,
+    /// MMIO platform (non-virtio) devices state
+    pub mmio_platform_state: MMIOPlatformDevicesState,
     /// ACPI devices state
     pub acpi_state: persist::ACPIDeviceManagerState,
     /// PCI devices state
@@ -725,6 +735,7 @@ impl<'a> Persist<'a> for DeviceManager {
     fn save(&self) -> Self::State {
         DevicesState {
             mmio_state: self.mmio_devices.save(),
+            mmio_platform_state: self.mmio_platform_devices.save(),
             acpi_state: self.acpi_devices.save(),
             pci_state: self.pci_devices.save(),
             serial_state: self.serial_state(),
@@ -749,14 +760,24 @@ impl<'a> Persist<'a> for DeviceManager {
             constructor_args.vm_resources.serial_rate_limiter(),
         )?;
 
-        // Restore MMIO devices
+        // Restore MMIO platform devices
+        let platform_ctor_args = MMIOPlatformDevicesConstructorArgs {
+            vm: constructor_args.vm,
+            event_manager: constructor_args.event_manager,
+            vm_resources: constructor_args.vm_resources,
+            serial_state: state.serial_state.as_ref(),
+        };
+        let mmio_platform_devices =
+            MMIOPlatformDevices::restore(platform_ctor_args, &state.mmio_platform_state)
+                .map_err(DeviceManagerPersistError::MmioRestore)?;
+
+        // Restore Virtio-over-MMIO devices
         let mmio_ctor_args = MMIODevManagerConstructorArgs {
             mem: constructor_args.mem,
             vm: constructor_args.vm,
             event_manager: constructor_args.event_manager,
             vm_resources: constructor_args.vm_resources,
             instance_id: constructor_args.instance_id,
-            serial_state: state.serial_state.as_ref(),
         };
         let mmio_devices = MMIODeviceManager::restore(mmio_ctor_args, &state.mmio_state)
             .map_err(DeviceManagerPersistError::MmioRestore)?;
@@ -776,6 +797,7 @@ impl<'a> Persist<'a> for DeviceManager {
             .map_err(DeviceManagerPersistError::PciRestore)?;
 
         Ok(DeviceManager {
+            mmio_platform_devices,
             mmio_devices,
             #[cfg(target_arch = "x86_64")]
             legacy_devices: Some(legacy_devices),
@@ -805,6 +827,7 @@ pub(crate) mod tests {
 
     pub(crate) fn default_device_manager() -> DeviceManager {
         let mut resource_allocator = ResourceAllocator::new();
+        let mmio_platform_devices = MMIOPlatformDevices::new();
         let mmio_devices = MMIODeviceManager::new();
         let acpi_devices = ACPIDeviceManager::new(
             VmGenId::new(&mut resource_allocator).unwrap(),
@@ -823,6 +846,7 @@ pub(crate) mod tests {
         };
 
         DeviceManager {
+            mmio_platform_devices,
             mmio_devices,
             #[cfg(target_arch = "x86_64")]
             legacy_devices: Some(legacy_devices),
@@ -835,8 +859,8 @@ pub(crate) mod tests {
     #[test]
     fn test_attach_legacy_serial() {
         let mut vmm = default_vmm();
-        assert!(vmm.device_manager.mmio_devices.rtc.is_none());
-        assert!(vmm.device_manager.mmio_devices.serial.is_none());
+        assert!(vmm.device_manager.mmio_platform_devices.rtc.is_none());
+        assert!(vmm.device_manager.mmio_platform_devices.serial.is_none());
 
         let mut cmdline = Cmdline::new(4096).unwrap();
         let mut event_manager = EventManager::new().unwrap();
@@ -849,8 +873,8 @@ pub(crate) mod tests {
                 None,
             )
             .unwrap();
-        assert!(vmm.device_manager.mmio_devices.rtc.is_some());
-        assert!(vmm.device_manager.mmio_devices.serial.is_none());
+        assert!(vmm.device_manager.mmio_platform_devices.rtc.is_some());
+        assert!(vmm.device_manager.mmio_platform_devices.serial.is_none());
 
         let mut vmm = default_vmm();
         cmdline.insert("console", "/dev/blah").unwrap();
@@ -863,8 +887,8 @@ pub(crate) mod tests {
                 None,
             )
             .unwrap();
-        assert!(vmm.device_manager.mmio_devices.rtc.is_some());
-        assert!(vmm.device_manager.mmio_devices.serial.is_some());
+        assert!(vmm.device_manager.mmio_platform_devices.rtc.is_some());
+        assert!(vmm.device_manager.mmio_platform_devices.serial.is_some());
 
         assert!(
             cmdline
@@ -875,7 +899,7 @@ pub(crate) mod tests {
                 .contains(&format!(
                     "earlycon=uart,mmio,0x{:08x}",
                     vmm.device_manager
-                        .mmio_devices
+                        .mmio_platform_devices
                         .serial
                         .as_ref()
                         .unwrap()

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -262,9 +262,7 @@ impl DeviceManager {
         vm: &Arc<KvmVm>,
     ) -> Result<VirtioDevices, PciManagerError> {
         if pci_enabled {
-            let mut pci_devices = PciDevices::new();
-            pci_devices.attach_pci_segment(vm)?;
-            Ok(VirtioDevices::Pci(pci_devices))
+            Ok(VirtioDevices::Pci(PciDevices::new(vm)?))
         } else {
             Ok(VirtioDevices::Mmio(MMIOVirtioDevices::new()))
         }
@@ -825,9 +823,7 @@ pub(crate) mod tests {
 
     pub(crate) fn default_device_manager_with_pci(vm: &Arc<KvmVm>) -> DeviceManager {
         let mut device_manager = default_device_manager();
-        let mut pci_devices = PciDevices::new();
-        pci_devices.attach_pci_segment(vm).unwrap();
-        device_manager.virtio_devices = VirtioDevices::Pci(pci_devices);
+        device_manager.virtio_devices = VirtioDevices::Pci(PciDevices::new(vm).unwrap());
         device_manager
     }
 

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -82,6 +82,8 @@ pub enum DeviceManagerCreateError {
     #[cfg(target_arch = "x86_64")]
     /// Legacy device manager error: {0}
     PortIOError(#[from] LegacyDeviceError),
+    /// PCI device manager error: {0}
+    PciDeviceManager(#[from] PciManagerError),
     /// Resource allocator error: {0}
     ResourceAllocator(#[from] vm_allocator::Error),
 }
@@ -234,9 +236,10 @@ impl DeviceManager {
     pub fn new(
         event_manager: &mut EventManager,
         vcpus_exit_evt: &EventFd,
-        vm: &KvmVm,
+        vm: &Arc<KvmVm>,
         serial_output: Option<&PathBuf>,
         serial_rate_limiter: Option<TokenBucket>,
+        pci_enabled: bool,
     ) -> Result<Self, DeviceManagerCreateError> {
         #[cfg(target_arch = "x86_64")]
         let legacy_devices = Self::create_legacy_devices(
@@ -247,6 +250,11 @@ impl DeviceManager {
             None,
             serial_rate_limiter,
         )?;
+
+        let mut pci_devices = PciDevices::new();
+        if pci_enabled {
+            pci_devices.attach_pci_segment(vm)?;
+        }
 
         Ok(DeviceManager {
             mmio_platform_devices: MMIOPlatformDevices::new(),
@@ -378,11 +386,6 @@ impl DeviceManager {
         self.mmio_platform_devices
             .register_mmio_rtc(vm, rtc, None)?;
         Ok(())
-    }
-
-    /// Enables PCIe support for Firecracker devices
-    pub fn enable_pci(&mut self, vm: &Arc<KvmVm>) -> Result<(), PciManagerError> {
-        self.pci_devices.attach_pci_segment(vm)
     }
 
     /// Artificially kick VirtIO devices as if they had external events.
@@ -820,7 +823,8 @@ pub(crate) mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use crate::builder::tests::{
-        CustomBlockConfig, default_kernel_cmdline, default_vmm, insert_block_devices,
+        CustomBlockConfig, default_kernel_cmdline, default_vmm, default_vmm_with_pci,
+        insert_block_devices,
     };
     use crate::devices::acpi::vmclock::VmClock;
     use crate::devices::acpi::vmgenid::VmGenId;
@@ -933,10 +937,7 @@ pub(crate) mod tests {
     #[test]
     fn test_hotplug_block() {
         let mut evt_manager = EventManager::new().unwrap();
-        let mut vmm = default_vmm();
-        vmm.device_manager
-            .enable_pci(vmm.vm.as_kvm().unwrap())
-            .unwrap();
+        let mut vmm = default_vmm_with_pci();
         let f = TempFile::new().unwrap();
 
         // Successful case
@@ -1023,10 +1024,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_hotplug_pmem() {
-        let mut vmm = default_vmm();
-        vmm.device_manager
-            .enable_pci(vmm.vm.as_kvm().unwrap())
-            .unwrap();
+        let mut vmm = default_vmm_with_pci();
         let mut evt_manager = EventManager::new().unwrap();
         let f = TempFile::new().unwrap();
         f.as_file().set_len(0x1000).unwrap();
@@ -1084,10 +1082,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_hotplug_net() {
-        let mut vmm = default_vmm();
-        vmm.device_manager
-            .enable_pci(vmm.vm.as_kvm().unwrap())
-            .unwrap();
+        let mut vmm = default_vmm_with_pci();
         let mut evt_manager = EventManager::new().unwrap();
 
         let mac = "AA:FC:00:00:00:01";
@@ -1147,10 +1142,7 @@ pub(crate) mod tests {
     #[test]
     fn test_unplug_root_block() {
         let mut evt_manager = EventManager::new().unwrap();
-        let mut vmm = default_vmm();
-        vmm.device_manager
-            .enable_pci(vmm.vm.as_kvm().unwrap())
-            .unwrap();
+        let mut vmm = default_vmm_with_pci();
         let f = TempFile::new().unwrap();
 
         // Simulate a root block device added pre-boot by attaching it
@@ -1179,10 +1171,7 @@ pub(crate) mod tests {
     #[test]
     fn test_unplug_root_pmem() {
         let mut evt_manager = EventManager::new().unwrap();
-        let mut vmm = default_vmm();
-        vmm.device_manager
-            .enable_pci(vmm.vm.as_kvm().unwrap())
-            .unwrap();
+        let mut vmm = default_vmm_with_pci();
         let f = TempFile::new().unwrap();
         f.as_file().set_len(0x1000).unwrap();
 

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -5,12 +5,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::convert::Infallible;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use acpi::ACPIDeviceManager;
+#[cfg(target_arch = "x86_64")]
+use acpi_tables::Aml;
 use event_manager::{MutEventSubscriber, SubscriberOps};
 #[cfg(target_arch = "x86_64")]
 use legacy::{LegacyDeviceError, PortIODeviceManager};
@@ -45,10 +46,8 @@ use crate::devices::virtio::net::persist::NetPersistError;
 use crate::devices::virtio::pmem::device::Pmem;
 use crate::devices::virtio::pmem::persist::PmemPersistError;
 use crate::devices::virtio::rng::persist::EntropyPersistError;
-use crate::devices::virtio::transport::mmio::{IrqTrigger, MmioTransport};
-use crate::devices::virtio::transport::pci::device::CAPABILITY_BAR_SIZE;
 use crate::devices::virtio::vsock::{VsockError, VsockUnixBackendError};
-use crate::logger::{error, info, warn};
+use crate::logger::{error, info};
 use crate::rate_limiter::TokenBucket;
 use crate::resources::VmResources;
 use crate::rpc_interface::VmmActionError;
@@ -121,15 +120,13 @@ pub enum FindDeviceError {
 pub struct DeviceManager {
     /// MMIO Platform devices (non-virtio)
     pub mmio_platform_devices: MMIOPlatformDevices,
-    /// Virtio devices using an MMIO transport.
-    pub mmio_virtio_devices: MMIOVirtioDevices,
     #[cfg(target_arch = "x86_64")]
     /// Legacy devices (`None` if not initialized)
     pub legacy_devices: Option<PortIODeviceManager>,
     /// ACPI devices
     pub acpi_devices: ACPIDeviceManager,
-    /// PCIe devices
-    pub pci_devices: PciDevices,
+    /// Virtio devices (MMIO or PCI)
+    pub virtio_devices: VirtioDevices,
 }
 
 impl DeviceManager {
@@ -251,49 +248,29 @@ impl DeviceManager {
             serial_rate_limiter,
         )?;
 
-        let mut pci_devices = PciDevices::new();
-        if pci_enabled {
-            pci_devices.attach_pci_segment(vm)?;
-        }
-
         Ok(DeviceManager {
             mmio_platform_devices: MMIOPlatformDevices::new(),
-            mmio_virtio_devices: MMIOVirtioDevices::new(),
             #[cfg(target_arch = "x86_64")]
             legacy_devices: Some(legacy_devices),
             acpi_devices: ACPIDeviceManager::default(),
-            pci_devices: PciDevices::new(),
+            virtio_devices: Self::create_virtio_devices(pci_enabled, vm)?,
         })
     }
 
-    /// Attaches an MMIO VirtioDevice device to the device manager and event manager.
-    pub(crate) fn attach_mmio_virtio_device<
-        T: 'static + VirtioDevice + MutEventSubscriber + Debug,
-    >(
-        &mut self,
-        vm: &KvmVm,
-        id: String,
-        device: Arc<Mutex<T>>,
-        cmdline: &mut Cmdline,
-        event_manager: &mut EventManager,
-        is_vhost_user: bool,
-    ) -> Result<(), AttachDeviceError> {
-        let interrupt = Arc::new(IrqTrigger::new());
-        // The device mutex mustn't be locked here otherwise it will deadlock.
-        let device =
-            MmioTransport::new(vm.guest_memory().clone(), interrupt, device, is_vhost_user);
-        self.mmio_virtio_devices.register_mmio_virtio_for_boot(
-            vm,
-            id,
-            device,
-            event_manager,
-            cmdline,
-        )?;
-
-        Ok(())
+    fn create_virtio_devices(
+        pci_enabled: bool,
+        vm: &Arc<KvmVm>,
+    ) -> Result<VirtioDevices, PciManagerError> {
+        if pci_enabled {
+            let mut pci_devices = PciDevices::new();
+            pci_devices.attach_pci_segment(vm)?;
+            Ok(VirtioDevices::Pci(pci_devices))
+        } else {
+            Ok(VirtioDevices::Mmio(MMIOVirtioDevices::new()))
+        }
     }
 
-    /// Attaches a boot-time VirtioDevice device to the device manager and event manager.
+    /// Attaches a boot-time VirtioDevice device to the device and event managers.
     pub(crate) fn attach_boot_virtio_device<
         T: 'static + VirtioDevice + MutEventSubscriber + Debug,
     >(
@@ -305,25 +282,15 @@ impl DeviceManager {
         event_manager: &mut EventManager,
         is_vhost_user: bool,
     ) -> Result<(), AttachDeviceError> {
-        let kvm_vm = vm
-            .as_kvm()
-            .cloned()
-            .ok_or(AttachDeviceError::NotSupported)?;
-        if self.is_pci_enabled() {
-            self.pci_devices
-                .attach_pci_virtio_device(&kvm_vm, id, device, event_manager)?;
-        } else {
-            self.attach_mmio_virtio_device(
-                &kvm_vm,
-                id,
-                device,
-                cmdline,
-                event_manager,
-                is_vhost_user,
-            )?;
+        let vm = vm.as_kvm().ok_or(AttachDeviceError::NotSupported)?;
+        match &mut self.virtio_devices {
+            VirtioDevices::Mmio(mmio_devices) => mmio_devices
+                .attach_mmio_virtio_device(vm, id, device, cmdline, event_manager, is_vhost_user)
+                .map_err(AttachDeviceError::from),
+            VirtioDevices::Pci(pci_devices) => pci_devices
+                .attach_pci_virtio_device(vm, id, device, event_manager)
+                .map_err(AttachDeviceError::from),
         }
-
-        Ok(())
     }
 
     /// Attaches a [`BootTimer`] to the VM
@@ -350,6 +317,35 @@ impl DeviceManager {
         self.acpi_devices.attach_vmclock(vm)?;
         self.acpi_devices.activate_vmclock(vm)?;
         Ok(())
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) fn append_aml_bytes(
+        &self,
+        dsdt_data: &mut Vec<u8>,
+    ) -> Result<(), acpi_tables::aml::AmlError> {
+        match &self.virtio_devices {
+            VirtioDevices::Mmio(devices) => devices.append_aml_bytes(dsdt_data)?,
+            VirtioDevices::Pci(devices) => devices.append_aml_bytes(dsdt_data)?,
+        }
+
+        self.acpi_devices.append_aml_bytes(dsdt_data)
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn mmio_virtio_devices(&self) -> Option<&MMIOVirtioDevices> {
+        match &self.virtio_devices {
+            VirtioDevices::Mmio(mmio_devices) => Some(mmio_devices),
+            VirtioDevices::Pci(_) => None,
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn pci_devices(&self) -> Option<&PciDevices> {
+        match &self.virtio_devices {
+            VirtioDevices::Pci(pci_devices) => Some(pci_devices),
+            VirtioDevices::Mmio(_) => None,
+        }
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -391,59 +387,20 @@ impl DeviceManager {
     /// Artificially kick VirtIO devices as if they had external events.
     pub fn kick_virtio_devices(&self) {
         info!("Artificially kick devices");
-        // Go through MMIO VirtIO devices
-        let _: Result<(), MmioError> =
-            self.mmio_virtio_devices
-                .for_each_virtio_mmio_device(|_, _, device| {
-                    let mmio_transport_locked = device.inner.lock().expect("Poisoned lock");
-                    mmio_transport_locked
-                        .device()
-                        .lock()
-                        .expect("Poisoned lock")
-                        .kick();
-                    Ok(())
-                });
-        // Go through PCI VirtIO devices
-        for virtio_pci_device in self.pci_devices.virtio_devices.values() {
-            virtio_pci_device
-                .lock()
-                .expect("Poisoned lock")
-                .virtio_device()
-                .lock()
-                .expect("Poisoned lock")
-                .kick();
-        }
-    }
-
-    fn do_mark_virtio_queue_memory_dirty(
-        device: Arc<Mutex<dyn VirtioDevice>>,
-        mem: &GuestMemoryMmap,
-    ) {
-        // SAFETY:
-        // This should never fail as we mark pages only if device has already been activated,
-        // and the address validation was already performed on device activation.
-        let mut locked_device = device.lock().expect("Poisoned lock");
-        if locked_device.is_activated() {
-            locked_device.mark_queue_memory_dirty(mem).unwrap()
-        }
+        self.for_each_virtio_device_mut(|_, device| device.kick());
     }
 
     /// Mark queue memory dirty for activated VirtIO devices
     pub fn mark_virtio_queue_memory_dirty(&self, mem: &GuestMemoryMmap) {
-        // Go through MMIO VirtIO devices
-        let _: Result<(), Infallible> =
-            self.mmio_virtio_devices
-                .for_each_virtio_mmio_device(|_, _, device| {
-                    let mmio_transport_locked = device.inner.lock().expect("Poisoned locked");
-                    Self::do_mark_virtio_queue_memory_dirty(mmio_transport_locked.device(), mem);
-                    Ok(())
-                });
-
-        // Go through PCI VirtIO devices
-        for device in self.pci_devices.virtio_devices.values() {
-            let virtio_device = device.lock().expect("Poisoned lock").virtio_device();
-            Self::do_mark_virtio_queue_memory_dirty(virtio_device, mem);
-        }
+        self.for_each_virtio_device_mut(|_, device| {
+            if device.is_activated() {
+                // SAFETY:
+                // This should never fail as we mark pages only if device has already been
+                // activated, and the address validation was already performed on device
+                // activation.
+                device.mark_queue_memory_dirty(mem).unwrap();
+            }
+        });
     }
 
     /// Get a VirtIO device of type `virtio_type` with ID `device_id`
@@ -452,27 +409,9 @@ impl DeviceManager {
         device_type: VirtioDeviceType,
         device_id: &str,
     ) -> Option<Arc<Mutex<dyn VirtioDevice>>> {
-        if self.is_pci_enabled() {
-            let pci_device = self.pci_devices.get_virtio_device(device_type, device_id)?;
-            Some(
-                pci_device
-                    .lock()
-                    .expect("Poisoned lock")
-                    .virtio_device()
-                    .clone(),
-            )
-        } else {
-            let mmio_device = self
-                .mmio_virtio_devices
-                .get_virtio_device(device_type, device_id)?;
-            Some(
-                mmio_device
-                    .inner
-                    .lock()
-                    .expect("Poisoned lock")
-                    .device()
-                    .clone(),
-            )
+        match &self.virtio_devices {
+            VirtioDevices::Mmio(devices) => devices.get_device(device_type, device_id),
+            VirtioDevices::Pci(devices) => devices.get_device(device_type, device_id),
         }
     }
 
@@ -495,15 +434,24 @@ impl DeviceManager {
 
     /// Run fn `f()` on all virtio devices
     pub fn for_each_virtio_device(&self, mut f: impl FnMut(VirtioDeviceType, &dyn VirtioDevice)) {
-        if self.is_pci_enabled() {
-            self.pci_devices.for_each_virtio_device(&mut f);
-        } else {
-            self.mmio_virtio_devices.for_each_virtio_device(&mut f);
+        match &self.virtio_devices {
+            VirtioDevices::Mmio(mmio_devices) => mmio_devices.for_each_virtio_device(&mut f),
+            VirtioDevices::Pci(pci_devices) => pci_devices.for_each_virtio_device(&mut f),
         }
     }
 
-    pub fn is_pci_enabled(&self) -> bool {
-        self.pci_devices.pci_segment.is_some()
+    fn for_each_virtio_device_mut(
+        &self,
+        mut f: impl FnMut(VirtioDeviceType, &mut dyn VirtioDevice),
+    ) {
+        match &self.virtio_devices {
+            VirtioDevices::Mmio(mmio_devices) => {
+                mmio_devices.for_each_virtio_device_mut(&mut f);
+            }
+            VirtioDevices::Pci(pci_devices) => {
+                pci_devices.for_each_virtio_device_mut(&mut f);
+            }
+        }
     }
 
     /// Attaches a device after VM start
@@ -513,19 +461,17 @@ impl DeviceManager {
         config: HotplugDeviceConfig,
         event_manager: &mut EventManager,
     ) -> Result<(), VmmActionError> {
-        if !self.is_pci_enabled() {
-            return Err(VmmActionError::PciNotEnabled);
-        }
-
         let dev_type = config.device_type();
         let dev_id = config.device_id().to_string();
+        let device_id = (dev_type, dev_id.clone());
 
-        if self
-            .pci_devices
-            .virtio_devices
-            .contains_key(&(dev_type, dev_id.clone()))
-        {
-            return Err(VmmActionError::DeviceIdInUse);
+        match &self.virtio_devices {
+            VirtioDevices::Pci(pci_devices) => {
+                if pci_devices.contains_virtio_device(&device_id) {
+                    return Err(VmmActionError::DeviceIdInUse);
+                }
+            }
+            VirtioDevices::Mmio(_) => return Err(VmmActionError::PciNotEnabled),
         }
 
         let device = match config {
@@ -534,9 +480,12 @@ impl DeviceManager {
             HotplugDeviceConfig::Net(cfg) => self.hotplug_make_net(cfg)?,
         };
 
-        self.pci_devices
-            .attach_pci_virtio_device(&vm, dev_id, device, event_manager)?;
-        Ok(())
+        match &mut self.virtio_devices {
+            VirtioDevices::Pci(pci_devices) => pci_devices
+                .attach_pci_virtio_device(&vm, dev_id, device, event_manager)
+                .map_err(VmmActionError::PciManager),
+            VirtioDevices::Mmio(_) => Err(VmmActionError::PciNotEnabled),
+        }
     }
 
     fn hotplug_make_block(
@@ -584,6 +533,31 @@ impl DeviceManager {
         Ok(Arc::new(Mutex::new(net)))
     }
 
+    /// Detaches a device after VM start
+    pub fn hot_unplug_device(
+        &mut self,
+        vm: Arc<KvmVm>,
+        device_id: VirtioDeviceId,
+        event_manager: &mut EventManager,
+    ) -> Result<(), VmmActionError> {
+        match &mut self.virtio_devices {
+            VirtioDevices::Pci(pci_devices) => {
+                let virtio_device = pci_devices
+                    .get_device(device_id.0, &device_id.1)
+                    .ok_or(VmmActionError::DeviceNotFound)?;
+
+                if Self::is_root_device(&*virtio_device.lock().expect("Poisoned lock")) {
+                    return Err(VmmActionError::CannotUnplugRootDevice);
+                }
+
+                pci_devices
+                    .detach_pci_virtio_device(&vm, device_id, event_manager)
+                    .map_err(VmmActionError::PciManager)
+            }
+            VirtioDevices::Mmio(_) => Err(VmmActionError::PciNotEnabled),
+        }
+    }
+
     /// Returns true if the given virtio device is a root block or pmem device.
     fn is_root_device(device: &dyn VirtioDevice) -> bool {
         if let Some(block) = device.as_any().downcast_ref::<Block>() {
@@ -594,58 +568,17 @@ impl DeviceManager {
         }
         false
     }
+}
 
-    /// Detaches a device after VM start
-    pub fn hot_unplug_device(
-        &mut self,
-        vm: Arc<KvmVm>,
-        device_id: VirtioDeviceId,
-        event_manager: &mut EventManager,
-    ) -> Result<(), VmmActionError> {
-        if !self.is_pci_enabled() {
-            return Err(VmmActionError::PciNotEnabled);
-        }
+#[derive(Debug)]
+pub enum VirtioDevices {
+    Mmio(MMIOVirtioDevices),
+    Pci(PciDevices),
+}
 
-        let virtio_device = self
-            .get_virtio_device(device_id.0, &device_id.1)
-            .ok_or(VmmActionError::DeviceNotFound)?;
-
-        if Self::is_root_device(&*virtio_device.lock().expect("Poisoned lock")) {
-            return Err(VmmActionError::CannotUnplugRootDevice);
-        }
-
-        let pci_device_arc = self.pci_devices.virtio_devices.remove(&device_id).unwrap();
-        let pci_device = pci_device_arc.lock().expect("Poisoned lock");
-
-        pci_device
-            .unregister_notification_ioevents(&vm)
-            .map_err(PciManagerError::Kvm)?;
-
-        vm.common
-            .mmio_bus
-            .remove(pci_device.config_bar_addr(), CAPABILITY_BAR_SIZE)
-            .map_err(PciManagerError::Bus)?;
-
-        self.pci_devices
-            .pci_segment
-            .as_ref()
-            .unwrap()
-            .pci_bus
-            .lock()
-            .expect("Poisoned lock")
-            .remove_device(pci_device.sbdf.device());
-
-        if let Some(sub_id) = pci_device.sub_id
-            && event_manager.remove_subscriber(sub_id).is_err()
-        {
-            warn!("Failed to remove event subscriber for device {device_id:?}");
-        }
-
-        // Ensure no other references to the device remain, so it is freed when
-        // this function returns.
-        assert_eq!(Arc::strong_count(&pci_device_arc), 1);
-
-        Ok(())
+impl Default for VirtioDevices {
+    fn default() -> Self {
+        Self::Mmio(MMIOVirtioDevices::new())
     }
 }
 
@@ -743,11 +676,24 @@ impl<'a> Persist<'a> for DeviceManager {
     type Error = DeviceManagerPersistError;
 
     fn save(&self) -> Self::State {
+        // Save both transport slots for now; only the active variant has
+        // devices, so the inactive slot serialises its default (empty) state.
+        // The next commit changes the wire format to hold only the active
+        // transport.
+        let (mmio_state, pci_state) = match &self.virtio_devices {
+            VirtioDevices::Mmio(mmio_devices) => {
+                (mmio_devices.save(), pci_mngr::PciDevicesState::default())
+            }
+            VirtioDevices::Pci(pci_devices) => {
+                (persist::DeviceStates::default(), pci_devices.save())
+            }
+        };
+
         DevicesState {
-            mmio_state: self.mmio_virtio_devices.save(),
+            mmio_state,
             mmio_platform_state: self.mmio_platform_devices.save(),
             acpi_state: self.acpi_devices.save(),
-            pci_state: self.pci_devices.save(),
+            pci_state,
             serial_state: self.serial_state(),
         }
     }
@@ -781,38 +727,42 @@ impl<'a> Persist<'a> for DeviceManager {
             MMIOPlatformDevices::restore(platform_ctor_args, &state.mmio_platform_state)
                 .map_err(DeviceManagerPersistError::MmioRestore)?;
 
-        // Restore Virtio-over-MMIO devices
-        let mmio_ctor_args = MMIODevManagerConstructorArgs {
-            mem: constructor_args.mem,
-            vm: constructor_args.vm,
-            event_manager: constructor_args.event_manager,
-            vm_resources: constructor_args.vm_resources,
-            instance_id: constructor_args.instance_id,
-        };
-        let mmio_virtio_devices = MMIOVirtioDevices::restore(mmio_ctor_args, &state.mmio_state)
-            .map_err(DeviceManagerPersistError::MmioRestore)?;
-
         // Restore ACPI devices
         let acpi_devices = ACPIDeviceManager::restore(constructor_args.vm, &state.acpi_state)?;
 
-        // Restore PCI devices
-        let pci_ctor_args = PciDevicesConstructorArgs {
-            vm: constructor_args.vm,
-            mem: constructor_args.mem,
-            vm_resources: constructor_args.vm_resources,
-            instance_id: constructor_args.instance_id,
-            event_manager: constructor_args.event_manager,
+        // The wire format carries both transport slots; the pci_enabled flag
+        // says which one was active. The next commit changes the format to
+        // hold only the active transport.
+        let virtio_devices = if state.pci_state.pci_enabled {
+            let pci_ctor_args = PciDevicesConstructorArgs {
+                vm: constructor_args.vm,
+                mem: constructor_args.mem,
+                vm_resources: constructor_args.vm_resources,
+                instance_id: constructor_args.instance_id,
+                event_manager: constructor_args.event_manager,
+            };
+            let pci_devices = PciDevices::restore(pci_ctor_args, &state.pci_state)
+                .map_err(DeviceManagerPersistError::PciRestore)?;
+            VirtioDevices::Pci(pci_devices)
+        } else {
+            let mmio_ctor_args = MMIODevManagerConstructorArgs {
+                mem: constructor_args.mem,
+                vm: constructor_args.vm,
+                event_manager: constructor_args.event_manager,
+                vm_resources: constructor_args.vm_resources,
+                instance_id: constructor_args.instance_id,
+            };
+            let mmio_virtio_devices = MMIOVirtioDevices::restore(mmio_ctor_args, &state.mmio_state)
+                .map_err(DeviceManagerPersistError::MmioRestore)?;
+            VirtioDevices::Mmio(mmio_virtio_devices)
         };
-        let pci_devices = PciDevices::restore(pci_ctor_args, &state.pci_state)
-            .map_err(DeviceManagerPersistError::PciRestore)?;
 
         Ok(DeviceManager {
             mmio_platform_devices,
-            mmio_virtio_devices,
             #[cfg(target_arch = "x86_64")]
             legacy_devices: Some(legacy_devices),
             acpi_devices,
-            pci_devices,
+            virtio_devices,
         })
     }
 }
@@ -839,12 +789,11 @@ pub(crate) mod tests {
     pub(crate) fn default_device_manager() -> DeviceManager {
         let mut resource_allocator = ResourceAllocator::new();
         let mmio_platform_devices = MMIOPlatformDevices::new();
-        let mmio_virtio_devices = MMIOVirtioDevices::new();
         let acpi_devices = ACPIDeviceManager::new(
             VmGenId::new(&mut resource_allocator).unwrap(),
             VmClock::new(&mut resource_allocator).unwrap(),
         );
-        let pci_devices = PciDevices::new();
+        let virtio_devices = VirtioDevices::Mmio(MMIOVirtioDevices::new());
 
         #[cfg(target_arch = "x86_64")]
         let legacy_devices = PortIODeviceManager {
@@ -858,12 +807,41 @@ pub(crate) mod tests {
 
         DeviceManager {
             mmio_platform_devices,
-            mmio_virtio_devices,
             #[cfg(target_arch = "x86_64")]
             legacy_devices: Some(legacy_devices),
             acpi_devices,
-            pci_devices,
+            virtio_devices,
         }
+    }
+
+    pub(crate) fn default_device_manager_with_pci(vm: &Arc<KvmVm>) -> DeviceManager {
+        let mut device_manager = default_device_manager();
+        let mut pci_devices = PciDevices::new();
+        pci_devices.attach_pci_segment(vm).unwrap();
+        device_manager.virtio_devices = VirtioDevices::Pci(pci_devices);
+        device_manager
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn mmio_devices_mut(device_manager: &mut DeviceManager) -> &mut MMIOVirtioDevices {
+        let VirtioDevices::Mmio(mmio_devices) = &mut device_manager.virtio_devices else {
+            panic!("MMIO transport should be enabled");
+        };
+        mmio_devices
+    }
+
+    pub(crate) fn pci_devices(device_manager: &DeviceManager) -> &PciDevices {
+        let VirtioDevices::Pci(pci_devices) = &device_manager.virtio_devices else {
+            panic!("PCI transport should be enabled");
+        };
+        pci_devices
+    }
+
+    pub(crate) fn pci_devices_mut(device_manager: &mut DeviceManager) -> &mut PciDevices {
+        let VirtioDevices::Pci(pci_devices) = &mut device_manager.virtio_devices else {
+            panic!("PCI transport should be enabled");
+        };
+        pci_devices
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -944,8 +922,7 @@ pub(crate) mod tests {
         let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
         vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
         assert!(
-            vmm.device_manager
-                .pci_devices
+            pci_devices(&vmm.device_manager)
                 .virtio_devices
                 .contains_key(&(VirtioDeviceType::Block, "block0".to_string()))
         );
@@ -978,8 +955,7 @@ pub(crate) mod tests {
         vmm.hot_unplug_device(device_id.clone(), &mut evt_manager)
             .unwrap();
         assert!(
-            !vmm.device_manager
-                .pci_devices
+            !pci_devices(&vmm.device_manager)
                 .virtio_devices
                 .contains_key(&device_id)
         );
@@ -1039,8 +1015,7 @@ pub(crate) mod tests {
         });
         vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
         assert!(
-            vmm.device_manager
-                .pci_devices
+            pci_devices(&vmm.device_manager)
                 .virtio_devices
                 .contains_key(&(VirtioDeviceType::Pmem, "pmem0".to_string()))
         );
@@ -1073,8 +1048,7 @@ pub(crate) mod tests {
         vmm.hot_unplug_device(device_id.clone(), &mut evt_manager)
             .unwrap();
         assert!(
-            !vmm.device_manager
-                .pci_devices
+            !pci_devices(&vmm.device_manager)
                 .virtio_devices
                 .contains_key(&device_id)
         );
@@ -1098,8 +1072,7 @@ pub(crate) mod tests {
         });
         vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
         assert!(
-            vmm.device_manager
-                .pci_devices
+            pci_devices(&vmm.device_manager)
                 .virtio_devices
                 .contains_key(&(VirtioDeviceType::Net, "eth0".to_string()))
         );
@@ -1132,8 +1105,7 @@ pub(crate) mod tests {
         vmm.hot_unplug_device(device_id.clone(), &mut evt_manager)
             .unwrap();
         assert!(
-            !vmm.device_manager
-                .pci_devices
+            !pci_devices(&vmm.device_manager)
                 .virtio_devices
                 .contains_key(&device_id)
         );
@@ -1150,8 +1122,7 @@ pub(crate) mod tests {
         // rejects root devices).
         let cfg = make_hotplug_block_cfg("rootfs", &f, true);
         let block = Block::new(cfg).unwrap();
-        vmm.device_manager
-            .pci_devices
+        pci_devices_mut(&mut vmm.device_manager)
             .attach_pci_virtio_device(
                 vmm.vm.as_kvm().unwrap(),
                 "rootfs".to_string(),
@@ -1185,8 +1156,7 @@ pub(crate) mod tests {
             ..Default::default()
         };
         let pmem = Pmem::new(vmm.vm.as_kvm().unwrap().clone(), cfg).unwrap();
-        vmm.device_manager
-            .pci_devices
+        pci_devices_mut(&mut vmm.device_manager)
             .attach_pci_virtio_device(
                 vmm.vm.as_kvm().unwrap(),
                 "pmem_root".to_string(),

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -582,17 +582,35 @@ impl Default for VirtioDevices {
     }
 }
 
+/// Serialised state of the virtio devices, mirroring the active [`VirtioDevices`]
+/// transport variant. Only the transport actually in use is serialised.
+///
+/// Prefer large enum over Box + heap-alloc, since snapshot restore is latency sensitive.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum VirtioDevicesState {
+    /// Virtio devices attached over the MMIO transport.
+    Mmio(persist::DeviceStates),
+    /// Virtio devices attached over the PCI transport.
+    Pci(pci_mngr::PciDevicesState),
+}
+
+impl Default for VirtioDevicesState {
+    fn default() -> Self {
+        // Mirror `VirtioDevices::default()`, which uses the MMIO transport.
+        Self::Mmio(persist::DeviceStates::default())
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 /// State of devices in the system
 pub struct DevicesState {
-    /// MMIO virtio devices state
-    pub mmio_state: persist::DeviceStates,
+    /// Virtio devices state
+    pub virtio_state: VirtioDevicesState,
     /// MMIO platform (non-virtio) devices state
     pub mmio_platform_state: MMIOPlatformDevicesState,
     /// ACPI devices state
     pub acpi_state: persist::ACPIDeviceManagerState,
-    /// PCI devices state
-    pub pci_state: pci_mngr::PciDevicesState,
     /// Serial device state
     pub serial_state: Option<persist::SerialState>,
 }
@@ -676,24 +694,15 @@ impl<'a> Persist<'a> for DeviceManager {
     type Error = DeviceManagerPersistError;
 
     fn save(&self) -> Self::State {
-        // Save both transport slots for now; only the active variant has
-        // devices, so the inactive slot serialises its default (empty) state.
-        // The next commit changes the wire format to hold only the active
-        // transport.
-        let (mmio_state, pci_state) = match &self.virtio_devices {
-            VirtioDevices::Mmio(mmio_devices) => {
-                (mmio_devices.save(), pci_mngr::PciDevicesState::default())
-            }
-            VirtioDevices::Pci(pci_devices) => {
-                (persist::DeviceStates::default(), pci_devices.save())
-            }
+        let virtio_state = match &self.virtio_devices {
+            VirtioDevices::Mmio(mmio_devices) => VirtioDevicesState::Mmio(mmio_devices.save()),
+            VirtioDevices::Pci(pci_devices) => VirtioDevicesState::Pci(pci_devices.save()),
         };
 
         DevicesState {
-            mmio_state,
+            virtio_state,
             mmio_platform_state: self.mmio_platform_devices.save(),
             acpi_state: self.acpi_devices.save(),
-            pci_state,
             serial_state: self.serial_state(),
         }
     }
@@ -730,31 +739,31 @@ impl<'a> Persist<'a> for DeviceManager {
         // Restore ACPI devices
         let acpi_devices = ACPIDeviceManager::restore(constructor_args.vm, &state.acpi_state)?;
 
-        // The wire format carries both transport slots; the pci_enabled flag
-        // says which one was active. The next commit changes the format to
-        // hold only the active transport.
-        let virtio_devices = if state.pci_state.pci_enabled {
-            let pci_ctor_args = PciDevicesConstructorArgs {
-                vm: constructor_args.vm,
-                mem: constructor_args.mem,
-                vm_resources: constructor_args.vm_resources,
-                instance_id: constructor_args.instance_id,
-                event_manager: constructor_args.event_manager,
-            };
-            let pci_devices = PciDevices::restore(pci_ctor_args, &state.pci_state)
-                .map_err(DeviceManagerPersistError::PciRestore)?;
-            VirtioDevices::Pci(pci_devices)
-        } else {
-            let mmio_ctor_args = MMIODevManagerConstructorArgs {
-                mem: constructor_args.mem,
-                vm: constructor_args.vm,
-                event_manager: constructor_args.event_manager,
-                vm_resources: constructor_args.vm_resources,
-                instance_id: constructor_args.instance_id,
-            };
-            let mmio_virtio_devices = MMIOVirtioDevices::restore(mmio_ctor_args, &state.mmio_state)
-                .map_err(DeviceManagerPersistError::MmioRestore)?;
-            VirtioDevices::Mmio(mmio_virtio_devices)
+        let virtio_devices = match &state.virtio_state {
+            VirtioDevicesState::Pci(pci_state) => {
+                let pci_ctor_args = PciDevicesConstructorArgs {
+                    vm: constructor_args.vm,
+                    mem: constructor_args.mem,
+                    vm_resources: constructor_args.vm_resources,
+                    instance_id: constructor_args.instance_id,
+                    event_manager: constructor_args.event_manager,
+                };
+                let pci_devices = PciDevices::restore(pci_ctor_args, pci_state)
+                    .map_err(DeviceManagerPersistError::PciRestore)?;
+                VirtioDevices::Pci(pci_devices)
+            }
+            VirtioDevicesState::Mmio(mmio_state) => {
+                let mmio_ctor_args = MMIODevManagerConstructorArgs {
+                    mem: constructor_args.mem,
+                    vm: constructor_args.vm,
+                    event_manager: constructor_args.event_manager,
+                    vm_resources: constructor_args.vm_resources,
+                    instance_id: constructor_args.instance_id,
+                };
+                let mmio_virtio_devices = MMIOVirtioDevices::restore(mmio_ctor_args, mmio_state)
+                    .map_err(DeviceManagerPersistError::MmioRestore)?;
+                VirtioDevices::Mmio(mmio_virtio_devices)
+            }
         };
 
         Ok(DeviceManager {

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -651,10 +651,7 @@ mod tests {
         // Set up a vmm with one of each device, and get the serialized DeviceStates.
         {
             let mut event_manager = EventManager::new().expect("Unable to create EventManager");
-            let mut vmm = default_vmm();
-            vmm.device_manager
-                .enable_pci(&vmm.vm.as_kvm().unwrap().clone())
-                .unwrap();
+            let mut vmm = default_vmm_with_pci();
             let mut cmdline = default_kernel_cmdline();
 
             // Add a balloon device.

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -44,10 +44,10 @@ use crate::vstate::interrupts::InterruptError;
 use crate::vstate::memory::GuestMemoryMmap;
 use crate::vstate::vm::KvmVm;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PciDevices {
-    /// PCIe segment of the VMM, if PCI is enabled. We currently support a single PCIe segment.
-    pub pci_segment: Option<PciSegment>,
+    /// PCIe segment of the VMM. We currently support a single PCIe segment.
+    pub pci_segment: PciSegment,
     /// All VirtIO PCI devices of the system
     pub virtio_devices: HashMap<VirtioDeviceId, Arc<Mutex<VirtioPciDevice>>>,
 }
@@ -69,21 +69,15 @@ pub enum PciManagerError {
 }
 
 impl PciDevices {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    pub fn attach_pci_segment(&mut self, vm: &Arc<KvmVm>) -> Result<(), PciManagerError> {
-        // We only support a single PCIe segment. Calling this function twice is a Firecracker
-        // internal error.
-        assert!(self.pci_segment.is_none());
-
+    pub fn new(vm: &Arc<KvmVm>) -> Result<Self, PciManagerError> {
         // Currently we don't assign any IRQs to PCI devices. We will be using MSI-X interrupts
         // only.
         let pci_segment = PciSegment::new(0, vm, &[0u8; 32])?;
-        self.pci_segment = Some(pci_segment);
 
-        Ok(())
+        Ok(Self {
+            pci_segment,
+            virtio_devices: HashMap::new(),
+        })
     }
 
     fn register_bars_with_bus(
@@ -115,10 +109,7 @@ impl PciDevices {
         virtio_device: Arc<Mutex<VirtioPciDevice>>,
         event_manager: &mut EventManager,
     ) -> Result<(), PciManagerError> {
-        // We should only be reaching this point if PCI is enabled
-        let pci_segment = self.pci_segment.as_ref().unwrap();
-
-        pci_segment
+        self.pci_segment
             .pci_bus
             .lock()
             .expect("Poisoned lock")
@@ -145,9 +136,7 @@ impl PciDevices {
         device: Arc<Mutex<dyn VirtioDevice>>,
         event_manager: &mut EventManager,
     ) -> Result<(), PciManagerError> {
-        // We should only be reaching this point if PCI is enabled
-        let pci_segment = self.pci_segment.as_ref().unwrap();
-        let sbdf = pci_segment.next_device_sbdf()?;
+        let sbdf = self.pci_segment.next_device_sbdf()?;
         debug!("Allocating SBDF: {sbdf:?} for device");
         let mem = vm.guest_memory().clone();
 
@@ -174,6 +163,10 @@ impl PciDevices {
         self.attach_common(vm, device_type, id, sbdf, virtio_device, event_manager)
     }
 
+    pub(crate) fn pci_segment(&self) -> &PciSegment {
+        &self.pci_segment
+    }
+
     #[cfg(target_arch = "x86_64")]
     pub(crate) fn append_aml_bytes(
         &self,
@@ -181,10 +174,7 @@ impl PciDevices {
     ) -> Result<(), acpi_tables::aml::AmlError> {
         use acpi_tables::Aml;
 
-        if let Some(pci_segment) = &self.pci_segment {
-            pci_segment.append_aml_bytes(dsdt_data)?;
-        }
-        Ok(())
+        self.pci_segment().append_aml_bytes(dsdt_data)
     }
 
     pub(crate) fn detach_pci_virtio_device(
@@ -209,8 +199,6 @@ impl PciDevices {
             .map_err(PciManagerError::Bus)?;
 
         self.pci_segment
-            .as_ref()
-            .unwrap()
             .pci_bus
             .lock()
             .expect("Poisoned lock")
@@ -502,8 +490,7 @@ impl<'a> Persist<'a> for PciDevices {
         state: &Self::State,
     ) -> Result<Self, Self::Error> {
         let mem = constructor_args.mem;
-        let mut pci_devices = PciDevices::new();
-        pci_devices.attach_pci_segment(constructor_args.vm)?;
+        let mut pci_devices = PciDevices::new(constructor_args.vm)?;
 
         if let Some(balloon_state) = &state.balloon_device {
             let device = Arc::new(Mutex::new(Balloon::restore(

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -315,8 +315,6 @@ pub struct VirtioDeviceState<T> {
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct PciDevicesState {
-    /// Whether PCI is enabled
-    pub pci_enabled: bool,
     /// Block device states.
     pub block_devices: Vec<VirtioDeviceState<BlockState>>,
     /// Net device states.
@@ -361,11 +359,6 @@ impl<'a> Persist<'a> for PciDevices {
 
     fn save(&self) -> Self::State {
         let mut state = PciDevicesState::default();
-        if self.pci_segment.is_some() {
-            state.pci_enabled = true;
-        } else {
-            return state;
-        }
 
         for pci_dev in self.virtio_devices.values() {
             let locked_pci_dev = pci_dev.lock().expect("Poisoned lock");
@@ -510,10 +503,6 @@ impl<'a> Persist<'a> for PciDevices {
     ) -> Result<Self, Self::Error> {
         let mem = constructor_args.mem;
         let mut pci_devices = PciDevices::new();
-        if !state.pci_enabled {
-            return Ok(pci_devices);
-        }
-
         pci_devices.attach_pci_segment(constructor_args.vm)?;
 
         if let Some(balloon_state) = &state.balloon_device {
@@ -824,7 +813,10 @@ mod tests {
 
         let device_manager_state: device_manager::DevicesState =
             bitcode::deserialize(&serialized_data).unwrap();
-        let pci_state = &device_manager_state.pci_state;
+        let device_manager::VirtioDevicesState::Pci(pci_state) = &device_manager_state.virtio_state
+        else {
+            panic!("expected PCI virtio device state");
+        };
         let vm_resources = &mut VmResources::default();
         let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let restore_args = PciDevicesConstructorArgs {

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -174,6 +174,61 @@ impl PciDevices {
         self.attach_common(vm, device_type, id, sbdf, virtio_device, event_manager)
     }
 
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) fn append_aml_bytes(
+        &self,
+        dsdt_data: &mut Vec<u8>,
+    ) -> Result<(), acpi_tables::aml::AmlError> {
+        use acpi_tables::Aml;
+
+        if let Some(pci_segment) = &self.pci_segment {
+            pci_segment.append_aml_bytes(dsdt_data)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn detach_pci_virtio_device(
+        &mut self,
+        vm: &KvmVm,
+        device_id: VirtioDeviceId,
+        event_manager: &mut EventManager,
+    ) -> Result<(), PciManagerError> {
+        let pci_device_arc = self
+            .virtio_devices
+            .remove(&device_id)
+            .expect("device presence should be checked before detach");
+        let pci_device = pci_device_arc.lock().expect("Poisoned lock");
+
+        pci_device
+            .unregister_notification_ioevents(vm)
+            .map_err(PciManagerError::Kvm)?;
+
+        vm.common
+            .mmio_bus
+            .remove(pci_device.config_bar_addr(), CAPABILITY_BAR_SIZE)
+            .map_err(PciManagerError::Bus)?;
+
+        self.pci_segment
+            .as_ref()
+            .unwrap()
+            .pci_bus
+            .lock()
+            .expect("Poisoned lock")
+            .remove_device(pci_device.sbdf.device());
+
+        if let Some(sub_id) = pci_device.sub_id
+            && event_manager.remove_subscriber(sub_id).is_err()
+        {
+            warn!("Failed to remove event subscriber for device {device_id:?}");
+        }
+
+        // Ensure no other references to the device remain, so it is freed when
+        // this function returns.
+        assert_eq!(Arc::strong_count(&pci_device_arc), 1);
+
+        Ok(())
+    }
+
     fn restore_pci_device<T: 'static + VirtioDevice + MutEventSubscriber + Debug>(
         &mut self,
         vm: &Arc<KvmVm>,
@@ -213,11 +268,35 @@ impl PciDevices {
             .get(&(device_type, device_id.to_string()))
     }
 
+    pub(crate) fn get_device(
+        &self,
+        device_type: VirtioDeviceType,
+        device_id: &str,
+    ) -> Option<Arc<Mutex<dyn VirtioDevice>>> {
+        self.get_virtio_device(device_type, device_id)
+            .map(|device| device.lock().expect("Poisoned lock").virtio_device())
+    }
+
+    pub(crate) fn contains_virtio_device(&self, device_id: &VirtioDeviceId) -> bool {
+        self.virtio_devices.contains_key(device_id)
+    }
+
     pub fn for_each_virtio_device(&self, mut f: impl FnMut(VirtioDeviceType, &dyn VirtioDevice)) {
         for ((device_type, _), pci_device) in &self.virtio_devices {
             let device_arc = pci_device.lock().expect("Poisoned lock").virtio_device();
             let device = device_arc.lock().expect("Poisoned lock");
             f(*device_type, &*device);
+        }
+    }
+
+    pub(crate) fn for_each_virtio_device_mut(
+        &self,
+        mut f: impl FnMut(VirtioDeviceType, &mut dyn VirtioDevice),
+    ) {
+        for ((device_type, _), pci_device) in &self.virtio_devices {
+            let device_arc = pci_device.lock().expect("Poisoned lock").virtio_device();
+            let mut device = device_arc.lock().expect("Poisoned lock");
+            f(*device_type, &mut *device);
         }
     }
 }
@@ -734,9 +813,9 @@ mod tests {
 
         let mut event_manager = EventManager::new().expect("Unable to create EventManager");
         // Keep in mind we are re-creating here an empty DeviceManager. Restoring later on
-        // will create a new PciDevices manager different than vmm.pci_devices. We're doing
-        // this to avoid restoring the whole Vmm, since what we really need from Vmm is the KvmVm
-        // object and calling default_vmm() is the easiest way to create one.
+        // will create a new PciDevices manager different from vmm's virtio devices. We're
+        // doing this to avoid restoring the whole Vmm, since what we really need from Vmm is the
+        // KvmVm object and calling default_vmm() is the easiest way to create one.
         let vmm = default_vmm();
         // Restore the source allocator's state so the restored devices' GSIs match what their
         // `MsixVectorGroup::Drop` will try to free at end-of-test.
@@ -745,6 +824,7 @@ mod tests {
 
         let device_manager_state: device_manager::DevicesState =
             bitcode::deserialize(&serialized_data).unwrap();
+        let pci_state = &device_manager_state.pci_state;
         let vm_resources = &mut VmResources::default();
         let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let restore_args = PciDevicesConstructorArgs {
@@ -754,8 +834,7 @@ mod tests {
             instance_id: "microvm-id",
             event_manager: &mut event_manager,
         };
-        let _restored_dev_manager =
-            PciDevices::restore(restore_args, &device_manager_state.pci_state).unwrap();
+        let _restored_dev_manager = PciDevices::restore(restore_args, pci_state).unwrap();
 
         let expected_vm_resources = format!(
             r#"{{
@@ -849,10 +928,7 @@ mod tests {
                 .version(),
             MmdsVersion::V2
         );
-        assert_eq!(
-            device_manager_state.pci_state.mmds.unwrap().version,
-            MmdsVersion::V2
-        );
+        assert_eq!(pci_state.mmds.as_ref().unwrap().version, MmdsVersion::V2);
         assert_eq!(
             expected_vm_resources,
             serde_json::to_string_pretty(&VmmConfig::from(&*vm_resources)).unwrap()

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -11,8 +11,6 @@ use serde::{Deserialize, Serialize};
 use super::acpi::ACPIDeviceManager;
 use super::mmio::*;
 use crate::EventManager;
-#[cfg(target_arch = "aarch64")]
-use crate::arch::DeviceType;
 use crate::device_manager::DevicePersistError;
 use crate::device_manager::acpi::ACPIDeviceError;
 use crate::devices::acpi::vmclock::{VmClock, VmClockState};
@@ -106,28 +104,15 @@ pub struct VirtioDeviceState<T> {
     pub device_info: MMIODeviceInfo,
 }
 
-/// Holds the state of a legacy device connected to the MMIO space.
-#[cfg(target_arch = "aarch64")]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConnectedLegacyState {
-    /// Device identifier.
-    pub type_: DeviceType,
-    /// VmmResources.
-    pub device_info: MMIODeviceInfo,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MmdsState {
     pub version: MmdsVersion,
     pub imds_compat: bool,
 }
 
-/// Holds the device states.
+/// Holds the states of the virtio devices connected over the MMIO transport.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct DeviceStates {
-    #[cfg(target_arch = "aarch64")]
-    // State of legacy devices in MMIO space.
-    pub legacy_devices: Vec<ConnectedLegacyState>,
     /// Block device states.
     pub block_devices: Vec<VirtioDeviceState<BlockState>>,
     /// Net device states.
@@ -152,8 +137,25 @@ pub struct MMIODevManagerConstructorArgs<'a> {
     pub event_manager: &'a mut EventManager,
     pub vm_resources: &'a mut VmResources,
     pub instance_id: &'a str,
+}
+
+pub struct MMIOPlatformDevicesConstructorArgs<'a> {
+    pub vm: &'a Arc<KvmVm>,
+    pub event_manager: &'a mut EventManager,
+    pub vm_resources: &'a mut VmResources,
     pub serial_state: Option<&'a SerialState>,
 }
+
+impl fmt::Debug for MMIOPlatformDevicesConstructorArgs<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MMIOPlatformDevicesConstructorArgs")
+            .field("vm", &self.vm)
+            .field("event_manager", &"?")
+            .field("vm_resources", &self.vm_resources)
+            .finish()
+    }
+}
+
 impl fmt::Debug for MMIODevManagerConstructorArgs<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MMIODevManagerConstructorArgs")
@@ -171,6 +173,17 @@ impl fmt::Debug for MMIODevManagerConstructorArgs<'_> {
 pub struct ACPIDeviceManagerState {
     vmgenid: VMGenIDState,
     vmclock: VmClockState,
+}
+
+/// Holds the states of the non-virtio (platform) devices connected over the MMIO transport.
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct MMIOPlatformDevicesState {
+    #[cfg(target_arch = "aarch64")]
+    /// State of the serial device in MMIO space.
+    pub serial: Option<MMIODeviceInfo>,
+    #[cfg(target_arch = "aarch64")]
+    /// State of the RTC device in MMIO space.
+    pub rtc: Option<MMIODeviceInfo>,
 }
 
 impl<'a> Persist<'a> for ACPIDeviceManager {
@@ -205,6 +218,56 @@ impl<'a> Persist<'a> for ACPIDeviceManager {
     }
 }
 
+impl<'a> Persist<'a> for MMIOPlatformDevices {
+    type State = MMIOPlatformDevicesState;
+    type ConstructorArgs = MMIOPlatformDevicesConstructorArgs<'a>;
+    type Error = DevicePersistError;
+
+    fn save(&self) -> Self::State {
+        MMIOPlatformDevicesState {
+            #[cfg(target_arch = "aarch64")]
+            serial: self.serial.as_ref().map(|device| device.resources),
+            #[cfg(target_arch = "aarch64")]
+            rtc: self.rtc.as_ref().map(|device| device.resources),
+        }
+    }
+
+    #[allow(unused_variables)]
+    #[cfg_attr(not(target_arch = "aarch64"), allow(unused_mut))]
+    fn restore(
+        constructor_args: Self::ConstructorArgs,
+        state: &Self::State,
+    ) -> Result<Self, Self::Error> {
+        let mut platform_devices = MMIOPlatformDevices::new();
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            if let Some(device_info) = state.serial {
+                let serial_state = constructor_args.serial_state.map(Into::into);
+                let serial = crate::DeviceManager::setup_serial_device(
+                    constructor_args.event_manager,
+                    constructor_args.vm_resources.serial_out_path.as_ref(),
+                    serial_state.as_ref(),
+                    constructor_args.vm_resources.serial_rate_limiter(),
+                )?;
+
+                platform_devices.register_mmio_serial(
+                    constructor_args.vm,
+                    serial,
+                    Some(device_info),
+                )?;
+            }
+
+            if let Some(device_info) = state.rtc {
+                let rtc = Arc::new(Mutex::new(RTCDevice::new()));
+                platform_devices.register_mmio_rtc(constructor_args.vm, rtc, Some(device_info))?;
+            }
+        }
+
+        Ok(platform_devices)
+    }
+}
+
 impl<'a> Persist<'a> for MMIODeviceManager {
     type State = DeviceStates;
     type ConstructorArgs = MMIODevManagerConstructorArgs<'a>;
@@ -212,23 +275,6 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 
     fn save(&self) -> Self::State {
         let mut states = DeviceStates::default();
-
-        #[cfg(target_arch = "aarch64")]
-        {
-            if let Some(device) = &self.serial {
-                states.legacy_devices.push(ConnectedLegacyState {
-                    type_: DeviceType::Serial,
-                    device_info: device.resources,
-                });
-            }
-
-            if let Some(device) = &self.rtc {
-                states.legacy_devices.push(ConnectedLegacyState {
-                    type_: DeviceType::Rtc,
-                    device_info: device.resources,
-                });
-            }
-        }
 
         let _: Result<(), ()> = self.for_each_virtio_mmio_device(|_, devid, device| {
             let mmio_transport_locked = device.inner.lock().expect("Poisoned lock");
@@ -361,28 +407,6 @@ impl<'a> Persist<'a> for MMIODeviceManager {
         let mut dev_manager = MMIODeviceManager::new();
         let mem = constructor_args.mem;
         let vm = constructor_args.vm;
-
-        #[cfg(target_arch = "aarch64")]
-        {
-            for state in &state.legacy_devices {
-                if state.type_ == DeviceType::Serial {
-                    let serial_state: Option<vm_superio::serial::SerialState> =
-                        constructor_args.serial_state.map(Into::into);
-                    let serial = crate::DeviceManager::setup_serial_device(
-                        constructor_args.event_manager,
-                        constructor_args.vm_resources.serial_out_path.as_ref(),
-                        serial_state.as_ref(),
-                        constructor_args.vm_resources.serial_rate_limiter(),
-                    )?;
-
-                    dev_manager.register_mmio_serial(vm, serial, Some(state.device_info))?;
-                }
-                if state.type_ == DeviceType::Rtc {
-                    let rtc = Arc::new(Mutex::new(RTCDevice::new()));
-                    dev_manager.register_mmio_rtc(vm, rtc, Some(state.device_info))?;
-                }
-            }
-        }
 
         let mut restore_helper = |device: Arc<Mutex<dyn VirtioDevice>>,
                                   activated: bool,
@@ -671,7 +695,7 @@ mod tests {
                 }
             }
 
-            self.boot_timer == other.boot_timer
+            true
         }
     }
 
@@ -779,7 +803,6 @@ mod tests {
             event_manager: &mut event_manager,
             vm_resources,
             instance_id: "microvm-id",
-            serial_state: None,
         };
         let _restored_dev_manager =
             MMIODeviceManager::restore(restore_args, &device_manager_state.mmio_state).unwrap();

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -268,7 +268,7 @@ impl<'a> Persist<'a> for MMIOPlatformDevices {
     }
 }
 
-impl<'a> Persist<'a> for MMIODeviceManager {
+impl<'a> Persist<'a> for MMIOVirtioDevices {
     type State = DeviceStates;
     type ConstructorArgs = MMIODevManagerConstructorArgs<'a>;
     type Error = DevicePersistError;
@@ -404,7 +404,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
         constructor_args: Self::ConstructorArgs,
         state: &Self::State,
     ) -> Result<Self, Self::Error> {
-        let mut dev_manager = MMIODeviceManager::new();
+        let mut dev_manager = MMIOVirtioDevices::new();
         let mem = constructor_args.mem;
         let vm = constructor_args.vm;
 
@@ -682,8 +682,8 @@ mod tests {
         }
     }
 
-    impl PartialEq for MMIODeviceManager {
-        fn eq(&self, other: &MMIODeviceManager) -> bool {
+    impl PartialEq for MMIOVirtioDevices {
+        fn eq(&self, other: &MMIOVirtioDevices) -> bool {
             // We only care about the device hashmap.
             if self.virtio_devices.len() != other.virtio_devices.len() {
                 return false;
@@ -805,7 +805,7 @@ mod tests {
             instance_id: "microvm-id",
         };
         let _restored_dev_manager =
-            MMIODeviceManager::restore(restore_args, &device_manager_state.mmio_state).unwrap();
+            MMIOVirtioDevices::restore(restore_args, &device_manager_state.mmio_state).unwrap();
 
         let expected_vm_resources = format!(
             r#"{{

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -795,6 +795,11 @@ mod tests {
         let vmm = default_vmm();
         let device_manager_state: device_manager::DevicesState =
             bitcode::deserialize(&serialized_data).unwrap();
+        let device_manager::VirtioDevicesState::Mmio(mmio_state) =
+            &device_manager_state.virtio_state
+        else {
+            panic!("expected MMIO virtio device state");
+        };
         let vm_resources = &mut VmResources::default();
         let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let restore_args = MMIODevManagerConstructorArgs {
@@ -804,8 +809,7 @@ mod tests {
             vm_resources,
             instance_id: "microvm-id",
         };
-        let _restored_dev_manager =
-            MMIOVirtioDevices::restore(restore_args, &device_manager_state.mmio_state).unwrap();
+        let _restored_dev_manager = MMIOVirtioDevices::restore(restore_args, mmio_state).unwrap();
 
         let expected_vm_resources = format!(
             r#"{{
@@ -899,10 +903,7 @@ mod tests {
                 .version(),
             MmdsVersion::V2
         );
-        assert_eq!(
-            device_manager_state.mmio_state.mmds.unwrap().version,
-            MmdsVersion::V2
-        );
+        assert_eq!(mmio_state.mmds.as_ref().unwrap().version, MmdsVersion::V2);
         assert_eq!(
             expected_vm_resources,
             serde_json::to_string_pretty(&VmmConfig::from(&*vm_resources)).unwrap()

--- a/src/vmm/src/devices/virtio/net/persist.rs
+++ b/src/vmm/src/devices/virtio/net/persist.rs
@@ -105,7 +105,7 @@ impl Persist<'_> for Net {
             state.config_space.mtu,
         )?;
 
-        // We trust the MMIODeviceManager::restore to pass us an MMDS data store reference if
+        // We trust the MMIOVirtioDevices::restore to pass us an MMDS data store reference if
         // there is at least one net device having the MMDS NS present and/or the mmds version was
         // persisted in the snapshot.
         if let Some(mmds_ns) = &state.mmds_ns {
@@ -207,13 +207,13 @@ mod tests {
         validate_save_and_restore(default_net(), mmds.as_ref().cloned());
         validate_save_and_restore(default_net_no_mmds(), None);
 
-        // Check what happens if the MMIODeviceManager gives us the reference to the MMDS
+        // Check what happens if MMIOVirtioDevices::restore gives us the reference to the MMDS
         // data store even if this device does not have mmds ns configured.
         // The restore should be conservative and not configure the mmds ns.
         validate_save_and_restore(default_net_no_mmds(), mmds);
 
-        // Check what happens if the MMIODeviceManager does not give us the reference to the MMDS
-        // data store. This will return an error.
+        // Check what happens if MMIOVirtioDevices::restore does not give us the reference to the
+        // MMDS data store. This will return an error.
         validate_save_and_restore(default_net(), None);
     }
 }

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -1095,7 +1095,7 @@ mod tests {
     use super::{PciCapabilityType, VirtioPciDevice};
     use crate::Vmm;
     use crate::arch::MEM_64BIT_DEVICES_START;
-    use crate::builder::tests::default_vmm;
+    use crate::builder::tests::default_vmm_with_pci;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
     use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
     use crate::devices::virtio::rng::Entropy;
@@ -1116,10 +1116,7 @@ mod tests {
     use crate::vstate::resources::ResourceAllocator;
 
     fn create_vmm_with_virtio_pci_device() -> Vmm {
-        let mut vmm = default_vmm();
-        vmm.device_manager
-            .enable_pci(&vmm.vm.as_kvm().unwrap().clone())
-            .unwrap();
+        let mut vmm = default_vmm_with_pci();
         let entropy = Arc::new(Mutex::new(Entropy::new(RateLimiter::default()).unwrap()));
         let mut event_manager = crate::EventManager::new().unwrap();
         vmm.device_manager

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -1123,7 +1123,7 @@ mod tests {
         let entropy = Arc::new(Mutex::new(Entropy::new(RateLimiter::default()).unwrap()));
         let mut event_manager = crate::EventManager::new().unwrap();
         vmm.device_manager
-            .attach_virtio_device(
+            .attach_boot_virtio_device(
                 &vmm.vm,
                 "rng".to_string(),
                 entropy.clone(),

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -1096,6 +1096,7 @@ mod tests {
     use crate::Vmm;
     use crate::arch::MEM_64BIT_DEVICES_START;
     use crate::builder::tests::default_vmm_with_pci;
+    use crate::device_manager::tests::pci_devices;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
     use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
     use crate::devices::virtio::rng::Entropy;
@@ -1133,8 +1134,7 @@ mod tests {
     }
 
     fn get_virtio_device(vmm: &Vmm) -> Arc<Mutex<VirtioPciDevice>> {
-        vmm.device_manager
-            .pci_devices
+        pci_devices(&vmm.device_manager)
             .get_virtio_device(VirtioDeviceType::Rng, "rng")
             .unwrap()
             .clone()

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -26,6 +26,9 @@ use crate::cpu_config::x86_64::cpuid::CpuidTrait;
 #[cfg(target_arch = "x86_64")]
 use crate::cpu_config::x86_64::cpuid::common::get_vendor_id_from_host;
 use crate::device_manager::{DevicePersistError, DevicesState};
+// Re-exported so external crates inspecting a `MicrovmState` snapshot can match on the
+// serialised virtio transport variant.
+pub use crate::device_manager::VirtioDevicesState;
 use crate::logger::{info, warn};
 use crate::resources::VmResources;
 use crate::seccomp::BpfThreadMap;
@@ -368,21 +371,22 @@ pub fn restore_from_snapshot(
 ) -> Result<Arc<Mutex<Vmm>>, RestoreFromSnapshotError> {
     let mut microvm_state = snapshot_state_from_file(&params.snapshot_path)?;
     for entry in &params.network_overrides {
-        microvm_state
-            .device_states
-            .mmio_state
-            .net_devices
-            .iter_mut()
-            .map(|device| &mut device.device_state)
-            .chain(
-                microvm_state
-                    .device_states
-                    .pci_state
-                    .net_devices
-                    .iter_mut()
-                    .map(|device| &mut device.device_state),
-            )
-            .find(|x| x.id == entry.iface_id)
+        // Only the active transport carries virtio device state, so we look at whichever
+        // variant this snapshot was saved with. The MMIO and PCI transports wrap their net
+        // devices in distinct types, so we map down to the shared inner `NetState` in each arm.
+        let device_state = match &mut microvm_state.device_states.virtio_state {
+            VirtioDevicesState::Mmio(mmio_state) => mmio_state
+                .net_devices
+                .iter_mut()
+                .map(|device| &mut device.device_state)
+                .find(|x| x.id == entry.iface_id),
+            VirtioDevicesState::Pci(pci_state) => pci_state
+                .net_devices
+                .iter_mut()
+                .map(|device| &mut device.device_state)
+                .find(|x| x.id == entry.iface_id),
+        };
+        device_state
             .map(|device_state| device_state.tap_if_name.clone_from(&entry.host_dev_name))
             .ok_or(SnapshotStateFromFileError::UnknownNetworkDevice)?;
     }
@@ -390,21 +394,17 @@ pub fn restore_from_snapshot(
     if let Some(vsock_override) = &params.vsock_override {
         // There should only ever be at most one vsock device, therefore this
         // should correctly find it and modify the path if such a device exists.
-        let device_state = microvm_state
-            .device_states
-            .mmio_state
-            .vsock_device
-            .as_mut()
-            .map(|device| &mut device.device_state)
-            .or_else(|| {
-                microvm_state
-                    .device_states
-                    .pci_state
-                    .vsock_device
-                    .as_mut()
-                    .map(|device| &mut device.device_state)
-            })
-            .ok_or(SnapshotStateFromFileError::UnknownVsockDevice)?;
+        let device_state = match &mut microvm_state.device_states.virtio_state {
+            VirtioDevicesState::Mmio(mmio_state) => mmio_state
+                .vsock_device
+                .as_mut()
+                .map(|device| &mut device.device_state),
+            VirtioDevicesState::Pci(pci_state) => pci_state
+                .vsock_device
+                .as_mut()
+                .map(|device| &mut device.device_state),
+        }
+        .ok_or(SnapshotStateFromFileError::UnknownVsockDevice)?;
 
         device_state
             .backend
@@ -732,10 +732,13 @@ mod tests {
 
         // Only checking that all devices are saved, actual device state
         // is tested by that device's tests.
-        assert_eq!(states.mmio_state.block_devices.len(), 1);
-        assert_eq!(states.mmio_state.net_devices.len(), 1);
-        assert!(states.mmio_state.vsock_device.is_some());
-        assert!(states.mmio_state.balloon_device.is_some());
+        let VirtioDevicesState::Mmio(mmio_state) = &states.virtio_state else {
+            panic!("expected MMIO virtio device state");
+        };
+        assert_eq!(mmio_state.block_devices.len(), 1);
+        assert_eq!(mmio_state.net_devices.len(), 1);
+        assert!(mmio_state.vsock_device.is_some());
+        assert!(mmio_state.balloon_device.is_some());
 
         let vcpu_states = vec![VcpuState::default()];
         #[cfg(target_arch = "aarch64")]
@@ -759,10 +762,13 @@ mod tests {
         let restored_microvm_state: MicrovmState = bitcode::deserialize(&serialized_data).unwrap();
 
         assert_eq!(restored_microvm_state.vm_info, microvm_state.vm_info);
-        assert_eq!(
-            restored_microvm_state.device_states.mmio_state,
-            microvm_state.device_states.mmio_state
-        )
+        let (VirtioDevicesState::Mmio(restored_mmio), VirtioDevicesState::Mmio(mmio)) = (
+            &restored_microvm_state.device_states.virtio_state,
+            &microvm_state.device_states.virtio_state,
+        ) else {
+            panic!("expected MMIO virtio device state");
+        };
+        assert_eq!(restored_mmio, mmio)
     }
 
     #[test]

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 
 use vmm::builder::build_and_boot_microvm;
 use vmm::devices::virtio::block::CacheType;
-use vmm::persist::{MicrovmState, MicrovmStateError, VmInfo, snapshot_state_sanity_check};
+use vmm::persist::{
+    MicrovmState, MicrovmStateError, VirtioDevicesState, VmInfo, snapshot_state_sanity_check,
+};
 use vmm::resources::VmResources;
 use vmm::rpc_interface::{
     LoadSnapshotError, PrebootApiController, RuntimeApiController, VmmAction, VmmActionError,
@@ -265,29 +267,20 @@ fn verify_create_snapshot(
 
     // Verify deserialized data.
     // The default vmm has no devices and one vCPU.
-    assert_eq!(
-        restored_microvm_state
-            .device_states
-            .mmio_state
-            .block_devices
-            .len(),
-        0
-    );
-    assert_eq!(
-        restored_microvm_state
-            .device_states
-            .mmio_state
-            .net_devices
-            .len(),
-        0
-    );
-    assert!(
-        restored_microvm_state
-            .device_states
-            .mmio_state
-            .vsock_device
-            .is_none()
-    );
+    match &restored_microvm_state.device_states.virtio_state {
+        VirtioDevicesState::Mmio(state) => {
+            assert!(!pci_enabled);
+            assert_eq!(state.block_devices.len(), 0);
+            assert_eq!(state.net_devices.len(), 0);
+            assert!(state.vsock_device.is_none());
+        }
+        VirtioDevicesState::Pci(state) => {
+            assert!(pci_enabled);
+            assert_eq!(state.block_devices.len(), 0);
+            assert_eq!(state.net_devices.len(), 0);
+            assert!(state.vsock_device.is_none());
+        }
+    }
     assert_eq!(restored_microvm_state.vcpu_states.len(), 1);
 
     (snapshot_file, memory_file)


### PR DESCRIPTION
## Changes

- Separate `MMIOPlatformDevices` (boot timer, RTC [ARM], serial [ARM]) from `MMIOVirtioDevices`
- Put `PciDevices` / `MMIOVirtioDevices` in an enum, `VirtioDevices`, enforcing the already implied mutual exclusivity of PCI and MMIO for virtio devices
- Construct PCI segment at `PciDevices` construction, since now if `PciDevices` exists, then PCI is the chosen transport and the segment should be present.

## Reason

It has always been implied that virtio devices may use **either** PCI or MMIO as the transport, enforce that structurally by pushing them into an enum.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
