### PR TITLE
fix: verify mib values fit as bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project adheres to
 - [#5956](https://github.com/firecracker-microvm/firecracker/pull/5956): Fixed a
   TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
   `MIDR_EL1` information files copied into the chroot.
+- [#6076](https://github.com/firecracker-microvm/firecracker/pull/6076): Fixed
+  memory hotplug sizes silently wrapping when converted from MiB to bytes.
+  `requested_size_mib` on `PATCH /hotplug/memory` and `total_size_mib`,
+  `block_size_mib` and `slot_size_mib` on `PUT /hotplug/memory` are now bounded
+  to 32 bits. Values above that previously wrapped to a smaller byte count, so a
+  large enough request was accepted as a 0-byte region instead of being
+  rejected.
 - [#6031](https://github.com/firecracker-microvm/firecracker/pull/6031),
   [#6041](https://github.com/firecracker-microvm/firecracker/pull/6041): Fixed
   the vsock device re-arming its host-stream `EPOLLIN` interest while received

--- a/docs/memory-hotplug.md
+++ b/docs/memory-hotplug.md
@@ -56,7 +56,8 @@ started, the hotpluggable region will be completely unplugged.
 
 - `total_size_mib` (required): The maximum size of hotpluggable memory in MiB.
   This defines the upper bound of memory that can be added to the VM. Must be a
-  multiple of `slot_size_mib`.
+  multiple of `slot_size_mib`. The VM will fail to start if the requested region
+  does not fit in the address space reserved for hotpluggable memory.
 
 - `block_size_mib` (optional, default: 2): The size of individual memory blocks
   in MiB. Must be at least 2 MiB and a power of 2. Larger block sizes provide
@@ -143,6 +144,9 @@ memory available to the guest by updating the requested size, which is the
 target that the guest should reach by requesting to plug or unplug memory
 blocks. The initial value of the requested size is 0 MiB, meaning that no
 hotpluggable memory blocks are plugged on VM boot.
+
+`requested_size_mib` must be a multiple of `block_size_mib` and must not exceed
+the configured `total_size_mib`.
 
 ### Hotplugging Memory
 

--- a/src/firecracker/src/api_server/request/hotplug/memory.rs
+++ b/src/firecracker/src/api_server/request/hotplug/memory.rs
@@ -103,12 +103,18 @@ mod tests {
         }"#;
         parse_patch_memory_hotplug(&Body::new(body)).unwrap_err();
 
-        // PATCH with valid input fields.
+        // PATCH with a requested size that exceeds the u32 API limit.
         let body = r#"{
-            "requested_size_mib": 2048
+            "requested_size_mib": 4294967296
+        }"#;
+        parse_patch_memory_hotplug(&Body::new(body)).unwrap_err();
+
+        // PATCH with the largest valid requested size.
+        let body = r#"{
+            "requested_size_mib": 4294967295
         }"#;
         let expected_config = MemoryHotplugSizeUpdate {
-            requested_size_mib: 2048,
+            requested_size_mib: u32::MAX,
         };
         assert_eq!(
             vmm_action_from_request(parse_patch_memory_hotplug(&Body::new(body)).unwrap()),

--- a/src/firecracker/src/api_server/request/hotplug/memory.rs
+++ b/src/firecracker/src/api_server/request/hotplug/memory.rs
@@ -83,6 +83,25 @@ mod tests {
             vmm_action_from_request(parse_put_memory_hotplug(&Body::new(body)).unwrap()),
             VmmAction::SetMemoryHotplugDevice(expected_config)
         );
+
+        // PUT with sizes that exceed the u32 API limit. 2^44 MiB previously wrapped to 0 bytes
+        // when converted to a usize byte count.
+        let body = r#"{
+            "total_size_mib": 17592186044416
+        }"#;
+        parse_put_memory_hotplug(&Body::new(body)).unwrap_err();
+
+        let body = r#"{
+            "total_size_mib": 2048,
+            "block_size_mib": 4294967296
+        }"#;
+        parse_put_memory_hotplug(&Body::new(body)).unwrap_err();
+
+        let body = r#"{
+            "total_size_mib": 2048,
+            "slot_size_mib": 4294967296
+        }"#;
+        parse_put_memory_hotplug(&Body::new(body)).unwrap_err();
     }
 
     #[test]

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1827,6 +1827,8 @@ definitions:
     properties:
       requested_size_mib:
         type: integer
