### PR TITLE
feat(snapshot): Allow overriding huge-page configuration on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to
   support for booting `bzImage` guest kernels on x86_64, in addition to the
   existing uncompressed ELF (`vmlinux`) images. The kernel image format is
   detected automatically, so no configuration change is required.
+- [#6064](https://github.com/firecracker-microvm/firecracker/pull/6064): Added
+  the `huge_pages` field to `PUT /snapshot/load`, allowing the restored microVM
+  to reuse the snapshot's host page configuration or select `None`,
+  `Transparent`, or `2M`.
 
 ### Changed
 

--- a/docs/hugepages.md
+++ b/docs/hugepages.md
@@ -56,10 +56,15 @@ pool, please refer to the [Linux Documentation][hugetlbfs_docs].
 
 ### Huge Pages and Snapshotting
 
-Restoring a Firecracker snapshot of a microVM backed by huge pages will also use
-huge pages to back the restored guest. There is no option to flip between
-regular, 4K, pages and huge pages at restore time. Furthermore, snapshots of
-microVMs backed with huge pages can only be restored via UFFD.
+The `huge_pages` field on `PUT /snapshot/load` selects the page configuration
+for the restored microVM. `Snapshot` reuses the configuration serialized in the
+snapshot and is the default when the field is omitted. `None` uses the host's
+default memory-mapping behavior, while `Transparent` and `2M` select their
+corresponding huge page configurations.
+
+Explicit `2M` hugetlbfs pages require UFFD, so combining `2M` with file-backed
+restore returns an error. `Transparent` is accepted with UFFD, although UFFD may
+limit the effectiveness of transparent huge pages.
 
 When restoring snapshots via UFFD, Firecracker will send the configured page
 size (in KiB) for each memory region as part of the initial handshake, as

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -432,6 +432,14 @@ The meaning of `backend_path` depends on the `backend_type` chosen:
   used for communication between Firecracker and the user space process that
   handles page faults.
 
+The `huge_pages` field selects the host page configuration for the restored
+microVM. It accepts `Snapshot`, `None`, `Transparent`, and `2M`. `Snapshot`
+reuses the value stored in the snapshot and is the default when the field is
+omitted; `None` uses the host's default memory-mapping behavior. Explicit `2M`
+hugetlbfs pages require the `Uffd` backend, so combining `2M` with `File`
+returns an error. With `Uffd`, the effectiveness of transparent huge pages may
+be limited.
+
 When relying on the OS to handle page faults, the command below is also
 accepted. Note that `mem_file_path` field is currently under the deprecation
 policy. `mem_file_path` and `mem_backend` are mutually exclusive, therefore

--- a/src/firecracker/src/api_server/request/snapshot.rs
+++ b/src/firecracker/src/api_server/request/snapshot.rs
@@ -112,6 +112,7 @@ fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, RequestError> {
         network_overrides: snapshot_config.network_overrides,
         vsock_override: snapshot_config.vsock_override,
         clock_realtime: snapshot_config.clock_realtime,
+        huge_pages: snapshot_config.huge_pages,
     };
 
     // Construct the `ParsedRequest` object.
@@ -127,7 +128,9 @@ fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, RequestError> {
 
 #[cfg(test)]
 mod tests {
-    use vmm::vmm_config::snapshot::{MemBackendConfig, MemBackendType, NetworkOverride};
+    use vmm::vmm_config::snapshot::{
+        MemBackendConfig, MemBackendType, NetworkOverride, SnapshotLoadHugePageConfig,
+    };
 
     use super::*;
     use crate::api_server::parsed_request::tests::{depr_action_from_req, vmm_action_from_request};
@@ -178,7 +181,8 @@ mod tests {
             "mem_backend": {
                 "backend_path": "bar",
                 "backend_type": "File"
-            }
+            },
+            "huge_pages": "2M"
         }"#;
         let expected_config = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
@@ -191,6 +195,7 @@ mod tests {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            huge_pages: SnapshotLoadHugePageConfig::Hugetlbfs2M,
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(
@@ -223,6 +228,7 @@ mod tests {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            huge_pages: SnapshotLoadHugePageConfig::Snapshot,
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(
@@ -242,7 +248,8 @@ mod tests {
                 "backend_path": "bar",
                 "backend_type": "Uffd"
             },
-            "resume_vm": true
+            "resume_vm": true,
+            "huge_pages": "Snapshot"
         }"#;
         let expected_config = LoadSnapshotParams {
             snapshot_path: PathBuf::from("foo"),
@@ -255,6 +262,7 @@ mod tests {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            huge_pages: SnapshotLoadHugePageConfig::Snapshot,
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(
@@ -296,6 +304,7 @@ mod tests {
             }],
             vsock_override: None,
             clock_realtime: false,
+            huge_pages: SnapshotLoadHugePageConfig::Snapshot,
         };
         let mut parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert!(
@@ -325,6 +334,7 @@ mod tests {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            huge_pages: SnapshotLoadHugePageConfig::Snapshot,
         };
         let parsed_request = parse_put_snapshot(&Body::new(body), Some("load")).unwrap();
         assert_eq!(
@@ -345,6 +355,23 @@ mod tests {
                 .to_string(),
             "An error occurred when deserializing the json body of a request: missing field \
              `backend_type` at line 5 column 13."
+        );
+
+        let body = r#"{
+            "snapshot_path": "foo",
+            "mem_backend": {
+                "backend_path": "bar",
+                "backend_type": "File"
+            },
+            "huge_pages": "1M"
+        }"#;
+        assert!(
+            parse_put_snapshot(&Body::new(body), Some("load"))
+                .unwrap_err()
+                .to_string()
+                .contains(
+                    "unknown variant `1M`, expected one of `Snapshot`, `None`, `Transparent`, `2M`"
+                )
         );
 
         let body = r#"{

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1728,6 +1728,20 @@ definitions:
           elapsed since the snapshot was taken. When false (default), kvmclock resumes
           from where it was at snapshot time. This option may be extended to other clock
           sources and CPU architectures in the future."
+      huge_pages:
+        type: string
+        enum:
+          - Snapshot
+          - None
+          - Transparent
+          - 2M
+        description:
+          Selects the huge pages configuration for the restored microVM.
+          Snapshot reuses the value serialized in the snapshot and is the
+          default when this field is omitted; None uses the host's default
+          memory-mapping behavior. Explicit hugetlbfs (`2M`) pages require a UFFD
+          memory backend. With UFFD, the effectiveness of transparent huge pages
+          may be limited.
 
 
   TokenBucket:

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -428,7 +428,7 @@ pub fn restore_from_snapshot(
             smt: Some(microvm_state.vm_info.smt),
             cpu_template: Some(microvm_state.vm_info.cpu_template),
             track_dirty_pages: Some(track_dirty_pages),
-            huge_pages: Some(microvm_state.vm_info.huge_pages),
+            huge_pages: Some(params.huge_pages.resolve(microvm_state.vm_info.huge_pages)),
             #[cfg(feature = "gdb")]
             gdb_socket_path: None,
         })

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1037,7 +1037,9 @@ mod tests {
     use crate::builder::tests::default_vmm;
     use crate::mmds::data_store::MmdsVersion;
     use crate::seccomp::BpfThreadMap;
-    use crate::vmm_config::snapshot::{MemBackendConfig, MemBackendType};
+    use crate::vmm_config::snapshot::{
+        MemBackendConfig, MemBackendType, SnapshotLoadHugePageConfig,
+    };
 
     fn default_preboot<'a>(
         vm_resources: &'a mut VmResources,
@@ -1333,6 +1335,7 @@ mod tests {
                 network_overrides: vec![],
                 vsock_override: None,
                 clock_realtime: false,
+                huge_pages: SnapshotLoadHugePageConfig::Snapshot,
             },
         )));
         check_unsupported(runtime_request(VmmAction::SetEntropyDevice(

--- a/src/vmm/src/vmm_config/snapshot.rs
+++ b/src/vmm/src/vmm_config/snapshot.rs
@@ -9,6 +9,8 @@ use std::path::PathBuf;
 pub use semver::Version;
 use serde::{Deserialize, Serialize};
 
+use super::machine_config::HugePageConfig;
+
 /// The snapshot type options that are available when
 /// creating a new snapshot.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
@@ -64,6 +66,33 @@ pub struct VsockOverride {
     pub uds_path: String,
 }
 
+/// Selects the huge-page configuration to use when loading a snapshot.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
+pub enum SnapshotLoadHugePageConfig {
+    /// Reuse the huge-page configuration serialized in the snapshot.
+    #[default]
+    Snapshot,
+    /// Use the host's default memory-mapping behavior.
+    None,
+    /// Advise the kernel to use transparent huge pages for guest memory.
+    Transparent,
+    /// Back guest memory by 2 MiB hugetlbfs pages.
+    #[serde(rename = "2M")]
+    Hugetlbfs2M,
+}
+
+impl SnapshotLoadHugePageConfig {
+    /// Resolves the configuration against the value serialized in the snapshot.
+    pub fn resolve(self, snapshot: HugePageConfig) -> HugePageConfig {
+        match self {
+            Self::Snapshot => snapshot,
+            Self::None => HugePageConfig::None,
+            Self::Transparent => HugePageConfig::Transparent,
+            Self::Hugetlbfs2M => HugePageConfig::Hugetlbfs2M,
+        }
+    }
+}
+
 /// Stores the configuration that will be used for loading a snapshot.
 #[derive(Debug, PartialEq, Eq)]
 pub struct LoadSnapshotParams {
@@ -85,6 +114,8 @@ pub struct LoadSnapshotParams {
     /// advancing kvmclock by the wall-clock time elapsed since the snapshot was taken. When false
     /// (default), kvmclock resumes from where it was at snapshot time.
     pub clock_realtime: bool,
+    /// Selects the huge-page configuration to use for the restored microVM.
+    pub huge_pages: SnapshotLoadHugePageConfig,
 }
 
 /// Stores the configuration for loading a snapshot that is provided by the user.
@@ -120,6 +151,9 @@ pub struct LoadSnapshotConfig {
     /// [x86_64 only] When set to true, passes `KVM_CLOCK_REALTIME` to `KVM_SET_CLOCK` on restore.
     #[serde(default)]
     pub clock_realtime: bool,
+    /// Selects the huge-page configuration to use for the restored microVM.
+    #[serde(default)]
+    pub huge_pages: SnapshotLoadHugePageConfig,
 }
 
 /// Stores the configuration used for managing snapshot memory.

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 use vmm::builder::build_and_boot_microvm;
 use vmm::devices::virtio::block::CacheType;
 use vmm::persist::{
-    MicrovmState, MicrovmStateError, VirtioDevicesState, VmInfo, snapshot_state_sanity_check,
+    GuestMemoryFromFileError, MicrovmState, MicrovmStateError, RestoreFromSnapshotError,
+    RestoreFromSnapshotGuestMemoryError, VirtioDevicesState, VmInfo, snapshot_state_sanity_check,
 };
 use vmm::resources::VmResources;
 use vmm::rpc_interface::{
@@ -25,10 +26,11 @@ use vmm::vmm_config::balloon::BalloonDeviceConfig;
 use vmm::vmm_config::boot_source::BootSourceConfig;
 use vmm::vmm_config::drive::BlockDeviceConfig;
 use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
-use vmm::vmm_config::machine_config::{MachineConfig, MachineConfigUpdate};
+use vmm::vmm_config::machine_config::{HugePageConfig, MachineConfig, MachineConfigUpdate};
 use vmm::vmm_config::net::NetworkInterfaceConfig;
 use vmm::vmm_config::snapshot::{
-    CreateSnapshotParams, LoadSnapshotParams, MemBackendConfig, MemBackendType, SnapshotType,
+    CreateSnapshotParams, LoadSnapshotParams, MemBackendConfig, MemBackendType,
+    SnapshotLoadHugePageConfig, SnapshotType,
 };
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 use vmm::{DumpCpuConfigError, EventManager, FcExitCode, Vmm};
@@ -286,7 +288,12 @@ fn verify_create_snapshot(
     (snapshot_file, memory_file)
 }
 
-fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
+fn verify_load_snapshot(
+    snapshot_file: TempFile,
+    memory_file: TempFile,
+    huge_pages: SnapshotLoadHugePageConfig,
+) {
+    let expected_huge_pages = huge_pages.resolve(HugePageConfig::None);
     let mut event_manager = EventManager::new().unwrap();
     let empty_seccomp_filters = get_empty_filters();
     let mut vm_resources = VmResources::default();
@@ -310,12 +317,17 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
             network_overrides: vec![],
             vsock_override: None,
             clock_realtime: false,
+            huge_pages,
         }))
         .unwrap();
 
     let vmm = preboot_api_controller.built_vmm.take().unwrap();
 
-    assert_eq!(vmm.lock().unwrap().instance_info.state, VmState::Running);
+    {
+        let vmm = vmm.lock().unwrap();
+        assert_eq!(vmm.instance_info.state, VmState::Running);
+        assert_eq!(vmm.machine_config.huge_pages, expected_huge_pages);
+    }
     vmm.lock().unwrap().stop(FcExitCode::Ok);
 }
 
@@ -331,10 +343,64 @@ fn test_create_and_load_snapshot() {
                 // that a microVM can be built with no errors from given snapshot.
                 // It does _not_ verify that the guest is actually restored properly. We're using
                 // python integration tests for that.
-                verify_load_snapshot(snapshot_file, memory_file);
+                verify_load_snapshot(
+                    snapshot_file,
+                    memory_file,
+                    SnapshotLoadHugePageConfig::Snapshot,
+                );
             }
         }
     }
+}
+
+#[test]
+fn test_load_snapshot_huge_pages_override() {
+    let (snapshot_file, memory_file) = verify_create_snapshot(false, false, false);
+
+    verify_load_snapshot(
+        snapshot_file,
+        memory_file,
+        SnapshotLoadHugePageConfig::Transparent,
+    );
+}
+
+#[test]
+fn test_load_snapshot_rejects_hugetlbfs_with_file_backend() {
+    let (snapshot_file, memory_file) = verify_create_snapshot(false, false, false);
+    let mut event_manager = EventManager::new().unwrap();
+    let empty_seccomp_filters = get_empty_filters();
+    let mut vm_resources = VmResources::default();
+    let mut preboot_api_controller = PrebootApiController::new(
+        &empty_seccomp_filters,
+        InstanceInfo::default(),
+        &mut vm_resources,
+        &mut event_manager,
+    );
+
+    let error = preboot_api_controller
+        .handle_preboot_request(VmmAction::LoadSnapshot(LoadSnapshotParams {
+            snapshot_path: snapshot_file.as_path().to_path_buf(),
+            mem_backend: MemBackendConfig {
+                backend_path: memory_file.as_path().to_path_buf(),
+                backend_type: MemBackendType::File,
+            },
+            track_dirty_pages: false,
+            resume_vm: false,
+            network_overrides: vec![],
+            vsock_override: None,
+            clock_realtime: false,
+            huge_pages: SnapshotLoadHugePageConfig::Hugetlbfs2M,
+        }))
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        VmmActionError::LoadSnapshot(LoadSnapshotError::RestoreFromSnapshot(
+            RestoreFromSnapshotError::GuestMemory(RestoreFromSnapshotGuestMemoryError::File(
+                GuestMemoryFromFileError::HugetlbfsSnapshot
+            ))
+        ))
+    ));
 }
 
 #[test]
@@ -396,6 +462,7 @@ fn verify_load_snap_disallowed_after_boot_resources(res: VmmAction, res_name: &s
         network_overrides: vec![],
         vsock_override: None,
         clock_realtime: false,
+        huge_pages: SnapshotLoadHugePageConfig::Snapshot,
     });
     let err = preboot_api_controller.handle_preboot_request(req);
     assert!(

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -1098,6 +1098,7 @@ class Microvm:
         vsock_override: str = None,
         clock_realtime: bool = False,
         *,
+        huge_pages: Optional[HugePagesConfig] = None,
         uffd_handler_name: str = None,
     ):
         """Restore a snapshot"""
