### PR TITLE
[Block] Add VIRTIO_BLK_F_TOPOLOGY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to
   unless the capability is enabled on the VM.
 - [#6145](https://github.com/firecracker-microvm/firecracker/pull/6145): Added
   official support for AWS Graviton5 (m9g.metal-48xl) instances.
+- [#6098](https://github.com/firecracker-microvm/firecracker/pull/6098): Added
+  new VIRTIO_BLK_F_BLK_SIZE and VIRTIO_BLK_F_TOPOLOGY features to the
+  virtio-block device. More information is in the new [block](docs/block.md)
+  documentation.
 
 ### Changed
 

--- a/docs/block.md
+++ b/docs/block.md
@@ -1,0 +1,364 @@
+# Using the Firecracker Virtio-block Device
+
+### Kernel config
+
+- Guest kernel config has: `CONFIG_VIRTIO_BLK=y`
+
+To confirm that the block device is exposed to the guest, run the following
+inside the guest:
+
+```bash
+ls /sys/class/block/
+```
+
+and confirm that a `vd<x>` entry (e.g. `vda`, `vdb`) exists for each drive
+attached to the microVM.
+
+Example guest kernel configuration that Firecracker uses in its CI can be found
+[here](../resources/guest_configs/).
+
+## Firecracker Virtio-block
+
+Firecracker implements the
+[virtio-blk device model](https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html#x1-2740002)
+as defined by the VirtIO specification. Each drive is backed by a file (or a
+block device) on the host and exposed to the guest as a `/dev/vd<x>` device.
+
+Drives are attached before the microVM boots via the `/drives/{drive_id}` API
+endpoint or configured through the config file. The first drive marked as
+`is_root_device` becomes `/dev/vda` in the guest; the remaining drives appear in
+the order they were configured.
+
+Host IO is performed either synchronously (via blocking `read`/`write`/`fsync`
+system calls) or asynchronously (via `io_uring`). The engine is selectable per
+drive; see [IO Engine](#io-engine).
+
+## Setting up the Virtio-block Device
+
+A drive requires at minimum a `drive_id`, a `path_on_host` and the
+`is_root_device` flag:
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i \
+  -X PUT 'http://localhost/drives/rootfs' \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+      "drive_id": "rootfs",
+      "path_on_host": "./rootfs.ext4",
+      "is_root_device": true,
+      "is_read_only": false
+  }'
+```
+
+The equivalent block in a JSON configuration file will look like this:
+
+```json
+"drives": [
+    {
+        "drive_id": "rootfs",
+        "path_on_host": "./rootfs.ext4",
+        "is_root_device": true,
+        "is_read_only": false
+    }
+]
+```
+
+The `path_on_host` must be readable (and writable, when `is_read_only` is
+`false`) by the Firecracker process.
+
+## Configuration Options
+
+### Caching Strategy
+
+The `cache_type` field on a drive controls whether guest flush requests are
+honoured by the host. Two values are accepted:
+
+- `Unsafe` (default) — the device does not advertise `VIRTIO_BLK_F_FLUSH`. Guest
+  flushes are ignored.
+- `Writeback` — the device advertises `VIRTIO_BLK_F_FLUSH`. Each guest flush
+  translates into an `fsync` on the backing file.
+
+See [block-caching.md](api_requests/block-caching.md) for more information.
+
+### IO Engine
+
+The `io_engine` field selects the host-side IO backend:
+
+- `Sync` (default) — blocking `read`/`write` syscalls.
+- `Async` — `io_uring`-based, supports multiple in-flight requests. Requires
+  host kernel >= 5.10.51. Currently in **developer preview**.
+
+See [block-io-engine.md](api_requests/block-io-engine.md) for more information.
+
+### Read-only Devices
+
+Setting `is_read_only` to `true` causes Firecracker to open the backing file
+`O_RDONLY` and tell the guest to mark the device as read-only as well.
+
+### Rate Limiting
+
+The optional `rate_limiter` field caps IO bandwidth and/or request rate:
+
+```json
+"rate_limiter": {
+    "bandwidth": {
+        "size": 1048576,
+        "one_time_burst": 0,
+        "refill_time": 1000
+    },
+    "ops": {
+        "size": 500,
+        "one_time_burst": 0,
+        "refill_time": 1000
+    }
+}
+```
+
+`bandwidth` limits bytes/s; `ops` limits requests/s. `size` is the bucket
+capacity, `refill_time` the refill interval in milliseconds, `one_time_burst` a
+one-shot allowance available at boot.
+
+### Logical Block Size
+
+Firecracker always enables the `VIRTIO_BLK_F_BLK_SIZE` feature which allows the
+user to configure the logical block size. The value used in the configuration is
+picked in the following order:
+
+1. If the user set the optional `blk_size` field on the drive, that value is
+   used.
+1. Otherwise, if the backing file is a **host block device** and **no
+   [topology](#block-topology) is set**, Firecracker queries the kernel for its
+   logical sector size and uses that value instead.
+1. Otherwise Firecracker uses default of **512 bytes**, which matches the
+   virtio-blk default.
+
+Users can override the default with the optional `blk_size` field on the drive:
+
+```json
+"blk_size": 4096
+```
+
+The value must be a positive power of two and within a range acceptable to the
+kernel (typically [512..4096]). The guest kernel will check this value during
+device initialization. Advertising a larger logical block size (e.g. `4096`)
+forces the guest to submit all reads and writes aligned to that size.
+
+> [!NOTE]
+>
+> `blk_size` is also the unit in which every field of the
+> [Block Topology](#block-topology) config is expressed. Changing this value
+> changes how the guest scales `physical_block_exp`, `min_io_size` and
+> `opt_io_size` — see the next section.
+
+### Block Topology
+
+Firecracker always advertises the `VIRTIO_BLK_F_TOPOLOGY` feature to the guest.
+All four topology fields are on the wire in units of the
+[logical block size](#logical-block-size) (`blk_size`, 512 B by default). The
+guest kernel then computes:
+
+- `physical_block_size = blk_size << physical_block_exp`
+- `minimum_io_size     = blk_size * min_io_size`
+- `optimal_io_size     = blk_size * opt_io_size`
+
+and exposes those values under `/sys/block/vd<x>/queue/`.
+
+#### How topology values are chosen
+
+The values placed in the config space are picked in the following order:
+
+1. If the user set the optional `topology` field on the drive (see below), those
+   values are used.
+1. Otherwise, if the backing file is a **host block device** and **no
+   [blk_size](#logical-block-size) is set**, Firecracker derives
+   `physical_block_exp`, `min_io_size` and `opt_io_size` from the kernel. Each
+   byte value is divided by the device's logical sector size to convert bytes
+   into wire units. `alignment_offset` is always reported as `0`.
+1. Otherwise (regular file, or obtaining values from the kernel fails)
+   Firecracker falls back to a fixed set of defaults, described next.
+
+#### Default values
+
+Values below assume the default `blk_size` of 512 B; the byte figures scale with
+`blk_size` if it is overridden.
+
+```
+physical_block_exp: 0    # guest will default to physical size of 512
+alignment_offset:   0
+min_io_size:        0    # guest keeps its own default (no hint)
+opt_io_size:        128  # 128 *  512 B  = 64 KiB optimal I/O
+```
+
+#### Overriding via configuration
+
+Users can overwrite the defaults by setting the optional `topology` field:
+
+```json
+"topology": {
+    "physical_block_exp": 3,
+    "alignment_offset": 0,
+    "min_io_size": 8,
+    "opt_io_size": 128
+}
+```
+
+> [!NOTE]
+>
+> Specifying values as `0` makes the guest use its own defaults
+
+#### Deriving values from a host block device
+
+For a block-device backing this reproduces what Firecracker computes
+automatically; the same math is useful when configuring `topology` by hand for a
+file-backed drive that should mirror a particular disk. Values can be read from
+the host `/sys/block/<name>/queue/` directory; `alignment_offset` will be at the
+top level of the block device (`/sys/block/<name>/alignment_offset`):
+
+| Sysfs path (bytes)                    | Topology field       | Wire units (`blk_size` blocks)          |
+| ------------------------------------- | -------------------- | --------------------------------------- |
+| `queue/logical_block_size`            | -                    | -                                       |
+| `queue/physical_block_size`           | `physical_block_exp` | `log2(physical / logical)`              |
+| `queue/minimum_io_size`               | `min_io_size`        | `minimum_io_size / logical_block_size`  |
+| `queue/optimal_io_size`               | `opt_io_size`        | `optimal_io_size / logical_block_size`  |
+| `alignment_offset` (device top-level) | `alignment_offset`   | `alignment_offset / logical_block_size` |
+
+For example, if the backing device is `/dev/nvme0n1`:
+
+```console
+# for attr in queue/logical_block_size queue/physical_block_size \
+              queue/minimum_io_size    queue/optimal_io_size    \
+              alignment_offset; do
+      printf '%-30s %s\n' "$attr" "$(cat /sys/block/nvme0n1/$attr)"
+  done
+queue/logical_block_size       512
+queue/physical_block_size      4096
+queue/minimum_io_size          4096
+queue/optimal_io_size          65536
+alignment_offset               0
+```
+
+These values can be converted to the `topology` options:
+
+```json
+"topology": {
+    "physical_block_exp": 3,
+    "alignment_offset": 0,
+    "min_io_size": 8,
+    "opt_io_size": 128
+}
+```
+
+> [!NOTE]
+>
+> If **either** `blk_size` or `topology` options are set during configuration,
+> the automatic deduction of these values from the kernel is not performed. This
+> is done to remove ambiguity when these options are configured.
+
+## Updating a Drive at Runtime
+
+A `PATCH /drives/{drive_id}` request can change the `path_on_host` and/or
+`rate_limiter` of an existing virtio drive. See
+[patch-block.md](api_requests/patch-block.md) for more information.
+
+> [!NOTE]
+>
+> Patching block device does not change already configured `blk_size` or
+> `topology` fileds.
+
+## Examples
+
+### Root device from a file
+
+```bash
+curl --unix-socket ${socket} -i \
+     -X PUT "http://localhost/drives/rootfs" \
+     -H "Content-Type: application/json" \
+     -d '{
+         "drive_id": "rootfs",
+         "path_on_host": "./rootfs.ext4",
+         "is_root_device": true,
+         "is_read_only": false
+     }'
+```
+
+### Read-only scratch drive with `Writeback` caching and `Async` engine
+
+```bash
+curl --unix-socket ${socket} -i \
+     -X PUT "http://localhost/drives/scratch" \
+     -H "Content-Type: application/json" \
+     -d '{
+         "drive_id": "scratch",
+         "path_on_host": "./dummy.ext4",
+         "is_root_device": false,
+         "is_read_only": true,
+         "cache_type": "Writeback",
+         "io_engine": "Async"
+     }'
+```
+
+### Drive with a 1 MiB/s bandwidth cap and 500 ops/s
+
+```bash
+curl --unix-socket ${socket} -i \
+     -X PUT "http://localhost/drives/throttled" \
+     -H "Content-Type: application/json" \
+     -d '{
+         "drive_id": "throttled",
+         "path_on_host": "./dummy.ext4",
+         "is_root_device": false,
+         "is_read_only": false,
+         "rate_limiter": {
+             "bandwidth": { "size": 1048576, "one_time_burst": 0, "refill_time": 1000 },
+             "ops":       { "size": 500,     "one_time_burst": 0, "refill_time": 1000 }
+         }
+     }'
+```
+
+### Drive with custom topology values
+
+```bash
+curl --unix-socket ${socket} -i \
+     -X PUT "http://localhost/drives/data" \
+     -H "Content-Type: application/json" \
+     -d '{
+         "drive_id": "data",
+         "path_on_host": "./dummy.ext4",
+         "is_root_device": false,
+         "is_read_only": false,
+         "topology": {
+             "physical_block_exp": 3,
+             "alignment_offset": 0,
+             "min_io_size": 8,
+             "opt_io_size": 128
+         }
+     }'
+```
+
+### Booting from a PARTUUID
+
+```bash
+curl --unix-socket ${socket} -i \
+     -X PUT "http://localhost/drives/rootfs" \
+     -H "Content-Type: application/json" \
+     -d '{
+         "drive_id": "rootfs",
+         "path_on_host": "./disk.img",
+         "is_root_device": true,
+         "is_read_only": false,
+         "partuuid": "0eaa91a0-01"
+     }'
+```
+
+The guest's kernel command line must reference `root=PARTUUID=<value>`.
+
+## Known Limitations
+
+- The `Async` IO engine is in [developer preview](RELEASE_POLICY.md) — see the
+  [threat sections](api_requests/block-io-engine.md#developer-preview-status)
+  before enabling it in production.
+- The guest-visible capacity is snapshotted at boot from `stat` on the backing
+  file. Extending the file on the host does not grow the guest device until the
+  drive is patched (see
+  [Updating a Drive at Runtime](#updating-a-drive-at-runtime)).

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -685,6 +685,58 @@
                 ]
             },
             {
+                "syscall": "ioctl",
+                "comment": "Needed for querying the logical sector size of a block-device backing file during virtio-block init",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4712,
+                        "comment": "BLKSSZGET"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for querying the physical block size of a block-device backing file during virtio-block init",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4731,
+                        "comment": "BLKPBSZGET"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for querying the minimum I/O size of a block-device backing file during virtio-block init",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4728,
+                        "comment": "BLKIOMIN"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for querying the optimal I/O size of a block-device backing file during virtio-block init",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4729,
+                        "comment": "BLKIOOPT"
+                    }
+                ]
+            },
+            {
                 "syscall": "sched_yield",
                 "comment": "Used by the rust standard library in std::sync::mpmc. Firecracker uses mpsc channels from this module for inter-thread communication"
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -697,6 +697,58 @@
                 ]
             },
             {
+                "syscall": "ioctl",
+                "comment": "Needed for querying the logical sector size of a block-device backing file during virtio-block init",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4712,
+                        "comment": "BLKSSZGET"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for querying the physical block size of a block-device backing file during virtio-block init",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4731,
+                        "comment": "BLKPBSZGET"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for querying the minimum I/O size of a block-device backing file during virtio-block init",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4728,
+                        "comment": "BLKIOMIN"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "Needed for querying the optimal I/O size of a block-device backing file during virtio-block init",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4729,
+                        "comment": "BLKIOOPT"
+                    }
+                ]
+            },
+            {
                 "syscall": "sched_yield",
                 "comment": "Used by the rust standard library in std::sync::mpmc. Firecracker uses mpsc channels from this module for inter-thread communication"
             },

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1260,6 +1260,8 @@ definitions:
           This field is optional for virtio-block config and should be omitted
           for vhost-user-block configuration.
         default: 512
+      topology:
+        $ref: "#/definitions/BlockTopology"
 
       # VhostUserBlock specific parameters
       socket:
@@ -1267,6 +1269,28 @@ definitions:
         description:
           Path to the socket of vhost-user-block backend.
           This field is required for vhost-user-block config should be omitted for virtio-block configuration.
+
+  BlockTopology:
+    type: object
+    description:
+      Block device topology exposed to the guest via VIRTIO_BLK_F_TOPOLOGY.
+      When value is present, it is used instead of Firecracker defaults. All
+      I/O size fields are expressed in units of logical blocks. This field is
+      optional for virtio-block config and should be omitted for
+      vhost-user-block configuration.
+    properties:
+      physical_block_exp:
+        type: integer
+        description: log2 of the number of logical blocks per physical block.
+      alignment_offset:
+        type: integer
+        description: Offset of the first aligned logical block.
+      min_io_size:
+        type: integer
+        description: Suggested minimum I/O size, in units of logical blocks.
+      opt_io_size:
+        type: integer
+        description: Suggested optimal (maximum) I/O size, in units of logical blocks.
 
   Pmem:
     type: object

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1253,6 +1253,13 @@ definitions:
           This field is optional for virtio-block config and should be omitted for vhost-user-block configuration.
         enum: ["Sync", "Async"]
         default: "Sync"
+      blk_size:
+        type: integer
+        description:
+          Logical block size advertised to the guest via VIRTIO_BLK_F_BLK_SIZE.
+          This field is optional for virtio-block config and should be omitted
+          for vhost-user-block configuration.
+        default: 512
 
       # VhostUserBlock specific parameters
       socket:

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -906,6 +906,7 @@ pub(crate) mod tests {
                 rate_limiter: None,
                 file_engine_type: None,
                 blk_size: None,
+                topology: None,
 
                 socket: None,
             };

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -905,6 +905,7 @@ pub(crate) mod tests {
                 ),
                 rate_limiter: None,
                 file_engine_type: None,
+                blk_size: None,
 
                 socket: None,
             };

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -913,6 +913,7 @@ pub(crate) mod tests {
             path_on_host: Some(f.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
             socket: None,
         }
     }

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -914,6 +914,7 @@ pub(crate) mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
             socket: None,
         }
     }

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -857,6 +857,12 @@ mod tests {
       "rate_limiter": null,
       "io_engine": "Sync",
       "blk_size": 512,
+      "topology": {{
+        "physical_block_exp": 0,
+        "alignment_offset": 0,
+        "min_io_size": 0,
+        "opt_io_size": 128
+      }},
       "socket": null
     }}
   ],

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -856,6 +856,7 @@ mod tests {
       "path_on_host": "{}",
       "rate_limiter": null,
       "io_engine": "Sync",
+      "blk_size": 512,
       "socket": null
     }}
   ],

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -829,6 +829,12 @@ mod tests {
       "rate_limiter": null,
       "io_engine": "Sync",
       "blk_size": 512,
+      "topology": {{
+        "physical_block_exp": 0,
+        "alignment_offset": 0,
+        "min_io_size": 0,
+        "opt_io_size": 128
+      }},
       "socket": null
     }}
   ],

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -828,6 +828,7 @@ mod tests {
       "path_on_host": "{}",
       "rate_limiter": null,
       "io_engine": "Sync",
+      "blk_size": 512,
       "socket": null
     }}
   ],

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -67,12 +67,13 @@ impl TryFrom<&BlockDeviceConfig> for VhostUserBlockConfig {
     type Error = VhostUserBlockError;
 
     fn try_from(value: &BlockDeviceConfig) -> Result<Self, Self::Error> {
-        if let (Some(socket), None, None, None, None) = (
+        if let (Some(socket), None, None, None, None, None) = (
             &value.socket,
             &value.is_read_only,
             &value.path_on_host,
             &value.rate_limiter,
             &value.file_engine_type,
+            &value.blk_size,
         ) {
             Ok(Self {
                 drive_id: value.drive_id.clone(),
@@ -100,6 +101,7 @@ impl From<VhostUserBlockConfig> for BlockDeviceConfig {
             path_on_host: None,
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: Some(value.socket),
         }
@@ -416,6 +418,7 @@ mod tests {
             path_on_host: None,
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: Some("sock".to_string()),
         };
@@ -431,6 +434,7 @@ mod tests {
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
+            blk_size: None,
 
             socket: None,
         };
@@ -446,6 +450,7 @@ mod tests {
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
+            blk_size: None,
 
             socket: Some("sock".to_string()),
         };

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -67,13 +67,14 @@ impl TryFrom<&BlockDeviceConfig> for VhostUserBlockConfig {
     type Error = VhostUserBlockError;
 
     fn try_from(value: &BlockDeviceConfig) -> Result<Self, Self::Error> {
-        if let (Some(socket), None, None, None, None, None) = (
+        if let (Some(socket), None, None, None, None, None, None) = (
             &value.socket,
             &value.is_read_only,
             &value.path_on_host,
             &value.rate_limiter,
             &value.file_engine_type,
             &value.blk_size,
+            &value.topology,
         ) {
             Ok(Self {
                 drive_id: value.drive_id.clone(),
@@ -102,6 +103,7 @@ impl From<VhostUserBlockConfig> for BlockDeviceConfig {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: Some(value.socket),
         }
@@ -419,6 +421,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: Some("sock".to_string()),
         };
@@ -435,6 +438,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -451,6 +455,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
             blk_size: None,
+            topology: None,
 
             socket: Some("sock".to_string()),
         };

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -27,7 +27,7 @@ use crate::devices::virtio::block::CacheType;
 use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, BlockMetricsPerDevice};
 use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::{
-    VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES,
+    VIRTIO_BLK_F_BLK_SIZE, VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES,
 };
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
@@ -158,10 +158,26 @@ impl DiskProperties {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(C)]
 pub struct ConfigSpace {
     pub capacity: u64,
+    pub size_max: u32,
+    pub seg_max: u32,
+    pub geometry: u32,
+    pub blk_size: u32,
+}
+
+impl Default for ConfigSpace {
+    fn default() -> Self {
+        Self {
+            capacity: 0,
+            size_max: 0,
+            seg_max: 0,
+            geometry: 0,
+            blk_size: 512,
+        }
+    }
 }
 
 // SAFETY: `ConfigSpace` contains only PODs in `repr(C)` or `repr(transparent)`, without padding.
@@ -196,6 +212,8 @@ pub struct VirtioBlockConfig {
     #[serde(default)]
     #[serde(rename = "io_engine")]
     pub file_engine_type: FileEngineType,
+    /// Logical block size.
+    pub blk_size: Option<u32>,
 }
 
 impl TryFrom<&BlockDeviceConfig> for VirtioBlockConfig {
@@ -213,6 +231,7 @@ impl TryFrom<&BlockDeviceConfig> for VirtioBlockConfig {
                 path_on_host: path_on_host.clone(),
                 rate_limiter: value.rate_limiter,
                 file_engine_type: value.file_engine_type.unwrap_or_default(),
+                blk_size: value.blk_size,
             })
         } else {
             Err(VirtioBlockError::Config)
@@ -232,6 +251,7 @@ impl From<VirtioBlockConfig> for BlockDeviceConfig {
             path_on_host: Some(value.path_on_host),
             rate_limiter: value.rate_limiter,
             file_engine_type: Some(value.file_engine_type),
+            blk_size: value.blk_size,
 
             socket: None,
         }
@@ -294,7 +314,14 @@ impl VirtioBlock {
             .map(RateLimiter::from)
             .unwrap_or_default();
 
-        let mut avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_RING_F_EVENT_IDX);
+        let mut config_space = ConfigSpace {
+            capacity: disk_properties.nsectors.to_le(),
+            ..Default::default()
+        };
+
+        let mut avail_features = (1u64 << VIRTIO_F_VERSION_1)
+            | (1u64 << VIRTIO_RING_F_EVENT_IDX)
+            | (1u64 << VIRTIO_BLK_F_BLK_SIZE);
 
         if config.cache_type == CacheType::Writeback {
             avail_features |= 1u64 << VIRTIO_BLK_F_FLUSH;
@@ -302,15 +329,15 @@ impl VirtioBlock {
 
         if config.is_read_only {
             avail_features |= 1u64 << VIRTIO_BLK_F_RO;
-        };
+        }
+
+        if let Some(blk_size) = config.blk_size {
+            config_space.blk_size = blk_size;
+        }
 
         let queue_evts = [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?];
 
         let queues = BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect();
-
-        let config_space = ConfigSpace {
-            capacity: disk_properties.nsectors.to_le(),
-        };
 
         Ok(VirtioBlock {
             avail_features,
@@ -347,6 +374,7 @@ impl VirtioBlock {
             cache_type: self.cache_type,
             rate_limiter: rl.into_option(),
             file_engine_type: self.file_engine_type(),
+            blk_size: Some(self.config_space.blk_size),
         }
     }
 
@@ -725,6 +753,7 @@ mod tests {
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Default::default(),
+            blk_size: None,
 
             socket: None,
         };
@@ -740,6 +769,7 @@ mod tests {
             path_on_host: None,
             rate_limiter: None,
             file_engine_type: Default::default(),
+            blk_size: None,
 
             socket: Some("sock".to_string()),
         };
@@ -755,6 +785,7 @@ mod tests {
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Default::default(),
+            blk_size: None,
 
             socket: Some("sock".to_string()),
         };
@@ -794,7 +825,9 @@ mod tests {
 
             assert_eq!(block.device_type(), VirtioDeviceType::Block);
 
-            let features: u64 = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_RING_F_EVENT_IDX);
+            let features: u64 = (1u64 << VIRTIO_F_VERSION_1)
+                | (1u64 << VIRTIO_RING_F_EVENT_IDX)
+                | (1u64 << VIRTIO_BLK_F_BLK_SIZE);
 
             assert_eq!(
                 block.avail_features_by_page(0),
@@ -820,7 +853,10 @@ mod tests {
 
             let config = block.config_as_bytes();
             // The block's backing file size is 0x1000, so there are 8 (4096/512) sectors.
-            let expected_config_space = ConfigSpace { capacity: 8 };
+            let expected_config_space = ConfigSpace {
+                capacity: 8,
+                ..Default::default()
+            };
             assert_eq!(config, expected_config_space.as_slice());
         }
     }
@@ -840,6 +876,7 @@ mod tests {
                 0,
                 ConfigSpace {
                     capacity: 0x1122334455667788,
+                    ..Default::default()
                 }
                 .as_slice(),
             );

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -10,7 +10,9 @@ use std::convert::From;
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom};
 use std::ops::Deref;
+use std::os::fd::AsRawFd;
 use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::FileTypeExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -27,7 +29,8 @@ use crate::devices::virtio::block::CacheType;
 use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, BlockMetricsPerDevice};
 use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::{
-    VIRTIO_BLK_F_BLK_SIZE, VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES,
+    VIRTIO_BLK_F_BLK_SIZE, VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_F_TOPOLOGY,
+    VIRTIO_BLK_ID_BYTES,
 };
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
@@ -158,6 +161,93 @@ impl DiskProperties {
     }
 }
 
+/// Internal type to store attributes of the block device
+#[derive(Debug)]
+struct BlockDeviceAttributes {
+    logical_block_size: u32,
+    physical_block_size: u32,
+    min_io_size: u32,
+    opt_io_size: u32,
+}
+
+/// Try to obtain attributes of the block device from the file descriptor if possible
+fn query_blk_attrs(file: &File) -> Option<BlockDeviceAttributes> {
+    let Ok(metadata) = file.metadata() else {
+        return None;
+    };
+    let file_type = metadata.file_type();
+    if !file_type.is_block_device() {
+        return None;
+    };
+
+    // Have to use a macro here to pass the libc constants directly to the libc::ioctl since
+    // the types of constants differ between glibc(u64) and musl(i32)
+    macro_rules! block_attr {
+        ($file:expr, $attr:expr) => {{
+            let mut result: u32 = 0;
+            // SAFETY: FFI call with correct arguments
+            if unsafe { libc::ioctl($file.as_raw_fd(), $attr, &mut result) } != 0 {
+                None
+            } else {
+                Some(result)
+            }
+        }};
+    }
+
+    let attrs = BlockDeviceAttributes {
+        logical_block_size: block_attr!(file, libc::BLKSSZGET)?,
+        physical_block_size: block_attr!(file, libc::BLKPBSZGET)?,
+        min_io_size: block_attr!(file, libc::BLKIOMIN)?,
+        opt_io_size: block_attr!(file, libc::BLKIOOPT)?,
+    };
+    Some(attrs)
+}
+
+/// Try to convert block attributes into the topology value for the virtio-block device
+fn calculate_blk_size_and_topology(
+    attrs: BlockDeviceAttributes,
+) -> Option<(u32, VirtioBlkTopology)> {
+    // It is used as a divisor, so check just in case
+    if attrs.logical_block_size == 0 {
+        return None;
+    }
+
+    // This can technically be replaced by `(physical / logical).trailing_zeroes()`, but it assumes
+    // that the devision always results in a power of 2 value. Just in case we do the loop
+    // approach.
+    let mut physical_block_exp: u8 = 0;
+    let mut size = attrs.physical_block_size;
+    while attrs.logical_block_size < size {
+        physical_block_exp += 1;
+        size >>= 1;
+    }
+
+    let min_io_size =
+        u16::try_from(attrs.min_io_size / attrs.logical_block_size).unwrap_or(u16::MAX);
+    let opt_io_size = attrs.opt_io_size / attrs.logical_block_size;
+
+    let topology = VirtioBlkTopology {
+        physical_block_exp,
+        alignment_offset: 0,
+        min_io_size,
+        opt_io_size,
+    };
+    Some((attrs.logical_block_size, topology))
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[repr(C)]
+pub struct VirtioBlkTopology {
+    /// number of logical blocks per physical block (log2)
+    pub physical_block_exp: u8,
+    /// offset of first aligned logical block
+    pub alignment_offset: u8,
+    /// suggested minimum I/O size in blocks
+    pub min_io_size: u16,
+    /// optimal (suggested maximum) I/O size in blocks
+    pub opt_io_size: u32,
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(C)]
 pub struct ConfigSpace {
@@ -166,6 +256,7 @@ pub struct ConfigSpace {
     pub seg_max: u32,
     pub geometry: u32,
     pub blk_size: u32,
+    pub topology: VirtioBlkTopology,
 }
 
 impl Default for ConfigSpace {
@@ -176,6 +267,12 @@ impl Default for ConfigSpace {
             seg_max: 0,
             geometry: 0,
             blk_size: 512,
+            topology: VirtioBlkTopology {
+                physical_block_exp: 0,
+                alignment_offset: 0,
+                min_io_size: 0,
+                opt_io_size: 128,
+            },
         }
     }
 }
@@ -214,6 +311,8 @@ pub struct VirtioBlockConfig {
     pub file_engine_type: FileEngineType,
     /// Logical block size.
     pub blk_size: Option<u32>,
+    /// Block topology settings
+    pub topology: Option<VirtioBlkTopology>,
 }
 
 impl TryFrom<&BlockDeviceConfig> for VirtioBlockConfig {
@@ -232,6 +331,7 @@ impl TryFrom<&BlockDeviceConfig> for VirtioBlockConfig {
                 rate_limiter: value.rate_limiter,
                 file_engine_type: value.file_engine_type.unwrap_or_default(),
                 blk_size: value.blk_size,
+                topology: value.topology,
             })
         } else {
             Err(VirtioBlockError::Config)
@@ -252,6 +352,7 @@ impl From<VirtioBlockConfig> for BlockDeviceConfig {
             rate_limiter: value.rate_limiter,
             file_engine_type: Some(value.file_engine_type),
             blk_size: value.blk_size,
+            topology: value.topology,
 
             socket: None,
         }
@@ -314,14 +415,10 @@ impl VirtioBlock {
             .map(RateLimiter::from)
             .unwrap_or_default();
 
-        let mut config_space = ConfigSpace {
-            capacity: disk_properties.nsectors.to_le(),
-            ..Default::default()
-        };
-
         let mut avail_features = (1u64 << VIRTIO_F_VERSION_1)
             | (1u64 << VIRTIO_RING_F_EVENT_IDX)
-            | (1u64 << VIRTIO_BLK_F_BLK_SIZE);
+            | (1u64 << VIRTIO_BLK_F_BLK_SIZE)
+            | (1u64 << VIRTIO_BLK_F_TOPOLOGY);
 
         if config.cache_type == CacheType::Writeback {
             avail_features |= 1u64 << VIRTIO_BLK_F_FLUSH;
@@ -331,8 +428,25 @@ impl VirtioBlock {
             avail_features |= 1u64 << VIRTIO_BLK_F_RO;
         }
 
-        if let Some(blk_size) = config.blk_size {
-            config_space.blk_size = blk_size;
+        let mut config_space = ConfigSpace {
+            capacity: disk_properties.nsectors.to_le(),
+            ..Default::default()
+        };
+
+        if config.blk_size.is_none() && config.topology.is_none() {
+            if let Some(attrs) = query_blk_attrs(disk_properties.file_engine.file())
+                && let Some((blk_size, topology)) = calculate_blk_size_and_topology(attrs)
+            {
+                config_space.blk_size = blk_size;
+                config_space.topology = topology;
+            }
+        } else {
+            if let Some(blk_size) = config.blk_size {
+                config_space.blk_size = blk_size;
+            }
+            if let Some(topology) = config.topology {
+                config_space.topology = topology;
+            }
         }
 
         let queue_evts = [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?];
@@ -375,6 +489,7 @@ impl VirtioBlock {
             rate_limiter: rl.into_option(),
             file_engine_type: self.file_engine_type(),
             blk_size: Some(self.config_space.blk_size),
+            topology: Some(self.config_space.topology),
         }
     }
 
@@ -742,6 +857,30 @@ mod tests {
     use crate::vstate::memory::{Address, Bytes, GuestAddress};
 
     #[test]
+    fn test_calculate_blk_size_and_topology() {
+        let attrs = BlockDeviceAttributes {
+            logical_block_size: 0,
+            physical_block_size: 0,
+            min_io_size: 0,
+            opt_io_size: 0,
+        };
+        assert!(calculate_blk_size_and_topology(attrs).is_none());
+
+        let attrs = BlockDeviceAttributes {
+            logical_block_size: 512,
+            physical_block_size: 512 * (1 << 3),
+            min_io_size: 64 * 512,
+            opt_io_size: 128 * 512,
+        };
+        let (logical_size, topology) = calculate_blk_size_and_topology(attrs).unwrap();
+        assert_eq!(logical_size, 512);
+        assert_eq!(topology.physical_block_exp, 3);
+        assert_eq!(topology.alignment_offset, 0);
+        assert_eq!(topology.min_io_size, 64);
+        assert_eq!(topology.opt_io_size, 128);
+    }
+
+    #[test]
     fn test_from_config() {
         let block_config = BlockDeviceConfig {
             drive_id: "".to_string(),
@@ -754,6 +893,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: Default::default(),
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -770,6 +910,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: Default::default(),
             blk_size: None,
+            topology: None,
 
             socket: Some("sock".to_string()),
         };
@@ -786,6 +927,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: Default::default(),
             blk_size: None,
+            topology: None,
 
             socket: Some("sock".to_string()),
         };
@@ -827,7 +969,8 @@ mod tests {
 
             let features: u64 = (1u64 << VIRTIO_F_VERSION_1)
                 | (1u64 << VIRTIO_RING_F_EVENT_IDX)
-                | (1u64 << VIRTIO_BLK_F_BLK_SIZE);
+                | (1u64 << VIRTIO_BLK_F_BLK_SIZE)
+                | (1u64 << VIRTIO_BLK_F_TOPOLOGY);
 
             assert_eq!(
                 block.avail_features_by_page(0),

--- a/src/vmm/src/devices/virtio/block/virtio/io/async_io.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/async_io.rs
@@ -110,7 +110,6 @@ impl AsyncFileEngine {
         Ok(())
     }
 
-    #[cfg(test)]
     pub fn file(&self) -> &File {
         &self.file
     }

--- a/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/mod.rs
@@ -75,7 +75,6 @@ impl FileEngine {
         Ok(())
     }
 
-    #[cfg(test)]
     pub fn file(&self) -> &File {
         match self {
             FileEngine::Async(engine) => engine.file(),

--- a/src/vmm/src/devices/virtio/block/virtio/io/sync_io.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/io/sync_io.rs
@@ -33,7 +33,6 @@ impl SyncFileEngine {
         SyncFileEngine { file }
     }
 
-    #[cfg(test)]
     pub fn file(&self) -> &File {
         &self.file
     }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -60,6 +60,7 @@ pub struct VirtioBlockState {
     pub virtio_state: VirtioDeviceState,
     rate_limiter_state: RateLimiterState,
     file_engine_type: FileEngineTypeState,
+    blk_size: u32,
 }
 
 impl Persist<'_> for VirtioBlock {
@@ -78,6 +79,7 @@ impl Persist<'_> for VirtioBlock {
             virtio_state: VirtioDeviceState::from_device(self),
             rate_limiter_state: self.rate_limiter.save(),
             file_engine_type: FileEngineTypeState::from(self.file_engine_type()),
+            blk_size: self.config_space.blk_size,
         }
     }
 
@@ -112,6 +114,8 @@ impl Persist<'_> for VirtioBlock {
 
         let config_space = ConfigSpace {
             capacity: disk_properties.nsectors.to_le(),
+            blk_size: state.blk_size,
+            ..Default::default()
         };
 
         Ok(VirtioBlock {
@@ -162,6 +166,7 @@ mod tests {
             cache_type: CacheType::Writeback,
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            blk_size: None,
         };
 
         let block = VirtioBlock::new(config).unwrap();
@@ -203,6 +208,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            blk_size: None,
         };
 
         let block = VirtioBlock::new(config).unwrap();

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -11,6 +11,7 @@ use super::device::DiskProperties;
 use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
 use crate::devices::virtio::block::virtio::device::FileEngineType;
+use crate::devices::virtio::block::virtio::device::VirtioBlkTopology;
 use crate::devices::virtio::block::virtio::metrics::BlockMetricsPerDevice;
 use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::VIRTIO_BLK_F_RO;
@@ -61,6 +62,7 @@ pub struct VirtioBlockState {
     rate_limiter_state: RateLimiterState,
     file_engine_type: FileEngineTypeState,
     blk_size: u32,
+    topology: VirtioBlkTopology,
 }
 
 impl Persist<'_> for VirtioBlock {
@@ -80,6 +82,7 @@ impl Persist<'_> for VirtioBlock {
             rate_limiter_state: self.rate_limiter.save(),
             file_engine_type: FileEngineTypeState::from(self.file_engine_type()),
             blk_size: self.config_space.blk_size,
+            topology: self.config_space.topology,
         }
     }
 
@@ -115,6 +118,7 @@ impl Persist<'_> for VirtioBlock {
         let config_space = ConfigSpace {
             capacity: disk_properties.nsectors.to_le(),
             blk_size: state.blk_size,
+            topology: state.topology,
             ..Default::default()
         };
 
@@ -167,6 +171,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
             blk_size: None,
+            topology: None,
         };
 
         let block = VirtioBlock::new(config).unwrap();
@@ -209,6 +214,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
             blk_size: None,
+            topology: None,
         };
 
         let block = VirtioBlock::new(config).unwrap();

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -58,6 +58,7 @@ pub fn default_block_with_path(path: String, file_engine_type: FileEngineType) -
             }),
         }),
         file_engine_type,
+        blk_size: None,
     };
 
     // The default block device is read-write and non-root.

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -59,6 +59,7 @@ pub fn default_block_with_path(path: String, file_engine_type: FileEngineType) -
         }),
         file_engine_type,
         blk_size: None,
+        topology: None,
     };
 
     // The default block device is read-write and non-root.

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -623,6 +623,7 @@ mod tests {
                 path_on_host: Some(tmp_file.as_path().to_str().unwrap().to_string()),
                 rate_limiter: Some(RateLimiterConfig::default()),
                 file_engine_type: None,
+                blk_size: None,
 
                 socket: None,
             },
@@ -1237,7 +1238,8 @@ mod tests {
                             "path_on_host": "{}",
                             "is_root_device": true,
                             "is_read_only": false,
-                            "io_engine": "Sync"
+                            "io_engine": "Sync",
+                            "blk_size": 512
                         }}
                     ],
                     "network-interfaces": [
@@ -1312,7 +1314,8 @@ mod tests {
                             "path_on_host": "{}",
                             "is_root_device": true,
                             "is_read_only": false,
-                            "io_engine": "Sync"
+                            "io_engine": "Sync",
+                            "blk_size": 512
                         }}
                     ],
                     "network-interfaces": [
@@ -1372,7 +1375,8 @@ mod tests {
                             "path_on_host": "{}",
                             "is_root_device": true,
                             "is_read_only": false,
-                            "io_engine": "Sync"
+                            "io_engine": "Sync",
+                            "blk_size": 512
                         }}
                     ],
                     "network-interfaces": [

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -624,6 +624,7 @@ mod tests {
                 rate_limiter: Some(RateLimiterConfig::default()),
                 file_engine_type: None,
                 blk_size: None,
+                topology: None,
 
                 socket: None,
             },
@@ -1239,7 +1240,13 @@ mod tests {
                             "is_root_device": true,
                             "is_read_only": false,
                             "io_engine": "Sync",
-                            "blk_size": 512
+                            "blk_size": 512,
+                            "topology": {{
+                                "physical_block_exp": 0,
+                                "alignment_offset": 0,
+                                "min_io_size": 0,
+                                "opt_io_size": 128
+                            }}
                         }}
                     ],
                     "network-interfaces": [
@@ -1315,7 +1322,13 @@ mod tests {
                             "is_root_device": true,
                             "is_read_only": false,
                             "io_engine": "Sync",
-                            "blk_size": 512
+                            "blk_size": 512,
+                            "topology": {{
+                                "physical_block_exp": 0,
+                                "alignment_offset": 0,
+                                "min_io_size": 0,
+                                "opt_io_size": 128
+                            }}
                         }}
                     ],
                     "network-interfaces": [
@@ -1376,7 +1389,13 @@ mod tests {
                             "is_root_device": true,
                             "is_read_only": false,
                             "io_engine": "Sync",
-                            "blk_size": 512
+                            "blk_size": 512,
+                            "topology": {{
+                                "physical_block_exp": 0,
+                                "alignment_offset": 0,
+                                "min_io_size": 0,
+                                "opt_io_size": 128
+                            }}
                         }}
                     ],
                     "network-interfaces": [

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -61,6 +61,8 @@ pub struct BlockDeviceConfig {
     // pub file_engine_type: FileEngineType,
     #[serde(rename = "io_engine")]
     pub file_engine_type: Option<FileEngineType>,
+    /// Logical block size.
+    pub blk_size: Option<u32>,
 
     // VhostUserBlock specific fields
     /// Path to the vhost-user socket.
@@ -213,6 +215,7 @@ mod tests {
                 path_on_host: self.path_on_host.clone(),
                 rate_limiter: self.rate_limiter,
                 file_engine_type: self.file_engine_type,
+                blk_size: self.blk_size,
 
                 socket: self.socket.clone(),
             }
@@ -240,6 +243,7 @@ mod tests {
             path_on_host: Some(dummy_path),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -274,6 +278,7 @@ mod tests {
             path_on_host: Some(dummy_path),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -306,6 +311,7 @@ mod tests {
             path_on_host: Some(dummy_path),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -335,6 +341,7 @@ mod tests {
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -351,6 +358,7 @@ mod tests {
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -378,6 +386,7 @@ mod tests {
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -394,6 +403,7 @@ mod tests {
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -410,6 +420,7 @@ mod tests {
             path_on_host: Some(dummy_path_3),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -451,6 +462,7 @@ mod tests {
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -467,6 +479,7 @@ mod tests {
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -483,6 +496,7 @@ mod tests {
             path_on_host: Some(dummy_path_3),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -525,6 +539,7 @@ mod tests {
             path_on_host: Some(dummy_path_1.clone()),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -541,6 +556,7 @@ mod tests {
             path_on_host: Some(dummy_path_2.clone()),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -613,6 +629,7 @@ mod tests {
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -629,6 +646,7 @@ mod tests {
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };
@@ -655,6 +673,7 @@ mod tests {
             path_on_host: Some(dummy_file.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
+            blk_size: None,
 
             socket: None,
         };
@@ -685,6 +704,7 @@ mod tests {
             path_on_host: Some(backing_file.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: None,
+            blk_size: None,
 
             socket: None,
         };

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -11,6 +11,7 @@ use super::RateLimiterConfig;
 use crate::VmmError;
 use crate::devices::virtio::block::device::Block;
 pub use crate::devices::virtio::block::virtio::device::FileEngineType;
+use crate::devices::virtio::block::virtio::device::VirtioBlkTopology;
 use crate::devices::virtio::block::{BlockError, CacheType};
 use crate::devices::virtio::device::VirtioDevice;
 
@@ -63,6 +64,8 @@ pub struct BlockDeviceConfig {
     pub file_engine_type: Option<FileEngineType>,
     /// Logical block size.
     pub blk_size: Option<u32>,
+    /// Block topology settings
+    pub topology: Option<VirtioBlkTopology>,
 
     // VhostUserBlock specific fields
     /// Path to the vhost-user socket.
@@ -216,6 +219,7 @@ mod tests {
                 rate_limiter: self.rate_limiter,
                 file_engine_type: self.file_engine_type,
                 blk_size: self.blk_size,
+                topology: self.topology,
 
                 socket: self.socket.clone(),
             }
@@ -244,6 +248,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -279,6 +284,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -312,6 +318,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -342,6 +349,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -359,6 +367,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -387,6 +396,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -404,6 +414,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -421,6 +432,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -463,6 +475,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -480,6 +493,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -497,6 +511,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -540,6 +555,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -557,6 +573,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -630,6 +647,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -647,6 +665,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };
@@ -673,7 +692,13 @@ mod tests {
             path_on_host: Some(dummy_file.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
-            blk_size: None,
+            blk_size: Some(512),
+            topology: Some(VirtioBlkTopology {
+                physical_block_exp: 0,
+                alignment_offset: 0,
+                min_io_size: 0,
+                opt_io_size: 128,
+            }),
 
             socket: None,
         };
@@ -705,6 +730,7 @@ mod tests {
             rate_limiter: None,
             file_engine_type: None,
             blk_size: None,
+            topology: None,
 
             socket: None,
         };

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -497,6 +497,7 @@ fn test_preboot_load_snap_disallowed_after_boot_resources() {
         path_on_host: Some(tmp_file),
         rate_limiter: None,
         file_engine_type: None,
+        blk_size: None,
 
         socket: None,
     };

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -498,6 +498,7 @@ fn test_preboot_load_snap_disallowed_after_boot_resources() {
         rate_limiter: None,
         file_engine_type: None,
         blk_size: None,
+        topology: None,
 
         socket: None,
     };

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -913,6 +913,8 @@ class Microvm:
         partuuid=None,
         cache_type=None,
         io_engine=None,
+        topology=None,
+        blk_size=None,
     ):
         """Add a block device."""
 
@@ -925,6 +927,8 @@ class Microvm:
             partuuid=partuuid,
             cache_type=cache_type,
             io_engine=io_engine,
+            topology=topology,
+            blk_size=blk_size,
         )
         self.disks[drive_id] = path_on_host
 

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -15,6 +15,12 @@
       "io_engine": "Sync",
       "rate_limiter": null,
       "blk_size": 512,
+      "topology": {
+        "physical_block_exp": 0,
+        "alignment_offset": 0,
+        "min_io_size": 0,
+        "opt_io_size": 128
+      },
       "socket": null
     }
   ],

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -14,6 +14,7 @@
       "path_on_host": "bionic.rootfs.ext4",
       "io_engine": "Sync",
       "rate_limiter": null,
+      "blk_size": 512,
       "socket": null
     }
   ],

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -910,6 +910,12 @@ def _drive_patch(test_microvm, io_engine):
             "rate_limiter": None,
             "io_engine": "Sync",
             "blk_size": 512,
+            "topology": {
+                "physical_block_exp": 0,
+                "alignment_offset": 0,
+                "min_io_size": 0,
+                "opt_io_size": 128,
+            },
             "socket": None,
         },
         {
@@ -925,6 +931,12 @@ def _drive_patch(test_microvm, io_engine):
             },
             "io_engine": io_engine,
             "blk_size": 512,
+            "topology": {
+                "physical_block_exp": 0,
+                "alignment_offset": 0,
+                "min_io_size": 0,
+                "opt_io_size": 128,
+            },
             "socket": None,
         },
         {
@@ -937,6 +949,7 @@ def _drive_patch(test_microvm, io_engine):
             "rate_limiter": None,
             "io_engine": None,
             "blk_size": None,
+            "topology": None,
             "socket": str(
                 Path("/")
                 / test_microvm.disks_vhost_user["scratch_vub"].socket_path.name
@@ -1327,6 +1340,12 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_configure
             "rate_limiter": None,
             "io_engine": "Sync",
             "blk_size": 512,
+            "topology": {
+                "physical_block_exp": 0,
+                "alignment_offset": 0,
+                "min_io_size": 0,
+                "opt_io_size": 128,
+            },
             "socket": None,
         }
     ]
@@ -1468,6 +1487,12 @@ def test_get_full_config(uvm):
             "rate_limiter": None,
             "io_engine": "Sync",
             "blk_size": 512,
+            "topology": {
+                "physical_block_exp": 0,
+                "alignment_offset": 0,
+                "min_io_size": 0,
+                "opt_io_size": 128,
+            },
             "socket": None,
         }
     ]

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -909,6 +909,7 @@ def _drive_patch(test_microvm, io_engine):
             "path_on_host": "/" + test_microvm.rootfs_file.name,
             "rate_limiter": None,
             "io_engine": "Sync",
+            "blk_size": 512,
             "socket": None,
         },
         {
@@ -923,6 +924,7 @@ def _drive_patch(test_microvm, io_engine):
                 "ops": {"size": 500, "one_time_burst": None, "refill_time": 100},
             },
             "io_engine": io_engine,
+            "blk_size": 512,
             "socket": None,
         },
         {
@@ -934,6 +936,7 @@ def _drive_patch(test_microvm, io_engine):
             "path_on_host": None,
             "rate_limiter": None,
             "io_engine": None,
+            "blk_size": None,
             "socket": str(
                 Path("/")
                 / test_microvm.disks_vhost_user["scratch_vub"].socket_path.name
@@ -1323,6 +1326,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_configure
             "path_on_host": f"/{uvm_configured.rootfs_file.name}",
             "rate_limiter": None,
             "io_engine": "Sync",
+            "blk_size": 512,
             "socket": None,
         }
     ]
@@ -1463,6 +1467,7 @@ def test_get_full_config(uvm):
             "path_on_host": "/" + test_microvm.rootfs_file.name,
             "rate_limiter": None,
             "io_engine": "Sync",
+            "blk_size": 512,
             "socket": None,
         }
     ]

--- a/tests/integration_tests/functional/test_drive_virtio.py
+++ b/tests/integration_tests/functional/test_drive_virtio.py
@@ -421,3 +421,104 @@ def test_device_reset(uvm, io_engine):
     vm.ssh.check_output(f"echo {virtio_dev} > /sys/bus/virtio/drivers/virtio_blk/bind")
     vm.ssh.check_output("ls /dev/vdb")
     vm.ssh.check_output("mount /dev/vdb /tmp && umount /tmp")
+
+
+def _read_queue_attr(ssh, dev_name, attr):
+    _, stdout, stderr = ssh.run(f"cat /sys/block/{dev_name}/queue/{attr}")
+    assert stderr == ""
+    return int(stdout.strip())
+
+
+def test_blk_size(uvm, io_engine):
+    """
+    When blk_size is set, the guest must use this value as the logical
+    block size for the drive.
+    """
+    vm = uvm
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+
+    blk_size1 = 2048
+    fs1 = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "scratch1"), size=8)
+    vm.add_drive("scratch1", fs1.path, io_engine=io_engine, blk_size=blk_size1)
+
+    blk_size2 = 4096
+    fs2 = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "scratch2"), size=8)
+    vm.add_drive("scratch2", fs2.path, io_engine=io_engine, blk_size=blk_size2)
+
+    vm.start()
+
+    assert _read_queue_attr(vm.ssh, "vdb", "logical_block_size") == blk_size1
+    assert _read_queue_attr(vm.ssh, "vdc", "logical_block_size") == blk_size2
+
+
+LOGICAL_BLOCK_SIZE = 512
+
+
+def test_topology_defaults(uvm, io_engine):
+    """
+    If topology is not set by the user and the backing file is not a host
+    block device, Firecracker exposes a fixed set of defaults:
+      physical_block_exp = 0  -> physical_block_size = 512
+      min_io_size        = 0  -> guest clamps minimum_io_size up to
+                                 physical_block_size (512)
+      opt_io_size        = 128 -> optimal_io_size    = 512 * 128       = 65536
+
+    This test ensures same behaviour on all guest kernels.
+    """
+    vm = uvm
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+
+    fs = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "scratch"), size=8)
+    vm.add_drive("scratch", fs.path, io_engine=io_engine)
+    vm.start()
+
+    assert _read_queue_attr(vm.ssh, "vdb", "logical_block_size") == LOGICAL_BLOCK_SIZE
+    assert _read_queue_attr(vm.ssh, "vdb", "physical_block_size") == LOGICAL_BLOCK_SIZE
+    assert _read_queue_attr(vm.ssh, "vdb", "minimum_io_size") == LOGICAL_BLOCK_SIZE
+    assert (
+        _read_queue_attr(vm.ssh, "vdb", "optimal_io_size") == LOGICAL_BLOCK_SIZE * 128
+    )
+
+
+def test_topology_advertised(uvm, io_engine):
+    """
+    When topology is set, the guest must set the corresponding options for the queue.
+    """
+    vm = uvm
+    vm.spawn()
+    vm.basic_config()
+    vm.add_net_iface()
+
+    topology = {
+        "physical_block_exp": 4,
+        "alignment_offset": 0,
+        "min_io_size": 64,
+        "opt_io_size": 256,
+    }
+    expected = {
+        "physical_block_size": LOGICAL_BLOCK_SIZE * (1 << 4),
+        "minimum_io_size": LOGICAL_BLOCK_SIZE * 64,
+        "optimal_io_size": LOGICAL_BLOCK_SIZE * 256,
+    }
+
+    fs = drive_tools.FilesystemFile(os.path.join(vm.fsfiles, "scratch"), size=8)
+    vm.add_drive("scratch", fs.path, io_engine=io_engine, topology=topology)
+    vm.start()
+
+    assert _read_queue_attr(vm.ssh, "vdb", "logical_block_size") == LOGICAL_BLOCK_SIZE
+    assert (
+        _read_queue_attr(vm.ssh, "vdb", "physical_block_size")
+        == expected["physical_block_size"]
+    )
+    assert (
+        _read_queue_attr(vm.ssh, "vdb", "minimum_io_size")
+        == expected["minimum_io_size"]
+    )
+    assert (
+        _read_queue_attr(vm.ssh, "vdb", "optimal_io_size")
+        == expected["optimal_io_size"]
+    )


### PR DESCRIPTION
## Changes
Expose VIRTIO_BLK_F_TOPOLOGY feature to be configurable by the users. This allows greater flexibility in tuning the performance of the block device.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
