### PR TITLE
vmm: x86: expose staged vCPU configuration

### DIFF
--- a/src/vmm/src/arch/x86_64/vcpu.rs
+++ b/src/vmm/src/arch/x86_64/vcpu.rs
@@ -190,7 +190,17 @@ impl KvmVcpu {
     /// Normalizes and configures CPUID for this vCPU.
     ///
     /// Returns the KVM CPUID representation installed on the vCPU.
-    pub(crate) fn configure_cpuid(
+    ///
+    /// # Arguments
+    ///
+    /// * `cpuid` - The shared guest CPUID configuration.
+    /// * `vcpu_count` - The total number of logical vCPUs.
+    /// * `smt` - Whether simultaneous multithreading is enabled.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if CPUID cannot be normalized, converted, or installed on the vCPU.
+    pub fn configure_cpuid(
         &self,
         cpuid: &cpuid::Cpuid,
         vcpu_count: u8,
@@ -218,7 +228,16 @@ impl KvmVcpu {
     /// Configures CPU template and Linux boot MSRs for this vCPU.
     ///
     /// `configured_cpuid` must be the CPUID installed on this vCPU.
-    pub(crate) fn configure_msrs_for_boot(
+    ///
+    /// # Arguments
+    ///
+    /// * `msrs` - The CPU template MSR values to configure and save in snapshots.
+    /// * `configured_cpuid` - The value returned by [`Self::configure_cpuid`] for this vCPU.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the MSRs cannot be installed on the vCPU.
+    pub fn configure_msrs_for_boot(
         &mut self,
         msrs: &BTreeMap<u32, u64>,
         configured_cpuid: &CpuId,
@@ -261,8 +280,17 @@ impl KvmVcpu {
         Ok(())
     }
 
-    /// Configures the remaining Linux boot state for this vCPU.
-    pub(crate) fn configure_boot_state(
+    /// Configures the remaining Linux boot state after CPUID and MSRs for this vCPU.
+    ///
+    /// # Arguments
+    ///
+    /// * `guest_mem` - The guest memory used by the microVM.
+    /// * `kernel_entry_point` - The boot protocol and guest address of the kernel entry point.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the register, FPU, special register, or LINT setup fails.
+    pub fn configure_boot_state(
         &self,
         guest_mem: &GuestMemoryMmap,
         kernel_entry_point: EntryPoint,


### PR DESCRIPTION
## Changes

- Expose `KvmVcpu::configure_cpuid()`,
  `KvmVcpu::configure_msrs_for_boot()`, and
  `KvmVcpu::configure_boot_state()`.
- Document their arguments and failure modes.

## Reason

`KvmVcpu::configure()` was public before it was replaced by staged
configuration methods. Keep its replacements available to external users as
well.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
