### PR TITLE
[blk-threaded - 3/12] block: extract inline I/O processing into BlockWorker

### DIFF
--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -209,7 +209,7 @@ impl VirtioDevice for Block {
 
     fn is_activated(&self) -> bool {
         match self {
-            Self::Virtio(b) => b.device_state.is_activated(),
+            Self::Virtio(b) => b.is_activated(),
             Self::VhostUser(b) => b.device_state.is_activated(),
         }
     }

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -14,18 +14,17 @@ use std::os::linux::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use block_io::FileEngine;
 use serde::{Deserialize, Serialize};
 use vm_memory::ByteValued;
 use vmm_sys_util::eventfd::EventFd;
 
-use super::io::async_io;
-use super::request::*;
-use super::{BLOCK_QUEUE_SIZES, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError, io as block_io};
+use super::io::FileEngine;
+use super::worker::{BlockWorker, FlushMode};
+use super::{BLOCK_QUEUE_SIZES, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::block::CacheType;
 use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, BlockMetricsPerDevice};
-use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
+use crate::devices::virtio::device::{ActiveState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::{
     VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES,
 };
@@ -36,7 +35,6 @@ use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter};
-use crate::utils::u64_to_usize;
 use crate::vmm_config::drive::BlockDeviceConfig;
 use crate::vmm_config::{RateLimiterConfig, TokenBucketConfig};
 use crate::vstate::memory::GuestMemoryMmap;
@@ -248,12 +246,21 @@ pub struct VirtioBlock {
     pub config_space: ConfigSpace,
     pub activate_evt: EventFd,
 
-    pub device_state: DeviceState,
-
     pub(crate) config: VirtioBlockConfig,
     pub(crate) rate_limiter: Arc<Mutex<RateLimiter>>,
-    pub(crate) resources: BlockResources,
+    pub(crate) state: BlockState,
     pub metrics: Arc<BlockDeviceMetrics>,
+}
+
+/// State of the block data-path resources.
+#[derive(Debug)]
+pub(crate) enum BlockState {
+    // Vmm owns the runtime resources before activation
+    Configuring(BlockResources),
+    // Active state, worker owns data-path resources
+    Active(BlockWorker),
+    // Placeholder to hold state when activating
+    Placeholder,
 }
 
 /// Runtime resources used by the block data path.
@@ -271,18 +278,6 @@ fn apply_bucket_update(config: &mut Option<TokenBucketConfig>, update: &BucketUp
         BucketUpdate::Disabled => *config = None,
         BucketUpdate::Update(bucket) => *config = Some(bucket.into()),
     }
-}
-
-macro_rules! unwrap_async_file_engine_or_return {
-    ($file_engine: expr) => {
-        match $file_engine {
-            FileEngine::Async(engine) => engine,
-            FileEngine::Sync(_) => {
-                error!("The block device doesn't use an async IO engine");
-                return;
-            }
-        }
-    };
 }
 
 impl VirtioBlock {
@@ -324,15 +319,14 @@ impl VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            device_state: DeviceState::Inactive,
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            resources: BlockResources {
+            state: BlockState::Configuring(BlockResources {
                 queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
                 queue_evts: [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?],
                 disk: disk_properties,
                 is_io_engine_throttled: false,
-            },
+            }),
             metrics,
         })
     }
