### PR TITLE
[1.15] fix(aarch64): re-enable CONFIG_ARM64_ERRATUM_3194386 in guest kernels

### DIFF
--- a/resources/guest_configs/ci.config
+++ b/resources/guest_configs/ci.config
@@ -4,7 +4,6 @@ CONFIG_MSDOS_PARTITION=y
 CONFIG_SQUASHFS_ZSTD=y
 # aarch64 only TBD split into a separate file
 CONFIG_DEVMEM=y
-# CONFIG_ARM64_ERRATUM_3194386 is not set
 # Needed for CTRL+ALT+DEL support
 CONFIG_SERIO=y
 CONFIG_SERIO_I8042=y

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.skipif(
 G2_FEATS = set(
     (
         "fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp "
-        "asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs"
+        "asimdhp cpuid asimdrdm lrcpc dcpop asimddp"
     ).split()
 )
 

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -137,6 +137,13 @@ AMD_MILAN_HOST_ONLY_FEATS_6_1 = AMD_MILAN_HOST_ONLY_FEATS - {
     "sme",
 } | {"brs", "rapl", "v_spec_ctrl"}
 
+# Since v6.11, flags declared in cpufeatures.h without a quoted /proc/cpuinfo name
+# are hidden. VMSCAPE added IBPB_EXIT_TO_USER without one, so v6.18+ amzn2023 hides it.
+# https://github.com/torvalds/linux/commit/78ce84b9e0a54a0c91a7449f321c1f852c0cd3fc
+AMD_MILAN_HOST_ONLY_FEATS_6_18 = AMD_MILAN_HOST_ONLY_FEATS_6_1 - {
+    "ibpb_exit_to_user",
+} | {"xtopology", "debug_swap"}
+
 AMD_GENOA_HOST_ONLY_FEATS = AMD_MILAN_HOST_ONLY_FEATS | {
     "avic",
     "flush_l1d",
@@ -152,6 +159,56 @@ AMD_GENOA_HOST_ONLY_FEATS_6_1 = AMD_MILAN_HOST_ONLY_FEATS_6_1 - {"brs"} | {
     "perfmon_v2",
     "x2avic",
 }
+
+AMD_GENOA_HOST_ONLY_FEATS_6_18 = AMD_GENOA_HOST_ONLY_FEATS_6_1 - {
+    # Since v6.11, flags declared in cpufeatures.h without a quoted /proc/cpuinfo name
+    # are hidden. VMSCAPE added IBPB_EXIT_TO_USER without one, so v6.18+ amzn2023 hides it.
+    # https://github.com/torvalds/linux/commit/78ce84b9e0a54a0c91a7449f321c1f852c0cd3fc
+    "ibpb_exit_to_user",
+    # Propagated to the guest since:
+    # https://github.com/torvalds/linux/commit/8c19b6f257fa (KVM AUTOIBRS, v6.3)
+    # https://github.com/torvalds/linux/commit/e7862eda309e (guest synthesises ibrs_enhanced
+    # from AUTOIBRS, v6.3; backported to 5.10 and 6.1 LTSs, so our guest kernels pick it up)
+    "ibrs_enhanced",
+    # Propagated to the guest since:
+    # https://github.com/torvalds/linux/commit/45cf86f26148 (KVM advertises FLUSH_L1D, v6.2)
+    # https://github.com/torvalds/linux/commit/da3db168fb67 (KVM virtualises MSR_IA32_FLUSH_CMD on SVM, v6.4)
+    "flush_l1d",
+} | {"debug_swap", "cpuid_fault", "xtopology", "la57", "vnmi"}
+
+INTEL_SPR_GNR_HOST_ONLY_FEATS_6_18_REMOVED = {
+    # Since v6.11, flags declared in cpufeatures.h without a quoted /proc/cpuinfo name
+    # are hidden. VMSCAPE added IBPB_EXIT_TO_USER without one, so v6.18+ amzn2023 hides it.
+    # https://github.com/torvalds/linux/commit/78ce84b9e0a54a0c91a7449f321c1f852c0cd3fc
+    "ibpb_exit_to_user",
+    "pebs",
+    # Propagated to the guest since:
+    # https://github.com/torvalds/linux/commit/45cf86f26148 (KVM advertises FLUSH_L1D, v6.2)
+    "flush_l1d",
+    "dts",
+    "dtes64",
+    "bts",
+}
+INTEL_SPR_GNR_HOST_ONLY_FEATS_6_18_ADDED = {"la57"}
+
+# Intel Ice Lake is not vulnerable to VMScape (BHB clearing software mitigation), so
+# "ibpb_exit_to_user" is not needed.
+# https://docs.kernel.org/admin-guide/hw-vuln/vmscape.html#affected-processors
+INTEL_ICELAKE_HOST_ONLY_FEATS_5_10 = INTEL_HOST_ONLY_FEATS - {
+    "ibpb_exit_to_user",
+    "cdp_l3",
+} | {"pconfig", "tme", "split_lock_detect"}
+
+INTEL_ICELAKE_HOST_ONLY_FEATS_6_1 = INTEL_ICELAKE_HOST_ONLY_FEATS_5_10 - {
+    "bts",
+    "dtes64",
+    "dts",
+    "pebs",
+}
+
+INTEL_ICELAKE_HOST_ONLY_FEATS_6_18 = INTEL_ICELAKE_HOST_ONLY_FEATS_6_1 - {
+    "flush_l1d",
+} | {"la57"}
 
 
 def test_host_vs_guest_cpu_features(uvm_plain_any):
@@ -169,16 +226,20 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
         case CpuModel.AMD_MILAN:
             if global_props.host_linux_version_tpl < (6, 1):
                 assert host_feats - guest_feats == AMD_MILAN_HOST_ONLY_FEATS
-            else:
+            elif global_props.host_linux_version_tpl < (6, 18):
                 assert host_feats - guest_feats == AMD_MILAN_HOST_ONLY_FEATS_6_1
+            else:
+                assert host_feats - guest_feats == AMD_MILAN_HOST_ONLY_FEATS_6_18
 
             assert guest_feats - host_feats == AMD_GUEST_ONLY_FEATS
 
         case CpuModel.AMD_GENOA:
             if global_props.host_linux_version_tpl < (6, 1):
                 assert host_feats - guest_feats == AMD_GENOA_HOST_ONLY_FEATS
-            else:
+            elif global_props.host_linux_version_tpl < (6, 18):
                 assert host_feats - guest_feats == AMD_GENOA_HOST_ONLY_FEATS_6_1
+            else:
+                assert host_feats - guest_feats == AMD_GENOA_HOST_ONLY_FEATS_6_18
 
             assert guest_feats - host_feats == AMD_GUEST_ONLY_FEATS
 
@@ -189,7 +250,11 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
             # Ubuntu hasn't backported the patch for VMScape yet.
             # This is only requried for Intel Cascade Lake since we only run
             # tests on Intel Cascade Lake for Ubuntu.
-            if "amzn" not in global_props.host_os:
+            # Since v6.11, flags declared in cpufeatures.h without a quoted /proc/cpuinfo name
+            # are hidden. VMSCAPE added IBPB_EXIT_TO_USER without one, so v6.18+ amzn2023 hides it.
+            # https://github.com/torvalds/linux/commit/78ce84b9e0a54a0c91a7449f321c1f852c0cd3fc
+            host_version = global_props.host_linux_version_tpl
+            if "amzn" not in global_props.host_os or host_version >= (6, 18):
                 expected_host_minus_guest -= {"ibpb_exit_to_user"}
 
             # Linux kernel v6.4+ passes through the CPUID bit for "flush_l1d" to guests.
@@ -214,29 +279,13 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
             assert guest_feats - host_feats == expected_guest_minus_host
 
         case CpuModel.INTEL_ICELAKE:
-            expected_host_minus_guest = INTEL_HOST_ONLY_FEATS
-
-            # As long as BHB clearing software mitigation is enabled, Intel Ice Lake is not
-            # vulnerable to VMScape and "IBPB before exit to userspace" is not needed.
-            # https://docs.kernel.org/admin-guide/hw-vuln/vmscape.html#affected-processors
-            expected_host_minus_guest -= {"ibpb_exit_to_user"}
-
-            host_guest_diff_5_10 = expected_host_minus_guest - {"cdp_l3"} | {
-                "pconfig",
-                "tme",
-                "split_lock_detect",
-            }
-            host_guest_diff_6_1 = host_guest_diff_5_10 - {
-                "bts",
-                "dtes64",
-                "dts",
-                "pebs",
-            }
-
-            if global_props.host_linux_version_tpl < (6, 1):
-                assert host_feats - guest_feats == host_guest_diff_5_10
+            host_version = global_props.host_linux_version_tpl
+            if host_version < (6, 1):
+                assert host_feats - guest_feats == INTEL_ICELAKE_HOST_ONLY_FEATS_5_10
+            elif host_version < (6, 18):
+                assert host_feats - guest_feats == INTEL_ICELAKE_HOST_ONLY_FEATS_6_1
             else:
-                assert host_feats - guest_feats == host_guest_diff_6_1
+                assert host_feats - guest_feats == INTEL_ICELAKE_HOST_ONLY_FEATS_6_18
             assert guest_feats - host_feats == INTEL_GUEST_ONLY_FEATS - {"umip"}
         case CpuModel.INTEL_SAPPHIRE_RAPIDS | CpuModel.INTEL_GRANITE_RAPIDS:
             expected_host_minus_guest = INTEL_HOST_ONLY_FEATS.copy()
@@ -358,6 +407,10 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
                 # set on host.
                 "tsc_known_freq",
             }
+
+            if host_version >= (6, 18):
+                expected_host_minus_guest -= INTEL_SPR_GNR_HOST_ONLY_FEATS_6_18_REMOVED
+                expected_host_minus_guest |= INTEL_SPR_GNR_HOST_ONLY_FEATS_6_18_ADDED
 
             assert host_feats - guest_feats == expected_host_minus_guest
             assert guest_feats - host_feats == expected_guest_minus_host

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -224,24 +224,46 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
 
     match CPU_MODEL:
         case CpuModel.AMD_MILAN:
-            if global_props.host_linux_version_tpl < (6, 1):
+            host_version = global_props.host_linux_version_tpl
+            if host_version < (6, 1):
                 assert host_feats - guest_feats == AMD_MILAN_HOST_ONLY_FEATS
-            elif global_props.host_linux_version_tpl < (6, 18):
+            elif host_version < (6, 18):
                 assert host_feats - guest_feats == AMD_MILAN_HOST_ONLY_FEATS_6_1
             else:
                 assert host_feats - guest_feats == AMD_MILAN_HOST_ONLY_FEATS_6_18
 
-            assert guest_feats - host_feats == AMD_GUEST_ONLY_FEATS
+            expected_guest_minus_host = AMD_GUEST_ONLY_FEATS
+            # Linux kernel v6.6+ drops the "invpcid_single" synthetic bit, but our guest
+            # kernels (< 6.6) still synthesize it, so a v6.18 host (>= 6.6) sees it as guest-only.
+            # https://github.com/torvalds/linux/commit/54e3d9434ef61b97fd3263c141b928dc5635e50d
+            if host_version >= (6, 6) and vm.guest_kernel_version < (6, 6):
+                expected_guest_minus_host = AMD_GUEST_ONLY_FEATS | {"invpcid_single"}
+            assert guest_feats - host_feats == expected_guest_minus_host
 
         case CpuModel.AMD_GENOA:
-            if global_props.host_linux_version_tpl < (6, 1):
+            host_version = global_props.host_linux_version_tpl
+            if host_version < (6, 1):
                 assert host_feats - guest_feats == AMD_GENOA_HOST_ONLY_FEATS
-            elif global_props.host_linux_version_tpl < (6, 18):
+            elif host_version < (6, 18):
                 assert host_feats - guest_feats == AMD_GENOA_HOST_ONLY_FEATS_6_1
             else:
-                assert host_feats - guest_feats == AMD_GENOA_HOST_ONLY_FEATS_6_18
+                # KVM advertises AMD PerfMonV2 to guests since v6.5, so a v6.18 host
+                # (KVM >= 6.5) passes it through. The guest only reports "perfmon_v2" if its
+                # kernel knows the flag (added in v5.19), so it stays host-only for older
+                # guests (e.g. 5.10).
+                # https://github.com/torvalds/linux/commit/4a2771895ca6 (KVM AMD PerfMonV2, v6.5)
+                expected_host_minus_guest = AMD_GENOA_HOST_ONLY_FEATS_6_18.copy()
+                if vm.guest_kernel_version >= (5, 19):
+                    expected_host_minus_guest -= {"perfmon_v2"}
+                assert host_feats - guest_feats == expected_host_minus_guest
 
-            assert guest_feats - host_feats == AMD_GUEST_ONLY_FEATS
+            expected_guest_minus_host = AMD_GUEST_ONLY_FEATS
+            # Linux kernel v6.6+ drops the "invpcid_single" synthetic bit, but our guest
+            # kernels (< 6.6) still synthesize it, so a v6.18 host (>= 6.6) sees it as guest-only.
+            # https://github.com/torvalds/linux/commit/54e3d9434ef61b97fd3263c141b928dc5635e50d
+            if host_version >= (6, 6) and vm.guest_kernel_version < (6, 6):
+                expected_guest_minus_host = AMD_GUEST_ONLY_FEATS | {"invpcid_single"}
+            assert guest_feats - host_feats == expected_guest_minus_host
 
         case CpuModel.INTEL_CASCADELAKE:
             expected_host_minus_guest = INTEL_HOST_ONLY_FEATS
@@ -286,7 +308,14 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
                 assert host_feats - guest_feats == INTEL_ICELAKE_HOST_ONLY_FEATS_6_1
             else:
                 assert host_feats - guest_feats == INTEL_ICELAKE_HOST_ONLY_FEATS_6_18
-            assert guest_feats - host_feats == INTEL_GUEST_ONLY_FEATS - {"umip"}
+
+            expected_guest_minus_host = INTEL_GUEST_ONLY_FEATS - {"umip"}
+            # Linux kernel v6.6+ drops the "invpcid_single" synthetic bit, but our guest
+            # kernels (< 6.6) still synthesize it, so a v6.18 host (>= 6.6) sees it as guest-only.
+            # https://github.com/torvalds/linux/commit/54e3d9434ef61b97fd3263c141b928dc5635e50d
+            if host_version >= (6, 6) and vm.guest_kernel_version < (6, 6):
+                expected_guest_minus_host |= {"invpcid_single"}
+            assert guest_feats - host_feats == expected_guest_minus_host
         case CpuModel.INTEL_SAPPHIRE_RAPIDS | CpuModel.INTEL_GRANITE_RAPIDS:
             expected_host_minus_guest = INTEL_HOST_ONLY_FEATS.copy()
             expected_guest_minus_host = INTEL_GUEST_ONLY_FEATS.copy()
@@ -408,9 +437,25 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
                 "tsc_known_freq",
             }
 
