### PR TITLE
fix(dumbo): bound TCP segment length to what IPv4 can describe

### DIFF
--- a/src/vmm/src/dumbo/pdu/ipv4.rs
+++ b/src/vmm/src/dumbo/pdu/ipv4.rs
@@ -28,6 +28,8 @@ const OPTIONS_OFFSET: u8 = 20;
 
 /// Indicates version 4 of the IP protocol
 pub const IPV4_VERSION: u8 = 0x04;
+/// Length of an IPv4 header without any options.
+pub const IPV4_MIN_HEADER_LEN: u8 = OPTIONS_OFFSET;
 /// Default TTL value
 pub const DEFAULT_TTL: u8 = 1;
 

--- a/src/vmm/src/dumbo/pdu/tcp.rs
+++ b/src/vmm/src/dumbo/pdu/tcp.rs
@@ -47,6 +47,9 @@ const MSS_MIN: u16 = 100;
 // buffers we are given can be larger than that, hence the explicit bound.
 const MAX_SEGMENT_LEN: u16 = u16::MAX - IPV4_MIN_HEADER_LEN as u16;
 
+// A larger MSS could never be honoured, since the payload alone would not fit a segment.
+const MSS_MAX: u16 = MAX_SEGMENT_LEN - OPTIONS_OFFSET as u16;
+
 bitflags! {
     /// Represents the TCP header flags, with the exception of `NS`.
     ///
@@ -251,7 +254,7 @@ impl<T: NetworkBytes + Debug> TcpSegment<'_, T> {
                     // TODO: To be super strict, we should make sure there aren't additional MSS
                     // options present (which would be super wrong). Should we be super strict?
                     let mss = b.ntohs_unchecked(i + 2);
-                    if mss < MSS_MIN {
+                    if !(MSS_MIN..=MSS_MAX).contains(&mss) {
                         return Err(TcpError::MssOption);
                     }
                     // The unwarp() is safe because mms >= MSS_MIN at this point.
@@ -841,6 +844,33 @@ mod tests {
             seg.parse_mss_option_unchecked(header_len.into()),
             Err(TcpError::MssOption)
         );
+    }
+
+    #[test]
+    fn test_mss_option_range() {
+        let header_len = OPTIONS_OFFSET + OPTION_LEN_MSS;
+        let opts_start = usize::from(OPTIONS_OFFSET);
+
+        let parse_mss = |mss: u16| {
+            let mut buf = [0u8; 100];
+            {
+                let mut seg = TcpSegment::from_bytes_unchecked(buf.as_mut());
+                seg.set_header_len_rsvd_ns(header_len, false);
+                seg.bytes[opts_start] = OPTION_KIND_MSS;
+                seg.bytes[opts_start + 1] = OPTION_LEN_MSS;
+                seg.bytes.htons_unchecked(opts_start + 2, mss);
+            }
+            TcpSegment::from_bytes_unchecked(buf.as_ref())
+                .parse_mss_option_unchecked(header_len.into())
+        };
+
+        for mss in [MSS_MIN, 1460, MSS_MAX] {
+            assert_eq!(parse_mss(mss), Ok(Some(NonZeroU16::new(mss).unwrap())));
+        }
+
+        for mss in [0, MSS_MIN - 1, MSS_MAX + 1, u16::MAX] {
+            assert_eq!(parse_mss(mss), Err(TcpError::MssOption));
+        }
     }
 
     #[test]

--- a/src/vmm/src/dumbo/pdu/tcp.rs
+++ b/src/vmm/src/dumbo/pdu/tcp.rs
@@ -18,6 +18,7 @@ use super::Incomplete;
 use super::bytes::{InnerBytes, NetworkBytes, NetworkBytesMut};
 use crate::dumbo::ByteBuffer;
 use crate::dumbo::pdu::ChecksumProto;
+use crate::dumbo::pdu::ipv4::IPV4_MIN_HEADER_LEN;
 
 const SOURCE_PORT_OFFSET: usize = 0;
 const DESTINATION_PORT_OFFSET: usize = 2;
@@ -41,6 +42,10 @@ const OPTION_LEN_MSS: u8 = 0x04;
 
 // An arbitrarily chosen value, used for sanity checks.
 const MSS_MIN: u16 = 100;
+
+// A segment travels inside an IPv4 packet, whose `total length` field is 16 bits wide. The
+// buffers we are given can be larger than that, hence the explicit bound.
+const MAX_SEGMENT_LEN: u16 = u16::MAX - IPV4_MIN_HEADER_LEN as u16;
 
 bitflags! {
     /// Represents the TCP header flags, with the exception of `NS`.
@@ -531,8 +536,9 @@ impl<T: NetworkBytesMut + Debug> TcpSegment<'_, T> {
             let left_to_read = min(payload_buf.len(), max_payload_bytes);
 
             // The subtraction makes sense because we previously checked that
-            // buf.len() >= segment_len.
-            let mut room_for_payload = min(segment.len() - segment_len, mss_left);
+            // buf.len() >= segment_len, and segment_len <= MAX_SEGMENT_LEN.
+            let mut room_for_payload =
+                min(segment.len().min(MAX_SEGMENT_LEN) - segment_len, mss_left);
             // The unwrap is safe because room_for_payload is a u16.
             room_for_payload =
                 u16::try_from(min(usize::from(room_for_payload), left_to_read)).unwrap();
@@ -834,6 +840,33 @@ mod tests {
         assert_eq!(
             seg.parse_mss_option_unchecked(header_len.into()),
             Err(TcpError::MssOption)
+        );
+    }
+
+    #[test]
+    fn test_segment_len_bounded_for_large_buffer() {
+        // Larger than the largest IPv4 packet, like the buffer the net device hands to the MMDS.
+        let mut buf = vec![0u8; usize::from(u16::MAX) + 1];
+        let payload = vec![0u8; buf.len()];
+
+        // Only the buffer bounds the payload here, since the MSS is unlimited.
+        let segment = TcpSegment::write_incomplete_segment(
+            buf.as_mut(),
+            0,
+            0,
+            Flags::empty(),
+            10000,
+            None,
+            u16::MAX,
+            Some((payload.as_slice(), payload.len())),
+        )
+        .unwrap();
+
+        // The segment still leaves room for the IPv4 header within the total length field.
+        assert_eq!(segment.inner().len(), MAX_SEGMENT_LEN);
+        assert_eq!(
+            u32::from(IPV4_MIN_HEADER_LEN) + u32::from(MAX_SEGMENT_LEN),
+            u32::from(u16::MAX)
         );
     }
 }

--- a/src/vmm/src/dumbo/tcp/handler.rs
+++ b/src/vmm/src/dumbo/tcp/handler.rs
@@ -819,4 +819,48 @@ mod tests {
         assert_eq!(h.connections.len(), 1);
         assert_eq!(h.active_connections.len(), 0);
     }
+
+    #[test]
+    fn test_syn_with_unusable_mss() {
+        let local_addr = Ipv4Addr::new(169, 254, 169, 254);
+        let local_port = 80;
+        let remote_addr = Ipv4Addr::new(10, 0, 0, 1);
+        let remote_port = 1012;
+
+        let mut h = TcpIPv4Handler::new(
+            local_addr,
+            local_port,
+            NonZeroUsize::new(1).unwrap(),
+            NonZeroUsize::new(1).unwrap(),
+        );
+
+        let mut buf = [0u8; 100];
+        let mut p =
+            IPv4Packet::write_header(buf.as_mut(), PROTOCOL_TCP, remote_addr, local_addr).unwrap();
+        let segment_len = TcpSegment::write_segment::<[u8]>(
+            p.inner_mut().payload_mut(),
+            remote_port,
+            local_port,
+            123,
+            0,
+            TcpFlags::SYN,
+            10000,
+            Some(u16::MAX),
+            u16::MAX,
+            None,
+            None,
+        )
+        .unwrap()
+        .len();
+        let p = p.with_payload_len_unchecked(segment_len, false);
+
+        // No connection is created, and nothing is sent in response.
+        assert_eq!(
+            h.receive_packet(&p, mock_callback),
+            Ok(RecvEvent::FailedNewConnection)
+        );
+        assert_eq!(h.connections.len(), 0);
+        assert_eq!(h.next_segment_status(), NextSegmentStatus::Nothing);
+        assert_eq!(drain_packets(&mut h, local_addr, remote_addr), Ok(0));
+    }
 }


