### PR TITLE
fix(logger): do not log from the SIGPIPE handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,11 +82,15 @@ and this project adheres to
   Terminating a connection now also discards its TX buffer, so the device stops
   advertising `EPOLLOUT` for a host stream it will never write to again, which
   could otherwise busy-spin the event thread indefinitely.
-- [#6086](https://github.com/firecracker-microvm/firecracker/pull/6086): Fixed a
-  potential deadlock in the logger: a signal handler that logs while the
-  interrupted thread already held the logger lock would re-acquire it and hang
-  the VMM. The logger now uses an `RwLock` so logging takes a shared lock that a
-  nested (signal-handler) log can re-acquire without blocking.
+- [#6086](https://github.com/firecracker-microvm/firecracker/pull/6086),
+  [#6143](https://github.com/firecracker-microvm/firecracker/pull/6143): Fixed a
+  deadlock in the logger: a signal handler that logs while the interrupted
+  thread is already logging would hang the VMM and its API socket. This is
+  reachable whenever a `SIGPIPE` is raised by Firecracker's own log write, for
+  example when logging to `stdout` and the reader of that pipe exits. The logger
+  now uses an `RwLock`, and `sigpipe_handler` only increments the
+  `signals.sigpipe` metric instead of logging, so it no longer emits a
+  `Received signal 13, code 0.` line.
 - [#6120](https://github.com/firecracker-microvm/firecracker/pull/6120): Fixed a
   bug caused by a KVM behavior change introduced in Linux 6.13, which requires
   guest CPUID to be set before userspace reads CPUID-dependent MSRs. On x86_64

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -780,6 +780,10 @@
                 "comment": "rt_sigprocmask is used by Rust stdlib to remove custom signal handler during thread teardown."
             },
             {
+                "syscall": "rt_sigreturn",
+                "comment": "rt_sigreturn is needed so sigpipe_handler can return and resume the thread."
+            },
+            {
                 "syscall": "sigaltstack",
                 "comment": "sigaltstack is used by Rust stdlib to remove alternative signal stack during thread teardown."
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -792,6 +792,10 @@
                 "comment": "rt_sigprocmask is used by Rust stdlib to remove custom signal handler during thread teardown."
             },
             {
+                "syscall": "rt_sigreturn",
+                "comment": "rt_sigreturn is needed so sigpipe_handler can return and resume the thread."
+            },
+            {
                 "syscall": "sigaltstack",
                 "comment": "sigaltstack is used by Rust stdlib to remove alternative signal stack during thread teardown."
             },

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -145,9 +145,9 @@ extern "C" fn sigpipe_handler(num: c_int, info: *mut siginfo_t, _unused: *mut c_
         return;
     }
 
+    // Do not log here: the write that raised SIGPIPE is usually a log write, so
+    // logging would re-enter the logger mid-write on this same thread.
     METRICS.signals.sigpipe.inc();
-
-    error_unrestricted!("Received signal {}, code {}.", si_signo, si_code);
 }
 
 /// Registers all the required signal handlers.

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -5,12 +5,15 @@
 import json
 import os
 import resource as res
+import subprocess
+import urllib.parse
 from signal import SIGBUS, SIGHUP, SIGILL, SIGPIPE, SIGSEGV, SIGSYS, SIGXCPU, SIGXFSZ
 from time import sleep
 
 import pytest
 
 from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel, pin_rootfs_mode
+from framework.http_api import Session
 
 signum_str = {
     SIGBUS: "sigbus",
@@ -48,9 +51,8 @@ def test_generic_signal_handler(uvm, signum):
     assert len(line_metrics) == 1
 
     os.kill(microvm.firecracker_pid, signum)
-    # Firecracker gracefully handles SIGPIPE (doesn't terminate).
+    # Firecracker gracefully handles SIGPIPE (doesn't terminate) and logs nothing.
     if signum == int(SIGPIPE):
-        msg = "Received signal 13"
         # Flush metrics to file, so we can see the SIGPIPE at bottom assert.
         # This is going to fail if process has exited.
         microvm.api.actions.put(action_type="FlushMetrics")
@@ -59,11 +61,50 @@ def test_generic_signal_handler(uvm, signum):
 
         microvm.mark_killed()
 
-    microvm.check_log_message(msg)
+        microvm.check_log_message(msg)
 
     if signum != SIGSYS:
         metric_line = json.loads(metrics_fd.readlines()[0])
         assert metric_line["signals"][signum_str[signum]] == 1
+
+
+def test_sigpipe_from_log_write(microvm_factory, tmp_path):
+    """
+    Test that a SIGPIPE raised by Firecracker's own log write is survivable.
+
+    With no log path configured the log target is stdout, so putting stdout on a
+    pipe and dropping the read end makes the next request log, and so raise
+    SIGPIPE on the thread that is already inside the log write.
+    """
+    sock = tmp_path / "fc.sock"
+    url = f"http+unix://{urllib.parse.quote(str(sock), safe='')}/"
+    read_fd, write_fd = os.pipe()
+    proc = subprocess.Popen(
+        [str(microvm_factory.fc_binary_path), "--api-sock", str(sock)],
+        stdout=write_fd,
+        stderr=write_fd,
+    )
+    os.close(write_fd)
+    try:
+        for _ in range(100):
+            if sock.exists():
+                break
+            sleep(0.05)
+
+        session = Session()
+        assert session.get(url, timeout=5).status_code == 200
+
+        # Drop the read end, so the log write of the next request gets EPIPE.
+        os.close(read_fd)
+        read_fd = None
+
+        assert session.get(url, timeout=5).status_code == 200
+        assert proc.poll() is None, f"Firecracker exited with {proc.poll()}"
+    finally:
+        if read_fd is not None:
+            os.close(read_fd)
+        proc.kill()
+        proc.wait()
 
 
 @pin_guest_kernel(GUEST_KERNEL_DEFAULT)


### PR DESCRIPTION
## Changes

`sigpipe_handler` no longer logs; it only increments the `signals.sigpipe`
metric. `rt_sigreturn` is added to the `api` seccomp filter so the handler can
return on that thread. Adds a regression test.

## Reason

The write that raises SIGPIPE is usually a log write, so logging from the handler
re-enters the logger mid-write on the same thread. This wedges the API thread,
and with it the API socket, whenever Firecracker logs to `stdout` (the default)
and the reader of that pipe goes away — for instance a supervisor that captures
Firecracker's output and then restarts.

#6086 removed the logger mutex as the blocking point but not the reentrancy:
`std::io::Stdout` holds a `RefCell` across the write which is not reentrant, so
the nested log panics and the VMM aborts instead of hanging. SIGPIPE is not fatal
and the `EPIPE` is handled at the call site, so the handler has nothing to do but
count. Without the seccomp change it is trapped on `rt_sigreturn` and killed by
SIGSYS instead.

Reported with a deterministic reproduction in
https://github.com/firecracker-microvm/firecracker/pull/6086#issuecomment-5318282012.
`test_sigpipe_from_log_write` covers it, and fails without either half of the
fix. `test_generic_signal_handler` no longer expects a log message for SIGPIPE;
its metric assertion is unchanged.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
