### PR TITLE
doc: update Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ You can get in touch with the Firecracker community in the following ways:
 
 - Security-related issues, see our [security policy document](SECURITY.md).
 - Chat with us on our
-  [Slack workspace](https://join.slack.com/t/firecracker-microvm/shared_invite/zt-2tc0mfxpc-tU~HYAYSzLDl5XGGJU3YIg)
+  [Slack workspace](https://join.slack.com/t/firecracker-microvm/shared_invite/zt-3v81btcpe-usCf8Qk7k1gUlSAEKKdYMg)
   _Note: most of the maintainers are on a European time zone._
 - Open a GitHub issue in this repository.
 - Email the maintainers at


### PR DESCRIPTION
## Changes

Update the Firecracker Slack invite link in `README.md` to the invite
currently published on the [project website](https://firecracker-microvm.github.io).

## Reason

The invite link in the README expired again (a recurrence of #4860). The
website's link is still active, and this change brings the README back in
sync with it.

Fixes: #6102

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
