### PR TITLE
fix(test): Adjust MMD performance test iteration strategy

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -90,6 +90,12 @@ perf_test = {
         "label": "mmds",
         "tests": "integration_tests/performance/test_mmds.py",
         "devtool_opts": "-c 1-10 -m 0",
+        # The latency of consecutive MMDS calls is very correlated.
+        # To make datapoints more independent, we run more iterations to spread the datapoint collection over a longer
+        # period of time.
+        # Each iteration takes about 2 minutes (12 10-seconds tests), so the maximum total time is about ~1h:30
+        # accounting for all the additional test overheads.
+        "max_iterations": 30,
     },
 }
 
@@ -97,7 +103,7 @@ REVISION_A = os.environ.get("REVISION_A")
 REVISION_B = os.environ.get("REVISION_B")
 REVISION_A_ARTIFACTS = os.environ.get("REVISION_A_ARTIFACTS")
 REVISION_B_ARTIFACTS = os.environ.get("REVISION_B_ARTIFACTS")
-A_B_TEST_MAX_ITERATIONS = 4
+A_B_TEST_DEFAULT_MAX_ITERATIONS = 4
 
 # Either both are specified or neither. Only doing either is a bug. If you want to
 # run performance tests _on_ a specific commit, specify neither and put your commit
@@ -135,12 +141,13 @@ for test in tests:
     devtool_opts = test.pop("devtool_opts")
     test_selector = test.pop("tests")
     ab_opts = test.pop("ab_opts", "")
+    max_iterations = test.pop("max_iterations", A_B_TEST_DEFAULT_MAX_ITERATIONS)
     devtool_opts += " --performance"
     test_script_opts = ""
     artifacts = []
     if REVISION_A:
         devtool_opts += " --ab"
-        test_script_opts = f'{ab_opts} run --binaries-a build/{REVISION_A}/ --binaries-b build/{REVISION_B} --max-iterations={A_B_TEST_MAX_ITERATIONS} --pytest-opts "{test_selector}"'
+        test_script_opts = f'{ab_opts} run --binaries-a build/{REVISION_A}/ --binaries-b build/{REVISION_B} --max-iterations={max_iterations} --pytest-opts "{test_selector}"'
         if REVISION_A_ARTIFACTS:
             artifacts.append(REVISION_A_ARTIFACTS)
             artifacts.append(REVISION_B_ARTIFACTS)
@@ -160,7 +167,6 @@ for test in tests:
         # and the rest can be command arguments
         **test,
     )
-
 
 # Stores the info about pinning tests to agents with particular kernel versions.
 # For example, the following:

--- a/tests/integration_tests/performance/test_mmds.py
+++ b/tests/integration_tests/performance/test_mmds.py
@@ -3,6 +3,7 @@
 """Tests the performance of MMDS token generation and verification."""
 
 import re
+import time
 
 import pytest
 
@@ -11,8 +12,14 @@ from framework.utils import configure_mmds, populate_data_store
 # Default IPv4 address for MMDS
 DEFAULT_IPV4 = "169.254.169.254"
 
-# Number of iterations for performance measurements
-ITERATIONS = 500
+# Number of iterations (each iteration does multiple MMDS calls)
+ITERATIONS = 100
+MMDS_CALLS_PER_ITERATION = 10
+# How frequently iterations start.
+# Total time should be roughly ITERATIONS*ITERATION_PERIOD (unless each iteration takes longer than ITERATION_PERIOD)
+# A longer interval helps de-correlate the system noise between iterations.
+# The current target is approximately 10 seconds total (~=100ms per iteration)
+ITERATION_PERIOD = 0.100
 
 
 def parse_curl_timing(prefix: str, timing_line: str):
@@ -54,7 +61,9 @@ def test_mmds_token(mmds_microvm, metrics):
 
     This test measures the time it takes to generate MMDS session tokens
     and perform data requests using curl's built-in timing capabilities.
