### PR TITLE
[bar-reloc 4/5] pci: Add unit tests for BAR relocation

### DIFF
--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -1232,11 +1232,12 @@ mod tests {
 
     use event_manager::MutEventSubscriber;
     use linux_loader::loader::Cmdline;
+    use vm_allocator::{AllocPolicy, RangeInclusive};
     use vm_memory::{ByteValued, Le32};
 
-    use super::{PciCapabilityType, VirtioPciDevice};
+    use super::{EventFd, IoEventAddress, KvmVm, NoDatamatch, PciCapabilityType, VirtioPciDevice};
     use crate::Vmm;
-    use crate::arch::MEM_64BIT_DEVICES_START;
+    use crate::arch::{MEM_64BIT_DEVICES_SIZE, MEM_64BIT_DEVICES_START};
     use crate::builder::tests::default_vmm_with_pci;
     use crate::device_manager::tests::pci_devices;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
@@ -1244,14 +1245,15 @@ mod tests {
     use crate::devices::virtio::rng::Entropy;
     use crate::devices::virtio::transport::pci::common_config_offset::*;
     use crate::devices::virtio::transport::pci::device::{
-        COMMON_CONFIG_BAR_OFFSET, COMMON_CONFIG_SIZE, DEVICE_CONFIG_BAR_OFFSET, DEVICE_CONFIG_SIZE,
-        ISR_CONFIG_BAR_OFFSET, ISR_CONFIG_SIZE, NOTIFICATION_BAR_OFFSET, NOTIFICATION_SIZE,
-        NOTIFY_OFF_MULTIPLIER, PciVirtioSubclass, VirtioPciCap, VirtioPciCfgCap,
-        VirtioPciNotifyCap,
+        CAPABILITY_BAR_SIZE, COMMAND_MEMORY_SPACE_ENABLE, COMMAND_REG, COMMON_CONFIG_BAR_OFFSET,
+        COMMON_CONFIG_SIZE, DEVICE_CONFIG_BAR_OFFSET, DEVICE_CONFIG_SIZE, ISR_CONFIG_BAR_OFFSET,
+        ISR_CONFIG_SIZE, NOTIFICATION_BAR_OFFSET, NOTIFICATION_SIZE, NOTIFY_OFF_MULTIPLIER,
+        PciVirtioSubclass, VirtioPciCap, VirtioPciCfgCap, VirtioPciNotifyCap,
     };
     use crate::devices::virtio::transport::pci::device_status::{
         ACKNOWLEDGE, DRIVER, DRIVER_OK, FEATURES_OK,
     };
+    use crate::pci::configuration::BAR0_REG_IDX;
     use crate::pci::msix::MsixCap;
     use crate::pci::{PciCapabilityId, PciClassCode, PciDevice};
     use crate::rate_limiter::RateLimiter;
@@ -1435,6 +1437,145 @@ mod tests {
 
         // We create a capabilities BAR region of 0x80000 bytes
         assert_eq!(bar_size, 0x80000);
+    }
+
+    fn kvm_vm(vmm: &Vmm) -> &Arc<KvmVm> {
+        vmm.vm.as_kvm().unwrap()
+    }
+
+    fn write_bar_base(device: &mut VirtioPciDevice, base: u64) {
+        device.write_config_register(BAR0_REG_IDX, 0, &(base as u32).to_le_bytes());
+        device.write_config_register(BAR0_REG_IDX + 1, 0, &((base >> 32) as u32).to_le_bytes());
+    }
+
+    fn set_memory_space_enable(device: &mut VirtioPciDevice, enable: bool) {
+        let command = if enable {
+            COMMAND_MEMORY_SPACE_ENABLE as u16
+        } else {
+            0
+        };
+        device.write_config_register(COMMAND_REG, 0, &command.to_le_bytes());
+    }
+
+    fn allocate_bar_range(vmm: &Vmm, base: u64) -> Result<RangeInclusive, vm_allocator::Error> {
+        kvm_vm(vmm).resource_allocator().mmio64_memory.allocate(
+            CAPABILITY_BAR_SIZE,
+            CAPABILITY_BAR_SIZE,
+            AllocPolicy::ExactMatch(base),
+        )
+    }
+
+    /// Try to register an ioeventfd at the notification address of a BAR
+    /// mapped at `base`. KVM returns EEXIST if a colliding MMIO ioeventfd is
+    /// already registered there, which makes the notification ioeventfds of
+    /// the device directly observable.
+    fn register_probe_ioevent(vmm: &Vmm, base: u64) -> Result<(), kvm_ioctls::Error> {
+        let probe = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        let notify = IoEventAddress::Mmio(base + u64::from(NOTIFICATION_BAR_OFFSET));
+        kvm_vm(vmm)
+            .fd()
+            .register_ioevent(&probe, &notify, NoDatamatch)
+    }
+
+    #[test]
+    fn test_bar_relocation() {
+        let vmm = create_vmm_with_virtio_pci_device();
+        let device = get_virtio_device(&vmm);
+        let old_base = MEM_64BIT_DEVICES_START;
+        let new_base = old_base + CAPABILITY_BAR_SIZE;
+
+        {
+            let mut device = device.lock().unwrap();
+            assert_eq!(device.bar_address(), old_base);
+
+            // Writing the BAR does not move the device on its own. The
+            // relocation happens when memory space decoding gets enabled.
+            write_bar_base(&mut device, new_base);
+            assert_eq!(device.config_bar_addr(), new_base);
+            assert_eq!(device.bar_address(), old_base);
+
+            set_memory_space_enable(&mut device, true);
+            assert_eq!(device.bar_address(), new_base);
+        }
+
+        // The mmio bus mapping followed the BAR.
+        let mut data = [0u8; 4];
+        kvm_vm(&vmm)
+            .common
+            .mmio_bus
+            .read(new_base, &mut data)
+            .unwrap();
+        kvm_vm(&vmm)
+            .common
+            .mmio_bus
+            .read(old_base, &mut data)
+            .unwrap_err();
+
+        // The old range is free and the new one is taken.
+        allocate_bar_range(&vmm, old_base).unwrap();
+        allocate_bar_range(&vmm, new_base).unwrap_err();
+
+        // The notification ioeventfds followed the BAR: KVM rejects a second
+        // registration at the new notify address and accepts one at the old.
+        register_probe_ioevent(&vmm, new_base).unwrap_err();
+        register_probe_ioevent(&vmm, old_base).unwrap();
+    }
+
+    #[test]
+    fn test_bar_relocation_on_memory_space_enable_only() {
+        let vmm = create_vmm_with_virtio_pci_device();
+        let device = get_virtio_device(&vmm);
+        let mut device = device.lock().unwrap();
+        let old_base = MEM_64BIT_DEVICES_START;
+        let new_base = old_base + CAPABILITY_BAR_SIZE;
+
+        // Enabling memory space decoding with an unchanged BAR is a no-op.
+        set_memory_space_enable(&mut device, true);
+        assert_eq!(device.bar_address(), old_base);
+
+        // A BAR write while memory space decoding is already enabled does not
+        // relocate the device.
+        write_bar_base(&mut device, new_base);
+        assert_eq!(device.bar_address(), old_base);
+
+        // Only the transition from disabled to enabled does.
+        set_memory_space_enable(&mut device, false);
+        assert_eq!(device.bar_address(), old_base);
+        set_memory_space_enable(&mut device, true);
+        assert_eq!(device.bar_address(), new_base);
+    }
+
+    #[test]
+    fn test_bar_relocation_refused() {
+        let vmm = create_vmm_with_virtio_pci_device();
+        let device = get_virtio_device(&vmm);
+        let old_base = MEM_64BIT_DEVICES_START;
+
+        // A range that is already allocated to someone else.
+        let taken_base = old_base + CAPABILITY_BAR_SIZE;
+        allocate_bar_range(&vmm, taken_base).unwrap();
+        // A range outside the 64-bit MMIO window.
+        let outside_base = MEM_64BIT_DEVICES_START + MEM_64BIT_DEVICES_SIZE;
+
+        for base in [taken_base, outside_base] {
+            let mut device = device.lock().unwrap();
+            set_memory_space_enable(&mut device, false);
+            write_bar_base(&mut device, base);
+            set_memory_space_enable(&mut device, true);
+            assert_eq!(device.bar_address(), old_base);
+        }
+
+        // The device is still mapped at its old base.
+        let mut data = [0u8; 4];
+        kvm_vm(&vmm)
+            .common
+            .mmio_bus
+            .read(old_base, &mut data)
+            .unwrap();
+
+        // The notification ioeventfds did not move either: KVM rejects a
+        // second registration at the old notify address
+        register_probe_ioevent(&vmm, old_base).unwrap_err();
     }
 
     fn read_virtio_pci_cap(

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -884,4 +884,72 @@ mod tests {
         assert_eq!(bars.get_bar_size(2), 0x2000);
         assert_eq!(bars.get_bar_size_32(2), 0x2000);
     }
+
+    #[test]
+    fn test_bars_relocate_64bit() {
+        // A 64-bit prefetchable BAR the guest can reprogram.
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1_0000_0000, 0x1000, BarPrefetchable::Yes);
+        // Low register carries the type/prefetchable flags in its low nibble:
+        // bit 3 (prefetchable) + bits 2:1 = 0b10 (64-bit) => 0b1100 = 0xc.
+        assert_eq!(bars.bars[0].encoded_addr & 0xf, 0b1100);
+
+        // The guest reassigns the BAR to 0x2_0000_0000 by writing the low then
+        // the high half of the address register.
+        bars.write(0, 0, &0x0000_0000u32.to_le_bytes());
+        bars.write(1, 0, &0x0000_0002u32.to_le_bytes());
+        assert_eq!(bars.get_bar_addr_64(0), 0x2_0000_0000);
+        // Size is unchanged and the read-only flag bits are preserved.
+        assert_eq!(bars.get_bar_size_64(0), 0x1000);
+        assert_eq!(bars.bars[0].encoded_addr & 0xf, 0b1100);
+
+        // The low address bits inside the size mask are read-only: a write that
+        // sets them is masked off (0x1234 & !(0x1000-1) == 0x1000).
+        bars.write(0, 0, &0x0000_1234u32.to_le_bytes());
+        assert_eq!(bars.get_bar_addr_64(0), 0x2_0000_1000);
+    }
+
+    #[test]
+    fn test_bars_relocate_partial_write() {
+        // Reprogramming the address one byte at a time must accumulate, and the
+        // read-only flag bits in the low register must be preserved.
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1_0000_0000, 0x1000, BarPrefetchable::No);
+
+        // Write the high half (upper 32 bits of the address) byte-by-byte to 0x4000.
+        bars.write(1, 0, &[0x00]);
+        bars.write(1, 1, &[0x40]);
+        bars.write(1, 2, &[0x00]);
+        bars.write(1, 3, &[0x00]);
+        // Write the low half so the aligned base becomes 0x0020_0000.
+        bars.write(0, 0, &0x0020_0000u32.to_le_bytes());
+
+        assert_eq!(bars.get_bar_addr_64(0), 0x4000_0020_0000);
+        // The 64-bit type flag (bit 2) survives the low-register writes.
+        assert!(bars.bars[0].is_64bit());
+    }
+
+    #[test]
+    fn test_bars_sizing_probe() {
+        // Writing all 1s leaves the encoded size in the register.
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1_0000_0000, 0x1000, BarPrefetchable::No);
+
+        bars.write(0, 0, &0xffff_ffffu32.to_le_bytes());
+        let mut v: u32 = 0;
+        bars.read(0, 0, v.as_mut_bytes());
+        // Encoded size of a 4 KiB BAR, with the read-only 64-bit type flag
+        // (bit 2) preserved.
+        assert_eq!(v, 0xffff_f000 | 0b100);
+        // The register keeps reporting the size until the guest writes an
+        // address back, so a second read gives the same value.
+        bars.read(0, 0, v.as_mut_bytes());
+        assert_eq!(v, 0xffff_f000 | 0b100);
+
+        // The guest restores the address it saved before the probe.
+        bars.write(0, 0, &0x0000_0000u32.to_le_bytes());
+        assert_eq!(bars.get_bar_addr_64(0), 0x1_0000_0000);
+        assert_eq!(bars.get_bar_size_64(0), 0x1000);
+        assert!(bars.bars[0].is_64bit());
+    }
 }


### PR DESCRIPTION
**Commit Message**

```
pci: Add unit tests for BAR relocation

Cover the BAR register behaviour that BAR relocation relies on in
pci/configuration.rs and add unit tests for maybe_relocate_bar().

Signed-off-by: Ilias Stamatis <ilstam@amazon.com>
```
