### PR TITLE
test(fips): cover future guest kernels

### DIFF
--- a/tests/integration_tests/security/test_fips.py
+++ b/tests/integration_tests/security/test_fips.py
@@ -12,15 +12,19 @@ Tests verify that:
 import pytest
 
 from framework.artifacts import (
-    GUEST_KERNELS_6_1,
-    GUEST_KERNELS_6_18,
+    ALL_GUEST_KERNELS,
     pin_guest_kernel,
     pin_pci,
     pin_rootfs_mode,
 )
 
+# Linux 5.10 CI kernels are built without CONFIG_CRYPTO_FIPS.
+FIPS_GUEST_KERNELS = [
+    kernel for kernel in ALL_GUEST_KERNELS if not kernel.id.startswith("vmlinux-5.10.")
+]
+
 pytestmark = [
-    pin_guest_kernel(GUEST_KERNELS_6_1 + GUEST_KERNELS_6_18),
+    pin_guest_kernel(FIPS_GUEST_KERNELS),
     pin_rootfs_mode("rw"),
     pin_pci(False),
 ]


### PR DESCRIPTION
## Changes

- Derive the FIPS guest kernel matrix from `ALL_GUEST_KERNELS`.
- Exclude Linux 5.10 kernels and document why next to the filter.

## Reason

The existing 6.1 and 6.18 allowlist can silently omit newly supported
guest kernel versions. Deriving the matrix from all supported kernels
makes the coverage resilient as the supported kernel set grows.

The 5.10 CI kernels remain excluded because they are built without
`CONFIG_CRYPTO_FIPS`.

## Testing

The FIPS integration tests is running in CI for this pull request.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
