### PR TITLE
pci: Free the device BAR range on detach

### DIFF
--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -967,6 +967,38 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_pci_bar_is_freed_on_unplug() {
+        let mut evt_manager = EventManager::new().unwrap();
+        let mut vmm = default_vmm_with_pci();
+        let f = TempFile::new().unwrap();
+
+        let bar_addr = |vmm: &crate::Vmm, id: &str| {
+            pci_devices(&vmm.device_manager)
+                .get_virtio_device(VirtioDeviceType::Block, id)
+                .unwrap()
+                .lock()
+                .unwrap()
+                .config_bar_addr()
+        };
+
+        let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
+        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        let first_addr = bar_addr(&vmm, "block0");
+
+        vmm.hot_unplug_device(
+            (VirtioDeviceType::Block, "block0".to_string()),
+            &mut evt_manager,
+        )
+        .unwrap();
+
+        // The BAR range of the detached device must have been returned to the
+        // 64-bit MMIO allocator, so the next device gets the same address.
+        let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block1", &f, false));
+        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        assert_eq!(bar_addr(&vmm, "block1"), first_addr);
+    }
+
+    #[test]
     fn test_hotplug_pci_not_enabled() {
         let mut vmm = default_vmm();
         let mut evt_manager = EventManager::new().unwrap();

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -212,6 +212,11 @@ impl PciDevices {
             warn!("Failed to remove event subscriber for device {device_id:?}");
         }
 
+        pci_device_arc
+            .lock()
+            .expect("Poisoned lock")
+            .free_bars(&mut vm.resource_allocator().mmio64_memory);
+
         // Ensure no other references to the device remain, so it is freed when
         // this function returns.
         assert_eq!(Arc::strong_count(&pci_device_arc), 1);

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -364,6 +364,18 @@ impl VirtioPciDevice {
         self.add_pci_capabilities();
     }
 
+    /// Free the PCI BAR of the VirtIO device.
+    pub fn free_bars(&self, mmio64_allocator: &mut AddressAllocator) {
+        let bar_addr = self.config_bar_addr();
+        let bar_end = bar_addr
+            .checked_add(CAPABILITY_BAR_SIZE - 1)
+            .expect("virtio-pci BAR end address overflows");
+        let range = RangeInclusive::new(bar_addr, bar_end).expect("Invalid virtio-pci BAR range");
+        mmio64_allocator
+            .free(&range)
+            .expect("virtio-pci BAR is not allocated");
+    }
+
     /// Constructs a new PCI transport for the given virtio device.
     pub fn new(
         id: String,


### PR DESCRIPTION
detach_pci_virtio_device() did not free the device BAR from the mmio64_allocator, leaking parts of the address range. Add a free_bars() method to VirtioPciDevice and call it on detach. Also add a unit test to ensure we don't re-introduce the bug.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
