### PR TITLE
fix(test): gate Graviton5 wfxt expectation on the host kernel

### DIFF
--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -66,7 +66,8 @@ def test_guest_cpu_features(uvm_any):
 
     if (
         global_props.cpu_model == CpuModel.ARM_NEOVERSE_V3
-        and vm.guest_kernel_version >= (6, 1)
+        and global_props.host_linux_version_tpl >= (5, 19)
+        and vm.guest_kernel_version >= (5, 19)
     ):
         expected_cpu_features = expected_cpu_features | {"wfxt"}
 

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -662,15 +662,14 @@ def test_host_vs_guest_cpu_features(uvm):
                 "svesha3",
             }
 
-            # The "wfxt" (FEAT_WFxT) hwcap is exposed to userspace from kernel
-            # v6.1 (absent in v5.10, including Amazon Linux 5.10).
-            host_has_wfxt = global_props.host_linux_version_tpl >= (6, 1)
-            guest_has_wfxt = vm.guest_kernel_version >= (6, 1)
+            # The "wfxt" hwcap and its KVM exposure landed in kernel v5.19.
+            # https://github.com/torvalds/linux/commit/69bb02ebc38ace438c9cd7c5315cfe43862b51fe
+            # https://github.com/torvalds/linux/commit/06e0b802583d7bbc075476d90da995ee3e6053d5
+            host_has_wfxt = global_props.host_linux_version_tpl >= (5, 19)
+            guest_has_wfxt = host_has_wfxt and vm.guest_kernel_version >= (5, 19)
 
             if host_has_wfxt and not guest_has_wfxt:
                 expected_host_minus_guest |= {"wfxt"}
-            if not host_has_wfxt and guest_has_wfxt:
-                expected_guest_minus_host |= {"wfxt"}
 
             host_has_ssbs = global_props.host_os not in {
                 "amzn2",


### PR DESCRIPTION
## Changes
Gate the expectation on host kernel >= v5.19 as well, in both test_guest_cpu_features and test_host_vs_guest_cpu_features. The guest-only-has-wfxt diff direction is impossible (guest visibility implies host support), so drop it.

## Reason
The wfxt guest baseline was only on the guest kernel being >= v5.19 in the previous baseline commit, but the guest only sees the hwcap when the host KVM can expose the feature in the first place, and v5.10 host kernels have no WFxT support at all. On a 5.10 host with a 6.1/6.18 guest, the tests expected "wfxt" in the guest and failed.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
