### PR TITLE
test(vuln): skip spectre-meltdown-checker on Neoverse V3

### DIFF
--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -27,6 +27,17 @@ REMOTE_CHECKER_COMMAND = f"sh {REMOTE_CHECKER_PATH} --no-intel-db --batch json"
 
 VULN_DIR = "/sys/devices/system/cpu/vulnerabilities"
 
+# spectre-meltdown-checker does not recognise Neoverse V3 (MIDR part 0xd84), so it
+# falls back to reporting Spectre v2 and Variant 3a as vulnerable. The kernel itself
+# reports the CPU as mitigated (spectre_v2: "Mitigation: CSV2, BHB"), and Graviton4
+# (Neoverse V2, which the checker does recognise) passes the same tests.
+# TODO: remove this skip once the following issue is resolved:
+# https://github.com/speed47/spectre-meltdown-checker/issues/582
+SKIP_SMC_UNRECOGNISED_CPU = pytest.mark.skipif(
+    global_props.cpu_codename == "ARM_NEOVERSE_V3",
+    reason="spectre-meltdown-checker does not recognise Neoverse V3 (0xd84)",
+)
+
 
 class SpectreMeltdownChecker:
     """Helper class to use Spectre & Meltdown Checker"""
@@ -109,6 +120,7 @@ def download_spectre_meltdown_checker(tmp_path_factory):
 
 
 # Nothing can be sensibly tested in a PR context here
+@SKIP_SMC_UNRECOGNISED_CPU
 @pytest.mark.skipif(
     global_props.buildkite_pr or global_props.is_dev_env,
     reason="Test depends solely on factors external to GitHub repository",
@@ -241,6 +253,7 @@ def test_check_vulnerability_files_ab(request, uvm_any):
         assert not [x for x in res_b if "Vulnerable" in x["stdout"]]
 
 
+@SKIP_SMC_UNRECOGNISED_CPU
 @pin_pci(False)
 @pin_cpu_template(ALL_CPU_TEMPLATES)
 def test_spectre_meltdown_checker_on_guest(


### PR DESCRIPTION
## Changes
Skip test_spectre_meltdown_checker_on_host and test_spectre_meltdown_checker_on_guest on Neoverse V3 (Graviton5), via a shared skipif on cpu_codename == "ARM_NEOVERSE_V3". The sysfs-based vulnerability tests are unchanged.

## Reason
spectre-meltdown-checker doesn't recognise Neoverse V3 (MIDR 0xd84), so it falls back to flagging Spectre v2 and Variant 3a as vulnerable. These are false positives: the kernel reports the CPU mitigated (spectre_v2: Mitigation: CSV2, BHB), the kernel-based test_check_vulnerability_files_ab passes on G5, and Graviton4 (Neoverse V2, recognised by the checker) passes the same tests. Skip until upstream adds 0xd84 recognition.

upstream: https://github.com/speed47/spectre-meltdown-checker/blob/master/spectre-meltdown-checker.sh
upstream issue cut: https://github.com/speed47/spectre-meltdown-checker/issues/582

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
