### PR TITLE
[bar-reloc 1/5] pci: Free the device BAR range on detach

### DIFF
--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -967,6 +967,38 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_pci_bar_is_freed_on_unplug() {
+        let mut evt_manager = EventManager::new().unwrap();
+        let mut vmm = default_vmm_with_pci();
+        let f = TempFile::new().unwrap();
+
+        let bar_addr = |vmm: &crate::Vmm, id: &str| {
+            pci_devices(&vmm.device_manager)
+                .get_virtio_device(VirtioDeviceType::Block, id)
+                .unwrap()
+                .lock()
+                .unwrap()
+                .bar_address()
+        };
+
+        let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block0", &f, false));
+        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        let first_addr = bar_addr(&vmm, "block0");
+
+        vmm.hot_unplug_device(
+            (VirtioDeviceType::Block, "block0".to_string()),
+            &mut evt_manager,
+        )
+        .unwrap();
+
+        // The BAR range of the detached device must have been returned to the
+        // 64-bit MMIO allocator, so the next device gets the same address.
+        let cfg = HotplugDeviceConfig::Block(make_hotplug_block_cfg("block1", &f, false));
+        vmm.hotplug_device(cfg, &mut evt_manager).unwrap();
+        assert_eq!(bar_addr(&vmm, "block1"), first_addr);
+    }
+
+    #[test]
     fn test_hotplug_pci_not_enabled() {
         let mut vmm = default_vmm();
         let mut evt_manager = EventManager::new().unwrap();

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -211,6 +211,11 @@ impl PciDevices {
             warn!("Failed to remove event subscriber for device {device_id:?}");
         }
 
+        pci_device_arc
+            .lock()
+            .expect("Poisoned lock")
+            .free_bars(&mut vm.resource_allocator().mmio64_memory);
+
         // Ensure no other references to the device remain, so it is freed when
         // this function returns.
         assert_eq!(Arc::strong_count(&pci_device_arc), 1);

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -375,6 +375,20 @@ impl VirtioPciDevice {
         self.add_pci_capabilities();
     }
 
+    /// Free the PCI BAR of the VirtIO device.
+    pub fn free_bars(&mut self, mmio64_allocator: &mut AddressAllocator) {
+        let bar_end = self
+            .bar_address
+            .checked_add(CAPABILITY_BAR_SIZE - 1)
+            .expect("virtio-pci BAR end address overflows");
+        let range =
+            RangeInclusive::new(self.bar_address, bar_end).expect("Invalid virtio-pci BAR range");
+        mmio64_allocator
+            .free(&range)
+            .expect("virtio-pci BAR is not allocated");
+        self.bar_address = 0;
+    }
+
     /// Constructs a new PCI transport for the given virtio device.
     pub fn new(
         id: String,


### PR DESCRIPTION
**Commit Message**

```
pci: Free the device BAR range on detach

detach_pci_virtio_device() did not free the device BAR from the
mmio64_allocator, leaking parts of the address range. Add a free_bars()
method to VirtioPciDevice and call it on detach. Also add a unit test to
ensure we don't re-introduce the bug.

Signed-off-by: Ilias Stamatis <ilstam@amazon.com>
```