+            # Linux kernel v6.6+ drops the "invpcid_single" synthetic bit, but our guest
+            # kernels (< 6.6) still synthesize it, so a v6.18 host (>= 6.6) sees it as guest-only.
+            # https://github.com/torvalds/linux/commit/54e3d9434ef61b97fd3263c141b928dc5635e50d
+            if host_version >= (6, 6) and guest_version < (6, 6):
+                expected_guest_minus_host |= {"invpcid_single"}
+
             if host_version >= (6, 18):
                 expected_host_minus_guest -= INTEL_SPR_GNR_HOST_ONLY_FEATS_6_18_REMOVED
                 expected_host_minus_guest |= INTEL_SPR_GNR_HOST_ONLY_FEATS_6_18_ADDED
+
+                # KVM now advertises IBT to the guest, so it's no longer host-only for
+                # guests new enough to know the flag (added in v5.18).
+                if guest_version >= (5, 18):
+                    expected_host_minus_guest -= {"ibt"}
+
+                if CPU_MODEL == CpuModel.INTEL_GRANITE_RAPIDS:
+                    # Granite Rapids host kernel 6.18 enables split lock detection (a
+                    # host-only synthesized bit; the guest can't read MSR 0x33).
+                    expected_host_minus_guest |= {"split_lock_detect"}
 
             assert host_feats - guest_feats == expected_host_minus_guest
             assert guest_feats - host_feats == expected_guest_minus_host

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -365,25 +365,6 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
             expected_guest_minus_host = set()
             expected_host_minus_guest = set()
 