-    Curl invocations are batched into single SSH calls for efficiency.
+    The outer iteration loop runs in Python with a sleep between iterations
+    to decorrelate system noise, while the inner batch of curl calls is
+    executed in a single SSH command for efficiency.
     """
 
     metrics.set_dimensions(
@@ -64,19 +73,17 @@ def test_mmds_token(mmds_microvm, metrics):
         }
     )
 
-    # Batch all curl invocations in a single SSH call using a shell loop.
-    # Each iteration generates a token (PUT) then uses it to fetch data (GET).
-    # We use -o /tmp/mmds_token so curl writes the token body to file and only
-    # outputs the -w timing string to stdout. Then we cat the token and run the
-    # GET request. Output per iteration (4 lines + delimiter):
+    # Build the SSH command for a single iteration batch.
+    # Each iteration does MMDS_CALLS_PER_ITERATION curl round-trips.
+    # Output per curl pair (4 lines + delimiter):
     #   token_generation_time:<gen_seconds>
     #   <token>
     #   <response>
     #   request_time:<req_seconds>
     #   ---
     # noinspection HttpUrlsUsage
-    batch_cmd = (
-        f"for i in $(seq 1 {ITERATIONS}); do "
+    cmd = (
+        f"for i in $(seq 1 {MMDS_CALLS_PER_ITERATION}); do "
         f"curl -m 2 -s -w 'token_generation_time:%{{time_total}}\\n' "
         f"-X PUT -H 'X-metadata-token-ttl-seconds: 60' "
         f"-o /tmp/mmds_token "
@@ -91,33 +98,56 @@ def test_mmds_token(mmds_microvm, metrics):
         f"done"
     )
 
-    _, stdout, stderr = mmds_microvm.ssh.check_output(batch_cmd)
-    assert stderr == "", "Error calling MMDS"
+    next_iteration_time = time.monotonic()
 
-    # Parse batched output (splitting by '---', and removing last empty token)
-    iterations = stdout.split("---\n")
-    assert iterations[-1] == ""
-    iterations = iterations[:-1]
-    assert len(iterations) == ITERATIONS
+    for iter_idx in range(ITERATIONS):
+        _, stdout, stderr = mmds_microvm.ssh.check_output(cmd)
+        assert stderr == "", f"Error calling MMDS at iteration {iter_idx}: {stderr}"
 
-    for block in iterations:
-        lines = block.strip().split("\n")
-        assert len(lines) == 4, f"Unexpected output block: {block}"
+        # Parse output: split by "---\n"
+        calls = stdout.split("---\n")
+        if calls and calls[-1].strip() == "":
+            calls = calls[:-1]
+        assert len(calls) == MMDS_CALLS_PER_ITERATION, (
+            f"Iteration {iter_idx}: expected {MMDS_CALLS_PER_ITERATION} "
+            f"calls, got {len(calls)}"
+        )
 
-        # Line 0: time_total from token generation (body went to file)
-        generation_time_ms = parse_curl_timing("token_generation_time", lines[0])
-        metrics.put_metric("token_generation_time", generation_time_ms, "Milliseconds")
+        batch_token_sum = 0.0
+        batch_request_sum = 0.0
 
-        # Line 1: token value (from cat)
-        token = lines[1].strip()
-        assert len(token) > 0, f"Token generation failed. Block: {block}"
+        for call_idx in range(MMDS_CALLS_PER_ITERATION):
+            block = calls[call_idx]
+            lines = block.strip().split("\n")
+            assert len(lines) == 4, f"Unexpected output block: {block}"
 
-        # Line 2: response body from GET request
-        response = lines[2].strip()
-        assert (
-            response == '"i-1234567890abcdef0"'
-        ), f"MMDS request failed. Response: {response}"
+            # Line 0: time_total from token generation (body went to file)
+            batch_token_sum += parse_curl_timing("token_generation_time", lines[0])
 
-        # Line 3: time_total from GET request
-        request_time_ms = parse_curl_timing("request_time", lines[3])
-        metrics.put_metric("request_time", request_time_ms, "Milliseconds")
+            # Line 1: token value (from cat)
+            token = lines[1].strip()
+            assert len(token) > 0, f"Token generation failed. Block: {block}"
+
+            # Line 2: response body from GET request
+            response = lines[2].strip()
+            assert (
+                response == '"i-1234567890abcdef0"'
+            ), f"MMDS request failed. Response: {response}"
+
+            # Line 3: time_total from GET request
+            batch_request_sum += parse_curl_timing("request_time", lines[3])
+
+        # Emit one averaged datapoint per iteration
+        metrics.put_metric(
+            "token_generation_time",
+            batch_token_sum / MMDS_CALLS_PER_ITERATION,
+            "Milliseconds",
+        )
+        metrics.put_metric(
+            "request_time",
+            batch_request_sum / MMDS_CALLS_PER_ITERATION,
+            "Milliseconds",
+        )
+
+        next_iteration_time += ITERATION_PERIOD
+        time.sleep(max(0, next_iteration_time - time.monotonic()))


### PR DESCRIPTION
## Changes

The MMDS latency test (token_generation_time, request_time) exhibits a
bimodal distribution where average latencies can shift by up to ~200µs
between runs due to system-level modality (e.g. scheduling, cache
state), unrelated to code changes. This causes false positives in A/B
comparisons.

This commit significantly increases the number of collected datapoints,
and spreads the collection over a longer period of time.

Note: the true positive detection rate shouldn't be affected.

Tested by running the MMDS test in a loop (with the same parameters of the A/B tester)
for 20 hours; 0 regressions detected.

Run on Buildkite: https://buildkite.com/firecracker/mamarang-tmp-a-b/builds/5/list

## Reason

The main motivation is to increase the reliability of the A/B test.

Adding a small delay between datapoint collection helps reduce de-correlations within each iteration (e.g. in https://buildkite.com/firecracker/mamarang-tmp-a-b/builds/5, all MMDS checks passed in the first iteration).

However, in my tests it wasn't enough, because sometimes the noise that affects the latency has a period measured in ~minutes. So, increasing the max-iteration to 30 brings the max execution time in line with other performance tests. Additionally, it brings down the probability of false positives to effectively 0.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
