### PR TITLE
[bar-reloc 3/5] pci: Support virtio-pci BAR relocation

### DIFF
--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -128,7 +128,6 @@ impl PciDevices {
     ) -> Result<(), PciManagerError> {
         let sbdf = self.pci_segment.next_device_sbdf()?;
         debug!("Allocating SBDF: {sbdf:?} for device");
-        let mem = vm.guest_memory().clone();
 
         let device_type = device.lock().expect("Poisoned lock").device_type();
 
@@ -140,7 +139,7 @@ impl PciDevices {
 
         // Create the transport
         let mut virtio_device =
-            VirtioPciDevice::new(id.clone(), mem, device, Arc::new(msix_vectors), sbdf);
+            VirtioPciDevice::new(id.clone(), vm, device, Arc::new(msix_vectors), sbdf);
 
         // Don't hold the resource allocator lock across attach_common()
         // below: a device access holds the bus lock and can take the allocator

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -44,7 +44,6 @@ use crate::pci::{
 use crate::snapshot::Persist;
 use crate::vstate::bus::BusDevice;
 use crate::vstate::interrupts::{InterruptError, MsixVectorGroup};
-use crate::vstate::memory::GuestMemoryMmap;
 use crate::vstate::vm::KvmVm;
 
 /// Vector value used to disable MSI for a queue.
@@ -228,6 +227,11 @@ const MSIX_PBA_SIZE: u32 = 0x800;
 /// The BAR size must be a power of 2.
 pub const CAPABILITY_BAR_SIZE: u64 = 0x80000;
 
+/// PCI configuration register index of the Command/Status DWORD.
+const COMMAND_REG: u16 = 1;
+/// Command register "Memory Space Enable" bit
+const COMMAND_MEMORY_SPACE_ENABLE: u32 = 0x0000_0002;
+
 const NOTIFY_OFF_MULTIPLIER: u32 = 4; // A dword per notification address.
 
 const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;
@@ -283,8 +287,7 @@ pub struct VirtioPciDevice {
     // PCI interrupts.
     virtio_interrupt: Option<Arc<VirtioInterruptMsix>>,
 
-    // Guest memory
-    memory: GuestMemoryMmap,
+    vm: Arc<KvmVm>,
 
     // GPA base at which the capability BAR is currently mapped on the
     // mmio bus, and where the notification ioeventfds are registered.
@@ -392,7 +395,7 @@ impl VirtioPciDevice {
     /// Constructs a new PCI transport for the given virtio device.
     pub fn new(
         id: String,
-        memory: GuestMemoryMmap,
+        vm: &Arc<KvmVm>,
         device: Arc<Mutex<dyn VirtioDevice>>,
         msix_vectors: Arc<MsixVectorGroup>,
         sbdf: PciSBDF,
@@ -431,7 +434,7 @@ impl VirtioPciDevice {
             device,
             device_activated: Arc::new(AtomicBool::new(false)),
             virtio_interrupt: Some(interrupt),
-            memory,
+            vm: vm.clone(),
             bar_address: 0,
             cap_pci_cfg_info: VirtioPciCfgCapInfo::default(),
             bars: Bars::default(),
@@ -500,7 +503,7 @@ impl VirtioPciDevice {
             device,
             device_activated: Arc::new(AtomicBool::new(state.device_activated)),
             virtio_interrupt: Some(interrupt),
-            memory: vm.guest_memory().clone(),
+            vm: vm.clone(),
             bar_address: state.bar_address,
             cap_pci_cfg_info,
             bars: state.bars,
@@ -514,7 +517,7 @@ impl VirtioPciDevice {
                 .lock()
                 .expect("Poisoned lock")
                 .activate(
-                    virtio_pci_device.memory.clone(),
+                    virtio_pci_device.vm.guest_memory().clone(),
                     virtio_pci_device.virtio_interrupt.as_ref().unwrap().clone(),
                 );
         }
@@ -703,6 +706,77 @@ impl VirtioPciDevice {
             }
         }
         Ok(())
+    }
+
+    /// Return true if the guest has enabled memory-space decoding for this
+    /// device in the command register.
+    fn memory_space_enabled(&self) -> bool {
+        self.configuration.read_reg(COMMAND_REG) & COMMAND_MEMORY_SPACE_ENABLE != 0
+    }
+
+    /// Relocate the PCI bar if a new address was written to the registers
+    fn maybe_relocate_bar(&mut self) {
+        let old_base = self.bar_address;
+        let new_base = self.config_bar_addr();
+        if new_base == old_base {
+            return;
+        }
+
+        // Try to allocate the new range from the resource allocator.
+        let new_range = match self.vm.resource_allocator().mmio64_memory.allocate(
+            CAPABILITY_BAR_SIZE,
+            CAPABILITY_BAR_SIZE,
+            AllocPolicy::ExactMatch(new_base),
+        ) {
+            Ok(range) => range,
+            Err(err) => {
+                error!("Cannot reserve relocated BAR range at {new_base:#x}: {err:?}");
+                return;
+            }
+        };
+
+        // Register the new notification ioeventfds first. If this fails
+        // nothing has moved yet, so the device keeps working at its old base.
+        if let Err(err) = self.set_notification_ioevents(&self.vm, new_base, true) {
+            error!("Failed to add notification ioeventfds at {new_base:#x}: {err:?}");
+            // set_notification_ioevents() might leave some ioeventfds
+            // registered in case of failure. Do not return the possibly
+            // "poisoned" address range to the mmio64_allocator.
+            return;
+        }
+
+        if let Err(err) =
+            self.vm
+                .common
+                .mmio_bus
+                .move_range(old_base, new_base, CAPABILITY_BAR_SIZE)
+        {
+            error!("Failed to relocate BAR mapping {old_base:#x} -> {new_base:#x}: {err:?}");
+            if let Err(err) = self.set_notification_ioevents(&self.vm, new_base, false) {
+                error!("Failed to remove notification ioeventfds at {new_base:#x}: {err:?}");
+                // As above, only release the old range if it has no ioeventfds left.
+            } else {
+                let _ = self.vm.resource_allocator().mmio64_memory.free(&new_range);
+            }
+            return;
+        }
+
+        if let Err(err) = self.set_notification_ioevents(&self.vm, old_base, false) {
+            // As above, only release the old range if it has no ioeventfds left.
+            error!("Failed to remove old notification ioeventfds at {old_base:#x}: {err:?}");
+        } else {
+            // SAFETY: old_base was allocated from the resource allocator, comes
+            // from a previous relocation which validated it, or comes from a
+            // snapshot, which is trusted. So the range is always valid.
+            let old_end = old_base
+                .checked_add(CAPABILITY_BAR_SIZE - 1)
+                .expect("BAR end address overflows");
+            let old_range = RangeInclusive::new(old_base, old_end).expect("Invalid BAR range");
+            let _ = self.vm.resource_allocator().mmio64_memory.free(&old_range);
+        }
+
+        self.bar_address = new_base;
+        debug!("Relocated virtio-pci BAR mapping {old_base:#x} -> {new_base:#x}");
     }
 
     /// Register the IoEvent notifications for a VirtIO device.
@@ -923,8 +997,12 @@ impl PciDevice for VirtioPciDevice {
             let offset = (reg_idx * 4 + u16::from(offset) - self.cap_pci_cfg_info.offset) as usize;
             self.write_cap_pci_cfg(offset, data)
         } else {
+            let mem_enabled_before = self.memory_space_enabled();
             self.configuration
                 .write_config_register(reg_idx, offset, data);
+            if !mem_enabled_before && self.memory_space_enabled() {
+                self.maybe_relocate_bar();
+            }
             None
         }
     }
@@ -1081,7 +1159,7 @@ impl PciDevice for VirtioPciDevice {
             let interrupt = Arc::clone(self.virtio_interrupt.as_ref().unwrap());
             let device = self.virtio_device();
             let mut locked_device = device.lock().unwrap();
-            match locked_device.activate(self.memory.clone(), interrupt.clone()) {
+            match locked_device.activate(self.vm.guest_memory().clone(), interrupt.clone()) {
                 Ok(()) => {
                     self.device_activated.store(true, Ordering::SeqCst);
 

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -7,7 +7,7 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::IntoBytes;
 
 use crate::logger::warn;
 use crate::pci::{PciCapabilityId, PciClassCode};
@@ -68,8 +68,6 @@ pub struct Bar {
     pub encoded_addr: u32,
     /// Encoded size value of the register (according to PCI rules of size encoding).
     pub encoded_size: u32,
-    /// Indicator if the register was prepared to be read as the `size` instead of `addr`
-    pub about_to_be_read: bool,
 }
 
 impl Bar {
@@ -210,36 +208,30 @@ impl Bars {
         // There are only 6 registers each 4 bytes long
         assert!(bar_idx < NUM_BAR_REGS);
         assert!(offset as usize + data.len() <= 4);
-        if let Ok(value) = u32::read_from_bytes(data)
-            && value == 0xffff_ffff
-        {
-            self.bars[bar_idx as usize].about_to_be_read = true;
-        } else {
-            self.bars[bar_idx as usize].about_to_be_read = false;
-            // There is no BAR relocation support as of right now.
-            // PCI specification does not provide a way for a device to
-            // tell the driver that it does not support BAR relocation, but
-            // linux kernel does check this at:
-            // https://elixir.bootlin.com/linux/v6.19.8/source/drivers/pci/setup-res.c#L107
-        }
+
+        let bar = &mut self.bars[bar_idx as usize];
+
+        // Note that the actual BAR relocation takes effect when the guest
+        // enables memory-space decoding in the command register. This is
+        // because updating a 64-bit BAR requires more than one write.
+        // See maybe_relocate_bar().
+        let mut reg = bar.encoded_addr.to_le_bytes();
+        reg[offset as usize..][..data.len()].copy_from_slice(data);
+        let value = u32::from_le_bytes(reg);
+        // The address needs to be aligned to the BAR size. The low bits of the
+        // BAR corresponding to the size/alignment are non-writable. For
+        // example, if the BAR size is 2MiB, the last 20 bits are non-writable.
+        let writable = bar.encoded_size;
+        bar.encoded_addr = (value & writable) | (bar.encoded_addr & !writable);
     }
 
     /// Reads from a given BAR register at the given offset
-    pub fn read(&mut self, bar_idx: u8, offset: u8, data: &mut [u8]) {
+    pub fn read(&self, bar_idx: u8, offset: u8, data: &mut [u8]) {
         // There are only 6 registers each 4 bytes long
         assert!(bar_idx < NUM_BAR_REGS);
         assert!(offset as usize + data.len() <= 4);
-        let bar = &mut self.bars[bar_idx as usize];
-        let bytes = if bar.about_to_be_read {
-            // This technically allows for an inconsistent behaviour where the guest would read
-            // only a part of the `size` of the BAR on the first read, but will get `addr` bytes
-            // on following reads. Any sane driver will read the whole register, so this should
-            // not be an issue. This will be fixed once we support BAR relocation/resizing.
-            bar.about_to_be_read = false;
-            bar.encoded_size.as_bytes()
-        } else {
-            bar.encoded_addr.as_bytes()
-        };
+        let bar = &self.bars[bar_idx as usize];
+        let bytes = bar.encoded_addr.as_bytes();
         data.copy_from_slice(&bytes[offset as usize..][..data.len()]);
     }
 }


### PR DESCRIPTION
A guest write reprogramming a virtio-pci BAR used to be dropped: the
device's mmio mapping stayed at the address Firecracker chose at attach
time, so the guest could not move the BAR.

Store the guest-written address in the BAR register and when the guest
then enables memory-space decoding at a new base, relocate the mmio_bus
mapping and the notification ioeventfds to follow it.

Signed-off-by: Ilias Stamatis <ilstam@amazon.com>
