### PR TITLE
[blk-threaded - 11/12] api: expose threaded virtio-block

### DIFF
--- a/docs/seccompiler.md
+++ b/docs/seccompiler.md
@@ -77,8 +77,11 @@ This means that Firecracker has a JSON file for each supported target (currently
 determined by the arch-libc combinations). You can view them in
 `resources/seccomp`.
 
-At the top level, the file requires an object that maps thread categories (vmm,
-api and vcpu) to seccomp filters:
+At the top level, the file contains an object that maps thread categories to
+seccomp filters. Firecracker allows the `vmm`, `api`, `vcpu`, and `blk_worker`
+categories. The `vmm`, `api`, and `vcpu` categories are mandatory. The
+`blk_worker` category is optional and is needed only when a block device uses a
+dedicated worker thread.
 
 ```
 {
@@ -91,6 +94,7 @@ api and vcpu) to seccomp filters:
     },
     "api": {...},
     "vcpu": {...},
+    "blk_worker": {...}
 }
 ```
 

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -8,6 +8,10 @@
                 "comment": "Used when creating snapshots in vmm:persist::snapshot_memory_to_file through std::fs::File::metadata"
             },
             {
+                "syscall": "epoll_create1",
+                "comment": "Used by the threaded block worker's EventManager::new(), which runs on the spawned worker thread under the inherited vmm filter before it applies its own blk_worker filter"
+            },
+            {
                 "syscall": "epoll_ctl"
             },
             {
@@ -393,6 +397,28 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used to allocate the threaded block worker's thread stack (spawned from the VMM thread, so checked against this inherited filter)",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 131106,
+                        "comment": "libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_STACK"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {
+                            "masked_eq": 4
+                        },
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
                 "syscall": "memfd_create",
                 "comment": "Used by IovDeque ring buffer for net device hotplug",
                 "args": [
@@ -415,6 +441,19 @@
                         "op": "eq",
                         "val": 1033,
                         "comment": "F_ADD_SEALS"
+                    }
+                ]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "Used by EventFd::try_clone() when spawning the threaded block worker (control_evt/queue_evts duplication on the VMM thread)",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1030,
+                        "comment": "F_DUPFD_CLOEXEC"
                     }
                 ]
             },
@@ -710,6 +749,70 @@
                         "op": {"masked_eq": 4},
                         "val": 0,
                         "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "clone",
+                "comment": "Used by musl pthread_create to spawn the block worker thread",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": {"masked_eq": 4290772991},
+                        "val": 4001536,
+                        "comment": "Require the pthread clone flags and allow only the optional obsolete CLONE_DETACHED bit"
+                    }
+                ]
+            },
+            {
+                "syscall": "prctl",
+                "comment": "Used by musl to set the block worker thread name",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 15,
+                        "comment": "PR_SET_NAME"
+                    }
+                ]
+            },
+            {
+                "syscall": "prctl",
+                "comment": "Used to set no_new_privs before applying the block worker seccomp filter",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 38,
+                        "comment": "PR_SET_NO_NEW_PRIVS"
+                    },
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1
+                    }
+                ]
+            },
+            {
+                "syscall": "seccomp",
+                "comment": "Used to apply the block worker seccomp filter",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "SECCOMP_SET_MODE_FILTER"
+                    },
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 0
                     }
                 ]
             }
@@ -1347,6 +1450,201 @@
                         "comment": "KVM_IRQFD"
                     }
                 ]
+            }
+        ]
+    },
+    "blk_worker": {
+        "default_action": "trap",
+        "filter_action": "allow",
+        "filter": [
+            {
+                "syscall": "epoll_ctl"
+            },
+            {
+                "syscall": "epoll_pwait"
+            },
+            {
+                "syscall": "lseek",
+                "comment": "SyncFileEngine seeks to the request offset before each read/write"
+            },
+            {
+                "syscall": "futex",
+                "comment": "Locking the Arc<Mutex<ThreadedWorker>> data path"
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Allocator growth during I/O",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 34,
+                        "comment": "libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used by io_uring for mapping the queues during drive patch",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 32769,
+                        "comment": "libc::MAP_SHARED | libc::MAP_POPULATE"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used for reading the timezone in LocalTime::now()",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "libc::MAP_SHARED"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "munmap"
+            },
+            {
+                "syscall": "sigaltstack"
+            },
+            {
+                "syscall": "rt_sigprocmask"
+            },
+            {
+                "syscall": "rt_sigaction",
+                "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
+                "syscall": "exit",
+                "comment": "Worker thread exit on Finish"
+            },
+            {
+                "syscall": "exit_group",
+                "comment": "Used by the fatal signal handlers (vmm::signal_handler::exit_with_code) to terminate the process"
+            },
+            {
+                "syscall": "tkill",
+                "comment": "tkill is used by libc::abort during a panic to raise SIGABRT",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
+                "syscall": "read"
+            },
+            {
+                "syscall": "write"
+            },
+            {
+                "syscall": "fsync"
+            },
+            {
+                "syscall": "openat",
+                "comment": "Used to open the replacement backing file during drive patch and rescan"
+            },
+            {
+                "syscall": "close"
+            },
+            {
+                "syscall": "io_uring_enter",
+                "comment": "Used for submitting io_uring requests"
+            },
+            {
+                "syscall": "io_uring_setup",
+                "comment": "Rebuilding the io_uring ring on the worker thread during drive patch (update_file)"
+            },
+            {
+                "syscall": "io_uring_register",
+                "comment": "Registering fixed fds/opcode restrictions when rebuilding the ring on drive patch"
+            },
+            {
+                "syscall": "gettid",
+                "comment": "Rust std uses it during panic to print the thread id."
+            },
+            {
+                "syscall": "clock_gettime",
+                "comment": "Used for metrics and logging, via the helpers in utils/src/time.rs. It's not called on some platforms, because of vdso optimisations."
+            },
+            {
+                "syscall": "timerfd_settime",
+                "comment": "Needed for rate limiting and metrics",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 0
+                    }
+                ]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "Used by snapshotting, drive patching and rescanning",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 2,
+                        "comment": "FCNTL_F_SETFD"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "FCNTL_FD_CLOEXEC"
+                    }
+                ]
+            },
+            {
+                "syscall": "fstat",
+                "comment": "Used by disk update"
             }
         ]
     }

--- a/resources/seccomp/unimplemented.json
+++ b/resources/seccomp/unimplemented.json
@@ -13,5 +13,10 @@
         "default_action": "allow",
         "filter_action": "trap",
         "filter": []
+    },
+    "blk_worker": {
+        "default_action": "allow",
+        "filter_action": "trap",
+        "filter": []
     }
 }

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -8,6 +8,10 @@
                 "comment": "Used when creating snapshots in vmm:persist::snapshot_memory_to_file through std::fs::File::metadata"
             },
             {
+                "syscall": "epoll_create1",
+                "comment": "Used by the threaded block worker's EventManager::new(), which runs on the spawned worker thread under the inherited vmm filter before it applies its own blk_worker filter"
+            },
+            {
                 "syscall": "epoll_ctl"
             },
             {
@@ -393,6 +397,28 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used to allocate the threaded block worker's thread stack (spawned from the VMM thread, so checked against this inherited filter)",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 131106,
+                        "comment": "libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_STACK"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {
+                            "masked_eq": 4
+                        },
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
                 "syscall": "memfd_create",
                 "comment": "Used by IovDeque ring buffer for net device hotplug",
                 "args": [
@@ -415,6 +441,19 @@
                         "op": "eq",
                         "val": 1033,
                         "comment": "F_ADD_SEALS"
+                    }
+                ]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "Used by EventFd::try_clone() when spawning the threaded block worker (control_evt/queue_evts duplication on the VMM thread)",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1030,
+                        "comment": "F_DUPFD_CLOEXEC"
                     }
                 ]
             },
@@ -722,6 +761,70 @@
                         "op": {"masked_eq": 4},
                         "val": 0,
                         "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "clone",
+                "comment": "Used by musl pthread_create to spawn the block worker thread",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": {"masked_eq": 4290772991},
+                        "val": 4001536,
+                        "comment": "Require the pthread clone flags and allow only the optional obsolete CLONE_DETACHED bit"
+                    }
+                ]
+            },
+            {
+                "syscall": "prctl",
+                "comment": "Used by musl to set the block worker thread name",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 15,
+                        "comment": "PR_SET_NAME"
+                    }
+                ]
+            },
+            {
+                "syscall": "prctl",
+                "comment": "Used to set no_new_privs before applying the block worker seccomp filter",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 38,
+                        "comment": "PR_SET_NO_NEW_PRIVS"
+                    },
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1
+                    }
+                ]
+            },
+            {
+                "syscall": "seccomp",
+                "comment": "Used to apply the block worker seccomp filter",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "SECCOMP_SET_MODE_FILTER"
+                    },
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 0
                     }
                 ]
             }
@@ -1479,6 +1582,200 @@
                         "comment": "KVM_IRQFD"
                     }
                 ]
+            }
+        ]
+    },
+    "blk_worker": {
+        "default_action": "trap",
+        "filter_action": "allow",
+        "filter": [
+            {
+                "syscall": "epoll_ctl"
+            },
+            {
+                "syscall": "lseek",
+                "comment": "SyncFileEngine seeks to the request offset before each read/write"
+            },
+            {
+                "syscall": "futex",
+                "comment": "Locking the Arc<Mutex<ThreadedWorker>> data path"
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Allocator growth during I/O",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 34,
+                        "comment": "libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used by io_uring for mapping the queues during drive patch",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 32769,
+                        "comment": "libc::MAP_SHARED | libc::MAP_POPULATE"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used for reading the timezone in LocalTime::now()",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "libc::MAP_SHARED"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": {"masked_eq": 4},
+                        "val": 0,
+                        "comment": "Ensure PROT_EXEC is not set"
+                    }
+                ]
+            },
+            {
+                "syscall": "munmap"
+            },
+            {
+                "syscall": "sigaltstack"
+            },
+            {
+                "syscall": "rt_sigprocmask"
+            },
+            {
+                "syscall": "rt_sigaction",
+                "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
+                "syscall": "exit",
+                "comment": "Worker thread exit on Finish"
+            },
+            {
+                "syscall": "exit_group",
+                "comment": "Used by the fatal signal handlers (vmm::signal_handler::exit_with_code) to terminate the process"
+            },
+            {
+                "syscall": "tkill",
+                "comment": "tkill is used by libc::abort during a panic to raise SIGABRT",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
+                "syscall": "epoll_pwait"
+            },
+            {
+                "syscall": "read"
+            },
+            {
+                "syscall": "write"
+            },
+            {
+                "syscall": "fsync"
+            },
+            {
+                "syscall": "open"
+            },
+            {
+                "syscall": "close"
+            },
+            {
+                "syscall": "io_uring_enter",
+                "comment": "Used for submitting io_uring requests"
+            },
+            {
+                "syscall": "io_uring_setup",
+                "comment": "Rebuilding the io_uring ring on the worker thread during drive patch (update_file)"
+            },
+            {
+                "syscall": "io_uring_register",
+                "comment": "Registering fixed fds/opcode restrictions when rebuilding the ring on drive patch"
+            },
+            {
+                "syscall": "gettid",
+                "comment": "Rust std uses it during panic to print the thread id."
+            },
+            {
+                "syscall": "clock_gettime",
+                "comment": "Used for metrics and logging, via the helpers in utils/src/time.rs. It's not called on some platforms, because of vdso optimisations."
+            },
+            {
+                "syscall": "timerfd_settime",
+                "comment": "Needed for rate limiting and metrics",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 0
+                    }
+                ]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "Used by snapshotting, drive patching and rescanning",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 2,
+                        "comment": "FCNTL_F_SETFD"
+                    },
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "FCNTL_FD_CLOEXEC"
+                    }
+                ]
+            },
+            {
+                "syscall": "fstat",
+                "comment": "Used by disk update"
             }
         ]
     }

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -57,12 +57,13 @@ impl ApiServerAdapter {
         to_api: Sender<ApiResponse>,
         vmm: Arc<Mutex<Vmm>>,
         event_manager: &mut EventManager,
+        seccomp_filters: &BpfThreadMap,
     ) -> Result<(), ApiServerError> {
         let api_adapter = Arc::new(Mutex::new(Self {
             api_event_fd,
             from_api,
             to_api,
-            controller: RuntimeApiController::new(vmm.clone()),
+            controller: RuntimeApiController::new(vmm.clone(), seccomp_filters),
             request: None,
         }));
         event_manager.add_subscriber(api_adapter.clone());
@@ -262,7 +263,14 @@ pub(crate) fn run_with_api(
             .expect("Poisoned lock")
             .start(super::metrics::WRITE_METRICS_PERIOD_MS);
 
-        ApiServerAdapter::run_microvm(api_event_fd, from_api, to_api, vmm, &mut event_manager)
+        ApiServerAdapter::run_microvm(
+            api_event_fd,
+            from_api,
+            to_api,
+            vmm,
+            &mut event_manager,
+            seccomp_filters,
+        )
     });
 
     api_kill_switch.write(1).unwrap();

--- a/src/firecracker/src/seccomp.rs
+++ b/src/firecracker/src/seccomp.rs
@@ -7,7 +7,8 @@ use std::path::Path;
 
 use vmm::seccomp::{BpfThreadMap, DeserializationError, deserialize_binary, get_empty_filters};
 
-const THREAD_CATEGORIES: [&str; 3] = ["vmm", "api", "vcpu"];
+const ALLOWED_THREAD_CATEGORIES: [&str; 4] = ["vmm", "api", "vcpu", "blk_worker"];
+const MANDATORY_THREAD_CATEGORIES: [&str; 3] = ["vmm", "api", "vcpu"];
 
 /// Error retrieving seccomp filters.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -76,11 +77,12 @@ fn get_custom_filters<R: Read + Debug>(reader: R) -> Result<BpfThreadMap, Filter
     filter_thread_categories(map)
 }
 
