### PR TITLE
test: re-enable memory hotplug tests on Linux 5.10

### DIFF
--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -53,7 +53,7 @@ perf_test = {
         "devtool_opts": "-c 1-10 -m 0",
         # The test require polling (5 ms), so any change smaller than that is not significant.
         # Additionally, unplugging memory is dependent on how exactly it's being used, so some volatility is expected.
-        "ab_opts": "--absolute-strength 0.005",
+        "ab_opts": "--absolute-strength 0.005 --noise-threshold hotunplug_total_time=0.1",
     },
     "snapshot-latency": {
         "label": "snapshot-latency",

--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -8,8 +8,6 @@ This file also contains functional tests for virtio-mem because they need to be
 run on an ag=1 host due to the use of HugePages.
 """
 
-import platform
-
 import pytest
 from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
@@ -264,11 +262,6 @@ def check_hotunplug(uvm, requested_size_mib):
         assert rss_after < rss_before, "RSS didn't decrease"
 
 
-# TODO: remove this once the hotplug latency on 5.10 hosts is fixed
-@pytest.mark.skipif(
-    platform.machine() == "x86_64" and global_props.host_linux_version_tpl == (5, 10),
-    reason="GET /hotplug/memory intermittently exceeds the duration threshold on x86_64 5.10 hosts",
-)
 def test_virtio_mem_hotplug_hotunplug(uvm_any_memhp):
     """
     Check that memory can be hotplugged into the VM.
@@ -473,11 +466,6 @@ def timed_memory_hotplug(uvm, size, metrics, metric_prefix, fc_metric_name):
     )
 
 
-# TODO: remove this once the hotplug latency on 5.10 hosts is fixed
-@pytest.mark.skipif(
-    platform.machine() == "x86_64" and global_props.host_linux_version_tpl == (5, 10),
-    reason="GET /hotplug/memory intermittently exceeds the duration threshold on x86_64 5.10 hosts",
-)
 @pytest.mark.nonci
 @pytest.mark.parametrize(
     "hotplug_size",


### PR DESCRIPTION
## Changes

- Re-enable `test_virtio_mem_hotplug_hotunplug` and
  `test_memory_hotplug_latency` on x86_64 Linux 5.10 hosts.
- Restore the 10% noise threshold for the `hotunplug_total_time`
  A/B metric.

## Reason

#6007 temporarily skipped the tests while investigating a Linux 5.10
host kernel regression that caused memory hot-unplug API calls to exceed
their duration threshold.

Because the skipped latency test no longer emitted
`hotunplug_total_time`, #6011 temporarily removed its per-metric A/B
threshold.

The tests now pass on the current AL2 Linux 5.10 CI hosts, so restore the
original coverage and A/B configuration.

## Testing

Commit `54fc96f28b2e1bed3beb135e752e17ce8b937cbc` passed the following
steps in a private Buildkite pipeline.

Local test collection:

```sh
./tools/devtool --unattended test --no-build --no-kvm-check \
  --no-artifacts-check -- --collect-only --quiet \
  integration_tests/performance/test_hotplug_memory.py
```

Memory hotplug performance:

```sh
.buildkite/pipeline_perf.py \
  --test memory-hotplug \
  --platforms al2-linux_5.10 \
  | buildkite-agent pipeline upload
```

Memory hotplug A/B performance:

```sh
REVISION_A=f2f43b669a02f02fb3b588164081467c00ca2daf \
REVISION_B=54fc96f28b2e1bed3beb135e752e17ce8b937cbc \
.buildkite/pipeline_perf.py \
  --test memory-hotplug \
  --platforms al2-linux_5.10 \
  | buildkite-agent pipeline upload
```

Both performance steps ran across the default 12 instance types. All
normal performance jobs passed, including the re-enabled functional and
latency tests. All A/B jobs passed without detecting a regression.

The x86_64 jobs used host kernel
`5.10.260-259.1054.amzn2.x86_64`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
