### PR TITLE
vsock: fix h2g throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,17 @@ and this project adheres to
 - [#5956](https://github.com/firecracker-microvm/firecracker/pull/5956): Fixed a
   TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
   `MIDR_EL1` information files copied into the chroot.
-- [#6031](https://github.com/firecracker-microvm/firecracker/pull/6031): Fixed
+- [#6031](https://github.com/firecracker-microvm/firecracker/pull/6031),
+  [#6041](https://github.com/firecracker-microvm/firecracker/pull/6041): Fixed
   the vsock device re-arming its host-stream `EPOLLIN` interest while received
   data was still awaiting a guest RX buffer, which could busy-spin the event
-  thread until the guest posted buffers.
+  thread until the guest posted buffers. The device now drains the host stream
+  fully across successive RX operations instead of one packet per event loop
+  iteration, reducing the host-side CPU cost per gigabit of host-to-guest
+  traffic by up to ~50% and improving host-to-guest throughput by ~44% (median)
+  in most configurations. On single-vcpu microVMs on the newest Intel hosts
+  (m7i, m8i), host-to-guest throughput may instead decrease by ~15% (median),
+  where the single guest vCPU rather than the host becomes the bottleneck.
 
 ## [1.16.1]
 

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -239,6 +239,9 @@ where
                         // by self.peer_avail_credit(), a u32 internally.
                         pkt.hdr.set_op(uapi::VSOCK_OP_RW).set_len(read_cnt);
                         METRICS.rx_bytes_count.add(read_cnt as u64);
+                        // There may be more data to read, so keep `Rw` pending to stay
+                        // scheduled for another read.
+                        self.pending_rx.insert(PendingRx::Rw);
                     }
                     self.rx_cnt += Wrapping(pkt.hdr.len());
                     self.last_fwd_cnt_to_peer = self.fwd_cnt;
@@ -247,13 +250,7 @@ where
                 Err(VsockError::GuestMemoryMmap(GuestMemoryError::IOError(err)))
                     if err.kind() == ErrorKind::WouldBlock =>
                 {
-                    // This shouldn't actually happen (receiving EWOULDBLOCK after EPOLLIN), but
-                    // apparently it does, so we need to handle it gracefully.
-                    warn!(
-                        "vsock: unexpected EWOULDBLOCK while reading from backing stream: lp={}, \
-                         pp={}, err={:?}",
-                        self.local_port, self.peer_port, err
-                    );
+                    // Host stream drained: `Rw` stays cleared.
                 }
                 Err(err) => {
                     // We are not expecting any other errors when reading from the underlying
@@ -1057,9 +1054,46 @@ mod tests {
         // With an undeliverable Rw queued, IN must be suppressed.
         assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
 
-        // Draining the pending packet (guest posted an RX buffer) clears Rw and re-arms IN.
+        // The guest posts an RX buffer: the packet is delivered, but `Rw` stays pending for
+        // another read, so IN remains suppressed.
         ctx.recv();
         assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert!(ctx.conn.has_pending_rx());
+        assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
+
+        // Once the stream drains (read returns `WouldBlock`), `Rw` is cleared and IN re-armed.
+        ctx.conn.recv_pkt(&mut ctx.rx_pkt).unwrap_err();
+        assert!(!ctx.conn.has_pending_rx());
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
+    }
+
+    #[test]
+    fn test_rx_drains_multiple_packets_per_notification() {
+        // A single EPOLLIN notification must drain the whole host stream: `recv_pkt`
+        // keeps yielding RW packets across calls until a read would block.
+        let mut ctx = CsmTestContext::new_established();
+        let pkt_buf_size = ctx.rx_pkt.buf_size() as usize;
+        // More than one packet's worth of data, so draining needs several reads.
+        let data = vec![0xab_u8; pkt_buf_size + 1];
+        ctx.set_stream(TestStream::new_with_read_buf(&data));
+
+        // A single notification schedules the connection.
+        ctx.notify_epollin();
+
+        // First read fills a whole packet; `Rw` stays pending for the rest.
+        ctx.recv();
+        assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(ctx.rx_pkt.hdr.len() as usize, pkt_buf_size);
+        assert!(ctx.conn.has_pending_rx());
+
+        // Second read drains the remaining byte, without another notification.
+        ctx.recv();
+        assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(ctx.rx_pkt.hdr.len() as usize, 1);
+        assert!(ctx.conn.has_pending_rx());
+
+        // Stream now empty: the next read would block, clearing `Rw` and re-arming IN.
+        ctx.conn.recv_pkt(&mut ctx.rx_pkt).unwrap_err();
         assert!(!ctx.conn.has_pending_rx());
         assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
     }

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -173,30 +173,32 @@ where
         while let Some(head) = queue.pop_or_enable_notification()? {
             let index = head.index;
             let used_len = match self.rx_packet.parse(mem, head) {
-                Ok(()) => {
-                    if self.backend.recv_pkt(&mut self.rx_packet).is_ok() {
-                        match self.rx_packet.commit_hdr() {
-                            // This addition cannot overflow, because packet length
-                            // is previously validated against `MAX_PKT_BUF_SIZE`
-                            // bound as part of `commit_hdr()`.
-                            Ok(()) => VSOCK_PKT_HDR_SIZE + self.rx_packet.hdr.len(),
-                            Err(err) => {
-                                warn!(
-                                    "vsock: Error writing packet header to guest memory: \
-                                     {:?}.Discarding the package.",
-                                    err
-                                );
-                                0
-                            }
+                Ok(()) => match self.backend.recv_pkt(&mut self.rx_packet) {
+                    Ok(()) => match self.rx_packet.commit_hdr() {
+                        // This addition cannot overflow, because packet length
+                        // is previously validated against `MAX_PKT_BUF_SIZE`
+                        // bound as part of `commit_hdr()`.
+                        Ok(()) => VSOCK_PKT_HDR_SIZE + self.rx_packet.hdr.len(),
+                        Err(err) => {
+                            warn!(
+                                "vsock: Error writing packet header to guest memory: \
+                                 {:?}.Discarding the package.",
+                                err
+                            );
+                            0
                         }
-                    } else {
-                        // We are using a consuming iterator over the virtio buffers, so, if we
-                        // can't fill in this buffer, we'll need to undo the
-                        // last iterator step.
+                    },
+                    Err(VsockError::NoData) => {
+                        // No more data to deliver. Return the unused buffer to the queue.
                         queue.undo_pop();
                         break;
                     }
-                }
+                    Err(err) => {
+                        error!("vsock: error receiving packet from backend: {:?}", err);
+                        queue.undo_pop();
+                        break;
+                    }
+                },
                 Err(err) => {
                     warn!("vsock: RX queue error: {:?}. Discarding the package.", err);
                     0

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -1160,6 +1160,8 @@ mod tests {
         let buf = test_utils::read_packet_data(&ctx.tx_pkt, 4);
         assert_eq!(&buf, &data);
 
+        // The connection stays scheduled until the stream drains, then has no more pending RX.
+        ctx.muxer.recv_pkt(&mut ctx.rx_pkt).unwrap_err();
         assert!(!ctx.muxer.has_pending_rx());
     }
 
@@ -1227,10 +1229,14 @@ mod tests {
         assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
         assert_eq!(ctx.count_epoll_listeners().1, 0);
 
-        // The guest posts an RX buffer: recv drains the packet, clearing the pending RX
-        // and re-arming the epoll listener.
+        // The guest posts an RX buffer: recv delivers the packet, but the connection stays
+        // scheduled (and its listener dropped) while the stream may still hold data.
         ctx.recv();
         assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
+
+        // Draining the stream clears the pending RX and re-arms the epoll listener.
+        ctx.muxer.recv_pkt(&mut ctx.rx_pkt).unwrap_err();
         assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
         assert_eq!(ctx.count_epoll_listeners().1, 1);
     }


### PR DESCRIPTION
## Changes

In vsock connection, keep `PendingRx::Rw` active on successful reads indicating the host stream may have more data to read. Clear it only once the entire socket is drained successfully.

## Reason

#6031 regressed vsock performance since it made one single packet being processed for each Epoll wake up. This is because the change assumed that `PendingRx::Rw` was getting cleared when no pending data was left on the socket.

Fixes: #6031

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