@@ -1162,6 +1163,9 @@ class Microvm:
         if clock_realtime:
             optional_kwargs["clock_realtime"] = clock_realtime
 
+        if huge_pages is not None:
+            optional_kwargs["huge_pages"] = huge_pages
+
         self.api.snapshot_load.put(
             mem_backend=mem_backend,
             snapshot_path=str(jailed_vmstate),
@@ -1169,6 +1173,9 @@ class Microvm:
             resume_vm=resume,
             **optional_kwargs,
         )
+
+        if huge_pages is not None:
+            self.huge_pages = huge_pages
 
         if self.memory_monitor:
             response = self.api.machine_config.get()

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -81,10 +81,45 @@ def test_resume(uvm_configured, microvm_factory, resume_at_restore, huge_pages):
     restored_vm = microvm_factory.build()
     restored_vm.spawn()
     restored_vm.restore_from_snapshot(snapshot, resume=resume_at_restore)
+    assert restored_vm.api.machine_config.get().json()["huge_pages"] == huge_pages
     if not resume_at_restore:
         assert restored_vm.state == "Paused"
         restored_vm.resume()
     assert restored_vm.state == "Running"
+    restored_vm.ssh.check_output("true")
+
+
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+@pytest.mark.parametrize(
+    ("huge_pages", "restore_huge_pages"),
+    [
+        (HugePagesConfig.NONE, HugePagesConfig.TRANSPARENT),
+        (HugePagesConfig.TRANSPARENT, HugePagesConfig.NONE),
+    ],
+    indirect=["huge_pages"],
+)
+def test_snapshot_huge_pages_override(
+    uvm_configured, microvm_factory, huge_pages, restore_huge_pages
+):
+    """Restore a snapshot with a different host page configuration."""
+    vm = uvm_configured
+    assert vm.huge_pages == huge_pages
+    vm.add_net_iface()
+    vm.start()
+    snapshot = vm.snapshot_full()
+    vm.kill()
+
+    restored_vm = microvm_factory.build()
+    restored_vm.spawn()
+    restored_vm.restore_from_snapshot(
+        snapshot,
+        resume=True,
+        huge_pages=restore_huge_pages,
+    )
+
+    assert (
+        restored_vm.api.machine_config.get().json()["huge_pages"] == restore_huge_pages
+    )
     restored_vm.ssh.check_output("true")
 
 

