### PR TITLE
fix(vmm): enable KVM_CAP_ARM_WRITABLE_IMP_ID_REGS on aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to
   host page cache, so same-host reads still see the full contents. Block device
   backing files are always `fsync`'d regardless. See
   [snapshot documentation](docs/snapshotting/snapshot-support.md).
+- [#6116](https://github.com/firecracker-microvm/firecracker/pull/6116): On
+  aarch64, enable `KVM_CAP_ARM_WRITABLE_IMP_ID_REGS` when the host kernel offers
+  it (Linux 6.15 and later), adding support for custom CPU templates that modify
+  the implementation ID registers (`MIDR_EL1`, `REVIDR_EL1`, `AIDR_EL1`). Such
+  templates previously failed at boot with
+  `Failed to set register ... Invalid argument` because KVM rejects the write
+  unless the capability is enabled on the VM.
 
 ### Changed
 

--- a/docs/cpu_templates/cpu-templates.md
+++ b/docs/cpu_templates/cpu-templates.md
@@ -50,7 +50,11 @@ Firecracker supports two types of CPU templates:
 > CPU templates for ARM (both static and custom) require the following patch to
 > be available in the host kernel:
 > [Support writable CPU ID registers from userspace](https://lore.kernel.org/kvm/20230212215830.2975485-1-jingzhangos@google.com/#t).
-> Otherwise KVM will fail to write to the ARM registers.
+> Otherwise KVM will fail to write to the ARM registers. Additionally, modifying
+> the implementation ID registers (`MIDR_EL1`, `REVIDR_EL1`, `AIDR_EL1`)
+> requires a host kernel with `KVM_CAP_ARM_WRITABLE_IMP_ID_REGS` (Linux 6.15 or
+> later):
+> [KVM: arm64: writable MIDR/REVIDR](https://lore.kernel.org/lkml/20250210154953.27002-1-sebott@redhat.com/).
 
 ## Static CPU templates
 

--- a/src/vmm/src/arch/aarch64/vcpu.rs
+++ b/src/vmm/src/arch/aarch64/vcpu.rs
@@ -578,6 +578,36 @@ mod tests {
     }
 
     #[test]
+    fn test_writable_imp_id_regs() {
+        // MIDR_EL1: op0=3, op1=0, CRn=0, CRm=0, op2=0.
+        const MIDR_EL1: u64 = 0x6030_0000_0013_c000;
+        // An arbitrary valid MIDR value (implementer Arm, part Neoverse N1).
+        const FAKE_MIDR: u64 = 0x410f_d0c0;
+
+        // `KvmVm::new` enables KVM_CAP_ARM_WRITABLE_IMP_ID_REGS when the host
+        // kernel offers it, before any vCPU is created.
+        let vm = setup_vm_with_memory(0x1000);
+        if vm
+            .fd()
+            .check_extension_raw(u64::from(kvm_bindings::KVM_CAP_ARM_WRITABLE_IMP_ID_REGS))
+            != 1
+        {
+            // Host kernel predates writable implementation ID registers
+            // (Linux 6.15); there is nothing further to verify.
+            return;
+        }
+        let mut vcpu = KvmVcpu::new(0, &vm).unwrap();
+        vcpu.init(&[]).unwrap();
+
+        let mut val = [0u8; 8];
+        vcpu.fd
+            .set_one_reg(MIDR_EL1, &FAKE_MIDR.to_le_bytes())
+            .unwrap();
+        vcpu.fd.get_one_reg(MIDR_EL1, &mut val).unwrap();
+        assert_eq!(u64::from_le_bytes(val), FAKE_MIDR);
+    }
+
+    #[test]
     fn test_create_vcpu() {
         let vm = setup_vm_with_memory(0x1000);
 

--- a/src/vmm/src/arch/aarch64/vm.rs
+++ b/src/vmm/src/arch/aarch64/vm.rs
@@ -3,14 +3,29 @@
 
 use std::sync::Mutex;
 
+use kvm_bindings::{KVM_CAP_ARM_WRITABLE_IMP_ID_REGS, KVMIO, kvm_enable_cap};
 use serde::{Deserialize, Serialize};
+use vmm_sys_util::errno;
+use vmm_sys_util::ioctl::ioctl_with_ref;
+use vmm_sys_util::ioctl_iow_nr;
 
 use crate::Kvm;
 use crate::arch::aarch64::gic::GicState;
+use crate::logger::warn;
 use crate::snapshot::Persist;
 use crate::vstate::memory::{GuestMemoryExtension, GuestMemoryState};
 use crate::vstate::resources::{ResourceAllocator, ResourceAllocatorState};
 use crate::vstate::vm::{VmCommon, VmError};
+
+// TODO(https://github.com/rust-vmm/kvm/pull/382): kvm-ioctls does not expose
+// `VmFd::enable_cap` on aarch64 yet; this is the same definition it uses
+// internally. Replace the direct ioctl with `enable_cap` once a release
+// containing that PR is available.
+#[allow(missing_docs)]
+mod ioctls {
+    use super::*;
+    ioctl_iow_nr!(KVM_ENABLE_CAP, KVMIO, 0xa3, kvm_enable_cap);
+}
 
 /// Structure representing the current architecture's understand of what a "virtual machine" is.
 #[derive(Debug)]
@@ -38,6 +53,39 @@ impl KvmVm {
     /// Create a new `KvmVm` struct.
     pub fn new(kvm: Kvm) -> Result<KvmVm, VmError> {
         let common = Self::create_common(kvm)?;
+
+        // KVM gates writes to the implementation ID registers (MIDR_EL1,
+        // REVIDR_EL1, AIDR_EL1) behind KVM_CAP_ARM_WRITABLE_IMP_ID_REGS,
+        // which must be enabled before any vCPU is created. Without it, a
+        // custom CPU template that modifies these registers fails at boot
+        // with EINVAL when the template is applied. Enabling the capability
+        // on its own does not change guest-visible state: the registers keep
+        // their host values unless a template rewrites them, and writes of
+        // unchanged values (e.g. on snapshot restore) were already accepted
+        // before this capability existed.
+        if common
+            .fd
+            .check_extension_raw(u64::from(KVM_CAP_ARM_WRITABLE_IMP_ID_REGS))
+            == 1
+        {
+            let cap = kvm_enable_cap {
+                cap: KVM_CAP_ARM_WRITABLE_IMP_ID_REGS,
+                ..Default::default()
+            };
+            // SAFETY: The ioctl is safe because we allocated the struct and
+            // the kernel will only read the size of the struct.
+            let ret = unsafe { ioctl_with_ref(&common.fd, ioctls::KVM_ENABLE_CAP(), &cap) };
+            if ret != 0 {
+                // Not fatal: a VM whose CPU template does not touch the
+                // implementation ID registers is unaffected, and one that
+                // does will fail loudly when the template is applied.
+                warn!(
+                    "Failed to enable KVM_CAP_ARM_WRITABLE_IMP_ID_REGS: {}",
+                    errno::Error::last()
+                );
+            }
+        }
+
         Ok(KvmVm {
             common,
             irqchip_handle: None,


### PR DESCRIPTION
## Changes

On aarch64, enable `KVM_CAP_ARM_WRITABLE_IMP_ID_REGS` on the VM fd before vCPUs are created, whenever the host kernel offers the capability.

## Reason

Linux 6.15 made the implementation ID registers (`MIDR_EL1`, `REVIDR_EL1`, `AIDR_EL1`) writable from userspace ([KVM: arm64: writable MIDR/REVIDR](https://lore.kernel.org/lkml/20250210154953.27002-1-sebott@redhat.com/)), gated behind `KVM_CAP_ARM_WRITABLE_IMP_ID_REGS`, which the VMM must enable per VM before any vCPU is created. Firecracker never enables it, so a custom CPU template with a modifier for one of these registers fails at boot with EINVAL even on kernels that support the write:

```
Start microvm error: System configuration error: Error configuring the vcpu:
Error applying template: Failed to set register 0x603000000013c000 to value
0x00000000410fd0c0: Invalid argument (os error 22)
```

Being able to rewrite these registers matters for the same reason the capability was added to KVM: the guest sees the host CPU identity while KVM masks features like SVE from the ID feature registers, and guest software that dispatches on the identity rather than on the feature registers or hwcaps then executes instructions the VM traps, dying with SIGILL. We hit this in production with WebKit on Graviton4 (both Skia and Mesa llvmpipe's LLVM JIT key on the CPU part number and emit SVE). A CPU template that rewrites `MIDR_EL1` to a generic part resolves the whole class, but only once this capability is enabled.

Enabling the capability on its own does not change guest visible state: the registers keep their host values unless a template writes them, and same-value writes (for example on snapshot restore) were already accepted before the capability existed.

`VmFd::enable_cap` is not exposed for aarch64 by kvm-ioctls (up to and including current main), so the ioctl is issued directly with the same definition kvm-ioctls uses on other architectures. The kvm-ioctls side is now up as rust-vmm/kvm#382; once a release containing it exists, the direct ioctl here can be replaced with a plain `enable_cap` call, and I am happy to follow up with that change or to rebase this PR onto it now if waiting for the dependency is preferred.

Verified on an EC2 c7g.metal running Ubuntu 26.04 (kernel 7.0):

- Without this patch, the boot fails with the EINVAL above.
- With this patch, a microVM booted with a custom template containing a `MIDR_EL1` reg modifier comes up and the guest reads the templated value: `/proc/cpuinfo` reports `CPU part: 0xd0c` on a host whose part is `0xd40`.
- The new unit test passes on the same host (it returns early on kernels without the capability, verified against a 6.1 host where `KVM_CHECK_EXTENSION` reports 0).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the automated style checks.
- [x] I have described what is done in these changes, why they are needed, and how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs) in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue. (No pre-existing issue; the failure is described above.)
- [x] When making API changes, I have followed the [Runbook for Firecracker API changes][2]. (No API changes.)
- [x] I have tested all new and changed functionalities in unit tests and/or integration tests.
- [x] I have linked an issue to every new `TODO`. (No new TODOs.)

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1]. (The decision to enable the capability belongs in the VMM. The missing piece in rust-vmm is only the aarch64 `enable_cap` binding, which this PR works around with a direct ioctl; see the note above about lifting that cfg gate upstream.)

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
