### PR TITLE
fix(logger): use an RwLock so a signal handler can log without deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and this project adheres to
   Terminating a connection now also discards its TX buffer, so the device stops
   advertising `EPOLLOUT` for a host stream it will never write to again, which
   could otherwise busy-spin the event thread indefinitely.
+- [#6086](https://github.com/firecracker-microvm/firecracker/pull/6086): Fixed a
+  potential deadlock in the logger: a signal handler that logs while the
+  interrupted thread already held the logger lock would re-acquire it and hang
+  the VMM. The logger now uses an `RwLock` so logging takes a shared lock that a
+  nested (signal-handler) log can re-acquire without blocking.
 
 ## [1.16.1]
 

--- a/src/vmm/src/logger/logging.rs
+++ b/src/vmm/src/logger/logging.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{OnceLock, RwLock};
 use std::thread;
 
 use log::{Log, Metadata, Record};
@@ -26,7 +26,7 @@ pub static INSTANCE_ID: OnceLock<String> = OnceLock::new();
 /// The logger.
 ///
 /// Default values matching the swagger specification (`src/firecracker/swagger/firecracker.yaml`).
-pub static LOGGER: Logger = Logger(Mutex::new(LoggerConfiguration {
+pub static LOGGER: Logger = Logger(RwLock::new(LoggerConfiguration {
     target: None,
     filter: LogFilter { module: None },
     format: LogFormat {
@@ -62,7 +62,7 @@ impl Logger {
             .transpose()
             .map_err(LoggerUpdateError)?;
 
-        let mut guard = self.0.lock().unwrap();
+        let mut guard = self.0.write().unwrap();
         log::set_max_level(
             config
                 .level
@@ -86,10 +86,6 @@ impl Logger {
             guard.filter.module = Some(module);
         }
 
-        // Ensure we drop the guard before attempting to log, otherwise this
-        // would deadlock.
-        drop(guard);
-
         Ok(())
     }
 }
@@ -109,8 +105,13 @@ pub struct LoggerConfiguration {
     pub filter: LogFilter,
     pub format: LogFormat,
 }
+/// An RwLock lets log() take a read lock, which a signal handler that logs can
+/// re-acquire as a nested read. Only update() takes the write lock, and it runs
+/// pre-boot (the API rejects ConfigureLogger once the VM starts), so at runtime
+/// no writer blocks a read and a running VM cannot hang. A signal during a
+/// pre-boot update() can still block.
 #[derive(Debug)]
-pub struct Logger(pub Mutex<LoggerConfiguration>);
+pub struct Logger(pub RwLock<LoggerConfiguration>);
 
 impl Log for Logger {
     // No additional filters to <https://docs.rs/log/latest/log/fn.max_level.html>.
@@ -119,8 +120,7 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &Record) {
-        // Lock the logger.
-        let mut guard = self.0.lock().unwrap();
+        let guard = self.0.read().unwrap();
 
         // Check if the log message is enabled
         {
@@ -165,7 +165,10 @@ impl Log for Logger {
                 record.args()
             );
 
-            let result = if let Some(file) = &mut guard.target {
+            // Write through a shared &File so a read lock suffices; write_all
+            // needs &mut on the reference, not the File. One write_all per line
+            // keeps output atomic.
+            let result = if let Some(mut file) = guard.target.as_ref() {
                 file.write_all(message.as_bytes())
             } else {
                 std::io::stdout().write_all(message.as_bytes())
@@ -366,7 +369,7 @@ mod tests {
             .unwrap();
 
         // Create logger.
-        let logger = Logger(Mutex::new(LoggerConfiguration {
+        let logger = Logger(RwLock::new(LoggerConfiguration {
             target: Some(target),
             filter: LogFilter {
                 module: Some(String::from("module")),
@@ -409,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_logger_update_with_log_path() {
-        let logger = Logger(Mutex::new(LoggerConfiguration {
+        let logger = Logger(RwLock::new(LoggerConfiguration {
             target: None,
             filter: LogFilter { module: None },
             format: LogFormat {
@@ -428,6 +431,6 @@ mod tests {
                 module: None,
             })
             .unwrap();
-        assert!(logger.0.lock().unwrap().target.is_some());
+        assert!(logger.0.read().unwrap().target.is_some());
     }
 }


### PR DESCRIPTION
## Changes

Change the global logger from a `Mutex<LoggerConfiguration>` to an
`RwLock<LoggerConfiguration>`. `Logger::log` now takes a read lock (logging only
reads the configuration); `Logger::update` takes the write lock. `log()` writes
the line to the target through a shared `&File` (via `impl Write for &File`), so
the hot path needs no exclusive lock.

## Reason

`Logger::log` acquired the logger `Mutex` with a blocking `lock()`. Firecracker
installs signal handlers that log: the `SIGPIPE` handler, for one, calls
`error_unrestricted!`. Deliver such a signal to a thread already inside
`Logger::log` holding the lock, and the handler's log call tries to re-acquire
the same non-reentrant mutex and deadlocks. The interrupted thread parks in
`futex` forever, and every other thread that then logs blocks behind it, so the
whole VMM hangs. A tight `kill(SIGPIPE)` loop against a running microVM (1ms
between signals) reproduces the hang.

Logging needs only read access to the configuration, so an `RwLock` lets a
nested log from a signal handler take another shared read lock instead of
blocking on itself. Concurrent loggers no longer serialize on the lock, which
changes write atomicity: the `Mutex` held an exclusive lock across the whole
write, so lines could never interleave on any target. Now each thread writes
under a shared guard.

For a regular-file target this is still fully atomic (POSIX.1-2008 2.9.7; Linux
>= 3.14), so nothing changes there. For a pipe/FIFO target, a single `write` of
a whole line is atomic up to `PIPE_BUF` (`pipe(7)`), and Firecracker log lines
are short, so a line normally lands in one atomic `write`. The case that can
fragment or interleave is a pipe whose reader has stalled long enough to fill
it: the fd is `O_NONBLOCK`, so a full pipe yields a partial write followed by
`EAGAIN`, `write_all` drops the rest (bumping `missed_log_count`), and a
concurrent logger's bytes can land in the gap. That is an acceptable trade
against a whole-VMM deadlock: it needs a stuck log consumer, and it never blocks
or hangs the VMM.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
