### PR TITLE
[blk-threaded - 5/12] block: add worker thread activation

### DIFF
--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -201,7 +201,10 @@ impl MMIOVirtioDevices {
             let mmio_device = device.inner.lock().expect("Poisoned lock");
             let locked_device = mmio_device.locked_device();
             identifier = (locked_device.device_type(), device_id);
-            for (i, queue_evt) in locked_device.queue_events().iter().enumerate() {
+            for i in 0..locked_device.num_queues() {
+                let queue_evt = locked_device
+                    .queue_event(i)
+                    .expect("queue event must exist for each advertised queue");
                 let io_addr = IoEventAddress::Mmio(
                     device.resources.addr + u64::from(crate::devices::virtio::NOTIFY_REG_OFFSET),
                 );
@@ -519,7 +522,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::devices::virtio::ActivateError;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
-    use crate::devices::virtio::queue::Queue;
+    use crate::devices::virtio::queue::{Queue, QueueConfig, QueueError};
     use crate::devices::virtio::transport::VirtioInterrupt;
     use crate::devices::virtio::transport::mmio::IrqTrigger;
     use crate::test_utils::multi_region_mem_raw;
@@ -607,16 +610,20 @@ pub(crate) mod tests {
 
         fn set_acked_features(&mut self, _: u64) {}
 
-        fn queues(&self) -> &[Queue] {
-            &self.queues
+        fn num_queues(&self) -> usize {
+            self.queues.len()
         }
 
-        fn queues_mut(&mut self) -> &mut [Queue] {
-            &mut self.queues
+        fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+            self.queues.get(index).map(|queue| &queue.config)
         }
 
-        fn queue_events(&self) -> &[EventFd] {
-            &self.queue_evts
+        fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+            self.queues.get_mut(index).map(|queue| &mut queue.config)
+        }
+
+        fn queue_event(&self, index: usize) -> Option<&EventFd> {
+            self.queue_evts.get(index)
         }
 
         fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -653,6 +660,17 @@ pub(crate) mod tests {
 
         fn _reset(&mut self) -> bool {
             false
+        }
+
+        fn reset_queues(&mut self) {
+            self.queues.iter_mut().for_each(Queue::reset);
+        }
+
+        fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+            for queue in &mut self.queues {
+                queue.initialize(mem)?;
+            }
+            Ok(())
         }
     }
 
@@ -763,7 +781,7 @@ pub(crate) mod tests {
     fn test_dummy_device() {
         let dummy = DummyDevice::new();
         assert_eq!(dummy.device_type(), VirtioDeviceType::Net);
-        assert_eq!(dummy.queues().len(), QUEUE_SIZES.len());
+        assert_eq!(dummy.num_queues(), QUEUE_SIZES.len());
     }
 
     #[test]

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -144,7 +144,7 @@ impl PciDevices {
 
         // Allocate one MSI vector per queue, plus one for configuration
         let msix_num =
-            u16::try_from(device.lock().expect("Poisoned lock").queues().len() + 1).unwrap();
+            u16::try_from(device.lock().expect("Poisoned lock").num_queues() + 1).unwrap();
 
         let msix_vectors = KvmVm::create_msix_group(vm.clone(), msix_num)?;
 

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -11,7 +11,7 @@ use vmm_sys_util::eventfd::EventFd;
 
 use super::super::ActivateError;
 use super::super::device::{DeviceState, VirtioDevice};
-use super::super::queue::Queue;
+use super::super::queue::{Queue, QueueConfig, QueueError};
 use super::metrics::METRICS;
 use super::util::compact_page_frame_numbers;
 use super::{
@@ -907,16 +907,20 @@ impl VirtioDevice for Balloon {
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_evts
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -995,6 +999,17 @@ impl VirtioDevice for Balloon {
         true
     }
 
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
+    }
+
     fn kick(&mut self) {
         if self.is_activated() {
             if self.free_page_hinting() {
@@ -1035,7 +1050,7 @@ pub(crate) mod tests {
             self.queues = queues;
         }
 
-        fn num_queues(&self) -> usize {
+        fn num_queues_supported(&self) -> usize {
             let mut idx = STATS_INDEX;
 
             if self.stats_polling_interval_s > 0 {
@@ -1543,7 +1558,7 @@ pub(crate) mod tests {
             );
             check_metric_after_block!(METRICS.stats_updates_count, 1, {
                 // Trigger the queue event.
-                balloon.queue_events()[STATS_INDEX].write(1).unwrap();
+                balloon.queue_event(STATS_INDEX).unwrap().write(1).unwrap();
                 balloon.process_stats_queue_event().unwrap();
                 // Don't check for completion yet.
             });
@@ -2017,7 +2032,7 @@ pub(crate) mod tests {
             }
 
             set_request(&statsq, 0, stat_addr, tc.desc_len, VIRTQ_DESC_F_NEXT);
-            balloon.queue_events()[STATS_INDEX].write(1).unwrap();
+            balloon.queue_event(STATS_INDEX).unwrap().write(1).unwrap();
             balloon.process_stats_queue_event().unwrap();
 
             // The descriptor should always be held (stats protocol preserved)

--- a/src/vmm/src/devices/virtio/balloon/persist.rs
+++ b/src/vmm/src/devices/virtio/balloon/persist.rs
@@ -129,7 +129,7 @@ impl Persist<'_> for Balloon {
                 num_pages: self.config_space.num_pages,
                 actual_pages: self.config_space.actual_pages,
             },
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
         }
     }
 
@@ -238,7 +238,7 @@ mod tests {
             restored_balloon.config_space.free_page_hint_cmd_id,
             FREE_PAGE_HINT_DONE
         );
-        assert_eq!(restored_balloon.queues(), balloon.queues());
+        assert_eq!(restored_balloon.queues, balloon.queues);
         assert!(!restored_balloon.is_activated());
         assert!(!balloon.is_activated());
 

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -12,7 +12,7 @@ use super::vhost_user::device::{VhostUserBlock, VhostUserBlockConfig};
 use super::virtio::device::{VirtioBlock, VirtioBlockConfig};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
-use crate::devices::virtio::queue::{InvalidAvailIdx, Queue};
+use crate::devices::virtio::queue::{InvalidAvailIdx, QueueConfig, QueueError};
 use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::impl_device_type;
 use crate::rate_limiter::BucketUpdate;
@@ -147,24 +147,31 @@ impl VirtioDevice for Block {
         }
     }
 
-    fn queues(&self) -> &[Queue] {
+    fn num_queues(&self) -> usize {
         match self {
-            Self::Virtio(b) => &b.queues,
-            Self::VhostUser(b) => &b.queues,
+            Self::Virtio(b) => b.num_queues(),
+            Self::VhostUser(b) => b.num_queues(),
         }
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
         match self {
-            Self::Virtio(b) => &mut b.queues,
-            Self::VhostUser(b) => &mut b.queues,
+            Self::Virtio(b) => b.queue_config(index),
+            Self::VhostUser(b) => b.queue_config(index),
         }
     }
 
-    fn queue_events(&self) -> &[EventFd] {
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
         match self {
-            Self::Virtio(b) => &b.queue_evts,
-            Self::VhostUser(b) => &b.queue_evts,
+            Self::Virtio(b) => b.queue_config_mut(index),
+            Self::VhostUser(b) => b.queue_config_mut(index),
+        }
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        match self {
+            Self::Virtio(b) => b.queue_event(index),
+            Self::VhostUser(b) => b.queue_event(index),
         }
     }
 
@@ -218,6 +225,20 @@ impl VirtioDevice for Block {
         match self {
             Self::Virtio(b) => b._reset(),
             Self::VhostUser(b) => b._reset(),
+        }
+    }
+
+    fn reset_queues(&mut self) {
+        match self {
+            Self::Virtio(b) => b.reset_queues(),
+            Self::VhostUser(b) => b.reset_queues(),
+        }
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        match self {
+            Self::Virtio(b) => b.mark_queue_memory_dirty(mem),
+            Self::VhostUser(b) => b.mark_queue_memory_dirty(mem),
         }
     }
 

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -89,21 +89,21 @@ impl Block {
 
     pub fn root_device(&self) -> bool {
         match self {
-            Self::Virtio(b) => b.root_device,
+            Self::Virtio(b) => b.config.is_root_device,
             Self::VhostUser(b) => b.root_device,
         }
     }
 
     pub fn read_only(&self) -> bool {
         match self {
-            Self::Virtio(b) => b.read_only,
+            Self::Virtio(b) => b.config.is_read_only,
             Self::VhostUser(b) => b.read_only,
         }
     }
 
     pub fn partuuid(&self) -> &Option<String> {
         match self {
-            Self::Virtio(b) => &b.partuuid,
+            Self::Virtio(b) => &b.config.partuuid,
             Self::VhostUser(b) => &b.partuuid,
         }
     }

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -209,7 +209,7 @@ impl VirtioDevice for Block {
 
     fn is_activated(&self) -> bool {
         match self {
-            Self::Virtio(b) => b.device_state.is_activated(),
+            Self::Virtio(b) => b.is_activated(),
             Self::VhostUser(b) => b.device_state.is_activated(),
         }
     }

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -19,7 +19,7 @@ use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, Vir
 use crate::devices::virtio::generated::virtio_blk::{VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO};
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::{Queue, QueueConfig, QueueError};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::virtio::vhost_user::{VhostUserHandleBackend, VhostUserHandleImpl};
 use crate::devices::virtio::vhost_user_metrics::{
@@ -308,16 +308,20 @@ where
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_evts
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -382,6 +386,17 @@ where
 
     fn _reset(&mut self) -> bool {
         false
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -31,7 +31,7 @@ use crate::devices::virtio::generated::virtio_blk::{
 };
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::{InvalidAvailIdx, Queue};
+use crate::devices::virtio::queue::{InvalidAvailIdx, Queue, QueueConfig, QueueError};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, warn};
@@ -598,16 +598,20 @@ impl VirtioDevice for VirtioBlock {
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_evts
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -673,6 +677,17 @@ impl VirtioDevice for VirtioBlock {
         }
         self.is_io_engine_throttled = false;
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -12,7 +12,7 @@ use std::io::{Seek, SeekFrom};
 use std::ops::Deref;
 use std::os::linux::fs::MetadataExt;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use block_io::FileEngine;
 use serde::{Deserialize, Serialize};
@@ -251,6 +251,7 @@ pub struct VirtioBlock {
     pub device_state: DeviceState,
 
     pub(crate) config: VirtioBlockConfig,
+    pub(crate) rate_limiter: Arc<Mutex<RateLimiter>>,
     pub(crate) resources: BlockResources,
     pub metrics: Arc<BlockDeviceMetrics>,
 }
@@ -261,7 +262,6 @@ pub(crate) struct BlockResources {
     pub(crate) queues: Vec<Queue>,
     pub(crate) queue_evts: [EventFd; 1],
     pub(crate) disk: DiskProperties,
-    pub(crate) rate_limiter: RateLimiter,
     pub(crate) is_io_engine_throttled: bool,
 }
 
@@ -326,11 +326,11 @@ impl VirtioBlock {
 
             device_state: DeviceState::Inactive,
             config,
+            rate_limiter: Arc::new(Mutex::new(rate_limiter)),
             resources: BlockResources {
                 queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
                 queue_evts: [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?],
                 disk: disk_properties,
-                rate_limiter,
                 is_io_engine_throttled: false,
             },
             metrics,
@@ -354,8 +354,10 @@ impl VirtioBlock {
         &self.resources.disk
     }
 
-    pub(crate) fn rate_limiter(&self) -> &RateLimiter {
-        &self.resources.rate_limiter
+    pub(crate) fn rate_limiter(&self) -> MutexGuard<'_, RateLimiter> {
+        self.rate_limiter
+            .lock()
+            .expect("Poisoned block rate limiter lock")
     }
 
     /// Process a single event in the Virtio queue.
@@ -367,7 +369,7 @@ impl VirtioBlock {
         if let Err(err) = self.resources.queue_evts[0].read() {
             error!("Failed to get queue event: {:?}", err);
             self.metrics.event_fails.inc();
-        } else if self.resources.rate_limiter.is_blocked() {
+        } else if self.rate_limiter().is_blocked() {
             self.metrics.rate_limiter_throttled_events.inc();
         } else if self.resources.is_io_engine_throttled {
             self.metrics.io_engine_throttled_events.inc();
@@ -385,7 +387,7 @@ impl VirtioBlock {
         self.metrics.rate_limiter_event_count.inc();
         // Upon rate limiter event, call the rate limiter handler
         // and restart processing the queue.
-        if self.resources.rate_limiter.event_handler().is_ok() {
+        if self.rate_limiter().event_handler().is_ok() {
             self.process_queue(0).unwrap()
         }
     }
@@ -395,6 +397,7 @@ impl VirtioBlock {
         // This is safe since we checked in the event handler that the device is activated.
         let active_state = self.device_state.active_state().unwrap();
 
+        let rate_limiter = &self.rate_limiter;
         let queue = &mut self.resources.queues[queue_index];
         let mut used_any = false;
 
@@ -403,7 +406,13 @@ impl VirtioBlock {
             let processing_result =
                 match Request::parse(&head, &active_state.mem, self.resources.disk.nsectors) {
                     Ok(request) => {
-                        if request.rate_limit(&mut self.resources.rate_limiter) {
+                        let is_rate_limited = {
+                            let mut rate_limiter = rate_limiter
+                                .lock()
+                                .expect("Poisoned block rate limiter lock");
+                            request.rate_limit(&mut rate_limiter)
+                        };
+                        if is_rate_limited {
                             // Stop processing the queue and return this descriptor chain to the
                             // avail ring, for later processing.
                             queue.undo_pop();
@@ -563,7 +572,7 @@ impl VirtioBlock {
         apply_bucket_update(&mut rate_limiter.bandwidth, &bytes);
         apply_bucket_update(&mut rate_limiter.ops, &ops);
 
-        self.resources.rate_limiter.update_buckets(bytes, ops);
+        self.rate_limiter().update_buckets(bytes, ops);
         self.config.rate_limiter = rate_limiter.into_option();
     }
 

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -14,18 +14,17 @@ use std::os::linux::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use block_io::FileEngine;
 use serde::{Deserialize, Serialize};
 use vm_memory::ByteValued;
 use vmm_sys_util::eventfd::EventFd;
 
-use super::io::async_io;
-use super::request::*;
-use super::{BLOCK_QUEUE_SIZES, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError, io as block_io};
+use super::io::FileEngine;
+use super::worker::{BlockWorker, FlushMode};
+use super::{BLOCK_QUEUE_SIZES, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::block::CacheType;
 use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, BlockMetricsPerDevice};
-use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
+use crate::devices::virtio::device::{ActiveState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::{
     VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES,
 };
@@ -36,7 +35,6 @@ use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter};
-use crate::utils::u64_to_usize;
 use crate::vmm_config::drive::BlockDeviceConfig;
 use crate::vmm_config::{RateLimiterConfig, TokenBucketConfig};
 use crate::vstate::memory::GuestMemoryMmap;
@@ -248,12 +246,21 @@ pub struct VirtioBlock {
     pub config_space: ConfigSpace,
     pub activate_evt: EventFd,
 
-    pub device_state: DeviceState,
-
     pub(crate) config: VirtioBlockConfig,
     pub(crate) rate_limiter: Arc<Mutex<RateLimiter>>,
-    pub(crate) resources: BlockResources,
+    pub(crate) state: BlockState,
     pub metrics: Arc<BlockDeviceMetrics>,
+}
+
+/// State of the block data-path resources.
+#[derive(Debug)]
+pub(crate) enum BlockState {
+    // Vmm owns the runtime resources before activation
+    Configuring(BlockResources),
+    // Active state, worker owns data-path resources
+    Active(BlockWorker),
+    // Placeholder to hold state when activating
+    Placeholder,
 }
 
 /// Runtime resources used by the block data path.
@@ -271,18 +278,6 @@ fn apply_bucket_update(config: &mut Option<TokenBucketConfig>, update: &BucketUp
         BucketUpdate::Disabled => *config = None,
         BucketUpdate::Update(bucket) => *config = Some(bucket.into()),
     }
-}
-
-macro_rules! unwrap_async_file_engine_or_return {
-    ($file_engine: expr) => {
-        match $file_engine {
-            FileEngine::Async(engine) => engine,
-            FileEngine::Sync(_) => {
-                error!("The block device doesn't use an async IO engine");
-                return;
-            }
-        }
-    };
 }
 
 impl VirtioBlock {
@@ -324,15 +319,14 @@ impl VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            device_state: DeviceState::Inactive,
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            resources: BlockResources {
+            state: BlockState::Configuring(BlockResources {
                 queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
                 queue_evts: [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?],
                 disk: disk_properties,
                 is_io_engine_throttled: false,
-            },
+            }),
             metrics,
         })
     }
@@ -343,15 +337,23 @@ impl VirtioBlock {
     }
 
     pub(crate) fn resources(&self) -> &BlockResources {
-        &self.resources
+        match &self.state {
+            BlockState::Configuring(resources) => resources,
+            BlockState::Active(worker) => &worker.resources,
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     pub(crate) fn resources_mut(&mut self) -> &mut BlockResources {
-        &mut self.resources
+        match &mut self.state {
+            BlockState::Configuring(resources) => resources,
+            BlockState::Active(worker) => &mut worker.resources,
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     pub(crate) fn disk(&self) -> &DiskProperties {
-        &self.resources.disk
+        &self.resources().disk
     }
 
     pub(crate) fn rate_limiter(&self) -> MutexGuard<'_, RateLimiter> {
@@ -360,200 +362,62 @@ impl VirtioBlock {
             .expect("Poisoned block rate limiter lock")
     }
 
+    fn worker_mut(&mut self) -> &mut BlockWorker {
+        match &mut self.state {
+            BlockState::Active(worker) => worker,
+            BlockState::Configuring(_) => panic!("Device is not activated"),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
+    }
+
     /// Process a single event in the Virtio queue.
     ///
     /// This function is called by the event manager when the guest notifies us
     /// about new buffers in the queue.
     pub(crate) fn process_queue_event(&mut self) {
-        self.metrics.queue_event_count.inc();
-        if let Err(err) = self.resources.queue_evts[0].read() {
-            error!("Failed to get queue event: {:?}", err);
-            self.metrics.event_fails.inc();
-        } else if self.rate_limiter().is_blocked() {
-            self.metrics.rate_limiter_throttled_events.inc();
-        } else if self.resources.is_io_engine_throttled {
-            self.metrics.io_engine_throttled_events.inc();
-        } else {
-            self.process_virtio_queues().unwrap()
-        }
+        self.worker_mut().process_queue_event();
     }
 
     /// Process device virtio queue(s).
     pub fn process_virtio_queues(&mut self) -> Result<(), InvalidAvailIdx> {
-        self.process_queue(0)
+        self.worker_mut().process_virtio_queues()
     }
 
     pub(crate) fn process_rate_limiter_event(&mut self) {
         self.metrics.rate_limiter_event_count.inc();
+        if self.rate_limiter().event_handler().is_err() {
+            return;
+        }
+
         // Upon rate limiter event, call the rate limiter handler
         // and restart processing the queue.
-        if self.rate_limiter().event_handler().is_ok() {
-            self.process_queue(0).unwrap()
-        }
-    }
-
-    /// Device specific function for peaking inside a queue and processing descriptors.
-    pub fn process_queue(&mut self, queue_index: usize) -> Result<(), InvalidAvailIdx> {
-        // This is safe since we checked in the event handler that the device is activated.
-        let active_state = self.device_state.active_state().unwrap();
-
-        let rate_limiter = &self.rate_limiter;
-        let queue = &mut self.resources.queues[queue_index];
-        let mut used_any = false;
-
-        while let Some(head) = queue.pop_or_enable_notification()? {
-            self.metrics.remaining_reqs_count.add(queue.len().into());
-            let processing_result =
-                match Request::parse(&head, &active_state.mem, self.resources.disk.nsectors) {
-                    Ok(request) => {
-                        let is_rate_limited = {
-                            let mut rate_limiter = rate_limiter
-                                .lock()
-                                .expect("Poisoned block rate limiter lock");
-                            request.rate_limit(&mut rate_limiter)
-                        };
-                        if is_rate_limited {
-                            // Stop processing the queue and return this descriptor chain to the
-                            // avail ring, for later processing.
-                            queue.undo_pop();
-                            self.metrics.rate_limiter_throttled_events.inc();
-                            break;
-                        }
-
-                        request.process(
-                            &mut self.resources.disk,
-                            head.index,
-                            &active_state.mem,
-                            &self.metrics,
-                        )
-                    }
-                    Err(err) => {
-                        error!("Failed to parse available descriptor chain: {:?}", err);
-                        self.metrics.execute_fails.inc();
-                        ProcessingResult::Executed(FinishedRequest {
-                            num_bytes_to_mem: 0,
-                            desc_idx: head.index,
-                        })
-                    }
-                };
-
-            match processing_result {
-                ProcessingResult::Submitted => {}
-                ProcessingResult::Throttled => {
-                    queue.undo_pop();
-                    self.resources.is_io_engine_throttled = true;
-                    break;
-                }
-                ProcessingResult::Executed(finished) => {
-                    used_any = true;
-                    queue
-                        .add_used(head.index, finished.num_bytes_to_mem)
-                        .unwrap_or_else(|err| {
-                            error!(
-                                "Failed to add available descriptor head {}: {}",
-                                head.index, err
-                            )
-                        });
-                }
+        match &mut self.state {
+            BlockState::Active(worker) => {
+                worker.process_virtio_queues().unwrap();
             }
-        }
-        queue.advance_used_ring_idx();
-
-        if used_any && queue.prepare_kick() {
-            active_state
-                .interrupt
-                .trigger(VirtioInterruptType::Queue(0))
-                .unwrap_or_else(|_| {
-                    self.metrics.event_fails.inc();
-                });
-        }
-
-        if let FileEngine::Async(ref mut engine) = self.resources.disk.file_engine
-            && let Err(err) = engine.kick_submission_queue()
-        {
-            error!("BlockError submitting pending block requests: {:?}", err);
-        }
-
-        if !used_any {
-            self.metrics.no_avail_buffer.inc();
-        }
-
-        Ok(())
-    }
-
-    fn process_async_completion_queue(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
-
-        // This is safe since we checked in the event handler that the device is activated.
-        let active_state = self.device_state.active_state().unwrap();
-        let queue = &mut self.resources.queues[0];
-
-        loop {
-            match engine.pop(&active_state.mem) {
-                Err(error) => {
-                    error!("Failed to read completed io_uring entry: {:?}", error);
-                    break;
-                }
-                Ok(None) => break,
-                Ok(Some(cqe)) => {
-                    let res = cqe.result();
-                    let user_data = cqe.user_data();
-
-                    let (pending, res) = match res {
-                        Ok(count) => (user_data, Ok(count)),
-                        Err(error) => (
-                            user_data,
-                            Err(IoErr::FileEngine(block_io::BlockIoError::Async(
-                                async_io::AsyncIoError::IO(error),
-                            ))),
-                        ),
-                    };
-                    let finished = pending.finish(&active_state.mem, res, &self.metrics);
-                    queue
-                        .add_used(finished.desc_idx, finished.num_bytes_to_mem)
-                        .unwrap_or_else(|err| {
-                            error!(
-                                "Failed to add available descriptor head {}: {}",
-                                finished.desc_idx, err
-                            )
-                        });
-                }
-            }
-        }
-        queue.advance_used_ring_idx();
-
-        if queue.prepare_kick() {
-            active_state
-                .interrupt
-                .trigger(VirtioInterruptType::Queue(0))
-                .unwrap_or_else(|_| {
-                    self.metrics.event_fails.inc();
-                });
+            BlockState::Configuring(_) => {}
+            BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
 
     pub fn process_async_completion_event(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
-
-        if let Err(err) = engine.completion_evt().read() {
-            error!("Failed to get async completion event: {:?}", err);
-        } else {
-            self.process_async_completion_queue();
-
-            if self.resources.is_io_engine_throttled {
-                self.resources.is_io_engine_throttled = false;
-                self.process_queue(0).unwrap()
-            }
-        }
+        self.worker_mut().process_async_completion_event();
     }
 
     /// Update the backing file and the config space of the block device.
     pub fn update_disk_image(&mut self, disk_image_path: String) -> Result<(), VirtioBlockError> {
-        self.resources
-            .disk
-            .update(disk_image_path.clone(), self.config.is_read_only)?;
-        self.config_space.capacity = self.resources.disk.nsectors.to_le();
-        self.config.path_on_host = disk_image_path;
+        let config_path = disk_image_path.clone();
+        let read_only = self.config.is_read_only;
+        let nsectors = match &mut self.state {
+            BlockState::Configuring(resources) => {
+                resources.disk.update(disk_image_path, read_only)?;
+                resources.disk.nsectors
+            }
+            BlockState::Active(worker) => worker.update_disk_image(disk_image_path, read_only)?,
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        };
+        self.config_space.capacity = nsectors.to_le();
+        self.config.path_on_host = config_path;
 
         // Kick the driver to pick up the changes. (But only if the device is already activated).
         if self.is_activated() {
@@ -576,26 +440,15 @@ impl VirtioBlock {
         self.config.rate_limiter = rate_limiter.into_option();
     }
 
-    /// Retrieve the file engine type.
+    /// Retrieve the file engine type, which is fixed for the device lifetime.
     pub fn file_engine_type(&self) -> FileEngineType {
         self.config.file_engine_type
     }
 
-    fn drain_and_flush(&mut self, discard: bool) {
-        if let Err(err) = self.resources.disk.file_engine.drain_and_flush(discard) {
-            error!("Failed to drain ops and flush block data: {:?}", err);
-        }
-    }
-
     /// Prepare device for being snapshotted.
     pub fn prepare_save(&mut self) {
-        if !self.is_activated() {
-            return;
-        }
-
-        self.drain_and_flush(false);
-        if let FileEngine::Async(ref _engine) = self.resources.disk.file_engine {
-            self.process_async_completion_queue();
+        if let BlockState::Active(worker) = &mut self.state {
+            worker.prepare_save();
         }
     }
 }
@@ -620,30 +473,33 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn num_queues(&self) -> usize {
-        self.resources.queues.len()
+        self.resources().queues.len()
     }
 
     fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
-        self.resources.queues.get(index).map(|queue| &queue.config)
+        self.resources()
+            .queues
+            .get(index)
+            .map(|queue| &queue.config)
     }
 
     fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
-        self.resources
+        self.resources_mut()
             .queues
             .get_mut(index)
             .map(|queue| &mut queue.config)
     }
 
     fn queue_event(&self, index: usize) -> Option<&EventFd> {
-        self.resources.queue_evts.get(index)
+        self.resources().queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
-        self.device_state
-            .active_state()
-            .expect("Device is not initialized")
-            .interrupt
-            .deref()
+        match &self.state {
+            BlockState::Active(worker) => worker.active_state.interrupt.deref(),
+            BlockState::Configuring(_) => panic!("Device is not initialized"),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn config_as_bytes(&self) -> &[u8] {
@@ -666,14 +522,19 @@ impl VirtioDevice for VirtioBlock {
     ) -> Result<(), ActivateError> {
         assert!(!self.is_activated());
 
-        for q in self.resources.queues.iter_mut() {
+        let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
+
+        let BlockState::Configuring(resources) = &mut self.state else {
+            unreachable!("inactive device is not configurable");
+        };
+
+        for q in &mut resources.queues {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;
         }
 
-        let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
         if event_idx {
-            for queue in &mut self.resources.queues {
+            for queue in &mut resources.queues {
                 queue.enable_notif_suppression();
             }
         }
@@ -682,33 +543,59 @@ impl VirtioDevice for VirtioBlock {
             self.metrics.activate_fails.inc();
             return Err(ActivateError::EventFd);
         }
-        self.device_state = DeviceState::Activated(ActiveState { mem, interrupt });
+
+        let BlockState::Configuring(resources) =
+            std::mem::replace(&mut self.state, BlockState::Placeholder)
+        else {
+            unreachable!("state checked before activation");
+        };
+        let is_blocked = self.rate_limiter().clone_blocked_flag();
+        self.state = BlockState::Active(BlockWorker {
+            resources,
+            rate_limiter: self.rate_limiter.clone(),
+            is_blocked,
+            active_state: ActiveState { mem, interrupt },
+            metrics: self.metrics.clone(),
+        });
         Ok(())
     }
 
     fn is_activated(&self) -> bool {
-        self.device_state.is_activated()
+        matches!(&self.state, BlockState::Active(_))
     }
 
     fn deactivate(&mut self) {
-        self.device_state = DeviceState::Inactive;
+        let state = std::mem::replace(&mut self.state, BlockState::Placeholder);
+        self.state = match state {
+            BlockState::Active(worker) => BlockState::Configuring(worker.resources),
+            state => state,
+        };
     }
 
     fn _reset(&mut self) -> bool {
-        if let Err(err) = self.resources.disk.file_engine.drain(true) {
-            error!("Failed to reset block IO engine: {:?}", err);
-            return false;
+        match &mut self.state {
+            BlockState::Active(worker) => worker.reset(),
+            BlockState::Configuring(resources) => {
+                if let Err(err) = resources.disk.file_engine.drain(true) {
+                    error!("Failed to reset block IO engine: {:?}", err);
+                    return false;
+                }
+                resources.is_io_engine_throttled = false;
+                true
+            }
+            BlockState::Placeholder => unreachable!("not a runtime state"),
         }
-        self.resources.is_io_engine_throttled = false;
-        true
     }
 
     fn reset_queues(&mut self) {
-        self.resources.queues.iter_mut().for_each(Queue::reset);
+        self.resources_mut()
+            .queues
+            .iter_mut()
+            .for_each(Queue::reset);
     }
 
     fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
-        for queue in &mut self.resources.queues {
+        for queue in &mut self.resources_mut().queues {
             queue.initialize(mem)?;
         }
         Ok(())
@@ -717,15 +604,29 @@ impl VirtioDevice for VirtioBlock {
 
 impl Drop for VirtioBlock {
     fn drop(&mut self) {
-        match self.config.cache_type {
-            CacheType::Unsafe => {
-                if let Err(err) = self.resources.disk.file_engine.drain(true) {
-                    error!("Failed to drain ops on drop: {:?}", err);
+        let flush_mode = match self.config.cache_type {
+            CacheType::Unsafe => FlushMode::Drain,
+            CacheType::Writeback => FlushMode::DrainAndFlush,
+        };
+
+        match std::mem::replace(&mut self.state, BlockState::Placeholder) {
+            BlockState::Active(mut worker) => match flush_mode {
+                FlushMode::Drain => worker.drain(true),
+                FlushMode::DrainAndFlush => worker.drain_and_flush(true),
+            },
+            BlockState::Configuring(mut resources) => match flush_mode {
+                FlushMode::Drain => {
+                    if let Err(err) = resources.disk.file_engine.drain(true) {
+                        error!("Failed to drain ops on drop: {:?}", err);
+                    }
                 }
-            }
-            CacheType::Writeback => {
-                self.drain_and_flush(true);
-            }
+                FlushMode::DrainAndFlush => {
+                    if let Err(err) = resources.disk.file_engine.drain_and_flush(true) {
+                        error!("Failed to drain ops and flush block data: {:?}", err);
+                    }
+                }
+            },
+            BlockState::Placeholder => {}
         };
     }
 }
@@ -743,6 +644,7 @@ mod tests {
     use super::*;
     use crate::check_metric_after_block;
     use crate::devices::virtio::block::virtio::IO_URING_NUM_ENTRIES;
+    use crate::devices::virtio::block::virtio::request::*;
     use crate::devices::virtio::block::virtio::test_utils::{
         default_block, read_blk_req_descriptors, set_queue, set_rate_limiter,
         simulate_async_completion_event, simulate_queue_and_async_completion_events,
@@ -1716,7 +1618,6 @@ mod tests {
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
             set_queue(&mut block, 0, vq.create_queue());
-            block.activate(mem.clone(), interrupt).unwrap();
             read_blk_req_descriptors(&vq);
 
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -1730,6 +1631,7 @@ mod tests {
             assert!(rl.consume(512, TokenType::Bytes));
 
             set_rate_limiter(&mut block, rl);
+            block.activate(mem.clone(), interrupt).unwrap();
 
             mem.write_obj::<u32>(VIRTIO_BLK_T_OUT, request_type_addr)
                 .unwrap();
@@ -1786,7 +1688,6 @@ mod tests {
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
             set_queue(&mut block, 0, vq.create_queue());
-            block.activate(mem.clone(), interrupt).unwrap();
             read_blk_req_descriptors(&vq);
 
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -1799,6 +1700,7 @@ mod tests {
             assert!(rl.consume(1, TokenType::Ops));
 
             set_rate_limiter(&mut block, rl);
+            block.activate(mem.clone(), interrupt).unwrap();
 
             mem.write_obj::<u32>(VIRTIO_BLK_T_OUT, request_type_addr)
                 .unwrap();

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -37,8 +37,8 @@ use crate::impl_device_type;
 use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter};
 use crate::utils::u64_to_usize;
-use crate::vmm_config::RateLimiterConfig;
 use crate::vmm_config::drive::BlockDeviceConfig;
+use crate::vmm_config::{RateLimiterConfig, TokenBucketConfig};
 use crate::vstate::memory::GuestMemoryMmap;
 
 /// The engine file type, either Sync or Async (through io_uring).
@@ -169,7 +169,7 @@ pub struct ConfigSpace {
 unsafe impl ByteValued for ConfigSpace {}
 
 /// Use this structure to set up the Block Device before booting the kernel.
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct VirtioBlockConfig {
     /// Unique identifier of the drive.
@@ -248,23 +248,29 @@ pub struct VirtioBlock {
     pub config_space: ConfigSpace,
     pub activate_evt: EventFd,
 
-    // Transport related fields.
-    pub queues: Vec<Queue>,
-    pub queue_evts: [EventFd; 1],
     pub device_state: DeviceState,
 
-    // Implementation specific fields.
-    pub id: String,
-    pub partuuid: Option<String>,
-    pub cache_type: CacheType,
-    pub root_device: bool,
-    pub read_only: bool,
-
-    // Host file and properties.
-    pub disk: DiskProperties,
-    pub rate_limiter: RateLimiter,
-    pub is_io_engine_throttled: bool,
+    pub(crate) config: VirtioBlockConfig,
+    pub(crate) resources: BlockResources,
     pub metrics: Arc<BlockDeviceMetrics>,
+}
+
+/// Runtime resources used by the block data path.
+#[derive(Debug)]
+pub(crate) struct BlockResources {
+    pub(crate) queues: Vec<Queue>,
+    pub(crate) queue_evts: [EventFd; 1],
+    pub(crate) disk: DiskProperties,
+    pub(crate) rate_limiter: RateLimiter,
+    pub(crate) is_io_engine_throttled: bool,
+}
+
+fn apply_bucket_update(config: &mut Option<TokenBucketConfig>, update: &BucketUpdate) {
+    match update {
+        BucketUpdate::None => {}
+        BucketUpdate::Disabled => *config = None,
+        BucketUpdate::Update(bucket) => *config = Some(bucket.into()),
+    }
 }
 
 macro_rules! unwrap_async_file_engine_or_return {
@@ -283,9 +289,9 @@ impl VirtioBlock {
     /// Create a new virtio block device that operates on the given file.
     ///
     /// The given file must be seekable and sizable.
-    pub fn new(config: VirtioBlockConfig) -> Result<VirtioBlock, VirtioBlockError> {
+    pub fn new(mut config: VirtioBlockConfig) -> Result<VirtioBlock, VirtioBlockError> {
         let disk_properties = DiskProperties::new(
-            config.path_on_host,
+            config.path_on_host.clone(),
             config.is_read_only,
             config.file_engine_type,
         )?;
@@ -294,6 +300,8 @@ impl VirtioBlock {
             .rate_limiter
             .map(RateLimiter::from)
             .unwrap_or_default();
+        let rate_limiter_config: RateLimiterConfig = (&rate_limiter).into();
+        config.rate_limiter = rate_limiter_config.into_option();
 
         let mut avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_RING_F_EVENT_IDX);
 
@@ -305,13 +313,10 @@ impl VirtioBlock {
             avail_features |= 1u64 << VIRTIO_BLK_F_RO;
         };
 
-        let queue_evts = [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?];
-
-        let queues = BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect();
-
         let config_space = ConfigSpace {
             capacity: disk_properties.nsectors.to_le(),
         };
+        let metrics = BlockMetricsPerDevice::alloc(config.drive_id.clone());
 
         Ok(VirtioBlock {
             avail_features,
@@ -319,36 +324,38 @@ impl VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            queues,
-            queue_evts,
             device_state: DeviceState::Inactive,
-
-            id: config.drive_id.clone(),
-            partuuid: config.partuuid,
-            cache_type: config.cache_type,
-            root_device: config.is_root_device,
-            read_only: config.is_read_only,
-
-            disk: disk_properties,
-            rate_limiter,
-            is_io_engine_throttled: false,
-            metrics: BlockMetricsPerDevice::alloc(config.drive_id),
+            config,
+            resources: BlockResources {
+                queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
+                queue_evts: [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?],
+                disk: disk_properties,
+                rate_limiter,
+                is_io_engine_throttled: false,
+            },
+            metrics,
         })
     }
 
     /// Returns a copy of a device config
     pub fn config(&self) -> VirtioBlockConfig {
-        let rl: RateLimiterConfig = (&self.rate_limiter).into();
-        VirtioBlockConfig {
-            drive_id: self.id.clone(),
-            path_on_host: self.disk.file_path.clone(),
-            is_root_device: self.root_device,
-            partuuid: self.partuuid.clone(),
-            is_read_only: self.read_only,
-            cache_type: self.cache_type,
-            rate_limiter: rl.into_option(),
-            file_engine_type: self.file_engine_type(),
-        }
+        self.config.clone()
+    }
+
+    pub(crate) fn resources(&self) -> &BlockResources {
+        &self.resources
+    }
+
+    pub(crate) fn resources_mut(&mut self) -> &mut BlockResources {
+        &mut self.resources
+    }
+
+    pub(crate) fn disk(&self) -> &DiskProperties {
+        &self.resources.disk
+    }
+
+    pub(crate) fn rate_limiter(&self) -> &RateLimiter {
+        &self.resources.rate_limiter
     }
 
     /// Process a single event in the Virtio queue.
@@ -357,12 +364,12 @@ impl VirtioBlock {
     /// about new buffers in the queue.
     pub(crate) fn process_queue_event(&mut self) {
         self.metrics.queue_event_count.inc();
-        if let Err(err) = self.queue_evts[0].read() {
+        if let Err(err) = self.resources.queue_evts[0].read() {
             error!("Failed to get queue event: {:?}", err);
             self.metrics.event_fails.inc();
-        } else if self.rate_limiter.is_blocked() {
+        } else if self.resources.rate_limiter.is_blocked() {
             self.metrics.rate_limiter_throttled_events.inc();
-        } else if self.is_io_engine_throttled {
+        } else if self.resources.is_io_engine_throttled {
             self.metrics.io_engine_throttled_events.inc();
         } else {
             self.process_virtio_queues().unwrap()
@@ -378,7 +385,7 @@ impl VirtioBlock {
         self.metrics.rate_limiter_event_count.inc();
         // Upon rate limiter event, call the rate limiter handler
         // and restart processing the queue.
-        if self.rate_limiter.event_handler().is_ok() {
+        if self.resources.rate_limiter.event_handler().is_ok() {
             self.process_queue(0).unwrap()
         }
     }
@@ -388,15 +395,15 @@ impl VirtioBlock {
         // This is safe since we checked in the event handler that the device is activated.
         let active_state = self.device_state.active_state().unwrap();
 
-        let queue = &mut self.queues[queue_index];
+        let queue = &mut self.resources.queues[queue_index];
         let mut used_any = false;
 
         while let Some(head) = queue.pop_or_enable_notification()? {
             self.metrics.remaining_reqs_count.add(queue.len().into());
             let processing_result =
-                match Request::parse(&head, &active_state.mem, self.disk.nsectors) {
+                match Request::parse(&head, &active_state.mem, self.resources.disk.nsectors) {
                     Ok(request) => {
-                        if request.rate_limit(&mut self.rate_limiter) {
+                        if request.rate_limit(&mut self.resources.rate_limiter) {
                             // Stop processing the queue and return this descriptor chain to the
                             // avail ring, for later processing.
                             queue.undo_pop();
@@ -405,7 +412,7 @@ impl VirtioBlock {
                         }
 
                         request.process(
-                            &mut self.disk,
+                            &mut self.resources.disk,
                             head.index,
                             &active_state.mem,
                             &self.metrics,
@@ -425,7 +432,7 @@ impl VirtioBlock {
                 ProcessingResult::Submitted => {}
                 ProcessingResult::Throttled => {
                     queue.undo_pop();
-                    self.is_io_engine_throttled = true;
+                    self.resources.is_io_engine_throttled = true;
                     break;
                 }
                 ProcessingResult::Executed(finished) => {
@@ -452,7 +459,7 @@ impl VirtioBlock {
                 });
         }
 
-        if let FileEngine::Async(ref mut engine) = self.disk.file_engine
+        if let FileEngine::Async(ref mut engine) = self.resources.disk.file_engine
             && let Err(err) = engine.kick_submission_queue()
         {
             error!("BlockError submitting pending block requests: {:?}", err);
@@ -466,11 +473,11 @@ impl VirtioBlock {
     }
 
     fn process_async_completion_queue(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.disk.file_engine);
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
 
         // This is safe since we checked in the event handler that the device is activated.
         let active_state = self.device_state.active_state().unwrap();
-        let queue = &mut self.queues[0];
+        let queue = &mut self.resources.queues[0];
 
         loop {
             match engine.pop(&active_state.mem) {
@@ -517,15 +524,15 @@ impl VirtioBlock {
     }
 
     pub fn process_async_completion_event(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.disk.file_engine);
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
 
         if let Err(err) = engine.completion_evt().read() {
             error!("Failed to get async completion event: {:?}", err);
         } else {
             self.process_async_completion_queue();
 
-            if self.is_io_engine_throttled {
-                self.is_io_engine_throttled = false;
+            if self.resources.is_io_engine_throttled {
+                self.resources.is_io_engine_throttled = false;
                 self.process_queue(0).unwrap()
             }
         }
@@ -533,8 +540,11 @@ impl VirtioBlock {
 
     /// Update the backing file and the config space of the block device.
     pub fn update_disk_image(&mut self, disk_image_path: String) -> Result<(), VirtioBlockError> {
-        self.disk.update(disk_image_path, self.read_only)?;
-        self.config_space.capacity = self.disk.nsectors.to_le(); // virtio_block_config_space();
+        self.resources
+            .disk
+            .update(disk_image_path.clone(), self.config.is_read_only)?;
+        self.config_space.capacity = self.resources.disk.nsectors.to_le();
+        self.config.path_on_host = disk_image_path;
 
         // Kick the driver to pick up the changes. (But only if the device is already activated).
         if self.is_activated() {
@@ -549,19 +559,21 @@ impl VirtioBlock {
 
     /// Updates the parameters for the rate limiter
     pub fn update_rate_limiter(&mut self, bytes: BucketUpdate, ops: BucketUpdate) {
-        self.rate_limiter.update_buckets(bytes, ops);
+        let mut rate_limiter = self.config.rate_limiter.unwrap_or_default();
+        apply_bucket_update(&mut rate_limiter.bandwidth, &bytes);
+        apply_bucket_update(&mut rate_limiter.ops, &ops);
+
+        self.resources.rate_limiter.update_buckets(bytes, ops);
+        self.config.rate_limiter = rate_limiter.into_option();
     }
 
     /// Retrieve the file engine type.
     pub fn file_engine_type(&self) -> FileEngineType {
-        match self.disk.file_engine {
-            FileEngine::Sync(_) => FileEngineType::Sync,
-            FileEngine::Async(_) => FileEngineType::Async,
-        }
+        self.config.file_engine_type
     }
 
     fn drain_and_flush(&mut self, discard: bool) {
-        if let Err(err) = self.disk.file_engine.drain_and_flush(discard) {
+        if let Err(err) = self.resources.disk.file_engine.drain_and_flush(discard) {
             error!("Failed to drain ops and flush block data: {:?}", err);
         }
     }
@@ -573,7 +585,7 @@ impl VirtioBlock {
         }
 
         self.drain_and_flush(false);
-        if let FileEngine::Async(ref _engine) = self.disk.file_engine {
+        if let FileEngine::Async(ref _engine) = self.resources.disk.file_engine {
             self.process_async_completion_queue();
         }
     }
@@ -583,7 +595,7 @@ impl VirtioDevice for VirtioBlock {
     impl_device_type!(VirtioDeviceType::Block);
 
     fn id(&self) -> &str {
-        &self.id
+        &self.config.drive_id
     }
 
     fn avail_features(&self) -> u64 {
@@ -599,19 +611,22 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn num_queues(&self) -> usize {
-        self.queues.len()
+        self.resources.queues.len()
     }
 
     fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
-        self.queues.get(index).map(|queue| &queue.config)
+        self.resources.queues.get(index).map(|queue| &queue.config)
     }
 
     fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
-        self.queues.get_mut(index).map(|queue| &mut queue.config)
+        self.resources
+            .queues
+            .get_mut(index)
+            .map(|queue| &mut queue.config)
     }
 
     fn queue_event(&self, index: usize) -> Option<&EventFd> {
-        self.queue_evts.get(index)
+        self.resources.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -642,14 +657,14 @@ impl VirtioDevice for VirtioBlock {
     ) -> Result<(), ActivateError> {
         assert!(!self.is_activated());
 
-        for q in self.queues.iter_mut() {
+        for q in self.resources.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;
         }
 
         let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
         if event_idx {
-            for queue in &mut self.queues {
+            for queue in &mut self.resources.queues {
                 queue.enable_notif_suppression();
             }
         }
@@ -671,20 +686,20 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn _reset(&mut self) -> bool {
-        if let Err(err) = self.disk.file_engine.drain(true) {
+        if let Err(err) = self.resources.disk.file_engine.drain(true) {
             error!("Failed to reset block IO engine: {:?}", err);
             return false;
         }
-        self.is_io_engine_throttled = false;
+        self.resources.is_io_engine_throttled = false;
         true
     }
 
     fn reset_queues(&mut self) {
-        self.queues.iter_mut().for_each(Queue::reset);
+        self.resources.queues.iter_mut().for_each(Queue::reset);
     }
 
     fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
-        for queue in &mut self.queues {
+        for queue in &mut self.resources.queues {
             queue.initialize(mem)?;
         }
         Ok(())
@@ -693,9 +708,9 @@ impl VirtioDevice for VirtioBlock {
 
 impl Drop for VirtioBlock {
     fn drop(&mut self) {
-        match self.cache_type {
+        match self.config.cache_type {
             CacheType::Unsafe => {
-                if let Err(err) = self.disk.file_engine.drain(true) {
+                if let Err(err) = self.resources.disk.file_engine.drain(true) {
                     error!("Failed to drain ops on drop: {:?}", err);
                 }
             }
@@ -839,6 +854,16 @@ mod tests {
             let expected_config_space = ConfigSpace { capacity: 8 };
             assert_eq!(config, expected_config_space.as_slice());
         }
+    }
+
+    #[test]
+    fn test_config_tracks_rate_limiter_updates() {
+        let mut block = default_block(FileEngineType::Sync);
+        assert!(block.config().rate_limiter.is_some());
+
+        block.update_rate_limiter(BucketUpdate::Disabled, BucketUpdate::Disabled);
+
+        assert_eq!(block.config().rate_limiter, None);
     }
 
     #[test]
@@ -1117,12 +1142,17 @@ mod tests {
                 // Check that the data wasn't written to the file
                 let mut buf = [0u8; 512];
                 block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .seek(SeekFrom::Start(0))
                     .unwrap();
-                block.disk.file_engine.file().read_exact(&mut buf).unwrap();
+                block
+                    .disk()
+                    .file_engine
+                    .file()
+                    .read_exact(&mut buf)
+                    .unwrap();
                 assert_eq!(buf, empty_data.as_slice());
             }
 
@@ -1257,12 +1287,12 @@ mod tests {
                 mem.write_slice(empty_data.as_slice(), data_addr).unwrap();
 
                 let size = block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .seek(SeekFrom::End(0))
                     .unwrap();
-                block.disk.file_engine.file().set_len(size / 2).unwrap();
+                block.disk().file_engine.file().set_len(size / 2).unwrap();
                 mem.write_obj(10, GuestAddress(request_type_addr.0 + 8))
                     .unwrap();
 
@@ -1291,12 +1321,12 @@ mod tests {
                     .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
 
                 let size = block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .seek(SeekFrom::End(0))
                     .unwrap();
-                block.disk.file_engine.file().set_len(size / 2).unwrap();
+                block.disk().file_engine.file().set_len(size / 2).unwrap();
                 // Update sector number: stored at `request_type_addr.0 + 8`
                 mem.write_obj(5, GuestAddress(request_type_addr.0 + 8))
                     .unwrap();
@@ -1340,13 +1370,13 @@ mod tests {
                     .unwrap();
 
                 block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .seek(SeekFrom::Start(512))
                     .unwrap();
                 block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .write_all(&rand_data[512..])
@@ -1472,7 +1502,7 @@ mod tests {
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
             let data_addr = GuestAddress(vq.dtable[1].addr.get());
             let status_addr = GuestAddress(vq.dtable[2].addr.get());
-            let blk_metadata = block.disk.file_engine.file().metadata();
+            let blk_metadata = block.disk().file_engine.file().metadata();
 
             // Test that the driver receives the correct device id.
             {
@@ -1590,31 +1620,31 @@ mod tests {
             let mem = default_mem();
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, IO_URING_NUM_ENTRIES * 4);
-            block.queues[0] = vq.create_queue();
+            block.resources_mut().queues[0] = vq.create_queue();
             block.activate(mem.clone(), interrupt).unwrap();
 
             // Run scenario that doesn't trigger FullSq BlockError: Add sq_size flush requests.
             add_flush_requests_batch(&mut block, &vq, IO_URING_NUM_ENTRIES);
             simulate_queue_event(&mut block, Some(false));
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             simulate_async_completion_event(&mut block, true);
             check_flush_requests_batch(IO_URING_NUM_ENTRIES, &vq);
 
             // Run scenario that triggers FullSqError : Add sq_size + 10 flush requests.
             add_flush_requests_batch(&mut block, &vq, IO_URING_NUM_ENTRIES + 10);
             simulate_queue_event(&mut block, Some(false));
-            assert!(block.is_io_engine_throttled);
+            assert!(block.resources().is_io_engine_throttled);
             // When the async_completion_event is triggered:
             // 1. sq_size requests should be processed processed.
             // 2. is_io_engine_throttled should be set back to false.
             // 3. process_queue() should be called again.
             simulate_async_completion_event(&mut block, true);
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             check_flush_requests_batch(IO_URING_NUM_ENTRIES, &vq);
             // check that process_queue() was called again resulting in the processing of the
             // remaining 10 ops.
             simulate_async_completion_event(&mut block, true);
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             check_flush_requests_batch(IO_URING_NUM_ENTRIES + 10, &vq);
         }
 
@@ -1625,25 +1655,25 @@ mod tests {
             let mem = default_mem();
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, IO_URING_NUM_ENTRIES * 4);
-            block.queues[0] = vq.create_queue();
+            block.resources_mut().queues[0] = vq.create_queue();
             block.activate(mem.clone(), interrupt).unwrap();
 
             // Run scenario that triggers FullCqError. Push 2 * IO_URING_NUM_ENTRIES and wait for
             // completion. Then try to push another entry.
             add_flush_requests_batch(&mut block, &vq, IO_URING_NUM_ENTRIES);
             simulate_queue_event(&mut block, Some(false));
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             thread::sleep(Duration::from_millis(150));
             add_flush_requests_batch(&mut block, &vq, IO_URING_NUM_ENTRIES);
             simulate_queue_event(&mut block, Some(false));
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             thread::sleep(Duration::from_millis(150));
 
             add_flush_requests_batch(&mut block, &vq, 1);
             simulate_queue_event(&mut block, Some(false));
-            assert!(block.is_io_engine_throttled);
+            assert!(block.resources().is_io_engine_throttled);
             simulate_async_completion_event(&mut block, true);
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             check_flush_requests_batch(IO_URING_NUM_ENTRIES * 2, &vq);
         }
     }
@@ -1656,7 +1686,7 @@ mod tests {
             let mem = default_mem();
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
-            block.queues[0] = vq.create_queue();
+            block.resources_mut().queues[0] = vq.create_queue();
             block.activate(mem.clone(), interrupt).unwrap();
 
             // Add a batch of flush requests.
@@ -1709,7 +1739,7 @@ mod tests {
                 );
 
                 // Assert that limiter is blocked.
-                assert!(block.rate_limiter.is_blocked());
+                assert!(block.rate_limiter().is_blocked());
                 // Make sure the data is still queued for processing.
                 assert_eq!(vq.used.idx.get(), 0);
             }
@@ -1726,7 +1756,7 @@ mod tests {
                     block.process_rate_limiter_event()
                 );
                 // Validate the rate_limiter is no longer blocked.
-                assert!(!block.rate_limiter.is_blocked());
+                assert!(!block.rate_limiter().is_blocked());
                 // Complete async IO ops if needed
                 simulate_async_completion_event(&mut block, true);
 
@@ -1778,7 +1808,7 @@ mod tests {
                 );
 
                 // Assert that limiter is blocked.
-                assert!(block.rate_limiter.is_blocked());
+                assert!(block.rate_limiter().is_blocked());
                 // Make sure the data is still queued for processing.
                 assert_eq!(vq.used.idx.get(), 0);
             }
@@ -1793,7 +1823,7 @@ mod tests {
                 );
 
                 // Assert that limiter is blocked.
-                assert!(block.rate_limiter.is_blocked());
+                assert!(block.rate_limiter().is_blocked());
                 // Make sure the data is still queued for processing.
                 assert_eq!(vq.used.idx.get(), 0);
             }
@@ -1810,7 +1840,7 @@ mod tests {
                     block.process_rate_limiter_event()
                 );
                 // Validate the rate_limiter is no longer blocked.
-                assert!(!block.rate_limiter.is_blocked());
+                assert!(!block.rate_limiter().is_blocked());
                 // Complete async IO ops if needed
                 simulate_async_completion_event(&mut block, true);
 
@@ -1846,11 +1876,12 @@ mod tests {
                 .update_disk_image(String::from(path.to_str().unwrap()))
                 .unwrap();
 
+            assert_eq!(block.config().path_on_host, path.to_str().unwrap());
             assert_eq!(
-                block.disk.file_engine.file().metadata().unwrap().st_ino(),
+                block.disk().file_engine.file().metadata().unwrap().st_ino(),
                 mdata.st_ino()
             );
-            assert_eq!(block.disk.image_id, id.as_slice());
+            assert_eq!(block.disk().image_id, id.as_slice());
         }
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -19,7 +19,7 @@ use vm_memory::ByteValued;
 use vmm_sys_util::eventfd::EventFd;
 
 use super::io::FileEngine;
-use super::worker::{BlockWorker, FlushMode};
+use super::worker::{BlockWorker, FlushMode, WorkerHandle};
 use super::{BLOCK_QUEUE_SIZES, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::block::CacheType;
@@ -256,11 +256,30 @@ pub struct VirtioBlock {
 #[derive(Debug)]
 pub(crate) enum BlockState {
     // Vmm owns the runtime resources before activation
-    Configuring(BlockResources),
+    // In threaded mode, it also owns a parked worker thread
+    Configuring(BlockResources, Option<WorkerHandle>),
     // Active state, worker owns data-path resources
-    Active(BlockWorker),
+    Active(ActiveBlock),
     // Placeholder to hold state when activating
     Placeholder,
+}
+
+/// Active block data path.
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum ActiveBlock {
+    // Data path on VMM thread (single thread)
+    Inline(BlockWorker),
+    // Data path on a dedicated worker thread (multi thread)
+    Threaded(ThreadedActive),
+}
+
+/// VMM-side state when data path runs on a worker thread
+#[derive(Debug)]
+pub(crate) struct ThreadedActive {
+    worker_handle: WorkerHandle,
+    interrupt: Arc<dyn VirtioInterrupt>,
+    queue_config: Vec<QueueConfig>,
 }
 
 /// Runtime resources used by the block data path.
@@ -321,12 +340,17 @@ impl VirtioBlock {
 
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            state: BlockState::Configuring(BlockResources {
-                queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
-                queue_evts: [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?],
-                disk: disk_properties,
-                is_io_engine_throttled: false,
-            }),
+            state: BlockState::Configuring(
+                BlockResources {
+                    queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
+                    queue_evts: [
+                        EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?
+                    ],
+                    disk: disk_properties,
+                    is_io_engine_throttled: false,
+                },
+                None,
+            ),
             metrics,
         })
     }
@@ -338,16 +362,22 @@ impl VirtioBlock {
 
     pub(crate) fn resources(&self) -> &BlockResources {
         match &self.state {
-            BlockState::Configuring(resources) => resources,
-            BlockState::Active(worker) => &worker.resources,
+            BlockState::Configuring(resources, _) => resources,
+            BlockState::Active(ActiveBlock::Inline(worker)) => &worker.resources,
+            BlockState::Active(ActiveBlock::Threaded(_)) => {
+                unreachable!("worker thread owns the runtime resources")
+            }
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
 
     pub(crate) fn resources_mut(&mut self) -> &mut BlockResources {
         match &mut self.state {
-            BlockState::Configuring(resources) => resources,
-            BlockState::Active(worker) => &mut worker.resources,
+            BlockState::Configuring(resources, _) => resources,
+            BlockState::Active(ActiveBlock::Inline(worker)) => &mut worker.resources,
+            BlockState::Active(ActiveBlock::Threaded(_)) => {
+                unreachable!("worker thread owns the runtime resources")
+            }
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
@@ -362,12 +392,8 @@ impl VirtioBlock {
             .expect("Poisoned block rate limiter lock")
     }
 
-    fn worker_mut(&mut self) -> &mut BlockWorker {
-        match &mut self.state {
-            BlockState::Active(worker) => worker,
-            BlockState::Configuring(_) => panic!("Device is not activated"),
-            BlockState::Placeholder => unreachable!("not a runtime state"),
-        }
+    pub(crate) fn is_threaded_active(&self) -> bool {
+        matches!(self.state, BlockState::Active(ActiveBlock::Threaded(_)))
     }
 
     /// Process a single event in the Virtio queue.
@@ -375,12 +401,18 @@ impl VirtioBlock {
     /// This function is called by the event manager when the guest notifies us
     /// about new buffers in the queue.
     pub(crate) fn process_queue_event(&mut self) {
-        self.worker_mut().process_queue_event();
+        if let BlockState::Active(ActiveBlock::Inline(worker)) = &mut self.state {
+            worker.process_queue_event();
+        }
     }
 
     /// Process device virtio queue(s).
     pub fn process_virtio_queues(&mut self) -> Result<(), InvalidAvailIdx> {
-        self.worker_mut().process_virtio_queues()
+        if let BlockState::Active(ActiveBlock::Inline(worker)) = &mut self.state {
+            worker.process_virtio_queues()
+        } else {
+            Ok(())
+        }
     }
 
     pub(crate) fn process_rate_limiter_event(&mut self) {
@@ -392,16 +424,21 @@ impl VirtioBlock {
         // Upon rate limiter event, call the rate limiter handler
         // and restart processing the queue.
         match &mut self.state {
-            BlockState::Active(worker) => {
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
                 worker.process_virtio_queues().unwrap();
             }
-            BlockState::Configuring(_) => {}
+            BlockState::Active(ActiveBlock::Threaded(_)) => {
+                unreachable!("worker control messages are not connected yet")
+            }
+            BlockState::Configuring(_, _) => {}
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
 
     pub fn process_async_completion_event(&mut self) {
-        self.worker_mut().process_async_completion_event();
+        if let BlockState::Active(ActiveBlock::Inline(worker)) = &mut self.state {
+            worker.process_async_completion_event();
+        }
     }
 
     /// Update the backing file and the config space of the block device.
@@ -409,11 +446,16 @@ impl VirtioBlock {
         let config_path = disk_image_path.clone();
         let read_only = self.config.is_read_only;
         let nsectors = match &mut self.state {
-            BlockState::Configuring(resources) => {
+            BlockState::Configuring(resources, _) => {
                 resources.disk.update(disk_image_path, read_only)?;
                 resources.disk.nsectors
             }
-            BlockState::Active(worker) => worker.update_disk_image(disk_image_path, read_only)?,
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                worker.update_disk_image(disk_image_path, read_only)?
+            }
+            BlockState::Active(ActiveBlock::Threaded(_)) => {
+                unreachable!("worker control messages are not connected yet")
+            }
             BlockState::Placeholder => unreachable!("not a runtime state"),
         };
         self.config_space.capacity = nsectors.to_le();
@@ -447,9 +489,29 @@ impl VirtioBlock {
 
     /// Prepare device for being snapshotted.
     pub fn prepare_save(&mut self) {
-        if let BlockState::Active(worker) = &mut self.state {
+        if let BlockState::Active(ActiveBlock::Inline(worker)) = &mut self.state {
             worker.prepare_save();
         }
+    }
+
+    /// Spawn a parked worker thread for the next activation.
+    // Currently unused because threaded mode is not exposed through device configuration yet.
+    #[allow(dead_code)]
+    pub(crate) fn spawn_worker(&mut self) -> Result<(), VirtioBlockError> {
+        if let BlockState::Configuring(resources, worker_handle @ None) = &mut self.state {
+            let queue_evts = resources
+                .queue_evts
+                .iter()
+                .map(EventFd::try_clone)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(VirtioBlockError::EventFd)?;
+
+            let name = format!("fc_{}", self.config.drive_id);
+
+            *worker_handle =
+                Some(WorkerHandle::spawn(queue_evts, name).map_err(VirtioBlockError::ThreadSpawn)?);
+        }
+        Ok(())
     }
 }
 
@@ -473,31 +535,65 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn num_queues(&self) -> usize {
-        self.resources().queues.len()
+        match &self.state {
+            BlockState::Configuring(resources, _) => resources.queues.len(),
+            BlockState::Active(ActiveBlock::Inline(worker)) => worker.resources.queues.len(),
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.queue_config.len(),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
-        self.resources()
-            .queues
-            .get(index)
-            .map(|queue| &queue.config)
+        match &self.state {
+            BlockState::Configuring(resources, _) => {
+                resources.queues.get(index).map(|queue| &queue.config)
+            }
+            BlockState::Active(ActiveBlock::Inline(worker)) => worker
+                .resources
+                .queues
+                .get(index)
+                .map(|queue| &queue.config),
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.queue_config.get(index),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
-        self.resources_mut()
-            .queues
-            .get_mut(index)
-            .map(|queue| &mut queue.config)
+        match &mut self.state {
+            BlockState::Configuring(resources, _) => resources
+                .queues
+                .get_mut(index)
+                .map(|queue| &mut queue.config),
+            BlockState::Active(ActiveBlock::Inline(worker)) => worker
+                .resources
+                .queues
+                .get_mut(index)
+                .map(|queue| &mut queue.config),
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.queue_config.get_mut(index),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn queue_event(&self, index: usize) -> Option<&EventFd> {
-        self.resources().queue_evts.get(index)
+        match &self.state {
+            BlockState::Configuring(resources, _) => resources.queue_evts.get(index),
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                worker.resources.queue_evts.get(index)
+            }
+            BlockState::Active(ActiveBlock::Threaded(active)) => {
+                active.worker_handle.queue_events().get(index)
+            }
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
         match &self.state {
-            BlockState::Active(worker) => worker.active_state.interrupt.deref(),
-            BlockState::Configuring(_) => panic!("Device is not initialized"),
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                worker.active_state.interrupt.deref()
+            }
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.interrupt.deref(),
+            BlockState::Configuring(_, _) => panic!("Device is not initialized"),
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
@@ -524,7 +620,7 @@ impl VirtioDevice for VirtioBlock {
 
         let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
 
-        let BlockState::Configuring(resources) = &mut self.state else {
+        let BlockState::Configuring(resources, _) = &mut self.state else {
             unreachable!("inactive device is not configurable");
         };
 
@@ -544,19 +640,40 @@ impl VirtioDevice for VirtioBlock {
             return Err(ActivateError::EventFd);
         }
 
-        let BlockState::Configuring(resources) =
+        let BlockState::Configuring(resources, worker_handle) =
             std::mem::replace(&mut self.state, BlockState::Placeholder)
         else {
             unreachable!("state checked before activation");
         };
+
+        let queue_config = resources
+            .queues
+            .iter()
+            .map(|queue| queue.config.clone())
+            .collect();
+
         let is_blocked = self.rate_limiter().clone_blocked_flag();
-        self.state = BlockState::Active(BlockWorker {
+        let worker = BlockWorker {
             resources,
             rate_limiter: self.rate_limiter.clone(),
             is_blocked,
-            active_state: ActiveState { mem, interrupt },
+            active_state: ActiveState {
+                mem,
+                interrupt: interrupt.clone(),
+            },
             metrics: self.metrics.clone(),
-        });
+        };
+
+        self.state = if let Some(worker_handle) = worker_handle {
+            worker_handle.start(worker);
+            BlockState::Active(ActiveBlock::Threaded(ThreadedActive {
+                worker_handle,
+                interrupt,
+                queue_config,
+            }))
+        } else {
+            BlockState::Active(ActiveBlock::Inline(worker))
+        };
         Ok(())
     }
 
@@ -567,15 +684,18 @@ impl VirtioDevice for VirtioBlock {
     fn deactivate(&mut self) {
         let state = std::mem::replace(&mut self.state, BlockState::Placeholder);
         self.state = match state {
-            BlockState::Active(worker) => BlockState::Configuring(worker.resources),
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                BlockState::Configuring(worker.resources, None)
+            }
             state => state,
         };
     }
 
     fn _reset(&mut self) -> bool {
         match &mut self.state {
-            BlockState::Active(worker) => worker.reset(),
-            BlockState::Configuring(resources) => {
+            BlockState::Active(ActiveBlock::Inline(worker)) => worker.reset(),
+            BlockState::Active(ActiveBlock::Threaded(_)) => false,
+            BlockState::Configuring(resources, _) => {
                 if let Err(err) = resources.disk.file_engine.drain(true) {
                     error!("Failed to reset block IO engine: {:?}", err);
                     return false;
@@ -588,15 +708,32 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn reset_queues(&mut self) {
-        self.resources_mut()
-            .queues
-            .iter_mut()
-            .for_each(Queue::reset);
+        match &mut self.state {
+            BlockState::Configuring(resources, _) => {
+                resources.queues.iter_mut().for_each(Queue::reset);
+            }
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                worker.resources.queues.iter_mut().for_each(Queue::reset);
+            }
+            BlockState::Active(ActiveBlock::Threaded(_)) => {}
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
-        for queue in &mut self.resources_mut().queues {
-            queue.initialize(mem)?;
+        match &mut self.state {
+            BlockState::Configuring(resources, _) => {
+                for queue in &mut resources.queues {
+                    queue.initialize(mem)?;
+                }
+            }
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                for queue in &mut worker.resources.queues {
+                    queue.initialize(mem)?;
+                }
+            }
+            BlockState::Active(ActiveBlock::Threaded(_)) => {}
+            BlockState::Placeholder => unreachable!("not a runtime state"),
         }
         Ok(())
     }
@@ -610,22 +747,30 @@ impl Drop for VirtioBlock {
         };
 
         match std::mem::replace(&mut self.state, BlockState::Placeholder) {
-            BlockState::Active(mut worker) => match flush_mode {
+            BlockState::Active(ActiveBlock::Inline(mut worker)) => match flush_mode {
                 FlushMode::Drain => worker.drain(true),
                 FlushMode::DrainAndFlush => worker.drain_and_flush(true),
             },
-            BlockState::Configuring(mut resources) => match flush_mode {
-                FlushMode::Drain => {
-                    if let Err(err) = resources.disk.file_engine.drain(true) {
-                        error!("Failed to drain ops on drop: {:?}", err);
+            // Worker teardown is connected in the follow-up lifecycle commit.
+            BlockState::Active(ActiveBlock::Threaded(_)) => {}
+            BlockState::Configuring(mut resources, worker_handle) => {
+                match flush_mode {
+                    FlushMode::Drain => {
+                        if let Err(err) = resources.disk.file_engine.drain(true) {
+                            error!("Failed to drain ops on drop: {:?}", err);
+                        }
+                    }
+                    FlushMode::DrainAndFlush => {
+                        if let Err(err) = resources.disk.file_engine.drain_and_flush(true) {
+                            error!("Failed to drain ops and flush block data: {:?}", err);
+                        }
                     }
                 }
-                FlushMode::DrainAndFlush => {
-                    if let Err(err) = resources.disk.file_engine.drain_and_flush(true) {
-                        error!("Failed to drain ops and flush block data: {:?}", err);
-                    }
+                if let Some(worker_handle) = worker_handle {
+                    // a parked worker owns no runtime resources, it just joins the thread
+                    worker_handle.finish(FlushMode::Drain);
                 }
-            },
+            }
             BlockState::Placeholder => {}
         };
     }

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -166,7 +166,13 @@ mod tests {
             mem.write_obj::<u64>(123_456_789, data_addr).unwrap();
 
             // Trigger the queue event.
-            block.lock().unwrap().queue_evts[0].write(1).unwrap();
+            block
+                .lock()
+                .unwrap()
+                .queue_event(0)
+                .unwrap()
+                .write(1)
+                .unwrap();
         }
 
         // EventManager should report no events since block has only registered

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -57,8 +57,12 @@ impl VirtioBlock {
         if let Err(err) = self.activate_evt.read() {
             error!("Failed to consume block activate event: {:?}", err);
         }
+
         self.register_rate_limiter_event(ops);
-        self.register_runtime_events(ops);
+        if !self.is_threaded_active() {
+            self.register_runtime_events(ops);
+        }
+
         if let Err(err) = ops.remove(Events::with_data(
             &self.activate_evt,
             Self::PROCESS_ACTIVATE,
@@ -121,7 +125,9 @@ impl MutEventSubscriber for VirtioBlock {
         //  - on device restore from snapshot.
         if self.is_activated() {
             self.register_rate_limiter_event(ops);
-            self.register_runtime_events(ops);
+            if !self.is_threaded_active() {
+                self.register_runtime_events(ops);
+            }
         } else {
             self.register_activate_event(ops);
         }

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -22,13 +22,6 @@ impl VirtioBlock {
         )) {
             error!("Failed to register queue event: {}", err);
         }
-        if let Err(err) = ops.add(Events::with_data(
-            &self.resources().rate_limiter,
-            Self::PROCESS_RATE_LIMITER,
-            EventSet::IN,
-        )) {
-            error!("Failed to register ratelimiter event: {}", err);
-        }
         if let FileEngine::Async(ref engine) = self.resources().disk.file_engine
             && let Err(err) = ops.add(Events::with_data(
                 engine.completion_evt(),
@@ -37,6 +30,16 @@ impl VirtioBlock {
             ))
         {
             error!("Failed to register IO engine completion event: {}", err);
+        }
+    }
+
+    fn register_rate_limiter_event(&self, ops: &mut EventOps) {
+        if let Err(err) = ops.add(Events::with_data(
+            &*self.rate_limiter(),
+            Self::PROCESS_RATE_LIMITER,
+            EventSet::IN,
+        )) {
+            error!("Failed to register rate limiter event: {}", err);
         }
     }
 
@@ -54,6 +57,7 @@ impl VirtioBlock {
         if let Err(err) = self.activate_evt.read() {
             error!("Failed to consume block activate event: {:?}", err);
         }
+        self.register_rate_limiter_event(ops);
         self.register_runtime_events(ops);
         if let Err(err) = ops.remove(Events::with_data(
             &self.activate_evt,
@@ -98,7 +102,7 @@ impl MutEventSubscriber for VirtioBlock {
             match source {
                 Self::PROCESS_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
-                    self.resources_mut().rate_limiter.event_handler();
+                    self.rate_limiter().event_handler();
                 }
                 Self::PROCESS_ASYNC_COMPLETION => {
                     if let FileEngine::Async(ref engine) = self.resources().disk.file_engine {
@@ -116,6 +120,7 @@ impl MutEventSubscriber for VirtioBlock {
         //  - on device activation (is-activated already true at this point),
         //  - on device restore from snapshot.
         if self.is_activated() {
+            self.register_rate_limiter_event(ops);
             self.register_runtime_events(ops);
         } else {
             self.register_activate_event(ops);

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -16,20 +16,20 @@ impl VirtioBlock {
 
     fn register_runtime_events(&self, ops: &mut EventOps) {
         if let Err(err) = ops.add(Events::with_data(
-            &self.queue_evts[0],
+            &self.resources().queue_evts[0],
             Self::PROCESS_QUEUE,
             EventSet::IN,
         )) {
             error!("Failed to register queue event: {}", err);
         }
         if let Err(err) = ops.add(Events::with_data(
-            &self.rate_limiter,
+            &self.resources().rate_limiter,
             Self::PROCESS_RATE_LIMITER,
             EventSet::IN,
         )) {
             error!("Failed to register ratelimiter event: {}", err);
         }
-        if let FileEngine::Async(ref engine) = self.disk.file_engine
+        if let FileEngine::Async(ref engine) = self.resources().disk.file_engine
             && let Err(err) = ops.add(Events::with_data(
                 engine.completion_evt(),
                 Self::PROCESS_ASYNC_COMPLETION,
@@ -98,10 +98,10 @@ impl MutEventSubscriber for VirtioBlock {
             match source {
                 Self::PROCESS_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
-                    self.rate_limiter.event_handler();
+                    self.resources_mut().rate_limiter.event_handler();
                 }
                 Self::PROCESS_ASYNC_COMPLETION => {
-                    if let FileEngine::Async(ref engine) = self.disk.file_engine {
+                    if let FileEngine::Async(ref engine) = self.resources().disk.file_engine {
                         engine.completion_evt().read();
                     }
                 }

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -10,6 +10,7 @@ pub mod metrics;
 pub mod persist;
 pub mod request;
 pub mod test_utils;
+mod worker;
 
 use vm_memory::GuestMemoryError;
 

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -64,4 +64,6 @@ pub enum VirtioBlockError {
     RateLimiter(std::io::Error),
     /// Persistence error: {0}
     Persist(crate::devices::virtio::persist::PersistError),
+    /// Error spawning the block worker thread: {0}
+    ThreadSpawn(std::io::Error),
 }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -75,7 +75,7 @@ impl Persist<'_> for VirtioBlock {
             cache_type: self.cache_type,
             root_device: self.root_device,
             disk_path: self.disk.file_path.clone(),
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
             rate_limiter_state: self.rate_limiter.save(),
             file_engine_type: FileEngineTypeState::from(self.file_engine_type()),
         }
@@ -221,7 +221,7 @@ mod tests {
         assert_eq!(restored_block.device_type(), VirtioDeviceType::Block);
         assert_eq!(restored_block.avail_features(), block.avail_features());
         assert_eq!(restored_block.acked_features(), block.acked_features());
-        assert_eq!(restored_block.queues(), block.queues());
+        assert_eq!(restored_block.queues, block.queues);
         assert!(!block.is_activated());
         assert!(!restored_block.is_activated());
 

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -5,6 +5,7 @@
 
 use device::ConfigSpace;
 use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
 use vmm_sys_util::eventfd::EventFd;
 
 use super::device::{BlockResources, DiskProperties};
@@ -129,7 +130,6 @@ impl Persist<'_> for VirtioBlock {
             queues,
             queue_evts,
             disk: disk_properties,
-            rate_limiter,
             is_io_engine_throttled: false,
         };
 
@@ -141,6 +141,7 @@ impl Persist<'_> for VirtioBlock {
 
             device_state: DeviceState::Inactive,
             config,
+            rate_limiter: Arc::new(Mutex::new(rate_limiter)),
             resources,
             metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
         })

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -7,17 +7,18 @@ use device::ConfigSpace;
 use serde::{Deserialize, Serialize};
 use vmm_sys_util::eventfd::EventFd;
 
-use super::device::DiskProperties;
+use super::device::{BlockResources, DiskProperties};
 use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
-use crate::devices::virtio::block::virtio::device::FileEngineType;
+use crate::devices::virtio::block::virtio::device::{FileEngineType, VirtioBlockConfig};
 use crate::devices::virtio::block::virtio::metrics::BlockMetricsPerDevice;
-use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDeviceType};
+use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::VIRTIO_BLK_F_RO;
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::rate_limiter::RateLimiter;
 use crate::rate_limiter::persist::RateLimiterState;
 use crate::snapshot::Persist;
+use crate::vmm_config::RateLimiterConfig;
 
 /// Holds info about block's file engine type. Gets saved in snapshot.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -70,13 +71,13 @@ impl Persist<'_> for VirtioBlock {
     fn save(&self) -> Self::State {
         // Save device state.
         VirtioBlockState {
-            id: self.id.clone(),
-            partuuid: self.partuuid.clone(),
-            cache_type: self.cache_type,
-            root_device: self.root_device,
-            disk_path: self.disk.file_path.clone(),
-            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
-            rate_limiter_state: self.rate_limiter.save(),
+            id: self.config.drive_id.clone(),
+            partuuid: self.config.partuuid.clone(),
+            cache_type: self.config.cache_type,
+            root_device: self.config.is_root_device,
+            disk_path: self.disk().file_path.clone(),
+            virtio_state: VirtioDeviceState::from_device(self, &self.resources().queues),
+            rate_limiter_state: self.rate_limiter().save(),
             file_engine_type: FileEngineTypeState::from(self.file_engine_type()),
         }
     }
@@ -88,6 +89,17 @@ impl Persist<'_> for VirtioBlock {
         let is_read_only = state.virtio_state.avail_features & (1u64 << VIRTIO_BLK_F_RO) != 0;
         let rate_limiter = RateLimiter::restore((), &state.rate_limiter_state)
             .map_err(VirtioBlockError::RateLimiter)?;
+        let rate_limiter_config: RateLimiterConfig = (&rate_limiter).into();
+        let config = VirtioBlockConfig {
+            drive_id: state.id.clone(),
+            partuuid: state.partuuid.clone(),
+            is_root_device: state.root_device,
+            cache_type: state.cache_type,
+            is_read_only,
+            path_on_host: state.disk_path.clone(),
+            rate_limiter: rate_limiter_config.into_option(),
+            file_engine_type: state.file_engine_type.into(),
+        };
 
         let disk_properties = DiskProperties::new(
             state.disk_path.clone(),
@@ -113,6 +125,13 @@ impl Persist<'_> for VirtioBlock {
         let config_space = ConfigSpace {
             capacity: disk_properties.nsectors.to_le(),
         };
+        let resources = BlockResources {
+            queues,
+            queue_evts,
+            disk: disk_properties,
+            rate_limiter,
+            is_io_engine_throttled: false,
+        };
 
         Ok(VirtioBlock {
             avail_features,
@@ -120,19 +139,9 @@ impl Persist<'_> for VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            queues,
-            queue_evts,
             device_state: DeviceState::Inactive,
-
-            id: state.id.clone(),
-            partuuid: state.partuuid.clone(),
-            cache_type: state.cache_type,
-            root_device: state.root_device,
-            read_only: is_read_only,
-
-            disk: disk_properties,
-            rate_limiter,
-            is_io_engine_throttled: false,
+            config,
+            resources,
             metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
         })
     }
@@ -143,7 +152,6 @@ mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::devices::virtio::block::virtio::device::VirtioBlockConfig;
     use crate::devices::virtio::device::VirtioDevice;
     use crate::devices::virtio::test_utils::{default_interrupt, default_mem};
 
@@ -221,11 +229,11 @@ mod tests {
         assert_eq!(restored_block.device_type(), VirtioDeviceType::Block);
         assert_eq!(restored_block.avail_features(), block.avail_features());
         assert_eq!(restored_block.acked_features(), block.acked_features());
-        assert_eq!(restored_block.queues, block.queues);
+        assert_eq!(restored_block.resources().queues, block.resources().queues);
         assert!(!block.is_activated());
         assert!(!restored_block.is_activated());
 
         // Test that block specific fields are the same.
-        assert_eq!(restored_block.disk.file_path, block.disk.file_path);
+        assert_eq!(restored_block.disk().file_path, block.disk().file_path);
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -8,12 +8,12 @@ use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 use vmm_sys_util::eventfd::EventFd;
 
-use super::device::{BlockResources, DiskProperties};
+use super::device::{BlockResources, BlockState, DiskProperties};
 use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
 use crate::devices::virtio::block::virtio::device::{FileEngineType, VirtioBlockConfig};
 use crate::devices::virtio::block::virtio::metrics::BlockMetricsPerDevice;
-use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
+use crate::devices::virtio::device::VirtioDeviceType;
 use crate::devices::virtio::generated::virtio_blk::VIRTIO_BLK_F_RO;
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::rate_limiter::RateLimiter;
@@ -139,10 +139,9 @@ impl Persist<'_> for VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            device_state: DeviceState::Inactive,
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            resources,
+            state: BlockState::Configuring(resources),
             metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
         })
     }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -141,7 +141,7 @@ impl Persist<'_> for VirtioBlock {
 
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            state: BlockState::Configuring(resources),
+            state: BlockState::Configuring(resources, None),
             metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
         })
     }

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -80,7 +80,7 @@ pub fn rate_limiter(blk: &mut VirtioBlock) -> &RateLimiter {
 pub fn simulate_queue_event(b: &mut VirtioBlock, maybe_expected_irq: Option<bool>) {
     // Trigger the queue event.
 
-    b.queue_evts[0].write(1).unwrap();
+    b.queue_event(0).unwrap().write(1).unwrap();
     // Handle event.
     b.process_queue_event();
     // Validate the queue operation finished successfully.

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -69,11 +69,7 @@ pub fn set_queue(blk: &mut VirtioBlock, idx: usize, q: Queue) {
 }
 
 pub fn set_rate_limiter(blk: &mut VirtioBlock, rl: RateLimiter) {
-    blk.resources_mut().rate_limiter = rl;
-}
-
-pub fn rate_limiter(blk: &mut VirtioBlock) -> &RateLimiter {
-    blk.rate_limiter()
+    *blk.rate_limiter() = rl;
 }
 
 #[cfg(test)]

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -65,15 +65,15 @@ pub fn default_block_with_path(path: String, file_engine_type: FileEngineType) -
 }
 
 pub fn set_queue(blk: &mut VirtioBlock, idx: usize, q: Queue) {
-    blk.queues[idx] = q;
+    blk.resources_mut().queues[idx] = q;
 }
 
 pub fn set_rate_limiter(blk: &mut VirtioBlock, rl: RateLimiter) {
-    blk.rate_limiter = rl;
+    blk.resources_mut().rate_limiter = rl;
 }
 
 pub fn rate_limiter(blk: &mut VirtioBlock) -> &RateLimiter {
-    &blk.rate_limiter
+    blk.rate_limiter()
 }
 
 #[cfg(test)]
@@ -95,7 +95,7 @@ pub fn simulate_queue_event(b: &mut VirtioBlock, maybe_expected_irq: Option<bool
 
 #[cfg(test)]
 pub fn simulate_async_completion_event(b: &mut VirtioBlock, expected_irq: bool) {
-    if let FileEngine::Async(ref mut engine) = b.disk.file_engine {
+    if let FileEngine::Async(ref mut engine) = b.resources_mut().disk.file_engine {
         // Wait for all the async operations to complete.
         engine.drain(false).unwrap();
         // Wait for the async completion event to be sent.
@@ -114,7 +114,7 @@ pub fn simulate_async_completion_event(b: &mut VirtioBlock, expected_irq: bool) 
 
 #[cfg(test)]
 pub fn simulate_queue_and_async_completion_events(b: &mut VirtioBlock, expected_irq: bool) {
-    match b.disk.file_engine {
+    match b.resources().disk.file_engine {
         FileEngine::Async(_) => {
             simulate_queue_event(b, None);
             simulate_async_completion_event(b, expected_irq);

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -54,8 +54,6 @@ enum ControlMsg {
 }
 
 /// VMM-side handle for controlling and joining a block worker thread.
-// Handle gets connected to VirtioBlock in follow-up commits
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct WorkerHandle {
     to_worker: Sender<ControlMsg>,
@@ -295,8 +293,6 @@ impl BlockWorker {
     }
 }
 
-// Handle gets connected to VirtioBlock in follow-up commits
-#[allow(dead_code)]
 impl WorkerHandle {
     /// Spawn a parked block worker thread.
     pub(crate) fn spawn(queue_evts: Vec<EventFd>, name: String) -> Result<Self, std::io::Error> {

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -1,0 +1,254 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::device::BlockResources;
+use super::io::{BlockIoError, FileEngine, async_io};
+use super::metrics::BlockDeviceMetrics;
+use super::{FinishedRequest, IoErr, ProcessingResult, Request, VirtioBlockError};
+use crate::devices::virtio::device::ActiveState;
+use crate::devices::virtio::queue::InvalidAvailIdx;
+use crate::devices::virtio::transport::VirtioInterruptType;
+use crate::logger::{IncMetric, error};
+use crate::rate_limiter::RateLimiter;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Runtime state and processing logic for an active block device.
+#[derive(Debug)]
+pub(crate) struct BlockWorker {
+    pub(crate) resources: BlockResources,
+    pub(crate) active_state: ActiveState,
+    pub(crate) rate_limiter: Arc<Mutex<RateLimiter>>,
+    pub(crate) is_blocked: Arc<AtomicBool>,
+    pub(crate) metrics: Arc<BlockDeviceMetrics>,
+}
+
+pub(crate) enum FlushMode {
+    Drain,
+    DrainAndFlush,
+}
+
+macro_rules! unwrap_async_file_engine_or_return {
+    ($file_engine: expr) => {
+        match $file_engine {
+            FileEngine::Async(engine) => engine,
+            FileEngine::Sync(_) => {
+                error!("The block device doesn't use an async IO engine");
+                return;
+            }
+        }
+    };
+}
+
+impl BlockWorker {
+    /// Process a single event in the Virtio queue.
+    ///
+    /// This function is called by the event manager when the guest notifies us
+    /// about new buffers in the queue.
+    pub(crate) fn process_queue_event(&mut self) {
+        self.metrics.queue_event_count.inc();
+        if let Err(err) = self.resources.queue_evts[0].read() {
+            error!("Failed to get queue event: {:?}", err);
+            self.metrics.event_fails.inc();
+        } else if self.is_blocked.load(Ordering::Relaxed) {
+            self.metrics.rate_limiter_throttled_events.inc();
+        } else if self.resources.is_io_engine_throttled {
+            self.metrics.io_engine_throttled_events.inc();
+        } else {
+            self.process_virtio_queues().unwrap()
+        }
+    }
+
+    /// Process device virtio queue(s).
+    pub(crate) fn process_virtio_queues(&mut self) -> Result<(), InvalidAvailIdx> {
+        self.process_queue(0)
+    }
+
+    /// Device specific function for peaking inside a queue and processing descriptors.
+    fn process_queue(&mut self, queue_index: usize) -> Result<(), InvalidAvailIdx> {
+        let rate_limiter = &self.rate_limiter;
+        let queue = &mut self.resources.queues[queue_index];
+        let mut used_any = false;
+
+        while let Some(head) = queue.pop_or_enable_notification()? {
+            self.metrics.remaining_reqs_count.add(queue.len().into());
+            let processing_result =
+                match Request::parse(&head, &self.active_state.mem, self.resources.disk.nsectors) {
+                    Ok(request) => {
+                        let is_rate_limited = {
+                            let mut rate_limiter = rate_limiter
+                                .lock()
+                                .expect("Poisoned block rate limiter lock");
+                            request.rate_limit(&mut rate_limiter)
+                        };
+                        if is_rate_limited {
+                            // Stop processing the queue and return this descriptor chain to the
+                            // avail ring, for later processing.
+                            queue.undo_pop();
+                            self.metrics.rate_limiter_throttled_events.inc();
+                            break;
+                        }
+
+                        request.process(
+                            &mut self.resources.disk,
+                            head.index,
+                            &self.active_state.mem,
+                            &self.metrics,
+                        )
+                    }
+                    Err(err) => {
+                        error!("Failed to parse available descriptor chain: {:?}", err);
+                        self.metrics.execute_fails.inc();
+                        ProcessingResult::Executed(FinishedRequest {
+                            num_bytes_to_mem: 0,
+                            desc_idx: head.index,
+                        })
+                    }
+                };
+
+            match processing_result {
+                ProcessingResult::Submitted => {}
+                ProcessingResult::Throttled => {
+                    queue.undo_pop();
+                    self.resources.is_io_engine_throttled = true;
+                    break;
+                }
+                ProcessingResult::Executed(finished) => {
+                    used_any = true;
+                    queue
+                        .add_used(head.index, finished.num_bytes_to_mem)
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "Failed to add available descriptor head {}: {}",
+                                head.index, err
+                            )
+                        });
+                }
+            }
+        }
+        queue.advance_used_ring_idx();
+
+        if used_any && queue.prepare_kick() {
+            self.active_state
+                .interrupt
+                .trigger(VirtioInterruptType::Queue(0))
+                .unwrap_or_else(|_| {
+                    self.metrics.event_fails.inc();
+                });
+        }
+
+        if let FileEngine::Async(ref mut engine) = self.resources.disk.file_engine
+            && let Err(err) = engine.kick_submission_queue()
+        {
+            error!("BlockError submitting pending block requests: {:?}", err);
+        }
+
+        if !used_any {
+            self.metrics.no_avail_buffer.inc();
+        }
+
+        Ok(())
+    }
+
+    fn process_async_completion_queue(&mut self) {
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
+        let queue = &mut self.resources.queues[0];
+
+        loop {
+            match engine.pop(&self.active_state.mem) {
+                Err(error) => {
+                    error!("Failed to read completed io_uring entry: {:?}", error);
+                    break;
+                }
+                Ok(None) => break,
+                Ok(Some(cqe)) => {
+                    let res = cqe.result();
+                    let user_data = cqe.user_data();
+
+                    let (pending, res) = match res {
+                        Ok(count) => (user_data, Ok(count)),
+                        Err(error) => (
+                            user_data,
+                            Err(IoErr::FileEngine(BlockIoError::Async(
+                                async_io::AsyncIoError::IO(error),
+                            ))),
+                        ),
+                    };
+                    let finished = pending.finish(&self.active_state.mem, res, &self.metrics);
+                    queue
+                        .add_used(finished.desc_idx, finished.num_bytes_to_mem)
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "Failed to add available descriptor head {}: {}",
+                                finished.desc_idx, err
+                            )
+                        });
+                }
+            }
+        }
+        queue.advance_used_ring_idx();
+
+        if queue.prepare_kick() {
+            self.active_state
+                .interrupt
+                .trigger(VirtioInterruptType::Queue(0))
+                .unwrap_or_else(|_| {
+                    self.metrics.event_fails.inc();
+                });
+        }
+    }
+
+    pub(crate) fn process_async_completion_event(&mut self) {
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
+
+        if let Err(err) = engine.completion_evt().read() {
+            error!("Failed to get async completion event: {:?}", err);
+        } else {
+            self.process_async_completion_queue();
+
+            if self.resources.is_io_engine_throttled {
+                self.resources.is_io_engine_throttled = false;
+                self.process_queue(0).unwrap()
+            }
+        }
+    }
+
+    pub(crate) fn drain_and_flush(&mut self, discard: bool) {
+        if let Err(err) = self.resources.disk.file_engine.drain_and_flush(discard) {
+            error!("Failed to drain ops and flush block data: {:?}", err);
+        }
+    }
+
+    pub(crate) fn drain(&mut self, discard: bool) {
+        if let Err(err) = self.resources.disk.file_engine.drain(discard) {
+            error!("Failed to drain ops: {:?}", err);
+        }
+    }
+
+    pub(crate) fn reset(&mut self) -> bool {
+        if let Err(err) = self.resources.disk.file_engine.drain(true) {
+            error!("Failed to reset block IO engine: {:?}", err);
+            return false;
+        }
+        self.resources.is_io_engine_throttled = false;
+        true
+    }
+
+    /// Prepare device for being snapshotted.
+    pub(crate) fn prepare_save(&mut self) {
+        self.drain_and_flush(false);
+        if matches!(&self.resources.disk.file_engine, FileEngine::Async(_)) {
+            self.process_async_completion_queue();
+        }
+    }
+
+    /// Update the backing file and return the new sector count.
+    pub fn update_disk_image(
+        &mut self,
+        disk_image_path: String,
+        read_only: bool,
+    ) -> Result<u64, VirtioBlockError> {
+        self.resources.disk.update(disk_image_path, read_only)?;
+        Ok(self.resources.disk.nsectors)
+    }
+}

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -1,17 +1,24 @@
 // Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use event_manager::{EventOps, Events, MutEventSubscriber, SubscriberOps};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender, channel};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use vmm_sys_util::epoll::EventSet;
+use vmm_sys_util::eventfd::EventFd;
+
 use super::device::BlockResources;
 use super::io::{BlockIoError, FileEngine, async_io};
 use super::metrics::BlockDeviceMetrics;
 use super::{FinishedRequest, IoErr, ProcessingResult, Request, VirtioBlockError};
+use crate::EventManager;
 use crate::devices::virtio::device::ActiveState;
 use crate::devices::virtio::queue::InvalidAvailIdx;
 use crate::devices::virtio::transport::VirtioInterruptType;
-use crate::logger::{IncMetric, error};
+use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::RateLimiter;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 
 /// Runtime state and processing logic for an active block device.
 #[derive(Debug)]
@@ -23,6 +30,41 @@ pub(crate) struct BlockWorker {
     pub(crate) metrics: Arc<BlockDeviceMetrics>,
 }
 
+/// Worker state and control channel side (recv ctl msg)
+#[derive(Debug)]
+struct ThreadedWorker {
+    state: WorkerState,
+    control_evt: EventFd,
+    from_vmm: Receiver<ControlMsg>,
+}
+
+/// Data-path ownership state of the worker thread.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+enum WorkerState {
+    Parked,
+    Running(BlockWorker),
+    Finished,
+}
+
+#[allow(clippy::large_enum_variant)]
+enum ControlMsg {
+    Start(BlockWorker),
+    Finish(FlushMode),
+}
+
+/// VMM-side handle for controlling and joining a block worker thread.
+// Handle gets connected to VirtioBlock in follow-up commits
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct WorkerHandle {
+    to_worker: Sender<ControlMsg>,
+    control_evt: EventFd,
+    join: JoinHandle<()>,
+    queue_evts: Vec<EventFd>,
+}
+
+/// Determines how pending I/O is handled during worker teardown.
 pub(crate) enum FlushMode {
     Drain,
     DrainAndFlush,
@@ -250,5 +292,224 @@ impl BlockWorker {
     ) -> Result<u64, VirtioBlockError> {
         self.resources.disk.update(disk_image_path, read_only)?;
         Ok(self.resources.disk.nsectors)
+    }
+}
+
+// Handle gets connected to VirtioBlock in follow-up commits
+#[allow(dead_code)]
+impl WorkerHandle {
+    /// Spawn a parked block worker thread.
+    pub(crate) fn spawn(queue_evts: Vec<EventFd>, name: String) -> Result<Self, std::io::Error> {
+        // handle writes and worker reads the control eventfd
+        let control_evt = EventFd::new(libc::EFD_NONBLOCK)?;
+        let handle_evt = control_evt.try_clone()?;
+        let (to_worker, from_vmm) = channel::<ControlMsg>();
+
+        let join = thread::Builder::new().name(name).spawn(move || {
+            let event_manager =
+                EventManager::new().expect("Failed to create block worker EventManager");
+            run_worker_loop(event_manager, control_evt, from_vmm);
+        })?;
+
+        Ok(Self {
+            to_worker,
+            control_evt: handle_evt,
+            join,
+            queue_evts,
+        })
+    }
+
+    pub(crate) fn queue_events(&self) -> &[EventFd] {
+        &self.queue_evts
+    }
+
+    /// Transfer data-path resources to the worker thread and start processing.
+    pub(crate) fn start(&self, worker: BlockWorker) {
+        if let Err(err) = self.to_worker.send(ControlMsg::Start(worker)) {
+            error!("Failed to send block worker start message: {:?}", err);
+            return;
+        }
+
+        if let Err(err) = self.control_evt.write(1) {
+            error!("Failed to notify block worker: {:?}", err);
+        }
+    }
+
+    /// Stop the worker and wait for its thread to exit.
+    pub(crate) fn finish(self, flush_mode: FlushMode) {
+        if let Err(err) = self.to_worker.send(ControlMsg::Finish(flush_mode)) {
+            error!("Block worker receiver already dropped: {:?}", err);
+        } else if let Err(err) = self.control_evt.write(1) {
+            error!("Block worker control event is closed: {:?}", err);
+        }
+
+        self.join.join().unwrap_or_else(|err| {
+            error!("Block worker thread panicked during teardown: {:?}", err);
+        });
+    }
+}
+
+impl ThreadedWorker {
+    const PROCESS_QUEUE: u32 = 0;
+    const PROCESS_ASYNC_COMPLETION: u32 = 1;
+    const PROCESS_CONTROL: u32 = 2;
+
+    fn register_control_event(&self, ops: &mut EventOps) {
+        if let Err(err) = ops.add(Events::with_data(
+            &self.control_evt,
+            Self::PROCESS_CONTROL,
+            EventSet::IN,
+        )) {
+            error!("Failed to register block worker control event: {}", err);
+        }
+    }
+
+    fn register_runtime_events(resources: &BlockResources, ops: &mut EventOps) {
+        if let Err(err) = ops.add(Events::with_data(
+            &resources.queue_evts[0],
+            Self::PROCESS_QUEUE,
+            EventSet::IN,
+        )) {
+            error!("Failed to register queue event: {}", err);
+        }
+        if let FileEngine::Async(ref engine) = resources.disk.file_engine
+            && let Err(err) = ops.add(Events::with_data(
+                engine.completion_evt(),
+                Self::PROCESS_ASYNC_COMPLETION,
+                EventSet::IN,
+            ))
+        {
+            error!("Failed to register IO engine completion event: {}", err);
+        }
+    }
+
+    fn unregister_runtime_events(resources: &BlockResources, ops: &mut EventOps) {
+        if let Err(err) = ops.remove(Events::with_data(
+            &resources.queue_evts[0],
+            Self::PROCESS_QUEUE,
+            EventSet::IN,
+        )) {
+            error!("Failed to unregister queue event: {}", err);
+        }
+        if let FileEngine::Async(ref engine) = resources.disk.file_engine
+            && let Err(err) = ops.remove(Events::with_data(
+                engine.completion_evt(),
+                Self::PROCESS_ASYNC_COMPLETION,
+                EventSet::IN,
+            ))
+        {
+            error!("Failed to unregister IO engine completion event: {}", err);
+        }
+    }
+
+    fn process_control_event(&mut self, ops: &mut EventOps) {
+        if let Err(err) = self.control_evt.read() {
+            error!("Failed to consume block worker control event: {:?}", err);
+            if let WorkerState::Running(worker) = &self.state {
+                worker.metrics.event_fails.inc();
+            }
+            return;
+        }
+
+        while let Ok(msg) = self.from_vmm.try_recv() {
+            match msg {
+                ControlMsg::Start(worker) => self.start_worker(worker, ops),
+                ControlMsg::Finish(flush_mode) => self.finish_worker(flush_mode, ops),
+            }
+
+            if self.is_finished() {
+                break;
+            }
+        }
+    }
+
+    fn start_worker(&mut self, worker: BlockWorker, ops: &mut EventOps) {
+        if !matches!(self.state, WorkerState::Parked) {
+            warn!("Start requested while block worker is not parked");
+            return;
+        }
+
+        Self::register_runtime_events(&worker.resources, ops);
+        self.state = WorkerState::Running(worker);
+    }
+
+    fn finish_worker(&mut self, flush_mode: FlushMode, ops: &mut EventOps) {
+        if let WorkerState::Running(mut worker) =
+            std::mem::replace(&mut self.state, WorkerState::Finished)
+        {
+            Self::unregister_runtime_events(&worker.resources, ops);
+            match flush_mode {
+                FlushMode::Drain => worker.drain(true),
+                FlushMode::DrainAndFlush => worker.drain_and_flush(true),
+            }
+            worker.resources.is_io_engine_throttled = false;
+        }
+    }
+
+    fn is_finished(&self) -> bool {
+        matches!(self.state, WorkerState::Finished)
+    }
+}
+
+fn run_worker_loop(
+    mut event_manager: EventManager,
+    control_evt: EventFd,
+    from_vmm: Receiver<ControlMsg>,
+) {
+    let worker = Arc::new(Mutex::new(ThreadedWorker {
+        state: WorkerState::Parked,
+        control_evt,
+        from_vmm,
+    }));
+    let subscriber: Arc<Mutex<dyn MutEventSubscriber>> = worker.clone();
+    event_manager.add_subscriber(subscriber);
+
+    loop {
+        if let Err(err) = event_manager.run() {
+            error!("Block worker event loop error: {:?}", err);
+        }
+        if worker
+            .lock()
+            .expect("Poisoned block worker lock")
+            .is_finished()
+        {
+            break;
+        }
+    }
+}
+
+impl MutEventSubscriber for ThreadedWorker {
+    fn process(&mut self, event: Events, ops: &mut EventOps) {
+        let source = event.data();
+        let event_set = event.event_set();
+
+        if !EventSet::IN.contains(event_set) {
+            warn!(
+                "Block worker received unknown event: {:?} from source: {:?}",
+                event_set, source
+            );
+            return;
+        }
+
+        if let WorkerState::Running(worker) = &mut self.state {
+            match source {
+                Self::PROCESS_QUEUE => worker.process_queue_event(),
+                Self::PROCESS_ASYNC_COMPLETION => worker.process_async_completion_event(),
+                Self::PROCESS_CONTROL => self.process_control_event(ops),
+                _ => warn!("Block: Spurious event received: {:?}", source),
+            }
+        } else {
+            match source {
+                Self::PROCESS_CONTROL => self.process_control_event(ops),
+                _ => warn!(
+                    "Block: The device worker is not yet activated. Spurious event received: {:?}",
+                    source
+                ),
+            }
+        }
+    }
+
+    fn init(&mut self, ops: &mut EventOps) {
+        self.register_control_event(ops);
     }
 }

--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use vmm_sys_util::eventfd::EventFd;
 
 use super::ActivateError;
-use super::queue::{Queue, QueueError};
+use super::queue::{QueueConfig, QueueError};
 use super::transport::VirtioInterrupt;
 use crate::MutEventSubscriber;
 use crate::devices::virtio::AsAny;
@@ -78,8 +78,7 @@ pub type VirtioDeviceId = (VirtioDeviceType, String);
 ///
 /// The lifecycle of a virtio device is to be moved to a virtio transport, which will then query the
 /// device. The virtio devices needs to create queues, events and event fds for interrupts and
-/// expose them to the transport via get_queues/get_queue_events/get_interrupt/get_interrupt_status
-/// fns.
+/// expose their queue configuration, events, and interrupt state to the transport.
 pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
     /// Get the available features offered by device.
     fn avail_features(&self) -> u64;
@@ -110,14 +109,23 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
     /// Returns unique device id
     fn id(&self) -> &str;
 
-    /// Returns the device queues.
-    fn queues(&self) -> &[Queue];
+    /// Returns the number of queues offered by the device.
+    fn num_queues(&self) -> usize;
 
-    /// Returns a mutable reference to the device queues.
-    fn queues_mut(&mut self) -> &mut [Queue];
+    /// Returns the transport-visible configuration for the selected queue.
+    ///
+    /// This must return `Some` exactly for indices below [`Self::num_queues`].
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig>;
 
-    /// Returns the device queues event fds.
-    fn queue_events(&self) -> &[EventFd];
+    /// Returns the mutable transport-visible configuration for the selected queue.
+    ///
+    /// This must return `Some` exactly for indices below [`Self::num_queues`].
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig>;
+
+    /// Returns the event fd for the selected queue.
+    ///
+    /// This must return `Some` exactly for indices below [`Self::num_queues`].
+    fn queue_event(&self, index: usize) -> Option<&EventFd>;
 
     /// Returns the current device interrupt status.
     fn interrupt_status(&self) -> Arc<AtomicU32> {
@@ -205,9 +213,7 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
         }
         self.deactivate();
         self.set_acked_features(0);
-        for queue in self.queues_mut() {
-            *queue = Queue::new(queue.max_size);
-        }
+        self.reset_queues();
         true
     }
 
@@ -215,18 +221,19 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
     /// backend does not support reset.
     fn _reset(&mut self) -> bool;
 
+    /// Resets device-owned queue configuration and runtime state.
+    fn reset_queues(&mut self);
+
     /// Mark pages used by queues as dirty.
-    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
-        for queue in self.queues_mut() {
-            queue.initialize(mem)?
-        }
-        Ok(())
-    }
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError>;
 
     /// Notify all queues by writing to the eventfds.
     fn notify_queue_events(&mut self) {
         info!("[{:?}:{}] notifying queues", self.device_type(), self.id());
-        for (i, eventfd) in self.queue_events().iter().enumerate() {
+        for i in 0..self.num_queues() {
+            let eventfd = self
+                .queue_event(i)
+                .expect("queue event must exist for each advertised queue");
             if let Err(err) = eventfd.write(1) {
                 error!(
                     "[{:?}:{}] error notifying queue {}: {}",
@@ -243,7 +250,10 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
     /// notifications. This is used if a notification arrives while a device
     /// is being reset and before it's activated again.
     fn drain_queue_events(&self) {
-        for event in self.queue_events() {
+        for i in 0..self.num_queues() {
+            let event = self
+                .queue_event(i)
+                .expect("queue event must exist for each advertised queue");
             event.read();
         }
     }
@@ -316,15 +326,19 @@ pub(crate) mod tests {
             self.acked_features = acked_features
         }
 
-        fn queues(&self) -> &[Queue] {
+        fn num_queues(&self) -> usize {
             todo!()
         }
 
-        fn queues_mut(&mut self) -> &mut [Queue] {
+        fn queue_config(&self, _index: usize) -> Option<&QueueConfig> {
             todo!()
         }
 
-        fn queue_events(&self) -> &[EventFd] {
+        fn queue_config_mut(&mut self, _index: usize) -> Option<&mut QueueConfig> {
+            todo!()
+        }
+
+        fn queue_event(&self, _index: usize) -> Option<&EventFd> {
             todo!()
         }
 
@@ -357,6 +371,14 @@ pub(crate) mod tests {
         }
 
         fn _reset(&mut self) -> bool {
+            todo!()
+        }
+
+        fn reset_queues(&mut self) {
+            todo!()
+        }
+
+        fn mark_queue_memory_dirty(&mut self, _mem: &GuestMemoryMmap) -> Result<(), QueueError> {
             todo!()
         }
     }

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -578,7 +578,7 @@ mod tests {
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
         let mut q = vq.create_queue();
-        q.ready = true;
+        q.config.ready = true;
 
         let flags = if is_write_only {
             VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -26,7 +26,7 @@ use crate::devices::virtio::mem::VIRTIO_MEM_DEV_ID;
 use crate::devices::virtio::mem::metrics::METRICS;
 use crate::devices::virtio::mem::request::{BlockRangeState, Request, RequestedRange, Response};
 use crate::devices::virtio::queue::{
-    DescriptorChain, FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue, QueueError,
+    DescriptorChain, FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue, QueueConfig, QueueError,
 };
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
@@ -606,16 +606,20 @@ impl VirtioDevice for VirtioMem {
         VIRTIO_MEM_DEV_ID
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_events
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_events.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -667,6 +671,17 @@ impl VirtioDevice for VirtioMem {
         // Note: the Linux virtio-mem driver does not support rebinding when
         // memory is plugged
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 
     fn activate(
@@ -723,7 +738,7 @@ pub(crate) mod test_utils {
             self.queues = queues;
         }
 
-        fn num_queues(&self) -> usize {
+        fn num_queues_supported(&self) -> usize {
             MEM_NUM_QUEUES
         }
     }
@@ -778,8 +793,9 @@ mod tests {
 
         assert!(!mem.is_activated());
 
-        assert_eq!(mem.queues().len(), MEM_NUM_QUEUES);
-        assert_eq!(mem.queue_events().len(), MEM_NUM_QUEUES);
+        assert_eq!(mem.queues.len(), MEM_NUM_QUEUES);
+        assert_eq!(mem.num_queues(), MEM_NUM_QUEUES);
+        assert!((0..mem.num_queues()).all(|index| mem.queue_event(index).is_some()));
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/mem/event_handler.rs
+++ b/src/vmm/src/devices/virtio/mem/event_handler.rs
@@ -15,7 +15,7 @@ impl VirtioMem {
 
     fn register_runtime_events(&self, ops: &mut EventOps) {
         if let Err(err) = ops.add(Events::with_data(
-            &self.queue_events()[MEM_QUEUE],
+            self.queue_event(MEM_QUEUE).unwrap(),
             Self::PROCESS_MEM_QUEUE,
             EventSet::IN,
         )) {
@@ -114,7 +114,7 @@ mod tests {
 
         // Set up queue
         let virtq = VirtQueue::new(GuestAddress(0), &mem, 16);
-        mem_device.queues_mut()[MEM_QUEUE] = virtq.create_queue();
+        mem_device.queues[MEM_QUEUE] = virtq.create_queue();
 
         let mem_device = Arc::new(Mutex::new(mem_device));
         let _id = event_manager.add_subscriber(mem_device.clone());
@@ -154,7 +154,7 @@ mod tests {
 
         // Set up queue
         let virtq = VirtQueue::new(GuestAddress(0), &mem, 16);
-        mem_device.queues_mut()[MEM_QUEUE] = virtq.create_queue();
+        mem_device.queues[MEM_QUEUE] = virtq.create_queue();
         mem_device.set_acked_features(mem_device.avail_features());
 
         let mem_device = Arc::new(Mutex::new(mem_device));
@@ -165,7 +165,11 @@ mod tests {
         event_manager.run_with_timeout(50).unwrap(); // Process activation
 
         // Trigger queue event
-        mem_device.lock().unwrap().queue_events()[MEM_QUEUE]
+        mem_device
+            .lock()
+            .unwrap()
+            .queue_event(MEM_QUEUE)
+            .unwrap()
             .write(1)
             .unwrap();
 
@@ -182,7 +186,11 @@ mod tests {
         let _id = event_manager.add_subscriber(mem_device.clone());
 
         // Try to trigger queue event before activation
-        mem_device.lock().unwrap().queue_events()[MEM_QUEUE]
+        mem_device
+            .lock()
+            .unwrap()
+            .queue_event(MEM_QUEUE)
+            .unwrap()
             .write(1)
             .unwrap();
 

--- a/src/vmm/src/devices/virtio/mem/persist.rs
+++ b/src/vmm/src/devices/virtio/mem/persist.rs
@@ -58,7 +58,7 @@ impl Persist<'_> for VirtioMem {
 
     fn save(&self) -> Self::State {
         VirtioMemState {
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
             addr: self.config.addr,
             region_size: self.config.region_size,
             block_size: self.config.block_size,

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -33,7 +33,9 @@ use crate::devices::virtio::net::tap::Tap;
 use crate::devices::virtio::net::{
     MAX_BUFFER_SIZE, NET_QUEUE_SIZES, NetError, NetQueue, RX_INDEX, TX_INDEX, generated,
 };
-use crate::devices::virtio::queue::{DescriptorChain, InvalidAvailIdx, Queue};
+use crate::devices::virtio::queue::{
+    DescriptorChain, InvalidAvailIdx, Queue, QueueConfig, QueueError,
+};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::{DeviceError, report_net_event_fail};
 use crate::dumbo::pdu::arp::ETH_IPV4_FRAME_LEN;
@@ -1010,16 +1012,20 @@ impl VirtioDevice for Net {
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_evts
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -1089,6 +1095,17 @@ impl VirtioDevice for Net {
         self.rx_buffer.clear();
         self.tx_buffer.clear();
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 
     /// Prepare saving state
@@ -2575,13 +2592,14 @@ pub mod tests {
         let net = th.net.lock().unwrap();
 
         // Test queues count (TX and RX).
-        let queues = net.queues();
+        let queues = &net.queues;
         assert_eq!(queues.len(), NET_QUEUE_SIZES.len());
-        assert_eq!(queues[RX_INDEX].size, th.rxq.size());
-        assert_eq!(queues[TX_INDEX].size, th.txq.size());
+        assert_eq!(queues[RX_INDEX].config.size, th.rxq.size());
+        assert_eq!(queues[TX_INDEX].config.size, th.txq.size());
 
         // Test corresponding queues events.
-        assert_eq!(net.queue_events().len(), NET_QUEUE_SIZES.len());
+        assert_eq!(net.num_queues(), NET_QUEUE_SIZES.len());
+        assert!((0..net.num_queues()).all(|index| net.queue_event(index).is_some()));
 
         // Test interrupts.
         assert!(
@@ -2604,7 +2622,7 @@ pub mod tests {
         th.activate_net();
 
         let net = th.net();
-        let queues = net.queues();
+        let queues = &net.queues;
         assert!(queues[RX_INDEX].uses_notif_suppression);
         assert!(queues[TX_INDEX].uses_notif_suppression);
     }

--- a/src/vmm/src/devices/virtio/net/persist.rs
+++ b/src/vmm/src/devices/virtio/net/persist.rs
@@ -85,7 +85,7 @@ impl Persist<'_> for Net {
                 guest_mac: self.guest_mac,
                 mtu: self.mtu(),
             },
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
         }
     }
 
@@ -163,7 +163,7 @@ mod tests {
             tap_if_name = net.iface_name();
             has_mmds_ns = net.mmds_ns.is_some();
             allow_mmds_requests = has_mmds_ns && mmds_ds.is_some();
-            virtio_state = VirtioDeviceState::from_device(&net);
+            virtio_state = VirtioDeviceState::from_device(&net, &net.queues);
         }
 
         // Drop the initial net device so that we don't get an error when trying to recreate the

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -13,7 +13,7 @@ use super::queue::{InvalidAvailIdx, QueueError};
 use super::transport::mmio::IrqTrigger;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::{Queue, QueueConfig};
 use crate::devices::virtio::transport::mmio::MmioTransport;
 use crate::snapshot::Persist;
 use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
@@ -73,12 +73,12 @@ impl Persist<'_> for Queue {
 
     fn save(&self) -> Self::State {
         QueueState {
-            max_size: self.max_size,
-            size: self.size,
-            ready: self.ready,
-            desc_table: self.desc_table_address.0,
-            avail_ring: self.avail_ring_address.0,
-            used_ring: self.used_ring_address.0,
+            max_size: self.config.max_size,
+            size: self.config.size,
+            ready: self.config.ready,
+            desc_table: self.config.desc_table_address.0,
+            avail_ring: self.config.avail_ring_address.0,
+            used_ring: self.config.used_ring_address.0,
             next_avail: self.next_avail,
             next_used: self.next_used,
             num_added: self.num_added,
@@ -90,12 +90,14 @@ impl Persist<'_> for Queue {
         state: &Self::State,
     ) -> Result<Self, Self::Error> {
         let mut queue = Queue {
-            max_size: state.max_size,
-            size: state.size,
-            ready: state.ready,
-            desc_table_address: GuestAddress(state.desc_table),
-            avail_ring_address: GuestAddress(state.avail_ring),
-            used_ring_address: GuestAddress(state.used_ring),
+            config: QueueConfig {
+                max_size: state.max_size,
+                size: state.size,
+                ready: state.ready,
+                desc_table_address: GuestAddress(state.desc_table),
+                avail_ring_address: GuestAddress(state.avail_ring),
+                used_ring_address: GuestAddress(state.used_ring),
+            },
 
             desc_table_ptr: std::ptr::null(),
             avail_ring_ptr: std::ptr::null_mut(),
@@ -130,12 +132,15 @@ pub struct VirtioDeviceState {
 
 impl VirtioDeviceState {
     /// Construct the virtio state of a device.
-    pub fn from_device(device: &dyn VirtioDevice) -> Self {
+    pub fn from_device<'a>(
+        device: &dyn VirtioDevice,
+        queues: impl IntoIterator<Item = &'a Queue>,
+    ) -> Self {
         VirtioDeviceState {
             device_type: device.device_type(),
             avail_features: device.avail_features(),
             acked_features: device.acked_features(),
-            queues: device.queues().iter().map(Persist::save).collect(),
+            queues: queues.into_iter().map(Persist::save).collect(),
             activated: device.is_activated(),
         }
     }
@@ -182,7 +187,7 @@ impl VirtioDeviceState {
 
         for q in &queues {
             // Sanity check queue size and queue max size.
-            if q.max_size != expected_queue_max_size {
+            if q.config.max_size != expected_queue_max_size {
                 return Err(PersistError::InvalidInput);
             }
         }
@@ -365,8 +370,8 @@ mod tests {
         let mem = default_mem();
 
         let mut queue = Queue::new(128);
-        queue.ready = true;
-        queue.size = queue.max_size;
+        queue.config.ready = true;
+        queue.config.size = queue.config.max_size;
         queue.initialize(&mem).unwrap();
 
         let queue_state = queue.save();
@@ -385,8 +390,9 @@ mod tests {
     #[test]
     fn test_virtio_device_state_serde() {
         let dummy = DummyDevice::new();
+        let queues = [Queue::new(16), Queue::new(32)];
 
-        let state = VirtioDeviceState::from_device(&dummy);
+        let state = VirtioDeviceState::from_device(&dummy, &queues);
         let serialized_data = bitcode::serialize(&state).unwrap();
 
         let restored_state: VirtioDeviceState = bitcode::deserialize(&serialized_data).unwrap();

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -18,7 +18,9 @@ use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, Vir
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::pmem::PMEM_QUEUE_SIZE;
 use crate::devices::virtio::pmem::metrics::{PmemMetrics, PmemMetricsPerDevice};
-use crate::devices::virtio::queue::{DescriptorChain, InvalidAvailIdx, Queue, QueueError};
+use crate::devices::virtio::queue::{
+    DescriptorChain, InvalidAvailIdx, Queue, QueueConfig, QueueError,
+};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::logger::{IncMetric, error, info, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter, TokenType};
@@ -532,16 +534,20 @@ impl VirtioDevice for Pmem {
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_events
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_events.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -595,6 +601,17 @@ impl VirtioDevice for Pmem {
 
     fn _reset(&mut self) -> bool {
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 
     fn kick(&mut self) {

--- a/src/vmm/src/devices/virtio/pmem/persist.rs
+++ b/src/vmm/src/devices/virtio/pmem/persist.rs
@@ -50,7 +50,7 @@ impl<'a> Persist<'a> for Pmem {
 
     fn save(&self) -> Self::State {
         PmemState {
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
             config_space: self.guest_region.config_space,
             config: self.config.clone(),
             rate_limiter_state: self.rate_limiter.save(),

--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -196,8 +196,8 @@ impl Iterator for DescriptorIterator {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-/// A virtio queue's parameters.
-pub struct Queue {
+/// The transport-visible configuration of a virtio queue.
+pub struct QueueConfig {
     /// The maximal size in elements offered by the device
     pub max_size: u16,
 
@@ -215,6 +215,27 @@ pub struct Queue {
 
     /// Guest physical address of the used ring
     pub used_ring_address: GuestAddress,
+}
+
+impl QueueConfig {
+    /// Constructs an unconfigured virtio queue config with the given maximum size.
+    pub fn new(max_size: u16) -> Self {
+        Self {
+            max_size,
+            size: max_size,
+            ready: false,
+            desc_table_address: GuestAddress(0),
+            avail_ring_address: GuestAddress(0),
+            used_ring_address: GuestAddress(0),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// A virtio queue's configuration and runtime state.
+pub struct Queue {
+    /// Configuration exposed to the virtio transport.
+    pub config: QueueConfig,
 
     /// Host virtual address pointer to the descriptor table
     /// in the guest memory .
@@ -280,12 +301,7 @@ impl Queue {
     /// Constructs an empty virtio queue with the given `max_size`.
     pub fn new(max_size: u16) -> Queue {
         Queue {
-            max_size,
-            size: max_size,
-            ready: false,
-            desc_table_address: GuestAddress(0),
-            avail_ring_address: GuestAddress(0),
-            used_ring_address: GuestAddress(0),
+            config: QueueConfig::new(max_size),
 
             desc_table_ptr: std::ptr::null(),
             avail_ring_ptr: std::ptr::null_mut(),
@@ -298,21 +314,26 @@ impl Queue {
         }
     }
 
+    /// Resets both configuration and runtime state while preserving the maximum size.
+    pub fn reset(&mut self) {
+        *self = Self::new(self.config.max_size);
+    }
+
     fn desc_table_size(&self) -> usize {
-        std::mem::size_of::<Descriptor>() * usize::from(self.size)
+        std::mem::size_of::<Descriptor>() * usize::from(self.config.size)
     }
 
     fn avail_ring_size(&self) -> usize {
         std::mem::size_of::<u16>()
             + std::mem::size_of::<u16>()
-            + std::mem::size_of::<u16>() * usize::from(self.size)
+            + std::mem::size_of::<u16>() * usize::from(self.config.size)
             + std::mem::size_of::<u16>()
     }
 
     fn used_ring_size(&self) -> usize {
         std::mem::size_of::<u16>()
             + std::mem::size_of::<u16>()
-            + std::mem::size_of::<UsedElement>() * usize::from(self.size)
+            + std::mem::size_of::<UsedElement>() * usize::from(self.config.size)
             + std::mem::size_of::<u16>()
     }
 
@@ -341,12 +362,15 @@ impl Queue {
     /// Set up pointers to the queue objects in the guest memory
     /// and mark memory dirty for those objects
     pub fn initialize<M: GuestMemoryBackend>(&mut self, mem: &M) -> Result<(), QueueError> {
-        if !self.ready {
+        if !self.config.ready {
             return Err(QueueError::NotReady);
         }
 
-        if self.size > self.max_size || self.size == 0 || (self.size & (self.size - 1)) != 0 {
-            return Err(QueueError::InvalidSize(self.size));
+        if self.config.size > self.config.max_size
+            || self.config.size == 0
+            || (self.config.size & (self.config.size - 1)) != 0
+        {
+            return Err(QueueError::InvalidSize(self.config.size));
         }
 
         // All the below pointers are verified to be aligned properly; otherwise some methods (e.g.
@@ -362,12 +386,24 @@ impl Queue {
         // > Available Ring   2
         // > Used Ring        4
         // > ================ ==========
-        self.desc_table_ptr =
-            self.get_aligned_slice_ptr(mem, self.desc_table_address, self.desc_table_size(), 16)?;
-        self.avail_ring_ptr =
-            self.get_aligned_slice_ptr(mem, self.avail_ring_address, self.avail_ring_size(), 2)?;
-        self.used_ring_ptr =
-            self.get_aligned_slice_ptr(mem, self.used_ring_address, self.used_ring_size(), 4)?;
+        self.desc_table_ptr = self.get_aligned_slice_ptr(
+            mem,
+            self.config.desc_table_address,
+            self.desc_table_size(),
+            16,
+        )?;
+        self.avail_ring_ptr = self.get_aligned_slice_ptr(
+            mem,
+            self.config.avail_ring_address,
+            self.avail_ring_size(),
+            2,
+        )?;
+        self.used_ring_ptr = self.get_aligned_slice_ptr(
+            mem,
+            self.config.used_ring_address,
+            self.used_ring_size(),
+            4,
+        )?;
 
         Ok(())
     }
@@ -394,7 +430,7 @@ impl Queue {
         // SAFETY: `used_event` is 2 + self.len u16 away from the start
         unsafe {
             self.avail_ring_ptr
-                .add(2_usize.unchecked_add(usize::from(self.size)))
+                .add(2_usize.unchecked_add(usize::from(self.config.size)))
                 .read_volatile()
         }
     }
@@ -434,7 +470,8 @@ impl Queue {
             self.used_ring_ptr
                 .add(
                     std::mem::size_of::<u16>().unchecked_mul(2)
-                        + std::mem::size_of::<UsedElement>().unchecked_mul(usize::from(self.size)),
+                        + std::mem::size_of::<UsedElement>()
+                            .unchecked_mul(usize::from(self.config.size)),
                 )
                 .cast::<u16>()
                 .read_volatile()
@@ -449,7 +486,8 @@ impl Queue {
             self.used_ring_ptr
                 .add(
                     std::mem::size_of::<u16>().unchecked_mul(2)
-                        + std::mem::size_of::<UsedElement>().unchecked_mul(usize::from(self.size)),
+                        + std::mem::size_of::<UsedElement>()
+                            .unchecked_mul(usize::from(self.config.size)),
                 )
                 .cast::<u16>()
                 .write_volatile(val)
@@ -484,9 +522,9 @@ impl Queue {
         // once. Checking and reporting such incorrect driver behavior
         // can prevent potential hanging and Denial-of-Service from
         // happening on the VMM side.
-        if self.size < len {
+        if self.config.size < len {
             return Err(InvalidAvailIdx {
-                queue_size: self.size,
+                queue_size: self.config.size,
                 reported_len: len,
             });
         }
@@ -538,15 +576,17 @@ impl Queue {
         //
         // We use `self.next_avail` to store the position, in `ring`, of the next available
         // descriptor index, with a twist: we always only increment `self.next_avail`, so the
-        // actual position will be `self.next_avail % self.size`.
-        let idx = self.next_avail.0 % self.size;
+        // actual position will be `self.next_avail % self.config.size`.
+        let idx = self.next_avail.0 % self.config.size;
         // SAFETY:
         // index is bound by the queue size
         let desc_index = unsafe { self.avail_ring_ring_get(usize::from(idx)) };
 
-        DescriptorChain::checked_new(self.desc_table_ptr, self.size, desc_index).inspect(|_| {
-            self.next_avail += Wrapping(1);
-        })
+        DescriptorChain::checked_new(self.desc_table_ptr, self.config.size, desc_index).inspect(
+            |_| {
+                self.next_avail += Wrapping(1);
+            },
+        )
     }
 
     /// Undo the effects of the last `self.pop()` call.
@@ -564,7 +604,7 @@ impl Queue {
         desc_index: u16,
         len: u32,
     ) -> Result<(), QueueError> {
-        if self.size <= desc_index {
+        if self.config.size <= desc_index {
             error!(
                 "attempted to add out of bounds descriptor to used ring: {}",
                 desc_index
@@ -572,7 +612,7 @@ impl Queue {
             return Err(QueueError::DescIndexOutOfBounds(desc_index));
         }
 
-        let next_used = (self.next_used + Wrapping(ring_index_offset)).0 % self.size;
+        let next_used = (self.next_used + Wrapping(ring_index_offset)).0 % self.config.size;
         let used_element = UsedElement {
             id: u32::from(desc_index),
             len,
@@ -621,9 +661,9 @@ impl Queue {
         if len != 0 {
             // The number of descriptor chain heads to process should always
             // be smaller or equal to the queue size.
-            if len > self.size {
+            if len > self.config.size {
                 return Err(InvalidAvailIdx {
-                    queue_size: self.size,
+                    queue_size: self.config.size,
                     reported_len: len,
                 });
             }
@@ -852,11 +892,11 @@ mod verification {
     fn less_arbitrary_queue() -> Queue {
         let mut queue = Queue::new(FIRECRACKER_MAX_QUEUE_SIZE);
 
-        queue.size = FIRECRACKER_MAX_QUEUE_SIZE;
-        queue.ready = true;
-        queue.desc_table_address = GuestAddress(QUEUE_BASE_ADDRESS);
-        queue.avail_ring_address = GuestAddress(AVAIL_RING_BASE_ADDRESS);
-        queue.used_ring_address = GuestAddress(USED_RING_BASE_ADDRESS);
+        queue.config.size = FIRECRACKER_MAX_QUEUE_SIZE;
+        queue.config.ready = true;
+        queue.config.desc_table_address = GuestAddress(QUEUE_BASE_ADDRESS);
+        queue.config.avail_ring_address = GuestAddress(AVAIL_RING_BASE_ADDRESS);
+        queue.config.used_ring_address = GuestAddress(USED_RING_BASE_ADDRESS);
         queue.next_avail = Wrapping(kani::any());
         queue.next_used = Wrapping(kani::any());
         queue.uses_notif_suppression = kani::any();
@@ -893,11 +933,11 @@ mod verification {
             // firecracker statically sets the maximal queue size to 256
             let mut queue = Queue::new(FIRECRACKER_MAX_QUEUE_SIZE);
 
-            queue.size = kani::any();
-            queue.ready = true;
-            queue.desc_table_address = GuestAddress(kani::any());
-            queue.avail_ring_address = GuestAddress(kani::any());
-            queue.used_ring_address = GuestAddress(kani::any());
+            queue.config.size = kani::any();
+            queue.config.ready = true;
+            queue.config.desc_table_address = GuestAddress(kani::any());
+            queue.config.avail_ring_address = GuestAddress(kani::any());
+            queue.config.used_ring_address = GuestAddress(kani::any());
             queue.next_avail = Wrapping(kani::any());
             queue.next_used = Wrapping(kani::any());
             queue.uses_notif_suppression = kani::any();
@@ -1034,7 +1074,7 @@ mod verification {
             // done. This is relying on implementation details of add_used, namely that
             // the check for out-of-bounds descriptor index happens at the very beginning of the
             // function.
-            assert!(used_desc_table_index >= queue.size);
+            assert!(used_desc_table_index >= queue.config.size);
         }
     }
 
@@ -1059,13 +1099,13 @@ mod verification {
                 if val == 0 { u64::MAX } else { val & (!val + 1) }
             }
 
-            assert!(alignment_of(queue.desc_table_address.0) >= 16);
-            assert!(alignment_of(queue.avail_ring_address.0) >= 2);
-            assert!(alignment_of(queue.used_ring_address.0) >= 4);
+            assert!(alignment_of(queue.config.desc_table_address.0) >= 16);
+            assert!(alignment_of(queue.config.avail_ring_address.0) >= 2);
+            assert!(alignment_of(queue.config.used_ring_address.0) >= 4);
 
             // length of queue must be power-of-two, and at most 2^15
-            assert_eq!(queue.size.count_ones(), 1);
-            assert!(queue.size <= 1u16 << 15);
+            assert_eq!(queue.config.size.count_ones(), 1);
+            assert!(queue.config.size <= 1u16 << 15);
         }
     }
 
@@ -1080,7 +1120,7 @@ mod verification {
     #[kani::unwind(0)]
     fn verify_avail_ring_ring_get() {
         let ProofContext(queue, _) = kani::any();
-        let x: usize = kani::any_where(|x| *x < usize::from(queue.size));
+        let x: usize = kani::any_where(|x| *x < usize::from(queue.config.size));
         unsafe { _ = queue.avail_ring_ring_get(x) };
     }
 
@@ -1102,7 +1142,7 @@ mod verification {
     #[kani::unwind(0)]
     fn verify_used_ring_ring_set() {
         let ProofContext(mut queue, _) = kani::any();
-        let x: usize = kani::any_where(|x| *x < usize::from(queue.size));
+        let x: usize = kani::any_where(|x| *x < usize::from(queue.config.size));
         let used_element = UsedElement {
             id: kani::any(),
             len: kani::any(),
@@ -1131,7 +1171,7 @@ mod verification {
         // is called when the queue is being initialized, e.g. empty. We compute it using
         // local variables here to make things easier on kani: One less roundtrip through vm-memory.
         let queue_len = queue.len();
-        kani::assume(queue_len <= queue.size);
+        kani::assume(queue_len <= queue.config.size);
 
         let next_avail = queue.next_avail;
 
@@ -1149,7 +1189,7 @@ mod verification {
         let ProofContext(mut queue, _) = kani::any();
 
         // See verify_pop for explanation
-        kani::assume(queue.len() <= queue.size);
+        kani::assume(queue.len() <= queue.config.size);
 
         let queue_clone = queue.clone();
         if let Some(_) = queue.pop().unwrap() {
@@ -1165,7 +1205,7 @@ mod verification {
     fn verify_try_enable_notification() {
         let ProofContext(mut queue, _) = ProofContext::bounded_queue();
 
-        kani::assume(queue.len() <= queue.size);
+        kani::assume(queue.len() <= queue.config.size);
 
         if queue.try_enable_notification().unwrap() && queue.uses_notif_suppression {
             // We only require new notifications if the queue is empty (e.g. we've processed
@@ -1183,16 +1223,17 @@ mod verification {
         let ProofContext(queue, mem) = kani::any();
 
         let index = kani::any();
-        let maybe_chain = DescriptorChain::checked_new(queue.desc_table_ptr, queue.size, index);
+        let maybe_chain =
+            DescriptorChain::checked_new(queue.desc_table_ptr, queue.config.size, index);
 
-        if index >= queue.size {
+        if index >= queue.config.size {
             assert!(maybe_chain.is_none())
         } else {
             // If the index was in-bounds for the descriptor table, we at least should be
             // able to compute the address of the descriptor table entry without going out
             // of bounds anywhere, and also read from that address.
             let desc_head = mem
-                .checked_offset(queue.desc_table_address, (index as usize) * 16)
+                .checked_offset(queue.config.desc_table_address, (index as usize) * 16)
                 .unwrap();
             mem.checked_offset(desc_head, 16).unwrap();
             let desc = mem.read_obj::<Descriptor>(desc_head).unwrap();
@@ -1200,7 +1241,7 @@ mod verification {
             match maybe_chain {
                 None => {
                     // This assert is the negation of the "is_valid" check in checked_new
-                    assert!(desc.flags & VIRTQ_DESC_F_NEXT == 1 && desc.next >= queue.size)
+                    assert!(desc.flags & VIRTQ_DESC_F_NEXT == 1 && desc.next >= queue.config.size)
                 }
                 Some(head) => {
                     assert!(head.is_valid())
@@ -1275,77 +1316,77 @@ mod tests {
         q.initialize(m).unwrap();
 
         // shouldn't be valid when not marked as ready
-        q.ready = false;
+        q.config.ready = false;
         assert!(matches!(q.initialize(m).unwrap_err(), QueueError::NotReady));
-        q.ready = true;
+        q.config.ready = true;
 
         // or when size > max_size
-        q.size = q.max_size << 1;
+        q.config.size = q.config.max_size << 1;
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::InvalidSize(_)
         ));
-        q.size = q.max_size;
+        q.config.size = q.config.max_size;
 
         // or when size is 0
-        q.size = 0;
+        q.config.size = 0;
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::InvalidSize(_)
         ));
-        q.size = q.max_size;
+        q.config.size = q.config.max_size;
 
         // or when size is not a power of 2
-        q.size = 11;
+        q.config.size = 11;
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::InvalidSize(_)
         ));
-        q.size = q.max_size;
+        q.config.size = q.config.max_size;
 
         // reset dirtied values
-        q.max_size = 16;
+        q.config.max_size = 16;
         q.next_avail = Wrapping(0);
-        m.write_obj::<u16>(0, q.avail_ring_address.unchecked_add(2))
+        m.write_obj::<u16>(0, q.config.avail_ring_address.unchecked_add(2))
             .unwrap();
 
         // or if the various addresses are off
 
-        q.desc_table_address = GuestAddress(0xffff_ff00);
+        q.config.desc_table_address = GuestAddress(0xffff_ff00);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::MemoryError(_)
         ));
-        q.desc_table_address = GuestAddress(0x1001);
+        q.config.desc_table_address = GuestAddress(0x1001);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::PointerNotAligned(_, _)
         ));
-        q.desc_table_address = vq.dtable_start();
+        q.config.desc_table_address = vq.dtable_start();
 
-        q.avail_ring_address = GuestAddress(0xffff_ff00);
+        q.config.avail_ring_address = GuestAddress(0xffff_ff00);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::MemoryError(_)
         ));
-        q.avail_ring_address = GuestAddress(0x1001);
+        q.config.avail_ring_address = GuestAddress(0x1001);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::PointerNotAligned(_, _)
         ));
-        q.avail_ring_address = vq.avail_start();
+        q.config.avail_ring_address = vq.avail_start();
 
-        q.used_ring_address = GuestAddress(0xffff_ff00);
+        q.config.used_ring_address = GuestAddress(0xffff_ff00);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::MemoryError(_)
         ));
-        q.used_ring_address = GuestAddress(0x1001);
+        q.config.used_ring_address = GuestAddress(0x1001);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::PointerNotAligned(_, _)
         ));
-        q.used_ring_address = vq.used_start();
+        q.config.used_ring_address = vq.used_start();
     }
 
     #[test]
@@ -1354,7 +1395,7 @@ mod tests {
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
         let mut q = vq.create_queue();
 
-        q.ready = true;
+        q.config.ready = true;
 
         // Let's create two simple descriptor chains.
 
@@ -1633,7 +1674,7 @@ mod tests {
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
         let mut q = vq.create_queue();
 
-        q.ready = true;
+        q.config.ready = true;
 
         // We create a simple descriptor chain
         vq.dtable[0].set(0x1000_u64, 0x1000, 0, 0);
@@ -1662,15 +1703,15 @@ mod tests {
     fn test_initialize_with_aligned_pointer() {
         let mut q = Queue::new(FIRECRACKER_MAX_QUEUE_SIZE);
 
-        q.ready = true;
-        q.size = q.max_size;
+        q.config.ready = true;
+        q.config.size = q.config.max_size;
 
         // Descriptor table must be 16-byte aligned.
-        q.desc_table_address = GuestAddress(16);
+        q.config.desc_table_address = GuestAddress(16);
         // Available ring must be 2-byte aligned.
-        q.avail_ring_address = GuestAddress(2);
+        q.config.avail_ring_address = GuestAddress(2);
         // Used ring must be 4-byte aligned.
-        q.avail_ring_address = GuestAddress(4);
+        q.config.avail_ring_address = GuestAddress(4);
 
         let mem = single_region_mem(0x10000);
         q.initialize(&mem).unwrap();
@@ -1679,12 +1720,12 @@ mod tests {
     #[test]
     fn test_initialize_with_misaligned_pointer() {
         let mut q = Queue::new(FIRECRACKER_MAX_QUEUE_SIZE);
-        q.ready = true;
-        q.size = q.max_size;
+        q.config.ready = true;
+        q.config.size = q.config.max_size;
         let mem = single_region_mem(0x1000);
 
         // Descriptor table must be 16-byte aligned.
-        q.desc_table_address = GuestAddress(0xb);
+        q.config.desc_table_address = GuestAddress(0xb);
         match q.initialize(&mem) {
             Ok(_) => panic!("Unexpected success"),
             Err(QueueError::PointerNotAligned(addr, alignment)) => {
@@ -1693,10 +1734,10 @@ mod tests {
             }
             Err(e) => panic!("Unexpected error {e:#?}"),
         }
-        q.desc_table_address = GuestAddress(0x0);
+        q.config.desc_table_address = GuestAddress(0x0);
 
         // Available ring must be 2-byte aligned.
-        q.avail_ring_address = GuestAddress(0x1);
+        q.config.avail_ring_address = GuestAddress(0x1);
         match q.initialize(&mem) {
             Ok(_) => panic!("Unexpected success"),
             Err(QueueError::PointerNotAligned(addr, alignment)) => {
@@ -1705,10 +1746,10 @@ mod tests {
             }
             Err(e) => panic!("Unexpected error {e:#?}"),
         }
-        q.avail_ring_address = GuestAddress(0x0);
+        q.config.avail_ring_address = GuestAddress(0x0);
 
         // Used ring must be 4-byte aligned.
-        q.used_ring_address = GuestAddress(0x3);
+        q.config.used_ring_address = GuestAddress(0x3);
         match q.initialize(&mem) {
             Ok(_) => panic!("unexpected success"),
             Err(QueueError::PointerNotAligned(addr, alignment)) => {

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -17,7 +17,9 @@ use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, Vir
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::iov_deque::IovDequeError;
 use crate::devices::virtio::iovec::IoVecBufferMut;
-use crate::devices::virtio::queue::{FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue};
+use crate::devices::virtio::queue::{
+    FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue, QueueConfig, QueueError,
+};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, debug, error};
@@ -267,16 +269,20 @@ impl VirtioDevice for Entropy {
         ENTROPY_DEV_ID
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_events
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_events.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -317,6 +323,17 @@ impl VirtioDevice for Entropy {
         true
     }
 
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
+    }
+
     fn activate(
         &mut self,
         mem: GuestMemoryMmap,
@@ -355,7 +372,7 @@ mod tests {
             self.queues = queues;
         }
 
-        fn num_queues(&self) -> usize {
+        fn num_queues_supported(&self) -> usize {
             RNG_NUM_QUEUES
         }
     }
@@ -434,7 +451,7 @@ mod tests {
         let mut entropy_dev = th.device();
 
         // This should succeed, we just added two descriptors
-        let desc = entropy_dev.queues_mut()[RNG_QUEUE].pop().unwrap().unwrap();
+        let desc = entropy_dev.queues[RNG_QUEUE].pop().unwrap().unwrap();
         assert!(matches!(
             // SAFETY: This descriptor chain is only loaded into one buffer
             unsafe { IoVecBufferMut::<256>::from_descriptor_chain(&mem, desc) },
@@ -442,7 +459,7 @@ mod tests {
         ));
 
         // This should succeed, we should have one more descriptor
-        let desc = entropy_dev.queues_mut()[RNG_QUEUE].pop().unwrap().unwrap();
+        let desc = entropy_dev.queues[RNG_QUEUE].pop().unwrap().unwrap();
         // SAFETY: This descriptor chain is only loaded into one buffer
         entropy_dev.buffer = unsafe { IoVecBufferMut::from_descriptor_chain(&mem, desc).unwrap() };
         entropy_dev.handle_one().unwrap();

--- a/src/vmm/src/devices/virtio/rng/event_handler.rs
+++ b/src/vmm/src/devices/virtio/rng/event_handler.rs
@@ -15,7 +15,7 @@ impl Entropy {
 
     fn register_runtime_events(&self, ops: &mut EventOps) {
         if let Err(err) = ops.add(Events::with_data(
-            &self.queue_events()[RNG_QUEUE],
+            self.queue_event(RNG_QUEUE).unwrap(),
             Self::PROCESS_ENTROPY_QUEUE,
             EventSet::IN,
         )) {

--- a/src/vmm/src/devices/virtio/rng/persist.rs
+++ b/src/vmm/src/devices/virtio/rng/persist.rs
@@ -45,7 +45,7 @@ impl Persist<'_> for Entropy {
 
     fn save(&self) -> Self::State {
         EntropyState {
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
             rate_limiter_state: self.rate_limiter().save(),
         }
     }

--- a/src/vmm/src/devices/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/test_utils.rs
@@ -295,11 +295,11 @@ impl<'a> VirtQueue<'a> {
     pub fn create_queue(&self) -> Queue {
         let mut q = Queue::new(self.size());
 
-        q.size = self.size();
-        q.ready = true;
-        q.desc_table_address = self.dtable_start();
-        q.avail_ring_address = self.avail_start();
-        q.used_ring_address = self.used_start();
+        q.config.size = self.size();
+        q.config.ready = true;
+        q.config.desc_table_address = self.dtable_start();
+        q.config.avail_ring_address = self.avail_start();
+        q.config.used_ring_address = self.used_start();
 
         q.initialize(self.memory()).unwrap();
 
@@ -346,7 +346,7 @@ pub(crate) mod test {
         /// Replace the queues used by the device
         fn set_queues(&mut self, queues: Vec<Queue>);
         /// Number of queues this device supports
-        fn num_queues(&self) -> usize;
+        fn num_queues_supported(&self) -> usize;
     }
 
     /// A helper type to allow testing VirtIO devices
@@ -402,7 +402,7 @@ pub(crate) mod test {
         pub fn new(mem: &'a GuestMemoryMmap, mut device: T) -> VirtioTestHelper<'a, T> {
             let mut event_manager = EventManager::new().unwrap();
 
-            let virtqueues = Self::create_virtqueues(mem, device.num_queues());
+            let virtqueues = Self::create_virtqueues(mem, device.num_queues_supported());
             let queues = virtqueues.iter().map(|vq| vq.create_queue()).collect();
             device.set_queues(queues);
             let device = Arc::new(Mutex::new(device));
@@ -466,7 +466,7 @@ pub(crate) mod test {
         ) {
             let device = self.device.lock().unwrap();
 
-            let event_fd = &device.queue_events()[queue];
+            let event_fd = device.queue_event(queue).unwrap();
             let vq = &self.virtqueues[queue];
 
             // Create the descriptor chain
@@ -518,7 +518,7 @@ pub(crate) mod test {
         ) {
             let device = self.device.lock().unwrap();
 
-            let event_fd = &device.queue_events()[queue];
+            let event_fd = device.queue_event(queue).unwrap();
             let vq = &self.virtqueues[queue];
 
             // Create the descriptor chain

--- a/src/vmm/src/devices/virtio/transport/mmio.rs
+++ b/src/vmm/src/devices/virtio/transport/mmio.rs
@@ -14,7 +14,7 @@ use vmm_sys_util::eventfd::EventFd;
 use super::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::virtio::device::VirtioDevice;
 use crate::devices::virtio::device_status;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::QueueConfig;
 use crate::logger::{IncMetric, METRICS, error, warn};
 use crate::utils::byte_order;
 use crate::vstate::bus::BusDevice;
@@ -101,24 +101,22 @@ impl MmioTransport {
 
     fn with_queue<U, F>(&self, d: U, f: F) -> U
     where
-        F: FnOnce(&Queue) -> U,
+        F: FnOnce(&QueueConfig) -> U,
         U: Debug,
     {
         match self
             .locked_device()
-            .queues()
-            .get(self.queue_select as usize)
+            .queue_config(self.queue_select as usize)
         {
             Some(queue) => f(queue),
             None => d,
         }
     }
 
-    fn with_queue_mut<F: FnOnce(&mut Queue)>(&mut self, f: F) -> bool {
+    fn with_queue_mut<F: FnOnce(&mut QueueConfig)>(&mut self, f: F) -> bool {
         if let Some(queue) = self
             .locked_device()
-            .queues_mut()
-            .get_mut(self.queue_select as usize)
+            .queue_config_mut(self.queue_select as usize)
         {
             f(queue);
             true
@@ -127,7 +125,7 @@ impl MmioTransport {
         }
     }
 
-    fn update_queue_field<F: FnOnce(&mut Queue)>(&mut self, f: F) {
+    fn update_queue_field<F: FnOnce(&mut QueueConfig)>(&mut self, f: F) {
         if self.check_device_status(
             device_status::FEATURES_OK,
             device_status::DRIVER_OK | device_status::FAILED,
@@ -479,6 +477,7 @@ pub(crate) mod tests {
     use crate::devices::virtio::ActivateError;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
     use crate::devices::virtio::device_status::DEVICE_NEEDS_RESET;
+    use crate::devices::virtio::queue::{Queue, QueueError};
     use crate::impl_device_type;
     use crate::test_utils::single_region_mem;
     use crate::utils::byte_order::{read_le_u32, write_le_u32};
@@ -545,16 +544,20 @@ pub(crate) mod tests {
             self.acked_features = acked_features;
         }
 
-        fn queues(&self) -> &[Queue] {
-            &self.queues
+        fn num_queues(&self) -> usize {
+            self.queues.len()
         }
 
-        fn queues_mut(&mut self) -> &mut [Queue] {
-            &mut self.queues
+        fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+            self.queues.get(index).map(|queue| &queue.config)
         }
 
-        fn queue_events(&self) -> &[EventFd] {
-            &self.queue_evts
+        fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+            self.queues.get_mut(index).map(|queue| &mut queue.config)
+        }
+
+        fn queue_event(&self, index: usize) -> Option<&EventFd> {
+            self.queue_evts.get(index)
         }
 
         fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -599,6 +602,17 @@ pub(crate) mod tests {
         fn _reset(&mut self) -> bool {
             !self.reset_should_fail
         }
+
+        fn reset_queues(&mut self) {
+            self.queues.iter_mut().for_each(Queue::reset);
+        }
+
+        fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+            for queue in &mut self.queues {
+                queue.initialize(mem)?;
+            }
+            Ok(())
+        }
     }
 
     fn set_device_status(d: &mut MmioTransport, status: u32) {
@@ -618,17 +632,32 @@ pub(crate) mod tests {
         // We just make sure here that the implementation of a mmio device behaves as we expect,
         // given a known virtio device implementation (the dummy device).
 
-        assert_eq!(d.locked_device().queue_events().len(), 2);
+        assert_eq!(d.locked_device().num_queues(), 2);
+        assert!(d.locked_device().queue_event(0).is_some());
+        assert!(d.locked_device().queue_event(1).is_some());
+        assert!(d.locked_device().queue_event(2).is_none());
 
         d.queue_select = 0;
         assert_eq!(d.with_queue(0, |q| q.max_size), 16);
         assert!(d.with_queue_mut(|q| q.size = 16));
-        assert_eq!(d.locked_device().queues()[d.queue_select as usize].size, 16);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(d.queue_select as usize)
+                .unwrap()
+                .size,
+            16
+        );
 
         d.queue_select = 1;
         assert_eq!(d.with_queue(0, |q| q.max_size), 32);
         assert!(d.with_queue_mut(|q| q.size = 16));
-        assert_eq!(d.locked_device().queues()[d.queue_select as usize].size, 16);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(d.queue_select as usize)
+                .unwrap()
+                .size,
+            16
+        );
 
         d.queue_select = 2;
         assert_eq!(d.with_queue(0, |q| q.max_size), 0);
@@ -818,43 +847,97 @@ pub(crate) mod tests {
         assert_eq!(d.queue_select, 3);
 
         d.queue_select = 0;
-        assert_eq!(d.locked_device().queues()[0].size, 16);
+        assert_eq!(d.locked_device().queue_config(0).unwrap().size, 16);
         write_le_u32(&mut buf[..], 16);
         d.write(0x0, 0x38, &buf[..]);
-        assert_eq!(d.locked_device().queues()[0].size, 16);
+        assert_eq!(d.locked_device().queue_config(0).unwrap().size, 16);
 
-        assert!(!d.locked_device().queues()[0].ready);
+        assert!(!d.locked_device().queue_config(0).unwrap().ready);
         write_le_u32(&mut buf[..], 1);
         d.write(0x0, 0x44, &buf[..]);
-        assert!(d.locked_device().queues()[0].ready);
+        assert!(d.locked_device().queue_config(0).unwrap().ready);
 
-        assert_eq!(d.locked_device().queues()[0].desc_table_address.0, 0);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .desc_table_address
+                .0,
+            0
+        );
         write_le_u32(&mut buf[..], 123);
         d.write(0x0, 0x80, &buf[..]);
-        assert_eq!(d.locked_device().queues()[0].desc_table_address.0, 123);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .desc_table_address
+                .0,
+            123
+        );
         d.write(0x0, 0x84, &buf[..]);
         assert_eq!(
-            d.locked_device().queues()[0].desc_table_address.0,
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .desc_table_address
+                .0,
             123 + (123 << 32)
         );
 
-        assert_eq!(d.locked_device().queues()[0].avail_ring_address.0, 0);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .avail_ring_address
+                .0,
+            0
+        );
         write_le_u32(&mut buf[..], 124);
         d.write(0x0, 0x90, &buf[..]);
-        assert_eq!(d.locked_device().queues()[0].avail_ring_address.0, 124);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .avail_ring_address
+                .0,
+            124
+        );
         d.write(0x0, 0x94, &buf[..]);
         assert_eq!(
-            d.locked_device().queues()[0].avail_ring_address.0,
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .avail_ring_address
+                .0,
             124 + (124 << 32)
         );
 
-        assert_eq!(d.locked_device().queues()[0].used_ring_address.0, 0);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .used_ring_address
+                .0,
+            0
+        );
         write_le_u32(&mut buf[..], 125);
         d.write(0x0, 0xa0, &buf[..]);
-        assert_eq!(d.locked_device().queues()[0].used_ring_address.0, 125);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .used_ring_address
+                .0,
+            125
+        );
         d.write(0x0, 0xa4, &buf[..]);
         assert_eq!(
-            d.locked_device().queues()[0].used_ring_address.0,
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .used_ring_address
+                .0,
             125 + (125 << 32)
         );
 
@@ -938,7 +1021,7 @@ pub(crate) mod tests {
         );
 
         let mut buf = [0; 4];
-        let queue_len = d.locked_device().queues().len();
+        let queue_len = d.locked_device().num_queues();
         for q in 0..queue_len {
             d.queue_select = q.try_into().unwrap();
             write_le_u32(&mut buf[..], 16);
@@ -990,7 +1073,7 @@ pub(crate) mod tests {
         );
 
         let mut buf = [0; 4];
-        let queue_len = d.locked_device().queues().len();
+        let queue_len = d.locked_device().num_queues();
         for q in 0..queue_len {
             d.queue_select = q.try_into().unwrap();
             write_le_u32(&mut buf[..], 16);
@@ -1037,7 +1120,7 @@ pub(crate) mod tests {
 
         // Setup queue data structures
         let mut buf = [0; 4];
-        let queues_count = d.locked_device().queues().len();
+        let queues_count = d.locked_device().num_queues();
         for q in 0..queues_count {
             d.queue_select = q.try_into().unwrap();
             write_le_u32(&mut buf[..], 16);
@@ -1218,11 +1301,23 @@ pub(crate) mod tests {
         dev.queue_select = 0;
 
         // Save the queue state right after activation.
-        let size_before = dev.locked_device().queues()[0].size;
-        let ready_before = dev.locked_device().queues()[0].ready;
-        let desc_before = dev.locked_device().queues()[0].desc_table_address;
-        let avail_before = dev.locked_device().queues()[0].avail_ring_address;
-        let used_before = dev.locked_device().queues()[0].used_ring_address;
+        let size_before = dev.locked_device().queue_config(0).unwrap().size;
+        let ready_before = dev.locked_device().queue_config(0).unwrap().ready;
+        let desc_before = dev
+            .locked_device()
+            .queue_config(0)
+            .unwrap()
+            .desc_table_address;
+        let avail_before = dev
+            .locked_device()
+            .queue_config(0)
+            .unwrap()
+            .avail_ring_address;
+        let used_before = dev
+            .locked_device()
+            .queue_config(0)
+            .unwrap()
+            .used_ring_address;
 
         // Attempt to poison every queue config register.
         let mut buf = [0u8; 4];
@@ -1230,19 +1325,28 @@ pub(crate) mod tests {
         // QueueNum (0x38)
         write_le_u32(&mut buf, 0);
         dev.write(0x0, 0x38, &buf);
-        assert_eq!(dev.locked_device().queues()[0].size, size_before);
+        assert_eq!(
+            dev.locked_device().queue_config(0).unwrap().size,
+            size_before
+        );
 
         // QueueReady (0x44)
         write_le_u32(&mut buf, 0);
         dev.write(0x0, 0x44, &buf);
-        assert_eq!(dev.locked_device().queues()[0].ready, ready_before);
+        assert_eq!(
+            dev.locked_device().queue_config(0).unwrap().ready,
+            ready_before
+        );
 
         // QueueDescLow/High (0x80, 0x84)
         write_le_u32(&mut buf, 0xDEADBEEF);
         dev.write(0x0, 0x80, &buf);
         dev.write(0x0, 0x84, &buf);
         assert_eq!(
-            dev.locked_device().queues()[0].desc_table_address,
+            dev.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .desc_table_address,
             desc_before
         );
 
@@ -1250,7 +1354,10 @@ pub(crate) mod tests {
         dev.write(0x0, 0x90, &buf);
         dev.write(0x0, 0x94, &buf);
         assert_eq!(
-            dev.locked_device().queues()[0].avail_ring_address,
+            dev.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .avail_ring_address,
             avail_before
         );
 
@@ -1258,7 +1365,10 @@ pub(crate) mod tests {
         dev.write(0x0, 0xa0, &buf);
         dev.write(0x0, 0xa4, &buf);
         assert_eq!(
-            dev.locked_device().queues()[0].used_ring_address,
+            dev.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .used_ring_address,
             used_before
         );
     }

--- a/src/vmm/src/devices/virtio/transport/pci/common_config.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/common_config.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use vm_memory::GuestAddress;
 
 use crate::devices::virtio::device::VirtioDevice;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::QueueConfig;
 use crate::devices::virtio::transport::pci::common_config_offset::*;
 use crate::devices::virtio::transport::pci::device::VIRTQ_MSI_NO_VECTOR;
 use crate::devices::virtio::transport::pci::device_status::*;
@@ -74,6 +74,7 @@ impl VirtioPciCommonConfig {
 
     pub fn read(&mut self, offset: u64, data: &mut [u8], device: Arc<Mutex<dyn VirtioDevice>>) {
         assert!(data.len() <= 8);
+        let queue_index = self.queue_select as usize;
 
         match data.len() {
             1 => {
@@ -81,11 +82,21 @@ impl VirtioPciCommonConfig {
                 data[0] = v;
             }
             2 => {
-                let v = self.read_common_config_word(offset, device.lock().unwrap().queues());
+                let locked_device = device.lock().unwrap();
+                let v = self.read_common_config_word(
+                    offset,
+                    locked_device.num_queues(),
+                    locked_device.queue_config(queue_index),
+                );
                 LittleEndian::write_u16(data, v);
             }
             4 => {
-                let v = self.read_common_config_dword(offset, device);
+                let locked_device = device.lock().unwrap();
+                let v = self.read_common_config_dword(
+                    offset,
+                    locked_device.avail_features(),
+                    locked_device.queue_config(queue_index),
+                );
                 LittleEndian::write_u32(data, v);
             }
             _ => warn!(
@@ -103,14 +114,18 @@ impl VirtioPciCommonConfig {
         device_activated: bool,
     ) {
         assert!(data.len() <= 8);
+        let queue_index = self.queue_select as usize;
 
         match data.len() {
             1 => self.write_common_config_byte(offset, data[0], device_activated),
-            2 => self.write_common_config_word(
-                offset,
-                LittleEndian::read_u16(data),
-                device.lock().unwrap().queues_mut(),
-            ),
+            2 => {
+                let mut locked_device = device.lock().unwrap();
+                self.write_common_config_word(
+                    offset,
+                    LittleEndian::read_u16(data),
+                    locked_device.queue_config_mut(queue_index),
+                );
+            }
             4 => self.write_common_config_dword(offset, LittleEndian::read_u32(data), device),
             _ => warn!(
                 "pci: invalid data length for virtio write: len {}",
@@ -206,12 +221,17 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    fn read_common_config_word(&self, offset: u64, queues: &[Queue]) -> u16 {
+    fn read_common_config_word(
+        &self,
+        offset: u64,
+        num_queues: usize,
+        queue: Option<&QueueConfig>,
+    ) -> u16 {
         match offset {
             MSIX_CONFIG => self.msix_config.load(Ordering::Acquire),
-            NUM_QUEUES => queues.len().try_into().unwrap(),
+            NUM_QUEUES => num_queues.try_into().unwrap(),
             QUEUE_SELECT => self.queue_select,
-            QUEUE_SIZE => self.with_queue(queues, |q| q.size).unwrap_or(0),
+            QUEUE_SIZE => queue.map(|q| q.size).unwrap_or(0),
             // If `queue_select` points to an invalid queue we should return NO_VECTOR.
             // Reading from here
             // https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-1280005:
@@ -225,7 +245,7 @@ impl VirtioPciCommonConfig {
                 .get(self.queue_select as usize)
                 .copied()
                 .unwrap_or(VIRTQ_MSI_NO_VECTOR),
-            QUEUE_ENABLE => u16::from(self.with_queue(queues, |q| q.ready).unwrap_or(false)),
+            QUEUE_ENABLE => u16::from(queue.map(|q| q.ready).unwrap_or(false)),
             QUEUE_NOTIFY_OFF => self.queue_select,
             _ => {
                 warn!("pci: invalid virtio register word read: 0x{:x}", offset);
@@ -241,10 +261,16 @@ impl VirtioPciCommonConfig {
     /// https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-1220001
     ///
     /// Queue configuration must only be done between FEATURES_OK and DRIVER_OK.
-    fn update_queue_field<F: FnOnce(&mut Queue)>(&mut self, queues: &mut [Queue], f: F) {
+    fn update_queue_field<F: FnOnce(&mut QueueConfig)>(
+        &mut self,
+        queue: Option<&mut QueueConfig>,
+        f: F,
+    ) {
         let status = self.driver_status;
         if status == (ACKNOWLEDGE | DRIVER | FEATURES_OK) {
-            self.with_queue_mut(queues, f);
+            if let Some(queue) = queue {
+                f(queue);
+            }
         } else {
             warn!(
                 "pci: queue config write not allowed in device status {:#x}",
@@ -253,7 +279,12 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    fn write_common_config_word(&mut self, offset: u64, value: u16, queues: &mut [Queue]) {
+    fn write_common_config_word(
+        &mut self,
+        offset: u64,
+        value: u16,
+        queue: Option<&mut QueueConfig>,
+    ) {
         match offset {
             MSIX_CONFIG => {
                 // Make sure that the guest doesn't select an invalid vector. We are offering
@@ -270,7 +301,7 @@ impl VirtioPciCommonConfig {
                 }
             }
             QUEUE_SELECT => self.queue_select = value,
-            QUEUE_SIZE => self.update_queue_field(queues, |q| q.size = value),
+            QUEUE_SIZE => self.update_queue_field(queue, |q| q.size = value),
             QUEUE_MSIX_VECTOR => {
                 let mut msix_queues = self.msix_queues.lock().expect("Poisoned lock");
                 let nr_vectors = msix_queues.len() + 1;
@@ -287,7 +318,7 @@ impl VirtioPciCommonConfig {
                     }
                 }
             }
-            QUEUE_ENABLE => self.update_queue_field(queues, |q| {
+            QUEUE_ENABLE => self.update_queue_field(queue, |q| {
                 if value != 0 {
                     q.ready = value == 1;
                 }
@@ -298,63 +329,42 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    fn read_common_config_dword(&self, offset: u64, device: Arc<Mutex<dyn VirtioDevice>>) -> u32 {
+    fn read_common_config_dword(
+        &self,
+        offset: u64,
+        avail_features: u64,
+        queue: Option<&QueueConfig>,
+    ) -> u32 {
         match offset {
             DEVICE_FEATURE_SELECT => self.device_feature_select,
             DEVICE_FEATURE => {
-                let locked_device = device.lock().unwrap();
                 // Only 64 bits of features (2 pages) are defined for now, so limit
                 // device_feature_select to avoid shifting by 64 or more bits.
                 if self.device_feature_select < 2 {
-                    ((locked_device.avail_features() >> (self.device_feature_select * 32))
-                        & 0xffff_ffff) as u32
+                    ((avail_features >> (self.device_feature_select * 32)) & 0xffff_ffff) as u32
                 } else {
                     0
                 }
             }
             DRIVER_FEATURE_SELECT => self.driver_feature_select,
-            QUEUE_DESC_LO => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.desc_table_address.0 & 0xffff_ffff) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_DESC_HI => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.desc_table_address.0 >> 32) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_AVAIL_LO => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.avail_ring_address.0 & 0xffff_ffff) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_AVAIL_HI => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.avail_ring_address.0 >> 32) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_USED_LO => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.used_ring_address.0 & 0xffff_ffff) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_USED_HI => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.used_ring_address.0 >> 32) as u32
-                })
-                .unwrap_or_default()
-            }
+            QUEUE_DESC_LO => queue
+                .map(|q| (q.desc_table_address.0 & 0xffff_ffff) as u32)
+                .unwrap_or_default(),
+            QUEUE_DESC_HI => queue
+                .map(|q| (q.desc_table_address.0 >> 32) as u32)
+                .unwrap_or_default(),
+            QUEUE_AVAIL_LO => queue
+                .map(|q| (q.avail_ring_address.0 & 0xffff_ffff) as u32)
+                .unwrap_or_default(),
+            QUEUE_AVAIL_HI => queue
+                .map(|q| (q.avail_ring_address.0 >> 32) as u32)
+                .unwrap_or_default(),
+            QUEUE_USED_LO => queue
+                .map(|q| (q.used_ring_address.0 & 0xffff_ffff) as u32)
+                .unwrap_or_default(),
+            QUEUE_USED_HI => queue
+                .map(|q| (q.used_ring_address.0 >> 32) as u32)
+                .unwrap_or_default(),
             _ => {
                 warn!("pci: invalid virtio register dword read: 0x{:x}", offset);
                 0
@@ -377,6 +387,7 @@ impl VirtioPciCommonConfig {
         }
 
         let mut locked_device = device.lock().unwrap();
+        let queue_index = self.queue_select as usize;
 
         match offset {
             DEVICE_FEATURE_SELECT => self.device_feature_select = value,
@@ -393,40 +404,33 @@ impl VirtioPciCommonConfig {
                     );
                 }
             }
-            QUEUE_DESC_LO => self.update_queue_field(locked_device.queues_mut(), |q| {
-                lo(&mut q.desc_table_address, value)
-            }),
-            QUEUE_DESC_HI => self.update_queue_field(locked_device.queues_mut(), |q| {
-                hi(&mut q.desc_table_address, value)
-            }),
-            QUEUE_AVAIL_LO => self.update_queue_field(locked_device.queues_mut(), |q| {
-                lo(&mut q.avail_ring_address, value)
-            }),
-            QUEUE_AVAIL_HI => self.update_queue_field(locked_device.queues_mut(), |q| {
-                hi(&mut q.avail_ring_address, value)
-            }),
-            QUEUE_USED_LO => self.update_queue_field(locked_device.queues_mut(), |q| {
-                lo(&mut q.used_ring_address, value)
-            }),
-            QUEUE_USED_HI => self.update_queue_field(locked_device.queues_mut(), |q| {
-                hi(&mut q.used_ring_address, value)
-            }),
+            QUEUE_DESC_LO => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    lo(&mut q.desc_table_address, value)
+                }),
+            QUEUE_DESC_HI => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    hi(&mut q.desc_table_address, value)
+                }),
+            QUEUE_AVAIL_LO => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    lo(&mut q.avail_ring_address, value)
+                }),
+            QUEUE_AVAIL_HI => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    hi(&mut q.avail_ring_address, value)
+                }),
+            QUEUE_USED_LO => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    lo(&mut q.used_ring_address, value)
+                }),
+            QUEUE_USED_HI => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    hi(&mut q.used_ring_address, value)
+                }),
             _ => {
                 warn!("pci: invalid virtio register dword write: 0x{:x}", offset);
             }
-        }
-    }
-
-    fn with_queue<U, F>(&self, queues: &[Queue], f: F) -> Option<U>
-    where
-        F: FnOnce(&Queue) -> U,
-    {
-        queues.get(self.queue_select as usize).map(f)
-    }
-
-    fn with_queue_mut<F: FnOnce(&mut Queue)>(&self, queues: &mut [Queue], f: F) {
-        if let Some(queue) = queues.get_mut(self.queue_select as usize) {
-            f(queue);
         }
     }
 }
@@ -779,7 +783,12 @@ mod tests {
             config.read(QUEUE_SIZE, len.as_mut_slice(), device.clone());
             assert_eq!(
                 len,
-                device.lock().unwrap().queues()[queue_id as usize].max_size
+                device
+                    .lock()
+                    .unwrap()
+                    .queue_config(queue_id as usize)
+                    .unwrap()
+                    .max_size
             );
             max_size[queue_id as usize] = len;
         }
@@ -1006,8 +1015,12 @@ mod tests {
         // > MAY access each of the high and low 32-bit parts of the field independently.
 
         // 64-bit fields
-        device.lock().unwrap().queues_mut()[0].desc_table_address =
-            GuestAddress(0x0000_1312_0000_1110);
+        device
+            .lock()
+            .unwrap()
+            .queue_config_mut(0)
+            .unwrap()
+            .desc_table_address = GuestAddress(0x0000_1312_0000_1110);
         let mut buffer = [0u8; 8];
         config.read(QUEUE_DESC_LO, &mut buffer[..1], device.clone());
         assert_eq!(buffer, [0u8; 8]);

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -370,7 +370,7 @@ impl VirtioPciDevice {
         msix_vectors: Arc<MsixVectorGroup>,
         sbdf: PciSBDF,
     ) -> Result<Self, VirtioPciDeviceError> {
-        let num_queues = device.lock().expect("Poisoned lock").queues().len();
+        let num_queues = device.lock().expect("Poisoned lock").num_queues();
 
         let msix_config = Arc::new(Mutex::new(MsixConfig::new(msix_vectors.clone(), sbdf)));
         let pci_config = Self::pci_configuration(
@@ -621,14 +621,11 @@ impl VirtioPciDevice {
 
     fn set_notification_ioevents(&self, vm: &KvmVm, assign: bool) -> Result<(), errno::Error> {
         let bar_addr = self.config_bar_addr();
-        for (i, queue_evt) in self
-            .device
-            .lock()
-            .expect("Poisoned lock")
-            .queue_events()
-            .iter()
-            .enumerate()
-        {
+        let device = self.device.lock().expect("Poisoned lock");
+        for i in 0..device.num_queues() {
+            let queue_evt = device
+                .queue_event(i)
+                .expect("queue event must exist for each advertised queue");
             let notify_base = bar_addr + u64::from(NOTIFICATION_BAR_OFFSET);
             let io_addr =
                 IoEventAddress::Mmio(notify_base + i as u64 * u64::from(NOTIFY_OFF_MULTIPLIER));

--- a/src/vmm/src/devices/virtio/vhost_user.rs
+++ b/src/vmm/src/devices/virtio/vhost_user.rs
@@ -408,24 +408,24 @@ impl<T: VhostUserHandleBackend> VhostUserHandleImpl<T> {
         // at early stage.
         for (queue_index, queue, _) in queues.iter() {
             self.vu
-                .set_vring_num(*queue_index, queue.size)
+                .set_vring_num(*queue_index, queue.config.size)
                 .map_err(VhostUserError::VhostUserSetVringNum)?;
         }
 
         for (queue_index, queue, queue_evt) in queues.iter() {
             let config_data = VringConfigData {
-                queue_max_size: queue.max_size,
-                queue_size: queue.size,
+                queue_max_size: queue.config.max_size,
+                queue_size: queue.config.size,
                 flags: 0u32,
                 desc_table_addr: mem
-                    .get_host_address(queue.desc_table_address)
+                    .get_host_address(queue.config.desc_table_address)
                     .map_err(VhostUserError::DescriptorTableAddress)?
                     as u64,
                 used_ring_addr: mem
-                    .get_host_address(queue.used_ring_address)
+                    .get_host_address(queue.config.used_ring_address)
                     .map_err(VhostUserError::UsedAddress)? as u64,
                 avail_ring_addr: mem
-                    .get_host_address(queue.avail_ring_address)
+                    .get_host_address(queue.config.avail_ring_address)
                     .map_err(VhostUserError::AvailAddress)? as u64,
                 log_addr: None,
             };
@@ -909,8 +909,8 @@ pub(crate) mod tests {
         let guest_memory = create_mem(file, &regions);
 
         let mut queue = Queue::new(128);
-        queue.ready = true;
-        queue.size = queue.max_size;
+        queue.config.ready = true;
+        queue.config.size = queue.config.max_size;
         queue.initialize(&guest_memory).unwrap();
 
         let event_fd = EventFd::new(0).unwrap();
@@ -931,13 +931,13 @@ pub(crate) mod tests {
                 queue_size: 128,
                 flags: 0,
                 desc_table_addr: guest_memory
-                    .get_host_address(queue.desc_table_address)
+                    .get_host_address(queue.config.desc_table_address)
                     .unwrap() as u64,
                 used_ring_addr: guest_memory
-                    .get_host_address(queue.used_ring_address)
+                    .get_host_address(queue.config.used_ring_address)
                     .unwrap() as u64,
                 avail_ring_addr: guest_memory
-                    .get_host_address(queue.avail_ring_address)
+                    .get_host_address(queue.config.avail_ring_address)
                     .unwrap() as u64,
                 log_addr: None,
             },

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -34,7 +34,7 @@ use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_config::{VIRTIO_F_IN_ORDER, VIRTIO_F_VERSION_1};
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::{InvalidAvailIdx, Queue as VirtQueue};
+use crate::devices::virtio::queue::{InvalidAvailIdx, Queue as VirtQueue, QueueConfig, QueueError};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::virtio::vsock::VsockError;
 use crate::devices::virtio::vsock::metrics::METRICS;
@@ -312,16 +312,20 @@ where
         self.acked_features = acked_features
     }
 
-    fn queues(&self) -> &[VirtQueue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [VirtQueue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_events
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_events.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -408,6 +412,17 @@ where
         self.tx_packet.clear();
         self.pending_event_ack = false;
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(VirtQueue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 
     fn kick(&mut self) {

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -91,7 +91,7 @@ where
     fn save(&self) -> Self::State {
         VsockFrontendState {
             cid: self.cid(),
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
         }
     }
 

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -125,9 +125,9 @@ impl TestContext {
         const MEM_SIZE: usize = 1024 * 1024 * 128;
         let mem = single_region_mem(MEM_SIZE);
         let mut device = Vsock::new(CID, TestBackend::new()).unwrap();
-        for q in device.queues_mut() {
-            q.ready = true;
-            q.size = q.max_size;
+        for q in &mut device.queues {
+            q.config.ready = true;
+            q.config.size = q.config.max_size;
         }
         Self {
             cid: CID,

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -3,6 +3,8 @@
 
 use std::fmt;
 use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use utils::time::TimerFd;
@@ -301,7 +303,7 @@ pub struct RateLimiter {
 
     timer_fd: TimerFd,
     // Internal flag that quickly determines timer state.
-    timer_active: bool,
+    timer_active: Arc<AtomicBool>,
 }
 
 impl PartialEq for RateLimiter {
@@ -367,7 +369,7 @@ impl RateLimiter {
             bandwidth: bytes_token_bucket,
             ops: ops_token_bucket,
             timer_fd,
-            timer_active: false,
+            timer_active: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -375,7 +377,7 @@ impl RateLimiter {
     fn activate_timer(&mut self, one_shot_duration: Duration) {
         // Register the timer; don't care about its previous state
         self.timer_fd.arm(one_shot_duration, None);
-        self.timer_active = true;
+        self.timer_active.store(true, Ordering::Relaxed);
     }
 
     /// Attempts to consume tokens and returns whether that is possible.
@@ -383,7 +385,7 @@ impl RateLimiter {
     /// If rate limiting is disabled on provided `token_type`, this function will always succeed.
     pub fn consume(&mut self, tokens: u64, token_type: TokenType) -> bool {
         // If the timer is active, we can't consume tokens from any bucket and the function fails.
-        if self.timer_active {
+        if self.is_blocked() {
             return false;
         }
 
@@ -400,7 +402,7 @@ impl RateLimiter {
                 // register a timer to replenish the bucket and resume processing;
                 // make sure there is only one running timer for this limiter.
                 BucketReduction::Failure => {
-                    if !self.timer_active {
+                    if !self.is_blocked() {
                         self.activate_timer(REFILL_TIMER_DURATION);
                     }
                     false
@@ -451,7 +453,7 @@ impl RateLimiter {
     /// budget for it.
     /// An event will be generated on the exported FD when the limiter 'unblocks'.
     pub fn is_blocked(&self) -> bool {
-        self.timer_active
+        self.timer_active.load(Ordering::Relaxed)
     }
 
     /// This function needs to be called every time there is an event on the
@@ -464,7 +466,7 @@ impl RateLimiter {
         match self.timer_fd.read() {
             0 => Err(RateLimiterError::SpuriousRateLimiterEvent),
             _ => {
-                self.timer_active = false;
+                self.timer_active.store(false, Ordering::Relaxed);
                 Ok(())
             }
         }

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -456,6 +456,11 @@ impl RateLimiter {
         self.timer_active.load(Ordering::Relaxed)
     }
 
+    /// Clones the shared blocked-state flag for lock free checks
+    pub(crate) fn clone_blocked_flag(&self) -> Arc<AtomicBool> {
+        self.timer_active.clone()
+    }
+
     /// This function needs to be called every time there is an event on the
     /// FD provided by this object's `AsRawFd` trait implementation.
     ///

--- a/src/vmm/src/rate_limiter/persist.rs
+++ b/src/vmm/src/rate_limiter/persist.rs
@@ -86,7 +86,7 @@ impl Persist<'_> for RateLimiter {
                 None
             },
             timer_fd: TimerFd::new(),
-            timer_active: false,
+            timer_active: Arc::new(AtomicBool::new(false)),
         };
 
         Ok(rate_limiter)


### PR DESCRIPTION
_[5/12] part of the PR stack starting with [#6123](https://github.com/firecracker-microvm/firecracker/pull/6123)_

## Changes

Add inline and threaded active states and transfer runtime resources to
the worker thread during activation.

Keep queue config and interrupt state on the VMM thread and register
runtime events on the thread that owns the data path.