-/// Return an error if the BpfThreadMap contains invalid thread categories.
+/// Return an error if the BpfThreadMap contains invalid thread categories or omits a mandatory
+/// category.
 fn filter_thread_categories(map: BpfThreadMap) -> Result<BpfThreadMap, FilterError> {
     let (filters, invalid_filters): (BpfThreadMap, BpfThreadMap) = map
         .into_iter()
-        .partition(|(k, _)| THREAD_CATEGORIES.contains(&k.as_str()));
+        .partition(|(k, _)| ALLOWED_THREAD_CATEGORIES.contains(&k.as_str()));
     if !invalid_filters.is_empty() {
         // build the error message
         let mut thread_categories_string =
@@ -95,7 +97,7 @@ fn filter_thread_categories(map: BpfThreadMap) -> Result<BpfThreadMap, FilterErr
         return Err(FilterError::ThreadCategories(thread_categories_string));
     }
 
-    for &category in THREAD_CATEGORIES.iter() {
+    for &category in MANDATORY_THREAD_CATEGORIES.iter() {
         let category_string = category.to_string();
         if !filters.contains_key(&category_string) {
             return Err(FilterError::MissingThreadCategory(category_string));
@@ -117,16 +119,18 @@ mod tests {
     #[test]
     fn test_get_filters() {
         let mut filters = get_empty_filters();
-        assert_eq!(filters.len(), 3);
+        assert_eq!(filters.len(), 4);
         assert!(filters.remove("vmm").is_some());
         assert!(filters.remove("api").is_some());
         assert!(filters.remove("vcpu").is_some());
+        assert!(filters.remove("blk_worker").is_some());
 
         let mut filters = get_empty_filters();
-        assert_eq!(filters.len(), 3);
+        assert_eq!(filters.len(), 4);
         assert_eq!(filters.remove("vmm").unwrap().len(), 0);
         assert_eq!(filters.remove("api").unwrap().len(), 0);
         assert_eq!(filters.remove("vcpu").unwrap().len(), 0);
+        assert_eq!(filters.remove("blk_worker").unwrap().len(), 0);
 
         let file = TempFile::new().unwrap().into_file();
 
@@ -136,6 +140,15 @@ mod tests {
     #[test]
     fn test_filter_thread_categories() {
         // correct categories
+        let mut map = BpfThreadMap::new();
+        map.insert("vcpu".to_string(), Arc::new(vec![]));
+        map.insert("vmm".to_string(), Arc::new(vec![]));
+        map.insert("api".to_string(), Arc::new(vec![]));
+        map.insert("blk_worker".to_string(), Arc::new(vec![]));
+
+        assert_eq!(filter_thread_categories(map).unwrap().len(), 4);
+
+        // optional category omitted
         let mut map = BpfThreadMap::new();
         map.insert("vcpu".to_string(), Arc::new(vec![]));
         map.insert("vmm".to_string(), Arc::new(vec![]));

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1238,6 +1238,12 @@ definitions:
         description:
           Is block read only.
           This field is required for virtio-block config and should be omitted for vhost-user-block configuration.
+      threaded:
+        type: boolean
+        description:
+          Whether to process requests on a dedicated worker thread.
+          This field is supported only for virtio-block configuration.
+        default: false
       path_on_host:
         type: string
         description:

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -47,6 +47,8 @@ pub enum CompilationError {
     MemfdCreate(std::io::Error),
     /// Cannot rewind memfd: {0}
     MemfdRewind(std::io::Error),
+    /// Cannot truncate memfd: {0}
+    MemfdTruncate(std::io::Error),
     /// Cannot read from memfd: {0}
     MemfdRead(std::io::Error),
     /// Cannot create output file: {0}
@@ -158,7 +160,12 @@ pub fn compile_bpf(
             }
         }
 
-        // SAFETY: Safe as all args are correect.
+        // `seccomp_export_bpf` does not truncate the output file.
+        // Reset the memfd so a shorter filter cannot retain instructions from a previous export.
+        memfd.set_len(0).map_err(CompilationError::MemfdTruncate)?;
+        memfd.rewind().map_err(CompilationError::MemfdRewind)?;
+
+        // SAFETY: Safe as all args are correct.
         unsafe {
             if seccomp_export_bpf(bpf_filter, memfd.as_raw_fd()) != 0 {
                 return Err(CompilationError::LibSeccompExport);

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -905,6 +905,7 @@ pub(crate) mod tests {
                 cache_type: custom_block_cfg.cache_type,
 
                 is_read_only: Some(custom_block_cfg.is_read_only),
+                threaded: false,
                 path_on_host: Some(
                     block_files
                         .last()

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -29,6 +29,7 @@ use crate::device_manager::{
     DeviceRestoreArgs,
 };
 use crate::devices::virtio::balloon::Balloon;
+use crate::devices::virtio::block::BlockError;
 use crate::devices::virtio::block::device::Block;
 use crate::devices::virtio::device::VirtioDevice;
 use crate::devices::virtio::mem::{VIRTIO_MEM_DEFAULT_SLOT_SIZE_MIB, VirtioMem};
@@ -109,6 +110,8 @@ pub enum StartMicrovmError {
     NetDeviceNotConfigured,
     /// Cannot open the block device backing file: {0}
     OpenBlockDevice(io::Error),
+    /// Failed to spawn the block worker thread: {0}
+    SpawnBlockWorker(BlockError),
     /// Cannot restore microvm state: {0}
     RestoreMicrovmState(MicrovmStateError),
     /// Cannot set vm resources: {0}
@@ -238,6 +241,7 @@ pub fn build_microvm_for_boot(
         &mut boot_cmdline,
         vm_resources.block.devices.iter(),
         event_manager,
+        seccomp_filters,
     )?;
     attach_net_devices(
         &mut device_manager,
@@ -502,6 +506,7 @@ pub fn build_microvm_from_snapshot(
         vm_resources,
         instance_id: &instance_info.id,
         vcpus_exit_evt: kvm_vm.vcpus_exit_evt(),
+        seccomp_filters,
     };
     #[allow(unused_mut)]
     let mut device_manager =
@@ -659,6 +664,7 @@ fn attach_block_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Block>>> + Debug>(
     cmdline: &mut LoaderKernelCmdline,
     blocks: I,
     event_manager: &mut EventManager,
+    seccomp_filters: &BpfThreadMap,
 ) -> Result<(), StartMicrovmError> {
     for block in blocks {
         let (id, is_vhost_user) = {
@@ -672,6 +678,13 @@ fn attach_block_devices<'a, I: Iterator<Item = &'a Arc<Mutex<Block>>> + Debug>(
             }
             (locked.id().to_string(), locked.is_vhost_user())
         };
+
+        block
+            .lock()
+            .expect("Poisoned lock")
+            .spawn_worker(seccomp_filters.get("blk_worker").cloned())
+            .map_err(StartMicrovmError::SpawnBlockWorker)?;
+
         // The device mutex mustn't be locked here otherwise it will deadlock.
         device_manager.attach_boot_virtio_device(
             vm,
@@ -778,6 +791,7 @@ pub(crate) mod tests {
     use crate::devices::virtio::vsock::VSOCK_DEV_ID;
     use crate::mmds::data_store::{Mmds, MmdsVersion};
     use crate::mmds::ns::MmdsNetworkStack;
+    use crate::seccomp::get_empty_filters;
     use crate::utils::mib_to_bytes;
     use crate::vmm_config::balloon::{BALLOON_DEV_ID, BalloonBuilder, BalloonDeviceConfig};
     use crate::vmm_config::boot_source::BootSourceConfig;
@@ -917,6 +931,7 @@ pub(crate) mod tests {
             cmdline,
             block_dev_configs.devices.iter(),
             event_manager,
+            &get_empty_filters(),
         )
         .unwrap();
         block_files

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -201,7 +201,10 @@ impl MMIOVirtioDevices {
             let mmio_device = device.inner.lock().expect("Poisoned lock");
             let locked_device = mmio_device.locked_device();
             identifier = (locked_device.device_type(), device_id);
-            for (i, queue_evt) in locked_device.queue_events().iter().enumerate() {
+            for i in 0..locked_device.num_queues() {
+                let queue_evt = locked_device
+                    .queue_event(i)
+                    .expect("queue event must exist for each advertised queue");
                 let io_addr = IoEventAddress::Mmio(
                     device.resources.addr + u64::from(crate::devices::virtio::NOTIFY_REG_OFFSET),
                 );
@@ -519,7 +522,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::devices::virtio::ActivateError;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
-    use crate::devices::virtio::queue::Queue;
+    use crate::devices::virtio::queue::{Queue, QueueConfig, QueueError};
     use crate::devices::virtio::transport::VirtioInterrupt;
     use crate::devices::virtio::transport::mmio::IrqTrigger;
     use crate::test_utils::multi_region_mem_raw;
@@ -607,16 +610,20 @@ pub(crate) mod tests {
 
         fn set_acked_features(&mut self, _: u64) {}
 
-        fn queues(&self) -> &[Queue] {
-            &self.queues
+        fn num_queues(&self) -> usize {
+            self.queues.len()
         }
 
-        fn queues_mut(&mut self) -> &mut [Queue] {
-            &mut self.queues
+        fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+            self.queues.get(index).map(|queue| &queue.config)
         }
 
-        fn queue_events(&self) -> &[EventFd] {
-            &self.queue_evts
+        fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+            self.queues.get_mut(index).map(|queue| &mut queue.config)
+        }
+
+        fn queue_event(&self, index: usize) -> Option<&EventFd> {
+            self.queue_evts.get(index)
         }
 
         fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -653,6 +660,17 @@ pub(crate) mod tests {
 
         fn _reset(&mut self) -> bool {
             false
+        }
+
+        fn reset_queues(&mut self) {
+            self.queues.iter_mut().for_each(Queue::reset);
+        }
+
+        fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+            for queue in &mut self.queues {
+                queue.initialize(mem)?;
+            }
+            Ok(())
         }
     }
 
@@ -763,7 +781,7 @@ pub(crate) mod tests {
     fn test_dummy_device() {
         let dummy = DummyDevice::new();
         assert_eq!(dummy.device_type(), VirtioDeviceType::Net);
-        assert_eq!(dummy.queues().len(), QUEUE_SIZES.len());
+        assert_eq!(dummy.num_queues(), QUEUE_SIZES.len());
     }
 
     #[test]

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -921,6 +921,7 @@ pub(crate) mod tests {
             is_root_device: is_root,
             cache_type: CacheType::Unsafe,
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(f.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: None,

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -51,6 +51,7 @@ use crate::logger::{error, info};
 use crate::rate_limiter::TokenBucket;
 use crate::resources::VmResources;
 use crate::rpc_interface::VmmActionError;
+use crate::seccomp::BpfThreadMap;
 use crate::snapshot::Persist;
 use crate::utils::open_file_nonblock;
 use crate::vmm_config::HotplugDeviceConfig;
@@ -458,6 +459,7 @@ impl DeviceManager {
         vm: Arc<KvmVm>,
         config: HotplugDeviceConfig,
         event_manager: &mut EventManager,
+        seccomp_filters: &BpfThreadMap,
     ) -> Result<(), VmmActionError> {
         let dev_type = config.device_type();
         let dev_id = config.device_id().to_string();
@@ -473,7 +475,7 @@ impl DeviceManager {
         }
 
         let device = match config {
-            HotplugDeviceConfig::Block(cfg) => Self::hotplug_make_block(cfg)?,
+            HotplugDeviceConfig::Block(cfg) => Self::hotplug_make_block(cfg, seccomp_filters)?,
             HotplugDeviceConfig::Pmem(cfg) => Self::hotplug_make_pmem(vm.clone(), cfg)?,
             HotplugDeviceConfig::Net(cfg) => self.hotplug_make_net(cfg)?,
         };
@@ -488,12 +490,17 @@ impl DeviceManager {
 
     fn hotplug_make_block(
         config: BlockDeviceConfig,
+        seccomp_filters: &BpfThreadMap,
     ) -> Result<Arc<Mutex<dyn VirtioDevice>>, VmmActionError> {
         if config.is_root_device {
             return Err(DriveError::RootBlockDeviceAlreadyAdded.into());
         }
 
-        let block = Block::new(config).map_err(DriveError::CreateBlockDevice)?;
+        let mut block = Block::new(config).map_err(DriveError::CreateBlockDevice)?;
+        block
+            .spawn_worker(seccomp_filters.get("blk_worker").cloned())
+            .map_err(DriveError::CreateBlockDevice)?;
+
         Ok(Arc::new(Mutex::new(block)))
     }
 
@@ -673,6 +680,7 @@ pub struct DeviceRestoreArgs<'a> {
     pub vcpus_exit_evt: &'a EventFd,
     pub vm_resources: &'a mut VmResources,
     pub instance_id: &'a str,
+    pub seccomp_filters: &'a BpfThreadMap,
 }
 
 impl std::fmt::Debug for DeviceRestoreArgs<'_> {
@@ -745,6 +753,7 @@ impl<'a> Persist<'a> for DeviceManager {
                     vm_resources: constructor_args.vm_resources,
                     instance_id: constructor_args.instance_id,
                     event_manager: constructor_args.event_manager,
+                    seccomp_filters: constructor_args.seccomp_filters,
                 };
                 let pci_devices = PciDevices::restore(pci_ctor_args, pci_state)
                     .map_err(DeviceManagerPersistError::PciRestore)?;
@@ -757,6 +766,7 @@ impl<'a> Persist<'a> for DeviceManager {
                     event_manager: constructor_args.event_manager,
                     vm_resources: constructor_args.vm_resources,
                     instance_id: constructor_args.instance_id,
+                    seccomp_filters: constructor_args.seccomp_filters,
                 };
                 let mmio_virtio_devices = MMIOVirtioDevices::restore(mmio_ctor_args, mmio_state)
                     .map_err(DeviceManagerPersistError::MmioRestore)?;
@@ -787,6 +797,7 @@ pub(crate) mod tests {
     use crate::devices::acpi::vmgenid::VmGenId;
     use crate::devices::virtio::block::CacheType;
     use crate::rpc_interface::VmmActionError;
+    use crate::seccomp::get_empty_filters;
     use crate::vmm_config::HotplugDeviceConfig;
     use crate::vmm_config::drive::{BlockDeviceConfig, DriveError};
     use crate::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceError};
@@ -920,12 +931,14 @@ pub(crate) mod tests {
     #[test]
     fn test_hotplug_block() {
         let mut evt_manager = EventManager::new().unwrap();
+        let seccomp_filters = get_empty_filters();
         let mut vmm = default_vmm_with_pci();
         let f = TempFile::new().unwrap();
 
         // Successful case
         let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
-        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        vmm.hotplug_device(cfg, &mut evt_manager, &seccomp_filters)
+            .unwrap();
         assert!(
             pci_devices(&vmm.device_manager)
                 .virtio_devices
@@ -935,14 +948,14 @@ pub(crate) mod tests {
         // Duplicate device ID is rejected
         let cfg2 = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
         assert!(matches!(
-            vmm.hotplug_device(cfg2, &mut evt_manager),
+            vmm.hotplug_device(cfg2, &mut evt_manager, &seccomp_filters),
             Err(VmmActionError::DeviceIdInUse)
         ));
 
         // Root block device is rejected
         let cfg3 = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block1", &f, true));
         assert!(matches!(
-            vmm.hotplug_device(cfg3, &mut evt_manager),
+            vmm.hotplug_device(cfg3, &mut evt_manager, &seccomp_filters),
             Err(VmmActionError::DriveConfig(
                 DriveError::RootBlockDeviceAlreadyAdded
             ))
@@ -970,11 +983,12 @@ pub(crate) mod tests {
     fn test_hotplug_pci_not_enabled() {
         let mut vmm = default_vmm();
         let mut evt_manager = EventManager::new().unwrap();
+        let seccomp_filters = get_empty_filters();
         let f = TempFile::new().unwrap();
 
         let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
         assert!(matches!(
-            vmm.hotplug_device(cfg, &mut evt_manager),
+            vmm.hotplug_device(cfg, &mut evt_manager, &seccomp_filters),
             Err(VmmActionError::PciNotEnabled)
         ));
     }
@@ -1007,6 +1021,7 @@ pub(crate) mod tests {
     fn test_hotplug_pmem() {
         let mut vmm = default_vmm_with_pci();
         let mut evt_manager = EventManager::new().unwrap();
+        let seccomp_filters = get_empty_filters();
         let f = TempFile::new().unwrap();
         f.as_file().set_len(0x1000).unwrap();
 
@@ -1018,7 +1033,8 @@ pub(crate) mod tests {
             read_only: false,
             ..Default::default()
         });
-        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        vmm.hotplug_device(cfg, &mut evt_manager, &seccomp_filters)
+            .unwrap();
         assert!(
             pci_devices(&vmm.device_manager)
                 .virtio_devices
@@ -1035,7 +1051,7 @@ pub(crate) mod tests {
             ..Default::default()
         });
         assert!(matches!(
-            vmm.hotplug_device(cfg2, &mut evt_manager),
+            vmm.hotplug_device(cfg2, &mut evt_manager, &seccomp_filters),
             Err(VmmActionError::PmemConfig(
                 PmemConfigError::AddingSecondRootDevice
             ))
@@ -1063,6 +1079,7 @@ pub(crate) mod tests {
     fn test_hotplug_net() {
         let mut vmm = default_vmm_with_pci();
         let mut evt_manager = EventManager::new().unwrap();
+        let seccomp_filters = get_empty_filters();
 
         let mac = "AA:FC:00:00:00:01";
 
@@ -1075,7 +1092,8 @@ pub(crate) mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
         });
-        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        vmm.hotplug_device(cfg, &mut evt_manager, &seccomp_filters)
+            .unwrap();
         assert!(
             pci_devices(&vmm.device_manager)
                 .virtio_devices
@@ -1092,7 +1110,7 @@ pub(crate) mod tests {
             tx_rate_limiter: None,
         });
         assert!(matches!(
-            vmm.hotplug_device(cfg2, &mut evt_manager),
+            vmm.hotplug_device(cfg2, &mut evt_manager, &seccomp_filters),
             Err(VmmActionError::NetworkConfig(
                 NetworkInterfaceError::GuestMacAddressInUse(_)
             ))

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -144,7 +144,7 @@ impl PciDevices {
 
         // Allocate one MSI vector per queue, plus one for configuration
         let msix_num =
-            u16::try_from(device.lock().expect("Poisoned lock").queues().len() + 1).unwrap();
+            u16::try_from(device.lock().expect("Poisoned lock").num_queues() + 1).unwrap();
 
         let msix_vectors = KvmVm::create_msix_group(vm.clone(), msix_num)?;
 

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -840,6 +840,7 @@ mod tests {
       "is_root_device": true,
       "cache_type": "Unsafe",
       "is_read_only": true,
+      "threaded": false,
       "path_on_host": "{}",
       "rate_limiter": null,
       "io_engine": "Sync",

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -37,6 +37,7 @@ use crate::logger::{debug, warn};
 use crate::pci::PciSBDF;
 use crate::pci::bus::PciRootError;
 use crate::resources::VmResources;
+use crate::seccomp::BpfThreadMap;
 use crate::snapshot::Persist;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
 use crate::vstate::bus::BusError;
@@ -327,6 +328,7 @@ pub struct PciDevicesConstructorArgs<'a> {
     pub vm_resources: &'a mut VmResources,
     pub instance_id: &'a str,
     pub event_manager: &'a mut EventManager,
+    pub seccomp_filters: &'a BpfThreadMap,
 }
 
 impl<'a> Debug for PciDevicesConstructorArgs<'a> {
@@ -518,6 +520,11 @@ impl<'a> Persist<'a> for PciDevices {
                 &block_state.device_state,
             )?));
 
+            device
+                .lock()
+                .expect("Poisoned lock")
+                .spawn_worker(constructor_args.seccomp_filters.get("blk_worker").cloned())?;
+
             constructor_args
                 .vm_resources
                 .block
@@ -685,6 +692,7 @@ mod tests {
     use crate::devices::virtio::block::CacheType;
     use crate::mmds::data_store::MmdsVersion;
     use crate::resources::VmmConfig;
+    use crate::seccomp::get_empty_filters;
     use crate::vmm_config::balloon::BalloonDeviceConfig;
     use crate::vmm_config::entropy::EntropyDeviceConfig;
     use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
@@ -812,6 +820,7 @@ mod tests {
             vm_resources,
             instance_id: "microvm-id",
             event_manager: &mut event_manager,
+            seccomp_filters: &get_empty_filters(),
         };
         let _restored_dev_manager = PciDevices::restore(restore_args, pci_state).unwrap();
 

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -38,6 +38,7 @@ use crate::devices::virtio::vsock::persist::{
 use crate::devices::virtio::vsock::{Vsock, VsockUnixBackend};
 use crate::mmds::data_store::MmdsVersion;
 use crate::resources::VmResources;
+use crate::seccomp::BpfThreadMap;
 use crate::snapshot::Persist;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
 use crate::vstate::memory::GuestMemoryMmap;
@@ -137,6 +138,7 @@ pub struct MMIODevManagerConstructorArgs<'a> {
     pub event_manager: &'a mut EventManager,
     pub vm_resources: &'a mut VmResources,
     pub instance_id: &'a str,
+    pub seccomp_filters: &'a BpfThreadMap,
 }
 
 pub struct MMIOPlatformDevicesConstructorArgs<'a> {
@@ -479,6 +481,11 @@ impl<'a> Persist<'a> for MMIOVirtioDevices {
                 &block_state.device_state,
             )?));
 
+            device
+                .lock()
+                .expect("Poisoned lock")
+                .spawn_worker(constructor_args.seccomp_filters.get("blk_worker").cloned())?;
+
             constructor_args
                 .vm_resources
                 .block
@@ -649,6 +656,7 @@ mod tests {
     use crate::device_manager;
     use crate::devices::virtio::block::CacheType;
     use crate::resources::VmmConfig;
+    use crate::seccomp::get_empty_filters;
     use crate::vmm_config::balloon::BalloonDeviceConfig;
     use crate::vmm_config::entropy::EntropyDeviceConfig;
     use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
@@ -806,6 +814,7 @@ mod tests {
             event_manager: &mut event_manager,
             vm_resources,
             instance_id: "microvm-id",
+            seccomp_filters: &get_empty_filters(),
         };
         let _restored_dev_manager = MMIOVirtioDevices::restore(restore_args, mmio_state).unwrap();
 

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -834,6 +834,7 @@ mod tests {
       "is_root_device": true,
       "cache_type": "Unsafe",
       "is_read_only": true,
+      "threaded": false,
       "path_on_host": "{}",
       "rate_limiter": null,
       "io_engine": "Sync",

--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -11,7 +11,7 @@ use vmm_sys_util::eventfd::EventFd;
 
 use super::super::ActivateError;
 use super::super::device::{DeviceState, VirtioDevice};
-use super::super::queue::Queue;
+use super::super::queue::{Queue, QueueConfig, QueueError};
 use super::metrics::METRICS;
 use super::util::compact_page_frame_numbers;
 use super::{
@@ -907,16 +907,20 @@ impl VirtioDevice for Balloon {
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_evts
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -995,6 +999,17 @@ impl VirtioDevice for Balloon {
         true
     }
 
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
+    }
+
     fn kick(&mut self) {
         if self.is_activated() {
             if self.free_page_hinting() {
@@ -1035,7 +1050,7 @@ pub(crate) mod tests {
             self.queues = queues;
         }
 
-        fn num_queues(&self) -> usize {
+        fn num_queues_supported(&self) -> usize {
             let mut idx = STATS_INDEX;
 
             if self.stats_polling_interval_s > 0 {
@@ -1543,7 +1558,7 @@ pub(crate) mod tests {
             );
             check_metric_after_block!(METRICS.stats_updates_count, 1, {
                 // Trigger the queue event.
-                balloon.queue_events()[STATS_INDEX].write(1).unwrap();
+                balloon.queue_event(STATS_INDEX).unwrap().write(1).unwrap();
                 balloon.process_stats_queue_event().unwrap();
                 // Don't check for completion yet.
             });
@@ -2017,7 +2032,7 @@ pub(crate) mod tests {
             }
 
             set_request(&statsq, 0, stat_addr, tc.desc_len, VIRTQ_DESC_F_NEXT);
-            balloon.queue_events()[STATS_INDEX].write(1).unwrap();
+            balloon.queue_event(STATS_INDEX).unwrap().write(1).unwrap();
             balloon.process_stats_queue_event().unwrap();
 
             // The descriptor should always be held (stats protocol preserved)

--- a/src/vmm/src/devices/virtio/balloon/persist.rs
+++ b/src/vmm/src/devices/virtio/balloon/persist.rs
@@ -129,7 +129,7 @@ impl Persist<'_> for Balloon {
                 num_pages: self.config_space.num_pages,
                 actual_pages: self.config_space.actual_pages,
             },
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
         }
     }
 
@@ -238,7 +238,7 @@ mod tests {
             restored_balloon.config_space.free_page_hint_cmd_id,
             FREE_PAGE_HINT_DONE
         );
-        assert_eq!(restored_balloon.queues(), balloon.queues());
+        assert_eq!(restored_balloon.queues, balloon.queues);
         assert!(!restored_balloon.is_activated());
         assert!(!balloon.is_activated());
 

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -12,7 +12,7 @@ use super::vhost_user::device::{VhostUserBlock, VhostUserBlockConfig};
 use super::virtio::device::{VirtioBlock, VirtioBlockConfig};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
-use crate::devices::virtio::queue::{InvalidAvailIdx, Queue};
+use crate::devices::virtio::queue::{InvalidAvailIdx, QueueConfig, QueueError};
 use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::impl_device_type;
 use crate::rate_limiter::BucketUpdate;
@@ -147,24 +147,31 @@ impl VirtioDevice for Block {
         }
     }
 
-    fn queues(&self) -> &[Queue] {
+    fn num_queues(&self) -> usize {
         match self {
-            Self::Virtio(b) => &b.queues,
-            Self::VhostUser(b) => &b.queues,
+            Self::Virtio(b) => b.num_queues(),
+            Self::VhostUser(b) => b.num_queues(),
         }
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
         match self {
-            Self::Virtio(b) => &mut b.queues,
-            Self::VhostUser(b) => &mut b.queues,
+            Self::Virtio(b) => b.queue_config(index),
+            Self::VhostUser(b) => b.queue_config(index),
         }
     }
 
-    fn queue_events(&self) -> &[EventFd] {
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
         match self {
-            Self::Virtio(b) => &b.queue_evts,
-            Self::VhostUser(b) => &b.queue_evts,
+            Self::Virtio(b) => b.queue_config_mut(index),
+            Self::VhostUser(b) => b.queue_config_mut(index),
+        }
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        match self {
+            Self::Virtio(b) => b.queue_event(index),
+            Self::VhostUser(b) => b.queue_event(index),
         }
     }
 
@@ -218,6 +225,20 @@ impl VirtioDevice for Block {
         match self {
             Self::Virtio(b) => b._reset(),
             Self::VhostUser(b) => b._reset(),
+        }
+    }
+
+    fn reset_queues(&mut self) {
+        match self {
+            Self::Virtio(b) => b.reset_queues(),
+            Self::VhostUser(b) => b.reset_queues(),
+        }
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        match self {
+            Self::Virtio(b) => b.mark_queue_memory_dirty(mem),
+            Self::VhostUser(b) => b.mark_queue_memory_dirty(mem),
         }
     }
 

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -242,6 +242,13 @@ impl VirtioDevice for Block {
         }
     }
 
+    fn kick(&mut self) {
+        match self {
+            Self::Virtio(b) => b.kick(),
+            Self::VhostUser(b) => b.kick(),
+        }
+    }
+
     fn prepare_save(&mut self) {
         match self {
             Self::Virtio(b) => b.prepare_save(),

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -89,21 +89,21 @@ impl Block {
 
     pub fn root_device(&self) -> bool {
         match self {
-            Self::Virtio(b) => b.root_device,
+            Self::Virtio(b) => b.config.is_root_device,
             Self::VhostUser(b) => b.root_device,
         }
     }
 
     pub fn read_only(&self) -> bool {
         match self {
-            Self::Virtio(b) => b.read_only,
+            Self::Virtio(b) => b.config.is_read_only,
             Self::VhostUser(b) => b.read_only,
         }
     }
 
     pub fn partuuid(&self) -> &Option<String> {
         match self {
-            Self::Virtio(b) => &b.partuuid,
+            Self::Virtio(b) => &b.config.partuuid,
             Self::VhostUser(b) => &b.partuuid,
         }
     }

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -209,7 +209,7 @@ impl VirtioDevice for Block {
 
     fn is_activated(&self) -> bool {
         match self {
-            Self::Virtio(b) => b.device_state.is_activated(),
+            Self::Virtio(b) => b.is_activated(),
             Self::VhostUser(b) => b.device_state.is_activated(),
         }
     }

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -16,6 +16,7 @@ use crate::devices::virtio::queue::{InvalidAvailIdx, QueueConfig, QueueError};
 use crate::devices::virtio::transport::VirtioInterrupt;
 use crate::impl_device_type;
 use crate::rate_limiter::BucketUpdate;
+use crate::seccomp::BpfProgram;
 use crate::snapshot::Persist;
 use crate::vmm_config::drive::BlockDeviceConfig;
 use crate::vstate::memory::GuestMemoryMmap;
@@ -112,6 +113,15 @@ impl Block {
         match self {
             Self::Virtio(_) => false,
             Self::VhostUser(_) => true,
+        }
+    }
+
+    pub(crate) fn spawn_worker(
+        &mut self,
+        _seccomp_filter: Option<Arc<BpfProgram>>,
+    ) -> Result<(), BlockError> {
+        match self {
+            Self::Virtio(_) | Self::VhostUser(_) => Ok(()),
         }
     }
 }

--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -9,6 +9,7 @@ use vmm_sys_util::eventfd::EventFd;
 use super::BlockError;
 use super::persist::{BlockConstructorArgs, BlockState};
 use super::vhost_user::device::{VhostUserBlock, VhostUserBlockConfig};
+use super::virtio::VirtioBlockError;
 use super::virtio::device::{VirtioBlock, VirtioBlockConfig};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
@@ -118,10 +119,14 @@ impl Block {
 
     pub(crate) fn spawn_worker(
         &mut self,
-        _seccomp_filter: Option<Arc<BpfProgram>>,
+        seccomp_filter: Option<Arc<BpfProgram>>,
     ) -> Result<(), BlockError> {
         match self {
-            Self::Virtio(_) | Self::VhostUser(_) => Ok(()),
+            Self::Virtio(b) if b.config.threaded => b
+                .spawn_worker(seccomp_filter.ok_or(BlockError::MissingSeccompFilter)?)
+                .map_err(BlockError::VirtioBackend),
+            Self::Virtio(_) => Ok(()),
+            Self::VhostUser(_) => Ok(()),
         }
     }
 }

--- a/src/vmm/src/devices/virtio/block/mod.rs
+++ b/src/vmm/src/devices/virtio/block/mod.rs
@@ -31,6 +31,8 @@ pub enum BlockError {
     InvalidBlockBackend,
     /// Can not restore any backend.
     BackendRestore,
+    /// Missing block worker seccomp filter.
+    MissingSeccompFilter,
     /// Virtio backend error: {0}
     VirtioBackend(VirtioBlockError),
     /// Vhost user backend error: {0}

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -19,7 +19,7 @@ use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, Vir
 use crate::devices::virtio::generated::virtio_blk::{VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO};
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::{Queue, QueueConfig, QueueError};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::virtio::vhost_user::{VhostUserHandleBackend, VhostUserHandleImpl};
 use crate::devices::virtio::vhost_user_metrics::{
@@ -308,16 +308,20 @@ where
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_evts
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -382,6 +386,17 @@ where
 
     fn _reset(&mut self) -> bool {
         false
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/vmm/src/devices/virtio/block/vhost_user/device.rs
+++ b/src/vmm/src/devices/virtio/block/vhost_user/device.rs
@@ -67,6 +67,10 @@ impl TryFrom<&BlockDeviceConfig> for VhostUserBlockConfig {
     type Error = VhostUserBlockError;
 
     fn try_from(value: &BlockDeviceConfig) -> Result<Self, Self::Error> {
+        if value.threaded {
+            return Err(VhostUserBlockError::Config);
+        }
+
         if let (Some(socket), None, None, None, None) = (
             &value.socket,
             &value.is_read_only,
@@ -97,6 +101,7 @@ impl From<VhostUserBlockConfig> for BlockDeviceConfig {
             cache_type: value.cache_type,
 
             is_read_only: None,
+            threaded: false,
             path_on_host: None,
             rate_limiter: None,
             file_engine_type: None,
@@ -428,6 +433,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: None,
+            threaded: false,
             path_on_host: None,
             rate_limiter: None,
             file_engine_type: None,
@@ -443,6 +449,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            threaded: false,
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
@@ -458,6 +465,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            threaded: false,
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -31,7 +31,7 @@ use crate::devices::virtio::generated::virtio_blk::{
 };
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::{InvalidAvailIdx, Queue};
+use crate::devices::virtio::queue::{InvalidAvailIdx, Queue, QueueConfig, QueueError};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, warn};
@@ -598,16 +598,20 @@ impl VirtioDevice for VirtioBlock {
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_evts
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -673,6 +677,17 @@ impl VirtioDevice for VirtioBlock {
         }
         self.is_io_engine_throttled = false;
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -501,8 +501,6 @@ impl VirtioBlock {
     }
 
     /// Spawn a parked worker thread for the next activation.
-    // Currently unused because threaded mode is not exposed through device configuration yet.
-    #[allow(dead_code)]
     pub(crate) fn spawn_worker(
         &mut self,
         seccomp_filter: Arc<BpfProgram>,
@@ -516,11 +514,9 @@ impl VirtioBlock {
                 .map_err(VirtioBlockError::EventFd)?;
 
             let name = format!("fc_{}", self.config.drive_id);
-
-            *worker_handle = Some(
-                WorkerHandle::spawn(seccomp_filter, queue_evts, name)
-                    .map_err(VirtioBlockError::ThreadSpawn)?,
-            );
+            let worker = WorkerHandle::spawn(seccomp_filter, queue_evts, name)
+                .map_err(VirtioBlockError::ThreadSpawn)?;
+            *worker_handle = Some(worker);
         }
         Ok(())
     }

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -427,9 +427,7 @@ impl VirtioBlock {
             BlockState::Active(ActiveBlock::Inline(worker)) => {
                 worker.process_virtio_queues().unwrap();
             }
-            BlockState::Active(ActiveBlock::Threaded(_)) => {
-                unreachable!("worker control messages are not connected yet")
-            }
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.worker_handle.kick(),
             BlockState::Configuring(_, _) => {}
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
@@ -453,9 +451,9 @@ impl VirtioBlock {
             BlockState::Active(ActiveBlock::Inline(worker)) => {
                 worker.update_disk_image(disk_image_path, read_only)?
             }
-            BlockState::Active(ActiveBlock::Threaded(_)) => {
-                unreachable!("worker control messages are not connected yet")
-            }
+            BlockState::Active(ActiveBlock::Threaded(active)) => active
+                .worker_handle
+                .update_disk_image(disk_image_path, read_only)?,
             BlockState::Placeholder => unreachable!("not a runtime state"),
         };
         self.config_space.capacity = nsectors.to_le();

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -12,7 +12,7 @@ use std::io::{Seek, SeekFrom};
 use std::ops::Deref;
 use std::os::linux::fs::MetadataExt;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use block_io::FileEngine;
 use serde::{Deserialize, Serialize};
@@ -251,6 +251,7 @@ pub struct VirtioBlock {
     pub device_state: DeviceState,
 
     pub(crate) config: VirtioBlockConfig,
+    pub(crate) rate_limiter: Arc<Mutex<RateLimiter>>,
     pub(crate) resources: BlockResources,
     pub metrics: Arc<BlockDeviceMetrics>,
 }
@@ -261,7 +262,6 @@ pub(crate) struct BlockResources {
     pub(crate) queues: Vec<Queue>,
     pub(crate) queue_evts: [EventFd; 1],
     pub(crate) disk: DiskProperties,
-    pub(crate) rate_limiter: RateLimiter,
     pub(crate) is_io_engine_throttled: bool,
 }
 
@@ -326,11 +326,11 @@ impl VirtioBlock {
 
             device_state: DeviceState::Inactive,
             config,
+            rate_limiter: Arc::new(Mutex::new(rate_limiter)),
             resources: BlockResources {
                 queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
                 queue_evts: [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?],
                 disk: disk_properties,
-                rate_limiter,
                 is_io_engine_throttled: false,
             },
             metrics,
@@ -354,8 +354,10 @@ impl VirtioBlock {
         &self.resources.disk
     }
 
-    pub(crate) fn rate_limiter(&self) -> &RateLimiter {
-        &self.resources.rate_limiter
+    pub(crate) fn rate_limiter(&self) -> MutexGuard<'_, RateLimiter> {
+        self.rate_limiter
+            .lock()
+            .expect("Poisoned block rate limiter lock")
     }
 
     /// Process a single event in the Virtio queue.
@@ -367,7 +369,7 @@ impl VirtioBlock {
         if let Err(err) = self.resources.queue_evts[0].read() {
             error!("Failed to get queue event: {:?}", err);
             self.metrics.event_fails.inc();
-        } else if self.resources.rate_limiter.is_blocked() {
+        } else if self.rate_limiter().is_blocked() {
             self.metrics.rate_limiter_throttled_events.inc();
         } else if self.resources.is_io_engine_throttled {
             self.metrics.io_engine_throttled_events.inc();
@@ -385,7 +387,7 @@ impl VirtioBlock {
         self.metrics.rate_limiter_event_count.inc();
         // Upon rate limiter event, call the rate limiter handler
         // and restart processing the queue.
-        if self.resources.rate_limiter.event_handler().is_ok() {
+        if self.rate_limiter().event_handler().is_ok() {
             self.process_queue(0).unwrap()
         }
     }
@@ -395,6 +397,7 @@ impl VirtioBlock {
         // This is safe since we checked in the event handler that the device is activated.
         let active_state = self.device_state.active_state().unwrap();
 
+        let rate_limiter = &self.rate_limiter;
         let queue = &mut self.resources.queues[queue_index];
         let mut used_any = false;
 
@@ -403,7 +406,13 @@ impl VirtioBlock {
             let processing_result =
                 match Request::parse(&head, &active_state.mem, self.resources.disk.nsectors) {
                     Ok(request) => {
-                        if request.rate_limit(&mut self.resources.rate_limiter) {
+                        let is_rate_limited = {
+                            let mut rate_limiter = rate_limiter
+                                .lock()
+                                .expect("Poisoned block rate limiter lock");
+                            request.rate_limit(&mut rate_limiter)
+                        };
+                        if is_rate_limited {
                             // Stop processing the queue and return this descriptor chain to the
                             // avail ring, for later processing.
                             queue.undo_pop();
@@ -563,7 +572,7 @@ impl VirtioBlock {
         apply_bucket_update(&mut rate_limiter.bandwidth, &bytes);
         apply_bucket_update(&mut rate_limiter.ops, &ops);
 
-        self.resources.rate_limiter.update_buckets(bytes, ops);
+        self.rate_limiter().update_buckets(bytes, ops);
         self.config.rate_limiter = rate_limiter.into_option();
     }
 

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -14,18 +14,17 @@ use std::os::linux::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use block_io::FileEngine;
 use serde::{Deserialize, Serialize};
 use vm_memory::ByteValued;
 use vmm_sys_util::eventfd::EventFd;
 
-use super::io::async_io;
-use super::request::*;
-use super::{BLOCK_QUEUE_SIZES, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError, io as block_io};
+use super::io::FileEngine;
+use super::worker::{BlockWorker, FlushMode};
+use super::{BLOCK_QUEUE_SIZES, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::block::CacheType;
 use crate::devices::virtio::block::virtio::metrics::{BlockDeviceMetrics, BlockMetricsPerDevice};
-use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
+use crate::devices::virtio::device::{ActiveState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::{
     VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES,
 };
@@ -36,7 +35,6 @@ use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter};
-use crate::utils::u64_to_usize;
 use crate::vmm_config::drive::BlockDeviceConfig;
 use crate::vmm_config::{RateLimiterConfig, TokenBucketConfig};
 use crate::vstate::memory::GuestMemoryMmap;
@@ -248,12 +246,21 @@ pub struct VirtioBlock {
     pub config_space: ConfigSpace,
     pub activate_evt: EventFd,
 
-    pub device_state: DeviceState,
-
     pub(crate) config: VirtioBlockConfig,
     pub(crate) rate_limiter: Arc<Mutex<RateLimiter>>,
-    pub(crate) resources: BlockResources,
+    pub(crate) state: BlockState,
     pub metrics: Arc<BlockDeviceMetrics>,
+}
+
+/// State of the block data-path resources.
+#[derive(Debug)]
+pub(crate) enum BlockState {
+    // Vmm owns the runtime resources before activation
+    Configuring(BlockResources),
+    // Active state, worker owns data-path resources
+    Active(BlockWorker),
+    // Placeholder to hold state when activating
+    Placeholder,
 }
 
 /// Runtime resources used by the block data path.
@@ -271,18 +278,6 @@ fn apply_bucket_update(config: &mut Option<TokenBucketConfig>, update: &BucketUp
         BucketUpdate::Disabled => *config = None,
         BucketUpdate::Update(bucket) => *config = Some(bucket.into()),
     }
-}
-
-macro_rules! unwrap_async_file_engine_or_return {
-    ($file_engine: expr) => {
-        match $file_engine {
-            FileEngine::Async(engine) => engine,
-            FileEngine::Sync(_) => {
-                error!("The block device doesn't use an async IO engine");
-                return;
-            }
-        }
-    };
 }
 
 impl VirtioBlock {
@@ -324,15 +319,14 @@ impl VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            device_state: DeviceState::Inactive,
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            resources: BlockResources {
+            state: BlockState::Configuring(BlockResources {
                 queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
                 queue_evts: [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?],
                 disk: disk_properties,
                 is_io_engine_throttled: false,
-            },
+            }),
             metrics,
         })
     }
@@ -343,15 +337,23 @@ impl VirtioBlock {
     }
 
     pub(crate) fn resources(&self) -> &BlockResources {
-        &self.resources
+        match &self.state {
+            BlockState::Configuring(resources) => resources,
+            BlockState::Active(worker) => &worker.resources,
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     pub(crate) fn resources_mut(&mut self) -> &mut BlockResources {
-        &mut self.resources
+        match &mut self.state {
+            BlockState::Configuring(resources) => resources,
+            BlockState::Active(worker) => &mut worker.resources,
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     pub(crate) fn disk(&self) -> &DiskProperties {
-        &self.resources.disk
+        &self.resources().disk
     }
 
     pub(crate) fn rate_limiter(&self) -> MutexGuard<'_, RateLimiter> {
@@ -360,200 +362,62 @@ impl VirtioBlock {
             .expect("Poisoned block rate limiter lock")
     }
 
+    fn worker_mut(&mut self) -> &mut BlockWorker {
+        match &mut self.state {
+            BlockState::Active(worker) => worker,
+            BlockState::Configuring(_) => panic!("Device is not activated"),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
+    }
+
     /// Process a single event in the Virtio queue.
     ///
     /// This function is called by the event manager when the guest notifies us
     /// about new buffers in the queue.
     pub(crate) fn process_queue_event(&mut self) {
-        self.metrics.queue_event_count.inc();
-        if let Err(err) = self.resources.queue_evts[0].read() {
-            error!("Failed to get queue event: {:?}", err);
-            self.metrics.event_fails.inc();
-        } else if self.rate_limiter().is_blocked() {
-            self.metrics.rate_limiter_throttled_events.inc();
-        } else if self.resources.is_io_engine_throttled {
-            self.metrics.io_engine_throttled_events.inc();
-        } else {
-            self.process_virtio_queues().unwrap()
-        }
+        self.worker_mut().process_queue_event();
     }
 
     /// Process device virtio queue(s).
     pub fn process_virtio_queues(&mut self) -> Result<(), InvalidAvailIdx> {
-        self.process_queue(0)
+        self.worker_mut().process_virtio_queues()
     }
 
     pub(crate) fn process_rate_limiter_event(&mut self) {
         self.metrics.rate_limiter_event_count.inc();
+        if self.rate_limiter().event_handler().is_err() {
+            return;
+        }
+
         // Upon rate limiter event, call the rate limiter handler
         // and restart processing the queue.
-        if self.rate_limiter().event_handler().is_ok() {
-            self.process_queue(0).unwrap()
-        }
-    }
-
-    /// Device specific function for peaking inside a queue and processing descriptors.
-    pub fn process_queue(&mut self, queue_index: usize) -> Result<(), InvalidAvailIdx> {
-        // This is safe since we checked in the event handler that the device is activated.
-        let active_state = self.device_state.active_state().unwrap();
-
-        let rate_limiter = &self.rate_limiter;
-        let queue = &mut self.resources.queues[queue_index];
-        let mut used_any = false;
-
-        while let Some(head) = queue.pop_or_enable_notification()? {
-            self.metrics.remaining_reqs_count.add(queue.len().into());
-            let processing_result =
-                match Request::parse(&head, &active_state.mem, self.resources.disk.nsectors) {
-                    Ok(request) => {
-                        let is_rate_limited = {
-                            let mut rate_limiter = rate_limiter
-                                .lock()
-                                .expect("Poisoned block rate limiter lock");
-                            request.rate_limit(&mut rate_limiter)
-                        };
-                        if is_rate_limited {
-                            // Stop processing the queue and return this descriptor chain to the
-                            // avail ring, for later processing.
-                            queue.undo_pop();
-                            self.metrics.rate_limiter_throttled_events.inc();
-                            break;
-                        }
-
-                        request.process(
-                            &mut self.resources.disk,
-                            head.index,
-                            &active_state.mem,
-                            &self.metrics,
-                        )
-                    }
-                    Err(err) => {
-                        error!("Failed to parse available descriptor chain: {:?}", err);
-                        self.metrics.execute_fails.inc();
-                        ProcessingResult::Executed(FinishedRequest {
-                            num_bytes_to_mem: 0,
-                            desc_idx: head.index,
-                        })
-                    }
-                };
-
-            match processing_result {
-                ProcessingResult::Submitted => {}
-                ProcessingResult::Throttled => {
-                    queue.undo_pop();
-                    self.resources.is_io_engine_throttled = true;
-                    break;
-                }
-                ProcessingResult::Executed(finished) => {
-                    used_any = true;
-                    queue
-                        .add_used(head.index, finished.num_bytes_to_mem)
-                        .unwrap_or_else(|err| {
-                            error!(
-                                "Failed to add available descriptor head {}: {}",
-                                head.index, err
-                            )
-                        });
-                }
+        match &mut self.state {
+            BlockState::Active(worker) => {
+                worker.process_virtio_queues().unwrap();
             }
-        }
-        queue.advance_used_ring_idx();
-
-        if used_any && queue.prepare_kick() {
-            active_state
-                .interrupt
-                .trigger(VirtioInterruptType::Queue(0))
-                .unwrap_or_else(|_| {
-                    self.metrics.event_fails.inc();
-                });
-        }
-
-        if let FileEngine::Async(ref mut engine) = self.resources.disk.file_engine
-            && let Err(err) = engine.kick_submission_queue()
-        {
-            error!("BlockError submitting pending block requests: {:?}", err);
-        }
-
-        if !used_any {
-            self.metrics.no_avail_buffer.inc();
-        }
-
-        Ok(())
-    }
-
-    fn process_async_completion_queue(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
-
-        // This is safe since we checked in the event handler that the device is activated.
-        let active_state = self.device_state.active_state().unwrap();
-        let queue = &mut self.resources.queues[0];
-
-        loop {
-            match engine.pop(&active_state.mem) {
-                Err(error) => {
-                    error!("Failed to read completed io_uring entry: {:?}", error);
-                    break;
-                }
-                Ok(None) => break,
-                Ok(Some(cqe)) => {
-                    let res = cqe.result();
-                    let user_data = cqe.user_data();
-
-                    let (pending, res) = match res {
-                        Ok(count) => (user_data, Ok(count)),
-                        Err(error) => (
-                            user_data,
-                            Err(IoErr::FileEngine(block_io::BlockIoError::Async(
-                                async_io::AsyncIoError::IO(error),
-                            ))),
-                        ),
-                    };
-                    let finished = pending.finish(&active_state.mem, res, &self.metrics);
-                    queue
-                        .add_used(finished.desc_idx, finished.num_bytes_to_mem)
-                        .unwrap_or_else(|err| {
-                            error!(
-                                "Failed to add available descriptor head {}: {}",
-                                finished.desc_idx, err
-                            )
-                        });
-                }
-            }
-        }
-        queue.advance_used_ring_idx();
-
-        if queue.prepare_kick() {
-            active_state
-                .interrupt
-                .trigger(VirtioInterruptType::Queue(0))
-                .unwrap_or_else(|_| {
-                    self.metrics.event_fails.inc();
-                });
+            BlockState::Configuring(_) => {}
+            BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
 
     pub fn process_async_completion_event(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
-
-        if let Err(err) = engine.completion_evt().read() {
-            error!("Failed to get async completion event: {:?}", err);
-        } else {
-            self.process_async_completion_queue();
-
-            if self.resources.is_io_engine_throttled {
-                self.resources.is_io_engine_throttled = false;
-                self.process_queue(0).unwrap()
-            }
-        }
+        self.worker_mut().process_async_completion_event();
     }
 
     /// Update the backing file and the config space of the block device.
     pub fn update_disk_image(&mut self, disk_image_path: String) -> Result<(), VirtioBlockError> {
-        self.resources
-            .disk
-            .update(disk_image_path.clone(), self.config.is_read_only)?;
-        self.config_space.capacity = self.resources.disk.nsectors.to_le();
-        self.config.path_on_host = disk_image_path;
+        let config_path = disk_image_path.clone();
+        let read_only = self.config.is_read_only;
+        let nsectors = match &mut self.state {
+            BlockState::Configuring(resources) => {
+                resources.disk.update(disk_image_path, read_only)?;
+                resources.disk.nsectors
+            }
+            BlockState::Active(worker) => worker.update_disk_image(disk_image_path, read_only)?,
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        };
+        self.config_space.capacity = nsectors.to_le();
+        self.config.path_on_host = config_path;
 
         // Kick the driver to pick up the changes. (But only if the device is already activated).
         if self.is_activated() {
@@ -576,26 +440,15 @@ impl VirtioBlock {
         self.config.rate_limiter = rate_limiter.into_option();
     }
 
-    /// Retrieve the file engine type.
+    /// Retrieve the file engine type, which is fixed for the device lifetime.
     pub fn file_engine_type(&self) -> FileEngineType {
         self.config.file_engine_type
     }
 
-    fn drain_and_flush(&mut self, discard: bool) {
-        if let Err(err) = self.resources.disk.file_engine.drain_and_flush(discard) {
-            error!("Failed to drain ops and flush block data: {:?}", err);
-        }
-    }
-
     /// Prepare device for being snapshotted.
     pub fn prepare_save(&mut self) {
-        if !self.is_activated() {
-            return;
-        }
-
-        self.drain_and_flush(false);
-        if let FileEngine::Async(ref _engine) = self.resources.disk.file_engine {
-            self.process_async_completion_queue();
+        if let BlockState::Active(worker) = &mut self.state {
+            worker.prepare_save();
         }
     }
 }
@@ -620,30 +473,33 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn num_queues(&self) -> usize {
-        self.resources.queues.len()
+        self.resources().queues.len()
     }
 
     fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
-        self.resources.queues.get(index).map(|queue| &queue.config)
+        self.resources()
+            .queues
+            .get(index)
+            .map(|queue| &queue.config)
     }
 
     fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
-        self.resources
+        self.resources_mut()
             .queues
             .get_mut(index)
             .map(|queue| &mut queue.config)
     }
 
     fn queue_event(&self, index: usize) -> Option<&EventFd> {
-        self.resources.queue_evts.get(index)
+        self.resources().queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
-        self.device_state
-            .active_state()
-            .expect("Device is not initialized")
-            .interrupt
-            .deref()
+        match &self.state {
+            BlockState::Active(worker) => worker.active_state.interrupt.deref(),
+            BlockState::Configuring(_) => panic!("Device is not initialized"),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn config_as_bytes(&self) -> &[u8] {
@@ -666,14 +522,19 @@ impl VirtioDevice for VirtioBlock {
     ) -> Result<(), ActivateError> {
         assert!(!self.is_activated());
 
-        for q in self.resources.queues.iter_mut() {
+        let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
+
+        let BlockState::Configuring(resources) = &mut self.state else {
+            unreachable!("inactive device is not configurable");
+        };
+
+        for q in &mut resources.queues {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;
         }
 
-        let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
         if event_idx {
-            for queue in &mut self.resources.queues {
+            for queue in &mut resources.queues {
                 queue.enable_notif_suppression();
             }
         }
@@ -682,33 +543,59 @@ impl VirtioDevice for VirtioBlock {
             self.metrics.activate_fails.inc();
             return Err(ActivateError::EventFd);
         }
-        self.device_state = DeviceState::Activated(ActiveState { mem, interrupt });
+
+        let BlockState::Configuring(resources) =
+            std::mem::replace(&mut self.state, BlockState::Placeholder)
+        else {
+            unreachable!("state checked before activation");
+        };
+        let is_blocked = self.rate_limiter().clone_blocked_flag();
+        self.state = BlockState::Active(BlockWorker {
+            resources,
+            rate_limiter: self.rate_limiter.clone(),
+            is_blocked,
+            active_state: ActiveState { mem, interrupt },
+            metrics: self.metrics.clone(),
+        });
         Ok(())
     }
 
     fn is_activated(&self) -> bool {
-        self.device_state.is_activated()
+        matches!(&self.state, BlockState::Active(_))
     }
 
     fn deactivate(&mut self) {
-        self.device_state = DeviceState::Inactive;
+        let state = std::mem::replace(&mut self.state, BlockState::Placeholder);
+        self.state = match state {
+            BlockState::Active(worker) => BlockState::Configuring(worker.resources),
+            state => state,
+        };
     }
 
     fn _reset(&mut self) -> bool {
-        if let Err(err) = self.resources.disk.file_engine.drain(true) {
-            error!("Failed to reset block IO engine: {:?}", err);
-            return false;
+        match &mut self.state {
+            BlockState::Active(worker) => worker.reset(),
+            BlockState::Configuring(resources) => {
+                if let Err(err) = resources.disk.file_engine.drain(true) {
+                    error!("Failed to reset block IO engine: {:?}", err);
+                    return false;
+                }
+                resources.is_io_engine_throttled = false;
+                true
+            }
+            BlockState::Placeholder => unreachable!("not a runtime state"),
         }
-        self.resources.is_io_engine_throttled = false;
-        true
     }
 
     fn reset_queues(&mut self) {
-        self.resources.queues.iter_mut().for_each(Queue::reset);
+        self.resources_mut()
+            .queues
+            .iter_mut()
+            .for_each(Queue::reset);
     }
 
     fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
-        for queue in &mut self.resources.queues {
+        for queue in &mut self.resources_mut().queues {
             queue.initialize(mem)?;
         }
         Ok(())
@@ -717,15 +604,29 @@ impl VirtioDevice for VirtioBlock {
 
 impl Drop for VirtioBlock {
     fn drop(&mut self) {
-        match self.config.cache_type {
-            CacheType::Unsafe => {
-                if let Err(err) = self.resources.disk.file_engine.drain(true) {
-                    error!("Failed to drain ops on drop: {:?}", err);
+        let flush_mode = match self.config.cache_type {
+            CacheType::Unsafe => FlushMode::Drain,
+            CacheType::Writeback => FlushMode::DrainAndFlush,
+        };
+
+        match std::mem::replace(&mut self.state, BlockState::Placeholder) {
+            BlockState::Active(mut worker) => match flush_mode {
+                FlushMode::Drain => worker.drain(true),
+                FlushMode::DrainAndFlush => worker.drain_and_flush(true),
+            },
+            BlockState::Configuring(mut resources) => match flush_mode {
+                FlushMode::Drain => {
+                    if let Err(err) = resources.disk.file_engine.drain(true) {
+                        error!("Failed to drain ops on drop: {:?}", err);
+                    }
                 }
-            }
-            CacheType::Writeback => {
-                self.drain_and_flush(true);
-            }
+                FlushMode::DrainAndFlush => {
+                    if let Err(err) = resources.disk.file_engine.drain_and_flush(true) {
+                        error!("Failed to drain ops and flush block data: {:?}", err);
+                    }
+                }
+            },
+            BlockState::Placeholder => {}
         };
     }
 }
@@ -743,6 +644,7 @@ mod tests {
     use super::*;
     use crate::check_metric_after_block;
     use crate::devices::virtio::block::virtio::IO_URING_NUM_ENTRIES;
+    use crate::devices::virtio::block::virtio::request::*;
     use crate::devices::virtio::block::virtio::test_utils::{
         default_block, read_blk_req_descriptors, set_queue, set_rate_limiter,
         simulate_async_completion_event, simulate_queue_and_async_completion_events,
@@ -1716,7 +1618,6 @@ mod tests {
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
             set_queue(&mut block, 0, vq.create_queue());
-            block.activate(mem.clone(), interrupt).unwrap();
             read_blk_req_descriptors(&vq);
 
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -1730,6 +1631,7 @@ mod tests {
             assert!(rl.consume(512, TokenType::Bytes));
 
             set_rate_limiter(&mut block, rl);
+            block.activate(mem.clone(), interrupt).unwrap();
 
             mem.write_obj::<u32>(VIRTIO_BLK_T_OUT, request_type_addr)
                 .unwrap();
@@ -1786,7 +1688,6 @@ mod tests {
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
             set_queue(&mut block, 0, vq.create_queue());
-            block.activate(mem.clone(), interrupt).unwrap();
             read_blk_req_descriptors(&vq);
 
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -1799,6 +1700,7 @@ mod tests {
             assert!(rl.consume(1, TokenType::Ops));
 
             set_rate_limiter(&mut block, rl);
+            block.activate(mem.clone(), interrupt).unwrap();
 
             mem.write_obj::<u32>(VIRTIO_BLK_T_OUT, request_type_addr)
                 .unwrap();

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -37,8 +37,8 @@ use crate::impl_device_type;
 use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter};
 use crate::utils::u64_to_usize;
-use crate::vmm_config::RateLimiterConfig;
 use crate::vmm_config::drive::BlockDeviceConfig;
+use crate::vmm_config::{RateLimiterConfig, TokenBucketConfig};
 use crate::vstate::memory::GuestMemoryMmap;
 
 /// The engine file type, either Sync or Async (through io_uring).
@@ -169,7 +169,7 @@ pub struct ConfigSpace {
 unsafe impl ByteValued for ConfigSpace {}
 
 /// Use this structure to set up the Block Device before booting the kernel.
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct VirtioBlockConfig {
     /// Unique identifier of the drive.
@@ -248,23 +248,29 @@ pub struct VirtioBlock {
     pub config_space: ConfigSpace,
     pub activate_evt: EventFd,
 
-    // Transport related fields.
-    pub queues: Vec<Queue>,
-    pub queue_evts: [EventFd; 1],
     pub device_state: DeviceState,
 
-    // Implementation specific fields.
-    pub id: String,
-    pub partuuid: Option<String>,
-    pub cache_type: CacheType,
-    pub root_device: bool,
-    pub read_only: bool,
-
-    // Host file and properties.
-    pub disk: DiskProperties,
-    pub rate_limiter: RateLimiter,
-    pub is_io_engine_throttled: bool,
+    pub(crate) config: VirtioBlockConfig,
+    pub(crate) resources: BlockResources,
     pub metrics: Arc<BlockDeviceMetrics>,
+}
+
+/// Runtime resources used by the block data path.
+#[derive(Debug)]
+pub(crate) struct BlockResources {
+    pub(crate) queues: Vec<Queue>,
+    pub(crate) queue_evts: [EventFd; 1],
+    pub(crate) disk: DiskProperties,
+    pub(crate) rate_limiter: RateLimiter,
+    pub(crate) is_io_engine_throttled: bool,
+}
+
+fn apply_bucket_update(config: &mut Option<TokenBucketConfig>, update: &BucketUpdate) {
+    match update {
+        BucketUpdate::None => {}
+        BucketUpdate::Disabled => *config = None,
+        BucketUpdate::Update(bucket) => *config = Some(bucket.into()),
+    }
 }
 
 macro_rules! unwrap_async_file_engine_or_return {
@@ -283,9 +289,9 @@ impl VirtioBlock {
     /// Create a new virtio block device that operates on the given file.
     ///
     /// The given file must be seekable and sizable.
-    pub fn new(config: VirtioBlockConfig) -> Result<VirtioBlock, VirtioBlockError> {
+    pub fn new(mut config: VirtioBlockConfig) -> Result<VirtioBlock, VirtioBlockError> {
         let disk_properties = DiskProperties::new(
-            config.path_on_host,
+            config.path_on_host.clone(),
             config.is_read_only,
             config.file_engine_type,
         )?;
@@ -294,6 +300,8 @@ impl VirtioBlock {
             .rate_limiter
             .map(RateLimiter::from)
             .unwrap_or_default();
+        let rate_limiter_config: RateLimiterConfig = (&rate_limiter).into();
+        config.rate_limiter = rate_limiter_config.into_option();
 
         let mut avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_RING_F_EVENT_IDX);
 
@@ -305,13 +313,10 @@ impl VirtioBlock {
             avail_features |= 1u64 << VIRTIO_BLK_F_RO;
         };
 
-        let queue_evts = [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?];
-
-        let queues = BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect();
-
         let config_space = ConfigSpace {
             capacity: disk_properties.nsectors.to_le(),
         };
+        let metrics = BlockMetricsPerDevice::alloc(config.drive_id.clone());
 
         Ok(VirtioBlock {
             avail_features,
@@ -319,36 +324,38 @@ impl VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            queues,
-            queue_evts,
             device_state: DeviceState::Inactive,
-
-            id: config.drive_id.clone(),
-            partuuid: config.partuuid,
-            cache_type: config.cache_type,
-            root_device: config.is_root_device,
-            read_only: config.is_read_only,
-
-            disk: disk_properties,
-            rate_limiter,
-            is_io_engine_throttled: false,
-            metrics: BlockMetricsPerDevice::alloc(config.drive_id),
+            config,
+            resources: BlockResources {
+                queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
+                queue_evts: [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?],
+                disk: disk_properties,
+                rate_limiter,
+                is_io_engine_throttled: false,
+            },
+            metrics,
         })
     }
 
     /// Returns a copy of a device config
     pub fn config(&self) -> VirtioBlockConfig {
-        let rl: RateLimiterConfig = (&self.rate_limiter).into();
-        VirtioBlockConfig {
-            drive_id: self.id.clone(),
-            path_on_host: self.disk.file_path.clone(),
-            is_root_device: self.root_device,
-            partuuid: self.partuuid.clone(),
-            is_read_only: self.read_only,
-            cache_type: self.cache_type,
-            rate_limiter: rl.into_option(),
-            file_engine_type: self.file_engine_type(),
-        }
+        self.config.clone()
+    }
+
+    pub(crate) fn resources(&self) -> &BlockResources {
+        &self.resources
+    }
+
+    pub(crate) fn resources_mut(&mut self) -> &mut BlockResources {
+        &mut self.resources
+    }
+
+    pub(crate) fn disk(&self) -> &DiskProperties {
+        &self.resources.disk
+    }
+
+    pub(crate) fn rate_limiter(&self) -> &RateLimiter {
+        &self.resources.rate_limiter
     }
 
     /// Process a single event in the Virtio queue.
@@ -357,12 +364,12 @@ impl VirtioBlock {
     /// about new buffers in the queue.
     pub(crate) fn process_queue_event(&mut self) {
         self.metrics.queue_event_count.inc();
-        if let Err(err) = self.queue_evts[0].read() {
+        if let Err(err) = self.resources.queue_evts[0].read() {
             error!("Failed to get queue event: {:?}", err);
             self.metrics.event_fails.inc();
-        } else if self.rate_limiter.is_blocked() {
+        } else if self.resources.rate_limiter.is_blocked() {
             self.metrics.rate_limiter_throttled_events.inc();
-        } else if self.is_io_engine_throttled {
+        } else if self.resources.is_io_engine_throttled {
             self.metrics.io_engine_throttled_events.inc();
         } else {
             self.process_virtio_queues().unwrap()
@@ -378,7 +385,7 @@ impl VirtioBlock {
         self.metrics.rate_limiter_event_count.inc();
         // Upon rate limiter event, call the rate limiter handler
         // and restart processing the queue.
-        if self.rate_limiter.event_handler().is_ok() {
+        if self.resources.rate_limiter.event_handler().is_ok() {
             self.process_queue(0).unwrap()
         }
     }
@@ -388,15 +395,15 @@ impl VirtioBlock {
         // This is safe since we checked in the event handler that the device is activated.
         let active_state = self.device_state.active_state().unwrap();
 
-        let queue = &mut self.queues[queue_index];
+        let queue = &mut self.resources.queues[queue_index];
         let mut used_any = false;
 
         while let Some(head) = queue.pop_or_enable_notification()? {
             self.metrics.remaining_reqs_count.add(queue.len().into());
             let processing_result =
-                match Request::parse(&head, &active_state.mem, self.disk.nsectors) {
+                match Request::parse(&head, &active_state.mem, self.resources.disk.nsectors) {
                     Ok(request) => {
-                        if request.rate_limit(&mut self.rate_limiter) {
+                        if request.rate_limit(&mut self.resources.rate_limiter) {
                             // Stop processing the queue and return this descriptor chain to the
                             // avail ring, for later processing.
                             queue.undo_pop();
@@ -405,7 +412,7 @@ impl VirtioBlock {
                         }
 
                         request.process(
-                            &mut self.disk,
+                            &mut self.resources.disk,
                             head.index,
                             &active_state.mem,
                             &self.metrics,
@@ -425,7 +432,7 @@ impl VirtioBlock {
                 ProcessingResult::Submitted => {}
                 ProcessingResult::Throttled => {
                     queue.undo_pop();
-                    self.is_io_engine_throttled = true;
+                    self.resources.is_io_engine_throttled = true;
                     break;
                 }
                 ProcessingResult::Executed(finished) => {
@@ -452,7 +459,7 @@ impl VirtioBlock {
                 });
         }
 
-        if let FileEngine::Async(ref mut engine) = self.disk.file_engine
+        if let FileEngine::Async(ref mut engine) = self.resources.disk.file_engine
             && let Err(err) = engine.kick_submission_queue()
         {
             error!("BlockError submitting pending block requests: {:?}", err);
@@ -466,11 +473,11 @@ impl VirtioBlock {
     }
 
     fn process_async_completion_queue(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.disk.file_engine);
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
 
         // This is safe since we checked in the event handler that the device is activated.
         let active_state = self.device_state.active_state().unwrap();
-        let queue = &mut self.queues[0];
+        let queue = &mut self.resources.queues[0];
 
         loop {
             match engine.pop(&active_state.mem) {
@@ -517,15 +524,15 @@ impl VirtioBlock {
     }
 
     pub fn process_async_completion_event(&mut self) {
-        let engine = unwrap_async_file_engine_or_return!(&mut self.disk.file_engine);
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
 
         if let Err(err) = engine.completion_evt().read() {
             error!("Failed to get async completion event: {:?}", err);
         } else {
             self.process_async_completion_queue();
 
-            if self.is_io_engine_throttled {
-                self.is_io_engine_throttled = false;
+            if self.resources.is_io_engine_throttled {
+                self.resources.is_io_engine_throttled = false;
                 self.process_queue(0).unwrap()
             }
         }
@@ -533,8 +540,11 @@ impl VirtioBlock {
 
     /// Update the backing file and the config space of the block device.
     pub fn update_disk_image(&mut self, disk_image_path: String) -> Result<(), VirtioBlockError> {
-        self.disk.update(disk_image_path, self.read_only)?;
-        self.config_space.capacity = self.disk.nsectors.to_le(); // virtio_block_config_space();
+        self.resources
+            .disk
+            .update(disk_image_path.clone(), self.config.is_read_only)?;
+        self.config_space.capacity = self.resources.disk.nsectors.to_le();
+        self.config.path_on_host = disk_image_path;
 
         // Kick the driver to pick up the changes. (But only if the device is already activated).
         if self.is_activated() {
@@ -549,19 +559,21 @@ impl VirtioBlock {
 
     /// Updates the parameters for the rate limiter
     pub fn update_rate_limiter(&mut self, bytes: BucketUpdate, ops: BucketUpdate) {
-        self.rate_limiter.update_buckets(bytes, ops);
+        let mut rate_limiter = self.config.rate_limiter.unwrap_or_default();
+        apply_bucket_update(&mut rate_limiter.bandwidth, &bytes);
+        apply_bucket_update(&mut rate_limiter.ops, &ops);
+
+        self.resources.rate_limiter.update_buckets(bytes, ops);
+        self.config.rate_limiter = rate_limiter.into_option();
     }
 
     /// Retrieve the file engine type.
     pub fn file_engine_type(&self) -> FileEngineType {
-        match self.disk.file_engine {
-            FileEngine::Sync(_) => FileEngineType::Sync,
-            FileEngine::Async(_) => FileEngineType::Async,
-        }
+        self.config.file_engine_type
     }
 
     fn drain_and_flush(&mut self, discard: bool) {
-        if let Err(err) = self.disk.file_engine.drain_and_flush(discard) {
+        if let Err(err) = self.resources.disk.file_engine.drain_and_flush(discard) {
             error!("Failed to drain ops and flush block data: {:?}", err);
         }
     }
@@ -573,7 +585,7 @@ impl VirtioBlock {
         }
 
         self.drain_and_flush(false);
-        if let FileEngine::Async(ref _engine) = self.disk.file_engine {
+        if let FileEngine::Async(ref _engine) = self.resources.disk.file_engine {
             self.process_async_completion_queue();
         }
     }
@@ -583,7 +595,7 @@ impl VirtioDevice for VirtioBlock {
     impl_device_type!(VirtioDeviceType::Block);
 
     fn id(&self) -> &str {
-        &self.id
+        &self.config.drive_id
     }
 
     fn avail_features(&self) -> u64 {
@@ -599,19 +611,22 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn num_queues(&self) -> usize {
-        self.queues.len()
+        self.resources.queues.len()
     }
 
     fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
-        self.queues.get(index).map(|queue| &queue.config)
+        self.resources.queues.get(index).map(|queue| &queue.config)
     }
 
     fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
-        self.queues.get_mut(index).map(|queue| &mut queue.config)
+        self.resources
+            .queues
+            .get_mut(index)
+            .map(|queue| &mut queue.config)
     }
 
     fn queue_event(&self, index: usize) -> Option<&EventFd> {
-        self.queue_evts.get(index)
+        self.resources.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -642,14 +657,14 @@ impl VirtioDevice for VirtioBlock {
     ) -> Result<(), ActivateError> {
         assert!(!self.is_activated());
 
-        for q in self.queues.iter_mut() {
+        for q in self.resources.queues.iter_mut() {
             q.initialize(&mem)
                 .map_err(ActivateError::QueueMemoryError)?;
         }
 
         let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
         if event_idx {
-            for queue in &mut self.queues {
+            for queue in &mut self.resources.queues {
                 queue.enable_notif_suppression();
             }
         }
@@ -671,20 +686,20 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn _reset(&mut self) -> bool {
-        if let Err(err) = self.disk.file_engine.drain(true) {
+        if let Err(err) = self.resources.disk.file_engine.drain(true) {
             error!("Failed to reset block IO engine: {:?}", err);
             return false;
         }
-        self.is_io_engine_throttled = false;
+        self.resources.is_io_engine_throttled = false;
         true
     }
 
     fn reset_queues(&mut self) {
-        self.queues.iter_mut().for_each(Queue::reset);
+        self.resources.queues.iter_mut().for_each(Queue::reset);
     }
 
     fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
-        for queue in &mut self.queues {
+        for queue in &mut self.resources.queues {
             queue.initialize(mem)?;
         }
         Ok(())
@@ -693,9 +708,9 @@ impl VirtioDevice for VirtioBlock {
 
 impl Drop for VirtioBlock {
     fn drop(&mut self) {
-        match self.cache_type {
+        match self.config.cache_type {
             CacheType::Unsafe => {
-                if let Err(err) = self.disk.file_engine.drain(true) {
+                if let Err(err) = self.resources.disk.file_engine.drain(true) {
                     error!("Failed to drain ops on drop: {:?}", err);
                 }
             }
@@ -839,6 +854,16 @@ mod tests {
             let expected_config_space = ConfigSpace { capacity: 8 };
             assert_eq!(config, expected_config_space.as_slice());
         }
+    }
+
+    #[test]
+    fn test_config_tracks_rate_limiter_updates() {
+        let mut block = default_block(FileEngineType::Sync);
+        assert!(block.config().rate_limiter.is_some());
+
+        block.update_rate_limiter(BucketUpdate::Disabled, BucketUpdate::Disabled);
+
+        assert_eq!(block.config().rate_limiter, None);
     }
 
     #[test]
@@ -1117,12 +1142,17 @@ mod tests {
                 // Check that the data wasn't written to the file
                 let mut buf = [0u8; 512];
                 block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .seek(SeekFrom::Start(0))
                     .unwrap();
-                block.disk.file_engine.file().read_exact(&mut buf).unwrap();
+                block
+                    .disk()
+                    .file_engine
+                    .file()
+                    .read_exact(&mut buf)
+                    .unwrap();
                 assert_eq!(buf, empty_data.as_slice());
             }
 
@@ -1257,12 +1287,12 @@ mod tests {
                 mem.write_slice(empty_data.as_slice(), data_addr).unwrap();
 
                 let size = block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .seek(SeekFrom::End(0))
                     .unwrap();
-                block.disk.file_engine.file().set_len(size / 2).unwrap();
+                block.disk().file_engine.file().set_len(size / 2).unwrap();
                 mem.write_obj(10, GuestAddress(request_type_addr.0 + 8))
                     .unwrap();
 
@@ -1291,12 +1321,12 @@ mod tests {
                     .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
 
                 let size = block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .seek(SeekFrom::End(0))
                     .unwrap();
-                block.disk.file_engine.file().set_len(size / 2).unwrap();
+                block.disk().file_engine.file().set_len(size / 2).unwrap();
                 // Update sector number: stored at `request_type_addr.0 + 8`
                 mem.write_obj(5, GuestAddress(request_type_addr.0 + 8))
                     .unwrap();
@@ -1340,13 +1370,13 @@ mod tests {
                     .unwrap();
 
                 block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .seek(SeekFrom::Start(512))
                     .unwrap();
                 block
-                    .disk
+                    .disk()
                     .file_engine
                     .file()
                     .write_all(&rand_data[512..])
@@ -1472,7 +1502,7 @@ mod tests {
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
             let data_addr = GuestAddress(vq.dtable[1].addr.get());
             let status_addr = GuestAddress(vq.dtable[2].addr.get());
-            let blk_metadata = block.disk.file_engine.file().metadata();
+            let blk_metadata = block.disk().file_engine.file().metadata();
 
             // Test that the driver receives the correct device id.
             {
@@ -1590,31 +1620,31 @@ mod tests {
             let mem = default_mem();
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, IO_URING_NUM_ENTRIES * 4);
-            block.queues[0] = vq.create_queue();
+            block.resources_mut().queues[0] = vq.create_queue();
             block.activate(mem.clone(), interrupt).unwrap();
 
             // Run scenario that doesn't trigger FullSq BlockError: Add sq_size flush requests.
             add_flush_requests_batch(&mut block, &vq, IO_URING_NUM_ENTRIES);
             simulate_queue_event(&mut block, Some(false));
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             simulate_async_completion_event(&mut block, true);
             check_flush_requests_batch(IO_URING_NUM_ENTRIES, &vq);
 
             // Run scenario that triggers FullSqError : Add sq_size + 10 flush requests.
             add_flush_requests_batch(&mut block, &vq, IO_URING_NUM_ENTRIES + 10);
             simulate_queue_event(&mut block, Some(false));
-            assert!(block.is_io_engine_throttled);
+            assert!(block.resources().is_io_engine_throttled);
             // When the async_completion_event is triggered:
             // 1. sq_size requests should be processed processed.
             // 2. is_io_engine_throttled should be set back to false.
             // 3. process_queue() should be called again.
             simulate_async_completion_event(&mut block, true);
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             check_flush_requests_batch(IO_URING_NUM_ENTRIES, &vq);
             // check that process_queue() was called again resulting in the processing of the
             // remaining 10 ops.
             simulate_async_completion_event(&mut block, true);
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             check_flush_requests_batch(IO_URING_NUM_ENTRIES + 10, &vq);
         }
 
@@ -1625,25 +1655,25 @@ mod tests {
             let mem = default_mem();
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, IO_URING_NUM_ENTRIES * 4);
-            block.queues[0] = vq.create_queue();
+            block.resources_mut().queues[0] = vq.create_queue();
             block.activate(mem.clone(), interrupt).unwrap();
 
             // Run scenario that triggers FullCqError. Push 2 * IO_URING_NUM_ENTRIES and wait for
             // completion. Then try to push another entry.
             add_flush_requests_batch(&mut block, &vq, IO_URING_NUM_ENTRIES);
             simulate_queue_event(&mut block, Some(false));
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             thread::sleep(Duration::from_millis(150));
             add_flush_requests_batch(&mut block, &vq, IO_URING_NUM_ENTRIES);
             simulate_queue_event(&mut block, Some(false));
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             thread::sleep(Duration::from_millis(150));
 
             add_flush_requests_batch(&mut block, &vq, 1);
             simulate_queue_event(&mut block, Some(false));
-            assert!(block.is_io_engine_throttled);
+            assert!(block.resources().is_io_engine_throttled);
             simulate_async_completion_event(&mut block, true);
-            assert!(!block.is_io_engine_throttled);
+            assert!(!block.resources().is_io_engine_throttled);
             check_flush_requests_batch(IO_URING_NUM_ENTRIES * 2, &vq);
         }
     }
@@ -1656,7 +1686,7 @@ mod tests {
             let mem = default_mem();
             let interrupt = default_interrupt();
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
-            block.queues[0] = vq.create_queue();
+            block.resources_mut().queues[0] = vq.create_queue();
             block.activate(mem.clone(), interrupt).unwrap();
 
             // Add a batch of flush requests.
@@ -1709,7 +1739,7 @@ mod tests {
                 );
 
                 // Assert that limiter is blocked.
-                assert!(block.rate_limiter.is_blocked());
+                assert!(block.rate_limiter().is_blocked());
                 // Make sure the data is still queued for processing.
                 assert_eq!(vq.used.idx.get(), 0);
             }
@@ -1726,7 +1756,7 @@ mod tests {
                     block.process_rate_limiter_event()
                 );
                 // Validate the rate_limiter is no longer blocked.
-                assert!(!block.rate_limiter.is_blocked());
+                assert!(!block.rate_limiter().is_blocked());
                 // Complete async IO ops if needed
                 simulate_async_completion_event(&mut block, true);
 
@@ -1778,7 +1808,7 @@ mod tests {
                 );
 
                 // Assert that limiter is blocked.
-                assert!(block.rate_limiter.is_blocked());
+                assert!(block.rate_limiter().is_blocked());
                 // Make sure the data is still queued for processing.
                 assert_eq!(vq.used.idx.get(), 0);
             }
@@ -1793,7 +1823,7 @@ mod tests {
                 );
 
                 // Assert that limiter is blocked.
-                assert!(block.rate_limiter.is_blocked());
+                assert!(block.rate_limiter().is_blocked());
                 // Make sure the data is still queued for processing.
                 assert_eq!(vq.used.idx.get(), 0);
             }
@@ -1810,7 +1840,7 @@ mod tests {
                     block.process_rate_limiter_event()
                 );
                 // Validate the rate_limiter is no longer blocked.
-                assert!(!block.rate_limiter.is_blocked());
+                assert!(!block.rate_limiter().is_blocked());
                 // Complete async IO ops if needed
                 simulate_async_completion_event(&mut block, true);
 
@@ -1846,11 +1876,12 @@ mod tests {
                 .update_disk_image(String::from(path.to_str().unwrap()))
                 .unwrap();
 
+            assert_eq!(block.config().path_on_host, path.to_str().unwrap());
             assert_eq!(
-                block.disk.file_engine.file().metadata().unwrap().st_ino(),
+                block.disk().file_engine.file().metadata().unwrap().st_ino(),
                 mdata.st_ino()
             );
-            assert_eq!(block.disk.image_id, id.as_slice());
+            assert_eq!(block.disk().image_id, id.as_slice());
         }
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -19,7 +19,7 @@ use vm_memory::ByteValued;
 use vmm_sys_util::eventfd::EventFd;
 
 use super::io::FileEngine;
-use super::worker::{BlockWorker, FlushMode};
+use super::worker::{BlockWorker, FlushMode, WorkerHandle};
 use super::{BLOCK_QUEUE_SIZES, SECTOR_SHIFT, SECTOR_SIZE, VirtioBlockError};
 use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::block::CacheType;
@@ -256,11 +256,30 @@ pub struct VirtioBlock {
 #[derive(Debug)]
 pub(crate) enum BlockState {
     // Vmm owns the runtime resources before activation
-    Configuring(BlockResources),
+    // In threaded mode, it also owns a parked worker thread
+    Configuring(BlockResources, Option<WorkerHandle>),
     // Active state, worker owns data-path resources
-    Active(BlockWorker),
+    Active(ActiveBlock),
     // Placeholder to hold state when activating
     Placeholder,
+}
+
+/// Active block data path.
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum ActiveBlock {
+    // Data path on VMM thread (single thread)
+    Inline(BlockWorker),
+    // Data path on a dedicated worker thread (multi thread)
+    Threaded(ThreadedActive),
+}
+
+/// VMM-side state when data path runs on a worker thread
+#[derive(Debug)]
+pub(crate) struct ThreadedActive {
+    worker_handle: WorkerHandle,
+    interrupt: Arc<dyn VirtioInterrupt>,
+    queue_config: Vec<QueueConfig>,
 }
 
 /// Runtime resources used by the block data path.
@@ -321,12 +340,17 @@ impl VirtioBlock {
 
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            state: BlockState::Configuring(BlockResources {
-                queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
-                queue_evts: [EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?],
-                disk: disk_properties,
-                is_io_engine_throttled: false,
-            }),
+            state: BlockState::Configuring(
+                BlockResources {
+                    queues: BLOCK_QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect(),
+                    queue_evts: [
+                        EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?
+                    ],
+                    disk: disk_properties,
+                    is_io_engine_throttled: false,
+                },
+                None,
+            ),
             metrics,
         })
     }
@@ -338,16 +362,22 @@ impl VirtioBlock {
 
     pub(crate) fn resources(&self) -> &BlockResources {
         match &self.state {
-            BlockState::Configuring(resources) => resources,
-            BlockState::Active(worker) => &worker.resources,
+            BlockState::Configuring(resources, _) => resources,
+            BlockState::Active(ActiveBlock::Inline(worker)) => &worker.resources,
+            BlockState::Active(ActiveBlock::Threaded(_)) => {
+                unreachable!("worker thread owns the runtime resources")
+            }
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
 
     pub(crate) fn resources_mut(&mut self) -> &mut BlockResources {
         match &mut self.state {
-            BlockState::Configuring(resources) => resources,
-            BlockState::Active(worker) => &mut worker.resources,
+            BlockState::Configuring(resources, _) => resources,
+            BlockState::Active(ActiveBlock::Inline(worker)) => &mut worker.resources,
+            BlockState::Active(ActiveBlock::Threaded(_)) => {
+                unreachable!("worker thread owns the runtime resources")
+            }
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
@@ -362,12 +392,8 @@ impl VirtioBlock {
             .expect("Poisoned block rate limiter lock")
     }
 
-    fn worker_mut(&mut self) -> &mut BlockWorker {
-        match &mut self.state {
-            BlockState::Active(worker) => worker,
-            BlockState::Configuring(_) => panic!("Device is not activated"),
-            BlockState::Placeholder => unreachable!("not a runtime state"),
-        }
+    pub(crate) fn is_threaded_active(&self) -> bool {
+        matches!(self.state, BlockState::Active(ActiveBlock::Threaded(_)))
     }
 
     /// Process a single event in the Virtio queue.
@@ -375,12 +401,18 @@ impl VirtioBlock {
     /// This function is called by the event manager when the guest notifies us
     /// about new buffers in the queue.
     pub(crate) fn process_queue_event(&mut self) {
-        self.worker_mut().process_queue_event();
+        if let BlockState::Active(ActiveBlock::Inline(worker)) = &mut self.state {
+            worker.process_queue_event();
+        }
     }
 
     /// Process device virtio queue(s).
     pub fn process_virtio_queues(&mut self) -> Result<(), InvalidAvailIdx> {
-        self.worker_mut().process_virtio_queues()
+        if let BlockState::Active(ActiveBlock::Inline(worker)) = &mut self.state {
+            worker.process_virtio_queues()
+        } else {
+            Ok(())
+        }
     }
 
     pub(crate) fn process_rate_limiter_event(&mut self) {
@@ -392,16 +424,21 @@ impl VirtioBlock {
         // Upon rate limiter event, call the rate limiter handler
         // and restart processing the queue.
         match &mut self.state {
-            BlockState::Active(worker) => {
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
                 worker.process_virtio_queues().unwrap();
             }
-            BlockState::Configuring(_) => {}
+            BlockState::Active(ActiveBlock::Threaded(_)) => {
+                unreachable!("worker control messages are not connected yet")
+            }
+            BlockState::Configuring(_, _) => {}
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
 
     pub fn process_async_completion_event(&mut self) {
-        self.worker_mut().process_async_completion_event();
+        if let BlockState::Active(ActiveBlock::Inline(worker)) = &mut self.state {
+            worker.process_async_completion_event();
+        }
     }
 
     /// Update the backing file and the config space of the block device.
@@ -409,11 +446,16 @@ impl VirtioBlock {
         let config_path = disk_image_path.clone();
         let read_only = self.config.is_read_only;
         let nsectors = match &mut self.state {
-            BlockState::Configuring(resources) => {
+            BlockState::Configuring(resources, _) => {
                 resources.disk.update(disk_image_path, read_only)?;
                 resources.disk.nsectors
             }
-            BlockState::Active(worker) => worker.update_disk_image(disk_image_path, read_only)?,
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                worker.update_disk_image(disk_image_path, read_only)?
+            }
+            BlockState::Active(ActiveBlock::Threaded(_)) => {
+                unreachable!("worker control messages are not connected yet")
+            }
             BlockState::Placeholder => unreachable!("not a runtime state"),
         };
         self.config_space.capacity = nsectors.to_le();
@@ -447,9 +489,29 @@ impl VirtioBlock {
 
     /// Prepare device for being snapshotted.
     pub fn prepare_save(&mut self) {
-        if let BlockState::Active(worker) = &mut self.state {
+        if let BlockState::Active(ActiveBlock::Inline(worker)) = &mut self.state {
             worker.prepare_save();
         }
+    }
+
+    /// Spawn a parked worker thread for the next activation.
+    // Currently unused because threaded mode is not exposed through device configuration yet.
+    #[allow(dead_code)]
+    pub(crate) fn spawn_worker(&mut self) -> Result<(), VirtioBlockError> {
+        if let BlockState::Configuring(resources, worker_handle @ None) = &mut self.state {
+            let queue_evts = resources
+                .queue_evts
+                .iter()
+                .map(EventFd::try_clone)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(VirtioBlockError::EventFd)?;
+
+            let name = format!("fc_{}", self.config.drive_id);
+
+            *worker_handle =
+                Some(WorkerHandle::spawn(queue_evts, name).map_err(VirtioBlockError::ThreadSpawn)?);
+        }
+        Ok(())
     }
 }
 
@@ -473,31 +535,65 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn num_queues(&self) -> usize {
-        self.resources().queues.len()
+        match &self.state {
+            BlockState::Configuring(resources, _) => resources.queues.len(),
+            BlockState::Active(ActiveBlock::Inline(worker)) => worker.resources.queues.len(),
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.queue_config.len(),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
-        self.resources()
-            .queues
-            .get(index)
-            .map(|queue| &queue.config)
+        match &self.state {
+            BlockState::Configuring(resources, _) => {
+                resources.queues.get(index).map(|queue| &queue.config)
+            }
+            BlockState::Active(ActiveBlock::Inline(worker)) => worker
+                .resources
+                .queues
+                .get(index)
+                .map(|queue| &queue.config),
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.queue_config.get(index),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
-        self.resources_mut()
-            .queues
-            .get_mut(index)
-            .map(|queue| &mut queue.config)
+        match &mut self.state {
+            BlockState::Configuring(resources, _) => resources
+                .queues
+                .get_mut(index)
+                .map(|queue| &mut queue.config),
+            BlockState::Active(ActiveBlock::Inline(worker)) => worker
+                .resources
+                .queues
+                .get_mut(index)
+                .map(|queue| &mut queue.config),
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.queue_config.get_mut(index),
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn queue_event(&self, index: usize) -> Option<&EventFd> {
-        self.resources().queue_evts.get(index)
+        match &self.state {
+            BlockState::Configuring(resources, _) => resources.queue_evts.get(index),
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                worker.resources.queue_evts.get(index)
+            }
+            BlockState::Active(ActiveBlock::Threaded(active)) => {
+                active.worker_handle.queue_events().get(index)
+            }
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
         match &self.state {
-            BlockState::Active(worker) => worker.active_state.interrupt.deref(),
-            BlockState::Configuring(_) => panic!("Device is not initialized"),
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                worker.active_state.interrupt.deref()
+            }
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.interrupt.deref(),
+            BlockState::Configuring(_, _) => panic!("Device is not initialized"),
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
@@ -524,7 +620,7 @@ impl VirtioDevice for VirtioBlock {
 
         let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
 
-        let BlockState::Configuring(resources) = &mut self.state else {
+        let BlockState::Configuring(resources, _) = &mut self.state else {
             unreachable!("inactive device is not configurable");
         };
 
@@ -544,19 +640,40 @@ impl VirtioDevice for VirtioBlock {
             return Err(ActivateError::EventFd);
         }
 
-        let BlockState::Configuring(resources) =
+        let BlockState::Configuring(resources, worker_handle) =
             std::mem::replace(&mut self.state, BlockState::Placeholder)
         else {
             unreachable!("state checked before activation");
         };
+
+        let queue_config = resources
+            .queues
+            .iter()
+            .map(|queue| queue.config.clone())
+            .collect();
+
         let is_blocked = self.rate_limiter().clone_blocked_flag();
-        self.state = BlockState::Active(BlockWorker {
+        let worker = BlockWorker {
             resources,
             rate_limiter: self.rate_limiter.clone(),
             is_blocked,
-            active_state: ActiveState { mem, interrupt },
+            active_state: ActiveState {
+                mem,
+                interrupt: interrupt.clone(),
+            },
             metrics: self.metrics.clone(),
-        });
+        };
+
+        self.state = if let Some(worker_handle) = worker_handle {
+            worker_handle.start(worker);
+            BlockState::Active(ActiveBlock::Threaded(ThreadedActive {
+                worker_handle,
+                interrupt,
+                queue_config,
+            }))
+        } else {
+            BlockState::Active(ActiveBlock::Inline(worker))
+        };
         Ok(())
     }
 
@@ -567,15 +684,18 @@ impl VirtioDevice for VirtioBlock {
     fn deactivate(&mut self) {
         let state = std::mem::replace(&mut self.state, BlockState::Placeholder);
         self.state = match state {
-            BlockState::Active(worker) => BlockState::Configuring(worker.resources),
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                BlockState::Configuring(worker.resources, None)
+            }
             state => state,
         };
     }
 
     fn _reset(&mut self) -> bool {
         match &mut self.state {
-            BlockState::Active(worker) => worker.reset(),
-            BlockState::Configuring(resources) => {
+            BlockState::Active(ActiveBlock::Inline(worker)) => worker.reset(),
+            BlockState::Active(ActiveBlock::Threaded(_)) => false,
+            BlockState::Configuring(resources, _) => {
                 if let Err(err) = resources.disk.file_engine.drain(true) {
                     error!("Failed to reset block IO engine: {:?}", err);
                     return false;
@@ -588,15 +708,32 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn reset_queues(&mut self) {
-        self.resources_mut()
-            .queues
-            .iter_mut()
-            .for_each(Queue::reset);
+        match &mut self.state {
+            BlockState::Configuring(resources, _) => {
+                resources.queues.iter_mut().for_each(Queue::reset);
+            }
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                worker.resources.queues.iter_mut().for_each(Queue::reset);
+            }
+            BlockState::Active(ActiveBlock::Threaded(_)) => {}
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
     }
 
     fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
-        for queue in &mut self.resources_mut().queues {
-            queue.initialize(mem)?;
+        match &mut self.state {
+            BlockState::Configuring(resources, _) => {
+                for queue in &mut resources.queues {
+                    queue.initialize(mem)?;
+                }
+            }
+            BlockState::Active(ActiveBlock::Inline(worker)) => {
+                for queue in &mut worker.resources.queues {
+                    queue.initialize(mem)?;
+                }
+            }
+            BlockState::Active(ActiveBlock::Threaded(_)) => {}
+            BlockState::Placeholder => unreachable!("not a runtime state"),
         }
         Ok(())
     }
@@ -610,22 +747,30 @@ impl Drop for VirtioBlock {
         };
 
         match std::mem::replace(&mut self.state, BlockState::Placeholder) {
-            BlockState::Active(mut worker) => match flush_mode {
+            BlockState::Active(ActiveBlock::Inline(mut worker)) => match flush_mode {
                 FlushMode::Drain => worker.drain(true),
                 FlushMode::DrainAndFlush => worker.drain_and_flush(true),
             },
-            BlockState::Configuring(mut resources) => match flush_mode {
-                FlushMode::Drain => {
-                    if let Err(err) = resources.disk.file_engine.drain(true) {
-                        error!("Failed to drain ops on drop: {:?}", err);
+            // Worker teardown is connected in the follow-up lifecycle commit.
+            BlockState::Active(ActiveBlock::Threaded(_)) => {}
+            BlockState::Configuring(mut resources, worker_handle) => {
+                match flush_mode {
+                    FlushMode::Drain => {
+                        if let Err(err) = resources.disk.file_engine.drain(true) {
+                            error!("Failed to drain ops on drop: {:?}", err);
+                        }
+                    }
+                    FlushMode::DrainAndFlush => {
+                        if let Err(err) = resources.disk.file_engine.drain_and_flush(true) {
+                            error!("Failed to drain ops and flush block data: {:?}", err);
+                        }
                     }
                 }
-                FlushMode::DrainAndFlush => {
-                    if let Err(err) = resources.disk.file_engine.drain_and_flush(true) {
-                        error!("Failed to drain ops and flush block data: {:?}", err);
-                    }
+                if let Some(worker_handle) = worker_handle {
+                    // a parked worker owns no runtime resources, it just joins the thread
+                    worker_handle.finish(FlushMode::Drain);
                 }
-            },
+            }
             BlockState::Placeholder => {}
         };
     }

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -35,6 +35,7 @@ use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter};
+use crate::seccomp::BpfProgram;
 use crate::vmm_config::drive::BlockDeviceConfig;
 use crate::vmm_config::{RateLimiterConfig, TokenBucketConfig};
 use crate::vstate::memory::GuestMemoryMmap;
@@ -502,7 +503,10 @@ impl VirtioBlock {
     /// Spawn a parked worker thread for the next activation.
     // Currently unused because threaded mode is not exposed through device configuration yet.
     #[allow(dead_code)]
-    pub(crate) fn spawn_worker(&mut self) -> Result<(), VirtioBlockError> {
+    pub(crate) fn spawn_worker(
+        &mut self,
+        seccomp_filter: Arc<BpfProgram>,
+    ) -> Result<(), VirtioBlockError> {
         if let BlockState::Configuring(resources, worker_handle @ None) = &mut self.state {
             let queue_evts = resources
                 .queue_evts
@@ -513,8 +517,10 @@ impl VirtioBlock {
 
             let name = format!("fc_{}", self.config.drive_id);
 
-            *worker_handle =
-                Some(WorkerHandle::spawn(queue_evts, name).map_err(VirtioBlockError::ThreadSpawn)?);
+            *worker_handle = Some(
+                WorkerHandle::spawn(seccomp_filter, queue_evts, name)
+                    .map_err(VirtioBlockError::ThreadSpawn)?,
+            );
         }
         Ok(())
     }
@@ -1968,7 +1974,7 @@ mod tests {
             for threaded in [false, true] {
                 let mut block = default_block(engine);
                 if threaded {
-                    block.spawn_worker().unwrap();
+                    block.spawn_worker(Arc::new(vec![])).unwrap();
                 }
 
                 let mem = default_mem();

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -277,7 +277,7 @@ pub(crate) enum ActiveBlock {
 /// VMM-side state when data path runs on a worker thread
 #[derive(Debug)]
 pub(crate) struct ThreadedActive {
-    worker_handle: WorkerHandle,
+    pub(crate) worker_handle: WorkerHandle,
     interrupt: Arc<dyn VirtioInterrupt>,
     queue_config: Vec<QueueConfig>,
 }
@@ -427,7 +427,7 @@ impl VirtioBlock {
             BlockState::Active(ActiveBlock::Inline(worker)) => {
                 worker.process_virtio_queues().unwrap();
             }
-            BlockState::Active(ActiveBlock::Threaded(active)) => active.worker_handle.kick(),
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.worker_handle.kick(false),
             BlockState::Configuring(_, _) => {}
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
@@ -487,8 +487,15 @@ impl VirtioBlock {
 
     /// Prepare device for being snapshotted.
     pub fn prepare_save(&mut self) {
-        if let BlockState::Active(ActiveBlock::Inline(worker)) = &mut self.state {
-            worker.prepare_save();
+        match &mut self.state {
+            BlockState::Active(ActiveBlock::Inline(worker)) => worker.prepare_save(),
+            BlockState::Active(ActiveBlock::Threaded(active)) => {
+                if let Err(err) = active.worker_handle.pause() {
+                    error!("Failed to pause block worker for snapshot: {:?}", err);
+                }
+            }
+            BlockState::Configuring(_, _) => {}
+            BlockState::Placeholder => unreachable!("not a runtime state"),
         }
     }
 
@@ -722,6 +729,15 @@ impl VirtioDevice for VirtioBlock {
         }
     }
 
+    fn kick(&mut self) {
+        match &self.state {
+            BlockState::Active(ActiveBlock::Threaded(active)) => active.worker_handle.kick(true),
+            BlockState::Active(ActiveBlock::Inline(_)) => self.notify_queue_events(),
+            BlockState::Configuring(_, _) => {}
+            BlockState::Placeholder => unreachable!("not a runtime state"),
+        }
+    }
+
     fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
         match &mut self.state {
             BlockState::Configuring(resources, _) => {
@@ -734,7 +750,9 @@ impl VirtioDevice for VirtioBlock {
                     queue.initialize(mem)?;
                 }
             }
-            BlockState::Active(ActiveBlock::Threaded(_)) => {}
+            BlockState::Active(ActiveBlock::Threaded(active)) => {
+                active.worker_handle.mark_queue_memory_dirty()?;
+            }
             BlockState::Placeholder => unreachable!("not a runtime state"),
         }
         Ok(())

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -682,41 +682,45 @@ impl VirtioDevice for VirtioBlock {
     }
 
     fn deactivate(&mut self) {
-        let state = std::mem::replace(&mut self.state, BlockState::Placeholder);
-        self.state = match state {
-            BlockState::Active(ActiveBlock::Inline(worker)) => {
-                BlockState::Configuring(worker.resources, None)
-            }
-            state => state,
-        };
+        // `_reset` moves data-path resources back into the configuring state.
     }
 
     fn _reset(&mut self) -> bool {
-        match &mut self.state {
-            BlockState::Active(ActiveBlock::Inline(worker)) => worker.reset(),
-            BlockState::Active(ActiveBlock::Threaded(_)) => false,
-            BlockState::Configuring(resources, _) => {
+        let state = std::mem::replace(&mut self.state, BlockState::Placeholder);
+        let (resources, worker_handle) = match state {
+            BlockState::Active(ActiveBlock::Threaded(active)) => {
+                let Some(resources) = active.worker_handle.reset() else {
+                    self.state = BlockState::Active(ActiveBlock::Threaded(active));
+                    return false;
+                };
+                (resources, Some(active.worker_handle))
+            }
+            BlockState::Active(ActiveBlock::Inline(mut worker)) => {
+                if !worker.reset() {
+                    self.state = BlockState::Active(ActiveBlock::Inline(worker));
+                    return false;
+                }
+                (worker.resources, None)
+            }
+            BlockState::Configuring(mut resources, worker_handle) => {
                 if let Err(err) = resources.disk.file_engine.drain(true) {
                     error!("Failed to reset block IO engine: {:?}", err);
+                    self.state = BlockState::Configuring(resources, worker_handle);
                     return false;
                 }
                 resources.is_io_engine_throttled = false;
-                true
+                (resources, worker_handle)
             }
             BlockState::Placeholder => unreachable!("not a runtime state"),
-        }
+        };
+
+        self.state = BlockState::Configuring(resources, worker_handle);
+        true
     }
 
     fn reset_queues(&mut self) {
-        match &mut self.state {
-            BlockState::Configuring(resources, _) => {
-                resources.queues.iter_mut().for_each(Queue::reset);
-            }
-            BlockState::Active(ActiveBlock::Inline(worker)) => {
-                worker.resources.queues.iter_mut().for_each(Queue::reset);
-            }
-            BlockState::Active(ActiveBlock::Threaded(_)) => {}
-            BlockState::Placeholder => unreachable!("not a runtime state"),
+        if let BlockState::Configuring(resources, _) = &mut self.state {
+            resources.queues.iter_mut().for_each(Queue::reset);
         }
     }
 
@@ -751,8 +755,9 @@ impl Drop for VirtioBlock {
                 FlushMode::Drain => worker.drain(true),
                 FlushMode::DrainAndFlush => worker.drain_and_flush(true),
             },
-            // Worker teardown is connected in the follow-up lifecycle commit.
-            BlockState::Active(ActiveBlock::Threaded(_)) => {}
+            BlockState::Active(ActiveBlock::Threaded(active)) => {
+                active.worker_handle.finish(flush_mode);
+            }
             BlockState::Configuring(mut resources, worker_handle) => {
                 match flush_mode {
                     FlushMode::Drain => {
@@ -1938,6 +1943,40 @@ mod tests {
                 mdata.st_ino()
             );
             assert_eq!(block.disk().image_id, id.as_slice());
+        }
+    }
+
+    #[test]
+    fn test_reset_and_reactivation() {
+        for engine in [FileEngineType::Sync, FileEngineType::Async] {
+            for threaded in [false, true] {
+                let mut block = default_block(engine);
+                if threaded {
+                    block.spawn_worker().unwrap();
+                }
+
+                let mem = default_mem();
+                let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
+                set_queue(&mut block, 0, vq.create_queue());
+                block.set_acked_features(1);
+                block.activate(mem.clone(), default_interrupt()).unwrap();
+
+                assert!(block.is_activated());
+                assert_eq!(block.is_threaded_active(), threaded);
+                assert!(block.reset());
+                assert!(!block.is_activated());
+                assert_eq!(block.acked_features(), 0);
+                assert!(!block.queue_config(0).unwrap().ready);
+                let BlockState::Configuring(_, worker_handle) = &block.state else {
+                    panic!("reset must leave the block device configuring");
+                };
+                assert_eq!(worker_handle.is_some(), threaded);
+
+                set_queue(&mut block, 0, vq.create_queue());
+                block.activate(mem, default_interrupt()).unwrap();
+                assert!(block.is_activated());
+                assert_eq!(block.is_threaded_active(), threaded);
+            }
         }
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -188,6 +188,9 @@ pub struct VirtioBlockConfig {
     /// If set to true, the drive is opened in read-only mode. Otherwise, the
     /// drive is opened as read-write.
     pub is_read_only: bool,
+    /// If set to true, process requests on a dedicated worker thread.
+    #[serde(default)]
+    pub threaded: bool,
     /// Path of the backing file on the host
     pub path_on_host: String,
     /// Rate Limiter for I/O operations.
@@ -210,6 +213,7 @@ impl TryFrom<&BlockDeviceConfig> for VirtioBlockConfig {
                 cache_type: value.cache_type,
 
                 is_read_only: value.is_read_only.unwrap_or(false),
+                threaded: value.threaded,
                 path_on_host: path_on_host.clone(),
                 rate_limiter: value.rate_limiter,
                 file_engine_type: value.file_engine_type.unwrap_or_default(),
@@ -229,6 +233,7 @@ impl From<VirtioBlockConfig> for BlockDeviceConfig {
             cache_type: value.cache_type,
 
             is_read_only: Some(value.is_read_only),
+            threaded: value.threaded,
             path_on_host: Some(value.path_on_host),
             rate_limiter: value.rate_limiter,
             file_engine_type: Some(value.file_engine_type),
@@ -832,6 +837,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            threaded: false,
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Default::default(),
@@ -847,6 +853,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: None,
+            threaded: false,
             path_on_host: None,
             rate_limiter: None,
             file_engine_type: Default::default(),
@@ -862,6 +869,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            threaded: false,
             path_on_host: Some("path".to_string()),
             rate_limiter: None,
             file_engine_type: Default::default(),
@@ -1970,6 +1978,7 @@ mod tests {
             for threaded in [false, true] {
                 let mut block = default_block(engine);
                 if threaded {
+                    block.config.threaded = true;
                     block.spawn_worker(Arc::new(vec![])).unwrap();
                 }
 

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -166,7 +166,13 @@ mod tests {
             mem.write_obj::<u64>(123_456_789, data_addr).unwrap();
 
             // Trigger the queue event.
-            block.lock().unwrap().queue_evts[0].write(1).unwrap();
+            block
+                .lock()
+                .unwrap()
+                .queue_event(0)
+                .unwrap()
+                .write(1)
+                .unwrap();
         }
 
         // EventManager should report no events since block has only registered

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -57,8 +57,12 @@ impl VirtioBlock {
         if let Err(err) = self.activate_evt.read() {
             error!("Failed to consume block activate event: {:?}", err);
         }
+
         self.register_rate_limiter_event(ops);
-        self.register_runtime_events(ops);
+        if !self.is_threaded_active() {
+            self.register_runtime_events(ops);
+        }
+
         if let Err(err) = ops.remove(Events::with_data(
             &self.activate_evt,
             Self::PROCESS_ACTIVATE,
@@ -121,7 +125,9 @@ impl MutEventSubscriber for VirtioBlock {
         //  - on device restore from snapshot.
         if self.is_activated() {
             self.register_rate_limiter_event(ops);
-            self.register_runtime_events(ops);
+            if !self.is_threaded_active() {
+                self.register_runtime_events(ops);
+            }
         } else {
             self.register_activate_event(ops);
         }

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -22,13 +22,6 @@ impl VirtioBlock {
         )) {
             error!("Failed to register queue event: {}", err);
         }
-        if let Err(err) = ops.add(Events::with_data(
-            &self.resources().rate_limiter,
-            Self::PROCESS_RATE_LIMITER,
-            EventSet::IN,
-        )) {
-            error!("Failed to register ratelimiter event: {}", err);
-        }
         if let FileEngine::Async(ref engine) = self.resources().disk.file_engine
             && let Err(err) = ops.add(Events::with_data(
                 engine.completion_evt(),
@@ -37,6 +30,16 @@ impl VirtioBlock {
             ))
         {
             error!("Failed to register IO engine completion event: {}", err);
+        }
+    }
+
+    fn register_rate_limiter_event(&self, ops: &mut EventOps) {
+        if let Err(err) = ops.add(Events::with_data(
+            &*self.rate_limiter(),
+            Self::PROCESS_RATE_LIMITER,
+            EventSet::IN,
+        )) {
+            error!("Failed to register rate limiter event: {}", err);
         }
     }
 
@@ -54,6 +57,7 @@ impl VirtioBlock {
         if let Err(err) = self.activate_evt.read() {
             error!("Failed to consume block activate event: {:?}", err);
         }
+        self.register_rate_limiter_event(ops);
         self.register_runtime_events(ops);
         if let Err(err) = ops.remove(Events::with_data(
             &self.activate_evt,
@@ -98,7 +102,7 @@ impl MutEventSubscriber for VirtioBlock {
             match source {
                 Self::PROCESS_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
-                    self.resources_mut().rate_limiter.event_handler();
+                    self.rate_limiter().event_handler();
                 }
                 Self::PROCESS_ASYNC_COMPLETION => {
                     if let FileEngine::Async(ref engine) = self.resources().disk.file_engine {
@@ -116,6 +120,7 @@ impl MutEventSubscriber for VirtioBlock {
         //  - on device activation (is-activated already true at this point),
         //  - on device restore from snapshot.
         if self.is_activated() {
+            self.register_rate_limiter_event(ops);
             self.register_runtime_events(ops);
         } else {
             self.register_activate_event(ops);

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -16,20 +16,20 @@ impl VirtioBlock {
 
     fn register_runtime_events(&self, ops: &mut EventOps) {
         if let Err(err) = ops.add(Events::with_data(
-            &self.queue_evts[0],
+            &self.resources().queue_evts[0],
             Self::PROCESS_QUEUE,
             EventSet::IN,
         )) {
             error!("Failed to register queue event: {}", err);
         }
         if let Err(err) = ops.add(Events::with_data(
-            &self.rate_limiter,
+            &self.resources().rate_limiter,
             Self::PROCESS_RATE_LIMITER,
             EventSet::IN,
         )) {
             error!("Failed to register ratelimiter event: {}", err);
         }
-        if let FileEngine::Async(ref engine) = self.disk.file_engine
+        if let FileEngine::Async(ref engine) = self.resources().disk.file_engine
             && let Err(err) = ops.add(Events::with_data(
                 engine.completion_evt(),
                 Self::PROCESS_ASYNC_COMPLETION,
@@ -98,10 +98,10 @@ impl MutEventSubscriber for VirtioBlock {
             match source {
                 Self::PROCESS_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
-                    self.rate_limiter.event_handler();
+                    self.resources_mut().rate_limiter.event_handler();
                 }
                 Self::PROCESS_ASYNC_COMPLETION => {
-                    if let FileEngine::Async(ref engine) = self.disk.file_engine {
+                    if let FileEngine::Async(ref engine) = self.resources().disk.file_engine {
                         engine.completion_evt().read();
                     }
                 }

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -66,4 +66,6 @@ pub enum VirtioBlockError {
     Persist(crate::devices::virtio::persist::PersistError),
     /// Error spawning the block worker thread: {0}
     ThreadSpawn(std::io::Error),
+    /// Error communicating with the block worker thread: {0}
+    WorkerControl(String),
 }

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -10,6 +10,7 @@ pub mod metrics;
 pub mod persist;
 pub mod request;
 pub mod test_utils;
+mod worker;
 
 use vm_memory::GuestMemoryError;
 

--- a/src/vmm/src/devices/virtio/block/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/mod.rs
@@ -64,4 +64,6 @@ pub enum VirtioBlockError {
     RateLimiter(std::io::Error),
     /// Persistence error: {0}
     Persist(crate::devices::virtio::persist::PersistError),
+    /// Error spawning the block worker thread: {0}
+    ThreadSpawn(std::io::Error),
 }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -75,7 +75,7 @@ impl Persist<'_> for VirtioBlock {
             cache_type: self.cache_type,
             root_device: self.root_device,
             disk_path: self.disk.file_path.clone(),
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
             rate_limiter_state: self.rate_limiter.save(),
             file_engine_type: FileEngineTypeState::from(self.file_engine_type()),
         }
@@ -221,7 +221,7 @@ mod tests {
         assert_eq!(restored_block.device_type(), VirtioDeviceType::Block);
         assert_eq!(restored_block.avail_features(), block.avail_features());
         assert_eq!(restored_block.acked_features(), block.acked_features());
-        assert_eq!(restored_block.queues(), block.queues());
+        assert_eq!(restored_block.queues, block.queues);
         assert!(!block.is_activated());
         assert!(!restored_block.is_activated());
 

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 use vmm_sys_util::eventfd::EventFd;
 
-use super::device::{BlockResources, BlockState, DiskProperties};
+use super::device::{ActiveBlock, BlockResources, BlockState, DiskProperties};
 use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
 use crate::devices::virtio::block::virtio::device::{FileEngineType, VirtioBlockConfig};
@@ -70,14 +70,25 @@ impl Persist<'_> for VirtioBlock {
     type Error = VirtioBlockError;
 
     fn save(&self) -> Self::State {
-        // Save device state.
+        let virtio_state = if let BlockState::Active(ActiveBlock::Threaded(active)) = &self.state {
+            VirtioDeviceState {
+                device_type: VirtioDeviceType::Block,
+                avail_features: self.avail_features,
+                acked_features: self.acked_features,
+                queues: active.worker_handle.get_queue_states(),
+                activated: true,
+            }
+        } else {
+            VirtioDeviceState::from_device(self, &self.resources().queues)
+        };
+
         VirtioBlockState {
             id: self.config.drive_id.clone(),
             partuuid: self.config.partuuid.clone(),
             cache_type: self.config.cache_type,
             root_device: self.config.is_root_device,
-            disk_path: self.disk().file_path.clone(),
-            virtio_state: VirtioDeviceState::from_device(self, &self.resources().queues),
+            disk_path: self.config.path_on_host.clone(),
+            virtio_state,
             rate_limiter_state: self.rate_limiter().save(),
             file_engine_type: FileEngineTypeState::from(self.file_engine_type()),
         }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -5,6 +5,7 @@
 
 use device::ConfigSpace;
 use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
 use vmm_sys_util::eventfd::EventFd;
 
 use super::device::{BlockResources, DiskProperties};
@@ -129,7 +130,6 @@ impl Persist<'_> for VirtioBlock {
             queues,
             queue_evts,
             disk: disk_properties,
-            rate_limiter,
             is_io_engine_throttled: false,
         };
 
@@ -141,6 +141,7 @@ impl Persist<'_> for VirtioBlock {
 
             device_state: DeviceState::Inactive,
             config,
+            rate_limiter: Arc::new(Mutex::new(rate_limiter)),
             resources,
             metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
         })

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -62,6 +62,8 @@ pub struct VirtioBlockState {
     pub virtio_state: VirtioDeviceState,
     rate_limiter_state: RateLimiterState,
     file_engine_type: FileEngineTypeState,
+    #[serde(default)]
+    threaded: bool,
 }
 
 impl Persist<'_> for VirtioBlock {
@@ -91,6 +93,7 @@ impl Persist<'_> for VirtioBlock {
             virtio_state,
             rate_limiter_state: self.rate_limiter().save(),
             file_engine_type: FileEngineTypeState::from(self.file_engine_type()),
+            threaded: self.config.threaded,
         }
     }
 
@@ -108,6 +111,7 @@ impl Persist<'_> for VirtioBlock {
             is_root_device: state.root_device,
             cache_type: state.cache_type,
             is_read_only,
+            threaded: state.threaded,
             path_on_host: state.disk_path.clone(),
             rate_limiter: rate_limiter_config.into_option(),
             file_engine_type: state.file_engine_type.into(),
@@ -178,6 +182,7 @@ mod tests {
             is_root_device: false,
             partuuid: None,
             is_read_only: false,
+            threaded: false,
             cache_type: CacheType::Writeback,
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
@@ -219,6 +224,7 @@ mod tests {
             is_root_device: false,
             partuuid: None,
             is_read_only: false,
+            threaded: false,
             cache_type: CacheType::Unsafe,
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -7,17 +7,18 @@ use device::ConfigSpace;
 use serde::{Deserialize, Serialize};
 use vmm_sys_util::eventfd::EventFd;
 
-use super::device::DiskProperties;
+use super::device::{BlockResources, DiskProperties};
 use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
-use crate::devices::virtio::block::virtio::device::FileEngineType;
+use crate::devices::virtio::block::virtio::device::{FileEngineType, VirtioBlockConfig};
 use crate::devices::virtio::block::virtio::metrics::BlockMetricsPerDevice;
-use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDeviceType};
+use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_blk::VIRTIO_BLK_F_RO;
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::rate_limiter::RateLimiter;
 use crate::rate_limiter::persist::RateLimiterState;
 use crate::snapshot::Persist;
+use crate::vmm_config::RateLimiterConfig;
 
 /// Holds info about block's file engine type. Gets saved in snapshot.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -70,13 +71,13 @@ impl Persist<'_> for VirtioBlock {
     fn save(&self) -> Self::State {
         // Save device state.
         VirtioBlockState {
-            id: self.id.clone(),
-            partuuid: self.partuuid.clone(),
-            cache_type: self.cache_type,
-            root_device: self.root_device,
-            disk_path: self.disk.file_path.clone(),
-            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
-            rate_limiter_state: self.rate_limiter.save(),
+            id: self.config.drive_id.clone(),
+            partuuid: self.config.partuuid.clone(),
+            cache_type: self.config.cache_type,
+            root_device: self.config.is_root_device,
+            disk_path: self.disk().file_path.clone(),
+            virtio_state: VirtioDeviceState::from_device(self, &self.resources().queues),
+            rate_limiter_state: self.rate_limiter().save(),
             file_engine_type: FileEngineTypeState::from(self.file_engine_type()),
         }
     }
@@ -88,6 +89,17 @@ impl Persist<'_> for VirtioBlock {
         let is_read_only = state.virtio_state.avail_features & (1u64 << VIRTIO_BLK_F_RO) != 0;
         let rate_limiter = RateLimiter::restore((), &state.rate_limiter_state)
             .map_err(VirtioBlockError::RateLimiter)?;
+        let rate_limiter_config: RateLimiterConfig = (&rate_limiter).into();
+        let config = VirtioBlockConfig {
+            drive_id: state.id.clone(),
+            partuuid: state.partuuid.clone(),
+            is_root_device: state.root_device,
+            cache_type: state.cache_type,
+            is_read_only,
+            path_on_host: state.disk_path.clone(),
+            rate_limiter: rate_limiter_config.into_option(),
+            file_engine_type: state.file_engine_type.into(),
+        };
 
         let disk_properties = DiskProperties::new(
             state.disk_path.clone(),
@@ -113,6 +125,13 @@ impl Persist<'_> for VirtioBlock {
         let config_space = ConfigSpace {
             capacity: disk_properties.nsectors.to_le(),
         };
+        let resources = BlockResources {
+            queues,
+            queue_evts,
+            disk: disk_properties,
+            rate_limiter,
+            is_io_engine_throttled: false,
+        };
 
         Ok(VirtioBlock {
             avail_features,
@@ -120,19 +139,9 @@ impl Persist<'_> for VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            queues,
-            queue_evts,
             device_state: DeviceState::Inactive,
-
-            id: state.id.clone(),
-            partuuid: state.partuuid.clone(),
-            cache_type: state.cache_type,
-            root_device: state.root_device,
-            read_only: is_read_only,
-
-            disk: disk_properties,
-            rate_limiter,
-            is_io_engine_throttled: false,
+            config,
+            resources,
             metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
         })
     }
@@ -143,7 +152,6 @@ mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::devices::virtio::block::virtio::device::VirtioBlockConfig;
     use crate::devices::virtio::device::VirtioDevice;
     use crate::devices::virtio::test_utils::{default_interrupt, default_mem};
 
@@ -221,11 +229,11 @@ mod tests {
         assert_eq!(restored_block.device_type(), VirtioDeviceType::Block);
         assert_eq!(restored_block.avail_features(), block.avail_features());
         assert_eq!(restored_block.acked_features(), block.acked_features());
-        assert_eq!(restored_block.queues, block.queues);
+        assert_eq!(restored_block.resources().queues, block.resources().queues);
         assert!(!block.is_activated());
         assert!(!restored_block.is_activated());
 
         // Test that block specific fields are the same.
-        assert_eq!(restored_block.disk.file_path, block.disk.file_path);
+        assert_eq!(restored_block.disk().file_path, block.disk().file_path);
     }
 }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -8,12 +8,12 @@ use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 use vmm_sys_util::eventfd::EventFd;
 
-use super::device::{BlockResources, DiskProperties};
+use super::device::{BlockResources, BlockState, DiskProperties};
 use super::*;
 use crate::devices::virtio::block::persist::BlockConstructorArgs;
 use crate::devices::virtio::block::virtio::device::{FileEngineType, VirtioBlockConfig};
 use crate::devices::virtio::block::virtio::metrics::BlockMetricsPerDevice;
-use crate::devices::virtio::device::{DeviceState, VirtioDeviceType};
+use crate::devices::virtio::device::VirtioDeviceType;
 use crate::devices::virtio::generated::virtio_blk::VIRTIO_BLK_F_RO;
 use crate::devices::virtio::persist::VirtioDeviceState;
 use crate::rate_limiter::RateLimiter;
@@ -139,10 +139,9 @@ impl Persist<'_> for VirtioBlock {
             config_space,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VirtioBlockError::EventFd)?,
 
-            device_state: DeviceState::Inactive,
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            resources,
+            state: BlockState::Configuring(resources),
             metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
         })
     }

--- a/src/vmm/src/devices/virtio/block/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/persist.rs
@@ -141,7 +141,7 @@ impl Persist<'_> for VirtioBlock {
 
             config,
             rate_limiter: Arc::new(Mutex::new(rate_limiter)),
-            state: BlockState::Configuring(resources),
+            state: BlockState::Configuring(resources, None),
             metrics: BlockMetricsPerDevice::alloc(state.id.clone()),
         })
     }

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -80,7 +80,7 @@ pub fn rate_limiter(blk: &mut VirtioBlock) -> &RateLimiter {
 pub fn simulate_queue_event(b: &mut VirtioBlock, maybe_expected_irq: Option<bool>) {
     // Trigger the queue event.
 
-    b.queue_evts[0].write(1).unwrap();
+    b.queue_event(0).unwrap().write(1).unwrap();
     // Handle event.
     b.process_queue_event();
     // Validate the queue operation finished successfully.

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -69,11 +69,7 @@ pub fn set_queue(blk: &mut VirtioBlock, idx: usize, q: Queue) {
 }
 
 pub fn set_rate_limiter(blk: &mut VirtioBlock, rl: RateLimiter) {
-    blk.resources_mut().rate_limiter = rl;
-}
-
-pub fn rate_limiter(blk: &mut VirtioBlock) -> &RateLimiter {
-    blk.rate_limiter()
+    *blk.rate_limiter() = rl;
 }
 
 #[cfg(test)]

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -43,6 +43,7 @@ pub fn default_block_with_path(path: String, file_engine_type: FileEngineType) -
         is_root_device: false,
         partuuid: None,
         is_read_only: false,
+        threaded: false,
         cache_type: CacheType::Unsafe,
         // Rate limiting is enabled but with a high operation rate (10 million ops/s).
         rate_limiter: Some(RateLimiterConfig {

--- a/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/test_utils.rs
@@ -65,15 +65,15 @@ pub fn default_block_with_path(path: String, file_engine_type: FileEngineType) -
 }
 
 pub fn set_queue(blk: &mut VirtioBlock, idx: usize, q: Queue) {
-    blk.queues[idx] = q;
+    blk.resources_mut().queues[idx] = q;
 }
 
 pub fn set_rate_limiter(blk: &mut VirtioBlock, rl: RateLimiter) {
-    blk.rate_limiter = rl;
+    blk.resources_mut().rate_limiter = rl;
 }
 
 pub fn rate_limiter(blk: &mut VirtioBlock) -> &RateLimiter {
-    &blk.rate_limiter
+    blk.rate_limiter()
 }
 
 #[cfg(test)]
@@ -95,7 +95,7 @@ pub fn simulate_queue_event(b: &mut VirtioBlock, maybe_expected_irq: Option<bool
 
 #[cfg(test)]
 pub fn simulate_async_completion_event(b: &mut VirtioBlock, expected_irq: bool) {
-    if let FileEngine::Async(ref mut engine) = b.disk.file_engine {
+    if let FileEngine::Async(ref mut engine) = b.resources_mut().disk.file_engine {
         // Wait for all the async operations to complete.
         engine.drain(false).unwrap();
         // Wait for the async completion event to be sent.
@@ -114,7 +114,7 @@ pub fn simulate_async_completion_event(b: &mut VirtioBlock, expected_irq: bool) 
 
 #[cfg(test)]
 pub fn simulate_queue_and_async_completion_events(b: &mut VirtioBlock, expected_irq: bool) {
-    match b.disk.file_engine {
+    match b.resources().disk.file_engine {
         FileEngine::Async(_) => {
             simulate_queue_event(b, None);
             simulate_async_completion_event(b, expected_irq);

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -54,8 +54,6 @@ enum ControlMsg {
 }
 
 /// VMM-side handle for controlling and joining a block worker thread.
-// Handle gets connected to VirtioBlock in follow-up commits
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct WorkerHandle {
     to_worker: Sender<ControlMsg>,
@@ -295,8 +293,6 @@ impl BlockWorker {
     }
 }
 
-// Handle gets connected to VirtioBlock in follow-up commits
-#[allow(dead_code)]
 impl WorkerHandle {
     /// Spawn a parked block worker thread.
     pub(crate) fn spawn(queue_evts: Vec<EventFd>, name: String) -> Result<Self, std::io::Error> {

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -36,6 +36,7 @@ struct ThreadedWorker {
     state: WorkerState,
     control_evt: EventFd,
     from_vmm: Receiver<ControlMsg>,
+    to_vmm: Sender<ControlResponse>,
 }
 
 /// Data-path ownership state of the worker thread.
@@ -50,13 +51,20 @@ enum WorkerState {
 #[allow(clippy::large_enum_variant)]
 enum ControlMsg {
     Start(BlockWorker),
+    Reset,
     Finish(FlushMode),
+}
+
+#[allow(clippy::large_enum_variant)]
+enum ControlResponse {
+    Reset(Option<BlockResources>),
 }
 
 /// VMM-side handle for controlling and joining a block worker thread.
 #[derive(Debug)]
 pub(crate) struct WorkerHandle {
     to_worker: Sender<ControlMsg>,
+    from_worker: Receiver<ControlResponse>,
     control_evt: EventFd,
     join: JoinHandle<()>,
     queue_evts: Vec<EventFd>,
@@ -299,16 +307,19 @@ impl WorkerHandle {
         // handle writes and worker reads the control eventfd
         let control_evt = EventFd::new(libc::EFD_NONBLOCK)?;
         let handle_evt = control_evt.try_clone()?;
+
         let (to_worker, from_vmm) = channel::<ControlMsg>();
+        let (to_vmm, from_worker) = channel::<ControlResponse>();
 
         let join = thread::Builder::new().name(name).spawn(move || {
             let event_manager =
                 EventManager::new().expect("Failed to create block worker EventManager");
-            run_worker_loop(event_manager, control_evt, from_vmm);
+            run_worker_loop(event_manager, control_evt, from_vmm, to_vmm);
         })?;
 
         Ok(Self {
             to_worker,
+            from_worker,
             control_evt: handle_evt,
             join,
             queue_evts,
@@ -331,11 +342,40 @@ impl WorkerHandle {
         }
     }
 
+    /// Stop processing and return the data-path resources to the VMM thread.
+    pub(crate) fn reset(&self) -> Option<BlockResources> {
+        if let Err(err) = self.to_worker.send(ControlMsg::Reset) {
+            error!(
+                "Block worker receiver already dropped during reset: {:?}",
+                err
+            );
+            return None;
+        }
+
+        if let Err(err) = self.control_evt.write(1) {
+            error!(
+                "Block worker control event is closed during reset: {:?}",
+                err
+            );
+            return None;
+        }
+
+        match self.from_worker.recv() {
+            Ok(ControlResponse::Reset(resources)) => resources,
+            Err(err) => {
+                error!("Block worker failed to acknowledge reset: {:?}", err);
+                None
+            }
+        }
+    }
+
     /// Stop the worker and wait for its thread to exit.
     pub(crate) fn finish(self, flush_mode: FlushMode) {
         if let Err(err) = self.to_worker.send(ControlMsg::Finish(flush_mode)) {
             error!("Block worker receiver already dropped: {:?}", err);
-        } else if let Err(err) = self.control_evt.write(1) {
+        }
+
+        if let Err(err) = self.control_evt.write(1) {
             error!("Block worker control event is closed: {:?}", err);
         }
 
@@ -410,6 +450,7 @@ impl ThreadedWorker {
         while let Ok(msg) = self.from_vmm.try_recv() {
             match msg {
                 ControlMsg::Start(worker) => self.start_worker(worker, ops),
+                ControlMsg::Reset => self.reset_worker(ops),
                 ControlMsg::Finish(flush_mode) => self.finish_worker(flush_mode, ops),
             }
 
@@ -427,6 +468,33 @@ impl ThreadedWorker {
 
         Self::register_runtime_events(&worker.resources, ops);
         self.state = WorkerState::Running(worker);
+    }
+
+    fn reset_worker(&mut self, ops: &mut EventOps) {
+        let resources = match std::mem::replace(&mut self.state, WorkerState::Parked) {
+            WorkerState::Running(mut worker) => {
+                Self::unregister_runtime_events(&worker.resources, ops);
+                if worker.reset() {
+                    Some(worker.resources)
+                } else {
+                    Self::register_runtime_events(&worker.resources, ops);
+                    self.state = WorkerState::Running(worker);
+                    None
+                }
+            }
+            WorkerState::Parked => {
+                warn!("Reset requested while block worker is parked");
+                None
+            }
+            WorkerState::Finished => {
+                self.state = WorkerState::Finished;
+                None
+            }
+        };
+
+        if let Err(err) = self.to_vmm.send(ControlResponse::Reset(resources)) {
+            error!("Failed to send block worker reset response: {:?}", err);
+        }
     }
 
     fn finish_worker(&mut self, flush_mode: FlushMode, ops: &mut EventOps) {
@@ -451,11 +519,13 @@ fn run_worker_loop(
     mut event_manager: EventManager,
     control_evt: EventFd,
     from_vmm: Receiver<ControlMsg>,
+    to_vmm: Sender<ControlResponse>,
 ) {
     let worker = Arc::new(Mutex::new(ThreadedWorker {
         state: WorkerState::Parked,
         control_evt,
         from_vmm,
+        to_vmm,
     }));
     let subscriber: Arc<Mutex<dyn MutEventSubscriber>> = worker.clone();
     event_manager.add_subscriber(subscriber);

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -51,12 +51,15 @@ enum WorkerState {
 #[allow(clippy::large_enum_variant)]
 enum ControlMsg {
     Start(BlockWorker),
+    UpdateDiskImage { path: String, read_only: bool },
+    Kick,
     Reset,
     Finish(FlushMode),
 }
 
 #[allow(clippy::large_enum_variant)]
 enum ControlResponse {
+    DiskUpdated(Result<u64, VirtioBlockError>), // returns nsectors on success
     Reset(Option<BlockResources>),
 }
 
@@ -360,12 +363,67 @@ impl WorkerHandle {
             return None;
         }
 
-        match self.from_worker.recv() {
-            Ok(ControlResponse::Reset(resources)) => resources,
-            Err(err) => {
-                error!("Block worker failed to acknowledge reset: {:?}", err);
-                None
+        loop {
+            match self.from_worker.recv() {
+                Ok(ControlResponse::Reset(resources)) => return resources,
+                Ok(ControlResponse::DiskUpdated(_)) => {
+                    warn!("Ignoring disk update response while waiting for reset");
+                }
+                Err(err) => {
+                    error!("Block worker failed to acknowledge reset: {:?}", err);
+                    return None;
+                }
             }
+        }
+    }
+
+    /// Replace the worker's backing file and return its new sector count.
+    pub(crate) fn update_disk_image(
+        &self,
+        disk_image_path: String,
+        read_only: bool,
+    ) -> Result<u64, VirtioBlockError> {
+        if let Err(err) = self.to_worker.send(ControlMsg::UpdateDiskImage {
+            path: disk_image_path,
+            read_only,
+        }) {
+            error!("Failed to send block worker disk update: {:?}", err);
+            return Err(VirtioBlockError::WorkerControl(format!(
+                "failed to send disk update: {err}"
+            )));
+        }
+
+        if let Err(err) = self.control_evt.write(1) {
+            error!("Failed to notify block worker of disk update: {:?}", err);
+            return Err(VirtioBlockError::WorkerControl(format!(
+                "failed to notify worker of disk update: {err}"
+            )));
+        }
+
+        loop {
+            match self.from_worker.recv() {
+                Ok(ControlResponse::DiskUpdated(result)) => return result,
+                Ok(ControlResponse::Reset(_)) => {
+                    warn!("Ignoring reset response while waiting for disk update");
+                }
+                Err(err) => {
+                    error!("Block worker failed to acknowledge disk update: {:?}", err);
+                    return Err(VirtioBlockError::WorkerControl(format!(
+                        "failed to receive disk update response: {err}"
+                    )));
+                }
+            }
+        }
+    }
+
+    pub(crate) fn kick(&self) {
+        if let Err(err) = self.to_worker.send(ControlMsg::Kick) {
+            error!("Failed to send block worker kick: {:?}", err);
+            return;
+        }
+
+        if let Err(err) = self.control_evt.write(1) {
+            error!("Failed to notify block worker of kick: {:?}", err);
         }
     }
 
@@ -450,6 +508,10 @@ impl ThreadedWorker {
         while let Ok(msg) = self.from_vmm.try_recv() {
             match msg {
                 ControlMsg::Start(worker) => self.start_worker(worker, ops),
+                ControlMsg::UpdateDiskImage { path, read_only } => {
+                    self.update_disk_image(path, read_only)
+                }
+                ControlMsg::Kick => self.kick_worker(),
                 ControlMsg::Reset => self.reset_worker(ops),
                 ControlMsg::Finish(flush_mode) => self.finish_worker(flush_mode, ops),
             }
@@ -468,6 +530,51 @@ impl ThreadedWorker {
 
         Self::register_runtime_events(&worker.resources, ops);
         self.state = WorkerState::Running(worker);
+    }
+
+    fn update_disk_image(&mut self, path: String, read_only: bool) {
+        let result = match &mut self.state {
+            WorkerState::Running(worker) => worker.update_disk_image(path, read_only),
+            WorkerState::Parked => {
+                warn!("Disk image update requested while block worker is parked");
+                Err(VirtioBlockError::WorkerControl(
+                    "disk update requested while worker is parked".to_string(),
+                ))
+            }
+            WorkerState::Finished => {
+                warn!("Disk image update requested after block worker finished");
+                Err(VirtioBlockError::WorkerControl(
+                    "disk update requested after worker finished".to_string(),
+                ))
+            }
+        };
+
+        if let Err(err) = self.to_vmm.send(ControlResponse::DiskUpdated(result)) {
+            error!(
+                "Failed to send block worker disk update response: {:?}",
+                err
+            );
+        }
+    }
+
+    fn kick_worker(&mut self) {
+        match std::mem::replace(&mut self.state, WorkerState::Parked) {
+            WorkerState::Running(worker) => {
+                self.state = WorkerState::Running(worker);
+            }
+            state => {
+                warn!("Kick requested while block worker is not active");
+                self.state = state;
+                return;
+            }
+        }
+
+        // process directly instead of going through epoll
+        if let WorkerState::Running(worker) = &mut self.state {
+            worker
+                .process_virtio_queues()
+                .unwrap_or_else(|err| error!("Failed to kick block worker queue: {:?}", err));
+        }
     }
 
     fn reset_worker(&mut self, ops: &mut EventOps) {

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -15,10 +15,12 @@ use super::metrics::BlockDeviceMetrics;
 use super::{FinishedRequest, IoErr, ProcessingResult, Request, VirtioBlockError};
 use crate::EventManager;
 use crate::devices::virtio::device::ActiveState;
-use crate::devices::virtio::queue::InvalidAvailIdx;
+use crate::devices::virtio::persist::QueueState;
+use crate::devices::virtio::queue::{InvalidAvailIdx, QueueError};
 use crate::devices::virtio::transport::VirtioInterruptType;
 use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::RateLimiter;
+use crate::snapshot::Persist;
 
 /// Runtime state and processing logic for an active block device.
 #[derive(Debug)]
@@ -45,6 +47,7 @@ struct ThreadedWorker {
 enum WorkerState {
     Parked,
     Running(BlockWorker),
+    Paused(BlockWorker),
     Finished,
 }
 
@@ -52,8 +55,11 @@ enum WorkerState {
 enum ControlMsg {
     Start(BlockWorker),
     UpdateDiskImage { path: String, read_only: bool },
-    Kick,
     Reset,
+    Pause,
+    GetQueueStates,
+    MarkQueueMemoryDirty,
+    Kick { resume: bool },
     Finish(FlushMode),
 }
 
@@ -61,6 +67,10 @@ enum ControlMsg {
 enum ControlResponse {
     DiskUpdated(Result<u64, VirtioBlockError>), // returns nsectors on success
     Reset(Option<BlockResources>),
+    Paused,
+    QueueStates(Vec<QueueState>),
+    QueueMemoryDirty(Result<(), QueueError>),
+    InvalidState(String),
 }
 
 /// VMM-side handle for controlling and joining a block worker thread.
@@ -89,6 +99,19 @@ macro_rules! unwrap_async_file_engine_or_return {
             }
         }
     };
+}
+
+impl ControlResponse {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::DiskUpdated(_) => "disk update",
+            Self::Reset(_) => "reset",
+            Self::Paused => "pause",
+            Self::QueueStates(_) => "queue states",
+            Self::QueueMemoryDirty(_) => "queue memory dirty",
+            Self::InvalidState(_) => "invalid state",
+        }
+    }
 }
 
 impl BlockWorker {
@@ -366,8 +389,11 @@ impl WorkerHandle {
         loop {
             match self.from_worker.recv() {
                 Ok(ControlResponse::Reset(resources)) => return resources,
-                Ok(ControlResponse::DiskUpdated(_)) => {
-                    warn!("Ignoring disk update response while waiting for reset");
+                Ok(response) => {
+                    warn!(
+                        "Ignoring {} response while waiting for reset",
+                        response.name()
+                    );
                 }
                 Err(err) => {
                     error!("Block worker failed to acknowledge reset: {:?}", err);
@@ -403,8 +429,11 @@ impl WorkerHandle {
         loop {
             match self.from_worker.recv() {
                 Ok(ControlResponse::DiskUpdated(result)) => return result,
-                Ok(ControlResponse::Reset(_)) => {
-                    warn!("Ignoring reset response while waiting for disk update");
+                Ok(response) => {
+                    warn!(
+                        "Ignoring {} response while waiting for disk update",
+                        response.name()
+                    );
                 }
                 Err(err) => {
                     error!("Block worker failed to acknowledge disk update: {:?}", err);
@@ -416,8 +445,105 @@ impl WorkerHandle {
         }
     }
 
-    pub(crate) fn kick(&self) {
-        if let Err(err) = self.to_worker.send(ControlMsg::Kick) {
+    /// Pause data-path processing after completing pending I/O.
+    pub(crate) fn pause(&self) -> Result<(), VirtioBlockError> {
+        if let Err(err) = self.to_worker.send(ControlMsg::Pause) {
+            error!("Failed to send block worker pause: {:?}", err);
+            return Err(VirtioBlockError::WorkerControl(err.to_string()));
+        }
+
+        if let Err(err) = self.control_evt.write(1) {
+            error!("Failed to notify block worker of pause: {:?}", err);
+            return Err(VirtioBlockError::WorkerControl(err.to_string()));
+        }
+
+        loop {
+            match self.from_worker.recv() {
+                Ok(ControlResponse::Paused) => return Ok(()),
+                Ok(ControlResponse::InvalidState(err)) => {
+                    return Err(VirtioBlockError::WorkerControl(err));
+                }
+                Ok(response) => {
+                    warn!(
+                        "Ignoring {} response while waiting for pause",
+                        response.name()
+                    );
+                }
+                Err(err) => {
+                    error!("Block worker failed to return pause ack: {:?}", err);
+                    return Err(VirtioBlockError::WorkerControl(err.to_string()));
+                }
+            }
+        }
+    }
+
+    /// Read queue state from a paused worker.
+    pub(crate) fn get_queue_states(&self) -> Vec<QueueState> {
+        if let Err(err) = self.to_worker.send(ControlMsg::GetQueueStates) {
+            error!("Failed to request block worker queue states: {:?}", err);
+        }
+
+        if let Err(err) = self.control_evt.write(1) {
+            error!(
+                "Failed to notify block worker of queue state request: {:?}",
+                err
+            );
+        }
+
+        loop {
+            match self.from_worker.recv() {
+                Ok(ControlResponse::QueueStates(states)) => return states,
+                Ok(response) => {
+                    warn!(
+                        "Ignoring {} response while waiting for queue states",
+                        response.name()
+                    );
+                }
+                Err(err) => {
+                    error!("Block worker failed to return queue states: {:?}", err);
+                }
+            }
+        }
+    }
+
+    /// Mark the worker-owned virtqueue memory dirty after a snapshot.
+    pub(crate) fn mark_queue_memory_dirty(&self) -> Result<(), QueueError> {
+        if let Err(err) = self.to_worker.send(ControlMsg::MarkQueueMemoryDirty) {
+            error!(
+                "Failed to request marking block worker queue memory dirty: {:?}",
+                err
+            );
+            return Err(QueueError::NotReady);
+        }
+
+        if let Err(err) = self.control_evt.write(1) {
+            error!(
+                "Failed to notify block worker to mark queue memory dirty: {:?}",
+                err
+            );
+            return Err(QueueError::NotReady);
+        }
+
+        loop {
+            match self.from_worker.recv() {
+                Ok(ControlResponse::QueueMemoryDirty(result)) => return result,
+                Ok(response) => {
+                    warn!(
+                        "Ignoring {} response while waiting for queue memory dirty",
+                        response.name()
+                    );
+                }
+                Err(err) => {
+                    error!("Block worker failed to mark queue memory dirty: {:?}", err);
+                    return Err(QueueError::NotReady);
+                }
+            }
+        }
+    }
+
+    /// Resume a paused worker and process pending queue entries.
+    pub(crate) fn kick(&self, resume: bool) {
+        if let Err(err) = self.to_worker.send(ControlMsg::Kick { resume }) {
             error!("Failed to send block worker kick: {:?}", err);
             return;
         }
@@ -499,7 +625,7 @@ impl ThreadedWorker {
     fn process_control_event(&mut self, ops: &mut EventOps) {
         if let Err(err) = self.control_evt.read() {
             error!("Failed to consume block worker control event: {:?}", err);
-            if let WorkerState::Running(worker) = &self.state {
+            if let WorkerState::Running(worker) | WorkerState::Paused(worker) = &self.state {
                 worker.metrics.event_fails.inc();
             }
             return;
@@ -511,7 +637,10 @@ impl ThreadedWorker {
                 ControlMsg::UpdateDiskImage { path, read_only } => {
                     self.update_disk_image(path, read_only)
                 }
-                ControlMsg::Kick => self.kick_worker(),
+                ControlMsg::Pause => self.pause_worker(ops),
+                ControlMsg::GetQueueStates => self.send_queue_states(),
+                ControlMsg::MarkQueueMemoryDirty => self.mark_queue_memory_dirty(),
+                ControlMsg::Kick { resume } => self.kick_worker(resume, ops),
                 ControlMsg::Reset => self.reset_worker(ops),
                 ControlMsg::Finish(flush_mode) => self.finish_worker(flush_mode, ops),
             }
@@ -534,7 +663,9 @@ impl ThreadedWorker {
 
     fn update_disk_image(&mut self, path: String, read_only: bool) {
         let result = match &mut self.state {
-            WorkerState::Running(worker) => worker.update_disk_image(path, read_only),
+            WorkerState::Running(worker) | WorkerState::Paused(worker) => {
+                worker.update_disk_image(path, read_only)
+            }
             WorkerState::Parked => {
                 warn!("Disk image update requested while block worker is parked");
                 Err(VirtioBlockError::WorkerControl(
@@ -557,26 +688,6 @@ impl ThreadedWorker {
         }
     }
 
-    fn kick_worker(&mut self) {
-        match std::mem::replace(&mut self.state, WorkerState::Parked) {
-            WorkerState::Running(worker) => {
-                self.state = WorkerState::Running(worker);
-            }
-            state => {
-                warn!("Kick requested while block worker is not active");
-                self.state = state;
-                return;
-            }
-        }
-
-        // process directly instead of going through epoll
-        if let WorkerState::Running(worker) = &mut self.state {
-            worker
-                .process_virtio_queues()
-                .unwrap_or_else(|err| error!("Failed to kick block worker queue: {:?}", err));
-        }
-    }
-
     fn reset_worker(&mut self, ops: &mut EventOps) {
         let resources = match std::mem::replace(&mut self.state, WorkerState::Parked) {
             WorkerState::Running(mut worker) => {
@@ -586,6 +697,14 @@ impl ThreadedWorker {
                 } else {
                     Self::register_runtime_events(&worker.resources, ops);
                     self.state = WorkerState::Running(worker);
+                    None
+                }
+            }
+            WorkerState::Paused(mut worker) => {
+                if worker.reset() {
+                    Some(worker.resources)
+                } else {
+                    self.state = WorkerState::Paused(worker);
                     None
                 }
             }
@@ -604,17 +723,118 @@ impl ThreadedWorker {
         }
     }
 
-    fn finish_worker(&mut self, flush_mode: FlushMode, ops: &mut EventOps) {
-        if let WorkerState::Running(mut worker) =
-            std::mem::replace(&mut self.state, WorkerState::Finished)
-        {
-            Self::unregister_runtime_events(&worker.resources, ops);
-            match flush_mode {
-                FlushMode::Drain => worker.drain(true),
-                FlushMode::DrainAndFlush => worker.drain_and_flush(true),
+    fn pause_worker(&mut self, ops: &mut EventOps) {
+        match std::mem::replace(&mut self.state, WorkerState::Parked) {
+            WorkerState::Running(mut worker) => {
+                Self::unregister_runtime_events(&worker.resources, ops);
+                worker.prepare_save();
+                self.state = WorkerState::Paused(worker);
             }
-            worker.resources.is_io_engine_throttled = false;
+            WorkerState::Paused(worker) => {
+                self.state = WorkerState::Paused(worker);
+            }
+            state => {
+                warn!("Pause requested while block worker is not running");
+                self.state = state;
+                if let Err(err) = self.to_vmm.send(ControlResponse::InvalidState(
+                    "pause requested while block worker is not running".to_string(),
+                )) {
+                    error!(
+                        "Failed to send block worker invalid-state response: {:?}",
+                        err
+                    );
+                }
+                return;
+            }
         }
+
+        if let Err(err) = self.to_vmm.send(ControlResponse::Paused) {
+            error!("Failed to send block worker pause response: {:?}", err);
+        }
+    }
+
+    fn send_queue_states(&self) {
+        let WorkerState::Paused(worker) = &self.state else {
+            warn!("Queue states requested while block worker is not paused");
+            return;
+        };
+
+        let states = worker.resources.queues.iter().map(Persist::save).collect();
+
+        if let Err(err) = self.to_vmm.send(ControlResponse::QueueStates(states)) {
+            error!("Failed to send block worker queue states: {:?}", err);
+        }
+    }
+
+    fn mark_queue_memory_dirty(&mut self) {
+        let result = if let WorkerState::Paused(worker) = &mut self.state {
+            let mem = worker.active_state.mem.clone();
+            let mut result = Ok(());
+            for queue in &mut worker.resources.queues {
+                if let Err(err) = queue.initialize(&mem) {
+                    result = Err(err);
+                    break;
+                }
+            }
+            result
+        } else {
+            warn!("Queue memory dirty requested while block worker is not paused");
+            Err(QueueError::NotReady)
+        };
+
+        if let Err(err) = self.to_vmm.send(ControlResponse::QueueMemoryDirty(result)) {
+            error!(
+                "Failed to send block worker queue memory dirty response: {:?}",
+                err
+            );
+        }
+    }
+
+    fn kick_worker(&mut self, resume: bool, ops: &mut EventOps) {
+        match std::mem::replace(&mut self.state, WorkerState::Parked) {
+            WorkerState::Paused(worker) if resume => {
+                Self::register_runtime_events(&worker.resources, ops);
+                self.state = WorkerState::Running(worker);
+            }
+            WorkerState::Paused(worker) => {
+                self.state = WorkerState::Paused(worker);
+                return;
+            }
+            WorkerState::Running(worker) => {
+                self.state = WorkerState::Running(worker);
+            }
+            state => {
+                warn!("Kick requested while block worker is not active");
+                self.state = state;
+                return;
+            }
+        }
+
+        // process directly instead of going through epoll
+        if let WorkerState::Running(worker) = &mut self.state {
+            worker
+                .process_virtio_queues()
+                .unwrap_or_else(|err| error!("Failed to kick block worker queue: {:?}", err));
+        }
+    }
+
+    fn finish_worker(&mut self, flush_mode: FlushMode, ops: &mut EventOps) {
+        match std::mem::replace(&mut self.state, WorkerState::Finished) {
+            WorkerState::Running(mut worker) => {
+                Self::unregister_runtime_events(&worker.resources, ops);
+                Self::flush_worker(&mut worker, flush_mode);
+            }
+            WorkerState::Paused(mut worker) => Self::flush_worker(&mut worker, flush_mode),
+            WorkerState::Parked | WorkerState::Finished => {}
+        }
+    }
+
+    fn flush_worker(worker: &mut BlockWorker, flush_mode: FlushMode) {
+        match flush_mode {
+            FlushMode::Drain => worker.drain(true),
+            FlushMode::DrainAndFlush => worker.drain_and_flush(true),
+        }
+        worker.resources.is_io_engine_throttled = false;
     }
 
     fn is_finished(&self) -> bool {

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -1,0 +1,254 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::device::BlockResources;
+use super::io::{BlockIoError, FileEngine, async_io};
+use super::metrics::BlockDeviceMetrics;
+use super::{FinishedRequest, IoErr, ProcessingResult, Request, VirtioBlockError};
+use crate::devices::virtio::device::ActiveState;
+use crate::devices::virtio::queue::InvalidAvailIdx;
+use crate::devices::virtio::transport::VirtioInterruptType;
+use crate::logger::{IncMetric, error};
+use crate::rate_limiter::RateLimiter;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Runtime state and processing logic for an active block device.
+#[derive(Debug)]
+pub(crate) struct BlockWorker {
+    pub(crate) resources: BlockResources,
+    pub(crate) active_state: ActiveState,
+    pub(crate) rate_limiter: Arc<Mutex<RateLimiter>>,
+    pub(crate) is_blocked: Arc<AtomicBool>,
+    pub(crate) metrics: Arc<BlockDeviceMetrics>,
+}
+
+pub(crate) enum FlushMode {
+    Drain,
+    DrainAndFlush,
+}
+
+macro_rules! unwrap_async_file_engine_or_return {
+    ($file_engine: expr) => {
+        match $file_engine {
+            FileEngine::Async(engine) => engine,
+            FileEngine::Sync(_) => {
+                error!("The block device doesn't use an async IO engine");
+                return;
+            }
+        }
+    };
+}
+
+impl BlockWorker {
+    /// Process a single event in the Virtio queue.
+    ///
+    /// This function is called by the event manager when the guest notifies us
+    /// about new buffers in the queue.
+    pub(crate) fn process_queue_event(&mut self) {
+        self.metrics.queue_event_count.inc();
+        if let Err(err) = self.resources.queue_evts[0].read() {
+            error!("Failed to get queue event: {:?}", err);
+            self.metrics.event_fails.inc();
+        } else if self.is_blocked.load(Ordering::Relaxed) {
+            self.metrics.rate_limiter_throttled_events.inc();
+        } else if self.resources.is_io_engine_throttled {
+            self.metrics.io_engine_throttled_events.inc();
+        } else {
+            self.process_virtio_queues().unwrap()
+        }
+    }
+
+    /// Process device virtio queue(s).
+    pub(crate) fn process_virtio_queues(&mut self) -> Result<(), InvalidAvailIdx> {
+        self.process_queue(0)
+    }
+
+    /// Device specific function for peaking inside a queue and processing descriptors.
+    fn process_queue(&mut self, queue_index: usize) -> Result<(), InvalidAvailIdx> {
+        let rate_limiter = &self.rate_limiter;
+        let queue = &mut self.resources.queues[queue_index];
+        let mut used_any = false;
+
+        while let Some(head) = queue.pop_or_enable_notification()? {
+            self.metrics.remaining_reqs_count.add(queue.len().into());
+            let processing_result =
+                match Request::parse(&head, &self.active_state.mem, self.resources.disk.nsectors) {
+                    Ok(request) => {
+                        let is_rate_limited = {
+                            let mut rate_limiter = rate_limiter
+                                .lock()
+                                .expect("Poisoned block rate limiter lock");
+                            request.rate_limit(&mut rate_limiter)
+                        };
+                        if is_rate_limited {
+                            // Stop processing the queue and return this descriptor chain to the
+                            // avail ring, for later processing.
+                            queue.undo_pop();
+                            self.metrics.rate_limiter_throttled_events.inc();
+                            break;
+                        }
+
+                        request.process(
+                            &mut self.resources.disk,
+                            head.index,
+                            &self.active_state.mem,
+                            &self.metrics,
+                        )
+                    }
+                    Err(err) => {
+                        error!("Failed to parse available descriptor chain: {:?}", err);
+                        self.metrics.execute_fails.inc();
+                        ProcessingResult::Executed(FinishedRequest {
+                            num_bytes_to_mem: 0,
+                            desc_idx: head.index,
+                        })
+                    }
+                };
+
+            match processing_result {
+                ProcessingResult::Submitted => {}
+                ProcessingResult::Throttled => {
+                    queue.undo_pop();
+                    self.resources.is_io_engine_throttled = true;
+                    break;
+                }
+                ProcessingResult::Executed(finished) => {
+                    used_any = true;
+                    queue
+                        .add_used(head.index, finished.num_bytes_to_mem)
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "Failed to add available descriptor head {}: {}",
+                                head.index, err
+                            )
+                        });
+                }
+            }
+        }
+        queue.advance_used_ring_idx();
+
+        if used_any && queue.prepare_kick() {
+            self.active_state
+                .interrupt
+                .trigger(VirtioInterruptType::Queue(0))
+                .unwrap_or_else(|_| {
+                    self.metrics.event_fails.inc();
+                });
+        }
+
+        if let FileEngine::Async(ref mut engine) = self.resources.disk.file_engine
+            && let Err(err) = engine.kick_submission_queue()
+        {
+            error!("BlockError submitting pending block requests: {:?}", err);
+        }
+
+        if !used_any {
+            self.metrics.no_avail_buffer.inc();
+        }
+
+        Ok(())
+    }
+
+    fn process_async_completion_queue(&mut self) {
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
+        let queue = &mut self.resources.queues[0];
+
+        loop {
+            match engine.pop(&self.active_state.mem) {
+                Err(error) => {
+                    error!("Failed to read completed io_uring entry: {:?}", error);
+                    break;
+                }
+                Ok(None) => break,
+                Ok(Some(cqe)) => {
+                    let res = cqe.result();
+                    let user_data = cqe.user_data();
+
+                    let (pending, res) = match res {
+                        Ok(count) => (user_data, Ok(count)),
+                        Err(error) => (
+                            user_data,
+                            Err(IoErr::FileEngine(BlockIoError::Async(
+                                async_io::AsyncIoError::IO(error),
+                            ))),
+                        ),
+                    };
+                    let finished = pending.finish(&self.active_state.mem, res, &self.metrics);
+                    queue
+                        .add_used(finished.desc_idx, finished.num_bytes_to_mem)
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "Failed to add available descriptor head {}: {}",
+                                finished.desc_idx, err
+                            )
+                        });
+                }
+            }
+        }
+        queue.advance_used_ring_idx();
+
+        if queue.prepare_kick() {
+            self.active_state
+                .interrupt
+                .trigger(VirtioInterruptType::Queue(0))
+                .unwrap_or_else(|_| {
+                    self.metrics.event_fails.inc();
+                });
+        }
+    }
+
+    pub(crate) fn process_async_completion_event(&mut self) {
+        let engine = unwrap_async_file_engine_or_return!(&mut self.resources.disk.file_engine);
+
+        if let Err(err) = engine.completion_evt().read() {
+            error!("Failed to get async completion event: {:?}", err);
+        } else {
+            self.process_async_completion_queue();
+
+            if self.resources.is_io_engine_throttled {
+                self.resources.is_io_engine_throttled = false;
+                self.process_queue(0).unwrap()
+            }
+        }
+    }
+
+    pub(crate) fn drain_and_flush(&mut self, discard: bool) {
+        if let Err(err) = self.resources.disk.file_engine.drain_and_flush(discard) {
+            error!("Failed to drain ops and flush block data: {:?}", err);
+        }
+    }
+
+    pub(crate) fn drain(&mut self, discard: bool) {
+        if let Err(err) = self.resources.disk.file_engine.drain(discard) {
+            error!("Failed to drain ops: {:?}", err);
+        }
+    }
+
+    pub(crate) fn reset(&mut self) -> bool {
+        if let Err(err) = self.resources.disk.file_engine.drain(true) {
+            error!("Failed to reset block IO engine: {:?}", err);
+            return false;
+        }
+        self.resources.is_io_engine_throttled = false;
+        true
+    }
+
+    /// Prepare device for being snapshotted.
+    pub(crate) fn prepare_save(&mut self) {
+        self.drain_and_flush(false);
+        if matches!(&self.resources.disk.file_engine, FileEngine::Async(_)) {
+            self.process_async_completion_queue();
+        }
+    }
+
+    /// Update the backing file and return the new sector count.
+    pub fn update_disk_image(
+        &mut self,
+        disk_image_path: String,
+        read_only: bool,
+    ) -> Result<u64, VirtioBlockError> {
+        self.resources.disk.update(disk_image_path, read_only)?;
+        Ok(self.resources.disk.nsectors)
+    }
+}

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -20,6 +20,7 @@ use crate::devices::virtio::queue::{InvalidAvailIdx, QueueError};
 use crate::devices::virtio::transport::VirtioInterruptType;
 use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::RateLimiter;
+use crate::seccomp::{BpfProgram, apply_filter};
 use crate::snapshot::Persist;
 
 /// Runtime state and processing logic for an active block device.
@@ -329,7 +330,11 @@ impl BlockWorker {
 
 impl WorkerHandle {
     /// Spawn a parked block worker thread.
-    pub(crate) fn spawn(queue_evts: Vec<EventFd>, name: String) -> Result<Self, std::io::Error> {
+    pub(crate) fn spawn(
+        seccomp_filter: Arc<BpfProgram>,
+        queue_evts: Vec<EventFd>,
+        name: String,
+    ) -> Result<Self, std::io::Error> {
         // handle writes and worker reads the control eventfd
         let control_evt = EventFd::new(libc::EFD_NONBLOCK)?;
         let handle_evt = control_evt.try_clone()?;
@@ -338,8 +343,14 @@ impl WorkerHandle {
         let (to_vmm, from_worker) = channel::<ControlResponse>();
 
         let join = thread::Builder::new().name(name).spawn(move || {
+            // Create epoll before applying the filter, which does not allow epoll_create1.
             let event_manager =
                 EventManager::new().expect("Failed to create block worker EventManager");
+
+            if let Err(err) = apply_filter(&seccomp_filter) {
+                panic!("Failed to apply seccomp filter on block worker: {err}");
+            }
+
             run_worker_loop(event_manager, control_evt, from_vmm, to_vmm);
         })?;
 

--- a/src/vmm/src/devices/virtio/block/virtio/worker.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/worker.rs
@@ -1,17 +1,24 @@
 // Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use event_manager::{EventOps, Events, MutEventSubscriber, SubscriberOps};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender, channel};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use vmm_sys_util::epoll::EventSet;
+use vmm_sys_util::eventfd::EventFd;
+
 use super::device::BlockResources;
 use super::io::{BlockIoError, FileEngine, async_io};
 use super::metrics::BlockDeviceMetrics;
 use super::{FinishedRequest, IoErr, ProcessingResult, Request, VirtioBlockError};
+use crate::EventManager;
 use crate::devices::virtio::device::ActiveState;
 use crate::devices::virtio::queue::InvalidAvailIdx;
 use crate::devices::virtio::transport::VirtioInterruptType;
-use crate::logger::{IncMetric, error};
+use crate::logger::{IncMetric, error, warn};
 use crate::rate_limiter::RateLimiter;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 
 /// Runtime state and processing logic for an active block device.
 #[derive(Debug)]
@@ -23,6 +30,41 @@ pub(crate) struct BlockWorker {
     pub(crate) metrics: Arc<BlockDeviceMetrics>,
 }
 
+/// Worker state and control channel side (recv ctl msg)
+#[derive(Debug)]
+struct ThreadedWorker {
+    state: WorkerState,
+    control_evt: EventFd,
+    from_vmm: Receiver<ControlMsg>,
+}
+
+/// Data-path ownership state of the worker thread.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+enum WorkerState {
+    Parked,
+    Running(BlockWorker),
+    Finished,
+}
+
+#[allow(clippy::large_enum_variant)]
+enum ControlMsg {
+    Start(BlockWorker),
+    Finish(FlushMode),
+}
+
+/// VMM-side handle for controlling and joining a block worker thread.
+// Handle gets connected to VirtioBlock in follow-up commits
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct WorkerHandle {
+    to_worker: Sender<ControlMsg>,
+    control_evt: EventFd,
+    join: JoinHandle<()>,
+    queue_evts: Vec<EventFd>,
+}
+
+/// Determines how pending I/O is handled during worker teardown.
 pub(crate) enum FlushMode {
     Drain,
     DrainAndFlush,
@@ -250,5 +292,224 @@ impl BlockWorker {
     ) -> Result<u64, VirtioBlockError> {
         self.resources.disk.update(disk_image_path, read_only)?;
         Ok(self.resources.disk.nsectors)
+    }
+}
+
+// Handle gets connected to VirtioBlock in follow-up commits
+#[allow(dead_code)]
+impl WorkerHandle {
+    /// Spawn a parked block worker thread.
+    pub(crate) fn spawn(queue_evts: Vec<EventFd>, name: String) -> Result<Self, std::io::Error> {
+        // handle writes and worker reads the control eventfd
+        let control_evt = EventFd::new(libc::EFD_NONBLOCK)?;
+        let handle_evt = control_evt.try_clone()?;
+        let (to_worker, from_vmm) = channel::<ControlMsg>();
+
+        let join = thread::Builder::new().name(name).spawn(move || {
+            let event_manager =
+                EventManager::new().expect("Failed to create block worker EventManager");
+            run_worker_loop(event_manager, control_evt, from_vmm);
+        })?;
+
+        Ok(Self {
+            to_worker,
+            control_evt: handle_evt,
+            join,
+            queue_evts,
+        })
+    }
+
+    pub(crate) fn queue_events(&self) -> &[EventFd] {
+        &self.queue_evts
+    }
+
+    /// Transfer data-path resources to the worker thread and start processing.
+    pub(crate) fn start(&self, worker: BlockWorker) {
+        if let Err(err) = self.to_worker.send(ControlMsg::Start(worker)) {
+            error!("Failed to send block worker start message: {:?}", err);
+            return;
+        }
+
+        if let Err(err) = self.control_evt.write(1) {
+            error!("Failed to notify block worker: {:?}", err);
+        }
+    }
+
+    /// Stop the worker and wait for its thread to exit.
+    pub(crate) fn finish(self, flush_mode: FlushMode) {
+        if let Err(err) = self.to_worker.send(ControlMsg::Finish(flush_mode)) {
+            error!("Block worker receiver already dropped: {:?}", err);
+        } else if let Err(err) = self.control_evt.write(1) {
+            error!("Block worker control event is closed: {:?}", err);
+        }
+
+        self.join.join().unwrap_or_else(|err| {
+            error!("Block worker thread panicked during teardown: {:?}", err);
+        });
+    }
+}
+
+impl ThreadedWorker {
+    const PROCESS_QUEUE: u32 = 0;
+    const PROCESS_ASYNC_COMPLETION: u32 = 1;
+    const PROCESS_CONTROL: u32 = 2;
+
+    fn register_control_event(&self, ops: &mut EventOps) {
+        if let Err(err) = ops.add(Events::with_data(
+            &self.control_evt,
+            Self::PROCESS_CONTROL,
+            EventSet::IN,
+        )) {
+            error!("Failed to register block worker control event: {}", err);
+        }
+    }
+
+    fn register_runtime_events(resources: &BlockResources, ops: &mut EventOps) {
+        if let Err(err) = ops.add(Events::with_data(
+            &resources.queue_evts[0],
+            Self::PROCESS_QUEUE,
+            EventSet::IN,
+        )) {
+            error!("Failed to register queue event: {}", err);
+        }
+        if let FileEngine::Async(ref engine) = resources.disk.file_engine
+            && let Err(err) = ops.add(Events::with_data(
+                engine.completion_evt(),
+                Self::PROCESS_ASYNC_COMPLETION,
+                EventSet::IN,
+            ))
+        {
+            error!("Failed to register IO engine completion event: {}", err);
+        }
+    }
+
+    fn unregister_runtime_events(resources: &BlockResources, ops: &mut EventOps) {
+        if let Err(err) = ops.remove(Events::with_data(
+            &resources.queue_evts[0],
+            Self::PROCESS_QUEUE,
+            EventSet::IN,
+        )) {
+            error!("Failed to unregister queue event: {}", err);
+        }
+        if let FileEngine::Async(ref engine) = resources.disk.file_engine
+            && let Err(err) = ops.remove(Events::with_data(
+                engine.completion_evt(),
+                Self::PROCESS_ASYNC_COMPLETION,
+                EventSet::IN,
+            ))
+        {
+            error!("Failed to unregister IO engine completion event: {}", err);
+        }
+    }
+
+    fn process_control_event(&mut self, ops: &mut EventOps) {
+        if let Err(err) = self.control_evt.read() {
+            error!("Failed to consume block worker control event: {:?}", err);
+            if let WorkerState::Running(worker) = &self.state {
+                worker.metrics.event_fails.inc();
+            }
+            return;
+        }
+
+        while let Ok(msg) = self.from_vmm.try_recv() {
+            match msg {
+                ControlMsg::Start(worker) => self.start_worker(worker, ops),
+                ControlMsg::Finish(flush_mode) => self.finish_worker(flush_mode, ops),
+            }
+
+            if self.is_finished() {
+                break;
+            }
+        }
+    }
+
+    fn start_worker(&mut self, worker: BlockWorker, ops: &mut EventOps) {
+        if !matches!(self.state, WorkerState::Parked) {
+            warn!("Start requested while block worker is not parked");
+            return;
+        }
+
+        Self::register_runtime_events(&worker.resources, ops);
+        self.state = WorkerState::Running(worker);
+    }
+
+    fn finish_worker(&mut self, flush_mode: FlushMode, ops: &mut EventOps) {
+        if let WorkerState::Running(mut worker) =
+            std::mem::replace(&mut self.state, WorkerState::Finished)
+        {
+            Self::unregister_runtime_events(&worker.resources, ops);
+            match flush_mode {
+                FlushMode::Drain => worker.drain(true),
+                FlushMode::DrainAndFlush => worker.drain_and_flush(true),
+            }
+            worker.resources.is_io_engine_throttled = false;
+        }
+    }
+
+    fn is_finished(&self) -> bool {
+        matches!(self.state, WorkerState::Finished)
+    }
+}
+
+fn run_worker_loop(
+    mut event_manager: EventManager,
+    control_evt: EventFd,
+    from_vmm: Receiver<ControlMsg>,
+) {
+    let worker = Arc::new(Mutex::new(ThreadedWorker {
+        state: WorkerState::Parked,
+        control_evt,
+        from_vmm,
+    }));
+    let subscriber: Arc<Mutex<dyn MutEventSubscriber>> = worker.clone();
+    event_manager.add_subscriber(subscriber);
+
+    loop {
+        if let Err(err) = event_manager.run() {
+            error!("Block worker event loop error: {:?}", err);
+        }
+        if worker
+            .lock()
+            .expect("Poisoned block worker lock")
+            .is_finished()
+        {
+            break;
+        }
+    }
+}
+
+impl MutEventSubscriber for ThreadedWorker {
+    fn process(&mut self, event: Events, ops: &mut EventOps) {
+        let source = event.data();
+        let event_set = event.event_set();
+
+        if !EventSet::IN.contains(event_set) {
+            warn!(
+                "Block worker received unknown event: {:?} from source: {:?}",
+                event_set, source
+            );
+            return;
+        }
+
+        if let WorkerState::Running(worker) = &mut self.state {
+            match source {
+                Self::PROCESS_QUEUE => worker.process_queue_event(),
+                Self::PROCESS_ASYNC_COMPLETION => worker.process_async_completion_event(),
+                Self::PROCESS_CONTROL => self.process_control_event(ops),
+                _ => warn!("Block: Spurious event received: {:?}", source),
+            }
+        } else {
+            match source {
+                Self::PROCESS_CONTROL => self.process_control_event(ops),
+                _ => warn!(
+                    "Block: The device worker is not yet activated. Spurious event received: {:?}",
+                    source
+                ),
+            }
+        }
+    }
+
+    fn init(&mut self, ops: &mut EventOps) {
+        self.register_control_event(ops);
     }
 }

--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use vmm_sys_util::eventfd::EventFd;
 
 use super::ActivateError;
-use super::queue::{Queue, QueueError};
+use super::queue::{QueueConfig, QueueError};
 use super::transport::VirtioInterrupt;
 use crate::MutEventSubscriber;
 use crate::devices::virtio::AsAny;
@@ -78,8 +78,7 @@ pub type VirtioDeviceId = (VirtioDeviceType, String);
 ///
 /// The lifecycle of a virtio device is to be moved to a virtio transport, which will then query the
 /// device. The virtio devices needs to create queues, events and event fds for interrupts and
-/// expose them to the transport via get_queues/get_queue_events/get_interrupt/get_interrupt_status
-/// fns.
+/// expose their queue configuration, events, and interrupt state to the transport.
 pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
     /// Get the available features offered by device.
     fn avail_features(&self) -> u64;
@@ -110,14 +109,23 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
     /// Returns unique device id
     fn id(&self) -> &str;
 
-    /// Returns the device queues.
-    fn queues(&self) -> &[Queue];
+    /// Returns the number of queues offered by the device.
+    fn num_queues(&self) -> usize;
 
-    /// Returns a mutable reference to the device queues.
-    fn queues_mut(&mut self) -> &mut [Queue];
+    /// Returns the transport-visible configuration for the selected queue.
+    ///
+    /// This must return `Some` exactly for indices below [`Self::num_queues`].
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig>;
 
-    /// Returns the device queues event fds.
-    fn queue_events(&self) -> &[EventFd];
+    /// Returns the mutable transport-visible configuration for the selected queue.
+    ///
+    /// This must return `Some` exactly for indices below [`Self::num_queues`].
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig>;
+
+    /// Returns the event fd for the selected queue.
+    ///
+    /// This must return `Some` exactly for indices below [`Self::num_queues`].
+    fn queue_event(&self, index: usize) -> Option<&EventFd>;
 
     /// Returns the current device interrupt status.
     fn interrupt_status(&self) -> Arc<AtomicU32> {
@@ -205,9 +213,7 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
         }
         self.deactivate();
         self.set_acked_features(0);
-        for queue in self.queues_mut() {
-            *queue = Queue::new(queue.max_size);
-        }
+        self.reset_queues();
         true
     }
 
@@ -215,18 +221,19 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
     /// backend does not support reset.
     fn _reset(&mut self) -> bool;
 
+    /// Resets device-owned queue configuration and runtime state.
+    fn reset_queues(&mut self);
+
     /// Mark pages used by queues as dirty.
-    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
-        for queue in self.queues_mut() {
-            queue.initialize(mem)?
-        }
-        Ok(())
-    }
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError>;
 
     /// Notify all queues by writing to the eventfds.
     fn notify_queue_events(&mut self) {
         info!("[{:?}:{}] notifying queues", self.device_type(), self.id());
-        for (i, eventfd) in self.queue_events().iter().enumerate() {
+        for i in 0..self.num_queues() {
+            let eventfd = self
+                .queue_event(i)
+                .expect("queue event must exist for each advertised queue");
             if let Err(err) = eventfd.write(1) {
                 error!(
                     "[{:?}:{}] error notifying queue {}: {}",
@@ -243,7 +250,10 @@ pub trait VirtioDevice: AsAny + MutEventSubscriber + Send {
     /// notifications. This is used if a notification arrives while a device
     /// is being reset and before it's activated again.
     fn drain_queue_events(&self) {
-        for event in self.queue_events() {
+        for i in 0..self.num_queues() {
+            let event = self
+                .queue_event(i)
+                .expect("queue event must exist for each advertised queue");
             event.read();
         }
     }
@@ -316,15 +326,19 @@ pub(crate) mod tests {
             self.acked_features = acked_features
         }
 
-        fn queues(&self) -> &[Queue] {
+        fn num_queues(&self) -> usize {
             todo!()
         }
 
-        fn queues_mut(&mut self) -> &mut [Queue] {
+        fn queue_config(&self, _index: usize) -> Option<&QueueConfig> {
             todo!()
         }
 
-        fn queue_events(&self) -> &[EventFd] {
+        fn queue_config_mut(&mut self, _index: usize) -> Option<&mut QueueConfig> {
+            todo!()
+        }
+
+        fn queue_event(&self, _index: usize) -> Option<&EventFd> {
             todo!()
         }
 
@@ -357,6 +371,14 @@ pub(crate) mod tests {
         }
 
         fn _reset(&mut self) -> bool {
+            todo!()
+        }
+
+        fn reset_queues(&mut self) {
+            todo!()
+        }
+
+        fn mark_queue_memory_dirty(&mut self, _mem: &GuestMemoryMmap) -> Result<(), QueueError> {
             todo!()
         }
     }

--- a/src/vmm/src/devices/virtio/iovec.rs
+++ b/src/vmm/src/devices/virtio/iovec.rs
@@ -578,7 +578,7 @@ mod tests {
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
         let mut q = vq.create_queue();
-        q.ready = true;
+        q.config.ready = true;
 
         let flags = if is_write_only {
             VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -26,7 +26,7 @@ use crate::devices::virtio::mem::VIRTIO_MEM_DEV_ID;
 use crate::devices::virtio::mem::metrics::METRICS;
 use crate::devices::virtio::mem::request::{BlockRangeState, Request, RequestedRange, Response};
 use crate::devices::virtio::queue::{
-    DescriptorChain, FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue, QueueError,
+    DescriptorChain, FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue, QueueConfig, QueueError,
 };
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
@@ -606,16 +606,20 @@ impl VirtioDevice for VirtioMem {
         VIRTIO_MEM_DEV_ID
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_events
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_events.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -667,6 +671,17 @@ impl VirtioDevice for VirtioMem {
         // Note: the Linux virtio-mem driver does not support rebinding when
         // memory is plugged
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 
     fn activate(
@@ -723,7 +738,7 @@ pub(crate) mod test_utils {
             self.queues = queues;
         }
 
-        fn num_queues(&self) -> usize {
+        fn num_queues_supported(&self) -> usize {
             MEM_NUM_QUEUES
         }
     }
@@ -778,8 +793,9 @@ mod tests {
 
         assert!(!mem.is_activated());
 
-        assert_eq!(mem.queues().len(), MEM_NUM_QUEUES);
-        assert_eq!(mem.queue_events().len(), MEM_NUM_QUEUES);
+        assert_eq!(mem.queues.len(), MEM_NUM_QUEUES);
+        assert_eq!(mem.num_queues(), MEM_NUM_QUEUES);
+        assert!((0..mem.num_queues()).all(|index| mem.queue_event(index).is_some()));
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/mem/event_handler.rs
+++ b/src/vmm/src/devices/virtio/mem/event_handler.rs
@@ -15,7 +15,7 @@ impl VirtioMem {
 
     fn register_runtime_events(&self, ops: &mut EventOps) {
         if let Err(err) = ops.add(Events::with_data(
-            &self.queue_events()[MEM_QUEUE],
+            self.queue_event(MEM_QUEUE).unwrap(),
             Self::PROCESS_MEM_QUEUE,
             EventSet::IN,
         )) {
@@ -114,7 +114,7 @@ mod tests {
 
         // Set up queue
         let virtq = VirtQueue::new(GuestAddress(0), &mem, 16);
-        mem_device.queues_mut()[MEM_QUEUE] = virtq.create_queue();
+        mem_device.queues[MEM_QUEUE] = virtq.create_queue();
 
         let mem_device = Arc::new(Mutex::new(mem_device));
         let _id = event_manager.add_subscriber(mem_device.clone());
@@ -154,7 +154,7 @@ mod tests {
 
         // Set up queue
         let virtq = VirtQueue::new(GuestAddress(0), &mem, 16);
-        mem_device.queues_mut()[MEM_QUEUE] = virtq.create_queue();
+        mem_device.queues[MEM_QUEUE] = virtq.create_queue();
         mem_device.set_acked_features(mem_device.avail_features());
 
         let mem_device = Arc::new(Mutex::new(mem_device));
@@ -165,7 +165,11 @@ mod tests {
         event_manager.run_with_timeout(50).unwrap(); // Process activation
 
         // Trigger queue event
-        mem_device.lock().unwrap().queue_events()[MEM_QUEUE]
+        mem_device
+            .lock()
+            .unwrap()
+            .queue_event(MEM_QUEUE)
+            .unwrap()
             .write(1)
             .unwrap();
 
@@ -182,7 +186,11 @@ mod tests {
         let _id = event_manager.add_subscriber(mem_device.clone());
 
         // Try to trigger queue event before activation
-        mem_device.lock().unwrap().queue_events()[MEM_QUEUE]
+        mem_device
+            .lock()
+            .unwrap()
+            .queue_event(MEM_QUEUE)
+            .unwrap()
             .write(1)
             .unwrap();
 

--- a/src/vmm/src/devices/virtio/mem/persist.rs
+++ b/src/vmm/src/devices/virtio/mem/persist.rs
@@ -58,7 +58,7 @@ impl Persist<'_> for VirtioMem {
 
     fn save(&self) -> Self::State {
         VirtioMemState {
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
             addr: self.config.addr,
             region_size: self.config.region_size,
             block_size: self.config.block_size,

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -33,7 +33,9 @@ use crate::devices::virtio::net::tap::Tap;
 use crate::devices::virtio::net::{
     MAX_BUFFER_SIZE, NET_QUEUE_SIZES, NetError, NetQueue, RX_INDEX, TX_INDEX, generated,
 };
-use crate::devices::virtio::queue::{DescriptorChain, InvalidAvailIdx, Queue};
+use crate::devices::virtio::queue::{
+    DescriptorChain, InvalidAvailIdx, Queue, QueueConfig, QueueError,
+};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::{DeviceError, report_net_event_fail};
 use crate::dumbo::pdu::arp::ETH_IPV4_FRAME_LEN;
@@ -1010,16 +1012,20 @@ impl VirtioDevice for Net {
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_evts
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_evts.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -1089,6 +1095,17 @@ impl VirtioDevice for Net {
         self.rx_buffer.clear();
         self.tx_buffer.clear();
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 
     /// Prepare saving state
@@ -2575,13 +2592,14 @@ pub mod tests {
         let net = th.net.lock().unwrap();
 
         // Test queues count (TX and RX).
-        let queues = net.queues();
+        let queues = &net.queues;
         assert_eq!(queues.len(), NET_QUEUE_SIZES.len());
-        assert_eq!(queues[RX_INDEX].size, th.rxq.size());
-        assert_eq!(queues[TX_INDEX].size, th.txq.size());
+        assert_eq!(queues[RX_INDEX].config.size, th.rxq.size());
+        assert_eq!(queues[TX_INDEX].config.size, th.txq.size());
 
         // Test corresponding queues events.
-        assert_eq!(net.queue_events().len(), NET_QUEUE_SIZES.len());
+        assert_eq!(net.num_queues(), NET_QUEUE_SIZES.len());
+        assert!((0..net.num_queues()).all(|index| net.queue_event(index).is_some()));
 
         // Test interrupts.
         assert!(
@@ -2604,7 +2622,7 @@ pub mod tests {
         th.activate_net();
 
         let net = th.net();
-        let queues = net.queues();
+        let queues = &net.queues;
         assert!(queues[RX_INDEX].uses_notif_suppression);
         assert!(queues[TX_INDEX].uses_notif_suppression);
     }

--- a/src/vmm/src/devices/virtio/net/persist.rs
+++ b/src/vmm/src/devices/virtio/net/persist.rs
@@ -85,7 +85,7 @@ impl Persist<'_> for Net {
                 guest_mac: self.guest_mac,
                 mtu: self.mtu(),
             },
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
         }
     }
 
@@ -163,7 +163,7 @@ mod tests {
             tap_if_name = net.iface_name();
             has_mmds_ns = net.mmds_ns.is_some();
             allow_mmds_requests = has_mmds_ns && mmds_ds.is_some();
-            virtio_state = VirtioDeviceState::from_device(&net);
+            virtio_state = VirtioDeviceState::from_device(&net, &net.queues);
         }
 
         // Drop the initial net device so that we don't get an error when trying to recreate the

--- a/src/vmm/src/devices/virtio/persist.rs
+++ b/src/vmm/src/devices/virtio/persist.rs
@@ -13,7 +13,7 @@ use super::queue::{InvalidAvailIdx, QueueError};
 use super::transport::mmio::IrqTrigger;
 use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::{Queue, QueueConfig};
 use crate::devices::virtio::transport::mmio::MmioTransport;
 use crate::snapshot::Persist;
 use crate::vstate::memory::{GuestAddress, GuestMemoryMmap};
@@ -73,12 +73,12 @@ impl Persist<'_> for Queue {
 
     fn save(&self) -> Self::State {
         QueueState {
-            max_size: self.max_size,
-            size: self.size,
-            ready: self.ready,
-            desc_table: self.desc_table_address.0,
-            avail_ring: self.avail_ring_address.0,
-            used_ring: self.used_ring_address.0,
+            max_size: self.config.max_size,
+            size: self.config.size,
+            ready: self.config.ready,
+            desc_table: self.config.desc_table_address.0,
+            avail_ring: self.config.avail_ring_address.0,
+            used_ring: self.config.used_ring_address.0,
             next_avail: self.next_avail,
             next_used: self.next_used,
             num_added: self.num_added,
@@ -90,12 +90,14 @@ impl Persist<'_> for Queue {
         state: &Self::State,
     ) -> Result<Self, Self::Error> {
         let mut queue = Queue {
-            max_size: state.max_size,
-            size: state.size,
-            ready: state.ready,
-            desc_table_address: GuestAddress(state.desc_table),
-            avail_ring_address: GuestAddress(state.avail_ring),
-            used_ring_address: GuestAddress(state.used_ring),
+            config: QueueConfig {
+                max_size: state.max_size,
+                size: state.size,
+                ready: state.ready,
+                desc_table_address: GuestAddress(state.desc_table),
+                avail_ring_address: GuestAddress(state.avail_ring),
+                used_ring_address: GuestAddress(state.used_ring),
+            },
 
             desc_table_ptr: std::ptr::null(),
             avail_ring_ptr: std::ptr::null_mut(),
@@ -130,12 +132,15 @@ pub struct VirtioDeviceState {
 
 impl VirtioDeviceState {
     /// Construct the virtio state of a device.
-    pub fn from_device(device: &dyn VirtioDevice) -> Self {
+    pub fn from_device<'a>(
+        device: &dyn VirtioDevice,
+        queues: impl IntoIterator<Item = &'a Queue>,
+    ) -> Self {
         VirtioDeviceState {
             device_type: device.device_type(),
             avail_features: device.avail_features(),
             acked_features: device.acked_features(),
-            queues: device.queues().iter().map(Persist::save).collect(),
+            queues: queues.into_iter().map(Persist::save).collect(),
             activated: device.is_activated(),
         }
     }
@@ -182,7 +187,7 @@ impl VirtioDeviceState {
 
         for q in &queues {
             // Sanity check queue size and queue max size.
-            if q.max_size != expected_queue_max_size {
+            if q.config.max_size != expected_queue_max_size {
                 return Err(PersistError::InvalidInput);
             }
         }
@@ -365,8 +370,8 @@ mod tests {
         let mem = default_mem();
 
         let mut queue = Queue::new(128);
-        queue.ready = true;
-        queue.size = queue.max_size;
+        queue.config.ready = true;
+        queue.config.size = queue.config.max_size;
         queue.initialize(&mem).unwrap();
 
         let queue_state = queue.save();
@@ -385,8 +390,9 @@ mod tests {
     #[test]
     fn test_virtio_device_state_serde() {
         let dummy = DummyDevice::new();
+        let queues = [Queue::new(16), Queue::new(32)];
 
-        let state = VirtioDeviceState::from_device(&dummy);
+        let state = VirtioDeviceState::from_device(&dummy, &queues);
         let serialized_data = bitcode::serialize(&state).unwrap();
 
         let restored_state: VirtioDeviceState = bitcode::deserialize(&serialized_data).unwrap();

--- a/src/vmm/src/devices/virtio/pmem/device.rs
+++ b/src/vmm/src/devices/virtio/pmem/device.rs
@@ -18,7 +18,9 @@ use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, Vir
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::pmem::PMEM_QUEUE_SIZE;
 use crate::devices::virtio::pmem::metrics::{PmemMetrics, PmemMetricsPerDevice};
-use crate::devices::virtio::queue::{DescriptorChain, InvalidAvailIdx, Queue, QueueError};
+use crate::devices::virtio::queue::{
+    DescriptorChain, InvalidAvailIdx, Queue, QueueConfig, QueueError,
+};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::logger::{IncMetric, error, info, warn};
 use crate::rate_limiter::{BucketUpdate, RateLimiter, TokenType};
@@ -532,16 +534,20 @@ impl VirtioDevice for Pmem {
         self.acked_features = acked_features;
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_events
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_events.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -595,6 +601,17 @@ impl VirtioDevice for Pmem {
 
     fn _reset(&mut self) -> bool {
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 
     fn kick(&mut self) {

--- a/src/vmm/src/devices/virtio/pmem/persist.rs
+++ b/src/vmm/src/devices/virtio/pmem/persist.rs
@@ -50,7 +50,7 @@ impl<'a> Persist<'a> for Pmem {
 
     fn save(&self) -> Self::State {
         PmemState {
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
             config_space: self.guest_region.config_space,
             config: self.config.clone(),
             rate_limiter_state: self.rate_limiter.save(),

--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -196,8 +196,8 @@ impl Iterator for DescriptorIterator {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-/// A virtio queue's parameters.
-pub struct Queue {
+/// The transport-visible configuration of a virtio queue.
+pub struct QueueConfig {
     /// The maximal size in elements offered by the device
     pub max_size: u16,
 
@@ -215,6 +215,27 @@ pub struct Queue {
 
     /// Guest physical address of the used ring
     pub used_ring_address: GuestAddress,
+}
+
+impl QueueConfig {
+    /// Constructs an unconfigured virtio queue config with the given maximum size.
+    pub fn new(max_size: u16) -> Self {
+        Self {
+            max_size,
+            size: max_size,
+            ready: false,
+            desc_table_address: GuestAddress(0),
+            avail_ring_address: GuestAddress(0),
+            used_ring_address: GuestAddress(0),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// A virtio queue's configuration and runtime state.
+pub struct Queue {
+    /// Configuration exposed to the virtio transport.
+    pub config: QueueConfig,
 
     /// Host virtual address pointer to the descriptor table
     /// in the guest memory .
@@ -280,12 +301,7 @@ impl Queue {
     /// Constructs an empty virtio queue with the given `max_size`.
     pub fn new(max_size: u16) -> Queue {
         Queue {
-            max_size,
-            size: max_size,
-            ready: false,
-            desc_table_address: GuestAddress(0),
-            avail_ring_address: GuestAddress(0),
-            used_ring_address: GuestAddress(0),
+            config: QueueConfig::new(max_size),
 
             desc_table_ptr: std::ptr::null(),
             avail_ring_ptr: std::ptr::null_mut(),
@@ -298,21 +314,26 @@ impl Queue {
         }
     }
 
+    /// Resets both configuration and runtime state while preserving the maximum size.
+    pub fn reset(&mut self) {
+        *self = Self::new(self.config.max_size);
+    }
+
     fn desc_table_size(&self) -> usize {
-        std::mem::size_of::<Descriptor>() * usize::from(self.size)
+        std::mem::size_of::<Descriptor>() * usize::from(self.config.size)
     }
 
     fn avail_ring_size(&self) -> usize {
         std::mem::size_of::<u16>()
             + std::mem::size_of::<u16>()
-            + std::mem::size_of::<u16>() * usize::from(self.size)
+            + std::mem::size_of::<u16>() * usize::from(self.config.size)
             + std::mem::size_of::<u16>()
     }
 
     fn used_ring_size(&self) -> usize {
         std::mem::size_of::<u16>()
             + std::mem::size_of::<u16>()
-            + std::mem::size_of::<UsedElement>() * usize::from(self.size)
+            + std::mem::size_of::<UsedElement>() * usize::from(self.config.size)
             + std::mem::size_of::<u16>()
     }
 
@@ -341,12 +362,15 @@ impl Queue {
     /// Set up pointers to the queue objects in the guest memory
     /// and mark memory dirty for those objects
     pub fn initialize<M: GuestMemoryBackend>(&mut self, mem: &M) -> Result<(), QueueError> {
-        if !self.ready {
+        if !self.config.ready {
             return Err(QueueError::NotReady);
         }
 
-        if self.size > self.max_size || self.size == 0 || (self.size & (self.size - 1)) != 0 {
-            return Err(QueueError::InvalidSize(self.size));
+        if self.config.size > self.config.max_size
+            || self.config.size == 0
+            || (self.config.size & (self.config.size - 1)) != 0
+        {
+            return Err(QueueError::InvalidSize(self.config.size));
         }
 
         // All the below pointers are verified to be aligned properly; otherwise some methods (e.g.
@@ -362,12 +386,24 @@ impl Queue {
         // > Available Ring   2
         // > Used Ring        4
         // > ================ ==========
-        self.desc_table_ptr =
-            self.get_aligned_slice_ptr(mem, self.desc_table_address, self.desc_table_size(), 16)?;
-        self.avail_ring_ptr =
-            self.get_aligned_slice_ptr(mem, self.avail_ring_address, self.avail_ring_size(), 2)?;
-        self.used_ring_ptr =
-            self.get_aligned_slice_ptr(mem, self.used_ring_address, self.used_ring_size(), 4)?;
+        self.desc_table_ptr = self.get_aligned_slice_ptr(
+            mem,
+            self.config.desc_table_address,
+            self.desc_table_size(),
+            16,
+        )?;
+        self.avail_ring_ptr = self.get_aligned_slice_ptr(
+            mem,
+            self.config.avail_ring_address,
+            self.avail_ring_size(),
+            2,
+        )?;
+        self.used_ring_ptr = self.get_aligned_slice_ptr(
+            mem,
+            self.config.used_ring_address,
+            self.used_ring_size(),
+            4,
+        )?;
 
         Ok(())
     }
@@ -394,7 +430,7 @@ impl Queue {
         // SAFETY: `used_event` is 2 + self.len u16 away from the start
         unsafe {
             self.avail_ring_ptr
-                .add(2_usize.unchecked_add(usize::from(self.size)))
+                .add(2_usize.unchecked_add(usize::from(self.config.size)))
                 .read_volatile()
         }
     }
@@ -434,7 +470,8 @@ impl Queue {
             self.used_ring_ptr
                 .add(
                     std::mem::size_of::<u16>().unchecked_mul(2)
-                        + std::mem::size_of::<UsedElement>().unchecked_mul(usize::from(self.size)),
+                        + std::mem::size_of::<UsedElement>()
+                            .unchecked_mul(usize::from(self.config.size)),
                 )
                 .cast::<u16>()
                 .read_volatile()
@@ -449,7 +486,8 @@ impl Queue {
             self.used_ring_ptr
                 .add(
                     std::mem::size_of::<u16>().unchecked_mul(2)
-                        + std::mem::size_of::<UsedElement>().unchecked_mul(usize::from(self.size)),
+                        + std::mem::size_of::<UsedElement>()
+                            .unchecked_mul(usize::from(self.config.size)),
                 )
                 .cast::<u16>()
                 .write_volatile(val)
@@ -484,9 +522,9 @@ impl Queue {
         // once. Checking and reporting such incorrect driver behavior
         // can prevent potential hanging and Denial-of-Service from
         // happening on the VMM side.
-        if self.size < len {
+        if self.config.size < len {
             return Err(InvalidAvailIdx {
-                queue_size: self.size,
+                queue_size: self.config.size,
                 reported_len: len,
             });
         }
@@ -538,15 +576,17 @@ impl Queue {
         //
         // We use `self.next_avail` to store the position, in `ring`, of the next available
         // descriptor index, with a twist: we always only increment `self.next_avail`, so the
-        // actual position will be `self.next_avail % self.size`.
-        let idx = self.next_avail.0 % self.size;
+        // actual position will be `self.next_avail % self.config.size`.
+        let idx = self.next_avail.0 % self.config.size;
         // SAFETY:
         // index is bound by the queue size
         let desc_index = unsafe { self.avail_ring_ring_get(usize::from(idx)) };
 
-        DescriptorChain::checked_new(self.desc_table_ptr, self.size, desc_index).inspect(|_| {
-            self.next_avail += Wrapping(1);
-        })
+        DescriptorChain::checked_new(self.desc_table_ptr, self.config.size, desc_index).inspect(
+            |_| {
+                self.next_avail += Wrapping(1);
+            },
+        )
     }
 
     /// Undo the effects of the last `self.pop()` call.
@@ -564,7 +604,7 @@ impl Queue {
         desc_index: u16,
         len: u32,
     ) -> Result<(), QueueError> {
-        if self.size <= desc_index {
+        if self.config.size <= desc_index {
             error!(
                 "attempted to add out of bounds descriptor to used ring: {}",
                 desc_index
@@ -572,7 +612,7 @@ impl Queue {
             return Err(QueueError::DescIndexOutOfBounds(desc_index));
         }
 
-        let next_used = (self.next_used + Wrapping(ring_index_offset)).0 % self.size;
+        let next_used = (self.next_used + Wrapping(ring_index_offset)).0 % self.config.size;
         let used_element = UsedElement {
             id: u32::from(desc_index),
             len,
@@ -621,9 +661,9 @@ impl Queue {
         if len != 0 {
             // The number of descriptor chain heads to process should always
             // be smaller or equal to the queue size.
-            if len > self.size {
+            if len > self.config.size {
                 return Err(InvalidAvailIdx {
-                    queue_size: self.size,
+                    queue_size: self.config.size,
                     reported_len: len,
                 });
             }
@@ -852,11 +892,11 @@ mod verification {
     fn less_arbitrary_queue() -> Queue {
         let mut queue = Queue::new(FIRECRACKER_MAX_QUEUE_SIZE);
 
-        queue.size = FIRECRACKER_MAX_QUEUE_SIZE;
-        queue.ready = true;
-        queue.desc_table_address = GuestAddress(QUEUE_BASE_ADDRESS);
-        queue.avail_ring_address = GuestAddress(AVAIL_RING_BASE_ADDRESS);
-        queue.used_ring_address = GuestAddress(USED_RING_BASE_ADDRESS);
+        queue.config.size = FIRECRACKER_MAX_QUEUE_SIZE;
+        queue.config.ready = true;
+        queue.config.desc_table_address = GuestAddress(QUEUE_BASE_ADDRESS);
+        queue.config.avail_ring_address = GuestAddress(AVAIL_RING_BASE_ADDRESS);
+        queue.config.used_ring_address = GuestAddress(USED_RING_BASE_ADDRESS);
         queue.next_avail = Wrapping(kani::any());
         queue.next_used = Wrapping(kani::any());
         queue.uses_notif_suppression = kani::any();
@@ -893,11 +933,11 @@ mod verification {
             // firecracker statically sets the maximal queue size to 256
             let mut queue = Queue::new(FIRECRACKER_MAX_QUEUE_SIZE);
 
-            queue.size = kani::any();
-            queue.ready = true;
-            queue.desc_table_address = GuestAddress(kani::any());
-            queue.avail_ring_address = GuestAddress(kani::any());
-            queue.used_ring_address = GuestAddress(kani::any());
+            queue.config.size = kani::any();
+            queue.config.ready = true;
+            queue.config.desc_table_address = GuestAddress(kani::any());
+            queue.config.avail_ring_address = GuestAddress(kani::any());
+            queue.config.used_ring_address = GuestAddress(kani::any());
             queue.next_avail = Wrapping(kani::any());
             queue.next_used = Wrapping(kani::any());
             queue.uses_notif_suppression = kani::any();
@@ -1034,7 +1074,7 @@ mod verification {
             // done. This is relying on implementation details of add_used, namely that
             // the check for out-of-bounds descriptor index happens at the very beginning of the
             // function.
-            assert!(used_desc_table_index >= queue.size);
+            assert!(used_desc_table_index >= queue.config.size);
         }
     }
 
@@ -1059,13 +1099,13 @@ mod verification {
                 if val == 0 { u64::MAX } else { val & (!val + 1) }
             }
 
-            assert!(alignment_of(queue.desc_table_address.0) >= 16);
-            assert!(alignment_of(queue.avail_ring_address.0) >= 2);
-            assert!(alignment_of(queue.used_ring_address.0) >= 4);
+            assert!(alignment_of(queue.config.desc_table_address.0) >= 16);
+            assert!(alignment_of(queue.config.avail_ring_address.0) >= 2);
+            assert!(alignment_of(queue.config.used_ring_address.0) >= 4);
 
             // length of queue must be power-of-two, and at most 2^15
-            assert_eq!(queue.size.count_ones(), 1);
-            assert!(queue.size <= 1u16 << 15);
+            assert_eq!(queue.config.size.count_ones(), 1);
+            assert!(queue.config.size <= 1u16 << 15);
         }
     }
 
@@ -1080,7 +1120,7 @@ mod verification {
     #[kani::unwind(0)]
     fn verify_avail_ring_ring_get() {
         let ProofContext(queue, _) = kani::any();
-        let x: usize = kani::any_where(|x| *x < usize::from(queue.size));
+        let x: usize = kani::any_where(|x| *x < usize::from(queue.config.size));
         unsafe { _ = queue.avail_ring_ring_get(x) };
     }
 
@@ -1102,7 +1142,7 @@ mod verification {
     #[kani::unwind(0)]
     fn verify_used_ring_ring_set() {
         let ProofContext(mut queue, _) = kani::any();
-        let x: usize = kani::any_where(|x| *x < usize::from(queue.size));
+        let x: usize = kani::any_where(|x| *x < usize::from(queue.config.size));
         let used_element = UsedElement {
             id: kani::any(),
             len: kani::any(),
@@ -1131,7 +1171,7 @@ mod verification {
         // is called when the queue is being initialized, e.g. empty. We compute it using
         // local variables here to make things easier on kani: One less roundtrip through vm-memory.
         let queue_len = queue.len();
-        kani::assume(queue_len <= queue.size);
+        kani::assume(queue_len <= queue.config.size);
 
         let next_avail = queue.next_avail;
 
@@ -1149,7 +1189,7 @@ mod verification {
         let ProofContext(mut queue, _) = kani::any();
 
         // See verify_pop for explanation
-        kani::assume(queue.len() <= queue.size);
+        kani::assume(queue.len() <= queue.config.size);
 
         let queue_clone = queue.clone();
         if let Some(_) = queue.pop().unwrap() {
@@ -1165,7 +1205,7 @@ mod verification {
     fn verify_try_enable_notification() {
         let ProofContext(mut queue, _) = ProofContext::bounded_queue();
 
-        kani::assume(queue.len() <= queue.size);
+        kani::assume(queue.len() <= queue.config.size);
 
         if queue.try_enable_notification().unwrap() && queue.uses_notif_suppression {
             // We only require new notifications if the queue is empty (e.g. we've processed
@@ -1183,16 +1223,17 @@ mod verification {
         let ProofContext(queue, mem) = kani::any();
 
         let index = kani::any();
-        let maybe_chain = DescriptorChain::checked_new(queue.desc_table_ptr, queue.size, index);
+        let maybe_chain =
+            DescriptorChain::checked_new(queue.desc_table_ptr, queue.config.size, index);
 
-        if index >= queue.size {
+        if index >= queue.config.size {
             assert!(maybe_chain.is_none())
         } else {
             // If the index was in-bounds for the descriptor table, we at least should be
             // able to compute the address of the descriptor table entry without going out
             // of bounds anywhere, and also read from that address.
             let desc_head = mem
-                .checked_offset(queue.desc_table_address, (index as usize) * 16)
+                .checked_offset(queue.config.desc_table_address, (index as usize) * 16)
                 .unwrap();
             mem.checked_offset(desc_head, 16).unwrap();
             let desc = mem.read_obj::<Descriptor>(desc_head).unwrap();
@@ -1200,7 +1241,7 @@ mod verification {
             match maybe_chain {
                 None => {
                     // This assert is the negation of the "is_valid" check in checked_new
-                    assert!(desc.flags & VIRTQ_DESC_F_NEXT == 1 && desc.next >= queue.size)
+                    assert!(desc.flags & VIRTQ_DESC_F_NEXT == 1 && desc.next >= queue.config.size)
                 }
                 Some(head) => {
                     assert!(head.is_valid())
@@ -1275,77 +1316,77 @@ mod tests {
         q.initialize(m).unwrap();
 
         // shouldn't be valid when not marked as ready
-        q.ready = false;
+        q.config.ready = false;
         assert!(matches!(q.initialize(m).unwrap_err(), QueueError::NotReady));
-        q.ready = true;
+        q.config.ready = true;
 
         // or when size > max_size
-        q.size = q.max_size << 1;
+        q.config.size = q.config.max_size << 1;
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::InvalidSize(_)
         ));
-        q.size = q.max_size;
+        q.config.size = q.config.max_size;
 
         // or when size is 0
-        q.size = 0;
+        q.config.size = 0;
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::InvalidSize(_)
         ));
-        q.size = q.max_size;
+        q.config.size = q.config.max_size;
 
         // or when size is not a power of 2
-        q.size = 11;
+        q.config.size = 11;
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::InvalidSize(_)
         ));
-        q.size = q.max_size;
+        q.config.size = q.config.max_size;
 
         // reset dirtied values
-        q.max_size = 16;
+        q.config.max_size = 16;
         q.next_avail = Wrapping(0);
-        m.write_obj::<u16>(0, q.avail_ring_address.unchecked_add(2))
+        m.write_obj::<u16>(0, q.config.avail_ring_address.unchecked_add(2))
             .unwrap();
 
         // or if the various addresses are off
 
-        q.desc_table_address = GuestAddress(0xffff_ff00);
+        q.config.desc_table_address = GuestAddress(0xffff_ff00);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::MemoryError(_)
         ));
-        q.desc_table_address = GuestAddress(0x1001);
+        q.config.desc_table_address = GuestAddress(0x1001);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::PointerNotAligned(_, _)
         ));
-        q.desc_table_address = vq.dtable_start();
+        q.config.desc_table_address = vq.dtable_start();
 
-        q.avail_ring_address = GuestAddress(0xffff_ff00);
+        q.config.avail_ring_address = GuestAddress(0xffff_ff00);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::MemoryError(_)
         ));
-        q.avail_ring_address = GuestAddress(0x1001);
+        q.config.avail_ring_address = GuestAddress(0x1001);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::PointerNotAligned(_, _)
         ));
-        q.avail_ring_address = vq.avail_start();
+        q.config.avail_ring_address = vq.avail_start();
 
-        q.used_ring_address = GuestAddress(0xffff_ff00);
+        q.config.used_ring_address = GuestAddress(0xffff_ff00);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::MemoryError(_)
         ));
-        q.used_ring_address = GuestAddress(0x1001);
+        q.config.used_ring_address = GuestAddress(0x1001);
         assert!(matches!(
             q.initialize(m).unwrap_err(),
             QueueError::PointerNotAligned(_, _)
         ));
-        q.used_ring_address = vq.used_start();
+        q.config.used_ring_address = vq.used_start();
     }
 
     #[test]
@@ -1354,7 +1395,7 @@ mod tests {
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
         let mut q = vq.create_queue();
 
-        q.ready = true;
+        q.config.ready = true;
 
         // Let's create two simple descriptor chains.
 
@@ -1633,7 +1674,7 @@ mod tests {
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
         let mut q = vq.create_queue();
 
-        q.ready = true;
+        q.config.ready = true;
 
         // We create a simple descriptor chain
         vq.dtable[0].set(0x1000_u64, 0x1000, 0, 0);
@@ -1662,15 +1703,15 @@ mod tests {
     fn test_initialize_with_aligned_pointer() {
         let mut q = Queue::new(FIRECRACKER_MAX_QUEUE_SIZE);
 
-        q.ready = true;
-        q.size = q.max_size;
+        q.config.ready = true;
+        q.config.size = q.config.max_size;
 
         // Descriptor table must be 16-byte aligned.
-        q.desc_table_address = GuestAddress(16);
+        q.config.desc_table_address = GuestAddress(16);
         // Available ring must be 2-byte aligned.
-        q.avail_ring_address = GuestAddress(2);
+        q.config.avail_ring_address = GuestAddress(2);
         // Used ring must be 4-byte aligned.
-        q.avail_ring_address = GuestAddress(4);
+        q.config.avail_ring_address = GuestAddress(4);
 
         let mem = single_region_mem(0x10000);
         q.initialize(&mem).unwrap();
@@ -1679,12 +1720,12 @@ mod tests {
     #[test]
     fn test_initialize_with_misaligned_pointer() {
         let mut q = Queue::new(FIRECRACKER_MAX_QUEUE_SIZE);
-        q.ready = true;
-        q.size = q.max_size;
+        q.config.ready = true;
+        q.config.size = q.config.max_size;
         let mem = single_region_mem(0x1000);
 
         // Descriptor table must be 16-byte aligned.
-        q.desc_table_address = GuestAddress(0xb);
+        q.config.desc_table_address = GuestAddress(0xb);
         match q.initialize(&mem) {
             Ok(_) => panic!("Unexpected success"),
             Err(QueueError::PointerNotAligned(addr, alignment)) => {
@@ -1693,10 +1734,10 @@ mod tests {
             }
             Err(e) => panic!("Unexpected error {e:#?}"),
         }
-        q.desc_table_address = GuestAddress(0x0);
+        q.config.desc_table_address = GuestAddress(0x0);
 
         // Available ring must be 2-byte aligned.
-        q.avail_ring_address = GuestAddress(0x1);
+        q.config.avail_ring_address = GuestAddress(0x1);
         match q.initialize(&mem) {
             Ok(_) => panic!("Unexpected success"),
             Err(QueueError::PointerNotAligned(addr, alignment)) => {
@@ -1705,10 +1746,10 @@ mod tests {
             }
             Err(e) => panic!("Unexpected error {e:#?}"),
         }
-        q.avail_ring_address = GuestAddress(0x0);
+        q.config.avail_ring_address = GuestAddress(0x0);
 
         // Used ring must be 4-byte aligned.
-        q.used_ring_address = GuestAddress(0x3);
+        q.config.used_ring_address = GuestAddress(0x3);
         match q.initialize(&mem) {
             Ok(_) => panic!("unexpected success"),
             Err(QueueError::PointerNotAligned(addr, alignment)) => {

--- a/src/vmm/src/devices/virtio/rng/device.rs
+++ b/src/vmm/src/devices/virtio/rng/device.rs
@@ -17,7 +17,9 @@ use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, Vir
 use crate::devices::virtio::generated::virtio_config::VIRTIO_F_VERSION_1;
 use crate::devices::virtio::iov_deque::IovDequeError;
 use crate::devices::virtio::iovec::IoVecBufferMut;
-use crate::devices::virtio::queue::{FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue};
+use crate::devices::virtio::queue::{
+    FIRECRACKER_MAX_QUEUE_SIZE, InvalidAvailIdx, Queue, QueueConfig, QueueError,
+};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::impl_device_type;
 use crate::logger::{IncMetric, debug, error};
@@ -267,16 +269,20 @@ impl VirtioDevice for Entropy {
         ENTROPY_DEV_ID
     }
 
-    fn queues(&self) -> &[Queue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [Queue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_events
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_events.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -317,6 +323,17 @@ impl VirtioDevice for Entropy {
         true
     }
 
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(Queue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
+    }
+
     fn activate(
         &mut self,
         mem: GuestMemoryMmap,
@@ -355,7 +372,7 @@ mod tests {
             self.queues = queues;
         }
 
-        fn num_queues(&self) -> usize {
+        fn num_queues_supported(&self) -> usize {
             RNG_NUM_QUEUES
         }
     }
@@ -434,7 +451,7 @@ mod tests {
         let mut entropy_dev = th.device();
 
         // This should succeed, we just added two descriptors
-        let desc = entropy_dev.queues_mut()[RNG_QUEUE].pop().unwrap().unwrap();
+        let desc = entropy_dev.queues[RNG_QUEUE].pop().unwrap().unwrap();
         assert!(matches!(
             // SAFETY: This descriptor chain is only loaded into one buffer
             unsafe { IoVecBufferMut::<256>::from_descriptor_chain(&mem, desc) },
@@ -442,7 +459,7 @@ mod tests {
         ));
 
         // This should succeed, we should have one more descriptor
-        let desc = entropy_dev.queues_mut()[RNG_QUEUE].pop().unwrap().unwrap();
+        let desc = entropy_dev.queues[RNG_QUEUE].pop().unwrap().unwrap();
         // SAFETY: This descriptor chain is only loaded into one buffer
         entropy_dev.buffer = unsafe { IoVecBufferMut::from_descriptor_chain(&mem, desc).unwrap() };
         entropy_dev.handle_one().unwrap();

--- a/src/vmm/src/devices/virtio/rng/event_handler.rs
+++ b/src/vmm/src/devices/virtio/rng/event_handler.rs
@@ -15,7 +15,7 @@ impl Entropy {
 
     fn register_runtime_events(&self, ops: &mut EventOps) {
         if let Err(err) = ops.add(Events::with_data(
-            &self.queue_events()[RNG_QUEUE],
+            self.queue_event(RNG_QUEUE).unwrap(),
             Self::PROCESS_ENTROPY_QUEUE,
             EventSet::IN,
         )) {

--- a/src/vmm/src/devices/virtio/rng/persist.rs
+++ b/src/vmm/src/devices/virtio/rng/persist.rs
@@ -45,7 +45,7 @@ impl Persist<'_> for Entropy {
 
     fn save(&self) -> Self::State {
         EntropyState {
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
             rate_limiter_state: self.rate_limiter().save(),
         }
     }

--- a/src/vmm/src/devices/virtio/test_utils.rs
+++ b/src/vmm/src/devices/virtio/test_utils.rs
@@ -295,11 +295,11 @@ impl<'a> VirtQueue<'a> {
     pub fn create_queue(&self) -> Queue {
         let mut q = Queue::new(self.size());
 
-        q.size = self.size();
-        q.ready = true;
-        q.desc_table_address = self.dtable_start();
-        q.avail_ring_address = self.avail_start();
-        q.used_ring_address = self.used_start();
+        q.config.size = self.size();
+        q.config.ready = true;
+        q.config.desc_table_address = self.dtable_start();
+        q.config.avail_ring_address = self.avail_start();
+        q.config.used_ring_address = self.used_start();
 
         q.initialize(self.memory()).unwrap();
 
@@ -346,7 +346,7 @@ pub(crate) mod test {
         /// Replace the queues used by the device
         fn set_queues(&mut self, queues: Vec<Queue>);
         /// Number of queues this device supports
-        fn num_queues(&self) -> usize;
+        fn num_queues_supported(&self) -> usize;
     }
 
     /// A helper type to allow testing VirtIO devices
@@ -402,7 +402,7 @@ pub(crate) mod test {
         pub fn new(mem: &'a GuestMemoryMmap, mut device: T) -> VirtioTestHelper<'a, T> {
             let mut event_manager = EventManager::new().unwrap();
 
-            let virtqueues = Self::create_virtqueues(mem, device.num_queues());
+            let virtqueues = Self::create_virtqueues(mem, device.num_queues_supported());
             let queues = virtqueues.iter().map(|vq| vq.create_queue()).collect();
             device.set_queues(queues);
             let device = Arc::new(Mutex::new(device));
@@ -466,7 +466,7 @@ pub(crate) mod test {
         ) {
             let device = self.device.lock().unwrap();
 
-            let event_fd = &device.queue_events()[queue];
+            let event_fd = device.queue_event(queue).unwrap();
             let vq = &self.virtqueues[queue];
 
             // Create the descriptor chain
@@ -518,7 +518,7 @@ pub(crate) mod test {
         ) {
             let device = self.device.lock().unwrap();
 
-            let event_fd = &device.queue_events()[queue];
+            let event_fd = device.queue_event(queue).unwrap();
             let vq = &self.virtqueues[queue];
 
             // Create the descriptor chain

--- a/src/vmm/src/devices/virtio/transport/mmio.rs
+++ b/src/vmm/src/devices/virtio/transport/mmio.rs
@@ -14,7 +14,7 @@ use vmm_sys_util::eventfd::EventFd;
 use super::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::virtio::device::VirtioDevice;
 use crate::devices::virtio::device_status;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::QueueConfig;
 use crate::logger::{IncMetric, METRICS, error, warn};
 use crate::utils::byte_order;
 use crate::vstate::bus::BusDevice;
@@ -101,24 +101,22 @@ impl MmioTransport {
 
     fn with_queue<U, F>(&self, d: U, f: F) -> U
     where
-        F: FnOnce(&Queue) -> U,
+        F: FnOnce(&QueueConfig) -> U,
         U: Debug,
     {
         match self
             .locked_device()
-            .queues()
-            .get(self.queue_select as usize)
+            .queue_config(self.queue_select as usize)
         {
             Some(queue) => f(queue),
             None => d,
         }
     }
 
-    fn with_queue_mut<F: FnOnce(&mut Queue)>(&mut self, f: F) -> bool {
+    fn with_queue_mut<F: FnOnce(&mut QueueConfig)>(&mut self, f: F) -> bool {
         if let Some(queue) = self
             .locked_device()
-            .queues_mut()
-            .get_mut(self.queue_select as usize)
+            .queue_config_mut(self.queue_select as usize)
         {
             f(queue);
             true
@@ -127,7 +125,7 @@ impl MmioTransport {
         }
     }
 
-    fn update_queue_field<F: FnOnce(&mut Queue)>(&mut self, f: F) {
+    fn update_queue_field<F: FnOnce(&mut QueueConfig)>(&mut self, f: F) {
         if self.check_device_status(
             device_status::FEATURES_OK,
             device_status::DRIVER_OK | device_status::FAILED,
@@ -479,6 +477,7 @@ pub(crate) mod tests {
     use crate::devices::virtio::ActivateError;
     use crate::devices::virtio::device::{VirtioDevice, VirtioDeviceType};
     use crate::devices::virtio::device_status::DEVICE_NEEDS_RESET;
+    use crate::devices::virtio::queue::{Queue, QueueError};
     use crate::impl_device_type;
     use crate::test_utils::single_region_mem;
     use crate::utils::byte_order::{read_le_u32, write_le_u32};
@@ -545,16 +544,20 @@ pub(crate) mod tests {
             self.acked_features = acked_features;
         }
 
-        fn queues(&self) -> &[Queue] {
-            &self.queues
+        fn num_queues(&self) -> usize {
+            self.queues.len()
         }
 
-        fn queues_mut(&mut self) -> &mut [Queue] {
-            &mut self.queues
+        fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+            self.queues.get(index).map(|queue| &queue.config)
         }
 
-        fn queue_events(&self) -> &[EventFd] {
-            &self.queue_evts
+        fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+            self.queues.get_mut(index).map(|queue| &mut queue.config)
+        }
+
+        fn queue_event(&self, index: usize) -> Option<&EventFd> {
+            self.queue_evts.get(index)
         }
 
         fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -599,6 +602,17 @@ pub(crate) mod tests {
         fn _reset(&mut self) -> bool {
             !self.reset_should_fail
         }
+
+        fn reset_queues(&mut self) {
+            self.queues.iter_mut().for_each(Queue::reset);
+        }
+
+        fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+            for queue in &mut self.queues {
+                queue.initialize(mem)?;
+            }
+            Ok(())
+        }
     }
 
     fn set_device_status(d: &mut MmioTransport, status: u32) {
@@ -618,17 +632,32 @@ pub(crate) mod tests {
         // We just make sure here that the implementation of a mmio device behaves as we expect,
         // given a known virtio device implementation (the dummy device).
 
-        assert_eq!(d.locked_device().queue_events().len(), 2);
+        assert_eq!(d.locked_device().num_queues(), 2);
+        assert!(d.locked_device().queue_event(0).is_some());
+        assert!(d.locked_device().queue_event(1).is_some());
+        assert!(d.locked_device().queue_event(2).is_none());
 
         d.queue_select = 0;
         assert_eq!(d.with_queue(0, |q| q.max_size), 16);
         assert!(d.with_queue_mut(|q| q.size = 16));
-        assert_eq!(d.locked_device().queues()[d.queue_select as usize].size, 16);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(d.queue_select as usize)
+                .unwrap()
+                .size,
+            16
+        );
 
         d.queue_select = 1;
         assert_eq!(d.with_queue(0, |q| q.max_size), 32);
         assert!(d.with_queue_mut(|q| q.size = 16));
-        assert_eq!(d.locked_device().queues()[d.queue_select as usize].size, 16);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(d.queue_select as usize)
+                .unwrap()
+                .size,
+            16
+        );
 
         d.queue_select = 2;
         assert_eq!(d.with_queue(0, |q| q.max_size), 0);
@@ -818,43 +847,97 @@ pub(crate) mod tests {
         assert_eq!(d.queue_select, 3);
 
         d.queue_select = 0;
-        assert_eq!(d.locked_device().queues()[0].size, 16);
+        assert_eq!(d.locked_device().queue_config(0).unwrap().size, 16);
         write_le_u32(&mut buf[..], 16);
         d.write(0x0, 0x38, &buf[..]);
-        assert_eq!(d.locked_device().queues()[0].size, 16);
+        assert_eq!(d.locked_device().queue_config(0).unwrap().size, 16);
 
-        assert!(!d.locked_device().queues()[0].ready);
+        assert!(!d.locked_device().queue_config(0).unwrap().ready);
         write_le_u32(&mut buf[..], 1);
         d.write(0x0, 0x44, &buf[..]);
-        assert!(d.locked_device().queues()[0].ready);
+        assert!(d.locked_device().queue_config(0).unwrap().ready);
 
-        assert_eq!(d.locked_device().queues()[0].desc_table_address.0, 0);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .desc_table_address
+                .0,
+            0
+        );
         write_le_u32(&mut buf[..], 123);
         d.write(0x0, 0x80, &buf[..]);
-        assert_eq!(d.locked_device().queues()[0].desc_table_address.0, 123);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .desc_table_address
+                .0,
+            123
+        );
         d.write(0x0, 0x84, &buf[..]);
         assert_eq!(
-            d.locked_device().queues()[0].desc_table_address.0,
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .desc_table_address
+                .0,
             123 + (123 << 32)
         );
 
-        assert_eq!(d.locked_device().queues()[0].avail_ring_address.0, 0);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .avail_ring_address
+                .0,
+            0
+        );
         write_le_u32(&mut buf[..], 124);
         d.write(0x0, 0x90, &buf[..]);
-        assert_eq!(d.locked_device().queues()[0].avail_ring_address.0, 124);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .avail_ring_address
+                .0,
+            124
+        );
         d.write(0x0, 0x94, &buf[..]);
         assert_eq!(
-            d.locked_device().queues()[0].avail_ring_address.0,
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .avail_ring_address
+                .0,
             124 + (124 << 32)
         );
 
-        assert_eq!(d.locked_device().queues()[0].used_ring_address.0, 0);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .used_ring_address
+                .0,
+            0
+        );
         write_le_u32(&mut buf[..], 125);
         d.write(0x0, 0xa0, &buf[..]);
-        assert_eq!(d.locked_device().queues()[0].used_ring_address.0, 125);
+        assert_eq!(
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .used_ring_address
+                .0,
+            125
+        );
         d.write(0x0, 0xa4, &buf[..]);
         assert_eq!(
-            d.locked_device().queues()[0].used_ring_address.0,
+            d.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .used_ring_address
+                .0,
             125 + (125 << 32)
         );
 
@@ -938,7 +1021,7 @@ pub(crate) mod tests {
         );
 
         let mut buf = [0; 4];
-        let queue_len = d.locked_device().queues().len();
+        let queue_len = d.locked_device().num_queues();
         for q in 0..queue_len {
             d.queue_select = q.try_into().unwrap();
             write_le_u32(&mut buf[..], 16);
@@ -990,7 +1073,7 @@ pub(crate) mod tests {
         );
 
         let mut buf = [0; 4];
-        let queue_len = d.locked_device().queues().len();
+        let queue_len = d.locked_device().num_queues();
         for q in 0..queue_len {
             d.queue_select = q.try_into().unwrap();
             write_le_u32(&mut buf[..], 16);
@@ -1037,7 +1120,7 @@ pub(crate) mod tests {
 
         // Setup queue data structures
         let mut buf = [0; 4];
-        let queues_count = d.locked_device().queues().len();
+        let queues_count = d.locked_device().num_queues();
         for q in 0..queues_count {
             d.queue_select = q.try_into().unwrap();
             write_le_u32(&mut buf[..], 16);
@@ -1218,11 +1301,23 @@ pub(crate) mod tests {
         dev.queue_select = 0;
 
         // Save the queue state right after activation.
-        let size_before = dev.locked_device().queues()[0].size;
-        let ready_before = dev.locked_device().queues()[0].ready;
-        let desc_before = dev.locked_device().queues()[0].desc_table_address;
-        let avail_before = dev.locked_device().queues()[0].avail_ring_address;
-        let used_before = dev.locked_device().queues()[0].used_ring_address;
+        let size_before = dev.locked_device().queue_config(0).unwrap().size;
+        let ready_before = dev.locked_device().queue_config(0).unwrap().ready;
+        let desc_before = dev
+            .locked_device()
+            .queue_config(0)
+            .unwrap()
+            .desc_table_address;
+        let avail_before = dev
+            .locked_device()
+            .queue_config(0)
+            .unwrap()
+            .avail_ring_address;
+        let used_before = dev
+            .locked_device()
+            .queue_config(0)
+            .unwrap()
+            .used_ring_address;
 
         // Attempt to poison every queue config register.
         let mut buf = [0u8; 4];
@@ -1230,19 +1325,28 @@ pub(crate) mod tests {
         // QueueNum (0x38)
         write_le_u32(&mut buf, 0);
         dev.write(0x0, 0x38, &buf);
-        assert_eq!(dev.locked_device().queues()[0].size, size_before);
+        assert_eq!(
+            dev.locked_device().queue_config(0).unwrap().size,
+            size_before
+        );
 
         // QueueReady (0x44)
         write_le_u32(&mut buf, 0);
         dev.write(0x0, 0x44, &buf);
-        assert_eq!(dev.locked_device().queues()[0].ready, ready_before);
+        assert_eq!(
+            dev.locked_device().queue_config(0).unwrap().ready,
+            ready_before
+        );
 
         // QueueDescLow/High (0x80, 0x84)
         write_le_u32(&mut buf, 0xDEADBEEF);
         dev.write(0x0, 0x80, &buf);
         dev.write(0x0, 0x84, &buf);
         assert_eq!(
-            dev.locked_device().queues()[0].desc_table_address,
+            dev.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .desc_table_address,
             desc_before
         );
 
@@ -1250,7 +1354,10 @@ pub(crate) mod tests {
         dev.write(0x0, 0x90, &buf);
         dev.write(0x0, 0x94, &buf);
         assert_eq!(
-            dev.locked_device().queues()[0].avail_ring_address,
+            dev.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .avail_ring_address,
             avail_before
         );
 
@@ -1258,7 +1365,10 @@ pub(crate) mod tests {
         dev.write(0x0, 0xa0, &buf);
         dev.write(0x0, 0xa4, &buf);
         assert_eq!(
-            dev.locked_device().queues()[0].used_ring_address,
+            dev.locked_device()
+                .queue_config(0)
+                .unwrap()
+                .used_ring_address,
             used_before
         );
     }

--- a/src/vmm/src/devices/virtio/transport/pci/common_config.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/common_config.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use vm_memory::GuestAddress;
 
 use crate::devices::virtio::device::VirtioDevice;
-use crate::devices::virtio::queue::Queue;
+use crate::devices::virtio::queue::QueueConfig;
 use crate::devices::virtio::transport::pci::common_config_offset::*;
 use crate::devices::virtio::transport::pci::device::VIRTQ_MSI_NO_VECTOR;
 use crate::devices::virtio::transport::pci::device_status::*;
@@ -74,6 +74,7 @@ impl VirtioPciCommonConfig {
 
     pub fn read(&mut self, offset: u64, data: &mut [u8], device: Arc<Mutex<dyn VirtioDevice>>) {
         assert!(data.len() <= 8);
+        let queue_index = self.queue_select as usize;
 
         match data.len() {
             1 => {
@@ -81,11 +82,21 @@ impl VirtioPciCommonConfig {
                 data[0] = v;
             }
             2 => {
-                let v = self.read_common_config_word(offset, device.lock().unwrap().queues());
+                let locked_device = device.lock().unwrap();
+                let v = self.read_common_config_word(
+                    offset,
+                    locked_device.num_queues(),
+                    locked_device.queue_config(queue_index),
+                );
                 LittleEndian::write_u16(data, v);
             }
             4 => {
-                let v = self.read_common_config_dword(offset, device);
+                let locked_device = device.lock().unwrap();
+                let v = self.read_common_config_dword(
+                    offset,
+                    locked_device.avail_features(),
+                    locked_device.queue_config(queue_index),
+                );
                 LittleEndian::write_u32(data, v);
             }
             _ => warn!(
@@ -103,14 +114,18 @@ impl VirtioPciCommonConfig {
         device_activated: bool,
     ) {
         assert!(data.len() <= 8);
+        let queue_index = self.queue_select as usize;
 
         match data.len() {
             1 => self.write_common_config_byte(offset, data[0], device_activated),
-            2 => self.write_common_config_word(
-                offset,
-                LittleEndian::read_u16(data),
-                device.lock().unwrap().queues_mut(),
-            ),
+            2 => {
+                let mut locked_device = device.lock().unwrap();
+                self.write_common_config_word(
+                    offset,
+                    LittleEndian::read_u16(data),
+                    locked_device.queue_config_mut(queue_index),
+                );
+            }
             4 => self.write_common_config_dword(offset, LittleEndian::read_u32(data), device),
             _ => warn!(
                 "pci: invalid data length for virtio write: len {}",
@@ -206,12 +221,17 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    fn read_common_config_word(&self, offset: u64, queues: &[Queue]) -> u16 {
+    fn read_common_config_word(
+        &self,
+        offset: u64,
+        num_queues: usize,
+        queue: Option<&QueueConfig>,
+    ) -> u16 {
         match offset {
             MSIX_CONFIG => self.msix_config.load(Ordering::Acquire),
-            NUM_QUEUES => queues.len().try_into().unwrap(),
+            NUM_QUEUES => num_queues.try_into().unwrap(),
             QUEUE_SELECT => self.queue_select,
-            QUEUE_SIZE => self.with_queue(queues, |q| q.size).unwrap_or(0),
+            QUEUE_SIZE => queue.map(|q| q.size).unwrap_or(0),
             // If `queue_select` points to an invalid queue we should return NO_VECTOR.
             // Reading from here
             // https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-1280005:
@@ -225,7 +245,7 @@ impl VirtioPciCommonConfig {
                 .get(self.queue_select as usize)
                 .copied()
                 .unwrap_or(VIRTQ_MSI_NO_VECTOR),
-            QUEUE_ENABLE => u16::from(self.with_queue(queues, |q| q.ready).unwrap_or(false)),
+            QUEUE_ENABLE => u16::from(queue.map(|q| q.ready).unwrap_or(false)),
             QUEUE_NOTIFY_OFF => self.queue_select,
             _ => {
                 warn!("pci: invalid virtio register word read: 0x{:x}", offset);
@@ -241,10 +261,16 @@ impl VirtioPciCommonConfig {
     /// https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-1220001
     ///
     /// Queue configuration must only be done between FEATURES_OK and DRIVER_OK.
-    fn update_queue_field<F: FnOnce(&mut Queue)>(&mut self, queues: &mut [Queue], f: F) {
+    fn update_queue_field<F: FnOnce(&mut QueueConfig)>(
+        &mut self,
+        queue: Option<&mut QueueConfig>,
+        f: F,
+    ) {
         let status = self.driver_status;
         if status == (ACKNOWLEDGE | DRIVER | FEATURES_OK) {
-            self.with_queue_mut(queues, f);
+            if let Some(queue) = queue {
+                f(queue);
+            }
         } else {
             warn!(
                 "pci: queue config write not allowed in device status {:#x}",
@@ -253,7 +279,12 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    fn write_common_config_word(&mut self, offset: u64, value: u16, queues: &mut [Queue]) {
+    fn write_common_config_word(
+        &mut self,
+        offset: u64,
+        value: u16,
+        queue: Option<&mut QueueConfig>,
+    ) {
         match offset {
             MSIX_CONFIG => {
                 // Make sure that the guest doesn't select an invalid vector. We are offering
@@ -270,7 +301,7 @@ impl VirtioPciCommonConfig {
                 }
             }
             QUEUE_SELECT => self.queue_select = value,
-            QUEUE_SIZE => self.update_queue_field(queues, |q| q.size = value),
+            QUEUE_SIZE => self.update_queue_field(queue, |q| q.size = value),
             QUEUE_MSIX_VECTOR => {
                 let mut msix_queues = self.msix_queues.lock().expect("Poisoned lock");
                 let nr_vectors = msix_queues.len() + 1;
@@ -287,7 +318,7 @@ impl VirtioPciCommonConfig {
                     }
                 }
             }
-            QUEUE_ENABLE => self.update_queue_field(queues, |q| {
+            QUEUE_ENABLE => self.update_queue_field(queue, |q| {
                 if value != 0 {
                     q.ready = value == 1;
                 }
@@ -298,63 +329,42 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    fn read_common_config_dword(&self, offset: u64, device: Arc<Mutex<dyn VirtioDevice>>) -> u32 {
+    fn read_common_config_dword(
+        &self,
+        offset: u64,
+        avail_features: u64,
+        queue: Option<&QueueConfig>,
+    ) -> u32 {
         match offset {
             DEVICE_FEATURE_SELECT => self.device_feature_select,
             DEVICE_FEATURE => {
-                let locked_device = device.lock().unwrap();
                 // Only 64 bits of features (2 pages) are defined for now, so limit
                 // device_feature_select to avoid shifting by 64 or more bits.
                 if self.device_feature_select < 2 {
-                    ((locked_device.avail_features() >> (self.device_feature_select * 32))
-                        & 0xffff_ffff) as u32
+                    ((avail_features >> (self.device_feature_select * 32)) & 0xffff_ffff) as u32
                 } else {
                     0
                 }
             }
             DRIVER_FEATURE_SELECT => self.driver_feature_select,
-            QUEUE_DESC_LO => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.desc_table_address.0 & 0xffff_ffff) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_DESC_HI => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.desc_table_address.0 >> 32) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_AVAIL_LO => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.avail_ring_address.0 & 0xffff_ffff) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_AVAIL_HI => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.avail_ring_address.0 >> 32) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_USED_LO => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.used_ring_address.0 & 0xffff_ffff) as u32
-                })
-                .unwrap_or_default()
-            }
-            QUEUE_USED_HI => {
-                let locked_device = device.lock().unwrap();
-                self.with_queue(locked_device.queues(), |q| {
-                    (q.used_ring_address.0 >> 32) as u32
-                })
-                .unwrap_or_default()
-            }
+            QUEUE_DESC_LO => queue
+                .map(|q| (q.desc_table_address.0 & 0xffff_ffff) as u32)
+                .unwrap_or_default(),
+            QUEUE_DESC_HI => queue
+                .map(|q| (q.desc_table_address.0 >> 32) as u32)
+                .unwrap_or_default(),
+            QUEUE_AVAIL_LO => queue
+                .map(|q| (q.avail_ring_address.0 & 0xffff_ffff) as u32)
+                .unwrap_or_default(),
+            QUEUE_AVAIL_HI => queue
+                .map(|q| (q.avail_ring_address.0 >> 32) as u32)
+                .unwrap_or_default(),
+            QUEUE_USED_LO => queue
+                .map(|q| (q.used_ring_address.0 & 0xffff_ffff) as u32)
+                .unwrap_or_default(),
+            QUEUE_USED_HI => queue
+                .map(|q| (q.used_ring_address.0 >> 32) as u32)
+                .unwrap_or_default(),
             _ => {
                 warn!("pci: invalid virtio register dword read: 0x{:x}", offset);
                 0
@@ -377,6 +387,7 @@ impl VirtioPciCommonConfig {
         }
 
         let mut locked_device = device.lock().unwrap();
+        let queue_index = self.queue_select as usize;
 
         match offset {
             DEVICE_FEATURE_SELECT => self.device_feature_select = value,
@@ -393,40 +404,33 @@ impl VirtioPciCommonConfig {
                     );
                 }
             }
-            QUEUE_DESC_LO => self.update_queue_field(locked_device.queues_mut(), |q| {
-                lo(&mut q.desc_table_address, value)
-            }),
-            QUEUE_DESC_HI => self.update_queue_field(locked_device.queues_mut(), |q| {
-                hi(&mut q.desc_table_address, value)
-            }),
-            QUEUE_AVAIL_LO => self.update_queue_field(locked_device.queues_mut(), |q| {
-                lo(&mut q.avail_ring_address, value)
-            }),
-            QUEUE_AVAIL_HI => self.update_queue_field(locked_device.queues_mut(), |q| {
-                hi(&mut q.avail_ring_address, value)
-            }),
-            QUEUE_USED_LO => self.update_queue_field(locked_device.queues_mut(), |q| {
-                lo(&mut q.used_ring_address, value)
-            }),
-            QUEUE_USED_HI => self.update_queue_field(locked_device.queues_mut(), |q| {
-                hi(&mut q.used_ring_address, value)
-            }),
+            QUEUE_DESC_LO => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    lo(&mut q.desc_table_address, value)
+                }),
+            QUEUE_DESC_HI => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    hi(&mut q.desc_table_address, value)
+                }),
+            QUEUE_AVAIL_LO => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    lo(&mut q.avail_ring_address, value)
+                }),
+            QUEUE_AVAIL_HI => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    hi(&mut q.avail_ring_address, value)
+                }),
+            QUEUE_USED_LO => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    lo(&mut q.used_ring_address, value)
+                }),
+            QUEUE_USED_HI => self
+                .update_queue_field(locked_device.queue_config_mut(queue_index), |q| {
+                    hi(&mut q.used_ring_address, value)
+                }),
             _ => {
                 warn!("pci: invalid virtio register dword write: 0x{:x}", offset);
             }
-        }
-    }
-
-    fn with_queue<U, F>(&self, queues: &[Queue], f: F) -> Option<U>
-    where
-        F: FnOnce(&Queue) -> U,
-    {
-        queues.get(self.queue_select as usize).map(f)
-    }
-
-    fn with_queue_mut<F: FnOnce(&mut Queue)>(&self, queues: &mut [Queue], f: F) {
-        if let Some(queue) = queues.get_mut(self.queue_select as usize) {
-            f(queue);
         }
     }
 }
@@ -779,7 +783,12 @@ mod tests {
             config.read(QUEUE_SIZE, len.as_mut_slice(), device.clone());
             assert_eq!(
                 len,
-                device.lock().unwrap().queues()[queue_id as usize].max_size
+                device
+                    .lock()
+                    .unwrap()
+                    .queue_config(queue_id as usize)
+                    .unwrap()
+                    .max_size
             );
             max_size[queue_id as usize] = len;
         }
@@ -1006,8 +1015,12 @@ mod tests {
         // > MAY access each of the high and low 32-bit parts of the field independently.
 
         // 64-bit fields
-        device.lock().unwrap().queues_mut()[0].desc_table_address =
-            GuestAddress(0x0000_1312_0000_1110);
+        device
+            .lock()
+            .unwrap()
+            .queue_config_mut(0)
+            .unwrap()
+            .desc_table_address = GuestAddress(0x0000_1312_0000_1110);
         let mut buffer = [0u8; 8];
         config.read(QUEUE_DESC_LO, &mut buffer[..1], device.clone());
         assert_eq!(buffer, [0u8; 8]);

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -370,7 +370,7 @@ impl VirtioPciDevice {
         msix_vectors: Arc<MsixVectorGroup>,
         sbdf: PciSBDF,
     ) -> Result<Self, VirtioPciDeviceError> {
-        let num_queues = device.lock().expect("Poisoned lock").queues().len();
+        let num_queues = device.lock().expect("Poisoned lock").num_queues();
 
         let msix_config = Arc::new(Mutex::new(MsixConfig::new(msix_vectors.clone(), sbdf)));
         let pci_config = Self::pci_configuration(
@@ -621,14 +621,11 @@ impl VirtioPciDevice {
 
     fn set_notification_ioevents(&self, vm: &KvmVm, assign: bool) -> Result<(), errno::Error> {
         let bar_addr = self.config_bar_addr();
-        for (i, queue_evt) in self
-            .device
-            .lock()
-            .expect("Poisoned lock")
-            .queue_events()
-            .iter()
-            .enumerate()
-        {
+        let device = self.device.lock().expect("Poisoned lock");
+        for i in 0..device.num_queues() {
+            let queue_evt = device
+                .queue_event(i)
+                .expect("queue event must exist for each advertised queue");
             let notify_base = bar_addr + u64::from(NOTIFICATION_BAR_OFFSET);
             let io_addr =
                 IoEventAddress::Mmio(notify_base + i as u64 * u64::from(NOTIFY_OFF_MULTIPLIER));

--- a/src/vmm/src/devices/virtio/vhost_user.rs
+++ b/src/vmm/src/devices/virtio/vhost_user.rs
@@ -408,24 +408,24 @@ impl<T: VhostUserHandleBackend> VhostUserHandleImpl<T> {
         // at early stage.
         for (queue_index, queue, _) in queues.iter() {
             self.vu
-                .set_vring_num(*queue_index, queue.size)
+                .set_vring_num(*queue_index, queue.config.size)
                 .map_err(VhostUserError::VhostUserSetVringNum)?;
         }
 
         for (queue_index, queue, queue_evt) in queues.iter() {
             let config_data = VringConfigData {
-                queue_max_size: queue.max_size,
-                queue_size: queue.size,
+                queue_max_size: queue.config.max_size,
+                queue_size: queue.config.size,
                 flags: 0u32,
                 desc_table_addr: mem
-                    .get_host_address(queue.desc_table_address)
+                    .get_host_address(queue.config.desc_table_address)
                     .map_err(VhostUserError::DescriptorTableAddress)?
                     as u64,
                 used_ring_addr: mem
-                    .get_host_address(queue.used_ring_address)
+                    .get_host_address(queue.config.used_ring_address)
                     .map_err(VhostUserError::UsedAddress)? as u64,
                 avail_ring_addr: mem
-                    .get_host_address(queue.avail_ring_address)
+                    .get_host_address(queue.config.avail_ring_address)
                     .map_err(VhostUserError::AvailAddress)? as u64,
                 log_addr: None,
             };
@@ -909,8 +909,8 @@ pub(crate) mod tests {
         let guest_memory = create_mem(file, &regions);
 
         let mut queue = Queue::new(128);
-        queue.ready = true;
-        queue.size = queue.max_size;
+        queue.config.ready = true;
+        queue.config.size = queue.config.max_size;
         queue.initialize(&guest_memory).unwrap();
 
         let event_fd = EventFd::new(0).unwrap();
@@ -931,13 +931,13 @@ pub(crate) mod tests {
                 queue_size: 128,
                 flags: 0,
                 desc_table_addr: guest_memory
-                    .get_host_address(queue.desc_table_address)
+                    .get_host_address(queue.config.desc_table_address)
                     .unwrap() as u64,
                 used_ring_addr: guest_memory
-                    .get_host_address(queue.used_ring_address)
+                    .get_host_address(queue.config.used_ring_address)
                     .unwrap() as u64,
                 avail_ring_addr: guest_memory
-                    .get_host_address(queue.avail_ring_address)
+                    .get_host_address(queue.config.avail_ring_address)
                     .unwrap() as u64,
                 log_addr: None,
             },

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -34,7 +34,7 @@ use crate::devices::virtio::ActivateError;
 use crate::devices::virtio::device::{ActiveState, DeviceState, VirtioDevice, VirtioDeviceType};
 use crate::devices::virtio::generated::virtio_config::{VIRTIO_F_IN_ORDER, VIRTIO_F_VERSION_1};
 use crate::devices::virtio::generated::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use crate::devices::virtio::queue::{InvalidAvailIdx, Queue as VirtQueue};
+use crate::devices::virtio::queue::{InvalidAvailIdx, Queue as VirtQueue, QueueConfig, QueueError};
 use crate::devices::virtio::transport::{VirtioInterrupt, VirtioInterruptType};
 use crate::devices::virtio::vsock::VsockError;
 use crate::devices::virtio::vsock::metrics::METRICS;
@@ -312,16 +312,20 @@ where
         self.acked_features = acked_features
     }
 
-    fn queues(&self) -> &[VirtQueue] {
-        &self.queues
+    fn num_queues(&self) -> usize {
+        self.queues.len()
     }
 
-    fn queues_mut(&mut self) -> &mut [VirtQueue] {
-        &mut self.queues
+    fn queue_config(&self, index: usize) -> Option<&QueueConfig> {
+        self.queues.get(index).map(|queue| &queue.config)
     }
 
-    fn queue_events(&self) -> &[EventFd] {
-        &self.queue_events
+    fn queue_config_mut(&mut self, index: usize) -> Option<&mut QueueConfig> {
+        self.queues.get_mut(index).map(|queue| &mut queue.config)
+    }
+
+    fn queue_event(&self, index: usize) -> Option<&EventFd> {
+        self.queue_events.get(index)
     }
 
     fn interrupt_trigger(&self) -> &dyn VirtioInterrupt {
@@ -408,6 +412,17 @@ where
         self.tx_packet.clear();
         self.pending_event_ack = false;
         true
+    }
+
+    fn reset_queues(&mut self) {
+        self.queues.iter_mut().for_each(VirtQueue::reset);
+    }
+
+    fn mark_queue_memory_dirty(&mut self, mem: &GuestMemoryMmap) -> Result<(), QueueError> {
+        for queue in &mut self.queues {
+            queue.initialize(mem)?;
+        }
+        Ok(())
     }
 
     fn kick(&mut self) {

--- a/src/vmm/src/devices/virtio/vsock/persist.rs
+++ b/src/vmm/src/devices/virtio/vsock/persist.rs
@@ -91,7 +91,7 @@ where
     fn save(&self) -> Self::State {
         VsockFrontendState {
             cid: self.cid(),
-            virtio_state: VirtioDeviceState::from_device(self),
+            virtio_state: VirtioDeviceState::from_device(self, &self.queues),
         }
     }
 

--- a/src/vmm/src/devices/virtio/vsock/test_utils.rs
+++ b/src/vmm/src/devices/virtio/vsock/test_utils.rs
@@ -125,9 +125,9 @@ impl TestContext {
         const MEM_SIZE: usize = 1024 * 1024 * 128;
         let mem = single_region_mem(MEM_SIZE);
         let mut device = Vsock::new(CID, TestBackend::new()).unwrap();
-        for q in device.queues_mut() {
-            q.ready = true;
-            q.size = q.max_size;
+        for q in &mut device.queues {
+            q.config.ready = true;
+            q.config.size = q.config.max_size;
         }
         Self {
             cid: CID,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -150,6 +150,7 @@ use crate::persist::{MicrovmState, MicrovmStateError, VmInfo};
 use crate::rate_limiter::BucketUpdate;
 use crate::resources::VmmConfig;
 use crate::rpc_interface::VmmActionError;
+use crate::seccomp::BpfThreadMap;
 use crate::vmm_config::HotplugDeviceConfig;
 use crate::vmm_config::balloon::BalloonDeviceConfig;
 use crate::vmm_config::boot_source::BootSourceConfig;
@@ -708,6 +709,7 @@ impl Vmm {
         &mut self,
         config: HotplugDeviceConfig,
         event_manager: &mut EventManager,
+        seccomp_filters: &BpfThreadMap,
     ) -> Result<(), VmmActionError> {
         log_dev_preview_warning("PCI device hotplug", None);
         let kvm_vm = self
@@ -716,7 +718,7 @@ impl Vmm {
             .ok_or_else(|| VmmActionError::NotSupported("Operation requires KVM".to_string()))?
             .clone();
         self.device_manager
-            .hotplug_device(kvm_vm, config, event_manager)
+            .hotplug_device(kvm_vm, config, event_manager, seccomp_filters)
     }
 
     /// Detaches a device after VM start

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -3,6 +3,8 @@
 
 use std::fmt;
 use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use utils::time::TimerFd;
@@ -301,7 +303,7 @@ pub struct RateLimiter {
 
     timer_fd: TimerFd,
     // Internal flag that quickly determines timer state.
-    timer_active: bool,
+    timer_active: Arc<AtomicBool>,
 }
 
 impl PartialEq for RateLimiter {
@@ -367,7 +369,7 @@ impl RateLimiter {
             bandwidth: bytes_token_bucket,
             ops: ops_token_bucket,
             timer_fd,
-            timer_active: false,
+            timer_active: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -375,7 +377,7 @@ impl RateLimiter {
     fn activate_timer(&mut self, one_shot_duration: Duration) {
         // Register the timer; don't care about its previous state
         self.timer_fd.arm(one_shot_duration, None);
-        self.timer_active = true;
+        self.timer_active.store(true, Ordering::Relaxed);
     }
 
     /// Attempts to consume tokens and returns whether that is possible.
@@ -383,7 +385,7 @@ impl RateLimiter {
     /// If rate limiting is disabled on provided `token_type`, this function will always succeed.
     pub fn consume(&mut self, tokens: u64, token_type: TokenType) -> bool {
         // If the timer is active, we can't consume tokens from any bucket and the function fails.
-        if self.timer_active {
+        if self.is_blocked() {
             return false;
         }
 
@@ -400,7 +402,7 @@ impl RateLimiter {
                 // register a timer to replenish the bucket and resume processing;
                 // make sure there is only one running timer for this limiter.
                 BucketReduction::Failure => {
-                    if !self.timer_active {
+                    if !self.is_blocked() {
                         self.activate_timer(REFILL_TIMER_DURATION);
                     }
                     false
@@ -451,7 +453,7 @@ impl RateLimiter {
     /// budget for it.
     /// An event will be generated on the exported FD when the limiter 'unblocks'.
     pub fn is_blocked(&self) -> bool {
-        self.timer_active
+        self.timer_active.load(Ordering::Relaxed)
     }
 
     /// This function needs to be called every time there is an event on the
@@ -464,7 +466,7 @@ impl RateLimiter {
         match self.timer_fd.read() {
             0 => Err(RateLimiterError::SpuriousRateLimiterEvent),
             _ => {
-                self.timer_active = false;
+                self.timer_active.store(false, Ordering::Relaxed);
                 Ok(())
             }
         }

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -456,6 +456,11 @@ impl RateLimiter {
         self.timer_active.load(Ordering::Relaxed)
     }
 
+    /// Clones the shared blocked-state flag for lock free checks
+    pub(crate) fn clone_blocked_flag(&self) -> Arc<AtomicBool> {
+        self.timer_active.clone()
+    }
+
     /// This function needs to be called every time there is an event on the
     /// FD provided by this object's `AsRawFd` trait implementation.
     ///

--- a/src/vmm/src/rate_limiter/persist.rs
+++ b/src/vmm/src/rate_limiter/persist.rs
@@ -86,7 +86,7 @@ impl Persist<'_> for RateLimiter {
                 None
             },
             timer_fd: TimerFd::new(),
-            timer_active: false,
+            timer_active: Arc::new(AtomicBool::new(false)),
         };
 
         Ok(rate_limiter)

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -620,6 +620,7 @@ mod tests {
                 cache_type: CacheType::Unsafe,
 
                 is_read_only: Some(false),
+                threaded: false,
                 path_on_host: Some(tmp_file.as_path().to_str().unwrap().to_string()),
                 rate_limiter: Some(RateLimiterConfig::default()),
                 file_engine_type: None,

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -690,6 +690,7 @@ impl<'a> PrebootApiController<'a> {
 #[derive(Debug)]
 pub struct RuntimeApiController {
     vmm: Arc<Mutex<Vmm>>,
+    seccomp_filters: BpfThreadMap,
 }
 
 impl RuntimeApiController {
@@ -765,19 +766,31 @@ impl RuntimeApiController {
                 .vmm
                 .lock()
                 .expect("Poisoned lock")
-                .hotplug_device(HotplugDeviceConfig::Block(config), event_manager)
+                .hotplug_device(
+                    HotplugDeviceConfig::Block(config),
+                    event_manager,
+                    &self.seccomp_filters,
+                )
                 .map(|()| VmmData::Empty),
             InsertPmemDevice(config) => self
                 .vmm
                 .lock()
                 .expect("Poisoned lock")
-                .hotplug_device(HotplugDeviceConfig::Pmem(config), event_manager)
+                .hotplug_device(
+                    HotplugDeviceConfig::Pmem(config),
+                    event_manager,
+                    &self.seccomp_filters,
+                )
                 .map(|()| VmmData::Empty),
             InsertNetworkDevice(config) => self
                 .vmm
                 .lock()
                 .expect("Poisoned lock")
-                .hotplug_device(HotplugDeviceConfig::Net(config), event_manager)
+                .hotplug_device(
+                    HotplugDeviceConfig::Net(config),
+                    event_manager,
+                    &self.seccomp_filters,
+                )
                 .map(|()| VmmData::Empty),
             HotUnplugDevice(device_id) => self
                 .vmm
@@ -862,8 +875,11 @@ impl RuntimeApiController {
     }
 
     /// Creates a new `RuntimeApiController`.
-    pub fn new(vmm: Arc<Mutex<Vmm>>) -> Self {
-        Self { vmm }
+    pub fn new(vmm: Arc<Mutex<Vmm>>, seccomp_filters: &BpfThreadMap) -> Self {
+        Self {
+            vmm,
+            seccomp_filters: seccomp_filters.clone(),
+        }
     }
 
     /// Pauses the microVM by pausing the vCPUs.
@@ -1253,7 +1269,8 @@ mod tests {
 
     fn runtime_request(request: VmmAction) -> Result<VmmData, VmmActionError> {
         let vmm = Arc::new(Mutex::new(default_vmm()));
-        let mut runtime = RuntimeApiController::new(vmm.clone());
+        let seccomp_filters = BpfThreadMap::new();
+        let mut runtime = RuntimeApiController::new(vmm.clone(), &seccomp_filters);
         let mut event_manager = EventManager::new().unwrap();
         runtime.handle_request(request, &mut event_manager)
     }

--- a/src/vmm/src/seccomp.rs
+++ b/src/vmm/src/seccomp.rs
@@ -42,6 +42,7 @@ pub fn get_empty_filters() -> BpfThreadMap {
     map.insert("vmm".to_string(), Arc::new(vec![]));
     map.insert("api".to_string(), Arc::new(vec![]));
     map.insert("vcpu".to_string(), Arc::new(vec![]));
+    map.insert("blk_worker".to_string(), Arc::new(vec![]));
     map
 }
 

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -51,6 +51,9 @@ pub struct BlockDeviceConfig {
     /// If set to true, the drive is opened in read-only mode. Otherwise, the
     /// drive is opened as read-write.
     pub is_read_only: Option<bool>,
+    /// If set to true, process requests on a dedicated worker thread.
+    #[serde(default)]
+    pub threaded: bool,
     /// Path of the drive.
     pub path_on_host: Option<String>,
     /// Rate Limiter for I/O operations.
@@ -208,6 +211,7 @@ mod tests {
                 partuuid: self.partuuid.clone(),
                 is_root_device: self.is_root_device,
                 is_read_only: self.is_read_only,
+                threaded: self.threaded,
                 cache_type: self.cache_type,
 
                 path_on_host: self.path_on_host.clone(),
@@ -237,6 +241,7 @@ mod tests {
             cache_type: CacheType::Writeback,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path),
             rate_limiter: None,
             file_engine_type: None,
@@ -271,6 +276,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            threaded: false,
             path_on_host: Some(dummy_path),
             rate_limiter: None,
             file_engine_type: None,
@@ -303,6 +309,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            threaded: false,
             path_on_host: Some(dummy_path),
             rate_limiter: None,
             file_engine_type: None,
@@ -332,6 +339,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
@@ -348,6 +356,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
@@ -375,6 +384,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
@@ -391,6 +401,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
@@ -407,6 +418,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_3),
             rate_limiter: None,
             file_engine_type: None,
@@ -448,6 +460,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
@@ -464,6 +477,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
@@ -480,6 +494,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_3),
             rate_limiter: None,
             file_engine_type: None,
@@ -522,6 +537,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_1.clone()),
             rate_limiter: None,
             file_engine_type: None,
@@ -538,6 +554,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_2.clone()),
             rate_limiter: None,
             file_engine_type: None,
@@ -610,6 +627,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_1),
             rate_limiter: None,
             file_engine_type: None,
@@ -626,6 +644,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(false),
+            threaded: false,
             path_on_host: Some(dummy_path_2),
             rate_limiter: None,
             file_engine_type: None,
@@ -652,6 +671,7 @@ mod tests {
             cache_type: CacheType::Unsafe,
 
             is_read_only: Some(true),
+            threaded: false,
             path_on_host: Some(dummy_file.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: Some(FileEngineType::Sync),
@@ -682,6 +702,7 @@ mod tests {
             cache_type: CacheType::default(),
 
             is_read_only: Some(true),
+            threaded: false,
             path_on_host: Some(backing_file.as_path().to_str().unwrap().to_string()),
             rate_limiter: None,
             file_engine_type: None,

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -426,6 +426,7 @@ fn test_preboot_load_snap_disallowed_after_boot_resources() {
         cache_type: CacheType::Unsafe,
 
         is_read_only: Some(false),
+        threaded: false,
         path_on_host: Some(tmp_file),
         rate_limiter: None,
         file_engine_type: None,

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -104,7 +104,7 @@ fn test_build_microvm() {
 }
 
 fn pause_resume_microvm(vmm: Arc<Mutex<Vmm>>) {
-    let mut api_controller = RuntimeApiController::new(vmm.clone());
+    let mut api_controller = RuntimeApiController::new(vmm.clone(), &get_empty_filters());
     let mut event_manager = EventManager::new().unwrap();
 
     // There's a race between this thread and the vcpu thread, but this thread
@@ -228,7 +228,7 @@ fn verify_create_snapshot(
     );
 
     let vm_info = VmInfo::from(&*vmm.lock().unwrap());
-    let mut controller = RuntimeApiController::new(vmm.clone());
+    let mut controller = RuntimeApiController::new(vmm.clone(), &get_empty_filters());
     let mut event_manager = EventManager::new().unwrap();
 
     // Be sure that the microVM is running.

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -913,6 +913,7 @@ class Microvm:
         partuuid=None,
         cache_type=None,
         io_engine=None,
+        threaded=None,
     ):
         """Add a block device."""
 
@@ -925,6 +926,7 @@ class Microvm:
             partuuid=partuuid,
             cache_type=cache_type,
             io_engine=io_engine,
+            threaded=threaded,
         )
         self.disks[drive_id] = path_on_host
 

--- a/tests/framework/static_analysis.py
+++ b/tests/framework/static_analysis.py
@@ -103,6 +103,8 @@ class InstructionX86_64(Instruction):  # pylint: disable=invalid-name
         if reg not in affected_registers:
             return reg
 
+        partial_reg = ArchitectureX86_64.partial_reg(reg)
+
         match self.mnemonic:
             case "mov":
                 if len(self.args) != 2:
@@ -113,10 +115,18 @@ class InstructionX86_64(Instruction):  # pylint: disable=invalid-name
                 if dst == reg:
                     # an immediate load
                     if src.startswith("$"):
-                        return int(src[3:], 16)
+                        value = int(src[3:], 16)
+                        if partial_reg is not None:
+                            full_reg, mask = partial_reg
+                            return full_reg, lambda previous: (
+                                (previous & ~mask) | (value & mask)
+                            )
+                        return value
                     # We moved something into our target register. If it's a new register, we understand
                     # what's going on. Anything else, and tough luck
                     if re.match(r"^%\w{2,4}$", src):
+                        if partial_reg is not None:
+                            raise UnsupportedInstructionError(self, reg)
                         return src
                     raise UnsupportedInstructionError(self, reg)
                 return reg
@@ -126,6 +136,9 @@ class InstructionX86_64(Instruction):  # pylint: disable=invalid-name
                 if src == dst:
                     # we know that reg is part of the arguments, and we know that the arguments are identical
                     # Thus we have xor reg,reg, which is effectively zeroing reg
+                    if partial_reg is not None:
+                        full_reg, mask = partial_reg
+                        return full_reg, lambda previous: previous & ~mask
                     return 0
             case "push":
                 # a push doesn't do anything
@@ -292,21 +305,33 @@ class ArchitectureX86_64(  # pylint: disable=invalid-name
     syscall_argument_registers = ["%rdi", "%rsi", "%rdx", "%r10", "%r8", "%r9"]
     fn_call_argument_registers = ["%rdi", "%rsi", "%rdx", "%rcx", "%r8", "%r9"]
     seccomp_arch = seccomp.Arch.X86_64
+    REG_GROUPS = [
+        ("%rax", "%eax", "%ax", "%al"),
+        ("%rbx", "%ebx", "%bx", "%bl"),
+        ("%rcx", "%ecx", "%cx", "%cl"),
+        ("%rdx", "%edx", "%dx", "%dl"),
+        ("%rsi", "%esi", "%si", "%sil"),
+        ("%rdi", "%edi", "%di", "%dil"),
+        ("%rbp", "%ebp", "%bp", "%bpl"),
+        ("%rsp", "%esp", "%sp", "%spl"),
+    ] + [(f"%r{i}", f"%r{i}d", f"%r{i}w", f"%r{i}b") for i in range(8, 16)]
+    REG_ALIASES = {alias: group for group in REG_GROUPS for alias in group}
+
+    @staticmethod
+    def partial_reg(reg: str) -> tuple[str, int] | None:
+        """Return the full register and mask for a partial register."""
+        group = ArchitectureX86_64.REG_ALIASES.get(reg)
+        if group is None:
+            return None
+        if reg == group[2]:
+            return group[0], 0xFFFF
+        if reg == group[3]:
+            return group[0], 0xFF
+        return None
 
     @staticmethod
     def generalize_reg(reg: str) -> list[str]:
-        suffixes = ["ax", "bx", "cx", "dx", "si", "di", "bp", "sp"]
-        prefixes = ["%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15"]
-
-        for suffix in suffixes:
-            if reg.endswith(suffix):
-                return [f"%r{suffix}", f"%e{suffix}", f"%{suffix}"]
-
-        for prefix in prefixes:
-            if reg.startswith(prefix):
-                return [prefix, f"{prefix}d", f"{prefix}w"]
-
-        return [reg]
+        return list(ArchitectureX86_64.REG_ALIASES.get(reg, (reg,)))
 
 
 class ArchitectureAarch64(Architecture[InstructionAarch64]):
@@ -573,9 +598,11 @@ def load_seccomp_rules(seccomp_path: Path):
     For 'masked_eq' comparisons, mask is the bitmask value."""
     filters = json.loads(seccomp_path.read_text("utf-8"))
 
-    all_filters = (
-        filters["vcpu"]["filter"] + filters["vmm"]["filter"] + filters["api"]["filter"]
-    )
+    all_filters = [
+        seccomp_filter
+        for thread_filter in filters.values()
+        for seccomp_filter in thread_filter["filter"]
+    ]
     allowlist = defaultdict(list)
 
     for seccomp_filter in all_filters:

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -11,6 +11,7 @@
       "is_root_device": true,
       "cache_type": "Unsafe",
       "is_read_only": false,
+      "threaded": false,
       "path_on_host": "bionic.rootfs.ext4",
       "io_engine": "Sync",
       "rate_limiter": null,

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -757,6 +757,7 @@ def test_drive_patch(uvm, io_engine):
         is_root_device=False,
         is_read_only=False,
         io_engine=io_engine,
+        threaded=True,
     )
 
     fs_vub = drive_tools.FilesystemFile(
@@ -906,6 +907,7 @@ def _drive_patch(test_microvm, io_engine):
             "is_root_device": True,
             "cache_type": "Unsafe",
             "is_read_only": True,
+            "threaded": False,
             "path_on_host": "/" + test_microvm.rootfs_file.name,
             "rate_limiter": None,
             "io_engine": "Sync",
@@ -917,6 +919,7 @@ def _drive_patch(test_microvm, io_engine):
             "is_root_device": False,
             "cache_type": "Unsafe",
             "is_read_only": False,
+            "threaded": True,
             "path_on_host": "/scratch_new.ext4",
             "rate_limiter": {
                 "bandwidth": {"size": 5000, "one_time_burst": None, "refill_time": 100},
@@ -931,6 +934,7 @@ def _drive_patch(test_microvm, io_engine):
             "is_root_device": False,
             "cache_type": "Unsafe",
             "is_read_only": None,
+            "threaded": False,
             "path_on_host": None,
             "rate_limiter": None,
             "io_engine": None,
@@ -1320,6 +1324,7 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_configure
             "is_root_device": True,
             "cache_type": "Unsafe",
             "is_read_only": True,
+            "threaded": False,
             "path_on_host": f"/{uvm_configured.rootfs_file.name}",
             "rate_limiter": None,
             "io_engine": "Sync",
@@ -1460,6 +1465,7 @@ def test_get_full_config(uvm):
             "is_root_device": True,
             "cache_type": "Unsafe",
             "is_read_only": True,
+            "threaded": False,
             "path_on_host": "/" + test_microvm.rootfs_file.name,
             "rate_limiter": None,
             "io_engine": "Sync",


### PR DESCRIPTION
_[11/12] part of the PR stack starting with [#6123](https://github.com/firecracker-microvm/firecracker/pull/6123)_

## Changes

Add the threaded option to Swagger, Rust configuration, snapshot
serialization, and Python framework helpers.
Default to inline mode and reject threaded vhost-user configurations.