### PR TITLE
pci: Remove unused pci_devices_up/down fields

### DIFF
--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -37,10 +37,6 @@ pub struct PciSegment {
     #[cfg(target_arch = "x86_64")]
     pub(crate) pci_config_io: Option<Arc<Mutex<PciConfigIo>>>,
 
-    // Bitmap of PCI devices to hotplug.
-    pub(crate) pci_devices_up: u32,
-    // Bitmap of PCI devices to hotunplug.
-    pub(crate) pci_devices_down: u32,
     // List of allocated IRQs for each PCI slot.
     pub(crate) pci_irq_slots: [u8; 32],
 
@@ -58,8 +54,6 @@ impl std::fmt::Debug for PciSegment {
             .field("id", &self.id)
             .field("mmio_config_address", &self.mmio_config_address)
             .field("proximity_domain", &self.proximity_domain)
-            .field("pci_devices_up", &self.pci_devices_up)
-            .field("pci_devices_down", &self.pci_devices_down)
             .field("pci_irq_slots", &self.pci_irq_slots)
             .field("start_of_mem32_area", &self.start_of_mem32_area)
             .field("end_of_mem32_area", &self.end_of_mem32_area)
@@ -97,8 +91,6 @@ impl PciSegment {
             pci_config_mmio,
             mmio_config_address,
             proximity_domain: 0,
-            pci_devices_up: 0,
-            pci_devices_down: 0,
             #[cfg(target_arch = "x86_64")]
             pci_config_io: None,
             start_of_mem32_area,
@@ -491,8 +483,6 @@ mod tests {
         );
         assert_eq!(pci_segment.mmio_config_address, arch::PCI_MMCONFIG_START);
         assert_eq!(pci_segment.proximity_domain, 0);
-        assert_eq!(pci_segment.pci_devices_up, 0);
-        assert_eq!(pci_segment.pci_devices_down, 0);
         assert_eq!(pci_segment.pci_irq_slots, [0u8; 32]);
     }
 


### PR DESCRIPTION
Remove the pci_devices_up and pci_devices_down fields of the PciSegment that are never used and are essentially dead code.

No functional change intended.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
