### PR TITLE
[bar-reloc 1/12] pci_mngr: Fix attach vs reset deadlock by releasing allocator lock early

### DIFF
--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -3,7 +3,6 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
 
 use event_manager::{MutEventSubscriber, SubscriberOps};
@@ -143,11 +142,10 @@ impl PciDevices {
         let mut virtio_device =
             VirtioPciDevice::new(id.clone(), mem, device, Arc::new(msix_vectors), sbdf);
 
-        // Allocate bars
-        let mut resource_allocator_lock = vm.resource_allocator();
-        let resource_allocator = resource_allocator_lock.deref_mut();
-
-        virtio_device.allocate_bars(&mut resource_allocator.mmio64_memory);
+        // Don't hold the resource allocator lock across attach_common()
+        // below: a device access holds the bus lock and can take the allocator
+        // lock, so the reverse order can deadlock.
+        virtio_device.allocate_bars(&mut vm.resource_allocator().mmio64_memory);
 
         let virtio_device = Arc::new(Mutex::new(virtio_device));
 


### PR DESCRIPTION
attach_pci_virtio_device() binds the resource allocator lock to a local
that lives until the end of the function, so it is still held across
attach_common(), which inserts the device's BAR mapping into the
mmio_bus. That is the resource allocator lock taken before the mmio_bus
lock.

Since the bus holds its read lock for the duration of a device access, a
device access can take the two locks in the opposite order: a guest MMIO
access that resets a virtio-pci device runs under the mmio_bus read lock
and calls reset_msix() -> KvmVm::create_msix_group(), which allocates
from the resource allocator. A device hotplug concurrent with a guest
resetting an existing device therefore deadlocks (ABBA).

Hold the resource allocator lock only for as long as allocating the BARs
needs it, so it is released before any bus is touched. This is
independent of BAR relocation, which later adds another mmio_bus ->
resource allocator path.

Fixes: 548d79224525 ("bus: hold the read lock during device accesses")
Signed-off-by: Ilias Stamatis <ilstam@amazon.com>
