### PR TITLE
fix(test): Add retries for spectre-meltdown-checker download

### DIFF
--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 import requests
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 from framework import utils
 from framework.ab_test import git_clone
@@ -139,11 +140,22 @@ class SpectreMeltdownChecker:
 @pytest.fixture(scope="session", name="spectre_meltdown_checker")
 def download_spectre_meltdown_checker(tmp_path_factory):
     """Download spectre / meltdown checker script."""
-    resp = requests.get(CHECKER_URL, timeout=5)
-    resp.raise_for_status()
+    resp = _download_checker_script()
     path = tmp_path_factory.mktemp("tmp", True) / CHECKER_FILENAME
     path.write_bytes(resp.content)
     return SpectreMeltdownChecker(path)
+
+
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=2, min=1),
+    reraise=True,
+)
+def _download_checker_script():
+    """Download the spectre-meltdown-checker script with retries."""
+    resp = requests.get(CHECKER_URL, timeout=30)
+    resp.raise_for_status()
+    return resp
 
 
 # Nothing can be sensibly tested in a PR context here


### PR DESCRIPTION
## Changes

This commit adds retries for the download of the
spectre-meltdown-checker script.
This protects the test suit from transient network issue.

## Reason

Increase test reliability.

This made https://buildkite.com/firecracker/firecracker-pr-nightly/builds/4076 fail

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
