### PR TITLE
devices: Remove blanket #![allow(unused)]

### DIFF
--- a/src/vmm/src/devices/acpi/vmclock.rs
+++ b/src/vmm/src/devices/acpi/vmclock.rs
@@ -1,7 +1,6 @@
 // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::Infallible;
 use std::mem::offset_of;
 use std::sync::atomic::{Ordering, fence};
 
@@ -94,7 +93,7 @@ impl VmClock {
             EventFd::new(libc::EFD_NONBLOCK).map_err(VmClockError::CreateEventFd)?,
         );
 
-        let mut inner = vmclock_abi {
+        let inner = vmclock_abi {
             magic: VMCLOCK_MAGIC,
             size: VMCLOCK_SIZE,
             version: 1,
@@ -180,7 +179,7 @@ impl<'a> Persist<'a> for VmClock {
         }
     }
 
-    fn restore(vm: Self::ConstructorArgs, state: &Self::State) -> Result<Self, Self::Error> {
+    fn restore(_: Self::ConstructorArgs, state: &Self::State) -> Result<Self, Self::Error> {
         let interrupt_evt = EventFdTrigger::new(
             EventFd::new(libc::EFD_NONBLOCK).map_err(VmClockError::CreateEventFd)?,
         );
@@ -225,19 +224,14 @@ impl Aml for VmClock {
 #[cfg(test)]
 mod tests {
     use vm_memory::{Bytes, GuestAddress};
-    use vmm_sys_util::tempfile::TempFile;
 
-    #[cfg(target_arch = "x86_64")]
-    use crate::arch::x86_64::layout;
-    use crate::arch::{self, Kvm};
+    use crate::arch;
     use crate::devices::acpi::generated::vmclock_abi::vmclock_abi;
     use crate::devices::acpi::vmclock::{VMCLOCK_SIZE, VmClock};
-    use crate::devices::virtio::test_utils::default_mem;
-    use crate::snapshot::{Persist, Snapshot};
+    use crate::snapshot::Persist;
     use crate::test_utils::single_region_mem;
     use crate::utils::u64_to_usize;
     use crate::vstate::resources::ResourceAllocator;
-    use crate::vstate::vm::tests::setup_vm_with_memory;
 
     // We are allocating memory from the end of the system memory portion
     const VMCLOCK_TEST_GUEST_ADDR: GuestAddress =
@@ -258,7 +252,7 @@ mod tests {
         let guest_data: vmclock_abi = mem.read_obj(VMCLOCK_TEST_GUEST_ADDR).unwrap();
         assert_ne!(guest_data, vmclock.inner);
 
-        vmclock.activate(&mem);
+        vmclock.activate(&mem).unwrap();
 
         let guest_data: vmclock_abi = mem.read_obj(VMCLOCK_TEST_GUEST_ADDR).unwrap();
         assert_eq!(guest_data, vmclock.inner);
@@ -277,7 +271,7 @@ mod tests {
 
         let state = vmclock.save();
         let mut vmclock_new = VmClock::restore((), &state).unwrap();
-        vmclock_new.do_post_restore(&mem);
+        vmclock_new.do_post_restore(&mem).unwrap();
 
         let guest_data_new: vmclock_abi = mem.read_obj(VMCLOCK_TEST_GUEST_ADDR).unwrap();
         assert_ne!(guest_data_new, vmclock.inner);

--- a/src/vmm/src/devices/acpi/vmclock.rs
+++ b/src/vmm/src/devices/acpi/vmclock.rs
@@ -38,7 +38,7 @@ macro_rules! write_vmclock_field {
             $vmclock
                 .guest_address
                 .unchecked_add(offset_of!(vmclock_abi, $field) as u64),
-        );
+        )?;
     };
 }
 

--- a/src/vmm/src/devices/acpi/vmgenid.rs
+++ b/src/vmm/src/devices/acpi/vmgenid.rs
@@ -1,10 +1,7 @@
 // Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::Infallible;
-
 use acpi_tables::{Aml, aml};
-use aws_lc_rs::error::Unspecified as RandError;
 use aws_lc_rs::rand;
 use serde::{Deserialize, Serialize};
 use vm_memory::{GuestAddress, GuestMemoryError};

--- a/src/vmm/src/devices/mod.rs
+++ b/src/vmm/src/devices/mod.rs
@@ -7,8 +7,6 @@
 
 //! Emulates virtual and hardware devices.
 
-#![allow(unused)]
-
 use std::io;
 
 pub mod acpi;

--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -15,22 +15,22 @@ use std::sync::{Arc, Mutex};
 use acpi_tables::{Aml, aml};
 #[cfg(target_arch = "x86_64")]
 use uuid::Uuid;
-use vm_allocator::AddressAllocator;
 
 use crate::arch::{PCI_MMCONFIG_START, PCI_MMIO_CONFIG_SIZE_PER_SEGMENT};
 use crate::logger::info;
 use crate::pci::PciSBDF;
 #[cfg(target_arch = "x86_64")]
-use crate::pci::bus::{PCI_CONFIG_IO_PORT, PCI_CONFIG_IO_PORT_SIZE};
-use crate::pci::bus::{PciBus, PciConfigIo, PciConfigMmio, PciRoot, PciRootError};
+use crate::pci::bus::{PCI_CONFIG_IO_PORT, PCI_CONFIG_IO_PORT_SIZE, PciConfigIo};
+use crate::pci::bus::{PciBus, PciConfigMmio, PciRoot, PciRootError};
 use crate::vstate::bus::BusError;
-use crate::vstate::resources::ResourceAllocator;
 use crate::vstate::vm::KvmVm;
 
 pub struct PciSegment {
     pub(crate) id: u16,
     pub(crate) pci_bus: Arc<Mutex<PciBus>>,
-    pub(crate) pci_config_mmio: Arc<Mutex<PciConfigMmio>>,
+    // The MMIO bus only holds a weak reference to the device, so we need to keep
+    // the strong reference here alive for as long as the segment exists.
+    pub(crate) _pci_config_mmio: Arc<Mutex<PciConfigMmio>>,
     pub(crate) mmio_config_address: u64,
     pub(crate) proximity_domain: u32,
 
@@ -88,7 +88,7 @@ impl PciSegment {
         let segment = PciSegment {
             id,
             pci_bus,
-            pci_config_mmio,
+            _pci_config_mmio: pci_config_mmio,
             mmio_config_address,
             proximity_domain: 0,
             #[cfg(target_arch = "x86_64")]
@@ -492,7 +492,7 @@ mod tests {
         let vmm = default_vmm();
         let kvm_vm = vmm.vm.as_kvm().unwrap().clone();
         let pci_irq_slots = &[0u8; 32];
-        let pci_segment = PciSegment::new(0, &kvm_vm, pci_irq_slots).unwrap();
+        let _pci_segment = PciSegment::new(0, &kvm_vm, pci_irq_slots).unwrap();
 
         let mut data = [0u8; u64_to_usize(PCI_CONFIG_IO_PORT_SIZE)];
         kvm_vm.pio_bus.read(PCI_CONFIG_IO_PORT, &mut data).unwrap();

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -612,7 +612,7 @@ impl Balloon {
         }
 
         if complete && self.hinting_state.acknowledge_on_finish {
-            self.update_free_page_hint_cmd(FREE_PAGE_HINT_DONE);
+            self.update_free_page_hint_cmd(FREE_PAGE_HINT_DONE)?;
         }
 
         Ok(())
@@ -1003,7 +1003,13 @@ impl VirtioDevice for Balloon {
                     self.device_type(),
                     self.id()
                 );
-                self.update_free_page_hint_cmd(FREE_PAGE_HINT_DONE);
+                if let Err(err) = self.update_free_page_hint_cmd(FREE_PAGE_HINT_DONE) {
+                    error!(
+                        "[{:?}:{}] failed to reset free page hinting: {err}",
+                        self.device_type(),
+                        self.id()
+                    );
+                }
             }
             self.notify_queue_events();
         }

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -32,7 +32,6 @@ use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::queue::InvalidAvailIdx;
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::logger::{IncMetric, debug, error, info, log_dev_preview_warning, warn};
-use crate::utils::u64_to_usize;
 use crate::vstate::memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemoryExtension, GuestMemoryMmap,
 };
@@ -550,8 +549,6 @@ impl Balloon {
         let mut complete = false;
 
         while let Some(head) = queue.pop()? {
-            let head_index = head.index;
-
             let mut last_desc = Some(head);
             while let Some(desc) = last_desc {
                 last_desc = desc.next_descriptor();
@@ -630,8 +627,6 @@ impl Balloon {
         let mut needs_interrupt = false;
 
         while let Some(head) = queue.pop()? {
-            let head_index = head.index;
-
             let mut last_desc = Some(head);
             while let Some(desc) = last_desc {
                 METRICS.free_page_report_count.inc();
@@ -1596,7 +1591,7 @@ pub(crate) mod tests {
 
         let safe_addr = align_up!(th.data_address(), page_size);
 
-        th.add_scatter_gather(reporting_idx, 0, &[(0, safe_addr, page_size_chain, 0)]);
+        th.add_scatter_gather(reporting_idx, &[(0, safe_addr, page_size_chain, 0)]);
         check_metric_after_block!(
             METRICS.free_page_report_freed,
             page_size,
@@ -1606,7 +1601,6 @@ pub(crate) mod tests {
         // Test with multiple items
         th.add_scatter_gather(
             reporting_idx,
-            0,
             &[
                 (0, safe_addr, page_size_chain, 0),
                 (1, safe_addr + page_size, page_size_chain, 0),
@@ -1621,7 +1615,7 @@ pub(crate) mod tests {
         );
 
         // Test with unaligned length
-        th.add_scatter_gather(reporting_idx, 0, &[(1, safe_addr + 1, page_size_chain, 0)]);
+        th.add_scatter_gather(reporting_idx, &[(1, safe_addr + 1, page_size_chain, 0)]);
 
         check_metric_after_block!(
             METRICS.free_page_report_fails,
@@ -1691,7 +1685,6 @@ pub(crate) mod tests {
                 .unwrap();
             self.th.add_scatter_gather(
                 self.hinting_idx,
-                0,
                 &[
                     (0, self.safe_addr, 4, VIRTQ_DESC_F_WRITE),
                     (
@@ -1744,7 +1737,7 @@ pub(crate) mod tests {
                     )]
                 }
             };
-            self.th.add_scatter_gather(self.hinting_idx, 0, &payload);
+            self.th.add_scatter_gather(self.hinting_idx, &payload);
             check_metric_after_block!(
                 METRICS.free_page_hint_freed,
                 expected,
@@ -1821,7 +1814,6 @@ pub(crate) mod tests {
 
         // Test the good case
         ht.start_hinting(None);
-        let mut host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
 
         // Simulate the driver finishing a run. Any reported values after
         // should be ignored
@@ -1831,7 +1823,7 @@ pub(crate) mod tests {
         ht.test_hinting(None, 0);
 
         // As we had auto ack on finish the host cmd should be set to done
-        host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
+        let host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
         assert_eq!(host_cmd, FREE_PAGE_HINT_DONE);
     }
 
@@ -1842,14 +1834,13 @@ pub(crate) mod tests {
 
         // Test the good case
         ht.start_hinting(None);
-        let mut host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
 
         // Test no ack on stop behaviour
         ht.start_hinting(Some(StartHintingCmd {
             acknowledge_on_stop: false,
         }));
 
-        host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
+        let host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
         ht.test_hinting(Some(host_cmd), ht.page_size);
         ht.test_hinting(None, ht.page_size);
 
@@ -1865,14 +1856,13 @@ pub(crate) mod tests {
 
         // Test the good case
         ht.start_hinting(None);
-        let mut host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
+        let host_cmd = ht.th.device().get_hinting_status().unwrap().host_cmd;
 
         ht.test_hinting(Some(host_cmd), ht.page_size);
         ht.test_hinting(None, ht.page_size);
 
         ht.th.add_scatter_gather(
             ht.hinting_idx,
-            0,
             &[(0, ht.safe_addr + ht.page_size + 1, ht.page_size_chain, 0)],
         );
 

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -1637,7 +1637,7 @@ pub(crate) mod tests {
         fn new(mem: &'a GuestMemoryMmap) -> Self {
             let mut th = VirtioTestHelper::<Balloon>::new(
                 mem,
-                Balloon::new(0, true, 0, true, false).unwrap(),
+                Balloon::new(0, true, 0, true, true).unwrap(),
             );
             th.activate_device(mem);
 

--- a/src/vmm/src/devices/virtio/balloon/mod.rs
+++ b/src/vmm/src/devices/virtio/balloon/mod.rs
@@ -100,20 +100,6 @@ pub enum BalloonError {
     InvalidAvailIdx(#[from] InvalidAvailIdx),
 }
 
-#[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub enum RemoveRegionError {
-    /// Address translation error.
-    AddressTranslation,
-    /// Malformed guest address range.
-    MalformedRange,
-    /// Error calling madvise: {0}
-    MadviseFail(std::io::Error),
-    /// Error calling mmap: {0}
-    MmapFail(std::io::Error),
-    /// Region not found.
-    RegionNotFound,
-}
-
 pub(super) fn report_balloon_event_fail(err: BalloonError) {
     if let BalloonError::InvalidAvailIdx(err) = err {
         panic!("{}", err);

--- a/src/vmm/src/devices/virtio/balloon/persist.rs
+++ b/src/vmm/src/devices/virtio/balloon/persist.rs
@@ -3,17 +3,15 @@
 
 //! Defines the structures needed for saving/restoring balloon devices.
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 use super::*;
 use crate::devices::virtio::balloon::device::{BalloonStats, ConfigSpace, HintingState};
-use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDeviceType};
+use crate::devices::virtio::device::VirtioDeviceType;
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
-use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::snapshot::Persist;
 use crate::vstate::memory::GuestMemoryMmap;
 
@@ -205,7 +203,7 @@ impl Persist<'_> for Balloon {
 mod tests {
     use super::*;
     use crate::devices::virtio::device::VirtioDevice;
-    use crate::devices::virtio::test_utils::{default_interrupt, default_mem};
+    use crate::devices::virtio::test_utils::default_mem;
 
     #[test]
     fn test_persistence() {

--- a/src/vmm/src/devices/virtio/balloon/test_utils.rs
+++ b/src/vmm/src/devices/virtio/balloon/test_utils.rs
@@ -30,10 +30,12 @@ pub fn invoke_handler_for_queue_event(b: &mut Balloon, queue_index: usize) {
     match queue_index {
         INFLATE_INDEX => b.process_inflate_queue_event().unwrap(),
         DEFLATE_INDEX => b.process_deflate_queue_event().unwrap(),
-        reporting_idx if b.free_page_reporting() => {
+        idx if b.free_page_reporting() && idx == reporting_idx => {
             b.process_free_page_reporting_queue_event().unwrap()
         }
-        hinting_idx if b.free_page_hinting() => b.process_free_page_hinting_queue_event().unwrap(),
+        idx if b.free_page_hinting() && idx == hinting_idx => {
+            b.process_free_page_hinting_queue_event().unwrap()
+        }
         STATS_INDEX => b.process_stats_queue_event().unwrap(),
         _ => unreachable!(),
     };

--- a/src/vmm/src/devices/virtio/balloon/util.rs
+++ b/src/vmm/src/devices/virtio/balloon/util.rs
@@ -1,12 +1,8 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io;
-
-use super::{MAX_PAGE_COMPACT_BUFFER, RemoveRegionError};
+use super::MAX_PAGE_COMPACT_BUFFER;
 use crate::logger::error;
-use crate::utils::u64_to_usize;
-use crate::vstate::memory::{GuestAddress, GuestMemoryMmap, GuestMemoryRegion};
 
 /// This takes a vector of page frame numbers, and compacts them
 /// into ranges of consecutive pages. The result is a vector
@@ -70,12 +66,6 @@ mod tests {
     use std::fmt::Debug;
 
     use super::*;
-    use crate::vstate::memory::Bytes;
-
-    /// This asserts that $lhs matches $rhs.
-    macro_rules! assert_match {
-        ($lhs:expr, $rhs:pat) => {{ assert!(matches!($lhs, $rhs)) }};
-    }
 
     #[test]
     fn test_compact_page_indices() {
@@ -126,8 +116,6 @@ mod tests {
     /// -------------------------------------
     /// BEGIN PROPERTY BASED TESTING
     use proptest::prelude::*;
-
-    use crate::test_utils::single_region_mem;
 
     #[allow(clippy::let_with_type_underscore)]
     fn random_pfn_u32_max() -> impl Strategy<Value = Vec<u32>> {

--- a/src/vmm/src/devices/virtio/block/persist.rs
+++ b/src/vmm/src/devices/virtio/block/persist.rs
@@ -1,13 +1,10 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use serde::{Deserialize, Serialize};
 
 use super::vhost_user::persist::VhostUserBlockState;
 use super::virtio::persist::VirtioBlockState;
-use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::vstate::memory::GuestMemoryMmap;
 
 /// Block device state.
@@ -21,7 +18,7 @@ impl BlockState {
     pub fn is_activated(&self) -> bool {
         match self {
             BlockState::Virtio(virtio_block_state) => virtio_block_state.virtio_state.activated,
-            BlockState::VhostUser(vhost_user_block_state) => false,
+            BlockState::VhostUser(_) => false,
         }
     }
 }

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -25,7 +25,7 @@ use crate::devices::virtio::vhost_user::{VhostUserHandleBackend, VhostUserHandle
 use crate::devices::virtio::vhost_user_metrics::{
     VhostUserDeviceMetrics, VhostUserMetricsPerDevice,
 };
-use crate::logger::{IncMetric, StoreMetric, log_dev_preview_warning, warn};
+use crate::logger::{IncMetric, StoreMetric, log_dev_preview_warning};
 use crate::utils::u64_to_usize;
 use crate::vmm_config::drive::BlockDeviceConfig;
 use crate::vstate::memory::GuestMemoryMmap;

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -36,7 +36,6 @@ use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter};
-use crate::utils::u64_to_usize;
 use crate::vmm_config::RateLimiterConfig;
 use crate::vmm_config::drive::BlockDeviceConfig;
 use crate::vstate::memory::GuestMemoryMmap;

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -98,11 +98,11 @@ impl MutEventSubscriber for VirtioBlock {
             match source {
                 Self::PROCESS_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
-                    self.rate_limiter.event_handler();
+                    let _ = self.rate_limiter.event_handler();
                 }
                 Self::PROCESS_ASYNC_COMPLETION => {
                     if let FileEngine::Async(ref engine) = self.disk.file_engine {
-                        engine.completion_evt().read();
+                        let _ = engine.completion_evt().read();
                     }
                 }
                 _ => (),

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -12,7 +12,7 @@ use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
 use crate::devices::virtio::block::virtio::device::FileEngineType;
 use crate::devices::virtio::block::virtio::metrics::BlockMetricsPerDevice;
-use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDeviceType};
+use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::VIRTIO_BLK_F_RO;
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::rate_limiter::RateLimiter;
@@ -145,7 +145,7 @@ mod tests {
     use super::*;
     use crate::devices::virtio::block::virtio::device::VirtioBlockConfig;
     use crate::devices::virtio::device::VirtioDevice;
-    use crate::devices::virtio::test_utils::{default_interrupt, default_mem};
+    use crate::devices::virtio::test_utils::default_mem;
 
     #[test]
     fn test_cache_semantic_ser() {

--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -244,7 +244,7 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
     /// is being reset and before it's activated again.
     fn drain_queue_events(&self) {
         for event in self.queue_events() {
-            event.read();
+            let _ = event.read();
         }
     }
 

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -704,7 +704,9 @@ impl VirtioDevice for VirtioMem {
     fn kick(&mut self) {
         if self.is_activated() {
             info!("kick mem {}.", self.id());
-            self.process_virtio_queues();
+            if let Err(err) = self.process_virtio_queues() {
+                error!("virtio-mem: Failed to process queues: {err}");
+            }
         }
     }
 }

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -4,14 +4,10 @@
 use std::io;
 use std::ops::{Deref, Range};
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
 
 use bitvec::vec::BitVec;
 use serde::{Deserialize, Serialize};
-use vm_memory::{
-    Address, Bytes, GuestAddress, GuestMemory, GuestMemoryBackend, GuestMemoryError,
-    GuestMemoryRegion, GuestUsize,
-};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryBackend};
 use vmm_sys_util::eventfd::EventFd;
 
 use super::{MEM_NUM_QUEUES, MEM_QUEUE};
@@ -21,7 +17,6 @@ use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::generated::virtio_mem::{
     self, VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE, virtio_mem_config,
 };
-use crate::devices::virtio::iov_deque::IovDequeError;
 use crate::devices::virtio::mem::VIRTIO_MEM_DEV_ID;
 use crate::devices::virtio::mem::metrics::METRICS;
 use crate::devices::virtio::mem::request::{BlockRangeState, Request, RequestedRange, Response};
@@ -33,9 +28,7 @@ use crate::impl_device_type;
 use crate::logger::{IncMetric, debug, error, info, warn};
 use crate::utils::{bytes_to_u32_mib, u32_mib_to_bytes, u64_to_usize, usize_to_u64};
 use crate::vstate::interrupts::InterruptError;
-use crate::vstate::memory::{
-    ByteValued, GuestMemoryExtension, GuestMemoryMmap, GuestRegionMmap, GuestRegionType,
-};
+use crate::vstate::memory::{ByteValued, GuestMemoryExtension, GuestMemoryMmap, GuestRegionType};
 use crate::vstate::vm::{KvmVm, VmError};
 
 // SAFETY: virtio_mem_config only contains plain data types
@@ -315,7 +308,7 @@ impl VirtioMem {
             .ok_or(VirtioMemError::InvalidRange(*range))?;
 
         // Ensure the end offset (exclusive) is within the usable region
-        let end_off = start_off
+        let _end_off = start_off
             .checked_add(usize_to_u64(self.nb_blocks_to_len(range.nb_blocks)))
             .filter(|&end_off| end_off <= self.config.usable_region_size)
             .ok_or(VirtioMemError::InvalidRange(*range))?;
@@ -451,8 +444,6 @@ impl VirtioMem {
 
     fn process_mem_queue(&mut self) -> Result<(), VirtioMemError> {
         while let Some(desc) = self.queues[MEM_QUEUE].pop()? {
-            let index = desc.index;
-
             let (req, resp_addr, used_idx) = self.parse_request(&desc)?;
             debug!("virtio-mem: Request: {:?}", req);
             // Handle request and write response
@@ -548,15 +539,15 @@ impl VirtioMem {
         self.update_kvm_slots(range)?;
 
         // If unplugging, discard the range
-        if !plug {
-            self.guest_memory()
+        if !plug
+            && let Err(err) = self
+                .guest_memory()
                 .discard_range(range.addr, self.nb_blocks_to_len(range.nb_blocks))
-                .inspect_err(|err| {
-                    // Failure to discard is not fatal and is not reported to the driver. It only
-                    // gets logged.
-                    METRICS.unplug_discard_fails.inc();
-                    error!("virtio-mem: Failed to discard memory range: {}", err);
-                });
+        {
+            // Failure to discard is not fatal and is not reported to the driver. It only
+            // gets logged.
+            METRICS.unplug_discard_fails.inc();
+            error!("virtio-mem: Failed to discard memory range: {}", err);
         }
         Ok(())
     }
@@ -715,7 +706,6 @@ impl VirtioDevice for VirtioMem {
 pub(crate) mod test_utils {
     use super::*;
     use crate::devices::virtio::test_utils::test::VirtioTestDevice;
-    use crate::test_utils::single_region_mem;
     use crate::utils::mib_to_bytes;
     use crate::vmm_config::machine_config::HugePageConfig;
     use crate::vstate::memory;
@@ -744,7 +734,8 @@ pub(crate) mod test_utils {
             .pop()
             .unwrap(),
             mib_to_bytes(128),
-        );
+        )
+        .unwrap();
         let vm = Arc::new(vm);
         VirtioMem::new(vm, addr, 1024, 2, 128).unwrap()
     }
@@ -752,11 +743,6 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use std::ptr::null_mut;
-
-    use serde_json::de;
-    use vm_memory::guest_memory;
-    use vm_memory::mmap::MmapRegionBuilder;
 
     use super::*;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
@@ -869,7 +855,7 @@ mod tests {
 
     #[test]
     fn test_status() {
-        let mut mem = default_virtio_mem();
+        let mem = default_virtio_mem();
         let status = mem.status();
         assert_eq!(
             status,
@@ -922,7 +908,7 @@ mod tests {
 
     #[test]
     fn test_event_fail_descriptor_chain_too_short() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
@@ -938,7 +924,7 @@ mod tests {
 
     #[test]
     fn test_event_fail_descriptor_length_too_small() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
@@ -954,7 +940,7 @@ mod tests {
 
     #[test]
     fn test_event_fail_unexpected_writeonly_descriptor() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
@@ -970,7 +956,7 @@ mod tests {
 
     #[test]
     fn test_event_fail_unexpected_readonly_descriptor() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
@@ -986,7 +972,7 @@ mod tests {
 
     #[test]
     fn test_event_fail_response_descriptor_length_too_small() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
@@ -1013,7 +999,7 @@ mod tests {
 
     #[test]
     fn test_update_requested_size_invalid_size() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
@@ -1036,7 +1022,7 @@ mod tests {
 
     #[test]
     fn test_update_requested_size_success() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 
@@ -1046,10 +1032,10 @@ mod tests {
 
     #[test]
     fn test_plug_request_success() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
         let queue_event_count = METRICS.queue_event_count.count();
@@ -1075,10 +1061,10 @@ mod tests {
 
     #[test]
     fn test_plug_request_too_big() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(2);
+        th.device().update_requested_size(2).unwrap();
         let addr = th.device().guest_address();
 
         let plug_count = METRICS.plug_count.count();
@@ -1099,10 +1085,10 @@ mod tests {
 
     #[test]
     fn test_plug_request_already_plugged() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
         // First plug succeeds
@@ -1124,10 +1110,10 @@ mod tests {
 
     #[test]
     fn test_unplug_request_success() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
         let unplug_count = METRICS.unplug_count.count();
@@ -1159,10 +1145,10 @@ mod tests {
 
     #[test]
     fn test_unplug_request_not_plugged() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
         let unplug_count = METRICS.unplug_count.count();
@@ -1183,10 +1169,10 @@ mod tests {
 
     #[test]
     fn test_unplug_all_request() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
         let unplug_all_count = METRICS.unplug_all_count.count();
@@ -1212,10 +1198,10 @@ mod tests {
 
     #[test]
     fn test_state_request_unplugged() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
         let state_count = METRICS.state_count.count();
@@ -1234,10 +1220,10 @@ mod tests {
 
     #[test]
     fn test_state_request_plugged() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
         // Plug first
@@ -1259,10 +1245,10 @@ mod tests {
 
     #[test]
     fn test_state_request_mixed() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
         // Plug first block only
@@ -1284,10 +1270,10 @@ mod tests {
 
     #[test]
     fn test_invalid_range_unaligned() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address().unchecked_add(1);
 
         let state_count = METRICS.state_count.count();
@@ -1306,10 +1292,10 @@ mod tests {
 
     #[test]
     fn test_invalid_range_zero_blocks() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(1024);
+        th.device().update_requested_size(1024).unwrap();
         let addr = th.device().guest_address();
 
         let resp = emulate_request(
@@ -1322,10 +1308,10 @@ mod tests {
 
     #[test]
     fn test_invalid_range_out_of_bounds() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
-        th.device().update_requested_size(4);
+        th.device().update_requested_size(4).unwrap();
         let addr = th.device().guest_address();
 
         let resp = emulate_request(
@@ -1341,7 +1327,7 @@ mod tests {
 
     #[test]
     fn test_unsupported_request() {
-        let mut mem_dev = default_virtio_mem();
+        let mem_dev = default_virtio_mem();
         let guest_mem = mem_dev.vm.guest_memory().clone();
         let mut th = test_helper(mem_dev, &guest_mem);
 

--- a/src/vmm/src/devices/virtio/mem/event_handler.rs
+++ b/src/vmm/src/devices/virtio/mem/event_handler.rs
@@ -96,7 +96,6 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use event_manager::{EventManager, SubscriberOps};
-    use vmm_sys_util::epoll::EventSet;
 
     use super::*;
     use crate::devices::virtio::ActivateError;

--- a/src/vmm/src/devices/virtio/mem/mod.rs
+++ b/src/vmm/src/devices/virtio/mem/mod.rs
@@ -7,10 +7,7 @@ pub mod metrics;
 pub mod persist;
 mod request;
 
-use vm_memory::GuestAddress;
-
 pub use self::device::{VirtioMem, VirtioMemError, VirtioMemStatus};
-use crate::arch::FIRST_ADDR_PAST_64BITS_MMIO;
 
 pub(crate) const MEM_NUM_QUEUES: usize = 1;
 

--- a/src/vmm/src/devices/virtio/mem/persist.rs
+++ b/src/vmm/src/devices/virtio/mem/persist.rs
@@ -7,17 +7,14 @@ use std::sync::Arc;
 
 use bitvec::vec::BitVec;
 use serde::{Deserialize, Serialize};
-use vm_memory::Address;
 
 use crate::devices::virtio::device::VirtioDeviceType;
-use crate::devices::virtio::generated::virtio_ids::VIRTIO_ID_MEM;
 use crate::devices::virtio::generated::virtio_mem::virtio_mem_config;
 use crate::devices::virtio::mem::{MEM_NUM_QUEUES, VirtioMem, VirtioMemError};
 use crate::devices::virtio::persist::{PersistError as VirtioStateError, VirtioDeviceState};
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
 use crate::snapshot::Persist;
 use crate::utils::usize_to_u64;
-use crate::vstate::memory::{GuestMemoryMmap, GuestRegionMmap};
 use crate::vstate::vm::KvmVm;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/vmm/src/devices/virtio/mem/request.rs
+++ b/src/vmm/src/devices/virtio/mem/request.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use vm_memory::{Address, ByteValued, GuestAddress};
+use vm_memory::{ByteValued, GuestAddress};
 
 use crate::devices::virtio::generated::virtio_mem;
 
@@ -101,10 +101,12 @@ impl Response {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn is_ack(&self) -> bool {
         self.resp_type == ResponseType::Ack
     }
 
+    #[cfg(test)]
     pub(crate) fn is_error(&self) -> bool {
         self.resp_type == ResponseType::Error
     }
@@ -128,6 +130,8 @@ impl From<Response> for virtio_mem::virtio_mem_resp {
 
 #[cfg(test)]
 mod test_util {
+    use vm_memory::Address;
+
     use super::*;
 
     // Implement the reverse conversions to use in test code.
@@ -192,7 +196,7 @@ mod test_util {
                 },
                 // There is no way to know whether this is present or not as it depends on the
                 // request types. Callers should ignore this value if the request wasn't STATE
-                /// SAFETY: test code only. Uninitialized values are 0 and recognized as PLUGGED.
+                // SAFETY: test code only. Uninitialized values are 0 and recognized as PLUGGED.
                 state: Some(unsafe {
                     match resp.u.state.state.into() {
                         virtio_mem::VIRTIO_MEM_STATE_PLUGGED => BlockRangeState::Plugged,

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -44,7 +44,6 @@ use crate::mmds::data_store::Mmds;
 use crate::mmds::ns::MmdsNetworkStack;
 use crate::rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 use crate::utils::net::mac::MacAddr;
-use crate::utils::u64_to_usize;
 use crate::vstate::memory::{ByteValued, GuestMemoryMmap};
 
 const FRAME_HEADER_MAX_LEN: usize = PAYLOAD_OFFSET + ETH_IPV4_FRAME_LEN;
@@ -1231,7 +1230,7 @@ pub mod tests {
     #[test]
     fn test_mtu_advertised() {
         // "net-device%d" asks the kernel to assign a unique tap index.
-        let mut net = Net::new(
+        let net = Net::new(
             "mtu-test".to_string(),
             "net-device%d",
             None,

--- a/src/vmm/src/devices/virtio/net/event_handler.rs
+++ b/src/vmm/src/devices/virtio/net/event_handler.rs
@@ -117,10 +117,10 @@ impl MutEventSubscriber for Net {
             match source {
                 Self::PROCESS_VIRTQ_RX | Self::PROCESS_VIRTQ_TX => self.drain_queue_events(),
                 Self::PROCESS_RX_RATE_LIMITER => {
-                    self.rx_rate_limiter.event_handler();
+                    let _ = self.rx_rate_limiter.event_handler();
                 }
                 Self::PROCESS_TX_RATE_LIMITER => {
-                    self.tx_rate_limiter.event_handler();
+                    let _ = self.tx_rate_limiter.event_handler();
                 }
                 _ => (),
             }

--- a/src/vmm/src/devices/virtio/net/persist.rs
+++ b/src/vmm/src/devices/virtio/net/persist.rs
@@ -8,11 +8,10 @@ use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 
-use super::device::{Net, RxBuffers};
-use super::{NET_NUM_QUEUES, NET_QUEUE_MAX_SIZE, RX_INDEX, TapError};
-use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDeviceType};
+use super::device::Net;
+use super::{NET_NUM_QUEUES, NET_QUEUE_MAX_SIZE, TapError};
+use crate::devices::virtio::device::VirtioDeviceType;
 use crate::devices::virtio::persist::{PersistError as VirtioStateError, VirtioDeviceState};
-use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::mmds::data_store::Mmds;
 use crate::mmds::ns::MmdsNetworkStack;
 use crate::mmds::persist::MmdsNetworkStackState;
@@ -141,7 +140,7 @@ mod tests {
     use super::*;
     use crate::devices::virtio::device::VirtioDevice;
     use crate::devices::virtio::net::test_utils::{default_net, default_net_no_mmds};
-    use crate::devices::virtio::test_utils::{default_interrupt, default_mem};
+    use crate::devices::virtio::test_utils::default_mem;
 
     fn validate_save_and_restore(net: Net, mmds_ds: Option<Arc<Mutex<Mmds>>>) {
         let guest_mem = default_mem();

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -600,7 +600,9 @@ impl VirtioDevice for Pmem {
     fn kick(&mut self) {
         if self.is_activated() {
             info!("kick pmem {}.", self.config.id);
-            self.handle_queue();
+            if let Err(err) = self.handle_queue() {
+                error!("pmem: Failed to process queue: {err}");
+            }
         }
     }
 }

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -1,16 +1,15 @@
 // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::ops::Deref;
 use std::os::fd::AsRawFd;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use kvm_bindings::{KVM_MEM_READONLY, kvm_userspace_memory_region};
 use serde::{Deserialize, Serialize};
 use vm_allocator::{AllocPolicy, RangeInclusive};
-use vm_memory::mmap::{MmapRegionBuilder, MmapRegionError};
-use vm_memory::{GuestAddress, GuestMemoryError};
+use vm_memory::GuestMemoryError;
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::devices::virtio::ActivateError;
@@ -23,7 +22,6 @@ use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::logger::{IncMetric, error, info, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 use crate::utils::u64_to_usize;
-use crate::vmm_config::RateLimiterConfig;
 use crate::vmm_config::pmem::PmemConfig;
 use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap};
 use crate::vstate::vm::{KvmVm, VmError};
@@ -187,7 +185,7 @@ impl PmemMmap {
             .open(path)
             .map_err(PmemError::BackingFile)?;
         let file_len = file.metadata().unwrap().len();
-        if (file_len == 0) {
+        if file_len == 0 {
             return Err(PmemError::BackingFileZeroSize);
         }
 
@@ -197,7 +195,7 @@ impl PmemMmap {
         }
 
         let mmap_len = align_up!(file_len, Self::ALIGNMENT);
-        let mmap_ptr = if (mmap_len == file_len) {
+        let mmap_ptr = if mmap_len == file_len {
             // SAFETY: We are calling the system call with valid arguments and checking the returned
             // value
             unsafe {
@@ -609,6 +607,7 @@ impl VirtioDevice for Pmem {
 
 #[cfg(test)]
 mod tests {
+    use vm_memory::GuestAddress;
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
@@ -647,7 +646,7 @@ mod tests {
             PmemError::BackingFileZeroSize,
         ));
 
-        dummy_file.as_file().set_len(0x20_0000);
+        dummy_file.as_file().set_len(0x20_0000).unwrap();
         let config = PmemConfig {
             id: "1".into(),
             path_on_host: dummy_path,
@@ -664,7 +663,7 @@ mod tests {
         let vm = Arc::new(KvmVm::new(kvm).unwrap());
 
         let dummy_file = TempFile::new().unwrap();
-        dummy_file.as_file().set_len(0x20_0000);
+        dummy_file.as_file().set_len(0x20_0000).unwrap();
         let dummy_path = dummy_file.as_path().to_str().unwrap().to_string();
         let config = PmemConfig {
             id: "1".into(),

--- a/src/vmm/src/devices/virtio/pmem/event_handler.rs
+++ b/src/vmm/src/devices/virtio/pmem/event_handler.rs
@@ -81,7 +81,7 @@ impl MutEventSubscriber for Pmem {
             match source {
                 Self::PROCESS_PMEM_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
-                    self.rate_limiter.event_handler();
+                    let _ = self.rate_limiter.event_handler();
                 }
                 _ => (),
             }

--- a/src/vmm/src/devices/virtio/pmem/metrics.rs
+++ b/src/vmm/src/devices/virtio/pmem/metrics.rs
@@ -84,7 +84,7 @@ use std::sync::{Arc, RwLock};
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 
-use crate::logger::{IncMetric, LatencyAggregateMetrics, SharedIncMetric};
+use crate::logger::{IncMetric, SharedIncMetric};
 
 /// map of pmem drive id and metrics
 /// this should be protected by a lock before accessing.

--- a/src/vmm/src/devices/virtio/pmem/persist.rs
+++ b/src/vmm/src/devices/virtio/pmem/persist.rs
@@ -4,17 +4,16 @@
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
-use vm_memory::GuestAddress;
 
 use super::device::{ConfigSpace, Pmem, PmemError};
-use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
+use crate::devices::virtio::device::VirtioDeviceType;
 use crate::devices::virtio::persist::{PersistError as VirtioStateError, VirtioDeviceState};
 use crate::devices::virtio::pmem::{PMEM_NUM_QUEUES, PMEM_QUEUE_SIZE};
 use crate::rate_limiter::RateLimiter;
 use crate::rate_limiter::persist::RateLimiterState;
 use crate::snapshot::Persist;
 use crate::vmm_config::pmem::PmemConfig;
-use crate::vstate::memory::{GuestMemoryMmap, GuestRegionMmap};
+use crate::vstate::memory::GuestMemoryMmap;
 use crate::vstate::vm::{KvmVm, VmError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -96,7 +95,7 @@ mod tests {
     fn test_persistence() {
         // We create the backing file here so that it exists for the whole lifetime of the test.
         let dummy_file = TempFile::new().unwrap();
-        dummy_file.as_file().set_len(0x20_0000);
+        dummy_file.as_file().set_len(0x20_0000).unwrap();
         let dummy_path = dummy_file.as_path().to_str().unwrap().to_string();
         let config = PmemConfig {
             id: "1".into(),
@@ -142,7 +141,7 @@ mod tests {
     #[test]
     fn test_restore_rejects_mismatched_config_space_size() {
         let dummy_file = TempFile::new().unwrap();
-        dummy_file.as_file().set_len(0x20_0000);
+        dummy_file.as_file().set_len(0x20_0000).unwrap();
         let dummy_path = dummy_file.as_path().to_str().unwrap().to_string();
         let config = PmemConfig {
             id: "1".into(),

--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -11,7 +11,7 @@ use vm_memory::GuestMemoryBackend;
 
 use crate::logger::error;
 use crate::utils::u64_to_usize;
-use crate::vstate::memory::{Bitmap, ByteValued, GuestAddress, GuestMemoryMmap};
+use crate::vstate::memory::{Bitmap, ByteValued, GuestAddress};
 
 pub const VIRTQ_DESC_F_NEXT: u16 = 0x1;
 pub const VIRTQ_DESC_F_WRITE: u16 = 0x2;
@@ -1345,7 +1345,6 @@ mod tests {
             q.initialize(m).unwrap_err(),
             QueueError::PointerNotAligned(_, _)
         ));
-        q.used_ring_address = vq.used_start();
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -247,14 +247,6 @@ impl Entropy {
         self.acked_features = features;
     }
 
-    pub(crate) fn set_activated(
-        &mut self,
-        mem: GuestMemoryMmap,
-        interrupt: Arc<dyn VirtioInterrupt>,
-    ) {
-        self.device_state = DeviceState::Activated(ActiveState { mem, interrupt });
-    }
-
     pub(crate) fn activate_event(&self) -> &EventFd {
         &self.activate_event
     }

--- a/src/vmm/src/devices/virtio/rng/event_handler.rs
+++ b/src/vmm/src/devices/virtio/rng/event_handler.rs
@@ -86,7 +86,7 @@ impl MutEventSubscriber for Entropy {
             match source {
                 Self::PROCESS_ENTROPY_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
-                    self.rate_limiter.event_handler();
+                    let _ = self.rate_limiter.event_handler();
                 }
                 _ => (),
             }

--- a/src/vmm/src/devices/virtio/rng/persist.rs
+++ b/src/vmm/src/devices/virtio/rng/persist.rs
@@ -3,15 +3,12 @@
 
 //! Defines the structures needed for saving/restoring entropy devices.
 
-use std::sync::Arc;
-
 use serde::{Deserialize, Serialize};
 
 use crate::devices::virtio::device::VirtioDeviceType;
 use crate::devices::virtio::persist::{PersistError as VirtioStateError, VirtioDeviceState};
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
 use crate::devices::virtio::rng::{Entropy, EntropyError, RNG_NUM_QUEUES};
-use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::rate_limiter::RateLimiter;
 use crate::rate_limiter::persist::RateLimiterState;
 use crate::snapshot::Persist;
@@ -76,7 +73,6 @@ mod tests {
     use super::*;
     use crate::devices::virtio::device::VirtioDevice;
     use crate::devices::virtio::rng::device::ENTROPY_DEV_ID;
-    use crate::devices::virtio::test_utils::default_interrupt;
     use crate::devices::virtio::test_utils::test::create_virtio_mem;
 
     #[test]

--- a/src/vmm/src/devices/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/test_utils.rs
@@ -445,25 +445,18 @@ pub(crate) mod test {
 
         /// Add a new Descriptor in one of the device's queues in the form of scatter gather
         ///
-        /// This function adds in one of the queues of the device a DescriptorChain at some offset
-        /// in the "data range" of the guest memory. The number of descriptors to create is passed
-        /// as a list of descriptors (a tuple of (index, addr, length, flags)).
+        /// This function adds in one of the queues of the device a DescriptorChain. The
+        /// descriptors to create are passed as a list of descriptors (a tuple of
+        /// (index, addr, length, flags)), so each descriptor points to the address
+        /// given in the list.
         ///
         /// The total size of the buffer is the sum of all lengths of this list of descriptors.
-        /// The fist descriptor will be stored at `self.data_address() + addr_offset`. Subsequent
-        /// descriptors will be placed at random addresses after that.
         ///
         /// # Arguments
         ///
         /// * `queue` - The index of the device queue to use
-        /// * `addr_offset` - Offset within the data region where to put the first descriptor
         /// * `desc_list` - List of descriptors to create in the chain
-        pub fn add_scatter_gather(
-            &mut self,
-            queue: usize,
-            addr_offset: u64,
-            desc_list: &[(u16, u64, u32, u16)],
-        ) {
+        pub fn add_scatter_gather(&mut self, queue: usize, desc_list: &[(u16, u64, u32, u16)]) {
             let device = self.device.lock().unwrap();
 
             let event_fd = &device.queue_events()[queue];

--- a/src/vmm/src/devices/virtio/transport/mmio.rs
+++ b/src/vmm/src/devices/virtio/transport/mmio.rs
@@ -1082,7 +1082,7 @@ pub(crate) mod tests {
             false,
         );
 
-        let mut assert_rejected = |d: &mut MmioTransport, new: u32, expected: u32| {
+        let assert_rejected = |d: &mut MmioTransport, new: u32, expected: u32| {
             set_device_status(d, new);
             assert_eq!(
                 read_device_status(d),

--- a/src/vmm/src/devices/virtio/transport/pci/common_config.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/common_config.rs
@@ -259,7 +259,7 @@ impl VirtioPciCommonConfig {
                 // Make sure that the guest doesn't select an invalid vector. We are offering
                 // `num_queues + 1` vectors (plus one for configuration updates). If an invalid
                 // vector has been selected, we just store the `NO_VECTOR` value.
-                let mut msix_queues = self.msix_queues.lock().expect("Poisoned lock");
+                let msix_queues = self.msix_queues.lock().expect("Poisoned lock");
                 let nr_vectors = msix_queues.len() + 1;
 
                 if (value as usize) < nr_vectors {
@@ -437,7 +437,6 @@ mod tests {
 
     use super::*;
     use crate::devices::virtio::transport::mmio::tests::DummyDevice;
-    use crate::devices::virtio::transport::pci::common_config_offset::*;
 
     fn default_device() -> Arc<Mutex<DummyDevice>> {
         Arc::new(Mutex::new(DummyDevice::new()))
@@ -517,7 +516,7 @@ mod tests {
     #[test]
     fn test_device_feature() {
         let mut config = default_pci_common_config();
-        let mut device = default_device();
+        let device = default_device();
         let mut features = 0u32;
 
         device
@@ -550,7 +549,7 @@ mod tests {
     #[test]
     fn test_driver_feature() {
         let mut config = default_pci_common_config();
-        let mut device = default_device();
+        let device = default_device();
         device
             .lock()
             .unwrap()
@@ -604,7 +603,7 @@ mod tests {
     #[test]
     fn test_num_queues() {
         let mut config = default_pci_common_config();
-        let mut device = default_device();
+        let device = default_device();
         let mut num_queues = 0u16;
 
         config.read(NUM_QUEUES, num_queues.as_mut_slice(), device.clone());
@@ -669,7 +668,7 @@ mod tests {
         let device = default_device();
 
         // Helper to attempt a transition and verify it was rejected.
-        let mut assert_rejected = |config: &mut VirtioPciCommonConfig, new: u8, expected: u8| {
+        let assert_rejected = |config: &mut VirtioPciCommonConfig, new: u8, expected: u8| {
             config.write(DEVICE_STATUS, new.as_slice(), device.clone(), false);
             let mut s = 0u8;
             config.read(DEVICE_STATUS, s.as_mut_slice(), device.clone());
@@ -996,7 +995,7 @@ mod tests {
     #[test]
     fn test_bad_width_reads() {
         let mut config = default_pci_common_config();
-        let mut device = default_device();
+        let device = default_device();
 
         // According to the VirtIO specification (section 4.1.3.1)
         //

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -23,6 +23,7 @@ use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 use zerocopy::IntoBytes;
 
+use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_ids;
 use crate::devices::virtio::queue::Queue;
@@ -257,6 +258,8 @@ pub enum VirtioPciDeviceError {
     InvalidRestoreState(u8, u8),
     /// Restored MSI-X vector count ({0}) does not match the expected count ({1}) for this device
     UnexpectedMsixVectorCount(usize, usize),
+    /// Could not activate restored device: {0}
+    Activate(#[from] ActivateError),
 }
 
 pub struct VirtioPciDevice {
@@ -502,7 +505,7 @@ impl VirtioPciDevice {
                 .activate(
                     virtio_pci_device.memory.clone(),
                     virtio_pci_device.virtio_interrupt.as_ref().unwrap().clone(),
-                );
+                )?;
         }
 
         Ok(virtio_pci_device)

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -8,25 +8,21 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::cmp;
-use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-use std::io::{ErrorKind, Write};
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicUsize, Ordering};
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 
 use kvm_ioctls::{IoEventAddress, NoDatamatch};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
-use vm_allocator::{AddressAllocator, AllocPolicy, RangeInclusive};
-use vm_memory::{Address, ByteValued, GuestAddress, Le32};
+use vm_allocator::{AddressAllocator, AllocPolicy};
+use vm_memory::{ByteValued, Le32};
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 use zerocopy::IntoBytes;
 
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
-use crate::devices::virtio::generated::virtio_ids;
-use crate::devices::virtio::queue::Queue;
 use crate::devices::virtio::transport::pci::common_config::{
     VirtioPciCommonConfig, VirtioPciCommonConfigState,
 };
@@ -39,10 +35,9 @@ use crate::pci::configuration::{
 };
 use crate::pci::msix::{MsixCap, MsixConfig, MsixConfigState};
 use crate::pci::{
-    BarReprogrammingParams, PciCapabilityId, PciClassCode, PciDevice, PciMassStorageSubclass,
-    PciNetworkControllerSubclass, PciSBDF,
+    PciCapabilityId, PciClassCode, PciDevice, PciMassStorageSubclass, PciNetworkControllerSubclass,
+    PciSBDF,
 };
-use crate::snapshot::Persist;
 use crate::vstate::bus::BusDevice;
 use crate::vstate::interrupts::{InterruptError, MsixVectorGroup};
 use crate::vstate::memory::GuestMemoryMmap;
@@ -60,6 +55,7 @@ enum PciCapabilityType {
     Isr = 3,
     Device = 4,
     Pci = 5,
+    #[allow(dead_code)] // Defined by the virtio spec, but not used by us
     SharedMemory = 8,
 }
 
@@ -319,10 +315,7 @@ impl Debug for VirtioPciDevice {
 }
 
 impl VirtioPciDevice {
-    fn pci_configuration(
-        device_type: VirtioDeviceType,
-        msix_config: &Arc<Mutex<MsixConfig>>,
-    ) -> PciConfiguration {
+    fn pci_configuration(device_type: VirtioDeviceType) -> PciConfiguration {
         let pci_device_id = VIRTIO_PCI_DEVICE_ID_BASE + device_type as u16;
         let (class, subclass) = match device_type {
             VirtioDeviceType::Net => (
@@ -387,10 +380,8 @@ impl VirtioPciDevice {
         assert_eq!(msix_vectors.vectors.len(), num_queues + 1);
 
         let msix_config = Arc::new(Mutex::new(MsixConfig::new(msix_vectors.clone(), sbdf)));
-        let pci_config = Self::pci_configuration(
-            device.lock().expect("Poisoned lock").device_type(),
-            &msix_config,
-        );
+        let pci_config =
+            Self::pci_configuration(device.lock().expect("Poisoned lock").device_type());
 
         let virtio_common_config = VirtioPciCommonConfig::new(VirtioPciCommonConfigState {
             driver_status: 0,
@@ -519,7 +510,7 @@ impl VirtioPciDevice {
     }
 
     fn is_driver_ready(&self) -> bool {
-        let ready_bits = (ACKNOWLEDGE | DRIVER | DRIVER_OK | FEATURES_OK);
+        let ready_bits = ACKNOWLEDGE | DRIVER | DRIVER_OK | FEATURES_OK;
         self.common_config.driver_status == ready_bits
     }
 
@@ -868,12 +859,12 @@ impl VirtioInterrupt for VirtioInterruptMsix {
     }
 
     #[cfg(test)]
-    fn has_pending_interrupt(&self, interrupt_type: VirtioInterruptType) -> bool {
+    fn has_pending_interrupt(&self, _interrupt_type: VirtioInterruptType) -> bool {
         false
     }
 
     #[cfg(test)]
-    fn ack_interrupt(&self, interrupt_type: VirtioInterruptType) {
+    fn ack_interrupt(&self, _interrupt_type: VirtioInterruptType) {
         // Do nothing here
     }
 }
@@ -1138,7 +1129,6 @@ mod tests {
     use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
 
-    use event_manager::MutEventSubscriber;
     use linux_loader::loader::Cmdline;
     use vm_memory::{ByteValued, Le32};
 
@@ -1147,7 +1137,7 @@ mod tests {
     use crate::arch::MEM_64BIT_DEVICES_START;
     use crate::builder::tests::default_vmm_with_pci;
     use crate::device_manager::tests::pci_devices;
-    use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
+    use crate::devices::virtio::device::VirtioDeviceType;
     use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
     use crate::devices::virtio::rng::Entropy;
     use crate::devices::virtio::transport::pci::common_config_offset::*;
@@ -1163,8 +1153,6 @@ mod tests {
     use crate::pci::msix::MsixCap;
     use crate::pci::{PciCapabilityId, PciClassCode, PciDevice};
     use crate::rate_limiter::RateLimiter;
-    use crate::snapshot::Persist;
-    use crate::vstate::resources::ResourceAllocator;
 
     fn create_vmm_with_virtio_pci_device() -> Vmm {
         let mut vmm = default_vmm_with_pci();
@@ -1192,7 +1180,7 @@ mod tests {
 
     #[test]
     fn test_pci_device_config() {
-        let mut vmm = create_vmm_with_virtio_pci_device();
+        let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut locked_virtio_pci_device = device.lock().unwrap();
 
@@ -1290,7 +1278,7 @@ mod tests {
 
     #[test]
     fn test_reading_bars() {
-        let mut vmm = create_vmm_with_virtio_pci_device();
+        let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut locked_virtio_pci_device = device.lock().unwrap();
 
@@ -1426,7 +1414,7 @@ mod tests {
 
     #[test]
     fn test_capabilities() {
-        let mut vmm = create_vmm_with_virtio_pci_device();
+        let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut locked_virtio_pci_device = device.lock().unwrap();
 
@@ -1510,7 +1498,7 @@ mod tests {
         assert_eq!(next as u32, pci_config_cap_offset + cap.cap.cap_len as u32);
 
         let msix_cap_offset = next as u32;
-        let (id, next, cap) = read_msix_cap(&mut locked_virtio_pci_device, msix_cap_offset);
+        let (id, next, _cap) = read_msix_cap(&mut locked_virtio_pci_device, msix_cap_offset);
         assert_eq!(id, PciCapabilityId::MsiX);
         assert_eq!(next, 0);
     }
@@ -1553,7 +1541,7 @@ mod tests {
 
     #[test]
     fn test_pci_configuration_cap() {
-        let mut vmm = create_vmm_with_virtio_pci_device();
+        let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut locked_virtio_pci_device = device.lock().unwrap();
 
@@ -1626,7 +1614,7 @@ mod tests {
 
     #[test]
     fn test_isr_capability() {
-        let mut vmm = create_vmm_with_virtio_pci_device();
+        let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut locked_virtio_pci_device = device.lock().unwrap();
 
@@ -1639,7 +1627,7 @@ mod tests {
 
     #[test]
     fn test_notification_capability() {
-        let mut vmm = create_vmm_with_virtio_pci_device();
+        let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut locked_virtio_pci_device = device.lock().unwrap();
 
@@ -1723,7 +1711,7 @@ mod tests {
 
     #[test]
     fn test_device_initialization() {
-        let mut vmm = create_vmm_with_virtio_pci_device();
+        let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut locked_virtio_pci_device = device.lock().unwrap();
 
@@ -1789,7 +1777,7 @@ mod tests {
         // Verify that DEVICE_NEEDS_RESET is set in driver_status when device activation fails.
         use crate::devices::virtio::transport::pci::device_status::DEVICE_NEEDS_RESET;
 
-        let mut vmm = create_vmm_with_virtio_pci_device();
+        let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut locked = device.lock().unwrap();
 
@@ -1809,7 +1797,7 @@ mod tests {
 
     #[test]
     fn test_reset_and_reinitialization() {
-        let mut vmm = create_vmm_with_virtio_pci_device();
+        let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut locked = device.lock().unwrap();
 

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -356,9 +356,6 @@ impl VirtioPciDevice {
     /// known state, the BARs are already created with the right content, therefore we don't need
     /// to go through this codepath.
     pub fn allocate_bars(&mut self, mmio64_allocator: &mut AddressAllocator) {
-        let device_clone = self.device.clone();
-        let device = device_clone.lock().unwrap();
-
         // Allocate the virtio-pci capability BAR.
         // See http://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html#x1-740004
         self.bar_address = mmio64_allocator

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -27,7 +27,6 @@ use std::sync::Arc;
 use vmm_sys_util::eventfd::EventFd;
 
 use super::super::super::DeviceError;
-use super::defs::uapi;
 use super::packet::{VSOCK_PKT_HDR_SIZE, VsockPacketRx, VsockPacketTx};
 use super::{VsockBackend, defs};
 use crate::devices::virtio::ActivateError;
@@ -40,7 +39,6 @@ use crate::devices::virtio::vsock::VsockError;
 use crate::devices::virtio::vsock::metrics::METRICS;
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, info, warn};
-use crate::utils::byte_order;
 use crate::vstate::memory::{ByteValued, Bytes, GuestMemoryMmap};
 
 pub(crate) const RXQ_INDEX: usize = 0;
@@ -483,8 +481,8 @@ mod tests {
 
     use super::*;
     use crate::devices::virtio::queue::VIRTQ_DESC_F_WRITE;
-    use crate::devices::virtio::vsock::defs::uapi;
     use crate::devices::virtio::vsock::test_utils::{EventHandlerContext, TestContext};
+    use crate::utils::byte_order;
     use crate::vstate::memory::GuestAddress;
 
     /// Guest address used for the writable evq descriptor payload in tests.

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -4,15 +4,13 @@
 //! Defines state and support structures for persisting Vsock devices and backends.
 
 use std::fmt::Debug;
-use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDeviceType};
+use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::devices::virtio::queue::FIRECRACKER_MAX_QUEUE_SIZE;
-use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::snapshot::Persist;
 use crate::vstate::memory::GuestMemoryMmap;
 
@@ -130,8 +128,6 @@ pub(crate) mod tests {
     use super::device::AVAIL_FEATURES;
     use super::*;
     use crate::devices::virtio::device::VirtioDevice;
-    use crate::devices::virtio::test_utils::default_interrupt;
-    use crate::devices::virtio::vsock::defs::uapi;
     use crate::devices::virtio::vsock::test_utils::{TestBackend, TestContext};
     use crate::utils::byte_order;
 
@@ -147,7 +143,7 @@ pub(crate) mod tests {
             }
         }
 
-        fn restore(_: Self::ConstructorArgs, state: &Self::State) -> Result<Self, Self::Error> {
+        fn restore(_: Self::ConstructorArgs, _state: &Self::State) -> Result<Self, Self::Error> {
             Ok(TestBackend::new())
         }
     }

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -15,7 +15,7 @@ use crate::devices::virtio::device::VirtioDevice;
 use crate::devices::virtio::queue::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
 use crate::devices::virtio::test_utils::{VirtQueue as GuestQ, default_interrupt};
 use crate::devices::virtio::transport::VirtioInterrupt;
-use crate::devices::virtio::vsock::device::{EVQ_INDEX, RXQ_INDEX, TXQ_INDEX};
+use crate::devices::virtio::vsock::device::{RXQ_INDEX, TXQ_INDEX};
 use crate::devices::virtio::vsock::packet::VSOCK_PKT_HDR_SIZE;
 use crate::devices::virtio::vsock::{
     Vsock, VsockBackend, VsockChannel, VsockEpollListener, VsockError,


### PR DESCRIPTION
devices: Remove blanket #![allow(unused)]

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
