### PR TITLE
[bar-reloc 2/5] seccomp: Allow KVM_IOEVENTFD on the vCPU thread for BAR relocation

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -1235,6 +1235,19 @@
             },
             {
                 "syscall": "ioctl",
+                "comment": "Needed to relocate notify ioeventfds when the guest reprograms a BAR",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1077980793,
+                        "comment": "KVM_IOEVENTFD"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
                 "args": [
                     {
                         "index": 1,

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -1247,6 +1247,19 @@
             },
             {
                 "syscall": "ioctl",
+                "comment": "Needed to relocate notify ioeventfds when the guest reprograms a BAR",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1077980793,
+                        "comment": "KVM_IOEVENTFD"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
                 "args": [
                     {
                         "index": 1,


### PR DESCRIPTION
Relocating a PCI BAR moves the device's notify ioeventfds, which happens
on the vCPU thread while it handles the config-space write that enables
memory decoding. Allow KVM_IOEVENTFD on the vCPU thread on both x86_64
and aarch64. This is in preparation for a subsequent patch that will add
support for BAR relocation.

Signed-off-by: Ilias Stamatis <ilstam@amazon.com>
