### PR TITLE
Speed up the pre-submission checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,8 +18,8 @@ Certificate of Origin and signing off your commits, please check
 - [ ] I have read and understand [CONTRIBUTING.md][3].
 - [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
   build checks on all supported architectures.
-- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
-  automated style checks.
+- [ ] I have run `tools/devtool checkstyle --no-clippy` to verify that the PR
+  passes the automated style checks.
 - [ ] I have described what is done in these changes, why they are needed, and
   how they are solving the problem in a clear and encompassing way.
 - [ ] I have updated any relevant documentation (both in code and in the docs)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ following in the Firecracker root directory:
 
 ```
 cat >> .git/hooks/pre-commit << EOF
-./tools/devtool checkstyle || exit 1
+./tools/devtool checkstyle --no-clippy || exit 1
 ./tools/devtool checkbuild --all || exit 1
 EOF
 ```
@@ -72,7 +72,8 @@ when running `git commit`, as well as running any other checks our CI validates
 as part of its 'Style' step. Most reported violations can be automatically fixed
 using `./tools/devtool fmt`. The second command will then check that the code
 correctly compiles on all supported architectures, and that it passes Rust
-clippy rules defined for the project.
+clippy rules defined for the project. `--no-clippy` skips the clippy runs that
+the second command covers too; drop it if you run `checkstyle` on its own.
 
 Your contribution needs to meet the following standards:
 

--- a/tests/integration_tests/style/test_python.py
+++ b/tests/integration_tests/style/test_python.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests ensuring codebase style compliance for Python."""
 
+import os
 import sys
 from subprocess import run
 
@@ -27,8 +28,13 @@ def test_python_pylint():
     """
     Test that python code passes linter checks.
     """
+    # `jobs = 0` in pyproject.toml is meant to auto-detect the CPU count, but
+    # pylint reads it from cgroup v1 `cpu.shares`, which Docker leaves at 1024,
+    # so it settles on one job in the dev container however many CPUs we have.
+    jobs = min(len(os.sched_getaffinity(0)), 32)
+
     # List of linter commands that should be executed for each file
-    linter_cmd = "pylint --rcfile tests/pyproject.toml --output-format=colorized tests/ tools/ .buildkite/*.py"
+    linter_cmd = f"pylint --rcfile tests/pyproject.toml -j {jobs} --output-format=colorized tests/ tools/ .buildkite/*.py"
     run(
         linter_cmd,
         # we let pytest capture stdout/stderr for us

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -58,3 +58,11 @@ disable = [
     "too-many-branches",
     "too-many-statements",
 ]
+
+[tool.pylint.typecheck]
+
+# astroid builds a full AST for every imported module, and these are large
+# enough to dominate the run: tools/ab_plot.py alone took 15.4s. pylint
+# parallelises per file, so that one file set the floor for everything else.
+# They resolve too dynamically for the checks to fire anyway.
+ignored-modules = ["matplotlib", "numpy", "pandas", "scipy", "seaborn"]

--- a/tools/devtool
+++ b/tools/devtool
@@ -508,8 +508,9 @@ cmd_help() {
     mkdocs
         Use 'cargo doc' to generate rustdoc documentation
 
-    checkstyle
-        Run style checks
+    checkstyle [--no-clippy]
+        Run style checks. --no-clippy skips the clippy runs that
+        'checkbuild' already covers.
 
     checkbuild [--all|-m x86_64|aarch64]
         Run cargo check on the target architecture (supports cross compilation).
@@ -1245,6 +1246,18 @@ cmd_mkdocs() {
 }
 
 cmd_checkstyle() {
+    local clippy_tests=(integration_tests/build/test_clippy.py)
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            "-h"|"--help")  { cmd_help; exit 1; } ;;
+            "--no-clippy")  { clippy_tests=(); } ;;
+            *)
+                die "Unknown argument: $1. Please use --help for help."
+            ;;
+        esac
+        shift
+    done
+
     if [[ -z "$BUILDKITE" ]]; then
       cmd_sh "git-secrets --register-aws && git-secrets --scan"
     fi
@@ -1253,7 +1266,7 @@ cmd_checkstyle() {
     cmd_test --no-build --no-kvm-check --no-build-dir-check --no-artifacts-check -- \
         -n 4 --dist worksteal \
         integration_tests/style \
-        integration_tests/build/test_clippy.py \
+        "${clippy_tests[@]}" \
         --doctest-modules framework \
         || exit 1
 }


### PR DESCRIPTION
## Changes

Three independent speedups to the pre-submission checks:

- Pass pylint an explicit `-j`. Its `jobs = 0` auto-detect reads cgroup v1
  `cpu.shares`, which Docker leaves at its 1024 default, so it lints on one
  core inside the dev container however many the host has.
- Add the scientific stack to pylint's `ignored-modules`. pylint parallelises
  per file, so the slowest file bounds the whole run, and `tools/ab_plot.py`
  took 15.4s of a 15.8s run because astroid builds a full AST for matplotlib,
  numpy, pandas, scipy and seaborn.
- Add `checkstyle --no-clippy`. `checkstyle` and `checkbuild` run the same
  clippy command and differ only in which triples they cover, so running both
  checks the native architecture twice.

## Reason

`checkstyle` and `checkbuild --all` are what contributors run before pushing, so
their cost is paid on every commit. Measured on a 96-core host with a warm cargo
cache:

|                       | before, sequential | before, concurrent | after, sequential | after, concurrent |
| --------------------- | ------------------ | ------------------ | ----------------- | ----------------- |
| no source change      | 41.7s              | 43.5s              | 18.9s             | 17.5s             |
| one Rust file changed | 49.0s              | 39.9s              | 35.2s             | 19.1s             |

CI's `style` step runs `checkstyle` on its own, which goes from 39.0s to 16.4s
with no source change. pylint was 31.7s of that 39.0s.

`--no-clippy` does not remove clippy work, it moves the native run to
`checkbuild`, which then no longer inherits a warm cache from `checkstyle`
(9.6s to 18.4s). The gain is in not doing that run twice.

It also stops the two commands clippying the same triple, which is what makes
running them concurrently worthwhile. Before, concurrency still helped when
something had changed, because `checkstyle` was long enough to hide
`checkbuild` underneath it, but it cost time when nothing had, since the two
contend for the native triple and cargo holds a lock on the build directory for
the whole build. After, the two share no work and the concurrent column is the
fastest in both rows.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle --no-clippy` to verify that the PR
  passes the automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`. (None: this
  only touches developer tooling.)
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests. (No new tests: the changed code is the test tooling
  itself, and each commit was verified by running `checkstyle` on it alone.)
- [x] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
