### PR TITLE
fix(tests): Increase test_send_ctrl_alt_del timeout and add kernel mode

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -300,14 +300,14 @@ class Microvm:
     def __repr__(self):
         return f"<Microvm id={self.id}>"
 
-    def mark_killed(self):
+    def mark_killed(self, timeout=10.0):
         """
         Marks this `Microvm` as killed, meaning test tear down should not try to kill it
 
         raises an exception if the Firecracker process managing this VM is not actually dead
         """
         if self.firecracker_pid is not None:
-            utils.wait_process_termination(self.firecracker_pid)
+            utils.wait_process_termination(self.firecracker_pid, timeout=timeout)
 
         self._killed = True
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -776,12 +776,23 @@ def test_drive_patch(uvm, io_engine):
 @pytest.mark.skipif(
     platform.machine() != "x86_64", reason="not yet implemented on aarch64"
 )
-def test_send_ctrl_alt_del(uvm):
+@pytest.mark.parametrize(
+    "ctrl_alt_del_mode,timeout",
+    [("kernel", 10), ("userspace", 120)],
+    ids=["kernel", "userspace"],
+)
+def test_send_ctrl_alt_del(uvm, ctrl_alt_del_mode, timeout):
     """
-    Test shutting down the microVM gracefully on x86, by sending CTRL+ALT+DEL.
+    Test shutting down the microVM on x86 by sending CTRL+ALT+DEL.
+
+    This relies on the i8042 device and AT Keyboard support being present in
+    the guest kernel.
+
+    - kernel: sets /proc/sys/kernel/ctrl-alt-del to 1 so the kernel triggers an
+      immediate hard reboot, bypassing systemd. 10s timeout is sufficient.
+    - userspace: lets systemd handle graceful shutdown. Uses 120s timeout to
+      accommodate systemd's DefaultTimeoutStopSec (90s) for stuck services.
     """
-    # This relies on the i8042 device and AT Keyboard support being present in
-    # the guest kernel.
     test_microvm = uvm
     test_microvm.spawn()
 
@@ -789,11 +800,16 @@ def test_send_ctrl_alt_del(uvm):
     test_microvm.add_net_iface()
     test_microvm.start()
 
+    if ctrl_alt_del_mode == "kernel":
+        # Make Ctrl+Alt+Del trigger an immediate hard reboot, skipping graceful
+        # shutdown entirely.
+        test_microvm.ssh.run("echo 1 > /proc/sys/kernel/ctrl-alt-del")
+
     test_microvm.api.actions.put(action_type="SendCtrlAltDel")
 
     # If everything goes as expected, the guest OS will issue a reboot,
     # causing Firecracker to exit.
-    test_microvm.mark_killed()
+    test_microvm.mark_killed(timeout=timeout)
 
 
 def _drive_patch(test_microvm, io_engine):


### PR DESCRIPTION
## Changes

Parametrize test_send_ctrl_alt_del into two variants:
- "kernel": sets /proc/sys/kernel/ctrl-alt-del=1 before sending the key combo, triggering an immediate hard reboot that bypasses systemd. Uses a 10s timeout since the i8042 reset fires almost instantly.
- "userspace": exercises the graceful systemd shutdown path. Increases the timeout from 10s to 120s to accommodate systemd's DefaultTimeoutStopSec (90s) when a service gets stuck during shutdown.

The graceful path was flaking ~1-2 times per week on 6.1.x guest kernels because serial-getty@ttyS0.service occasionally hung during stop, causing the entire reboot transaction to stall past the 10s budget.

## Reason

Hanging processes in userspace shouldn't cause the test to fail.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
