### PR TITLE
Unique device access

### DIFF
--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -80,26 +80,6 @@ impl PciDevices {
         })
     }
 
-    fn register_bars_with_bus(
-        vm: &KvmVm,
-        virtio_device: &Arc<Mutex<VirtioPciDevice>>,
-    ) -> Result<(), PciManagerError> {
-        let virtio_device_locked = virtio_device.lock().expect("Poisoned lock");
-
-        debug!(
-            "Inserting MMIO BAR region: {:#x}:{:#x}",
-            virtio_device_locked.config_bar_addr(),
-            CAPABILITY_BAR_SIZE
-        );
-        vm.common.mmio_bus.insert(
-            virtio_device.clone(),
-            virtio_device_locked.config_bar_addr(),
-            CAPABILITY_BAR_SIZE,
-        )?;
-
-        Ok(())
-    }
-
     fn attach_common(
         &mut self,
         vm: &KvmVm,
@@ -109,22 +89,33 @@ impl PciDevices {
         virtio_device: Arc<Mutex<VirtioPciDevice>>,
         event_manager: &mut EventManager,
     ) -> Result<(), PciManagerError> {
+        let config_bar_addr = {
+            let mut device = virtio_device.lock().unwrap();
+
+            device.register_notification_ioevents(vm)?;
+
+            let sub_id = event_manager.add_subscriber(device.virtio_device());
+            device.sub_id = Some(sub_id);
+
+            device.config_bar_addr()
+        };
+
+        self.virtio_devices
+            .insert((device_type, id), virtio_device.clone());
+
         self.pci_segment
             .pci_bus
             .lock()
             .expect("Poisoned lock")
             .add_device(sbdf.device(), virtio_device.clone())?;
 
-        self.virtio_devices
-            .insert((device_type, id), virtio_device.clone());
-
-        Self::register_bars_with_bus(vm, &virtio_device)?;
-
-        let mut device = virtio_device.lock().expect("Poisoned lock");
-        device.register_notification_ioevents(vm)?;
-
-        let sub_id = event_manager.add_subscriber(device.virtio_device());
-        device.sub_id = Some(sub_id);
+        debug!(
+            "Inserting MMIO BAR region: {:#x}:{:#x}",
+            config_bar_addr, CAPABILITY_BAR_SIZE
+        );
+        vm.common
+            .mmio_bus
+            .insert(virtio_device.clone(), config_bar_addr, CAPABILITY_BAR_SIZE)?;
 
         Ok(())
     }

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -187,24 +187,35 @@ impl PciDevices {
             .virtio_devices
             .remove(&device_id)
             .expect("device presence should be checked before detach");
-        let pci_device = pci_device_arc.lock().expect("Poisoned lock");
 
-        pci_device
-            .unregister_notification_ioevents(vm)
-            .map_err(PciManagerError::Kvm)?;
+        // Next operations of removing device from mmio_bus and pci_bus need to wait for any other
+        // user of the device to finish. This requires us to not hold the lock for the device in
+        // case someone will try to access the device while we are in these several lines of code.
+        let (bar_addr, sbdf_device, sub_id) = {
+            let pci_device = pci_device_arc.lock().expect("Poisoned lock");
+
+            pci_device
+                .unregister_notification_ioevents(vm)
+                .map_err(PciManagerError::Kvm)?;
+            (
+                pci_device.config_bar_addr(),
+                pci_device.sbdf.device(),
+                pci_device.sub_id,
+            )
+        };
 
         vm.common
             .mmio_bus
-            .remove(pci_device.config_bar_addr(), CAPABILITY_BAR_SIZE)
+            .remove(bar_addr, CAPABILITY_BAR_SIZE)
             .map_err(PciManagerError::Bus)?;
 
         self.pci_segment
             .pci_bus
             .lock()
             .expect("Poisoned lock")
-            .remove_device(pci_device.sbdf.device());
+            .remove_device(sbdf_device);
 
-        if let Some(sub_id) = pci_device.sub_id
+        if let Some(sub_id) = sub_id
             && event_manager.remove_subscriber(sub_id).is_err()
         {
             warn!("Failed to remove event subscriber for device {device_id:?}");

--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -23,7 +23,7 @@ use crate::pci::PciSBDF;
 #[cfg(target_arch = "x86_64")]
 use crate::pci::bus::{PCI_CONFIG_IO_PORT, PCI_CONFIG_IO_PORT_SIZE};
 use crate::pci::bus::{PciBus, PciConfigIo, PciConfigMmio, PciRoot, PciRootError};
-use crate::vstate::bus::{BusDeviceSync, BusError};
+use crate::vstate::bus::BusError;
 use crate::vstate::resources::ResourceAllocator;
 use crate::vstate::vm::KvmVm;
 

--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -72,7 +72,7 @@ impl PciSegment {
         let mmio_config_address = PCI_MMCONFIG_START + PCI_MMIO_CONFIG_SIZE_PER_SEGMENT * id as u64;
 
         vm.common.mmio_bus.insert(
-            Arc::clone(&pci_config_mmio) as Arc<dyn BusDeviceSync>,
+            pci_config_mmio.clone(),
             mmio_config_address,
             PCI_MMIO_CONFIG_SIZE_PER_SEGMENT,
         )?;

--- a/src/vmm/src/pci/bus.rs
+++ b/src/vmm/src/pci/bus.rs
@@ -78,7 +78,7 @@ impl PciDevice for PciRoot {
 #[derive(Default)]
 pub struct PciBus {
     /// Devices attached to this bus. Slot 0 is reserved for host bridge.
-    pub devices: [Option<Arc<Mutex<dyn PciDevice>>>; NUM_DEVICE_IDS],
+    devices: [Option<Arc<Mutex<dyn PciDevice>>>; NUM_DEVICE_IDS],
 }
 
 impl Debug for PciBus {
@@ -96,6 +96,11 @@ impl PciBus {
         let mut bus: Self = Default::default();
         bus.devices[0] = Some(Arc::new(Mutex::new(pci_root)));
         bus
+    }
+
+    /// Get a reference to the device at index
+    pub fn get_device(&self, device_id: u8) -> Option<&Mutex<dyn PciDevice>> {
+        self.devices[device_id as usize].as_deref()
     }
 
     /// Insert a device in the bus at the specified slot (`device_id`).
@@ -179,11 +184,12 @@ impl PciConfigIo {
         // NOTE: Potential contention among vCPU threads on this lock. This should not
         // be a problem currently, since we mainly access this when we are setting up devices.
         // We might want to do some profiling to ensure this does not become a bottleneck.
-        self.pci_bus.as_ref().lock().unwrap().devices[usize::from(device)]
-            .as_ref()
-            .map_or(0xffff_ffff, |d| {
-                d.lock().unwrap().read_config_register(register)
-            })
+        let pci_bus = self.pci_bus.as_ref().lock().unwrap();
+        if let Some(d) = pci_bus.get_device(device) {
+            d.lock().unwrap().read_config_register(register)
+        } else {
+            0xffff_ffff
+        }
     }
 
     /// Handle a configuration space write over Port IO
@@ -216,7 +222,7 @@ impl PciConfigIo {
         // be a problem currently, since we mainly access this when we are setting up devices.
         // We might want to do some profiling to ensure this does not become a bottleneck.
         let pci_bus = self.pci_bus.as_ref().lock().unwrap();
-        if let Some(d) = pci_bus.devices[usize::from(device)].as_ref() {
+        if let Some(d) = pci_bus.get_device(device) {
             let mut device = d.lock().unwrap();
 
             // offset is validated to be < 4 at the top of this function.
@@ -312,11 +318,12 @@ impl PciConfigMmio {
             return 0xffff_ffff;
         }
 
-        self.pci_bus.lock().unwrap().devices[usize::from(device)]
-            .as_ref()
-            .map_or(0xffff_ffff, |d| {
-                d.lock().unwrap().read_config_register(register)
-            })
+        let pci_bus = self.pci_bus.lock().unwrap();
+        if let Some(d) = pci_bus.get_device(device) {
+            d.lock().unwrap().read_config_register(register)
+        } else {
+            0xffff_ffff
+        }
     }
 
     fn config_space_write(&mut self, config_address: u32, offset: u64, data: &[u8]) {
@@ -337,7 +344,7 @@ impl PciConfigMmio {
         }
 
         let pci_bus = self.pci_bus.lock().unwrap();
-        if let Some(d) = pci_bus.devices[usize::from(device)].as_ref() {
+        if let Some(d) = pci_bus.get_device(device) {
             let mut device = d.lock().unwrap();
 
             // offset is validated to be < 4 at the top of this function.

--- a/src/vmm/src/vstate/bus.rs
+++ b/src/vmm/src/vstate/bus.rs
@@ -25,32 +25,6 @@ pub trait BusDevice: Send {
     }
 }
 
-/// Trait similar to [`BusDevice`] with the extra requirement that a device is `Send` and `Sync`.
-#[allow(unused_variables)]
-pub trait BusDeviceSync: Send + Sync {
-    /// Reads at `offset` from this device
-    fn read(&self, base: u64, offset: u64, data: &mut [u8]) {}
-    /// Writes at `offset` into this device
-    fn write(&self, base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
-        None
-    }
-}
-
-impl<B: BusDevice> BusDeviceSync for Mutex<B> {
-    /// Reads at `offset` from this device
-    fn read(&self, base: u64, offset: u64, data: &mut [u8]) {
-        self.lock()
-            .expect("Failed to acquire device lock")
-            .read(base, offset, data)
-    }
-    /// Writes at `offset` into this device
-    fn write(&self, base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
-        self.lock()
-            .expect("Failed to acquire device lock")
-            .write(base, offset, data)
-    }
-}
-
 /// Error type for [`Bus`]-related operations.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum BusError {

--- a/src/vmm/src/vstate/bus.rs
+++ b/src/vmm/src/vstate/bus.rs
@@ -126,7 +126,7 @@ impl PartialOrd for BusRange {
 /// only restriction is that no two devices can overlap in this address space.
 #[derive(Default, Debug)]
 pub struct Bus {
-    devices: RwLock<BTreeMap<BusRange, Weak<dyn BusDeviceSync>>>,
+    devices: RwLock<BTreeMap<BusRange, Weak<Mutex<dyn BusDevice>>>>,
 }
 
 impl Bus {
@@ -137,28 +137,10 @@ impl Bus {
         }
     }
 
-    fn first_before(&self, addr: u64) -> Option<(BusRange, Arc<dyn BusDeviceSync>)> {
-        let devices = self.devices.read().unwrap();
-        let (range, dev) = devices.range(..=BusRange::new(addr, 1).ok()?).next_back()?;
-        dev.upgrade().map(|d| (*range, d.clone()))
-    }
-
-    #[allow(clippy::type_complexity)]
-    /// Get a reference to a device residing inside the bus at address [`addr`].
-    pub fn resolve(&self, addr: u64) -> Option<(u64, u64, Arc<dyn BusDeviceSync>)> {
-        if let Some((range, dev)) = self.first_before(addr)
-            && addr <= range.end()
-        {
-            let offset = addr - range.base();
-            return Some((range.base(), offset, dev));
-        }
-        None
-    }
-
     /// Insert a device into the [`Bus`] in the range [`addr`, `addr` + `len`].
     pub fn insert(
         &self,
-        device: Arc<dyn BusDeviceSync>,
+        device: Arc<Mutex<dyn BusDevice>>,
         base: u64,
         len: u64,
     ) -> Result<(), BusError> {
@@ -199,29 +181,42 @@ impl Bus {
         Ok(())
     }
 
+    // Lock the `devices` behind `read` lock, lock the device mutex and perform an operation on the
+    // device.
+    fn with_device<T>(
+        &self,
+        addr: u64,
+        f: impl FnOnce(&mut dyn BusDevice, u64, u64) -> T,
+    ) -> Result<T, BusError> {
+        let devices = self.devices.read().unwrap();
+        if let Some((range, dev)) = devices
+            .range(..=BusRange::new(addr, 1).unwrap())
+            .next_back()
+            && addr <= range.end()
+            && let Some(device) = dev.upgrade()
+        {
+            let mut device = device.lock().unwrap();
+            let base = range.base();
+            let offset = addr - range.base();
+            let result = f(&mut *device, base, offset);
+            Ok(result)
+        } else {
+            Err(BusError::MissingAddressRange)
+        }
+    }
+
     /// Reads data from the device that owns the range containing `addr` and puts it into `data`.
     ///
     /// Returns true on success, otherwise `data` is untouched.
     pub fn read(&self, addr: u64, data: &mut [u8]) -> Result<(), BusError> {
-        if let Some((base, offset, dev)) = self.resolve(addr) {
-            // OK to unwrap as lock() failing is a serious error condition and should panic.
-            dev.read(base, offset, data);
-            Ok(())
-        } else {
-            Err(BusError::MissingAddressRange)
-        }
+        self.with_device(addr, |dev, base, offset| dev.read(base, offset, data))
     }
 
     /// Writes `data` to the device that owns the range containing `addr`.
     ///
     /// Returns true on success, otherwise `data` is untouched.
     pub fn write(&self, addr: u64, data: &[u8]) -> Result<Option<Arc<Barrier>>, BusError> {
-        if let Some((base, offset, dev)) = self.resolve(addr) {
-            // OK to unwrap as lock() failing is a serious error condition and should panic.
-            Ok(dev.write(base, offset, data))
-        } else {
-            Err(BusError::MissingAddressRange)
-        }
+        self.with_device(addr, |dev, base, offset| dev.write(base, offset, data))
     }
 }
 
@@ -230,19 +225,19 @@ mod tests {
     use super::*;
 
     struct DummyDevice;
-    impl BusDeviceSync for DummyDevice {}
+    impl BusDevice for DummyDevice {}
 
     struct ConstantDevice;
-    impl BusDeviceSync for ConstantDevice {
+    impl BusDevice for ConstantDevice {
         #[allow(clippy::cast_possible_truncation)]
-        fn read(&self, _base: u64, offset: u64, data: &mut [u8]) {
+        fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
             for (i, v) in data.iter_mut().enumerate() {
                 *v = (offset as u8) + (i as u8);
             }
         }
 
         #[allow(clippy::cast_possible_truncation)]
-        fn write(&self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
             for (i, v) in data.iter().enumerate() {
                 assert_eq!(*v, (offset as u8) + (i as u8))
             }
@@ -297,7 +292,7 @@ mod tests {
     #[test]
     fn bus_insert() {
         let bus = Bus::new();
-        let dummy = Arc::new(DummyDevice);
+        let dummy = Arc::new(Mutex::new(DummyDevice));
         bus.insert(dummy.clone(), 0x10, 0).unwrap_err();
         bus.insert(dummy.clone(), 0x10, 0x10).unwrap();
 
@@ -317,7 +312,7 @@ mod tests {
     #[test]
     fn bus_remove() {
         let bus = Bus::new();
-        let dummy: Arc<dyn BusDeviceSync> = Arc::new(DummyDevice);
+        let dummy = Arc::new(Mutex::new(DummyDevice));
 
         bus.remove(0x42, 0x0).unwrap_err();
 
@@ -332,7 +327,7 @@ mod tests {
     #[allow(clippy::redundant_clone)]
     fn bus_read_write() {
         let bus = Bus::new();
-        let dummy = Arc::new(DummyDevice);
+        let dummy = Arc::new(Mutex::new(DummyDevice));
         bus.insert(dummy.clone(), 0x10, 0x10).unwrap();
         bus.read(0x10, &mut [0, 0, 0, 0]).unwrap();
         bus.write(0x10, &[0, 0, 0, 0]).unwrap();
@@ -350,7 +345,7 @@ mod tests {
     #[allow(clippy::redundant_clone)]
     fn bus_read_write_values() {
         let bus = Bus::new();
-        let dummy = Arc::new(ConstantDevice);
+        let dummy = Arc::new(Mutex::new(ConstantDevice));
         bus.insert(dummy.clone(), 0x10, 0x10).unwrap();
 
         let mut values = [0, 1, 2, 3];
@@ -376,7 +371,7 @@ mod tests {
 
         let bus = Bus::new();
         let mut data = [1, 2, 3, 4];
-        let device = Arc::new(DummyDevice);
+        let device = Arc::new(Mutex::new(DummyDevice));
         bus.insert(device.clone(), 0x10, 0x10).unwrap();
         bus.write(0x10, &data).unwrap();
         bus.read(0x10, &mut data).unwrap();


### PR DESCRIPTION
## Changes
Ensure that device accesses in `PciBus` and `Bus`(MMIO) don't leak `Arc`s to the devices. This fixes the issue in the pci device detach code where the vcpu thread could still hold the `Arc` to the device and perform operations on that device while the vmm thread tried to detach the device.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