-            # Upstream kernel v6.11+ hides "ssbs" from "lscpu" on Neoverse-N1 and Neoverse-V1 since
-            # they have an errata whereby an MSR to the SSBS special-purpose register does not
-            # affect subsequent speculative instructions, permitting speculative store bypassing for
-            # a window of time.
-            # https://github.com/torvalds/linux/commit/adeec61a4723fd3e39da68db4cc4d924e6d7f641
-            #
-            # While Amazon Linux kernels (v5.10 and v6.1) backported the above commit, our test
-            # ubuntu kernel (v6.8) and our guest kernels (v5.10 and v6.1) don't pick it.
-            host_has_ssbs = global_props.host_os not in {
-                "amzn2",
-                "amzn2023",
-            } and global_props.host_linux_version_tpl < (6, 11)
-            guest_has_ssbs = vm.guest_kernel_version < (6, 11)
-
-            if host_has_ssbs and not guest_has_ssbs:
-                expected_host_minus_guest |= {"ssbs"}
-            if not host_has_ssbs and guest_has_ssbs:
-                expected_guest_minus_host |= {"ssbs"}
-
             assert host_feats - guest_feats == expected_host_minus_guest
             assert guest_feats - host_feats == expected_guest_minus_host
 
@@ -401,25 +382,6 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
                     "sve2",
                     "svepmull",
                 }