--- a/tests/integration_tests/performance/test_huge_pages.py
+++ b/tests/integration_tests/performance/test_huge_pages.py
@@ -106,6 +106,51 @@ def test_hugetlbfs_snapshot(microvm_factory, uvm, snapshot_type):
     check_hugetlbfs_in_use(vm.firecracker_pid, "/anon_hugepage")
 
 
+@pytest.mark.parametrize(
+    ("source_huge_pages", "restore_huge_pages", "uffd_handler_name"),
+    [
+        (HugePagesConfig.NONE, HugePagesConfig.HUGETLBFS_2MB, "on_demand"),
+        (HugePagesConfig.HUGETLBFS_2MB, HugePagesConfig.NONE, None),
+        (HugePagesConfig.NONE, HugePagesConfig.TRANSPARENT, "on_demand"),
+    ],
+)
+def test_snapshot_huge_pages_override(
+    microvm_factory,
+    uvm,
+    snapshot_type,
+    source_huge_pages,
+    restore_huge_pages,
+    uffd_handler_name,
+):
+    """Restore snapshots using a different huge-page configuration."""
+    vm = uvm
+    vm.memory_monitor = None
+    vm.spawn()
+    vm.basic_config(
+        huge_pages=source_huge_pages,
+        mem_size_mib=128,
+        track_dirty_pages=snapshot_type.needs_dirty_page_tracking,
+    )
+    vm.add_net_iface()
+    vm.start()
+    snapshot = vm.make_snapshot(snapshot_type)
+    vm.kill()
+
+    vm = microvm_factory.build()
+    vm.spawn()
+    vm.restore_from_snapshot(
+        snapshot,
+        resume=True,
+        huge_pages=restore_huge_pages,
+        uffd_handler_name=uffd_handler_name,
+    )
+
+    assert vm.api.machine_config.get().json()["huge_pages"] == restore_huge_pages
+    vm.ssh.check_output("true")
+    if restore_huge_pages == HugePagesConfig.HUGETLBFS_2MB:
+        check_hugetlbfs_in_use(vm.firecracker_pid, "/anon_hugepage")
+
+
 @pytest.mark.parametrize("huge_pages", HugePagesConfig)
 def test_ept_violation_count(
     microvm_factory,


### PR DESCRIPTION
## Changes

Closes https://github.com/firecracker-microvm/firecracker/issues/6036

Add an optional huge_pages override to PUT /snapshot/load.

- Supports None, Transparent, and 2M.
- Preserves the snapshot’s configuration when omitted.
- Rejects 2M with file-backed restore; UFFD is required.

## Reason

Host page configuration does not affect guest-visible snapshot contents. Allowing it to be selected during restore avoids creating duplicate snapshots for each desired backing-page configuration.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
