### PR TITLE
Reduce calls to set_gsi_routes

### DIFF
--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -141,7 +141,7 @@ impl PciDevices {
 
         // Create the transport
         let mut virtio_device =
-            VirtioPciDevice::new(id.clone(), mem, device, Arc::new(msix_vectors), sbdf)?;
+            VirtioPciDevice::new(id.clone(), mem, device, Arc::new(msix_vectors), sbdf);
 
         // Allocate bars
         let mut resource_allocator_lock = vm.resource_allocator();

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -673,6 +673,23 @@ impl<'a> Persist<'a> for PciDevices {
             )?
         }
 
+        // After PCI devices are restored, we must set up the GSI routes (one KVM_SET_GSI_ROUTING call for all vectors),
+        // and enable all unmasked vectors (one kvm_irqfd call per vector).
+        // Ordering: routing must be set before IRQFDs to avoid kernel panics on
+        // older AMD/SVM hosts (see kernel commit a80ced6ea514).
+        if !pci_devices.virtio_devices.is_empty() {
+            constructor_args
+                .vm
+                .set_gsi_routes()
+                .map_err(PciManagerError::from)?;
+
+            for pci_device in pci_devices.virtio_devices.values() {
+                let dev = pci_device.lock().expect("Poisoned lock");
+                dev.enable_unmasked_vectors()
+                    .map_err(PciManagerError::from)?;
+            }
+        }
+
         Ok(pci_devices)
     }
 }

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -254,6 +254,8 @@ pub enum VirtioPciDeviceError {
     PciConfiguration(#[from] PciConfigurationError),
     /// Invalid restore state: driver_status {0:#x} is inconsistent with device_activated (expected {1:#x})
     InvalidRestoreState(u8, u8),
+    /// Restored MSI-X vector count ({0}) does not match the expected count ({1}) for this device
+    UnexpectedMsixVectorCount(usize, usize),
 }
 
 pub struct VirtioPciDevice {
@@ -371,6 +373,7 @@ impl VirtioPciDevice {
         sbdf: PciSBDF,
     ) -> Result<Self, VirtioPciDeviceError> {
         let num_queues = device.lock().expect("Poisoned lock").queues().len();
+        assert_eq!(msix_vectors.vectors.len(), num_queues + 1);
 
         let msix_config = Arc::new(Mutex::new(MsixConfig::new(msix_vectors.clone(), sbdf)));
         let pci_config = Self::pci_configuration(
@@ -421,6 +424,16 @@ impl VirtioPciDevice {
     ) -> Result<Self, VirtioPciDeviceError> {
         let msix_config = MsixConfig::from_state(state.msix_state, vm.clone(), state.sbdf)?;
         let vectors = msix_config.vectors.clone();
+
+        // Expecting one vector per queue, plus one for the configuration
+        let expected_num_vectors = device.lock().expect("Poisoned lock").queues().len() + 1;
+        if vectors.vectors.len() != expected_num_vectors {
+            return Err(VirtioPciDeviceError::UnexpectedMsixVectorCount(
+                vectors.vectors.len(),
+                expected_num_vectors,
+            ));
+        }
+
         let msix_config = Arc::new(Mutex::new(msix_config));
 
         let pci_config = PciConfiguration::type0_from_state(state.pci_configuration_state)?;

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -371,7 +371,7 @@ impl VirtioPciDevice {
         device: Arc<Mutex<dyn VirtioDevice>>,
         msix_vectors: Arc<MsixVectorGroup>,
         sbdf: PciSBDF,
-    ) -> Result<Self, VirtioPciDeviceError> {
+    ) -> Self {
         let num_queues = device.lock().expect("Poisoned lock").queues().len();
         assert_eq!(msix_vectors.vectors.len(), num_queues + 1);
 
@@ -397,7 +397,7 @@ impl VirtioPciDevice {
             msix_vectors,
         ));
 
-        let virtio_pci_device = VirtioPciDevice {
+        VirtioPciDevice {
             id,
             sub_id: None,
             sbdf,
@@ -411,9 +411,7 @@ impl VirtioPciDevice {
             bars: Bars::default(),
             msix_config,
             msix_config_cap_offset: 0,
-        };
-
-        Ok(virtio_pci_device)
+        }
     }
 
     pub fn new_from_state(

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -454,7 +454,7 @@ impl VirtioPciDevice {
             vectors,
         ));
 
-        let mut virtio_pci_device = VirtioPciDevice {
+        let virtio_pci_device = VirtioPciDevice {
             id,
             sub_id: None,
             sbdf: state.sbdf,
@@ -482,6 +482,16 @@ impl VirtioPciDevice {
         }
 
         Ok(virtio_pci_device)
+    }
+
+    /// Enable unmasked MSI-X vectors by registering IRQFDs with KVM.
+    ///
+    /// Must be called after the GSI routes have been set up (see [KvmVm::set_gsi_routes]).
+    pub fn enable_unmasked_vectors(&self) -> Result<(), InterruptError> {
+        self.msix_config
+            .lock()
+            .expect("Poisoned lock")
+            .enable_unmasked_vectors()
     }
 
     fn is_driver_ready(&self) -> bool {

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -115,7 +115,11 @@ impl MsixConfig {
         }
     }
 
-    /// Create an MSI-X configuration from snapshot state
+    /// Create an MSI-X configuration from snapshot state.
+    ///
+    /// This populates the in-memory GSI routing table entries but does NOT flush them to KVM
+    /// (`KVM_SET_GSI_ROUTING`) and does NOT register IRQFDs (`KVM_IRQFD`).
+    /// The caller must call [KvmVm::set_gsi_routes] and [MsixConfig::enable_unmasked_vectors].
     pub fn from_state(
         state: MsixConfigState,
         vm: Arc<KvmVm>,
@@ -135,7 +139,9 @@ impl MsixConfig {
                     devid: sbdf,
                 };
 
-                vectors.update(idx, config, state.masked)?;
+                // Only populate the in-memory routing entry; do not flush to KVM or
+                // register the IRQFD yet.
+                vectors.register(idx, config, state.masked)?;
             }
         }
 
@@ -147,6 +153,20 @@ impl MsixConfig {
             masked: state.masked,
             enabled: state.enabled,
         })
+    }
+
+    /// Enable unmasked MSI-X vectors by registering IRQFDs with KVM.
+    ///
+    /// Must be called after the GSI routes have been set up (see [KvmVm::set_gsi_routes]).
+    pub fn enable_unmasked_vectors(&self) -> Result<(), InterruptError> {
+        if self.enabled && !self.masked {
+            for (idx, table_entry) in self.table_entries.iter().enumerate() {
+                if !table_entry.masked() {
+                    self.vectors.vectors[idx].enable(&self.vectors.vm.common.fd)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Create the state object for serializing MSI-X vectors
@@ -575,6 +595,7 @@ mod tests {
     use crate::check_metric_after_block;
     use crate::logger::{IncMetric, METRICS};
     use crate::vstate::vm::KvmVm;
+    use std::sync::atomic::Ordering;
 
     fn msix_vector_group(nr_vectors: u16) -> Arc<MsixVectorGroup> {
         let vmm = default_vmm();
@@ -621,6 +642,46 @@ mod tests {
         config.set_msg_ctl(0x0);
         assert!(!config.enabled);
         assert!(!config.masked);
+    }
+
+    #[test]
+    fn test_msix_from_state() {
+        let sbdf = PciSBDF::from(0x42);
+
+        // Setting up the original configuration (first vector enabled and unmasked)
+        let mut original = MsixConfig::new(msix_vector_group(2), sbdf);
+        original.set_msg_ctl(0x8000);
+        original.write_table(8, &u64::to_le_bytes(0x0));
+        assert!(original.enabled);
+        assert!(!original.masked);
+        assert!(original.vectors.vectors[0].enabled.load(Ordering::Acquire));
+
+        // Restoring from original config
+        let vmm = default_vmm();
+        let restored =
+            MsixConfig::from_state(original.state(), vmm.vm.as_kvm().unwrap().clone(), sbdf)
+                .unwrap();
+        restored.enable_unmasked_vectors().unwrap();
+
+        // Assert state matches original
+        assert_eq!(original.enabled, restored.enabled);
+        assert_eq!(original.masked, restored.masked);
+        assert_eq!(original.table_entries, restored.table_entries);
+        assert_eq!(original.pba_entries, restored.pba_entries);
+        for idx in [0, 1] {
+            assert_eq!(
+                original.vectors.vectors[idx].gsi,
+                restored.vectors.vectors[idx].gsi,
+            );
+            assert_eq!(
+                original.vectors.vectors[idx]
+                    .enabled
+                    .load(Ordering::Acquire),
+                restored.vectors.vectors[idx]
+                    .enabled
+                    .load(Ordering::Acquire),
+            );
+        }
     }
 
     #[test]

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -173,17 +173,20 @@ impl MsixConfig {
         if old_masked != self.masked || old_enabled != self.enabled {
             if self.enabled && !self.masked {
                 debug!("MSI-X enabled for device {}", self.sbdf);
-                for (idx, table_entry) in self.table_entries.iter().enumerate() {
-                    let config = MsixVectorConfig {
+
+                let mut configs = Vec::with_capacity(self.table_entries.len());
+                let mut masks = Vec::with_capacity(self.table_entries.len());
+                for table_entry in &self.table_entries {
+                    configs.push(MsixVectorConfig {
                         high_addr: table_entry.msg_addr_hi,
                         low_addr: table_entry.msg_addr_lo,
                         data: table_entry.msg_data,
                         devid: self.sbdf,
-                    };
-
-                    if let Err(e) = self.vectors.update(idx, config, table_entry.masked()) {
-                        error!("Failed updating vector: {:?}", e);
-                    }
+                    });
+                    masks.push(table_entry.masked());
+                }
+                if let Err(e) = self.vectors.update_batched(&configs, &masks) {
+                    error!("Failed updating vectors: {:?}", e);
                 }
             } else if old_enabled || !old_masked {
                 debug!("MSI-X disabled for device {}", self.sbdf);
@@ -673,7 +676,7 @@ mod tests {
         // enabled and not masked
         check_metric_after_block!(
             METRICS.interrupts.config_updates,
-            2,
+            1,
             config.set_msg_ctl(0x8000)
         );
         let mut buffer = [0u8; 8];

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -15,7 +15,7 @@ use crate::logger::{debug, error, warn};
 use crate::pci::configuration::PciCapability;
 use crate::pci::{PciCapabilityId, PciSBDF};
 use crate::snapshot::Persist;
-use crate::vstate::interrupts::{InterruptError, MsixVectorConfig, MsixVectorGroup};
+use crate::vstate::interrupts::{InterruptError, MsixVectorGroup};
 use crate::vstate::vm::KvmVm;
 
 const MAX_MSIX_VECTORS_PER_DEVICE: u16 = 2048;
@@ -132,16 +132,9 @@ impl MsixConfig {
                     continue;
                 }
 
-                let config = MsixVectorConfig {
-                    high_addr: table_entry.msg_addr_hi,
-                    low_addr: table_entry.msg_addr_lo,
-                    data: table_entry.msg_data,
-                    devid: sbdf,
-                };
-
                 // Only populate the in-memory routing entry; do not flush to KVM or
                 // register the IRQFD yet.
-                vectors.register(idx, config, state.masked)?;
+                vectors.register(idx, table_entry, sbdf)?;
             }
         }
 
@@ -192,19 +185,7 @@ impl MsixConfig {
         if old_masked != self.masked || old_enabled != self.enabled {
             if self.enabled && !self.masked {
                 debug!("MSI-X enabled for device {}", self.sbdf);
-
-                let mut configs = Vec::with_capacity(self.table_entries.len());
-                let mut masks = Vec::with_capacity(self.table_entries.len());
-                for table_entry in &self.table_entries {
-                    configs.push(MsixVectorConfig {
-                        high_addr: table_entry.msg_addr_hi,
-                        low_addr: table_entry.msg_addr_lo,
-                        data: table_entry.msg_data,
-                        devid: self.sbdf,
-                    });
-                    masks.push(table_entry.masked());
-                }
-                if let Err(e) = self.vectors.update_batched(&configs, &masks) {
+                if let Err(e) = self.vectors.update_batched(&self.table_entries, self.sbdf) {
                     error!("Failed updating vectors: {:?}", e);
                 }
             } else if old_enabled || !old_masked {
@@ -353,17 +334,9 @@ impl MsixConfig {
         // Optimisation: only update routes if the entry is not masked;
         // this is safe because if the entry is masked (starts masked as per spec)
         // in the table then it won't be triggered.
-        if self.enabled && !self.masked && !table_entry.masked() {
-            let config = MsixVectorConfig {
-                high_addr: table_entry.msg_addr_hi,
-                low_addr: table_entry.msg_addr_lo,
-                data: table_entry.msg_data,
-                devid: self.sbdf,
-            };
-
-            if let Err(e) = self.vectors.update(index, config, table_entry.masked()) {
-                error!("Failed updating vector: {:?}", e);
-            }
+        let enabled = self.enabled && !self.masked && !table_entry.masked();
+        if enabled && let Err(e) = self.vectors.update(index, table_entry, self.sbdf) {
+            error!("Failed updating vector: {:?}", e);
         }
 
         // After the MSI-X table entry has been updated, it is necessary to
@@ -379,12 +352,7 @@ impl MsixConfig {
         let index = index as u16;
 
         // Check if bit has been flipped
-        if !self.masked
-            && self.enabled
-            && old_entry.masked()
-            && !table_entry.masked()
-            && self.get_pba_bit(index) == 1
-        {
+        if enabled && old_entry.masked() && self.get_pba_bit(index) == 1 {
             self.inject_msix_and_clear_pba(index);
         }
     }

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -136,7 +136,6 @@ impl MsixConfig {
                 };
 
                 vectors.update(idx, config, state.masked)?;
-                vectors.enable()?;
             }
         }
 

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -135,7 +135,7 @@ impl MsixConfig {
                     devid: sbdf,
                 };
 
-                vectors.update(idx, config, state.masked, true)?;
+                vectors.update(idx, config, state.masked)?;
                 vectors.enable()?;
             }
         }
@@ -181,7 +181,7 @@ impl MsixConfig {
                         devid: self.sbdf,
                     };
 
-                    if let Err(e) = self.vectors.update(idx, config, table_entry.masked(), true) {
+                    if let Err(e) = self.vectors.update(idx, config, table_entry.masked()) {
                         error!("Failed updating vector: {:?}", e);
                     }
                 }
@@ -339,10 +339,7 @@ impl MsixConfig {
                 devid: self.sbdf,
             };
 
-            if let Err(e) = self
-                .vectors
-                .update(index, config, table_entry.masked(), true)
-            {
+            if let Err(e) = self.vectors.update(index, config, table_entry.masked()) {
                 error!("Failed updating vector: {:?}", e);
             }
         }

--- a/src/vmm/src/pci/msix.rs
+++ b/src/vmm/src/pci/msix.rs
@@ -125,6 +125,33 @@ impl MsixConfig {
         vm: Arc<KvmVm>,
         sbdf: PciSBDF,
     ) -> Result<Self, InterruptError> {
+        let num_vectors = state.vectors.len();
+        if num_vectors > MAX_MSIX_VECTORS_PER_DEVICE as usize {
+            return Err(InterruptError::MsixStateSizeMismatch(format!(
+                "vectors length ({num_vectors}) exceeds maximum \
+                 ({MAX_MSIX_VECTORS_PER_DEVICE})"
+            )));
+        }
+
+        let num_table_entries = state.table_entries.len();
+        if num_table_entries != num_vectors {
+            return Err(InterruptError::MsixStateSizeMismatch(format!(
+                "table_entries length ({num_table_entries}) does not match \
+                 vectors length ({num_vectors})"
+            )));
+        }
+
+        let expected_pba_entries = u16::try_from(num_vectors)
+            .unwrap()
+            .div_ceil(BITS_PER_PBA_ENTRY) as usize;
+        if state.pba_entries.len() != expected_pba_entries {
+            return Err(InterruptError::MsixStateSizeMismatch(format!(
+                "pba_entries length ({}) does not match expected length \
+                 ({expected_pba_entries}) for {num_vectors} vectors",
+                state.pba_entries.len()
+            )));
+        }
+
         let vectors = Arc::new(MsixVectorGroup::restore(vm, &state.vectors)?);
         if state.enabled && !state.masked {
             for (idx, table_entry) in state.table_entries.iter().enumerate() {
@@ -650,6 +677,48 @@ mod tests {
                     .load(Ordering::Acquire),
             );
         }
+    }
+
+    #[test]
+    fn test_from_state_rejects_size_mismatches() {
+        let sbdf = PciSBDF::from(0x42);
+        let vmm = default_vmm();
+        let vm = vmm.vm.as_kvm().unwrap().clone();
+
+        let config = MsixConfig::new(msix_vector_group(2), sbdf);
+
+        // More table_entries than vectors
+        let mut state = config.state();
+        state.table_entries.push(MsixTableEntry::default());
+        assert!(matches!(
+            MsixConfig::from_state(state, vm.clone(), sbdf),
+            Err(InterruptError::MsixStateSizeMismatch(_))
+        ));
+
+        // Fewer table_entries than vectors
+        let mut state = config.state();
+        state.table_entries.pop();
+        assert!(matches!(
+            MsixConfig::from_state(state, vm.clone(), sbdf),
+            Err(InterruptError::MsixStateSizeMismatch(_))
+        ));
+
+        // Wrong number of pba_entries
+        let mut state = config.state();
+        state.pba_entries.push(0);
+        assert!(matches!(
+            MsixConfig::from_state(state, vm.clone(), sbdf),
+            Err(InterruptError::MsixStateSizeMismatch(_))
+        ));
+
+        // Too many vectors (exceeds MAX_MSIX_VECTORS_PER_DEVICE)
+        let mut state = config.state();
+        state.vectors = vec![0; 2049];
+        state.table_entries = vec![MsixTableEntry::default(); 2049];
+        assert!(matches!(
+            MsixConfig::from_state(state, vm, sbdf),
+            Err(InterruptError::MsixStateSizeMismatch(_))
+        ));
     }
 
     #[test]

--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -26,6 +26,8 @@ pub enum InterruptError {
     Kvm(#[from] kvm_ioctls::Error),
     /// Invalid vector index: {0}
     InvalidVectorIndex(usize),
+    /// MSI-X state size mismatch: {0}
+    MsixStateSizeMismatch(String),
 }
 
 /// Type that describes an allocated interrupt

--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -135,6 +135,15 @@ impl MsixVectorGroup {
         self.vectors.get(index).map(|route| &route.event_fd)
     }
 
+    /// Update the MSI-X configuration for all vectors in the group
+    pub fn update_batched(
+        &self,
+        msi_config: &[MsixVectorConfig],
+        masked: &[bool],
+    ) -> Result<(), InterruptError> {
+        self.update_vectors(msi_config, masked, &self.vectors)
+    }
+
     /// Update the MSI-X configuration for a vector in the group
     pub fn update(
         &self,
@@ -143,30 +152,45 @@ impl MsixVectorGroup {
         masked: bool,
     ) -> Result<(), InterruptError> {
         if let Some(vector) = self.vectors.get(index) {
-            METRICS.interrupts.config_updates.inc();
-            // When an interrupt is masked the GSI will not be passed to KVM through
-            // KVM_SET_GSI_ROUTING. So, call [`disable()`] to unregister the interrupt file
-            // descriptor before passing the interrupt routes to KVM
-            if masked {
+            self.update_vectors(&[msi_config], &[masked], std::slice::from_ref(vector))
+        } else {
+            Err(InterruptError::InvalidVectorIndex(index))
+        }
+    }
+
+    /// Update the MSI-X configuration for the given vectors
+    fn update_vectors(
+        &self,
+        msi_config: &[MsixVectorConfig],
+        masked: &[bool],
+        vectors: &[MsixVector],
+    ) -> Result<(), InterruptError> {
+        assert_eq!(msi_config.len(), vectors.len());
+        assert_eq!(masked.len(), vectors.len());
+
+        METRICS.interrupts.config_updates.inc();
+
+        // Disables masked vectors and update the config
+        for (idx, vector) in vectors.iter().enumerate() {
+            if masked[idx] {
                 vector.disable(&self.vm.common.fd)?;
             }
-
-            self.vm.register_msi(vector, masked, msi_config)?;
-            self.vm
-                .set_gsi_routes()
-                .map_err(|err| std::io::Error::other(format!("MSI-X update: {err}")))?;
-
-            // Assign KVM_IRQFD after KVM_SET_GSI_ROUTING to avoid
-            // panic on kernel which does not have commit a80ced6ea514
-            // (KVM: SVM: fix panic on out-of-bounds guest IRQ).
-            if !masked {
-                vector.enable(&self.vm.common.fd)?;
-            }
-
-            return Ok(());
+            self.vm.register_msi(vector, masked[idx], msi_config[idx])?;
         }
 
-        Err(InterruptError::InvalidVectorIndex(index))
+        self.vm
+            .set_gsi_routes()
+            .map_err(|err| std::io::Error::other(format!("MSI-X update: {err}")))?;
+
+        // Enables unmasked. Must be done after set_gsi_routes to avoid panic on kernel
+        // which does not have commit a80ced6ea514 (KVM: SVM: fix panic on out-of-bounds guest IRQ).
+        for (idx, vector) in vectors.iter().enumerate() {
+            if !masked[idx] {
+                vector.enable(&self.vm.common.fd)?;
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -141,7 +141,6 @@ impl MsixVectorGroup {
         index: usize,
         msi_config: MsixVectorConfig,
         masked: bool,
-        set_gsi: bool,
     ) -> Result<(), InterruptError> {
         if let Some(vector) = self.vectors.get(index) {
             METRICS.interrupts.config_updates.inc();
@@ -153,11 +152,9 @@ impl MsixVectorGroup {
             }
 
             self.vm.register_msi(vector, masked, msi_config)?;
-            if set_gsi {
-                self.vm
-                    .set_gsi_routes()
-                    .map_err(|err| std::io::Error::other(format!("MSI-X update: {err}")))?
-            }
+            self.vm
+                .set_gsi_routes()
+                .map_err(|err| std::io::Error::other(format!("MSI-X update: {err}")))?;
 
             // Assign KVM_IRQFD after KVM_SET_GSI_ROUTING to avoid
             // panic on kernel which does not have commit a80ced6ea514

--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -102,15 +102,6 @@ impl MsixVectorGroup {
         u16::try_from(self.vectors.len()).unwrap()
     }
 
-    /// Enable the MSI-X vector group
-    pub fn enable(&self) -> Result<(), InterruptError> {
-        for route in &self.vectors {
-            route.enable(&self.vm.common.fd)?;
-        }
-
-        Ok(())
-    }
-
     /// Disable the MSI-X vector group
     pub fn disable(&self) -> Result<(), InterruptError> {
         for route in &self.vectors {

--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -9,6 +9,7 @@ use vmm_sys_util::eventfd::EventFd;
 
 use crate::logger::{IncMetric, METRICS, error};
 use crate::pci::PciSBDF;
+use crate::pci::msix::MsixTableEntry;
 use crate::snapshot::Persist;
 use crate::vstate::vm::KvmVm;
 
@@ -25,19 +26,6 @@ pub enum InterruptError {
     Kvm(#[from] kvm_ioctls::Error),
     /// Invalid vector index: {0}
     InvalidVectorIndex(usize),
-}
-
-/// Configuration data for an MSI-X interrupt.
-#[derive(Copy, Clone, Debug, Default)]
-pub struct MsixVectorConfig {
-    /// High address to delivery message signaled interrupt.
-    pub high_addr: u32,
-    /// Low address to delivery message signaled interrupt.
-    pub low_addr: u32,
-    /// Data to write to delivery message signaled interrupt.
-    pub data: u32,
-    /// Devid of the device to delivery message signaled interrupt.
-    pub devid: PciSBDF,
 }
 
 /// Type that describes an allocated interrupt
@@ -131,11 +119,11 @@ impl MsixVectorGroup {
     pub fn register(
         &self,
         index: usize,
-        msi_config: MsixVectorConfig,
-        masked: bool,
+        table_entry: &MsixTableEntry,
+        pci_sbdf: PciSBDF,
     ) -> Result<(), InterruptError> {
         if let Some(vector) = self.vectors.get(index) {
-            self.vm.register_msi(vector, masked, msi_config)?;
+            self.vm.register_msi(vector, table_entry, pci_sbdf)?;
             return Ok(());
         }
 
@@ -145,21 +133,25 @@ impl MsixVectorGroup {
     /// Update the MSI-X configuration for all vectors in the group
     pub fn update_batched(
         &self,
-        msi_config: &[MsixVectorConfig],
-        masked: &[bool],
+        msi_config: &[MsixTableEntry],
+        pci_sbdf: PciSBDF,
     ) -> Result<(), InterruptError> {
-        self.update_vectors(msi_config, masked, &self.vectors)
+        self.update_vectors(msi_config, &self.vectors, pci_sbdf)
     }
 
     /// Update the MSI-X configuration for a vector in the group
     pub fn update(
         &self,
         index: usize,
-        msi_config: MsixVectorConfig,
-        masked: bool,
+        table_entry: &MsixTableEntry,
+        pci_sbdf: PciSBDF,
     ) -> Result<(), InterruptError> {
         if let Some(vector) = self.vectors.get(index) {
-            self.update_vectors(&[msi_config], &[masked], std::slice::from_ref(vector))
+            self.update_vectors(
+                std::slice::from_ref(table_entry),
+                std::slice::from_ref(vector),
+                pci_sbdf,
+            )
         } else {
             Err(InterruptError::InvalidVectorIndex(index))
         }
@@ -168,21 +160,21 @@ impl MsixVectorGroup {
     /// Update the MSI-X configuration for the given vectors
     fn update_vectors(
         &self,
-        msi_config: &[MsixVectorConfig],
-        masked: &[bool],
+        table_entries: &[MsixTableEntry],
         vectors: &[MsixVector],
+        pci_sbdf: PciSBDF,
     ) -> Result<(), InterruptError> {
-        assert_eq!(msi_config.len(), vectors.len());
-        assert_eq!(masked.len(), vectors.len());
+        assert_eq!(table_entries.len(), vectors.len());
 
         METRICS.interrupts.config_updates.inc();
 
         // Disables masked vectors and update the config
         for (idx, vector) in vectors.iter().enumerate() {
-            if masked[idx] {
+            let table_entry = &table_entries[idx];
+            if table_entry.masked() {
                 vector.disable(&self.vm.common.fd)?;
             }
-            self.vm.register_msi(vector, masked[idx], msi_config[idx])?;
+            self.vm.register_msi(vector, table_entry, pci_sbdf)?;
         }
 
         self.vm
@@ -192,7 +184,7 @@ impl MsixVectorGroup {
         // Enables unmasked. Must be done after set_gsi_routes to avoid panic on kernel
         // which does not have commit a80ced6ea514 (KVM: SVM: fix panic on out-of-bounds guest IRQ).
         for (idx, vector) in vectors.iter().enumerate() {
-            if !masked[idx] {
+            if !table_entries[idx].masked() {
                 vector.enable(&self.vm.common.fd)?;
             }
         }

--- a/src/vmm/src/vstate/interrupts.rs
+++ b/src/vmm/src/vstate/interrupts.rs
@@ -126,6 +126,22 @@ impl MsixVectorGroup {
         self.vectors.get(index).map(|route| &route.event_fd)
     }
 
+    /// Registers the configuration of a vector in the group in the VM.
+    /// Note: this function doesn't set the GSI routes. Please do that separately, or use [update]/[update_batched].
+    pub fn register(
+        &self,
+        index: usize,
+        msi_config: MsixVectorConfig,
+        masked: bool,
+    ) -> Result<(), InterruptError> {
+        if let Some(vector) = self.vectors.get(index) {
+            self.vm.register_msi(vector, masked, msi_config)?;
+            return Ok(());
+        }
+
+        Err(InterruptError::InvalidVectorIndex(index))
+    }
+
     /// Update the MSI-X configuration for all vectors in the group
     pub fn update_batched(
         &self,

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -876,8 +876,15 @@ pub(crate) mod tests {
         assert_eq!(msix_group.num_vectors(), 4);
     }
 
+    /// Enable all vectors MSI-X vector group
+    pub fn enable_all_vectors(vector_group: &MsixVectorGroup) {
+        for route in &vector_group.vectors {
+            route.enable(&vector_group.vm.common.fd).unwrap();
+        }
+    }
+
     #[test]
-    fn test_msi_vector_group_enable_disable() {
+    fn test_msi_vector_group_disable() {
         let mut vm = setup_vm_with_memory(mib_to_bytes(128));
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
@@ -887,14 +894,8 @@ pub(crate) mod tests {
         for route in &msix_group.vectors {
             assert!(!route.enabled.load(Ordering::Acquire))
         }
-
-        // Enable works
-        msix_group.enable().unwrap();
-        for route in &msix_group.vectors {
-            assert!(route.enabled.load(Ordering::Acquire));
-        }
-        // Enabling an enabled group doesn't error out
-        msix_group.enable().unwrap();
+        // Enabling vectors
+        enable_all_vectors(&msix_group);
 
         // Disable works
         msix_group.disable().unwrap();
@@ -990,7 +991,7 @@ pub(crate) mod tests {
         }
 
         // Simply enabling the vectors should not update the registered IRQ routes
-        msix_group.enable().unwrap();
+        enable_all_vectors(&msix_group);
         for i in 0..4 {
             let gsi = crate::arch::GSI_MSI_START + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
@@ -1031,7 +1032,7 @@ pub(crate) mod tests {
         let vm = Arc::new(vm);
         let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
 
-        msix_group.enable().unwrap();
+        enable_all_vectors(&msix_group);
         let state = msix_group.save();
 
         // On the real restore path the allocator state omits MSI GSIs before devices replay

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -946,8 +946,8 @@ pub(crate) mod tests {
             data: 0x12,
             devid: PciSBDF::from(0xafa),
         };
-        msix_group.update(0, config, true, true).unwrap();
-        msix_group.update(4, config, true, true).unwrap_err();
+        msix_group.update(0, config, true).unwrap();
+        msix_group.update(4, config, true).unwrap_err();
     }
 
     #[test]
@@ -967,7 +967,7 @@ pub(crate) mod tests {
         };
         for i in 0..4 {
             config.data = 0x12 * i;
-            msix_group.update(i as usize, config, true, false).unwrap();
+            msix_group.update(i as usize, config, true).unwrap();
         }
 
         // All vectors should be disabled
@@ -1009,7 +1009,7 @@ pub(crate) mod tests {
 
         // Updating the config of a vector should enable its route (and only its route)
         config.data = 0;
-        msix_group.update(0, config, false, true).unwrap();
+        msix_group.update(0, config, false).unwrap();
         for i in 0..4 {
             let gsi = crate::arch::GSI_MSI_START + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
@@ -1094,7 +1094,7 @@ pub(crate) mod tests {
                 devid: PciSBDF::from(0xafa),
             };
             for i in 0..group.num_vectors() as usize {
-                group.update(i, config, false, true).unwrap();
+                group.update(i, config, false).unwrap();
             }
             assert_eq!(vm.common.interrupts.lock().unwrap().len(), 4);
         }

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -1005,15 +1005,22 @@ pub(crate) mod tests {
                 assert_eq!(kvm_route.entry.u.msi.address_lo, 0x13);
                 assert_eq!(kvm_route.entry.u.msi.data, 0x12 * i);
             }
+            assert!(
+                msix_group.vectors[i as usize]
+                    .enabled
+                    .load(Ordering::Acquire)
+            );
         }
+        msix_group.disable().unwrap();
 
-        // Updating the config of a vector should enable its route (and only its route)
+        // `update` and `register` will update the in-memory GSI config of its route (and only its route)
         msix_group.update(0, configs[0], false).unwrap();
+        msix_group.register(1, configs[1], false).unwrap();
         for i in 0..4 {
             let gsi = crate::arch::GSI_MSI_START + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
             let kvm_route = interrupts.get(&gsi).unwrap();
-            assert_eq!(kvm_route.masked, i != 0);
+            assert_eq!(kvm_route.masked, i >= 2);
             assert_eq!(kvm_route.entry.gsi, gsi);
             assert_eq!(kvm_route.entry.type_, KVM_IRQ_ROUTING_MSI);
             // SAFETY: because we know we setup MSI routes.
@@ -1022,6 +1029,13 @@ pub(crate) mod tests {
                 assert_eq!(kvm_route.entry.u.msi.address_lo, 0x13);
                 assert_eq!(kvm_route.entry.u.msi.data, 0x12 * i);
             }
+            // However, only `update` (first vector) will actually enable be enabled
+            assert_eq!(
+                msix_group.vectors[i as usize]
+                    .enabled
+                    .load(Ordering::Acquire),
+                i == 0,
+            );
         }
     }
 

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -959,16 +959,15 @@ pub(crate) mod tests {
         let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
 
         // Set some configuration for the vectors. Initially all are masked
-        let mut config = MsixVectorConfig {
+        let configs: [_; 4] = std::array::from_fn(|idx| MsixVectorConfig {
             high_addr: 0x42,
             low_addr: 0x13,
-            data: 0x12,
+            data: 0x12 * idx as u32,
             devid: PciSBDF::from(0xafa),
-        };
-        for i in 0..4 {
-            config.data = 0x12 * i;
-            msix_group.update(i as usize, config, true).unwrap();
-        }
+        });
+        msix_group
+            .update_batched(&configs, &[true, true, true, true])
+            .unwrap();
 
         // All vectors should be disabled
         for vector in &msix_group.vectors {
@@ -1008,8 +1007,7 @@ pub(crate) mod tests {
         }
 
         // Updating the config of a vector should enable its route (and only its route)
-        config.data = 0;
-        msix_group.update(0, config, false).unwrap();
+        msix_group.update(0, configs[0], false).unwrap();
         for i in 0..4 {
             let gsi = crate::arch::GSI_MSI_START + i;
             let interrupts = vm.common.interrupts.lock().unwrap();

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -962,7 +962,7 @@ pub(crate) mod tests {
         let configs: [_; 4] = std::array::from_fn(|idx| MsixVectorConfig {
             high_addr: 0x42,
             low_addr: 0x13,
-            data: 0x12 * idx as u32,
+            data: 0x12 * u32::try_from(idx).unwrap(),
             devid: PciSBDF::from(0xafa),
         });
         msix_group

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -29,10 +29,12 @@ use vmm_sys_util::terminal::Terminal;
 use crate::arch::{GSI_MSI_END, host_page_size};
 pub use crate::arch::{KvmVm, KvmVmError, VmState};
 use crate::logger::{debug, info};
+use crate::pci::PciSBDF;
+use crate::pci::msix::MsixTableEntry;
 use crate::persist::CreateSnapshotError;
 use crate::vmm_config::snapshot::SnapshotType;
 use crate::vstate::bus::Bus;
-use crate::vstate::interrupts::{InterruptError, MsixVector, MsixVectorConfig, MsixVectorGroup};
+use crate::vstate::interrupts::{InterruptError, MsixVector, MsixVectorGroup};
 use crate::vstate::kvm::Kvm;
 use crate::vstate::memory::{
     GuestMemoryExtension, GuestMemoryMmap, GuestMemoryRegion, GuestMemoryState, GuestRegionMmap,
@@ -668,28 +670,34 @@ impl KvmVm {
     pub fn register_msi(
         &self,
         route: &MsixVector,
-        masked: bool,
-        config: MsixVectorConfig,
+        table_entry: &MsixTableEntry,
+        pci_sbdf: PciSBDF,
     ) -> Result<(), errno::Error> {
         let mut entry = kvm_irq_routing_entry {
             gsi: route.gsi,
             type_: KVM_IRQ_ROUTING_MSI,
             ..Default::default()
         };
-        entry.u.msi.address_lo = config.low_addr;
-        entry.u.msi.address_hi = config.high_addr;
-        entry.u.msi.data = config.data;
+        entry.u.msi.address_lo = table_entry.msg_addr_lo;
+        entry.u.msi.address_hi = table_entry.msg_addr_hi;
+        entry.u.msi.data = table_entry.msg_data;
 
         if self.common.fd.check_extension(kvm_ioctls::Cap::MsiDevid) {
             entry.flags = KVM_MSI_VALID_DEVID;
-            entry.u.msi.__bindgen_anon_1.devid = config.devid.into();
+            entry.u.msi.__bindgen_anon_1.devid = pci_sbdf.into();
         }
 
         self.common
             .interrupts
             .lock()
             .expect("Poisoned lock")
-            .insert(route.gsi, RoutingEntry { entry, masked });
+            .insert(
+                route.gsi,
+                RoutingEntry {
+                    entry,
+                    masked: table_entry.masked(),
+                },
+            );
 
         Ok(())
     }
@@ -763,6 +771,7 @@ fn mincore_bitmap(addr: *mut u8, len: usize) -> Result<Vec<u64>, VmError> {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::assert_matches;
     use std::sync::atomic::Ordering;
 
     use vm_memory::GuestAddress;
@@ -770,6 +779,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::arch;
     use crate::pci::PciSBDF;
+    use crate::pci::msix::MsixTableEntry;
     use crate::snapshot::Persist;
     use crate::test_utils::single_region_mem_raw;
     use crate::utils::mib_to_bytes;
@@ -941,14 +951,19 @@ pub(crate) mod tests {
         enable_irqchip(&mut vm);
         let vm = Arc::new(vm);
         let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
-        let config = MsixVectorConfig {
-            high_addr: 0x42,
-            low_addr: 0x12,
-            data: 0x12,
-            devid: PciSBDF::from(0xafa),
+        let sbdf = PciSBDF::from(0xafa);
+        let config = MsixTableEntry {
+            msg_addr_hi: 0x42,
+            msg_addr_lo: 0x12,
+            msg_data: 0x12,
+            // Masked
+            vector_ctl: 0x1,
         };
-        msix_group.update(0, config, true).unwrap();
-        msix_group.update(4, config, true).unwrap_err();
+        msix_group.update(0, &config, sbdf).unwrap();
+        assert_matches!(
+            msix_group.update(4, &config, sbdf),
+            Err(InterruptError::InvalidVectorIndex(4)),
+        );
     }
 
     #[test]
@@ -958,17 +973,16 @@ pub(crate) mod tests {
         let vm = Arc::new(vm);
         assert!(vm.common.interrupts.lock().unwrap().is_empty());
         let msix_group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
+        let pci_sbdf = PciSBDF::from(0xafa);
 
         // Set some configuration for the vectors. Initially all are masked
-        let configs: [_; 4] = std::array::from_fn(|idx| MsixVectorConfig {
-            high_addr: 0x42,
-            low_addr: 0x13,
-            data: 0x12 * u32::try_from(idx).unwrap(),
-            devid: PciSBDF::from(0xafa),
+        let configs: [_; 4] = std::array::from_fn(|idx| MsixTableEntry {
+            msg_addr_hi: 0x42,
+            msg_addr_lo: 0x13,
+            msg_data: 0x12 * u32::try_from(idx).unwrap(),
+            vector_ctl: 0x1, // Masked
         });
-        msix_group
-            .update_batched(&configs, &[true, true, true, true])
-            .unwrap();
+        msix_group.update_batched(&configs, pci_sbdf).unwrap();
 
         // All vectors should be disabled
         for vector in &msix_group.vectors {
@@ -1013,9 +1027,17 @@ pub(crate) mod tests {
         }
         msix_group.disable().unwrap();
 
+        let unmasked0 = MsixTableEntry {
+            vector_ctl: 0x0, // un-masked
+            ..configs[0].clone()
+        };
+        let unmasked1 = MsixTableEntry {
+            vector_ctl: 0x0, // un-masked
+            ..configs[1].clone()
+        };
         // `update` and `register` will update the in-memory GSI config of its route (and only its route)
-        msix_group.update(0, configs[0], false).unwrap();
-        msix_group.register(1, configs[1], false).unwrap();
+        msix_group.update(0, &unmasked0, pci_sbdf).unwrap();
+        msix_group.register(1, &unmasked1, pci_sbdf).unwrap();
         for i in 0..4 {
             let gsi = crate::arch::GSI_MSI_START + i;
             let interrupts = vm.common.interrupts.lock().unwrap();
@@ -1100,15 +1122,17 @@ pub(crate) mod tests {
         // table in the same state as before.
         {
             let group = KvmVm::create_msix_group(vm.clone(), 4).unwrap();
-            let config = MsixVectorConfig {
-                high_addr: 0x42,
-                low_addr: 0x13,
-                data: 0x12,
-                devid: PciSBDF::from(0xafa),
+            let table_entry = MsixTableEntry {
+                msg_addr_hi: 0x42,
+                msg_addr_lo: 0x13,
+                msg_data: 0x12,
+                // Unmasked
+                vector_ctl: 0x0,
             };
-            for i in 0..group.num_vectors() as usize {
-                group.update(i, config, false).unwrap();
-            }
+            let table_entries = vec![table_entry.clone(); 4];
+            group
+                .update_batched(&table_entries, PciSBDF::from(0xafa))
+                .unwrap();
             assert_eq!(vm.common.interrupts.lock().unwrap().len(), 4);
         }
 


### PR DESCRIPTION
## Changes

This PR reduces the calls to `set_gsi_routes`, to a single call per VM restore and for `set_msg_ctl`.

More precisely:
 - It's impossible to not update the GSI on `MsixVectorGroup.update`. The input combination `masked:false, set_gsi:false` was wrong and could lead to panic.  A new function `MsixVectorGroup.register` is introduced for callers not interested in updating the GSI routes.
 - updating the vector configuration is now done either in bulk for all vectors of a device (with a new `update_batched` function), or once for all devices (with the new `register` + `enable_unmasked_vectors`).
 - Metric changes (old behavior could easily be implemented, but I feel like counting like this makes more sense):
   - the `interrupts.config_updates` metric now is not updated on restore
   - the `interrupts.config_updates` metric is incremented once per device in `update_batched` (rather than once per vector)

## Reason

Snapshot restore latency with 250 concurrent restores (with 12 PCIe device per VM):

```
  ┌──────┬──────────┬──────────┬────────┐
  │ Stat │ Baseline │ Current  │ Change │
  ├──────┼──────────┼──────────┼────────┤
  │ Mean │ 313.7 ms │ 163.9 ms │ -47.8% │
  ├──────┼──────────┼──────────┼────────┤
  │ P50  │ 316.2 ms │ 146.0 ms │ -53.8% │
  ├──────┼──────────┼──────────┼────────┤
  │ P90  │ 516.6 ms │ 342.8 ms │ -33.6% │
  ├──────┼──────────┼──────────┼────────┤
  │ P99  │ 605.7 ms │ 387.7 ms │ -36.0% │
  └──────┴──────────┴──────────┴────────┘
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