-
-            # Upstream kernel v6.11+ hides "ssbs" from "lscpu" on Neoverse-N1 and Neoverse-V1 since
-            # they have an errata whereby an MSR to the SSBS special-purpose register does not
-            # affect subsequent speculative instructions, permitting speculative store bypassing for
-            # a window of time.
-            # https://github.com/torvalds/linux/commit/adeec61a4723fd3e39da68db4cc4d924e6d7f641
-            #
-            # While Amazon Linux kernels (v5.10 and v6.1) backported the above commit, our test
-            # ubuntu kernel (v6.8) and our guest kernels (v5.10 and v6.1) don't pick it.
-            host_has_ssbs = global_props.host_os not in {
-                "amzn2",
-                "amzn2023",
-            } and global_props.host_linux_version_tpl < (6, 11)
-            guest_has_ssbs = vm.guest_kernel_version < (6, 11)
-
-            if host_has_ssbs and not guest_has_ssbs:
-                expected_host_minus_guest |= {"ssbs"}
-            if not host_has_ssbs and guest_has_ssbs:
-                expected_guest_minus_host |= {"ssbs"}
 
             assert host_feats - guest_feats == expected_host_minus_guest
             assert guest_feats - host_feats == expected_guest_minus_host

--- a/tests/integration_tests/functional/test_cpu_template_helper.py
+++ b/tests/integration_tests/functional/test_cpu_template_helper.py
@@ -205,6 +205,10 @@ MSR_EXCEPTION_LIST = [
     # features are temporarily disabled. Guest OS disables TILEDATA by default
     # using the MSR.
     0x1C4,
+    # MSR_IA32_DEBUGCTL is a R/W MSR the guest OS modifies at runtime. On hosts
+    # that virtualize bus lock detection (6.18+), the guest enables it and sets
+    # DEBUGCTLMSR_BUS_LOCK_DETECT (bit 2), so it differs from the dumped config.
+    0x1D9,
     # IA32_PAT_MSR is R/W MSR for guest OS to control memory page attributes.
     0x277,
     # MSR_IA32_TSC_DEADLINE specifies the time at which a timer interrupt

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -241,3 +241,31 @@ def test_spectre_meltdown_checker_on_guest(
         assert res_b == spectre_meltdown_checker.expected_vulnerabilities(
             uvm_any_without_pci.cpu_template_name
         )
+
+
+
+# All Graviton generations (Neoverse N1/V1/V2/V3) are affected by erratum
+# 3194386: SSBS writes are not self-synchronizing, so the kernel workaround
+# adds a speculation barrier and hides the "ssbs" hwcap from userspace, which
+# must request the mitigation via prctl(PR_SET_SPECULATION_CTRL) instead of
+# toggling PSTATE.SSBS directly (this is why "ssbs" is absent from the
+# expectations in test_cpu_features_aarch64.py).
+# https://github.com/torvalds/linux/commit/adeec61a4723fd3e39da68db4cc4d924e6d7f641
+#
+# KVM passes the host MIDR through, so the guest kernel must detect the
+# erratum itself, while still seeing SSBS hardware support via the ID
+# registers KVM exposes.
+@pytest.mark.skipif(
+    global_props.cpu_architecture != "aarch64", reason="Only run in aarch64"
+)
+def test_spec_store_bypass_mitigated(uvm_plain):
+    """Check the guest kernel applies the SSBS erratum 3194386 workaround."""
+    uvm_plain.spawn()
+    uvm_plain.basic_config()
+    uvm_plain.add_net_iface()
+    uvm_plain.start()
+    dmesg = uvm_plain.ssh.check_output("dmesg").stdout
+    # KVM exposed SSBS hardware support to the guest
+    assert "Speculative Store Bypassing Safe (SSBS)" in dmesg
+    # the guest detected erratum 3194386 via the passed-through MIDR
+    assert "SSBS not fully self-synchronizing" in dmesg

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -243,7 +243,6 @@ def test_spectre_meltdown_checker_on_guest(
         )
 
 
-
 # All Graviton generations (Neoverse N1/V1/V2/V3) are affected by erratum
 # 3194386: SSBS writes are not self-synchronizing, so the kernel workaround
 # adds a speculation barrier and hides the "ssbs" hwcap from userspace, which


### PR DESCRIPTION
## Changes

Backport #6138 into v1.15

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
