### PR TITLE
feat(artifacts): build bzImage CI kernel image on x86_64

### DIFF
--- a/resources/rebuild.sh
+++ b/resources/rebuild.sh
@@ -141,12 +141,14 @@ function build_al_kernel {
     arch=$(uname -m)
     if [ "$arch" = "x86_64" ]; then
         format="elf"
-        target="vmlinux"
-        binary_path="$target"
+        target="vmlinux bzImage"
+        binary_path="vmlinux"
+        bzimage_path="arch/x86/boot/bzImage"
     elif [ "$arch" = "aarch64" ]; then
         format="pe"
         target="Image"
         binary_path="arch/arm64/boot/$target"
+        bzimage_path=""
     else
         echo "FATAL: Unsupported architecture!"
         exit 1
@@ -164,6 +166,9 @@ function build_al_kernel {
     OUTPUT_FILE=$OUTPUT_DIR/vmlinux-$normalized_version$flavour
     cp -v $binary_path $OUTPUT_FILE
     cp -v .config $OUTPUT_FILE.config
+    if [ -n "$bzimage_path" ]; then
+        cp -v $bzimage_path $OUTPUT_DIR/bzImage-$normalized_version$flavour
+    fi
 
     # Undo any patches previously applied, so that we can build the same kernel with different
     # configs, e.g. no-acpi


### PR DESCRIPTION
## Changes

Build a `bzImage` for each x86_64 CI guest kernel, alongside the existing
uncompressed ELF `vmlinux`. The `bzImage` is copied to the artifact output
directory as `bzImage-<version><flavour>` next to the `vmlinux-<version><flavour>`
files. aarch64 is unaffected.

This is an artifacts-only change: it adds the images to the build, but nothing
consumes them yet. Support for booting `bzImage` guest kernels in the VMM will
follow in a separate PR.

## Reason

Producing the `bzImage` variant in CI is a prerequisite for adding and testing
`bzImage` direct-boot support in a follow-up PR. Splitting the artifact build
out first lets the new images be published before the code that depends on them
is merged.

Verified locally with `tools/devtool build_ci_artifacts kernels`: a valid
`bzImage-<version>` is produced next to each `vmlinux-<version>` for all x86_64
CI kernels.

## CI Artifacts

Built via the artifacts CodeBuild batch against this branch; the batch
succeeded for both architectures. The published artifacts are available at:

```
s3://spec.ccfc.min/firecracker-ci-custom/bzimage-artifacts-pr6035-0/
```

On x86_64, a valid `bzImage-<version>` is produced next to each
`vmlinux-<version>` (`bzImage-5.10.260`, `bzImage-5.10.260-no-acpi`,
`bzImage-6.1.176`, `bzImage-6.18.36`); aarch64 is unchanged and contains only
the `vmlinux-<version>` images.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md

