### PR TITLE
[bar-reloc 7/12] pci: Detach devices from the PCI bus first

### DIFF
--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -177,32 +177,33 @@ impl PciDevices {
             .remove(&device_id)
             .expect("device presence should be checked before detach");
 
+        let sbdf_device = pci_device_arc.lock().expect("Poisoned lock").sbdf.device();
+
+        // Remove the device from the PCI bus first. A config space access runs
+        // with the PCI bus lock held and can relocate the BAR, so afterwards
+        // the BAR address of the device can no longer change under us.
+        self.pci_segment
+            .pci_bus
+            .lock()
+            .expect("Poisoned lock")
+            .remove_device(sbdf_device);
+
         // Next operations of removing device from mmio_bus and pci_bus need to wait for any other
         // user of the device to finish. This requires us to not hold the lock for the device in
         // case someone will try to access the device while we are in these several lines of code.
-        let (bar_addr, sbdf_device, sub_id) = {
+        let (bar_addr, sub_id) = {
             let pci_device = pci_device_arc.lock().expect("Poisoned lock");
 
             pci_device
                 .unregister_notification_ioevents(vm)
                 .map_err(PciManagerError::Kvm)?;
-            (
-                pci_device.bar_address(),
-                pci_device.sbdf.device(),
-                pci_device.sub_id,
-            )
+            (pci_device.bar_address(), pci_device.sub_id)
         };
 
         vm.common
             .mmio_bus
             .remove(bar_addr, CAPABILITY_BAR_SIZE)
             .map_err(PciManagerError::Bus)?;
-
-        self.pci_segment
-            .pci_bus
-            .lock()
-            .expect("Poisoned lock")
-            .remove_device(sbdf_device);
 
         if let Some(sub_id) = sub_id
             && event_manager.remove_subscriber(sub_id).is_err()


### PR DESCRIPTION
detach_pci_virtio_device() releases the device lock before removing the
device from the mmio bus, so that Bus::remove() can wait for any
in-flight access to the device to finish. That means the BAR address
read inside that scope is used after the lock is dropped.

Once we allow the guest to reprogram the BAR, that address becomes
mutable guest-controlled state: a vCPU doing a config space write can
relocate the mapping in that window, and mmio_bus.remove() would then
fail with MissingAddressRange, leaving the device registered on both
buses with no way to ever detach it.

Remove the device from the PCI bus before touching the mmio bus. Config
space accesses run with the PCI bus lock held for their whole duration,
so remove_device() waits for any in-flight access to complete and no new
one can reach the device afterwards, which keeps its BAR address stable
for the rest of the detach.

Signed-off-by: Ilias Stamatis <ilstam@amazon.com>
