### PR TITLE
[v1.17.0] Guest kernel 6.18 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to
   will use transparent huge pages for the guest memory via
   `madvise(MADV_HUGEPAGE)`. Guest memory must be a multiple of 2MB when using
   this option.
+- [#6013](https://github.com/firecracker-microvm/firecracker/pull/6013),
+  [#6017](https://github.com/firecracker-microvm/firecracker/pull/6017),
+  [#6021](https://github.com/firecracker-microvm/firecracker/pull/6021): Added
+  official support for 6.18 microVM guest kernels.
 - [#6037](https://github.com/firecracker-microvm/firecracker/pull/6037): Added
   support for booting `bzImage` guest kernels on x86_64, in addition to the
   existing uncompressed ELF (`vmlinux`) images. The kernel image format is


### PR DESCRIPTION
## Changes

- Add an Unreleased CHANGELOG entry for official Linux 6.18 microVM guest
  kernel support.
- Link the guest kernel configuration, artifact build, and validation pull
  requests that enabled support.

## Reason

Guest kernel 6.18 support is documented in the kernel support policy, but the
corresponding release information is missing from the CHANGELOG.

This pull request will be added to the Firecracker Roadmap under `Coming Soon`
once it gets merged.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
