### PR TITLE
test: hotplug: skip secret freedom with huge pages

### DIFF
--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -544,6 +544,12 @@ def test_memory_hotplug_latency(
 ):
     """Test the latency of hotplugging memory"""
 
+    # Secret free VMs are backed by guest_memfd, which cannot be combined with huge
+    # pages, so /machine-config rejects the combination. The two parameters are
+    # independent, so their product includes pairs that are invalid by construction.
+    if secret_free and huge_pages != HugePagesConfig.NONE:
+        pytest.skip("secret freedom and huge pages are mutually exclusive")
+
     for i in range(20):
         config = {
             "total_size_mib": hotplug_size,


### PR DESCRIPTION
## Changes

Skip secret freedom with huge pages in the memory hotplug tests as they are not
compatible.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
