### PR TITLE
test(fips): cover 6.18 guest kernels

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -56,14 +56,14 @@ def kernel_params(glob="vmlinux-*", select=kernels, artifact_dir=ARTIFACT_DIR) -
 # ids carry the kernel filename (e.g. "vmlinux-6.1.123") rather than "kernel0".
 ALL_GUEST_KERNELS = list(kernel_params("vmlinux-*"))
 ACPI_GUEST_KERNELS = [p for p in kernel_params("vmlinux-*") if "no-acpi" not in p.id]
-GUEST_KERNELS_5_10 = list(kernel_params("vmlinux-5.10*"))
-GUEST_KERNELS_6_1 = list(kernel_params("vmlinux-6.1*"))
+GUEST_KERNELS_5_10 = list(kernel_params("vmlinux-5.10.*"))
+GUEST_KERNELS_6_1 = list(kernel_params("vmlinux-6.1.*"))
 GUEST_KERNELS_6_1_DEBUG = list(
-    kernel_params("vmlinux-6.1*", artifact_dir=ARTIFACT_DIR / "debug")
+    kernel_params("vmlinux-6.1.*", artifact_dir=ARTIFACT_DIR / "debug")
 )
-GUEST_KERNELS_6_18 = list(kernel_params("vmlinux-6.18*"))
+GUEST_KERNELS_6_18 = list(kernel_params("vmlinux-6.18.*"))
 GUEST_KERNELS_6_18_DEBUG = list(
-    kernel_params("vmlinux-6.18*", artifact_dir=ARTIFACT_DIR / "debug")
+    kernel_params("vmlinux-6.18.*", artifact_dir=ARTIFACT_DIR / "debug")
 )
 # The single canonical kernel used when a test pins to one specific kernel
 # (e.g. tests of Firecracker functionality that don't depend on guest kernel).

--- a/tests/integration_tests/security/test_fips.py
+++ b/tests/integration_tests/security/test_fips.py
@@ -12,14 +12,15 @@ Tests verify that:
 import pytest
 
 from framework.artifacts import (
-    GUEST_KERNEL_DEFAULT,
+    GUEST_KERNELS_6_1,
+    GUEST_KERNELS_6_18,
     pin_guest_kernel,
     pin_pci,
     pin_rootfs_mode,
 )
 
 pytestmark = [
-    pin_guest_kernel(GUEST_KERNEL_DEFAULT),
+    pin_guest_kernel(GUEST_KERNELS_6_1 + GUEST_KERNELS_6_18),
     pin_rootfs_mode("rw"),
     pin_pci(False),
 ]


### PR DESCRIPTION
## Changes

- Tighten guest kernel catalogue globs by requiring a delimiter after the
  kernel version.
- Run the FIPS integration tests with both the 6.1 and 6.18 guest kernel
  catalogues instead of the single default kernel.

## Reason

The FIPS tests were pinned to the default guest kernel, which currently selects
only one 6.1 kernel. As a result, the 6.18 guest kernel to be vendor-affirmed was
not covered by these tests.

Additionally, the previous `vmlinux-6.1*` glob also matched 6.18 kernels.
Requiring the dot before the patch version keeps each kernel catalogue scoped
to its intended release line.

## Testing

```console
$ ./tools/devtool -y test -- integration_tests/security/test_fips.py
6 passed in 19.01s

$ tools/devtool checkbuild --all
Build check passed for x86_64 aarch64

$ tools/devtool checkstyle
20 passed, 4 skipped in 24.72s
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
