### PR TITLE
fix(virtio-balloon): reject guest writes to device-owned config fields

### DIFF
--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -930,23 +930,29 @@ impl VirtioDevice for Balloon {
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {
-        let config_space_bytes = self.config_space.as_mut_slice();
-        let start = usize::try_from(offset).ok();
-        let end = start.and_then(|s| s.checked_add(data.len()));
-        let Some(dst) = start
-            .zip(end)
-            .and_then(|(start, end)| config_space_bytes.get_mut(start..end))
-        else {
-            warn!(
-                "virtio-balloon: guest driver attempted to write device config out of bounds \
-                 (offset={:#x}, len={:#x})",
-                offset,
-                data.len()
-            );
-            return;
-        };
+        // Per the virtio-balloon spec, `actual` is the only driver-writable field: the guest
+        // reports the current balloon size through it. `num_pages` and `free_page_hint_cmd_id`
+        // are device-owned and are read back by the operator through the management API, so
+        // guest writes touching them (or landing out of bounds) are rejected.
+        let actual_start = std::mem::offset_of!(ConfigSpace, actual_pages);
+        let actual_end = actual_start + SIZE_OF_U32;
 
-        dst.copy_from_slice(data);
+        let start = usize::try_from(offset).ok();
+        let end = start.and_then(|start| start.checked_add(data.len()));
+        match (start, end) {
+            (Some(start), Some(end)) if start >= actual_start && end <= actual_end => {
+                self.config_space.as_mut_slice()[start..end].copy_from_slice(data);
+            }
+            _ => {
+                METRICS.cfg_fails.inc();
+                warn!(
+                    "virtio-balloon: guest driver attempted to write read-only device config \
+                     (offset={:#x}, len={:#x})",
+                    offset,
+                    data.len()
+                );
+            }
+        }
     }
 
     fn activate(
@@ -1226,29 +1232,76 @@ pub(crate) mod tests {
     fn test_virtio_write_config() {
         let mut balloon = Balloon::new(0, true, 0, false, false).unwrap();
 
-        let expected_config_space: [u8; BALLOON_CONFIG_SPACE_SIZE] = [
-            0x00, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        ];
-        balloon.write_config(0, &expected_config_space);
+        // `actual` is the only driver-writable field, so this write goes through.
+        let mut expected_config_space = [0u8; BALLOON_CONFIG_SPACE_SIZE];
+        expected_config_space[4..8].copy_from_slice(&0x5000u32.to_le_bytes());
+        check_metric_after_block!(METRICS.cfg_fails, 0, {
+            balloon.write_config(4, &0x5000u32.to_le_bytes())
+        });
 
         let mut actual_config_space = [0u8; BALLOON_CONFIG_SPACE_SIZE];
         balloon.read_config(0, &mut actual_config_space);
         assert_eq!(actual_config_space, expected_config_space);
 
+        // Writes to the device-owned `num_pages` and `free_page_hint_cmd_id` fields are
+        // rejected, as are writes straddling them.
+        for offset in [0, 6, 8] {
+            check_metric_after_block!(METRICS.cfg_fails, 1, {
+                balloon.write_config(offset, &0xdead_beefu32.to_le_bytes())
+            });
+            // Make sure nothing got written.
+            balloon.read_config(0, &mut actual_config_space);
+            assert_eq!(actual_config_space, expected_config_space);
+        }
+
         // Invalid write.
         let new_config_space = [
             0xd, 0xe, 0xa, 0xd, 0xb, 0xe, 0xe, 0xf, 0x00, 0x00, 0x00, 0x00,
         ];
-        balloon.write_config(5, &new_config_space);
+        check_metric_after_block!(METRICS.cfg_fails, 1, {
+            balloon.write_config(5, &new_config_space)
+        });
         // Make sure nothing got written.
         balloon.read_config(0, &mut actual_config_space);
         assert_eq!(actual_config_space, expected_config_space);
 
         // Large offset that may cause an overflow.
-        balloon.write_config(u64::MAX, &new_config_space);
+        check_metric_after_block!(METRICS.cfg_fails, 1, {
+            balloon.write_config(u64::MAX, &new_config_space)
+        });
         // Make sure nothing got written.
         balloon.read_config(0, &mut actual_config_space);
         assert_eq!(actual_config_space, expected_config_space);
+    }
+
+    #[test]
+    fn test_write_config_rejects_read_only_fields() {
+        let mut balloon = Balloon::new(0x10, true, 0, true, false).unwrap();
+        let num_pages = balloon.num_pages();
+        let free_page_hint_cmd_id = balloon.config_space.free_page_hint_cmd_id;
+
+        // A guest write to the device-owned `num_pages` must not change the balloon target
+        // the operator reads back through the management API.
+        check_metric_after_block!(METRICS.cfg_fails, 1, {
+            balloon.write_config(0, &0xdead_beefu32.to_le_bytes())
+        });
+        assert_eq!(balloon.num_pages(), num_pages);
+        assert_eq!(balloon.size_mb(), 0x10);
+
+        // Same for `free_page_hint_cmd_id`, which is driven by the device.
+        check_metric_after_block!(METRICS.cfg_fails, 1, {
+            balloon.write_config(8, &0xdead_beefu32.to_le_bytes())
+        });
+        assert_eq!(
+            balloon.config_space.free_page_hint_cmd_id,
+            free_page_hint_cmd_id
+        );
+
+        // `actual` stays driver-writable: the guest reports the current balloon size there.
+        check_metric_after_block!(METRICS.cfg_fails, 0, {
+            balloon.write_config(4, &1234u32.to_le_bytes())
+        });
+        assert_eq!(balloon.actual_pages(), 1234);
     }
 
     #[test]
@@ -1262,11 +1315,12 @@ pub(crate) mod tests {
         balloon.set_queue(balloon.free_page_hinting_idx(), infq.create_queue());
         balloon.activate(mem.clone(), interrupt).unwrap();
 
+        // `num_pages` is device-owned, so it is set through the device API.
+        balloon.update_num_pages(0x5000);
+
         let expected_config_space: [u8; BALLOON_CONFIG_SPACE_SIZE] = [
             0x00, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
-        balloon.write_config(0, &expected_config_space);
-
         let mut actual_config_space = [0u8; BALLOON_CONFIG_SPACE_SIZE];
         balloon.read_config(0, &mut actual_config_space);
         assert_eq!(actual_config_space, expected_config_space);
@@ -1995,11 +2049,15 @@ pub(crate) mod tests {
         assert_eq!(balloon.actual_pages(), 0x1234);
         assert_eq!(balloon.size_mb(), 16);
 
-        // Update fields through the config space.
-        let expected_config = vec![0x44, 0x33, 0x22, 0x11, 0x78, 0x56, 0x34, 0x12, 0, 0, 0, 0];
-        balloon.write_config(0, &expected_config);
-        assert_eq!(balloon.num_pages(), 0x1122_3344);
+        // The guest may only update `actual` through the config space.
+        balloon.write_config(4, &0x1234_5678u32.to_le_bytes());
         assert_eq!(balloon.actual_pages(), 0x1234_5678);
+
+        // `num_pages` is device-owned, so a guest write to it is rejected and the target
+        // set through the API is preserved.
+        balloon.write_config(0, &0x1122_3344u32.to_le_bytes());
+        assert_eq!(balloon.num_pages(), 0x1000);
+        assert_eq!(balloon.size_mb(), 16);
     }
 
     /// Test that process_stats_queue holds oversized descriptors without

--- a/src/vmm/src/devices/virtio/balloon/metrics.rs
+++ b/src/vmm/src/devices/virtio/balloon/metrics.rs
@@ -10,6 +10,7 @@
 //! ```json
 //!  "balloon": {
 //!     "activate_fails": "SharedIncMetric",
+//!     "cfg_fails": "SharedIncMetric",
 //!     "inflate_count": "SharedIncMetric",
 //!     "stats_updates_count": "SharedIncMetric",
 //!     ...
@@ -53,6 +54,8 @@ pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
 pub(super) struct BalloonDeviceMetrics {
     /// Number of times when activate failed on a balloon device.
     pub activate_fails: SharedIncMetric,
+    /// Number of times when handling a device config space write from the guest failed.
+    pub cfg_fails: SharedIncMetric,
     /// Number of balloon device inflations.
     pub inflate_count: SharedIncMetric,
     // Number of balloon statistics updates from the driver.
@@ -81,6 +84,7 @@ impl BalloonDeviceMetrics {
     const fn new() -> Self {
         Self {
             activate_fails: SharedIncMetric::new(),
+            cfg_fails: SharedIncMetric::new(),
             inflate_count: SharedIncMetric::new(),
             stats_updates_count: SharedIncMetric::new(),
             stats_update_fails: SharedIncMetric::new(),

--- a/tests/host_tools/fcmetrics.py
+++ b/tests/host_tools/fcmetrics.py
@@ -135,6 +135,7 @@ def validate_fc_metrics(metrics):
         ],
         "balloon": [
             "activate_fails",
+            "cfg_fails",
             "inflate_count",
             "stats_updates_count",
             "stats_update_fails",


### PR DESCRIPTION
## Changes

`VirtioDevice::write_config` for the balloon device now accepts a guest write
only when the whole byte range falls inside the `actual_pages` field of the
config space. Any write that touches `num_pages` or `free_page_hint_cmd_id`, or
that lands out of bounds, is rejected: nothing is copied, a warning is logged,
and the attempt is counted under a new balloon `cfg_fails` metric.

The accepted range is derived from `offset_of!(ConfigSpace, actual_pages)` and
the field size rather than hardcoded, so it stays correct if the struct layout
changes. The existing checked-arithmetic bounds handling is preserved.

The new metric is also listed in the balloon entry of the metrics schema used by
the integration tests (`tests/host_tools/fcmetrics.py`), which rejects unknown
fields.

## Reason

Before this change, `write_config` copied any in-bounds guest bytes straight
into the 12-byte balloon config space:

```rust
let Some(dst) = start
    .zip(end)
    .and_then(|(start, end)| config_space_bytes.get_mut(start..end))
else { /* warn and return */ };

dst.copy_from_slice(data);
```

`ConfigSpace` is:

```rust
#[repr(C)]
pub(crate) struct ConfigSpace {
    pub num_pages: u32,             // bytes 0..4  - device-owned
    pub actual_pages: u32,          // bytes 4..8  - driver-writable
    pub free_page_hint_cmd_id: u32, // bytes 8..12 - device-owned
}
```

Per the virtio-balloon spec, `actual` is the only driver-writable field — the
guest reports the current balloon size through it. `num_pages` and
`free_page_hint_cmd_id` are device-owned:

- `num_pages` is set by the operator via `PATCH /balloon` (`update_size()`), and
  is read back by the operator through `GET /balloon` (`amount_mib`, via
  `size_mb()`) and `GET /balloon/statistics` (`target_pages` / `target_mib`, via
  `latest_stats()`).
- `free_page_hint_cmd_id` is driven by the device (`update_free_page_hint_cmd`,
  `start_hinting`, `stop_hinting`).

Because the old code accepted any in-bounds offset, a guest could MMIO-write
offset 0 (or 8) and overwrite those fields. The practical impact is a
control-plane integrity issue: the guest can forge the balloon target that the
orchestrator subsequently reads back from the management API, making
`GET /balloon` and `GET /balloon/statistics` report a size the operator never
set. There is no memory-safety impact — the bounds check was and remains in
place, so the guest cannot write outside the 12-byte config space.

This mirrors the hardening already applied to virtio-block in commit 80fb45d
("fix(virtio-block): make device config space read-only for the guest"), which
made `VirtioBlock::write_config` reject all guest writes and count them under a
`cfg_fails` metric. Balloon cannot be made fully read-only, because `actual` is
legitimately driver-written, so the restriction here is field-scoped instead of
total.

## Testing

Unit tests updated/added in `src/vmm/src/devices/virtio/balloon/device.rs`:

- `test_write_config_rejects_read_only_fields` (new): asserts that guest writes
  to `num_pages` (offset 0) and `free_page_hint_cmd_id` (offset 8) leave those
  fields — and the operator-facing `size_mb()` — unchanged while incrementing
  `cfg_fails`, and that a write to `actual` (offset 4) is still accepted without
  incrementing `cfg_fails`.
- `test_virtio_write_config`: reworked for the new contract — the `actual` write
  is accepted; writes at offsets 0, 6 and 8, the out-of-bounds write and the
  `u64::MAX` offset write are all rejected and counted.
- `test_free_page_hinting_config` and `test_num_pages`: previously set
  `num_pages` through `write_config`; they now set it through the device API
  (`update_num_pages`), and `test_num_pages` additionally asserts that a guest
  write to `num_pages` is rejected.

Commands run on `x86_64` (Ubuntu 24.04, toolchain 1.97.0 as pinned by
`rust-toolchain.toml`) against the current commit, rebased onto `main` @
7699746. Unit tests were run single-threaded, as `tools/devtool test` runs them:

| Command | Result |
| --- | --- |
| `cargo test -p vmm --lib devices::virtio::balloon -- --test-threads=1` | 30 passed, 0 failed |
| `cargo test -p vmm --lib metrics -- --test-threads=1` | 25 passed, 0 failed |
| `cargo clippy -p vmm --all-targets -- -D warnings` | clean |
| `cargo clippy --all --all-targets -- -D warnings` | clean |
| `cargo fmt -- --check` | clean |
| `black --check` / `isort --check-only` on `tests/host_tools/fcmetrics.py` | clean |

The new regression test was also confirmed to fail against the unfixed
`write_config` (`assertion left == right failed: unexpected metric value, left:
0, right: 1`) and to pass with the fix applied, together with
`test_virtio_write_config` and `test_num_pages`.

Not run: the integration test suite (`tools/devtool test`) and any KVM-dependent
test — the development environment has no `/dev/kvm` and no Docker daemon. The
change is pure device config-space logic and is fully covered by the unit tests
above. Only `x86_64` was built and tested; the change is architecture
independent.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
  <!-- Not run: no Docker daemon available. `cargo build -p vmm`,
  `cargo clippy --all --all-targets -- -D warnings` and `cargo fmt -- --check`
  were run directly on x86_64 instead. -->
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
  <!-- Not run: no Docker daemon available. `cargo fmt -- --check` and
  `cargo clippy --all --all-targets -- -D warnings` were run directly. -->
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
  <!-- Code documentation is updated (the new metric is documented in the
  balloon metrics module doc comment). No file under `docs/` enumerates
  per-device metric fields, so no documentation change was required. -->
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
  <!-- Not done. The direct precedent (80fb45d, the equivalent virtio-block
  hardening) did not add a changelog entry; happy to add one if maintainers
  consider the new `cfg_fails` metric and the stricter config-space contract
  user-facing. -->
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
  <!-- No API changes. -->
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
  <!-- Unit tests only, see Testing above. No integration tests were run. -->
- [ ] I have linked an issue to every new `TODO`.
  <!-- No new TODOs. -->

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].
  <!-- This is a fix to Firecracker's own balloon device implementation. -->

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md

