### PR TITLE
[1.16] fix(aarch64): re-enable CONFIG_ARM64_ERRATUM_3194386 in guest kernels

### DIFF
--- a/resources/guest_configs/ci.config
+++ b/resources/guest_configs/ci.config
@@ -5,7 +5,6 @@ CONFIG_SQUASHFS_ZSTD=y
 # aarch64 only TBD split into a separate file
 CONFIG_DEVMEM=y
 CONFIG_STRICT_DEVMEM=y
-# CONFIG_ARM64_ERRATUM_3194386 is not set
 # Needed for CTRL+ALT+DEL support
 CONFIG_SERIO=y
 CONFIG_SERIO_I8042=y

--- a/tests/integration_tests/functional/test_cpu_features_aarch64.py
+++ b/tests/integration_tests/functional/test_cpu_features_aarch64.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.skipif(
 G2_FEATS = set(
     (
         "fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp "
-        "asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs"
+        "asimdhp cpuid asimdrdm lrcpc dcpop asimddp"
     ).split()
 )
 

--- a/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
+++ b/tests/integration_tests/functional/test_cpu_features_host_vs_guest.py
@@ -463,25 +463,6 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
             expected_guest_minus_host = set()
             expected_host_minus_guest = set()
 
-            # Upstream kernel v6.11+ hides "ssbs" from "lscpu" on Neoverse-N1 and Neoverse-V1 since
-            # they have an errata whereby an MSR to the SSBS special-purpose register does not
-            # affect subsequent speculative instructions, permitting speculative store bypassing for
-            # a window of time.
-            # https://github.com/torvalds/linux/commit/adeec61a4723fd3e39da68db4cc4d924e6d7f641
-            #
-            # While Amazon Linux kernels (v5.10 and v6.1) backported the above commit, our test
-            # ubuntu kernel (v6.8) and our guest kernels (v5.10 and v6.1) don't pick it.
-            host_has_ssbs = global_props.host_os not in {
-                "amzn2",
-                "amzn2023",
-            } and global_props.host_linux_version_tpl < (6, 11)
-            guest_has_ssbs = vm.guest_kernel_version < (6, 11)
-
-            if host_has_ssbs and not guest_has_ssbs:
-                expected_host_minus_guest |= {"ssbs"}
-            if not host_has_ssbs and guest_has_ssbs:
-                expected_guest_minus_host |= {"ssbs"}
-
             assert host_feats - guest_feats == expected_host_minus_guest
             assert guest_feats - host_feats == expected_guest_minus_host
 
@@ -499,25 +480,6 @@ def test_host_vs_guest_cpu_features(uvm_plain_any):
                     "sve2",
                     "svepmull",
                 }
-
-            # Upstream kernel v6.11+ hides "ssbs" from "lscpu" on Neoverse-N1 and Neoverse-V1 since
-            # they have an errata whereby an MSR to the SSBS special-purpose register does not
-            # affect subsequent speculative instructions, permitting speculative store bypassing for
-            # a window of time.
-            # https://github.com/torvalds/linux/commit/adeec61a4723fd3e39da68db4cc4d924e6d7f641
-            #
-            # While Amazon Linux kernels (v5.10 and v6.1) backported the above commit, our test
-            # ubuntu kernel (v6.8) and our guest kernels (v5.10 and v6.1) don't pick it.
-            host_has_ssbs = global_props.host_os not in {
-                "amzn2",
-                "amzn2023",
-            } and global_props.host_linux_version_tpl < (6, 11)
-            guest_has_ssbs = vm.guest_kernel_version < (6, 11)
-
-            if host_has_ssbs and not guest_has_ssbs:
-                expected_host_minus_guest |= {"ssbs"}
-            if not host_has_ssbs and guest_has_ssbs:
-                expected_guest_minus_host |= {"ssbs"}
 
             assert host_feats - guest_feats == expected_host_minus_guest
             assert guest_feats - host_feats == expected_guest_minus_host

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -241,3 +241,31 @@ def test_spectre_meltdown_checker_on_guest(
         assert res_b == spectre_meltdown_checker.expected_vulnerabilities(
             uvm_any_without_pci.cpu_template_name
         )
+
+
+
+# All Graviton generations (Neoverse N1/V1/V2/V3) are affected by erratum
+# 3194386: SSBS writes are not self-synchronizing, so the kernel workaround
+# adds a speculation barrier and hides the "ssbs" hwcap from userspace, which
+# must request the mitigation via prctl(PR_SET_SPECULATION_CTRL) instead of
+# toggling PSTATE.SSBS directly (this is why "ssbs" is absent from the
+# expectations in test_cpu_features_aarch64.py).
+# https://github.com/torvalds/linux/commit/adeec61a4723fd3e39da68db4cc4d924e6d7f641
+#
+# KVM passes the host MIDR through, so the guest kernel must detect the
+# erratum itself, while still seeing SSBS hardware support via the ID
+# registers KVM exposes.
+@pytest.mark.skipif(
+    global_props.cpu_architecture != "aarch64", reason="Only run in aarch64"
+)
+def test_spec_store_bypass_mitigated(uvm_plain):
+    """Check the guest kernel applies the SSBS erratum 3194386 workaround."""
+    uvm_plain.spawn()
+    uvm_plain.basic_config()
+    uvm_plain.add_net_iface()
+    uvm_plain.start()
+    dmesg = uvm_plain.ssh.check_output("dmesg").stdout
+    # KVM exposed SSBS hardware support to the guest
+    assert "Speculative Store Bypassing Safe (SSBS)" in dmesg
+    # the guest detected erratum 3194386 via the passed-through MIDR
+    assert "SSBS not fully self-synchronizing" in dmesg

--- a/tests/integration_tests/security/test_vulnerabilities.py
+++ b/tests/integration_tests/security/test_vulnerabilities.py
@@ -243,7 +243,6 @@ def test_spectre_meltdown_checker_on_guest(
         )
 
 
-
 # All Graviton generations (Neoverse N1/V1/V2/V3) are affected by erratum
 # 3194386: SSBS writes are not self-synchronizing, so the kernel workaround
 # adds a speculation barrier and hides the "ssbs" hwcap from userspace, which


### PR DESCRIPTION
## Changes

Backport #6138 into v1.16

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
