### PR TITLE
[bar-reloc 5/12] pci: Pass the BAR address to set_notification_ioevents()

### DIFF
--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -640,8 +640,12 @@ impl VirtioPciDevice {
         !self.device_activated.load(Ordering::SeqCst) && self.is_driver_ready()
     }
 
-    fn set_notification_ioevents(&self, vm: &KvmVm, assign: bool) -> Result<(), errno::Error> {
-        let bar_addr = self.config_bar_addr();
+    fn set_notification_ioevents(
+        &self,
+        vm: &KvmVm,
+        bar_addr: u64,
+        assign: bool,
+    ) -> Result<(), errno::Error> {
         for (i, queue_evt) in self
             .device
             .lock()
@@ -665,12 +669,12 @@ impl VirtioPciDevice {
 
     /// Register the IoEvent notifications for a VirtIO device.
     pub fn register_notification_ioevents(&self, vm: &KvmVm) -> Result<(), errno::Error> {
-        self.set_notification_ioevents(vm, true)
+        self.set_notification_ioevents(vm, self.config_bar_addr(), true)
     }
 
     /// Unregister the IoEvent notifications for a VirtIO device.
     pub fn unregister_notification_ioevents(&self, vm: &KvmVm) -> Result<(), errno::Error> {
-        self.set_notification_ioevents(vm, false)
+        self.set_notification_ioevents(vm, self.config_bar_addr(), false)
     }
 
     /// Tear down the MSI-X configuration. Used on device reset.


### PR DESCRIPTION
Make set_notification_ioevents take the BAR base address as an argument
instead of reading it from config_bar_addr() itself. This will be needed
in subsequent commits where the BAR address stored in the config space
doesn't necessarily match the address used when ioeventfds were
registered (during BAR relocation).

No functional change intended.

Signed-off-by: Ilias Stamatis <ilstam@amazon.com>