+        minimum: 0
+        maximum: 4294967295
         description: New target region size.
 
   MemoryHotplugStatus:

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1806,17 +1806,20 @@ definitions:
     properties:
       total_size_mib:
         type: integer
+        maximum: 4294967295
         description: Total size of the hotpluggable memory in MiB.
       slot_size_mib:
         type: integer
         default: 128
         minimum: 128
+        maximum: 4294967295
         description: Slot size for the hotpluggable memory in MiB. This will determine the granularity of
           hot-plug memory from the host. Refer to the device documentation on how to tune this value.
       block_size_mib:
         type: integer
         default: 2
         minimum: 2
+        maximum: 4294967295
         description: (Logical) Block size for the hotpluggable memory in MiB. This will determine the logical
           granularity of hot-plug memory for the guest. Refer to the device documentation on how to tune this value.
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -46,7 +46,7 @@ use crate::persist::{MicrovmState, MicrovmStateError};
 use crate::resources::VmResources;
 use crate::seccomp::BpfThreadMap;
 use crate::snapshot::Persist;
-use crate::utils::mib_to_bytes;
+use crate::utils::{u32_mib_to_bytes, u64_to_usize};
 use crate::vmm_config::boot_source::{
     DEFAULT_KERNEL_CMDLINE, append_root_device_cmdline, build_cmdline,
 };
