### PR TITLE
fdt: Fix size cell of 64-bit PCI MMIO range in device tree

### DIFF
--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -509,7 +509,7 @@ fn create_pci_nodes(fdt: &mut FdtWriter, segment: &PciSegment) -> Result<(), Fdt
         (MEM_64BIT_DEVICES_START & 0xffff_ffff) as u32,
         // Range size
         (MEM_64BIT_DEVICES_SIZE >> 32) as u32, // Range size
-        ((MEM_64BIT_DEVICES_SIZE & 0xffff_ffff) >> 32) as u32,
+        (MEM_64BIT_DEVICES_SIZE & 0xffff_ffff) as u32,
     ];
 
     // See kernel document Documentation/devicetree/bindings/pci/pci-msi.txt


### PR DESCRIPTION
The low 32-bit size cell of the 64-bit MMIO window in the PCI host bridge "ranges" property was computed as
((MEM_64BIT_DEVICES_SIZE & 0xffff_ffff) >> 32), which masks off the low bits and then shifts them away, so it always evaluates to 0. It only produced the correct size because the low 32 bits of the current constant happen to be zero; any value with non-zero low bits would silently under-report the window size to the guest.

Use the low 32 bits directly, matching the encoding of the other cells in the array.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
