### PR TITLE
fix(memory): use checked arithmetic in memfd_backed region sum

### DIFF
--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -870,7 +870,10 @@ pub fn memfd_backed(
     track_dirty_pages: bool,
     huge_pages: HugePageConfig,
 ) -> Result<Vec<GuestRegionMmap>, MemoryError> {
-    let size = regions.iter().map(|&(_, size)| size as u64).sum();
+    let size = regions
+        .iter()
+        .try_fold(0u64, |acc, &(_, size)| acc.checked_add(size as u64))
+        .ok_or(MemoryError::OffsetTooLarge)?;
     let memfd_file = create_memfd(size, huge_pages.into())?.into_file();
 
     create(
@@ -1298,6 +1301,16 @@ mod tests {
         let regions = vec![(GuestAddress(0), 2 * page_size)];
         let result = snapshot_file(file, regions.into_iter(), false, HugePageConfig::None);
         assert!(matches!(result.unwrap_err(), MemoryError::OffsetTooLarge));
+    }
+
+    #[test]
+    fn test_memfd_backed_size_overflow() {
+        let regions = [(GuestAddress(0), usize::MAX), (GuestAddress(0), 1)];
+
+        assert!(matches!(
+            memfd_backed(&regions, false, HugePageConfig::None),
+            Err(MemoryError::OffsetTooLarge)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `memfd_backed` function uses an unchecked `.sum()` to calculate the total size of memory regions:

```rust
let size = regions.iter().map(|&(_, size)| size as u64).sum();
```

This could theoretically overflow if given sufficiently large region sizes.

This PR applies the same fix that was made to `snapshot_file` in commit 837c2e782: replace the unchecked sum with `try_fold` and `checked_add`, returning `MemoryError::OffsetTooLarge` on overflow.

## Changes

- Replace `.sum()` with `.try_fold()` + `checked_add()` in `memfd_backed`
- Return `MemoryError::OffsetTooLarge` on overflow (consistent with `snapshot_file`)

## Test plan

- [ ] Existing unit tests pass
- [ ] The fix mirrors the pattern already used in `snapshot_file` (lines 909-912)

## Related

- Commit 837c2e782 fixed the same pattern in `snapshot_file`
- This ensures consistency across memory allocation functions