@@ -184,11 +184,14 @@ pub fn build_microvm_for_boot(
     let virtio_mem_addr = if let Some(memory_hotplug) = &vm_resources.memory_hotplug {
         let addr = allocate_virtio_mem_address(&vm, memory_hotplug.total_size_mib)?;
         let hotplug_memory_region = vm_resources
-            .allocate_memory_region(addr, mib_to_bytes(memory_hotplug.total_size_mib))
+            .allocate_memory_region(
+                addr,
+                u64_to_usize(u32_mib_to_bytes(memory_hotplug.total_size_mib)),
+            )
             .map_err(StartMicrovmError::GuestMemory)?;
         vm.register_hotpluggable_memory_region(
             hotplug_memory_region,
-            mib_to_bytes(memory_hotplug.slot_size_mib),
+            u64_to_usize(u32_mib_to_bytes(memory_hotplug.slot_size_mib)),
         )?;
         Some(addr)
     } else {
@@ -604,14 +607,14 @@ fn attach_entropy_device(
 
 fn allocate_virtio_mem_address(
     vm: &KvmVm,
-    total_size_mib: usize,
+    total_size_mib: u32,
 ) -> Result<GuestAddress, StartMicrovmError> {
     let addr = vm
         .resource_allocator()
         .past_mmio64_memory
         .allocate(
-            mib_to_bytes(total_size_mib) as u64,
-            mib_to_bytes(VIRTIO_MEM_DEFAULT_SLOT_SIZE_MIB) as u64,
+            u32_mib_to_bytes(total_size_mib),
+            u32_mib_to_bytes(VIRTIO_MEM_DEFAULT_SLOT_SIZE_MIB),
             AllocPolicy::FirstMatch,
         )?
         .start();

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -559,15 +559,12 @@ impl VirtioMem {
     }
 
     /// Updates the requested size of the virtio-mem device.
-    pub fn update_requested_size(
-        &mut self,
-        requested_size_mib: usize,
-    ) -> Result<(), VirtioMemError> {
-        let requested_size = usize_to_u64(mib_to_bytes(requested_size_mib));
+    pub fn update_requested_size(&mut self, requested_size_mib: u32) -> Result<(), VirtioMemError> {
         if !self.is_activated() {
             return Err(VirtioMemError::DeviceNotActive);
         }
 
+        let requested_size = u64::from(requested_size_mib) << 20;
         if !requested_size.is_multiple_of(self.config.block_size) {
             return Err(VirtioMemError::InvalidSize(requested_size));
         }
@@ -1020,6 +1017,14 @@ mod tests {
         // Size too large
         let result = th.device().update_requested_size(2048);
         assert!(matches!(result, Err(VirtioMemError::InvalidSize(_))));
+
+        // The largest request is converted without wrapping.
+        let expected_size = u64::from(u32::MAX) << 20;
+        let result = th.device().update_requested_size(u32::MAX);
+        assert!(matches!(
+            result,
+            Err(VirtioMemError::InvalidSize(size)) if size == expected_size
+        ));
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -31,7 +31,7 @@ use crate::devices::virtio::queue::{
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, debug, error, info, warn};
-use crate::utils::{bytes_to_mib, mib_to_bytes, u64_to_usize, usize_to_u64};
+use crate::utils::{bytes_to_u32_mib, u32_mib_to_bytes, u64_to_usize, usize_to_u64};
 use crate::vstate::interrupts::InterruptError;
 use crate::vstate::memory::{
     ByteValued, GuestMemoryExtension, GuestMemoryMmap, GuestRegionMmap, GuestRegionType,
@@ -106,39 +106,42 @@ pub struct VirtioMem {
 #[serde(deny_unknown_fields)]
 pub struct VirtioMemStatus {
     /// Block size in MiB.
-    pub block_size_mib: usize,
+    pub block_size_mib: u32,
     /// Total memory size in MiB that can be hotplugged.
-    pub total_size_mib: usize,
+    pub total_size_mib: u32,
     /// Size of the KVM slots in MiB.
-    pub slot_size_mib: usize,
+    pub slot_size_mib: u32,
     /// Currently plugged memory size in MiB.
-    pub plugged_size_mib: usize,
+    pub plugged_size_mib: u32,
     /// Requested memory size in MiB.
-    pub requested_size_mib: usize,
+    pub requested_size_mib: u32,
 }
 
 impl VirtioMem {
     pub fn new(
         vm: Arc<KvmVm>,
         addr: GuestAddress,
-        total_size_mib: usize,
-        block_size_mib: usize,
-        slot_size_mib: usize,
+        total_size_mib: u32,
+        block_size_mib: u32,
+        slot_size_mib: u32,
     ) -> Result<Self, VirtioMemError> {
         let queues = vec![Queue::new(FIRECRACKER_MAX_QUEUE_SIZE); MEM_NUM_QUEUES];
         let config = virtio_mem_config {
             addr: addr.raw_value(),
-            region_size: mib_to_bytes(total_size_mib) as u64,
-            block_size: mib_to_bytes(block_size_mib) as u64,
+            region_size: u32_mib_to_bytes(total_size_mib),
+            block_size: u32_mib_to_bytes(block_size_mib),
             ..Default::default()
         };
-        let plugged_blocks = BitVec::repeat(false, total_size_mib / block_size_mib);
+        let plugged_blocks = BitVec::repeat(
+            false,
+            u64_to_usize((total_size_mib / block_size_mib).into()),
+        );
 
         Self::from_state(
             vm,
             queues,
             config,
-            mib_to_bytes(slot_size_mib),
+            u64_to_usize(u32_mib_to_bytes(slot_size_mib)),
             plugged_blocks,
         )
     }
@@ -174,28 +177,28 @@ impl VirtioMem {
     }
 
     /// Gets the total hotpluggable size.
-    pub fn total_size_mib(&self) -> usize {
-        bytes_to_mib(u64_to_usize(self.config.region_size))
+    pub fn total_size_mib(&self) -> u32 {
+        bytes_to_u32_mib(self.config.region_size)
     }
 
     /// Gets the block size.
-    pub fn block_size_mib(&self) -> usize {
-        bytes_to_mib(u64_to_usize(self.config.block_size))
+    pub fn block_size_mib(&self) -> u32 {
+        bytes_to_u32_mib(self.config.block_size)
     }
 
     /// Gets the block size.
-    pub fn slot_size_mib(&self) -> usize {
-        bytes_to_mib(self.slot_size)
+    pub fn slot_size_mib(&self) -> u32 {
+        bytes_to_u32_mib(usize_to_u64(self.slot_size))
     }
 
     /// Gets the total size of the plugged memory blocks.
-    pub fn plugged_size_mib(&self) -> usize {
-        bytes_to_mib(u64_to_usize(self.config.plugged_size))
+    pub fn plugged_size_mib(&self) -> u32 {
+        bytes_to_u32_mib(self.config.plugged_size)
     }
 
     /// Gets the requested size
-    pub fn requested_size_mib(&self) -> usize {
-        bytes_to_mib(u64_to_usize(self.config.requested_size))
+    pub fn requested_size_mib(&self) -> u32 {
+        bytes_to_u32_mib(self.config.requested_size)
     }
 
     pub fn status(&self) -> VirtioMemStatus {
@@ -564,7 +567,7 @@ impl VirtioMem {
             return Err(VirtioMemError::DeviceNotActive);
         }
 
-        let requested_size = u64::from(requested_size_mib) << 20;
+        let requested_size = u32_mib_to_bytes(requested_size_mib);
         if !requested_size.is_multiple_of(self.config.block_size) {
             return Err(VirtioMemError::InvalidSize(requested_size));
         }
@@ -711,6 +714,7 @@ pub(crate) mod test_utils {
     use super::*;
     use crate::devices::virtio::test_utils::test::VirtioTestDevice;
     use crate::test_utils::single_region_mem;
+    use crate::utils::mib_to_bytes;
     use crate::vmm_config::machine_config::HugePageConfig;
     use crate::vstate::memory;
     use crate::vstate::vm::tests::setup_vm_with_memory;
@@ -757,6 +761,7 @@ mod tests {
     use crate::devices::virtio::mem::device::test_utils::default_virtio_mem;
     use crate::devices::virtio::queue::VIRTQ_DESC_F_WRITE;
     use crate::devices::virtio::test_utils::test::VirtioTestHelper;
+    use crate::utils::mib_to_bytes;
     use crate::vstate::vm::tests::setup_vm_with_memory;
 
     #[test]
@@ -785,28 +790,28 @@ mod tests {
         let vm = Arc::new(vm);
         let queues = vec![Queue::new(FIRECRACKER_MAX_QUEUE_SIZE); MEM_NUM_QUEUES];
         let addr = 512 << 30;
-        let region_size_mib = 2048;
-        let block_size_mib = 2;
-        let slot_size_mib = 128;
-        let plugged_size_mib = 512;
-        let usable_region_size = mib_to_bytes(1024) as u64;
+        let region_size_mib: u32 = 2048;
+        let block_size_mib: u32 = 2;
+        let slot_size_mib: u32 = 128;
+        let plugged_size_mib: u32 = 512;
+        let usable_region_size = u32_mib_to_bytes(1024);
         let config = virtio_mem_config {
             addr,
-            region_size: mib_to_bytes(region_size_mib) as u64,
-            block_size: mib_to_bytes(block_size_mib) as u64,
-            plugged_size: mib_to_bytes(plugged_size_mib) as u64,
+            region_size: u32_mib_to_bytes(region_size_mib),
+            block_size: u32_mib_to_bytes(block_size_mib),
+            plugged_size: u32_mib_to_bytes(plugged_size_mib),
             usable_region_size,
             ..Default::default()
         };
         let plugged_blocks = BitVec::repeat(
             false,
-            mib_to_bytes(region_size_mib) / mib_to_bytes(block_size_mib),
+            u64_to_usize((region_size_mib / block_size_mib).into()),
         );
         let mem = VirtioMem::from_state(
             vm,
             queues,
             config,
-            mib_to_bytes(slot_size_mib),
+            u64_to_usize(u32_mib_to_bytes(slot_size_mib)),
             plugged_blocks,
         )
         .unwrap();
@@ -826,7 +831,7 @@ mod tests {
         assert_eq!(config.len(), std::mem::size_of::<virtio_mem_config>());
         assert_eq!(
             u64::from_le_bytes(config[0..8].try_into().unwrap()),
-            mib_to_bytes(mem.block_size_mib()) as u64
+            u32_mib_to_bytes(mem.block_size_mib())
         );
         assert_eq!(
             u64::from_le_bytes(config[16..24].try_into().unwrap()),
@@ -834,7 +839,7 @@ mod tests {
         );
         assert_eq!(
             u64::from_le_bytes(config[24..32].try_into().unwrap()),
-            mib_to_bytes(mem.total_size_mib()) as u64
+            u32_mib_to_bytes(mem.total_size_mib())
         );
     }
 

--- a/src/vmm/src/devices/virtio/mem/mod.rs
+++ b/src/vmm/src/devices/virtio/mem/mod.rs
@@ -16,7 +16,7 @@ pub(crate) const MEM_NUM_QUEUES: usize = 1;
 
 pub(crate) const MEM_QUEUE: usize = 0;
 
-pub const VIRTIO_MEM_DEFAULT_BLOCK_SIZE_MIB: usize = 2;
-pub const VIRTIO_MEM_DEFAULT_SLOT_SIZE_MIB: usize = 128;
+pub const VIRTIO_MEM_DEFAULT_BLOCK_SIZE_MIB: u32 = 2;
+pub const VIRTIO_MEM_DEFAULT_SLOT_SIZE_MIB: u32 = 128;
 
 pub const VIRTIO_MEM_DEV_ID: &str = "mem";

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -657,7 +657,7 @@ impl Vmm {
     }
 
     /// Returns the current state of the memory hotplug device.
-    pub fn update_memory_hotplug_size(&self, requested_size_mib: usize) -> Result<(), VmmError> {
+    pub fn update_memory_hotplug_size(&self, requested_size_mib: u32) -> Result<(), VmmError> {
         self.device_manager
             .with_virtio_device(VIRTIO_MEM_DEV_ID, |dev: &mut VirtioMem| {
                 dev.update_requested_size(requested_size_mib)

--- a/src/vmm/src/utils/mod.rs
+++ b/src/vmm/src/utils/mod.rs
@@ -47,6 +47,23 @@ pub const fn mib_to_bytes(mib: usize) -> usize {
     mib << MIB_TO_BYTES_SHIFT
 }
 
+/// Converts MiB to Bytes, widening to `u64` first so the result cannot wrap.
+///
+/// The largest input yields just under 4 PiB, which always fits in a `u64` byte count.
+pub const fn u32_mib_to_bytes(mib: u32) -> u64 {
+    (mib as u64) << MIB_TO_BYTES_SHIFT
+}
+
+/// Converts Bytes to MiB, truncating any remainder.
+///
+/// # Panics
+///
+/// Panics if the resulting MiB count does not fit in a `u32`. Callers must only pass byte
+/// counts that originate from a `u32` MiB value, for which this is unreachable.
+pub fn bytes_to_u32_mib(bytes: u64) -> u32 {
+    u32::try_from(bytes >> MIB_TO_BYTES_SHIFT).expect("byte count does not originate from u32 MiB")
+}
+
 /// Converts Bytes to MiB, truncating any remainder
 pub const fn bytes_to_mib(bytes: usize) -> usize {
     bytes >> MIB_TO_BYTES_SHIFT
@@ -93,6 +110,32 @@ pub fn open_file_nonblock(path: &Path) -> Result<File, std::io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_u32_mib_to_bytes_does_not_wrap() {
+        assert_eq!(u32_mib_to_bytes(0), 0);
+        assert_eq!(u32_mib_to_bytes(1), 1 << 20);
+        // The largest input is just under 4 PiB and stays within a u64.
+        assert_eq!(u32_mib_to_bytes(u32::MAX), (u32::MAX as u64) << 20);
+        // The same value shifted as a usize MiB count would have wrapped; widening first
+        // means every u32 input is representable.
+        assert!(u32_mib_to_bytes(u32::MAX) > u32::MAX.into());
+    }
+
+    #[test]
+    fn test_bytes_to_u32_mib_round_trips() {
+        for mib in [0, 1, 2, 128, 1024, u32::MAX] {
+            assert_eq!(bytes_to_u32_mib(u32_mib_to_bytes(mib)), mib);
+        }
+        // Truncates a partial MiB, matching bytes_to_mib.
+        assert_eq!(bytes_to_u32_mib((1 << 20) - 1), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "byte count does not originate from u32 MiB")]
+    fn test_bytes_to_u32_mib_panics_above_u32_mib() {
+        bytes_to_u32_mib(u32_mib_to_bytes(u32::MAX) + (1 << 20));
+    }
 
     #[test]
     fn test_align_up_already_aligned() {

--- a/src/vmm/src/vmm_config/memory_hotplug.rs
+++ b/src/vmm/src/vmm_config/memory_hotplug.rs
@@ -11,24 +11,24 @@ use crate::devices::virtio::mem::{
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum MemoryHotplugConfigError {
     /// Block size must not be lower than {0} MiB
-    BlockSizeTooSmall(usize),
+    BlockSizeTooSmall(u32),
     /// Block size must be a power of 2
     BlockSizeNotPowerOfTwo,
     /// Slot size must not be lower than {0} MiB
-    SlotSizeTooSmall(usize),
+    SlotSizeTooSmall(u32),
     /// Slot size must be a multiple of block size ({0} MiB)
-    SlotSizeNotMultipleOfBlockSize(usize),
+    SlotSizeNotMultipleOfBlockSize(u32),
     /// Total size must not be lower than slot size ({0} MiB)
-    TotalSizeTooSmall(usize),
+    TotalSizeTooSmall(u32),
     /// Total size must be a multiple of slot size ({0} MiB)
-    TotalSizeNotMultipleOfSlotSize(usize),
+    TotalSizeNotMultipleOfSlotSize(u32),
 }
 
-fn default_block_size_mib() -> usize {
+fn default_block_size_mib() -> u32 {
     VIRTIO_MEM_DEFAULT_BLOCK_SIZE_MIB
 }
 
-fn default_slot_size_mib() -> usize {
+fn default_slot_size_mib() -> u32 {
     VIRTIO_MEM_DEFAULT_SLOT_SIZE_MIB
 }
 
@@ -37,13 +37,13 @@ fn default_slot_size_mib() -> usize {
 #[serde(deny_unknown_fields)]
 pub struct MemoryHotplugConfig {
     /// Total memory size in MiB that can be hotplugged.
-    pub total_size_mib: usize,
+    pub total_size_mib: u32,
     /// Block size in MiB. A block is the smallest unit the guest can hot(un)plug
     #[serde(default = "default_block_size_mib")]
-    pub block_size_mib: usize,
+    pub block_size_mib: u32,
     /// Slot size in MiB. A slot is the smallest unit the host can (de)attach memory
     #[serde(default = "default_slot_size_mib")]
-    pub slot_size_mib: usize,
+    pub slot_size_mib: u32,
 }
 
 impl MemoryHotplugConfig {

--- a/src/vmm/src/vmm_config/memory_hotplug.rs
+++ b/src/vmm/src/vmm_config/memory_hotplug.rs
@@ -101,7 +101,7 @@ impl From<&VirtioMem> for MemoryHotplugConfig {
 #[serde(deny_unknown_fields)]
 pub struct MemoryHotplugSizeUpdate {
     /// Requested size in MiB to resize the hotpluggable memory to.
-    pub requested_size_mib: usize,
+    pub requested_size_mib: u32,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Previously we did not validate the mib value provided would be overflow when converted to bytes.

Add a new method to validate the mib value would fit as bytes. Added some new error results for the new failure cases and added unit tests to validate the new behaviour.

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