@@ -343,15 +337,23 @@ impl VirtioBlock {
     }
 
     pub(crate) fn resources(&self) -> &BlockResources {
-        &self.resources
+        match &self.state {
+            BlockState::Configuring(resources) => resources,
+            BlockState::Active(worker) => &worker.resources,
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     pub(crate) fn resources_mut(&mut self) -> &mut BlockResources {
-        &mut self.resources
+        match &mut self.state {
+            BlockState::Configuring(resources) => resources,
+            BlockState::Active(worker) => &mut worker.resources,
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     pub(crate) fn disk(&self) -> &DiskProperties {
-        &self.resources.disk
+        &self.resources().disk
     }
 
     pub(crate) fn rate_limiter(&self) -> MutexGuard<'_, RateLimiter> {
@@ -360,200 +362,62 @@ impl VirtioBlock {
             .expect("Poisoned block rate limiter lock")
     }
 
+    fn worker_mut(&mut self) -> &mut BlockWorker {
+        match &mut self.state {
+            BlockState::Active(worker) => worker,
+            BlockState::Configuring(_) => panic!("Device is not activated"),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
+    }
+
     /// Process a single event in the Virtio queue.
     ///
     /// This function is called by the event manager when the guest notifies us
     /// about new buffers in the queue.
     pub(crate) fn process_queue_event(&mut self) {
-        self.metrics.queue_event_count.inc();
-        if let Err(err) = self.resources.queue_evts[0].read() {
-            error!("Failed to get queue event: {:?}", err);
-            self.metrics.event_fails.inc();
-        } else if self.rate_limiter().is_blocked() {
-            self.metrics.rate_limiter_throttled_events.inc();
-        } else if self.resources.is_io_engine_throttled {
-            self.metrics.io_engine_throttled_events.inc();
-        } else {
-            self.process_virtio_queues().unwrap()
-        }
+        self.worker_mut().process_queue_event();
     }
 
     /// Process device virtio queue(s).
     pub fn process_virtio_queues(&mut self) -> Result<(), InvalidAvailIdx> {
-        self.process_queue(0)
+        self.worker_mut().process_virtio_queues()
     }
 
     pub(crate) fn process_rate_limiter_event(&mut self) {
         self.metrics.rate_limiter_event_count.inc();
+        if self.rate_limiter().event_handler().is_err() {
+            return;
+        }
+
         // Upon rate limiter event, call the rate limiter handler
         // and restart processing the queue.
-        if self.rate_limiter().event_handler().is_ok() {
-            self.process_queue(0).unwrap()
-        }
-    }
-
-    /// Device specific function for peaking inside a queue and processing descriptors.
-    pub fn process_queue(&mut self, queue_index: usize) -> Result<(), InvalidAvailIdx> {
-        // This is safe since we checked in the event handler that the device is activated.
-        let active_state = self.device_state.active_state().unwrap();
-
-        let rate_limiter = &self.rate_limiter;
-        let queue = &mut self.resources.queues[queue_index];
-        let mut used_any = false;
-
-        while let Some(head) = queue.pop_or_enable_notification()? {
-            self.metrics.remaining_reqs_count.add(queue.len().into());
-            let processing_result =
-                match Request::parse(&head, &active_state.mem, self.resources.disk.nsectors) {
-                    Ok(request) => {
-                        let is_rate_limited = {
-                            let mut rate_limiter = rate_limiter
-                                .lock()
-                                .expect("Poisoned block rate limiter lock");
-                            request.rate_limit(&mut rate_limiter)
-                        };
-                        if is_rate_limited {
-                            // Stop processing the queue and return this descriptor chain to the
-                            // avail ring, for later processing.
-                            queue.undo_pop();
-                            self.metrics.rate_limiter_throttled_events.inc();
-                            break;
-                        }
-
-                        request.process(
-                            &mut self.resources.disk,
-                            head.index,
-                            &active_state.mem,
-                            &self.metrics,
-                        )
-                    }
-                    Err(err) => {
-                        error!("Failed to parse available descriptor chain: {:?}", err);
-                        self.metrics.execute_fails.inc();
-                        ProcessingResult::Executed(FinishedRequest {
-                            num_bytes_to_mem: 0,
-                            desc_idx: head.index,
-                        })
-                    }
-                };
-
-            match processing_result {
-                ProcessingResult::Submitted => {}
-                ProcessingResult::Throttled => {
-                    queue.undo_pop();
-                    self.resources.is_io_engine_throttled = true;
-                    break;
-                }
-                ProcessingResult::Executed(finished) => {
-                    used_any = true;
-                    queue
-                        .add_used(head.index, finished.num_bytes_to_mem)
-                        .unwrap_or_else(|err| {
-                            error!(
-                                "Failed to add available descriptor head {}: {}",
-                                head.index, err
-                            )
-                        });
-                }
+        match &mut self.state {
+            BlockState::Active(worker) => {
+                worker.process_virtio_queues().unwrap();
             }
-        }
-        queue.advance_used_ring_idx();
-
-        if used_any && queue.prepare_kick() {
-            active_state
-                .interrupt
-                .trigger(VirtioInterruptType::Queue(0))
-                .unwrap_or_else(|_| {
-                    self.metrics.event_fails.inc();
-                });
-        }
-
-        if let FileEngine::Async(ref mut engine) = self.resources.disk.file_engine
-            && let Err(err) = engine.kick_submission_queue()
-        {
-            error!("BlockError submitting pending block requests: {:?}", err);
-        }
-
-        if !used_any {
-            self.metrics.no_avail_buffer.inc();
-        }
-
-        Ok(())
-    }
-
-    fn process_async_completion_queue(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
-
-        // This is safe since we checked in the event handler that the device is activated.
-        let active_state = self.device_state.active_state().unwrap();
-        let queue = &mut self.resources.queues[0];
-
-        loop {
-            match engine.pop(&active_state.mem) {
-                Err(error) => {
-                    error!("Failed to read completed io_uring entry: {:?}", error);
-                    break;
-                }
-                Ok(None) => break,
-                Ok(Some(cqe)) => {
-                    let res = cqe.result();
-                    let user_data = cqe.user_data();
-
-                    let (pending, res) = match res {
-                        Ok(count) => (user_data, Ok(count)),
-                        Err(error) => (
-                            user_data,
-                            Err(IoErr::FileEngine(block_io::BlockIoError::Async(
-                                async_io::AsyncIoError::IO(error),
-                            ))),
-                        ),
-                    };
-                    let finished = pending.finish(&active_state.mem, res, &self.metrics);
-                    queue
-                        .add_used(finished.desc_idx, finished.num_bytes_to_mem)
-                        .unwrap_or_else(|err| {
-                            error!(
-                                "Failed to add available descriptor head {}: {}",
-                                finished.desc_idx, err
-                            )
-                        });
-                }
-            }
-        }
-        queue.advance_used_ring_idx();
-
-        if queue.prepare_kick() {
-            active_state
-                .interrupt
-                .trigger(VirtioInterruptType::Queue(0))
-                .unwrap_or_else(|_| {
-                    self.metrics.event_fails.inc();
-                });
+            BlockState::Configuring(_) => {}
+            BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
 
     pub fn process_async_completion_event(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
-
-        if let Err(err) = engine.completion_evt().read() {
-            error!("Failed to get async completion event: {:?}", err);
-        } else {
-            self.process_async_completion_queue();
-
-            if self.resources.is_io_engine_throttled {
-                self.resources.is_io_engine_throttled = false;
-                self.process_queue(0).unwrap()
-            }
-        }
+        self.worker_mut().process_async_completion_event();
     }
 
     /// Update the backing file and the config space of the block device.
     pub fn update_disk_image(&mut self, disk_image_path: String) -> Result<(), VirtioBlockError> {
-        self.resources
-            .disk
-            .update(disk_image_path.clone(), self.config.is_read_only)?;
-        self.config_space.capacity = self.resources.disk.nsectors.to_le();
-        self.config.path_on_host = disk_image_path;
+        let config_path = disk_image_path.clone();
+        let read_only = self.config.is_read_only;
+        let nsectors = match &mut self.state {
+            BlockState::Configuring(resources) => {
+                resources.disk.update(disk_image_path, read_only)?;
+                resources.disk.nsectors
+            }
+            BlockState::Active(worker) => worker.update_disk_image(disk_image_path, read_only)?,
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        };
+        self.config_space.capacity = nsectors.to_le();
+        self.config.path_on_host = config_path;
 
         // Kick the driver to pick up the changes. (But only if the device is already activated).
         if self.is_activated() {
@@ -576,26 +440,15 @@ impl VirtioBlock {
         self.config.rate_limiter = rate_limiter.into_option();
     }
 
-    /// Retrieve the file engine type.
+    /// Retrieve the file engine type, which is fixed for the device lifetime.
     pub fn file_engine_type(&self) -> FileEngineType {
         self.config.file_engine_type
     }
 
-    fn drain_and_flush(&mut self, discard: bool) {
-        if let Err(err) = self.resources.disk.file_engine.drain_and_flush(discard) {
-            error!("Failed to drain ops and flush block data: {:?}", err);
-        }
-    }
-
     /// Prepare device for being snapshotted.
     pub fn prepare_save(&mut self) {
-        if !self.is_activated() {
-            return;
-        }
-
-        self.drain_and_flush(false);
-        if let FileEngine::Async(ref _engine) = self.resources.disk.file_engine {
-            self.process_async_completion_queue();
+        if let BlockState::Active(worker) = &mut self.state {
+            worker.prepare_save();
         }
     }
 }
@@ -620,30 +473,33 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn num_queues(&self) -> usize {
-        self.resources.queues.len()
+        self.resources().queues.len()
     }
 
     fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
-        self.resources.queues.get(index).map(|queue| &queue.config)
+        self.resources()
+            .queues
+            .get(index)
+            .map(|queue| &queue.config)
     }
 
     fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
-        self.resources
+        self.resources_mut()
             .queues
             .get_mut(index)
             .map(|queue| &mut queue.config)
     }
 
     fn queue_event(&self, index: usize) -> Option<&EventFd> {
-        self.resources.queue_evts.get(index)
+        self.resources().queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
-        self.device_state
-            .active_state()
-            .expect("Device is not initialized")
-            .interrupt
-            .deref()
+        match &self.state {
+            BlockState::Active(worker) => worker.active_state.interrupt.deref(),
+            BlockState::Configuring(_) => panic!("Device is not initialized"),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn config_as_bytes(&self) -> &[u8] {
@@ -666,14 +522,19 @@ impl VirtioDevice for VirtioBlock {
     ) -> Result<(), ActivateError> {
         assert!(!self.is_activated());
 
-        for q in self.resources.queues.iter_mut() {
+        let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
+
+        let BlockState::Configuring(resources) = &mut self.state else {
+            unreachable!("inactive device is not configurable");
+        };
+
+        for q in &mut resources.queues {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;
         }
 
-        let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
         if event_idx {
-            for queue in &mut self.resources.queues {
+            for queue in &mut resources.queues {
                 queue.enable_notif_suppression();
             }
         }
@@ -682,33 +543,59 @@ impl VirtioDevice for VirtioBlock {
             self.metrics.activate_fails.inc();
             return Err(ActivateError::EventFd);
         }
-        self.device_state = DeviceState::Activated(ActiveState { mem, interrupt });
+
+        let BlockState::Configuring(resources) =
+            std::mem::replace(&mut self.state, BlockState::Placeholder)
+        else {
+            unreachable!("state checked before activation");
+        };
+        let is_blocked = self.rate_limiter().clone_blocked_flag();
+        self.state = BlockState::Active(BlockWorker {
+            resources,
+            rate_limiter: self.rate_limiter.clone(),
+            is_blocked,
+            active_state: ActiveState { mem, interrupt },
+            metrics: self.metrics.clone(),
+        });
         Ok(())
     }
 
     fn is_activated(&self) -> bool {
-        self.device_state.is_activated()
+        matches!(&self.state, BlockState::Active(_))
     }
 
     fn deactivate(&mut self) {
-        self.device_state = DeviceState::Inactive;
+        let state = std::mem::replace(&mut self.state, BlockState::Placeholder);
+        self.state = match state {
+            BlockState::Active(worker) => BlockState::Configuring(worker.resources),
+            state => state,
+        };
     }
 
     fn _reset(&mut self) -> bool {
-        if let Err(err) = self.resources.disk.file_engine.drain(true) {
-            error!("Failed to reset block IO engine: {:?}", err);
-            return false;
+        match &mut self.state {
+            BlockState::Active(worker) => worker.reset(),
+            BlockState::Configuring(resources) => {
+                if let Err(err) = resources.disk.file_engine.drain(true) {
+                    error!("Failed to reset block IO engine: {:?}", err);
+                    return false;
+                }
+                resources.is_io_engine_throttled = false;
+                true
+            }
+            BlockState::Placeholder => unreachable!("not a runtime state"),
         }
-        self.resources.is_io_engine_throttled = false;
-        true
     }
 
     fn reset_queues(&mut self) {
-        self.resources.queues.iter_mut().for_each(Queue::reset);
+        self.resources_mut()
+            .queues
+            .iter_mut()
+            .for_each(Queue::reset);
     }
 
     fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
-        for queue in &mut self.resources.queues {
+        for queue in &mut self.resources_mut().queues {
             queue.initialize(mem)?;
         }
         Ok(())
@@ -717,15 +604,29 @@ impl VirtioDevice for VirtioBlock {
 
 impl Drop for VirtioBlock {
     fn drop(&mut self) {
-        match self.config.cache_type {
-            CacheType::Unsafe => {
-                if let Err(err) = self.resources.disk.file_engine.drain(true) {
-                    error!("Failed to drain ops on drop: {:?}", err);
+        let flush_mode = match self.config.cache_type {
+            CacheType::Unsafe => FlushMode::Drain,
+            CacheType::Writeback => FlushMode::DrainAndFlush,
+        };
+
+        match std::mem::replace(&mut self.state, BlockState::Placeholder) {
+            BlockState::Active(mut worker) => match flush_mode {
+                FlushMode::Drain => worker.drain(true),
+                FlushMode::DrainAndFlush => worker.drain_and_flush(true),
+            },
+            BlockState::Configuring(mut resources) => match flush_mode {
+                FlushMode::Drain => {
+                    if let Err(err) = resources.disk.file_engine.drain(true) {
+                        error!("Failed to drain ops on drop: {:?}", err);
+                    }
                 }
-            }
-            CacheType::Writeback => {
-                self.drain_and_flush(true);
-            }
+                FlushMode::DrainAndFlush => {
+                    if let Err(err) = resources.disk.file_engine.drain_and_flush(true) {
+                        error!("Failed to drain ops and flush block data: {:?}", err);
+                    }
+                }
+            },
+            BlockState::Placeholder => {}
         };
     }
 }
@@ -743,6 +644,7 @@ mod tests {
     use super::*;
     use crate::check_metric_after_block;
     use crate::devices::virtio::block::virtio::IO_URING_NUM_ENTRIES;
+    use crate::devices::virtio::block::virtio::request::*;
     use crate::devices::virtio::block::virtio::test_utils::{
         default_block, read_blk_req_descriptors, set_queue, set_rate_limiter,
         simulate_async_completion_event, simulate_queue_and_async_completion_events,
@@ -1716,7 +1618,6 @@ mod tests {
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
             set_queue(&mut block, 0, vq.create_queue());
-            block.activate(mem.clone(), interrupt).unwrap();
             read_blk_req_descriptors(&vq);
 
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -1730,6 +1631,7 @@ mod tests {
             assert!(rl.consume(512, TokenType::Bytes));
 
             set_rate_limiter(&mut block, rl);
+            block.activate(mem.clone(), interrupt).unwrap();
 
             mem.write_obj::<u32>(VIRTIO_BLK_T_OUT, request_type_addr)
                 .unwrap();
@@ -1786,7 +1688,6 @@ mod tests {
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
             set_queue(&mut block, 0, vq.create_queue());
-            block.activate(mem.clone(), interrupt).unwrap();
             read_blk_req_descriptors(&vq);
 
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -1799,6 +1700,7 @@ mod tests {
             assert!(rl.consume(1, TokenType::Ops));
 
             set_rate_limiter(&mut block, rl);
+            block.activate(mem.clone(), interrupt).unwrap();
 
             mem.write_obj::<u32>(VIRTIO_BLK_T_OUT, request_type_addr)
                 .unwrap();

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -10,6 +10,7 @@ pub mod metrics;
 pub mod persist;
 pub mod request;
 pub mod test_utils;
+mod worker;
 
 use vm_memory::GuestMemoryError;
 

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -8,12 +8,12 @@ use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 use vmm_sys_util::eventfd::EventFd;
 
-use super::device::{BlockResources, DiskProperties};
+use super::device::{BlockResources, BlockState, DiskProperties};
 use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
 use crate::devices::virtio::block::virtio::device::{FileEngineType, VirtioBlockConfig};
 use crate::devices::virtio::block::virtio::metrics::BlockMetricsPerDevice;
-use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
+use crate::devices::virtio::device::VirtioDeviceType;
 use crate::devices::virtio::generated::virtio_blk::VIRTIO_BLK_F_RO;
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::rate_limiter::RateLimiter;
@@ -139,10 +139,9 @@ impl Persist<'_> for VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            device_state: DeviceState::Inactive,
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            resources,
+            state: BlockState::Configuring(resources),
             metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
         })
     }

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -1,0 +1,254 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::device::BlockResources;
+use super::io::{BlockIoError, FileEngine, async_io};
+use super::metrics::BlockDeviceMetrics;
+use super::{FinishedRequest, IoErr, ProcessingResult, Request, VirtioBlockError};
+use crate::devices::virtio::device::ActiveState;
+use crate::devices::virtio::queue::InvalidAvailIdx;
+use crate::devices::virtio::transport::VirtioInterruptType;
+use crate::logger::{IncMetric, error};
+use crate::rate_limiter::RateLimiter;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Runtime state and processing logic for an active block device.
+#[derive(Debug)]
+pub(crate) struct BlockWorker {
+    pub(crate) resources: BlockResources,
+    pub(crate) active_state: ActiveState,
+    pub(crate) rate_limiter: Arc<Mutex<RateLimiter>>,
+    pub(crate) is_blocked: Arc<AtomicBool>,
+    pub(crate) metrics: Arc<BlockDeviceMetrics>,
+}
+
+pub(crate) enum FlushMode {
+    Drain,
+    DrainAndFlush,
+}
+
+macro_rules! unwrap_async_file_engine_or_return {
+    ($file_engine: expr) => {
+        match $file_engine {
+            FileEngine::Async(engine) => engine,
+            FileEngine::Sync(_) => {
+                error!("The block device doesn't use an async IO engine");
+                return;
+            }
+        }
+    };
+}
+
+impl BlockWorker {
+    /// Process a single event in the Virtio queue.
+    ///
+    /// This function is called by the event manager when the guest notifies us
+    /// about new buffers in the queue.
+    pub(crate) fn process_queue_event(&mut self) {
+        self.metrics.queue_event_count.inc();
+        if let Err(err) = self.resources.queue_evts[0].read() {
+            error!("Failed to get queue event: {:?}", err);
+            self.metrics.event_fails.inc();
+        } else if self.is_blocked.load(Ordering::Relaxed) {
+            self.metrics.rate_limiter_throttled_events.inc();
+        } else if self.resources.is_io_engine_throttled {
+            self.metrics.io_engine_throttled_events.inc();
+        } else {
+            self.process_virtio_queues().unwrap()
+        }
+    }
+
+    /// Process device virtio queue(s).
+    pub(crate) fn process_virtio_queues(&mut self) -> Result<(), InvalidAvailIdx> {
+        self.process_queue(0)
+    }
+
+    /// Device specific function for peaking inside a queue and processing descriptors.
+    fn process_queue(&mut self, queue_index: usize) -> Result<(), InvalidAvailIdx> {
+        let rate_limiter = &self.rate_limiter;
+        let queue = &mut self.resources.queues[queue_index];
+        let mut used_any = false;
+
+        while let Some(head) = queue.pop_or_enable_notification()? {
+            self.metrics.remaining_reqs_count.add(queue.len().into());
+            let processing_result =
+                match Request::parse(&head, &self.active_state.mem, self.resources.disk.nsectors) {
+                    Ok(request) => {
+                        let is_rate_limited = {
+                            let mut rate_limiter = rate_limiter
+                                .lock()
+                                .expect("Poisoned block rate limiter lock");
+                            request.rate_limit(&mut rate_limiter)
+                        };
+                        if is_rate_limited {
+                            // Stop processing the queue and return this descriptor chain to the
+                            // avail ring, for later processing.
+                            queue.undo_pop();
+                            self.metrics.rate_limiter_throttled_events.inc();
+                            break;
+                        }
+
+                        request.process(
+                            &mut self.resources.disk,
+                            head.index,
+                            &self.active_state.mem,
+                            &self.metrics,
+                        )
+                    }
+                    Err(err) => {
+                        error!("Failed to parse available descriptor chain: {:?}", err);
+                        self.metrics.execute_fails.inc();
+                        ProcessingResult::Executed(FinishedRequest {
+                            num_bytes_to_mem: 0,
+                            desc_idx: head.index,
+                        })
+                    }
+                };
+
+            match processing_result {
+                ProcessingResult::Submitted => {}
+                ProcessingResult::Throttled => {
+                    queue.undo_pop();
+                    self.resources.is_io_engine_throttled = true;
+                    break;
+                }
+                ProcessingResult::Executed(finished) => {
+                    used_any = true;
+                    queue
+                        .add_used(head.index, finished.num_bytes_to_mem)
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "Failed to add available descriptor head {}: {}",
+                                head.index, err
+                            )
+                        });
+                }
+            }
+        }
+        queue.advance_used_ring_idx();
+
+        if used_any && queue.prepare_kick() {
+            self.active_state
+                .interrupt
+                .trigger(VirtioInterruptType::Queue(0))
+                .unwrap_or_else(|_| {
+                    self.metrics.event_fails.inc();
+                });
+        }
+
+        if let FileEngine::Async(ref mut engine) = self.resources.disk.file_engine
+            && let Err(err) = engine.kick_submission_queue()
+        {
+            error!("BlockError submitting pending block requests: {:?}", err);
+        }
+
+        if !used_any {
+            self.metrics.no_avail_buffer.inc();
+        }
+
+        Ok(())
+    }
+
+    fn process_async_completion_queue(&mut self) {
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
+        let queue = &mut self.resources.queues[0];
+
+        loop {
+            match engine.pop(&self.active_state.mem) {
+                Err(error) => {
+                    error!("Failed to read completed io_uring entry: {:?}", error);
+                    break;
+                }
+                Ok(None) => break,
+                Ok(Some(cqe)) => {
+                    let res = cqe.result();
+                    let user_data = cqe.user_data();
+
+                    let (pending, res) = match res {
+                        Ok(count) => (user_data, Ok(count)),
+                        Err(error) => (
+                            user_data,
+                            Err(IoErr::FileEngine(BlockIoError::Async(
+                                async_io::AsyncIoError::IO(error),
+                            ))),
+                        ),
+                    };
+                    let finished = pending.finish(&self.active_state.mem, res, &self.metrics);
+                    queue
+                        .add_used(finished.desc_idx, finished.num_bytes_to_mem)
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "Failed to add available descriptor head {}: {}",
+                                finished.desc_idx, err
+                            )
+                        });
+                }
+            }
+        }
+        queue.advance_used_ring_idx();
+
+        if queue.prepare_kick() {
+            self.active_state
+                .interrupt
+                .trigger(VirtioInterruptType::Queue(0))
+                .unwrap_or_else(|_| {
+                    self.metrics.event_fails.inc();
+                });
+        }
+    }
+
+    pub(crate) fn process_async_completion_event(&mut self) {
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
+
+        if let Err(err) = engine.completion_evt().read() {
+            error!("Failed to get async completion event: {:?}", err);
+        } else {
+            self.process_async_completion_queue();
+
+            if self.resources.is_io_engine_throttled {
+                self.resources.is_io_engine_throttled = false;
+                self.process_queue(0).unwrap()
+            }
+        }
+    }
+
+    pub(crate) fn drain_and_flush(&mut self, discard: bool) {
+        if let Err(err) = self.resources.disk.file_engine.drain_and_flush(discard) {
+            error!("Failed to drain ops and flush block data: {:?}", err);
+        }
+    }
+
+    pub(crate) fn drain(&mut self, discard: bool) {
+        if let Err(err) = self.resources.disk.file_engine.drain(discard) {
+            error!("Failed to drain ops: {:?}", err);
+        }
+    }
+
+    pub(crate) fn reset(&mut self) -> bool {
+        if let Err(err) = self.resources.disk.file_engine.drain(true) {
+            error!("Failed to reset block IO engine: {:?}", err);
+            return false;
+        }
+        self.resources.is_io_engine_throttled = false;
+        true
+    }
+
+    /// Prepare device for being snapshotted.
+    pub(crate) fn prepare_save(&mut self) {
+        self.drain_and_flush(false);
+        if matches!(&self.resources.disk.file_engine, FileEngine::Async(_)) {
+            self.process_async_completion_queue();
+        }
+    }
+
+    /// Update the backing file and return the new sector count.
+    pub fn update_disk_image(
+        &mut self,
+        disk_image_path: String,
+        read_only: bool,
+    ) -> Result<u64, VirtioBlockError> {
+        self.resources.disk.update(disk_image_path, read_only)?;
+        Ok(self.resources.disk.nsectors)
+    }
+}

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -456,6 +456,11 @@ impl RateLimiter {
         self.timer_active.load(Ordering::Relaxed)
     }
 
+    /// Clones the shared blocked-state flag for lock free checks
+    pub(crate) fn clone_blocked_flag(&self) -> Arc<AtomicBool> {
+        self.timer_active.clone()
+    }
+
     /// This function needs to be called every time there is an event on the
     /// FD provided by this object's `AsRawFd` trait implementation.
     ///


### PR DESCRIPTION
_[3/12] part of the PR stack starting with [#6123](https://github.com/firecracker-microvm/firecracker/pull/6123)_

## Changes

Move queue and completion processing into BlockWorker while keeping
execution on the VMM thread.

Transfer runtime resources to the worker on activation and return them
on deactivation. This prepares the data path for worker thread support.