### PR TITLE
[bar-reloc 6/12] pci: Add bar_address field to VirtioPciDevice

### DIFF
--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -88,7 +88,7 @@ impl PciDevices {
         virtio_device: Arc<Mutex<VirtioPciDevice>>,
         event_manager: &mut EventManager,
     ) -> Result<(), PciManagerError> {
-        let config_bar_addr = {
+        let bar_address = {
             let mut device = virtio_device.lock().unwrap();
 
             device.register_notification_ioevents(vm)?;
@@ -96,7 +96,7 @@ impl PciDevices {
             let sub_id = event_manager.add_subscriber(device.virtio_device());
             device.sub_id = Some(sub_id);
 
-            device.config_bar_addr()
+            device.bar_address()
         };
 
         self.virtio_devices
@@ -110,11 +110,11 @@ impl PciDevices {
 
         debug!(
             "Inserting MMIO BAR region: {:#x}:{:#x}",
-            config_bar_addr, CAPABILITY_BAR_SIZE
+            bar_address, CAPABILITY_BAR_SIZE
         );
         vm.common
             .mmio_bus
-            .insert(virtio_device.clone(), config_bar_addr, CAPABILITY_BAR_SIZE)?;
+            .insert(virtio_device.clone(), bar_address, CAPABILITY_BAR_SIZE)?;
 
         Ok(())
     }
@@ -187,7 +187,7 @@ impl PciDevices {
                 .unregister_notification_ioevents(vm)
                 .map_err(PciManagerError::Kvm)?;
             (
-                pci_device.config_bar_addr(),
+                pci_device.bar_address(),
                 pci_device.sbdf.device(),
                 pci_device.sub_id,
             )

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -244,6 +244,7 @@ pub struct VirtioPciDeviceState {
     pub msix_state: MsixConfigState,
     pub bars: Bars,
     pub msix_config_cap_offset: u16,
+    pub bar_address: u64,
 }
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -284,6 +285,16 @@ pub struct VirtioPciDevice {
 
     // Guest memory
     memory: GuestMemoryMmap,
+
+    // GPA base at which the capability BAR is currently mapped on the
+    // mmio bus, and where the notification ioeventfds are registered.
+    // 0 means unmapped
+    //
+    // It is not necessarily equal to `config_bar_addr()`: the latter reflects
+    // whatever the guest has last written into the BAR registers, which may be
+    // transient (a 64-bit BAR is programmed with two separate writes) or not
+    // yet in effect.
+    bar_address: u64,
 
     // Add a dedicated structure to hold information about the very specific
     // virtio-pci capability VIRTIO_PCI_CAP_PCI_CFG. This is needed to support
@@ -347,7 +358,7 @@ impl VirtioPciDevice {
 
         // Allocate the virtio-pci capability BAR.
         // See http://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html#x1-740004
-        let virtio_pci_bar_addr = mmio64_allocator
+        self.bar_address = mmio64_allocator
             .allocate(
                 CAPABILITY_BAR_SIZE,
                 CAPABILITY_BAR_SIZE,
@@ -357,7 +368,7 @@ impl VirtioPciDevice {
             .start();
         self.bars.set_bar_64(
             VIRTIO_BAR_INDEX,
-            virtio_pci_bar_addr,
+            self.bar_address,
             CAPABILITY_BAR_SIZE,
             BarPrefetchable::No,
         );
@@ -407,6 +418,7 @@ impl VirtioPciDevice {
             device_activated: Arc::new(AtomicBool::new(false)),
             virtio_interrupt: Some(interrupt),
             memory,
+            bar_address: 0,
             cap_pci_cfg_info: VirtioPciCfgCapInfo::default(),
             bars: Bars::default(),
             msix_config,
@@ -475,6 +487,7 @@ impl VirtioPciDevice {
             device_activated: Arc::new(AtomicBool::new(state.device_activated)),
             virtio_interrupt: Some(interrupt),
             memory: vm.guest_memory().clone(),
+            bar_address: state.bar_address,
             cap_pci_cfg_info,
             bars: state.bars,
             msix_config,
@@ -515,8 +528,19 @@ impl VirtioPciDevice {
         self.common_config.driver_status == INIT
     }
 
+    /// GPA base currently written in the BAR register.
+    ///
+    /// Might be different from bar_address() during BAR relocation.
     pub fn config_bar_addr(&self) -> u64 {
         self.bars.get_bar_addr_64(VIRTIO_BAR_INDEX)
+    }
+
+    /// GPA base at which the capability BAR is currently mapped on the
+    /// mmio bus, and where the notification ioeventfds are registered.
+    ///
+    /// Might be different from config_bar_addr() during BAR relocation.
+    pub fn bar_address(&self) -> u64 {
+        self.bar_address
     }
 
     fn add_pci_capabilities(&mut self) {
@@ -669,12 +693,12 @@ impl VirtioPciDevice {
 
     /// Register the IoEvent notifications for a VirtIO device.
     pub fn register_notification_ioevents(&self, vm: &KvmVm) -> Result<(), errno::Error> {
-        self.set_notification_ioevents(vm, self.config_bar_addr(), true)
+        self.set_notification_ioevents(vm, self.bar_address, true)
     }
 
     /// Unregister the IoEvent notifications for a VirtIO device.
     pub fn unregister_notification_ioevents(&self, vm: &KvmVm) -> Result<(), errno::Error> {
-        self.set_notification_ioevents(vm, self.config_bar_addr(), false)
+        self.set_notification_ioevents(vm, self.bar_address, false)
     }
 
     /// Tear down the MSI-X configuration. Used on device reset.
@@ -757,6 +781,7 @@ impl VirtioPciDevice {
                 .state(),
             bars: self.bars,
             msix_config_cap_offset: self.msix_config_cap_offset,
+            bar_address: self.bar_address,
         }
     }
 }


### PR DESCRIPTION
In preparation for BAR relocation, record the guest-physical base at
which the capability BAR is actually mapped on the mmio bus, separately
from the value held in the BAR registers (config_bar_addr()).
Registration, detach and the notification ioeventfds now key off this
tracked address.

Whatever the guest has last written into the BAR registers may be
transient (a 64-bit BAR is programmed with two separate writes) or not
yet in effect (the guest hasn't enabled memory accesses yet).

This is a non-functional change: the two are always equal today, since a
guest write to a BAR register is currently dropped. Tracking them
separately is what will let the mapping and its teardown stay correct
once the guest can reprogram the BAR.

Signed-off-by: Ilias Stamatis <ilstam@amazon.com>
