### PR TITLE
fix(ci): Ensure KVM modules are loaded for docker-popular pipeline

### DIFF
--- a/.buildkite/pipeline_docker_popular.py
+++ b/.buildkite/pipeline_docker_popular.py
@@ -27,6 +27,7 @@ pipeline.build_group_per_arch(
 pipeline.build_group(
     "docker-popular-containers",
     [
+        "./tools/devtool setup_kvm",
         "./tools/devtool ensure_current_artifacts",
         f'buildkite-agent artifact download "{ROOTFS_TAR}" .',
         f'tar xzf "{ROOTFS_TAR}" -C tools/test-popular-containers',

--- a/tools/devtool
+++ b/tools/devtool
@@ -513,6 +513,11 @@ cmd_help() {
 
     checkbuild [--all|-m x86_64|aarch64]
         Run cargo check on the target architecture (supports cross compilation).
+
+    setup_kvm
+        Ensure KVM is available on the host by loading kernel modules if needed.
+        Applies platform-specific tweaks (e.g. nx_huge_pages on Linux 6.1).
+        Safe to call from CI steps that need /dev/kvm before entering a container.
 EOF
 }
 
@@ -846,6 +851,15 @@ setup_kvm() {
     tail -v $itlb_multihit $nx_huge_pages
 
     [[ -c /dev/kvm ]] || die "/dev/kvm not found. Aborting."
+}
+
+# `$0 setup_kvm` - ensure KVM is available on the host.
+# Acquires the shared KVM lock and calls setup_kvm to load modules if needed.
+# Safe to call from any pipeline step that needs /dev/kvm before entering a
+# container.
+cmd_setup_kvm() {
+    acquire_shared_kvm_lock
+    setup_kvm
 }
 
 # Modifies the processors CPU governor and P-state configuration (x86_64 only) for consistent performance. This means


### PR DESCRIPTION
## Changes

The docker-popular-containers pipeline step boots microVMs via test-docker-rootfs.py but, unlike devtool test, never called setup_kvm to load KVM modules on the host. If the Buildkite agent starts on a host where kvm/kvm_intel/kvm_amd is not already loaded, /dev/kvm does not exist and Firecracker fails with "No such device (os error 19)".

Add a new `devtool setup_kvm` subcommand that wraps the existing setup_kvm function (with proper KVM lock acquisition) so any pipeline step can ensure KVM availability before entering a container. Call it in the docker-popular-containers group before running the tests.

Test run: https://buildkite.com/firecracker/mamarang-tmp/builds/14/list


## Reason

Fix test failure: https://buildkite.com/firecracker/firecracker-docker-popular/builds/217/canvas?jid=019f2f95-5e3f-4304-8e57-a3c1f25d0e22&tab=output

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
