### PR TITLE
pci: bars: remove incorrect assert in the get_bar_addr/size_32

### DIFF
--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -477,6 +477,12 @@ impl VirtioPciDevice {
             vectors,
         ));
 
+        if !state.bars.bar_idx_valid(VIRTIO_BAR_INDEX)
+            || !state.bars.bars[VIRTIO_BAR_INDEX as usize].is_64bit()
+        {
+            return Err(PciConfigurationError::InvalidBarIdx(VIRTIO_BAR_INDEX).into());
+        }
+
         let virtio_pci_device = VirtioPciDevice {
             id,
             sub_id: None,

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -170,10 +170,6 @@ impl Bars {
     /// Get the address of the 32bit bar
     pub fn get_bar_addr_32(&self, bar_idx: u8) -> u64 {
         assert!(bar_idx < NUM_BAR_REGS);
-        if 0 < bar_idx {
-            let previous_bar = &self.bars[bar_idx as usize - 1];
-            assert!(!previous_bar.is_64bit());
-        }
         let bar = &self.bars[bar_idx as usize];
         u64::from(bar.encoded_addr & !0b1111)
     }
@@ -189,10 +185,6 @@ impl Bars {
     /// Get the size of the 32bit bar
     pub fn get_bar_size_32(&self, bar_idx: u8) -> u64 {
         assert!(bar_idx < NUM_BAR_REGS);
-        if 0 < bar_idx {
-            let previous_bar = &self.bars[bar_idx as usize - 1];
-            assert!(!previous_bar.is_64bit());
-        }
         let bar = &self.bars[bar_idx as usize];
         u64::from(decode_32_bits_bar_size(bar.encoded_size))
     }

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -987,23 +987,29 @@ mod tests {
     #[test]
     fn test_bars_add_pci_bar() {
         let mut bars = Bars::default();
-        bars.set_bar_64(0, 0x1_0000_0000, 0x1000, BarPrefetchable::No);
+        // Explicitly use 0x4_0000_0000 address for 64bit bar so the top half of the BAR contains a
+        // value with the bit 2 set. This bit would qualify the top half as a 64bit BAR by itself
+        // if any code would use `is_64bit` call on it directly, but this must never happen.
+        bars.set_bar_64(0, 0x4_0000_0000, 0x1000, BarPrefetchable::No);
         assert!(bars.bars[0].used());
         assert!(bars.bars[0].is_64bit());
         assert!(bars.bars[1].used());
-        assert_eq!(bars.get_bar_addr(0), 0x1_0000_0000);
-        assert_eq!(bars.get_bar_addr_64(0), 0x1_0000_0000);
+        assert!(bars.bar_idx_valid(0));
+        assert!(!bars.bar_idx_valid(1));
+        assert_eq!(bars.get_bar_addr(0), 0x4_0000_0000);
+        assert_eq!(bars.get_bar_addr_64(0), 0x4_0000_0000);
         assert_eq!(bars.get_bar_size(0), 0x1000);
         assert_eq!(bars.get_bar_size_64(0), 0x1000);
         let mut v: u32 = 0;
         bars.read(0, 0, v.as_mut_bytes());
         assert_eq!(v & 0xffff_fff0, 0x0);
         bars.read(1, 0, v.as_mut_bytes());
-        assert_eq!(v, 1);
+        assert_eq!(v, 4);
 
         bars.set_bar_32(2, 0x2_0000, 0x2000, BarPrefetchable::Yes);
         assert!(bars.bars[2].used());
         assert!(!bars.bars[2].is_64bit());
+        assert!(bars.bar_idx_valid(2));
         assert_eq!(bars.get_bar_addr(2), 0x2_0000);
         assert_eq!(bars.get_bar_addr_32(2), 0x2_0000);
         assert_eq!(bars.get_bar_size(2), 0x2000);

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -23,6 +23,8 @@ pub enum PciConfigurationError {
     InvalidBarsLength(usize),
     /// Invalid cap_pci_cfg length: {0}
     InvalidCapPciCfgLength(usize),
+    /// Invalid bar_idx: {0}
+    InvalidBarIdx(u8),
 }
 
 // The number of 32bit registers in the config space, 4096 bytes.

--- a/src/vmm/src/pci/configuration.rs
+++ b/src/vmm/src/pci/configuration.rs
@@ -147,7 +147,7 @@ impl Bars {
 
     /// Get the address of the 32bit or 64bit BAR
     pub fn get_bar_addr(&self, bar_idx: u8) -> u64 {
-        assert!(bar_idx < NUM_BAR_REGS);
+        assert!(self.bar_idx_valid(bar_idx));
         let bar = &self.bars[bar_idx as usize];
         if bar.is_64bit() {
             self.get_bar_addr_64(bar_idx)
@@ -158,7 +158,7 @@ impl Bars {
 
     /// Get the size of the 32bit or 64bit BAR
     pub fn get_bar_size(&self, bar_idx: u8) -> u64 {
-        assert!(bar_idx < NUM_BAR_REGS);
+        assert!(self.bar_idx_valid(bar_idx));
         let bar = &self.bars[bar_idx as usize];
         if bar.is_64bit() {
             self.get_bar_size_64(bar_idx)
@@ -167,31 +167,60 @@ impl Bars {
         }
     }
 
+    /// Check if the bar_idx points to the valid BAR
+    pub fn bar_idx_valid(&self, bar_idx: u8) -> bool {
+        if NUM_BAR_REGS <= bar_idx {
+            return false;
+        }
+
+        // Start from BAR 0 and count up the used BARs. This way `i` always will point to the index
+        // of the beginning of the BAR (the 32bit BAR or the first part of 64bit BAR) If after this
+        // counting `i` is bigger than `bar_idx`, then `bar_idx` points to the upper part of the
+        // 64bit BAR and this is illegal.
+        let mut i: u8 = 0;
+        while i < bar_idx {
+            if self.bars[i as usize].is_64bit() {
+                i += 2;
+            } else {
+                i += 1;
+            }
+        }
+        i == bar_idx
+    }
+
     /// Get the address of the 32bit bar
     pub fn get_bar_addr_32(&self, bar_idx: u8) -> u64 {
-        assert!(bar_idx < NUM_BAR_REGS);
+        assert!(self.bar_idx_valid(bar_idx));
         let bar = &self.bars[bar_idx as usize];
+        assert!(!bar.is_64bit());
         u64::from(bar.encoded_addr & !0b1111)
     }
 
     /// Get the address of the 64bit bar
     pub fn get_bar_addr_64(&self, bar_idx: u8) -> u64 {
         assert!(bar_idx < NUM_BAR_REGS - 1);
+        assert!(self.bar_idx_valid(bar_idx));
+        let bar_lo = &self.bars[bar_idx as usize];
+        assert!(bar_lo.is_64bit());
         let addr_hi = self.bars[(bar_idx + 1) as usize].encoded_addr;
-        let addr_lo = self.bars[bar_idx as usize].encoded_addr & !0b1111;
+        let addr_lo = bar_lo.encoded_addr & !0b1111;
         (addr_hi as u64) << 32 | (addr_lo as u64)
     }
 
     /// Get the size of the 32bit bar
     pub fn get_bar_size_32(&self, bar_idx: u8) -> u64 {
-        assert!(bar_idx < NUM_BAR_REGS);
+        assert!(self.bar_idx_valid(bar_idx));
         let bar = &self.bars[bar_idx as usize];
+        assert!(!bar.is_64bit());
         u64::from(decode_32_bits_bar_size(bar.encoded_size))
     }
 
     /// Get the size of the 64bit bar
     pub fn get_bar_size_64(&self, bar_idx: u8) -> u64 {
         assert!(bar_idx < NUM_BAR_REGS - 1);
+        assert!(self.bar_idx_valid(bar_idx));
+        let bar_lo = &self.bars[bar_idx as usize];
+        assert!(bar_lo.is_64bit());
         let size_hi = self.bars[(bar_idx + 1) as usize].encoded_size;
         let size_lo = self.bars[bar_idx as usize].encoded_size;
         decode_64_bits_bar_size(size_hi, size_lo)
@@ -857,6 +886,102 @@ mod tests {
         let mut bars = Bars::default();
         bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
         bars.set_bar_64(1, 0x1000, 0x1000, BarPrefetchable::No);
+    }
+
+    #[test]
+    fn test_bars_get_bar_addr_32() {
+        let mut bars = Bars::default();
+        bars.set_bar_32(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.set_bar_32(1, 0x2000, 0x2000, BarPrefetchable::No);
+        assert_eq!(bars.get_bar_addr_32(0), 0x1000);
+        assert_eq!(bars.get_bar_addr_32(1), 0x2000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_get_bar_addr_32_on_64bit_bar() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.get_bar_addr_32(0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_get_bar_addr_32_on_top_half_of_64bit_bar() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.get_bar_addr_32(1);
+    }
+
+    #[test]
+    fn test_bars_get_bar_addr_64() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        assert_eq!(bars.get_bar_addr_64(0), 0x1000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_get_bar_addr_64_on_32bit_bar() {
+        let mut bars = Bars::default();
+        bars.set_bar_32(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.get_bar_addr_64(0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_get_bar_addr_64_on_top_half_of_64bit_bar() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.get_bar_addr_64(1);
+    }
+
+    #[test]
+    fn test_bars_get_bar_size_32() {
+        let mut bars = Bars::default();
+        bars.set_bar_32(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.set_bar_32(1, 0x2000, 0x2000, BarPrefetchable::No);
+        assert_eq!(bars.get_bar_size_32(0), 0x1000);
+        assert_eq!(bars.get_bar_size_32(1), 0x2000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_get_bar_size_32_on_64bit_bar() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.get_bar_size_32(0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_get_bar_size_32_on_top_half_of_64bit_bar() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.get_bar_size_32(1);
+    }
+
+    #[test]
+    fn test_bars_get_bar_size_64() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        assert_eq!(bars.get_bar_size_64(0), 0x1000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_get_bar_size_64_on_32bit_bar() {
+        let mut bars = Bars::default();
+        bars.set_bar_32(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.get_bar_size_64(0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bars_get_bar_size_64_on_top_half_of_64bit_bar() {
+        let mut bars = Bars::default();
+        bars.set_bar_64(0, 0x1000, 0x1000, BarPrefetchable::No);
+        bars.get_bar_size_64(1);
     }
 
     #[test]


### PR DESCRIPTION
## Changes

Asserts were meant to catch a case where the `bar_idx` passed to these functions was an upper half of the 64 bit BAR. But it did not account for the case where the previous BAR is an upper part of the 64 bit BAR because in that case the `is_64bit()` could return `true` if address stored in that BAR was just right (2nd bit set). The fix is to just remove asserts.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
