### PR TITLE
fix(vsock): host-initiated connections hang after bare pause/resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to
 
 ### Fixed
 
+- [#6100](https://github.com/firecracker-microvm/firecracker/pull/6100): Fixed
+  the vsock device permanently suppressing RX (host-to-guest) delivery after a
+  bare pause/resume cycle (`PATCH /vm` with `Paused` then `Resumed`, without a
+  snapshot). The resume kick armed the `TRANSPORT_RESET` RX gate even though no
+  reset event had been sent, so the guest could never acknowledge it and every
+  new host-initiated connection made after the resume hung forever. The gate is
+  now part of the persisted device state and the resume kick respects it instead
+  of arming it.
 - [#5956](https://github.com/firecracker-microvm/firecracker/pull/5956): Fixed a
   TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
   `MIDR_EL1` information files copied into the chroot.

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -412,21 +412,30 @@ where
 
     fn kick(&mut self) {
         if self.is_activated() {
-            self.pending_event_ack = true;
-
             // Vsock has a complicated protocol that isn't resilient to any packet loss,
             // so for Vsock we don't support connection persistence through snapshot. Any
             // in-flight packets or events are simply lost and Vsock is restored 'empty'.
-            // We signal the event queue to make the guest process the
-            // `TRANSPORT_RESET_EVENT` event we sent during snapshot creation. (We signal
-            // it host->guest rather than writing its eventfd, which would invoke the
+            //
+            // A set `pending_event_ack` means a `TRANSPORT_RESET_EVENT` sits in the
+            // event queue's used ring, not yet acknowledged by the guest: we are
+            // resuming either the VM a snapshot was just taken from, or a VM restored
+            // from a snapshot (the flag is part of the persisted device state). Signal
+            // the event queue so the guest processes the event. (We signal it
+            // host->guest rather than writing its eventfd, which would invoke the
             // guest's reset-ack path and clear `pending_event_ack` prematurely.)
-            info!(
-                "[{:?}:{}] signaling event queue",
-                self.device_type(),
-                self.id()
-            );
-            self.signal_used_queue(EVQ_INDEX).unwrap();
+            //
+            // On a bare pause/resume no reset event was published, so there is nothing
+            // to signal and the flag must stay clear: arming it here would gate
+            // `process_rx` on an acknowledgment the guest can never send, hanging all
+            // subsequent host-initiated connections.
+            if self.pending_event_ack {
+                info!(
+                    "[{:?}:{}] signaling event queue",
+                    self.device_type(),
+                    self.id()
+                );
+                self.signal_used_queue(EVQ_INDEX).unwrap();
+            }
 
             // Replay the TX queue notification, like the default `VirtioDevice::kick`
             // does for its data queues, so the device re-processes any TX descriptor
@@ -436,9 +445,11 @@ where
             // Under EVENT_IDX the guest only notifies us when `avail_idx` crosses
             // `avail_event`; since it is already past, the guest considers itself to
             // have notified us and stays silent, so we never process the queue and
-            // guest-to-host connections hang. RX needs no replay: it is gated by
-            // `pending_event_ack` until the guest acks the reset, and the host pulls
-            // from the backend rather than waiting on a guest RX notification.
+            // guest-to-host connections hang. RX needs no replay: on the snapshot path
+            // it is gated by `pending_event_ack` until the guest acks the reset (which
+            // drains RX and re-arms `avail_event`), on a bare resume the RX queue
+            // state was never disturbed, and in both cases the host pulls from the
+            // backend rather than waiting on a guest RX notification.
             info!(
                 "[{:?}:{}] notifying tx queue",
                 self.device_type(),
@@ -608,23 +619,24 @@ mod tests {
     }
 
     #[test]
-    fn test_kick_when_active_arms_pending_event_ack() {
+    fn test_kick_preserves_armed_pending_event_ack() {
         // Restore path: kick() is invoked after the snapshot is loaded to re-deliver the
-        // TRANSPORT_RESET interrupt. It must arm the RX gate so the post-restore RX/EVQ
-        // race cannot deliver data ahead of the guest ack.
+        // TRANSPORT_RESET interrupt. The RX gate, restored from the snapshot state, must
+        // stay armed so the post-restore RX/EVQ race cannot deliver data ahead of the
+        // guest ack.
         let test_ctx = TestContext::new();
         let mut ctx = test_ctx.create_event_handler_context();
         ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
 
-        ctx.device.pending_event_ack = false;
+        ctx.device.pending_event_ack = true;
         ctx.device.kick();
 
         assert!(
             ctx.device.pending_event_ack,
-            "kick() on an active device must arm the RX gate"
+            "kick() must keep the RX gate armed while a reset ack is outstanding"
         );
 
-        // After kick(), the gate must actually suppress RX delivery.
+        // The gate must actually suppress RX delivery.
         ctx.device.backend.set_pending_rx(true);
         let progressed = ctx.device.process_rx().unwrap();
         assert!(!progressed);
@@ -632,11 +644,37 @@ mod tests {
     }
 
     #[test]
+    fn test_bare_resume_kick_leaves_rx_ungated() {
+        // Bare pause/resume path: no TRANSPORT_RESET was published, so kick() must not
+        // arm the RX gate. Arming it would block RX forever, as the guest never acks an
+        // event it never received, and new host-initiated connections would hang.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());
+
+        assert!(!ctx.device.pending_event_ack);
+        ctx.device.kick();
+
+        assert!(
+            !ctx.device.pending_event_ack,
+            "kick() must not arm the RX gate when no reset ack is outstanding"
+        );
+
+        // RX delivery must still work after the kick.
+        ctx.device.backend.set_pending_rx(true);
+        let progressed = ctx.device.process_rx().unwrap();
+        assert!(progressed, "RX must flow after a bare resume");
+        assert_eq!(ctx.guest_rxvq.used.idx.get(), 1);
+    }
+
+    #[test]
     fn test_kick_replays_tx_notification_only() {
-        // On restore, kick() must replay only the TX data queue (to re-process in-flight
-        // TX and re-arm avail_event). RX is gated by pending_event_ack so it needs no
-        // replay, and the event queue's data eventfd must not be notified -- that is the
-        // guest's TRANSPORT_RESET ack path; the event queue is signaled host->guest.
+        // On resume, kick() must replay only the TX data queue (to re-process in-flight
+        // TX and re-arm avail_event). RX needs no replay: on the snapshot path it is
+        // gated by pending_event_ack until the guest acks the reset, and on a bare
+        // resume its queue state was never disturbed. The event queue's data eventfd
+        // must not be notified either -- that is the guest's TRANSPORT_RESET ack path;
+        // the event queue is signaled host->guest.
         let test_ctx = TestContext::new();
         let mut ctx = test_ctx.create_event_handler_context();
         ctx.mock_activate(test_ctx.mem.clone(), test_ctx.interrupt.clone());

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -31,6 +31,11 @@ pub struct VsockFrontendState {
     /// Context Identifier.
     pub cid: u64,
     pub virtio_state: VirtioDeviceState,
+    /// Whether a `TRANSPORT_RESET_EVENT` published to the guest's event queue
+    /// is still awaiting the driver's acknowledgment. RX delivery stays gated
+    /// until the guest acks, so a restored device must resume with the same
+    /// gate state the source device had.
+    pub pending_event_ack: bool,
 }
 
 /// The Vsock Unix Backend serializable state.
@@ -92,6 +97,7 @@ where
         VsockFrontendState {
             cid: self.cid(),
             virtio_state: VirtioDeviceState::from_device(self),
+            pending_event_ack: self.pending_event_ack,
         }
     }
 
@@ -114,6 +120,7 @@ where
         vsock.acked_features = state.virtio_state.acked_features;
         vsock.avail_features = state.virtio_state.avail_features;
         vsock.device_state = DeviceState::Inactive;
+        vsock.pending_event_ack = state.pending_event_ack;
         Ok(vsock)
     }
 }
@@ -142,6 +149,29 @@ pub(crate) mod tests {
 
         fn restore(_: Self::ConstructorArgs, state: &Self::State) -> Result<Self, Self::Error> {
             Ok(TestBackend::new())
+        }
+    }
+
+    #[test]
+    fn test_persist_pending_event_ack() {
+        // The RX gate must survive a save/restore cycle: a restored device must keep
+        // gating RX while a TRANSPORT_RESET ack is outstanding, and must not gate RX
+        // when none is.
+        let mut ctx = TestContext::new();
+        for armed in [false, true] {
+            ctx.device.pending_event_ack = armed;
+            let state = ctx.device.save();
+            assert_eq!(state.pending_event_ack, armed);
+
+            let restored = Vsock::restore(
+                VsockConstructorArgs {
+                    mem: ctx.mem.clone(),
+                    backend: TestBackend::new(),
+                },
+                &state,
+            )
+            .unwrap();
+            assert_eq!(restored.pending_event_ack, armed);
         }
     }
 

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -155,6 +155,47 @@ def test_vsock_epipe(vsock_uvm_any, bin_vsock_path, test_fc_session_root_path):
     validate_fc_metrics(metrics)
 
 
+def test_vsock_bare_pause_resume(
+    vsock_uvm_any, bin_vsock_path, test_fc_session_root_path
+):
+    """
+    Test the vsock device across a bare pause/resume cycle (no snapshot).
+
+    A bare pause/resume must leave all vsock traffic working, in particular
+    new host-initiated (host->guest, RX direction) connections made after the
+    resume. These used to hang forever: the resume kick armed the
+    TRANSPORT_RESET RX gate even though no reset event had been sent, so the
+    guest could never acknowledge it and RX delivery stayed suppressed.
+    """
+    vm = vsock_uvm_any
+
+    # Generate the random data blob file.
+    blob_path, blob_hash = make_blob(test_fc_session_root_path)
+    vm_blob_path = "/tmp/vsock/test.blob"
+
+    # Set up a tmpfs drive on the guest, so we can copy the blob there.
+    # Guest-initiated connections (echo workers) will use this blob.
+    _copy_vsock_data_to_guest(vm.ssh, blob_path, vm_blob_path, bin_vsock_path)
+
+    # Start guest echo server and check that host-initiated connections work
+    # before the pause.
+    uds_path = start_guest_echo_server(vm)
+    check_host_connections(uds_path, blob_path, blob_hash)
+
+    vm.pause()
+    vm.resume()
+
+    # Fresh host-initiated connections after the resume must still work.
+    check_host_connections(uds_path, blob_path, blob_hash)
+
+    # Guest-initiated connections must keep working as well.
+    path = os.path.join(vm.path, make_host_port_path(VSOCK_UDS_PATH, ECHO_SERVER_PORT))
+    check_guest_connections(vm, path, vm_blob_path, blob_hash)
+
+    metrics = vm.flush_metrics()
+    validate_fc_metrics(metrics)
+
+
 @pin_guest_kernel(ACPI_GUEST_KERNELS)
 @pytest.mark.parametrize("vsock_uvm", [1, 2], indirect=True, ids=["1vcpu", "2vcpu"])
 def test_vsock_transport_reset_h2g(


### PR DESCRIPTION
## Changes

- Persist `pending_event_ack` (the TRANSPORT_RESET RX gate) in `VsockFrontendState`, and restore it in `Vsock::restore()`. The saved value is accurate by construction: the device manager calls `prepare_save()` (which publishes the reset event and sets the flag) immediately before `save()`.
- `Vsock::kick()` no longer arms the gate. It signals the event queue only when a reset acknowledgment is actually outstanding, and keeps replaying the TX queue notification (#5958) unconditionally.
- Unit tests: kick now verified to preserve the gate in both states (armed stays armed and RX stays suppressed; disarmed stays disarmed and RX flows), plus a save/restore round-trip test for the flag.
- New integration test `test_vsock_bare_pause_resume`: host-initiated connections before and after a bare pause/resume, plus guest-initiated connections after.
- CHANGELOG entry.

No snapshot version bump: `SNAPSHOT_VERSION` already moved to 11.0.0 in this development cycle.

## Reason

After a bare pause/resume cycle (`PATCH /vm {"state": "Paused"}` then `{"state": "Resumed"}`, no snapshot involved), every new host-initiated connection to the hybrid-vsock UDS hangs forever: the `CONNECT <port>` handshake never receives its `OK` line. Guest-initiated connections keep working.

`resume_vm` kicks all virtio devices. The vsock kick set `pending_event_ack = true` unconditionally. That flag makes `process_rx()` return without delivering anything, enforcing #5882's guarantee that no RX data reaches the guest before it acknowledges the `TRANSPORT_RESET` event. Arming it in `kick()` was load-bearing for snapshot restore, because the flag was not part of the persisted state. On a bare resume, however, no reset event was ever published (`prepare_save()` only runs on snapshot creation), so the guest never performs the event-queue kick that clears the flag, and RX stays gated forever.

Since the flag mirrors guest-visible state (an un-acked reset event in the event queue's used ring, which lives in persisted guest memory), persisting it makes it correct on every path: restored VMs keep gating until the guest acks, resuming a VM that just had a snapshot taken keeps gating until the guest acks, and a bare resume leaves RX untouched.

Verified on an Intel/KVM host: the new integration test fails on current main in all 8 parametrizations (post-resume connect hangs to the pytest timeout) and passes with this change; `test_vsock_transport_reset_h2g` (16/16), `test_vsock_transport_reset_g2h` (12/12), `test_vsock`, `test_vsock_epipe`, and the snapshot-override tests all pass; `RUST_TEST_THREADS=1 cargo test -p vmm vsock` passes; `devtool checkstyle` and `devtool checkbuild --all` pass.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the automated style checks.
- [x] I have described what is done in these changes, why they are needed, and how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs) in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md

## LLM Disclosure

I prepared this change with the assistance of a LLM, specifically Anthropic's Claude Fable 5. I reviewed the changes and confirmed that they are correct given my best understanding of the issue. I am responsible for all code changes in this PR.
