### PR TITLE
aarch64: expose SMT topology in cpu-map and allow smt: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 
 ### Added
 
+- [#6154](https://github.com/firecracker-microvm/firecracker/pull/6154): Added
+  support for configuring SMT topology on aarch64 microVMs.
 - [#5891](https://github.com/firecracker-microvm/firecracker/pull/5891): Added
   support for virtio device reset.
 - [#5983](https://github.com/firecracker-microvm/firecracker/pull/5983): Add two

--- a/src/firecracker/src/api_server/request/machine_configuration.rs
+++ b/src/firecracker/src/api_server/request/machine_configuration.rs
@@ -261,11 +261,19 @@ mod tests {
         }"#;
         parse_patch_machine_config(&Body::new(body)).unwrap();
 
-        // On aarch64, we allow `smt` to be configured to `false` but not `true`.
+        // Test that `smt` can be configured to `false`.
         let body = r#"{
             "vcpu_count": 8,
             "mem_size_mib": 1024,
             "smt": false
+        }"#;
+        parse_patch_machine_config(&Body::new(body)).unwrap();
+
+        // Test that `smt` can be configured to `true`.
+        let body = r#"{
+            "vcpu_count": 8,
+            "mem_size_mib": 1024,
+            "smt": true
         }"#;
         parse_patch_machine_config(&Body::new(body)).unwrap();
 

--- a/src/firecracker/swagger/firecracker.yaml
+++ b/src/firecracker/swagger/firecracker.yaml
@@ -1459,7 +1459,7 @@ definitions:
       #   description: Path to the GDB socket. Requires the gdb feature to be enabled.
       smt:
         type: boolean
-        description: Flag for enabling/disabling simultaneous multithreading. Can be enabled only on x86.
+        description: Flag for enabling/disabling simultaneous multithreading.
         default: false
       mem_size_mib:
         type: integer

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -74,6 +74,7 @@ pub enum FdtError {
 pub fn create_fdt(
     guest_mem: &GuestMemoryMmap,
     vcpu_mpidr: Vec<u64>,
+    smt: bool,
     cmdline: CString,
     device_manager: &DeviceManager,
     gic_device: &GICDevice,
@@ -96,7 +97,7 @@ pub fn create_fdt(
     // This is not mandatory but we use it to point the root node to the node
     // containing description of the interrupt controller for this VM.
     fdt_writer.property_u32("interrupt-parent", GIC_PHANDLE)?;
-    create_cpu_nodes(&mut fdt_writer, &vcpu_mpidr)?;
+    create_cpu_nodes(&mut fdt_writer, &vcpu_mpidr, smt)?;
     create_memory_node(&mut fdt_writer, guest_mem)?;
     create_chosen_node(&mut fdt_writer, cmdline, initrd)?;
     create_gic_node(&mut fdt_writer, gic_device)?;
@@ -119,7 +120,7 @@ pub fn create_fdt(
 }
 
 // Following are the auxiliary function for creating the different nodes that we append to our FDT.
-fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &[u64]) -> Result<(), FdtError> {
+fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &[u64], smt: bool) -> Result<(), FdtError> {
     // Since the L1 caches are not shareable among CPUs and they are direct attributes of the
     // cpu in the device tree, we process the L1 and non-L1 caches separately.
     // We use sysfs for extracting the cache information.
@@ -233,12 +234,24 @@ fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &[u64]) -> Result<(), FdtEr
     // (matching host SoC topology) can be a follow-up once a config knob exists.
     //
     // Binding: Linux Documentation/devicetree/bindings/cpu/cpu-topology.txt
+    let threads_per_core = if smt && num_cpus > 1 { 2 } else { 1 };
+    let num_cores = num_cpus / threads_per_core;
+
     let cpu_map = fdt.begin_node("cpu-map")?;
     let cluster0 = fdt.begin_node("cluster0")?;
-    for cpu_index in 0..num_cpus {
-        let core = fdt.begin_node(&format!("core{cpu_index}"))?;
-        let cpu_phandle = CPU_PHANDLE_BASE + u32::try_from(cpu_index).unwrap();
-        fdt.property_u32("cpu", cpu_phandle)?;
+    for core_index in 0..num_cores {
+        let core = fdt.begin_node(&format!("core{core_index}"))?;
+        if threads_per_core > 1 {
+            for thread_index in 0..threads_per_core {
+                let cpu_index = core_index * threads_per_core + thread_index;
+                let thread = fdt.begin_node(&format!("thread{thread_index}"))?;
+                fdt.property_u32("cpu", CPU_PHANDLE_BASE + u32::try_from(cpu_index).unwrap())?;
+                fdt.end_node(thread)?;
+            }
+        } else {
+            let cpu_phandle = CPU_PHANDLE_BASE + u32::try_from(core_index).unwrap();
+            fdt.property_u32("cpu", cpu_phandle)?;
+        }
         fdt.end_node(core)?;
     }
     fdt.end_node(cluster0)?;
@@ -596,6 +609,61 @@ mod tests {
     use crate::{EventManager, Kvm};
 
     #[test]
+    fn test_create_cpu_nodes_without_smt() {
+        // MPIDR values as KVM defaults them: Aff0 holds the vcpu index.
+        let mpidrs = [0x8000_0000, 0x8000_0001];
+        let mut fdt = FdtWriter::new().unwrap();
+        let root = fdt.begin_node("").unwrap();
+        create_cpu_nodes(&mut fdt, &mpidrs, false).unwrap();
+        fdt.end_node(root).unwrap();
+
+        let generated_fdt = device_tree::DeviceTree::load(&fdt.finish().unwrap()).unwrap();
+
+        for cpu_index in 0..mpidrs.len() {
+            let phandle = CPU_PHANDLE_BASE + u32::try_from(cpu_index).unwrap();
+            let cpu = generated_fdt
+                .find(&format!("/cpus/cpu@{cpu_index:x}"))
+                .unwrap();
+            assert_eq!(cpu.prop_u32("phandle").unwrap(), phandle);
+
+            // Each core references its cpu directly, with no thread nodes in between.
+            let core = generated_fdt
+                .find(&format!("/cpus/cpu-map/cluster0/core{cpu_index}"))
+                .unwrap();
+            assert_eq!(core.prop_u32("cpu").unwrap(), phandle);
+        }
+    }
+
+    #[test]
+    fn test_create_cpu_nodes_with_smt() {
+        let mpidrs = [0x8000_0000, 0x8000_0001, 0x8000_0002, 0x8000_0003];
+        let mut fdt = FdtWriter::new().unwrap();
+        let root = fdt.begin_node("").unwrap();
+        create_cpu_nodes(&mut fdt, &mpidrs, true).unwrap();
+        fdt.end_node(root).unwrap();
+
+        let generated_fdt = device_tree::DeviceTree::load(&fdt.finish().unwrap()).unwrap();
+
+        // Consecutive vCPUs are the two thread siblings of a core.
+        for cpu_index in 0..mpidrs.len() {
+            let phandle = CPU_PHANDLE_BASE + u32::try_from(cpu_index).unwrap();
+            let cpu = generated_fdt
+                .find(&format!("/cpus/cpu@{cpu_index:x}"))
+                .unwrap();
+            assert_eq!(cpu.prop_u32("phandle").unwrap(), phandle);
+
+            let thread = generated_fdt
+                .find(&format!(
+                    "/cpus/cpu-map/cluster0/core{}/thread{}",
+                    cpu_index / 2,
+                    cpu_index % 2
+                ))
+                .unwrap();
+            assert_eq!(thread.prop_u32("cpu").unwrap(), phandle);
+        }
+    }
+
+    #[test]
     fn test_create_fdt() {
         let mem = arch_mem(FDT_MAX_SIZE + 0x1000);
         let mut event_manager = EventManager::new().unwrap();
@@ -629,6 +697,7 @@ mod tests {
         let dtb_bytes = create_fdt(
             &mem,
             vec![0],
+            false,
             CString::new("console=tty0").unwrap(),
             &device_manager,
             &gic,

--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -38,6 +38,12 @@ const MSI_PHANDLE: u32 = 3;
 // So, we start the indexing of the phandles used from a really big number and then subtract from
 // it as we need more and more phandle for each cache representation.
 const LAST_CACHE_PHANDLE: u32 = 4000;
+
+// Phandle base for cpu@N nodes.  Placed above LAST_CACHE_PHANDLE so the cpu
+// phandle range never collides with the cache phandles (which count DOWN
+// from LAST_CACHE_PHANDLE).  Used by /cpus/cpu-map/cluster*/core*/cpu
+// references for per-core distinct CPUs visible in the guest.
+const CPU_PHANDLE_BASE: u32 = 4001;
 // Read the documentation specified when appending the root node to the FDT.
 const ADDRESS_CELLS: u32 = 0x2;
 const SIZE_CELLS: u32 = 0x2;
@@ -139,6 +145,12 @@ fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &[u64]) -> Result<(), FdtEr
         // Set the field to first 24 bits of the MPIDR - Multiprocessor Affinity Register.
         // See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0488c/BABHBJCI.html.
         fdt.property_u64("reg", mpidr & 0x7FFFFF)?;
+        // Phandle so the /cpus/cpu-map nodes (emitted after this loop) can
+        // reference this cpu via `cpu = <&cpuN>`.  Without an explicit
+        // phandle, the cpu-map references would not resolve and the Linux
+        // FDT topology parser would skip the cpu-map entirely.
+        let cpu_phandle = CPU_PHANDLE_BASE + u32::try_from(cpu_index).unwrap();
+        fdt.property_u32("phandle", cpu_phandle)?;
 
         for cache in l1_caches.iter() {
             // Please check out
@@ -215,6 +227,22 @@ fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &[u64]) -> Result<(), FdtEr
 
         fdt.end_node(cpu)?;
     }
+    // Emit /cpus/cpu-map so the guest has an explicit cluster/core topology.
+    // Minimal viable shape: single cluster containing N cores. Mirrors
+    // crosvm/aarch64/src/fdt.rs::create_cpu_nodes. A real multi-cluster layout
+    // (matching host SoC topology) can be a follow-up once a config knob exists.
+    //
+    // Binding: Linux Documentation/devicetree/bindings/cpu/cpu-topology.txt
+    let cpu_map = fdt.begin_node("cpu-map")?;
+    let cluster0 = fdt.begin_node("cluster0")?;
+    for cpu_index in 0..num_cpus {
+        let core = fdt.begin_node(&format!("core{cpu_index}"))?;
+        let cpu_phandle = CPU_PHANDLE_BASE + u32::try_from(cpu_index).unwrap();
+        fdt.property_u32("cpu", cpu_phandle)?;
+        fdt.end_node(core)?;
+    }
+    fdt.end_node(cluster0)?;
+    fdt.end_node(cpu_map)?;
     fdt.end_node(cpus)?;
 
     Ok(())

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -150,6 +150,7 @@ pub fn configure_system_for_boot(
     let fdt = fdt::create_fdt(
         vm.guest_memory(),
         vcpu_mpidr,
+        vcpu_config.smt,
         cmdline,
         device_manager,
         vm.get_irqchip(),

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -1478,22 +1478,14 @@ mod tests {
             Err(MachineConfigError::InvalidVcpuCount)
         );
 
-        // Check that SMT is not supported on aarch64, and that on x86_64 enabling it requires vcpu
-        // count to be even.
+        // Check that enabling SMT requires vcpu count to be even.
         aux_vm_config.smt = Some(true);
-        #[cfg(target_arch = "aarch64")]
-        assert_eq!(
-            vm_resources.update_machine_config(&aux_vm_config),
-            Err(MachineConfigError::SmtNotSupported)
-        );
         aux_vm_config.vcpu_count = Some(3);
-        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             vm_resources.update_machine_config(&aux_vm_config),
             Err(MachineConfigError::InvalidVcpuCount)
         );
         aux_vm_config.vcpu_count = Some(32);
-        #[cfg(target_arch = "x86_64")]
         vm_resources.update_machine_config(&aux_vm_config).unwrap();
         aux_vm_config.smt = Some(false);
 

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -24,9 +24,6 @@ pub enum MachineConfigError {
     InvalidVcpuCount,
     /// Could not get the configuration of the previously installed balloon device to validate the memory size.
     InvalidVmState,
-    /// Enabling simultaneous multithreading is not supported on aarch64.
-    #[cfg(target_arch = "aarch64")]
-    SmtNotSupported,
     /// Could not determine host kernel version when checking hugetlbfs compatibility
     KernelVersion,
 }
@@ -258,11 +255,6 @@ impl MachineConfig {
         let vcpu_count = update.vcpu_count.unwrap_or(self.vcpu_count);
 
         let smt = update.smt.unwrap_or(self.smt);
-
-        #[cfg(target_arch = "aarch64")]
-        if smt {
-            return Err(MachineConfigError::SmtNotSupported);
-        }
 
         if vcpu_count == 0 || vcpu_count > MAX_SUPPORTED_VCPUS {
             return Err(MachineConfigError::InvalidVcpuCount);

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -348,15 +348,8 @@ def test_api_machine_config(uvm):
     response = test_microvm.api.machine_config.get()
     assert response.json()["smt"] is False
 
-    # Test that smt=True errors on ARM.
-    if platform.machine() == "x86_64":
-        test_microvm.api.machine_config.patch(smt=True)
-    elif platform.machine() == "aarch64":
-        expected_msg = (
-            "Enabling simultaneous multithreading is not supported on aarch64"
-        )
-        with pytest.raises(RuntimeError, match=expected_msg):
-            test_microvm.api.machine_config.patch(smt=True)
+    # Test that smt=True is accepted.
+    test_microvm.api.machine_config.patch(smt=True)
 
     # Test invalid mem_size_mib < 0.
     with pytest.raises(RuntimeError):

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -15,7 +15,7 @@ import semver
 
 import host_tools.drive as drive_tools
 import host_tools.network as net_tools
-from framework import utils, utils_cpuid
+from framework import utils
 from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.utils import get_firecracker_version_from_toml
 from framework.utils_cpu_templates import (
@@ -152,7 +152,7 @@ def test_api_put_update_pre_boot(uvm, io_engine):
     # The machine configuration has a default value, so all PUTs are updates.
     microvm_config_json = {
         "vcpu_count": 4,
-        "smt": platform.machine() == "x86_64",
+        "smt": True,
         "mem_size_mib": 256,
         "track_dirty_pages": True,
     }
@@ -1369,7 +1369,6 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_configure
     Test the configuration of a microVM after restoring from a snapshot.
     """
     net_iface = uvm_configured.add_net_iface()
-    cpu_vendor = utils_cpuid.get_cpu_vendor()
 
     setup_cfg = {}
     # Basic config also implies a root block device.
@@ -1380,9 +1379,6 @@ def test_get_full_config_after_restoring_snapshot(microvm_factory, uvm_configure
         "track_dirty_pages": False,
         "huge_pages": "None",
     }
-
-    if cpu_vendor == utils_cpuid.CpuVendor.ARM:
-        setup_cfg["machine-config"]["smt"] = False
 
     if len(SUPPORTED_CPU_TEMPLATES) != 0:
         setup_cfg["machine-config"]["cpu_template"] = SUPPORTED_CPU_TEMPLATES[0]

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -4,7 +4,6 @@
 
 import json
 import os
-import platform
 import re
 import shutil
 from pathlib import Path
@@ -204,8 +203,8 @@ def test_config_bad_machine_config(uvm, vm_config_file):
 @pytest.mark.parametrize(
     "test_config",
     [
-        ("framework/vm_config_cpu_template_C3.json", True, False),
-        ("framework/vm_config_smt_true.json", False, True),
+        ("framework/vm_config_cpu_template_C3.json", True),
+        ("framework/vm_config_smt_true.json", False),
     ],
 )
 def test_config_machine_config_params(uvm, test_config):
@@ -216,7 +215,7 @@ def test_config_machine_config_params(uvm, test_config):
 
     # Test configuration determines if the file is a valid config or not
     # based on the CPU
-    vm_config_file, cpu_template_used, smt_used = test_config
+    vm_config_file, cpu_template_used = test_config
 
     _configure_vm_from_json(test_microvm, vm_config_file)
     test_microvm.jailer.extra_args.update({"no-api": None})
@@ -225,8 +224,6 @@ def test_config_machine_config_params(uvm, test_config):
 
     should_fail = False
     if cpu_template_used and "C3" not in SUPPORTED_CPU_TEMPLATES:
-        should_fail = True
-    if smt_used and (platform.machine() == "aarch64"):
         should_fail = True
 
     if should_fail:

--- a/tests/integration_tests/functional/test_topology.py
+++ b/tests/integration_tests/functional/test_topology.py
@@ -9,6 +9,7 @@ import pytest
 from packaging import version
 
 import framework.utils_cpuid as utils
+from framework.artifacts import GUEST_KERNEL_DEFAULT, pin_guest_kernel
 from framework.properties import global_props
 from framework.utils import get_kernel_version
 
@@ -35,7 +36,7 @@ def _check_cpu_topology(
         expected_lscpu_output = {
             "CPU(s)": str(expected_cpu_count),
             "On-line CPU(s) list": expected_cpus_list,
-            "Thread(s) per core": "1",
+            "Thread(s) per core": str(expected_threads_per_core),
             "Core(s) per cluster": str(
                 int(expected_cpu_count / expected_threads_per_core)
             ),
@@ -59,6 +60,8 @@ def _check_cpu_topology(
             "depth 7": f"{expected_cpu_count} PU (type #3)",
         }
     else:
+        threads_per_core = expected_threads_per_core
+        cores = int(expected_cpu_count / threads_per_core)
         expected_hwloc_output = {
             "depth 0": "1 Machine (type #0)",
             "depth 1": "1 Package (type #1)",
@@ -66,7 +69,7 @@ def _check_cpu_topology(
             "depth 3": f"{expected_cpu_count} L2Cache (type #5)",
             "depth 4": f"{expected_cpu_count} L1dCache (type #4)",
             "depth 5": f"{expected_cpu_count} L1iCache (type #9)",
-            "depth 6": f"{expected_cpu_count} Core (type #2)",
+            "depth 6": f"{cores} Core (type #2)",
             "depth 7": f"{expected_cpu_count} PU (type #3)",
         }
 
@@ -192,15 +195,43 @@ def _check_cache_topology_arm(test_microvm, no_cpus, kernel_version_tpl):
         assert guest_slice == host_slice
 
 
+@pin_guest_kernel(GUEST_KERNEL_DEFAULT)
+@pytest.mark.parametrize("num_vcpus", [2, 4])
+def test_aarch64_smt_threads_per_core(uvm, num_vcpus):
+    """
+    Check the guest-visible SMT topology without asserting cache hierarchy details.
+    """
+    if PLATFORM != "aarch64":
+        pytest.skip("This test verifies aarch64 SMT topology.")
+
+    vm = uvm
+    vm.spawn()
+    vm.basic_config(vcpu_count=num_vcpus, smt=True)
+    vm.add_net_iface()
+    vm.start()
+
+    utils.check_guest_cpuid_output(
+        vm,
+        "lscpu",
+        None,
+        ":",
+        {
+            "CPU(s)": str(num_vcpus),
+            "On-line CPU(s) list": "0,1" if num_vcpus == 2 else "0-3",
+            "Thread(s) per core": "2",
+            "Core(s) per cluster": str(num_vcpus // 2),
+            "Cluster(s)": "1",
+            "NUMA node(s)": "1",
+        },
+    )
+
+
 @pytest.mark.parametrize("num_vcpus", [1, 2, 16])
 @pytest.mark.parametrize("htt", [True, False], ids=["HTT_ON", "HTT_OFF"])
 def test_cpu_topology(uvm, num_vcpus, htt):
     """
     Check the CPU topology for a microvm with the specified config.
     """
-    if htt and PLATFORM == "aarch64":
-        pytest.skip("SMT is configurable only on x86.")
-
     # TODO:Remove (or adapt) this once we unify the way we expose the CPU cache hierarchy on
     # Aarch64 systems.
     if version.parse(get_kernel_version()) >= version.parse("6.14"):
@@ -232,8 +263,6 @@ def test_cache_topology(uvm, num_vcpus, htt):
     """
     Check the cache topology for a microvm with the specified config.
     """
-    if htt and PLATFORM == "aarch64":
-        pytest.skip("SMT is configurable only on x86.")
     vm = uvm
     vm.spawn()
     vm.basic_config(vcpu_count=num_vcpus, smt=htt)


### PR DESCRIPTION
## Changes

- Emit a /cpus/cpu-map node on aarch64 (one cluster, one core per vCPU by default) and give each cpu@N an explicit phandle so the map can reference it.
- When smt is enabled and there is more than one vCPU, pair consecutive vCPUs (2*i, 2*i+1) as thread0/thread1 under core i instead of as independent cores.
- Accept smt: true in machine-config on aarch64, using the same rule as x86_64: vcpu_count must be 1 or even. Update swagger, CHANGELOG, and tests.
- Add FDT unit tests for the map with and without SMT, and an aarch64 integration test that checks guest lscpu reports two threads per core.
- This describes topology to the guest only. It does not pin vCPUs to host SMT siblings, change MPIDR, or alter scheduling.

## Reason

aarch64 guests currently have no cpu-map, so Linux treats each vCPU as its own core (thread_id = -1). SMT pairing on arm64 comes from the device tree (parse_core() in arch_topology.c), not from MPIDR, so describing thread siblings in cpu-map is enough for the guest to show a real SMT topology. The API already had an smt flag; rejecting it only on aarch64 blocked that topology from being configured.

## Testing

On aarch64, a 2-vCPU guest with `smt: true` and guest kernel 6.1 reports:
- `lscpu`: CPU(s)=2, Thread(s) per core=2, Core(s) per cluster=1, Cluster(s)=1
- `/sys/devices/system/cpu/cpu0/topology/thread_siblings_list`: `0-1`
- `/proc/device-tree/cpus/cpu-map/cluster0/core0/`: `thread0`, `thread1`
`test_cpu_topology` skips on this host (kernel ≥ 6.14). The new ARM hwloc
expectations in that helper have not run here.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] ~~If a specific issue led to this PR, this PR closes the issue.~~
- [x] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] ~~I have linked an issue to every new `TODO`.~~

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
