### PR TITLE
[bar-reloc 4/12] vstate: bus: Add Bus::move_range() to relocate a device mapping

### DIFF
--- a/src/vmm/src/vstate/bus.rs
+++ b/src/vmm/src/vstate/bus.rs
@@ -209,6 +209,36 @@ impl Bus {
         Ok(f(&mut *locked, base, offset))
     }
 
+    /// Relocate an existing device mapping from `old_base` to `new_base`.
+    /// Only the `ranges` lock is taken, not the `devices` lock.
+    pub fn move_range(&self, old_base: u64, new_base: u64, len: u64) -> Result<(), BusError> {
+        let old_range = BusRange::new(old_base, len)?;
+        let new_range = BusRange::new(new_base, len)?;
+
+        let mut ranges = self.ranges.write().unwrap();
+
+        // Remove first because the new range might overlap the old range
+        let (registered, slot) = ranges
+            .remove_entry(&old_range)
+            .ok_or(BusError::MissingAddressRange)?;
+
+        assert_eq!(
+            registered.end(),
+            old_range.end(),
+            "Bus mapping at {old_base:#x} is registered with length {}, not {len}",
+            registered.end() - registered.base() + 1
+        );
+
+        // Reject if the destination overlaps another device
+        if ranges.keys().any(|range| range.overlaps(&new_range)) {
+            ranges.insert(old_range, slot);
+            return Err(BusError::Overlap);
+        }
+
+        ranges.insert(new_range, slot);
+        Ok(())
+    }
+
     /// Reads data from the device that owns the range containing `addr` and puts it into `data`.
     ///
     /// Returns true on success, otherwise `data` is untouched.
@@ -391,6 +421,68 @@ mod tests {
         bus.insert(dummy.clone(), 0x13, 0x12).unwrap();
         bus.remove(0x42, 0x42).unwrap_err();
         bus.remove(0x13, 0x12).unwrap();
+    }
+
+    #[test]
+    fn bus_move_range() {
+        let bus = Bus::new();
+        let dev = Arc::new(Mutex::new(ConstantDevice));
+        bus.insert(dev.clone(), 0x10, 0x10).unwrap();
+
+        // A zero length is rejected before the mapping is touched.
+        assert!(matches!(
+            bus.move_range(0x10, 0x30, 0),
+            Err(BusError::ZeroSizedRange)
+        ));
+
+        // Moving a range that is not registered fails and leaves the bus untouched.
+        assert!(matches!(
+            bus.move_range(0x2000, 0x3000, 0x10),
+            Err(BusError::MissingAddressRange)
+        ));
+
+        // The device is reachable at its original base but not at the target.
+        bus.read(0x10, &mut [0; 4]).unwrap();
+        bus.read(0x30, &mut [0; 4]).unwrap_err();
+
+        // Relocate the mapping; reads now resolve at the new base and the
+        // ConstantDevice still answers relative to the (new) range base.
+        bus.move_range(0x10, 0x30, 0x10).unwrap();
+        bus.read(0x10, &mut [0; 4]).unwrap_err();
+        let mut values = [0, 1, 2, 3];
+        bus.read(0x35, &mut values).unwrap();
+        assert_eq!(values, [5, 6, 7, 8]);
+
+        // Moving a mapping onto its own base is a no-op.
+        bus.move_range(0x30, 0x30, 0x10).unwrap();
+        bus.read(0x35, &mut [0; 4]).unwrap();
+
+        // A destination overlapping the source is accepted, because the old
+        // range is removed before the overlap check runs.
+        bus.move_range(0x30, 0x38, 0x10).unwrap();
+        bus.read(0x30, &mut [0; 4]).unwrap_err();
+        let mut values = [0, 1, 2, 3];
+        bus.read(0x3d, &mut values).unwrap();
+        assert_eq!(values, [5, 6, 7, 8]);
+
+        // A move onto a range occupied by another device is rejected, and the
+        // source mapping is left in place so nothing is lost.
+        bus.insert(dev.clone(), 0x10, 0x10).unwrap();
+        assert!(matches!(
+            bus.move_range(0x38, 0x18, 0x10),
+            Err(BusError::Overlap)
+        ));
+        bus.read(0x3d, &mut [0; 4]).unwrap();
+        bus.read(0x15, &mut [0; 4]).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "is registered with length")]
+    fn bus_move_range_wrong_len() {
+        let bus = Bus::new();
+        let dev = Arc::new(Mutex::new(DummyDevice));
+        bus.insert(dev, 0x10, 0x10).unwrap();
+        let _ = bus.move_range(0x10, 0x30, 0x20);
     }
 
     #[test]


### PR DESCRIPTION
Add a Bus::move_range() function to relocate a device mapping. This will
be used in a subsequent patch to support BAR relocation.

Signed-off-by: Ilias Stamatis <ilstam@amazon.com>