### PR DESCRIPTION
## Changes

Bound the TCP payload written by the MMDS network stack to the largest segment
which still leaves room for the IPv4 header, and reject an MSS option which no
segment could carry.

- `MAX_SEGMENT_LEN` joins the buffer-room and MSS bounds already applied in
  `TcpSegment::write_incomplete_segment`.
- `parse_mss_option_unchecked` gains an upper bound of 65495, derived from the
  header lengths, next to the existing lower bound of 100.

## Reason

`write_incomplete_segment` sized the payload from the room left in the buffer it
was given. That buffer can be larger than the largest IPv4 packet: the net
device hands the MMDS `MAX_BUFFER_SIZE` (65562) bytes, which after the vnet and
Ethernet headers leaves 65536 for the IPv4 packet — one more than the 16-bit
`total length` field can express.

A segment filling that buffer produced a total length of 65536, which wrapped to
0 in the enclosing packet. The inner byte sequence was then shrunk to nothing
before the length field was written to it.

The MSS option is the guest-supplied input which lets a segment grow that far,
and it was only checked against a lower bound. An MSS above `u16::MAX` minus the
IPv4 and TCP headers can never be honoured, so it is now rejected during the
handshake in the same way an under-range value already was. The bound matches
the MSS a guest derives from the largest MTU the net device accepts, so no
usable value is refused; typical values are far below it (1460 for a 1500 MTU,
8960 for jumbo frames).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
