### PR TITLE
fix(vsock): forfeit a killed connection's TX buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ and this project adheres to
   TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
   `MIDR_EL1` information files copied into the chroot.
 - [#6031](https://github.com/firecracker-microvm/firecracker/pull/6031),
-  [#6041](https://github.com/firecracker-microvm/firecracker/pull/6041): Fixed
+  [#6041](https://github.com/firecracker-microvm/firecracker/pull/6041),
+  [#6077](https://github.com/firecracker-microvm/firecracker/pull/6077): Fixed
   the vsock device re-arming its host-stream `EPOLLIN` interest while received
   data was still awaiting a guest RX buffer, which could busy-spin the event
   thread until the guest posted buffers. The device now drains the host stream
@@ -53,6 +54,9 @@ and this project adheres to
   in most configurations. On single-vcpu microVMs on the newest Intel hosts
   (m7i, m8i), host-to-guest throughput may instead decrease by ~15% (median),
   where the single guest vCPU rather than the host becomes the bottleneck.
+  Terminating a connection now also discards its TX buffer, so the device stops
+  advertising `EPOLLOUT` for a host stream it will never write to again, which
+  could otherwise busy-spin the event thread indefinitely.
 
 ## [1.16.1]
 

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -583,6 +583,8 @@ where
     pub fn kill(&mut self) {
         self.state = ConnState::Killed;
         self.pending_rx.insert(PendingRx::Rst);
+        // We're sending an RST, so anything still buffered for the host is forfeit.
+        self.tx_buf.clear();
     }
 
     /// Return the connections state.
@@ -1111,6 +1113,57 @@ mod tests {
         ctx.set_stream(stream);
         ctx.notify_epollin(); // sets PendingRx::Rw
         assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
+    }
+
+    #[test]
+    fn test_polled_evset_drops_out_when_killed() {
+        // A killed connection must not keep asking for EPOLLOUT: a peer-closed fd is
+        // writable forever while every write fails, which busy-spins the event thread.
+        let mut ctx = CsmTestContext::new_established();
+
+        // Buffer some guest data by making the host stream refuse writes.
+        let mut stream = TestStream::new();
+        stream.write_state = StreamState::WouldBlock;
+        ctx.set_stream(stream);
+        ctx.init_data_tx_pkt(&[1, 2, 3, 4]);
+        ctx.send();
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::OUT));
+
+        // The host end goes away: flushing fails and kills the connection.
+        let mut stream = TestStream::new();
+        stream.write_state = StreamState::Closed;
+        ctx.set_stream(stream);
+        ctx.notify_epollout();
+        assert_eq!(ctx.conn.state, ConnState::Killed);
+
+        // Wanting no events is what makes the muxer drop the listener.
+        assert!(ctx.conn.tx_buf.is_empty());
+        assert!(ctx.conn.get_polled_evset().is_empty());
+    }
+
+    #[test]
+    fn test_polled_evset_keeps_out_while_flushable() {
+        // Only a kill forfeits the buffer. `LocalClosed` still drains: a 0-length read
+        // only means the host shut down its write side. `PeerClosed(true, true)` drains
+        // too, and sends its RST once done.
+        for state in [
+            ConnState::Established,
+            ConnState::LocalClosed,
+            ConnState::PeerClosed(true, true),
+        ] {
+            let mut ctx = CsmTestContext::new_established();
+            let mut stream = TestStream::new();
+            stream.write_state = StreamState::WouldBlock;
+            ctx.set_stream(stream);
+            ctx.init_data_tx_pkt(&[1, 2, 3, 4]);
+            ctx.send();
+
+            ctx.conn.state = state;
+            assert!(
+                ctx.conn.get_polled_evset().contains(EventSet::OUT),
+                "OUT must stay armed in {state:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/csm/txbuf.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/txbuf.rs
@@ -135,6 +135,13 @@ impl TxBuf {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Discard any buffered data, freeing the backing allocation.
+    pub fn clear(&mut self) {
+        self.data = None;
+        self.head = Wrapping(0);
+        self.tail = Wrapping(0);
+    }
 }
 
 impl WriteVolatile for TxBuf {
@@ -256,6 +263,25 @@ mod tests {
             .unwrap();
         assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 4);
         assert_eq!(sink.data, [5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut txbuf = TxBuf::new();
+        let mut tmp = vec![0u8; 128];
+        txbuf
+            .push(&VolatileSlice::from(tmp.as_mut_slice()))
+            .unwrap();
+        assert!(!txbuf.is_empty());
+
+        txbuf.clear();
+        assert!(txbuf.is_empty());
+        assert_eq!(txbuf.len(), 0);
+        // The buffer can be reused afterwards.
+        txbuf
+            .push(&VolatileSlice::from(tmp.as_mut_slice()))
+            .unwrap();
+        assert_eq!(txbuf.len(), 128);
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -1242,6 +1242,50 @@ mod tests {
     }
 
     #[test]
+    fn test_killed_conn_drops_epoll_listener() {
+        // A killed connection must not keep an epoll listener, or the nested epoll fd
+        // re-fires forever on a peer-closed stream that no write can ever satisfy.
+        let mut ctx = MuxerTestContext::new("killed_conn_out");
+        let peer_port = 1025;
+        let (stream, local_port) = ctx.local_connect(peer_port);
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        let conn_fd = ctx.muxer.conn_map.get(&key).unwrap().as_raw_fd();
+        assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
+
+        // Fill the host socket's send buffer, so further data lands in the TX buffer.
+        let data = vec![0xffu8; ctx.tx_pkt.buf_size() as usize];
+        let mut sends = 0;
+        while !ctx
+            .muxer
+            .conn_map
+            .get(&key)
+            .unwrap()
+            .get_polled_evset()
+            .contains(EventSet::OUT)
+        {
+            ctx.init_data_tx_pkt(local_port, peer_port, data.as_slice());
+            ctx.send();
+            sends += 1;
+            assert!(sends < 1024, "TX buffer never filled up");
+        }
+
+        // The host end goes away while data is still buffered.
+        drop(stream);
+
+        // The failing flush kills the connection, which must drop its listener.
+        ctx.muxer.notify(EventSet::IN);
+        assert_eq!(
+            ctx.muxer.conn_map.get(&key).unwrap().state(),
+            ConnState::Killed
+        );
+        assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 0);
+    }
+
+    #[test]
     fn test_starvation_drops_epoll_listener_on_host_eof() {
         // Same as `test_starvation_drops_and_rearms_epoll_listener`, but the host closes
         // its end (EOF) instead of writing data. No host-side entity can break the loop,


### PR DESCRIPTION
## Changes

Clear the TX buffer in `VsockConnection::kill()`. Adds `TxBuf::clear()`, plus unit tests
and a muxer-level regression test.

## Reason

A guest can pin the event thread at 100% CPU:

1. The guest writes faster than the host application reads, so the remainder is buffered
   in `tx_buf` and the connection registers `EPOLLOUT` interest.
2. The host application closes its end. The fd is now permanently `EPOLLOUT|EPOLLHUP` —
   `EPOLLOUT` only promises that a write won't block, and a peer-closed socket has no send
   buffer to fill, so it reports ready forever while every `write(2)` fails `EPIPE`.
3. The flush fails and `kill()` runs, but nothing drains `tx_buf`: `flush_to()` only
   advances its tail on a successful write. `get_polled_evset()` still returns `{OUT}`, so
   the muxer keeps the connection's epoll listener.
4. Goto 2, with no sleep in between.

The `RST` that `kill()` queues would remove the connection, but delivering it needs a
guest RX buffer — a guest that stops posting descriptors makes the spin permanent. The
event manager is single-threaded, so this starves the other device backends and the API
socket. Same failure mode as #6031/#6041, which gated only the `IN` arm.

Clearing in `kill()` rather than special-casing `Killed` in `get_polled_evset()` keeps the
invariant where the decision is made — a connection sending an `RST` has forfeited its
buffered data — and frees the 64 KiB immediately instead of holding it until the guest
lets the `RST` out.

Connections that can still drain keep `EPOLLOUT`: `LocalClosed` may have seen only the
peer's `shutdown(SHUT_WR)`, and `PeerClosed(true, true)` drains before sending its `RST`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
