### PR TITLE
[Backport 1.16] jailer, vsock and logger fixes (#5956, #6031, #6041, #6077, #6086, #6143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to
   Terminating a connection now also discards its TX buffer, so the device stops
   advertising `EPOLLOUT` for a host stream it will never write to again, which
   could otherwise busy-spin the event thread indefinitely.
+- [#6086](https://github.com/firecracker-microvm/firecracker/pull/6086),
+  [#6143](https://github.com/firecracker-microvm/firecracker/pull/6143): Fixed a
+  deadlock in the logger: a signal handler that logs while the interrupted
+  thread is already logging would hang the VMM and its API socket. This is
+  reachable whenever a `SIGPIPE` is raised by Firecracker's own log write, for
+  example when logging to `stdout` and the reader of that pipe exits. The logger
+  now uses an `RwLock`, and `sigpipe_handler` only increments the
+  `signals.sigpipe` metric instead of logging, so it no longer emits a
+  `Received signal 13, code 0.` line.
 
 ## [1.16.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to
 - [#5956](https://github.com/firecracker-microvm/firecracker/pull/5956): Fixed a
   TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
   `MIDR_EL1` information files copied into the chroot.
+- [#6031](https://github.com/firecracker-microvm/firecracker/pull/6031),
+  [#6041](https://github.com/firecracker-microvm/firecracker/pull/6041),
+  [#6077](https://github.com/firecracker-microvm/firecracker/pull/6077): Fixed
+  the vsock device re-arming its host-stream `EPOLLIN` interest while received
+  data was still awaiting a guest RX buffer, which could busy-spin the event
+  thread until the guest posted buffers. The device now drains the host stream
+  fully across successive RX operations instead of one packet per event loop
+  iteration, reducing the host-side CPU cost per gigabit of host-to-guest
+  traffic by up to ~50% and improving host-to-guest throughput by ~44% (median)
+  in most configurations. On single-vcpu microVMs on the newest Intel hosts
+  (m7i, m8i), host-to-guest throughput may instead decrease by ~15% (median),
+  where the single guest vCPU rather than the host becomes the bottleneck.
+  Terminating a connection now also discards its TX buffer, so the device stops
+  advertising `EPOLLOUT` for a host stream it will never write to again, which
+  could otherwise busy-spin the event thread indefinitely.
 
 ## [1.16.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.2]
+
+### Fixed
+
+- [#5956](https://github.com/firecracker-microvm/firecracker/pull/5956): Fixed a
+  TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
+  `MIDR_EL1` information files copied into the chroot.
+
 ## [1.16.1]
 
 ### Fixed

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -780,6 +780,10 @@
                 "comment": "rt_sigprocmask is used by Rust stdlib to remove custom signal handler during thread teardown."
             },
             {
+                "syscall": "rt_sigreturn",
+                "comment": "rt_sigreturn is needed so sigpipe_handler can return and resume the thread."
+            },
+            {
                 "syscall": "sigaltstack",
                 "comment": "sigaltstack is used by Rust stdlib to remove alternative signal stack during thread teardown."
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -792,6 +792,10 @@
                 "comment": "rt_sigprocmask is used by Rust stdlib to remove custom signal handler during thread teardown."
             },
             {
+                "syscall": "rt_sigreturn",
+                "comment": "rt_sigreturn is needed so sigpipe_handler can return and resume the thread."
+            },
+            {
                 "syscall": "sigaltstack",
                 "comment": "sigaltstack is used by Rust stdlib to remove alternative signal stack during thread teardown."
             },

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -133,6 +133,28 @@ pub struct Env {
     uffd_dev_minor: Option<u32>,
 }
 
+/// Creates a new file owned by the given uid/gid at `dst` and writes `line`
+/// into it, plus a trailing newline.
+#[cfg(target_arch = "aarch64")]
+fn create_owned_file_with_data(
+    dst: &Path,
+    line: String,
+    uid: u32,
+    gid: u32,
+) -> Result<(), JailerError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        // `create_new` maps to `O_CREAT | O_EXCL`: fail if `dst` already exists.
+        .create_new(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(dst)
+        .map_err(|err| JailerError::Write(dst.to_path_buf(), err))?;
+    file.write_all(format!("{}\n", line).as_bytes())
+        .map_err(|err| JailerError::Write(dst.to_path_buf(), err))?;
+    fchown(&file, Some(uid), Some(gid))
+        .map_err(|err| JailerError::ChangeFileOwner(dst.to_path_buf(), err))
+}
+
 impl Env {
     pub fn new(
         arguments: &arg_parser::Arguments,
@@ -548,7 +570,7 @@ impl Env {
 
     #[cfg(target_arch = "aarch64")]
     fn copy_cache_info(&self) -> Result<(), JailerError> {
-        use crate::{readln_special, to_cstring, writeln_special};
+        use crate::readln_special;
 
         const HOST_CACHE_INFO: &str = "/sys/devices/system/cpu/cpu0/cache";
         // Based on https://elixir.free-electrons.com/linux/v4.9.62/source/arch/arm64/kernel/cacheinfo.c#L29.
@@ -592,18 +614,7 @@ impl Env {
                 let jailer_cache_file = jailer_path.join(entry);
 
                 if let Ok(line) = readln_special(&host_cache_file) {
-                    writeln_special(&jailer_cache_file, line)?;
-
-                    // We now change the permissions.
-                    let dest_path_cstr = to_cstring(&jailer_cache_file)?;
-                    // SAFETY: Safe because dest_path_cstr is null-terminated.
-                    SyscallReturnCode(unsafe {
-                        libc::chown(dest_path_cstr.as_ptr(), self.uid(), self.gid())
-                    })
-                    .into_empty_result()
-                    .map_err(|err| {
-                        JailerError::ChangeFileOwner(jailer_cache_file.to_owned(), err)
-                    })?;
+                    create_owned_file_with_data(&jailer_cache_file, line, self.uid(), self.gid())?;
                 }
             }
         }
@@ -612,7 +623,7 @@ impl Env {
 
     #[cfg(target_arch = "aarch64")]
     fn copy_midr_el1_info(&self) -> Result<(), JailerError> {
-        use crate::{readln_special, to_cstring, writeln_special};
+        use crate::readln_special;
 
         const HOST_MIDR_EL1_INFO: &str = "/sys/devices/system/cpu/cpu0/regs/identification";
 
@@ -624,16 +635,10 @@ impl Env {
         let host_midr_el1_file = PathBuf::from(format!("{}/midr_el1", HOST_MIDR_EL1_INFO));
         let jailer_midr_el1_file = jailer_midr_el1_directory.join("midr_el1");
 
-        // Read and copy the MIDR_EL1 file to Jailer
+        // Read the host MIDR_EL1 value and write it into the jail, owned by
+        // the jailed uid:gid.
         let line = readln_special(&host_midr_el1_file)?;
-        writeln_special(&jailer_midr_el1_file, line)?;
-
-        // Change the permissions.
-        let dest_path_cstr = to_cstring(&jailer_midr_el1_file)?;
-        // SAFETY: Safe because `dest_path_cstr` is null-terminated.
-        SyscallReturnCode(unsafe { libc::chown(dest_path_cstr.as_ptr(), self.uid(), self.gid()) })
-            .into_empty_result()
-            .map_err(|err| JailerError::ChangeFileOwner(jailer_midr_el1_file.to_owned(), err))?;
+        create_owned_file_with_data(&jailer_midr_el1_file, line, self.uid(), self.gid())?;
 
         Ok(())
     }
@@ -1427,6 +1432,10 @@ mod tests {
         mock_cgroups.add_v1_mounts().unwrap();
 
         let env = create_env(&mock_cgroups.proc_mounts_path);
+
+        // Clear any leftovers from a previous run of this test, as
+        // `copy_cache_info` expects to be creating these files.
+        let _ = fs::remove_dir_all(env.chroot_dir());
 
         // Create the required chroot dir hierarchy.
         fs::create_dir_all(env.chroot_dir()).expect("Could not create dir hierarchy.");

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -438,6 +438,12 @@ where
         match self.state {
             ConnState::Killed | ConnState::LocalClosed | ConnState::PeerClosed(true, _) => (),
             _ if self.need_credit_update_from_peer() => (),
+            // An `Rw` indication means the host stream is readable and its data is waiting to
+            // be delivered to the guest by `recv_pkt`, which needs a guest RX buffer. While
+            // that data is undeliverable, re-arming IN would just busy-spin the event thread
+            // on the level-triggered muxer epoll fd. IN is re-armed once `recv_pkt` clears
+            // the `Rw` (on RX-queue refill).
+            _ if self.pending_rx.contains(PendingRx::Rw) => (),
             _ => evset.insert(EventSet::IN),
         }
         evset
@@ -1033,6 +1039,44 @@ mod tests {
         ctx.notify_epollin();
         ctx.recv();
         assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RST);
+    }
+
+    #[test]
+    fn test_polled_evset_drops_in_while_rw_pending() {
+        // Regression test for the guest-RX-starvation busy-spin.
+        // An Established connection with an undeliverable RW indication (host wrote data,
+        // guest has not provided RX buffers) must NOT keep advertising EPOLLIN, or the
+        // level-triggered muxer epoll fd busy-spins the event thread. IN must be re-armed
+        // once the guest posts an RX buffer and the pending packet is delivered.
+        let mut ctx = CsmTestContext::new_established();
+        // Fresh Established connection is interested in IN.
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
+
+        ctx.set_stream(TestStream::new_with_read_buf(&[1, 2, 3, 4]));
+        ctx.notify_epollin(); // sets PendingRx::Rw
+        // With an undeliverable Rw queued, IN must be suppressed.
+        assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
+
+        // Draining the pending packet (guest posted an RX buffer) clears Rw and re-arms IN.
+        ctx.recv();
+        assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert!(!ctx.conn.has_pending_rx());
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
+    }
+
+    #[test]
+    fn test_polled_evset_drops_in_on_host_eof() {
+        // Same as `test_polled_evset_drops_in_while_rw_pending`, but the host closed its
+        // end (EOF) instead of writing data. The resulting undeliverable RW indication must
+        // still suppress EPOLLIN so the muxer epoll fd does not busy-spin the event thread.
+        let mut ctx = CsmTestContext::new_established();
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
+
+        let mut stream = TestStream::new();
+        stream.read_state = StreamState::Closed;
+        ctx.set_stream(stream);
+        ctx.notify_epollin(); // sets PendingRx::Rw
+        assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -239,6 +239,9 @@ where
                         // by self.peer_avail_credit(), a u32 internally.
                         pkt.hdr.set_op(uapi::VSOCK_OP_RW).set_len(read_cnt);
                         METRICS.rx_bytes_count.add(read_cnt as u64);
+                        // There may be more data to read, so keep `Rw` pending to stay
+                        // scheduled for another read.
+                        self.pending_rx.insert(PendingRx::Rw);
                     }
                     self.rx_cnt += Wrapping(pkt.hdr.len());
                     self.last_fwd_cnt_to_peer = self.fwd_cnt;
@@ -247,13 +250,7 @@ where
                 Err(VsockError::GuestMemoryMmap(GuestMemoryError::IOError(err)))
                     if err.kind() == ErrorKind::WouldBlock =>
                 {
-                    // This shouldn't actually happen (receiving EWOULDBLOCK after EPOLLIN), but
-                    // apparently it does, so we need to handle it gracefully.
-                    warn!(
-                        "vsock: unexpected EWOULDBLOCK while reading from backing stream: lp={}, \
-                         pp={}, err={:?}",
-                        self.local_port, self.peer_port, err
-                    );
+                    // Host stream drained: `Rw` stays cleared.
                 }
                 Err(err) => {
                     // We are not expecting any other errors when reading from the underlying
@@ -1057,9 +1054,46 @@ mod tests {
         // With an undeliverable Rw queued, IN must be suppressed.
         assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
 
-        // Draining the pending packet (guest posted an RX buffer) clears Rw and re-arms IN.
+        // The guest posts an RX buffer: the packet is delivered, but `Rw` stays pending for
+        // another read, so IN remains suppressed.
         ctx.recv();
         assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert!(ctx.conn.has_pending_rx());
+        assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
+
+        // Once the stream drains (read returns `WouldBlock`), `Rw` is cleared and IN re-armed.
+        ctx.conn.recv_pkt(&mut ctx.rx_pkt).unwrap_err();
+        assert!(!ctx.conn.has_pending_rx());
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
+    }
+
+    #[test]
+    fn test_rx_drains_multiple_packets_per_notification() {
+        // A single EPOLLIN notification must drain the whole host stream: `recv_pkt`
+        // keeps yielding RW packets across calls until a read would block.
+        let mut ctx = CsmTestContext::new_established();
+        let pkt_buf_size = ctx.rx_pkt.buf_size() as usize;
+        // More than one packet's worth of data, so draining needs several reads.
+        let data = vec![0xab_u8; pkt_buf_size + 1];
+        ctx.set_stream(TestStream::new_with_read_buf(&data));
+
+        // A single notification schedules the connection.
+        ctx.notify_epollin();
+
+        // First read fills a whole packet; `Rw` stays pending for the rest.
+        ctx.recv();
+        assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(ctx.rx_pkt.hdr.len() as usize, pkt_buf_size);
+        assert!(ctx.conn.has_pending_rx());
+
+        // Second read drains the remaining byte, without another notification.
+        ctx.recv();
+        assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(ctx.rx_pkt.hdr.len() as usize, 1);
+        assert!(ctx.conn.has_pending_rx());
+
+        // Stream now empty: the next read would block, clearing `Rw` and re-arming IN.
+        ctx.conn.recv_pkt(&mut ctx.rx_pkt).unwrap_err();
         assert!(!ctx.conn.has_pending_rx());
         assert!(ctx.conn.get_polled_evset().contains(EventSet::IN));
     }

--- a/src/vmm/src/devices/virtio/vsock/csm/connection.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/connection.rs
@@ -583,6 +583,8 @@ where
     pub fn kill(&mut self) {
         self.state = ConnState::Killed;
         self.pending_rx.insert(PendingRx::Rst);
+        // We're sending an RST, so anything still buffered for the host is forfeit.
+        self.tx_buf.clear();
     }
 
     /// Return the connections state.
@@ -1111,6 +1113,57 @@ mod tests {
         ctx.set_stream(stream);
         ctx.notify_epollin(); // sets PendingRx::Rw
         assert!(!ctx.conn.get_polled_evset().contains(EventSet::IN));
+    }
+
+    #[test]
+    fn test_polled_evset_drops_out_when_killed() {
+        // A killed connection must not keep asking for EPOLLOUT: a peer-closed fd is
+        // writable forever while every write fails, which busy-spins the event thread.
+        let mut ctx = CsmTestContext::new_established();
+
+        // Buffer some guest data by making the host stream refuse writes.
+        let mut stream = TestStream::new();
+        stream.write_state = StreamState::WouldBlock;
+        ctx.set_stream(stream);
+        ctx.init_data_tx_pkt(&[1, 2, 3, 4]);
+        ctx.send();
+        assert!(ctx.conn.get_polled_evset().contains(EventSet::OUT));
+
+        // The host end goes away: flushing fails and kills the connection.
+        let mut stream = TestStream::new();
+        stream.write_state = StreamState::Closed;
+        ctx.set_stream(stream);
+        ctx.notify_epollout();
+        assert_eq!(ctx.conn.state, ConnState::Killed);
+
+        // Wanting no events is what makes the muxer drop the listener.
+        assert!(ctx.conn.tx_buf.is_empty());
+        assert!(ctx.conn.get_polled_evset().is_empty());
+    }
+
+    #[test]
+    fn test_polled_evset_keeps_out_while_flushable() {
+        // Only a kill forfeits the buffer. `LocalClosed` still drains: a 0-length read
+        // only means the host shut down its write side. `PeerClosed(true, true)` drains
+        // too, and sends its RST once done.
+        for state in [
+            ConnState::Established,
+            ConnState::LocalClosed,
+            ConnState::PeerClosed(true, true),
+        ] {
+            let mut ctx = CsmTestContext::new_established();
+            let mut stream = TestStream::new();
+            stream.write_state = StreamState::WouldBlock;
+            ctx.set_stream(stream);
+            ctx.init_data_tx_pkt(&[1, 2, 3, 4]);
+            ctx.send();
+
+            ctx.conn.state = state;
+            assert!(
+                ctx.conn.get_polled_evset().contains(EventSet::OUT),
+                "OUT must stay armed in {state:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/csm/txbuf.rs
+++ b/src/vmm/src/devices/virtio/vsock/csm/txbuf.rs
@@ -135,6 +135,13 @@ impl TxBuf {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Discard any buffered data, freeing the backing allocation.
+    pub fn clear(&mut self) {
+        self.data = None;
+        self.head = Wrapping(0);
+        self.tail = Wrapping(0);
+    }
 }
 
 impl WriteVolatile for TxBuf {
@@ -256,6 +263,25 @@ mod tests {
             .unwrap();
         assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 4);
         assert_eq!(sink.data, [5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut txbuf = TxBuf::new();
+        let mut tmp = vec![0u8; 128];
+        txbuf
+            .push(&VolatileSlice::from(tmp.as_mut_slice()))
+            .unwrap();
+        assert!(!txbuf.is_empty());
+
+        txbuf.clear();
+        assert!(txbuf.is_empty());
+        assert_eq!(txbuf.len(), 0);
+        // The buffer can be reused afterwards.
+        txbuf
+            .push(&VolatileSlice::from(tmp.as_mut_slice()))
+            .unwrap();
+        assert_eq!(txbuf.len(), 128);
     }
 
     #[test]

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -173,30 +173,32 @@ where
         while let Some(head) = queue.pop_or_enable_notification()? {
             let index = head.index;
             let used_len = match self.rx_packet.parse(mem, head) {
-                Ok(()) => {
-                    if self.backend.recv_pkt(&mut self.rx_packet).is_ok() {
-                        match self.rx_packet.commit_hdr() {
-                            // This addition cannot overflow, because packet length
-                            // is previously validated against `MAX_PKT_BUF_SIZE`
-                            // bound as part of `commit_hdr()`.
-                            Ok(()) => VSOCK_PKT_HDR_SIZE + self.rx_packet.hdr.len(),
-                            Err(err) => {
-                                warn!(
-                                    "vsock: Error writing packet header to guest memory: \
-                                     {:?}.Discarding the package.",
-                                    err
-                                );
-                                0
-                            }
+                Ok(()) => match self.backend.recv_pkt(&mut self.rx_packet) {
+                    Ok(()) => match self.rx_packet.commit_hdr() {
+                        // This addition cannot overflow, because packet length
+                        // is previously validated against `MAX_PKT_BUF_SIZE`
+                        // bound as part of `commit_hdr()`.
+                        Ok(()) => VSOCK_PKT_HDR_SIZE + self.rx_packet.hdr.len(),
+                        Err(err) => {
+                            warn!(
+                                "vsock: Error writing packet header to guest memory: \
+                                 {:?}.Discarding the package.",
+                                err
+                            );
+                            0
                         }
-                    } else {
-                        // We are using a consuming iterator over the virtio buffers, so, if we
-                        // can't fill in this buffer, we'll need to undo the
-                        // last iterator step.
+                    },
+                    Err(VsockError::NoData) => {
+                        // No more data to deliver. Return the unused buffer to the queue.
                         queue.undo_pop();
                         break;
                     }
-                }
+                    Err(err) => {
+                        error!("vsock: error receiving packet from backend: {:?}", err);
+                        queue.undo_pop();
+                        break;
+                    }
+                },
                 Err(err) => {
                     warn!("vsock: RX queue error: {:?}. Discarding the package.", err);
                     0

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -83,11 +83,6 @@ pub struct Vsock<B> {
     pub(crate) pending_event_ack: bool,
 }
 
-// TODO: Detect / handle queue deadlock:
-// 1. If the driver halts RX queue processing, we'll need to notify `self.backend`, so that it can
-//    unregister any EPOLLIN listeners, since otherwise it will keep spinning, unable to consume its
-//    EPOLLIN events.
-
 impl<B> Vsock<B>
 where
     B: VsockBackend + Debug,

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -1219,6 +1219,50 @@ mod tests {
     }
 
     #[test]
+    fn test_killed_conn_drops_epoll_listener() {
+        // A killed connection must not keep an epoll listener, or the nested epoll fd
+        // re-fires forever on a peer-closed stream that no write can ever satisfy.
+        let mut ctx = MuxerTestContext::new("killed_conn_out");
+        let peer_port = 1025;
+        let (stream, local_port) = ctx.local_connect(peer_port);
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        let conn_fd = ctx.muxer.conn_map.get(&key).unwrap().as_raw_fd();
+        assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
+
+        // Fill the host socket's send buffer, so further data lands in the TX buffer.
+        let data = vec![0xffu8; ctx.tx_pkt.buf_size() as usize];
+        let mut sends = 0;
+        while !ctx
+            .muxer
+            .conn_map
+            .get(&key)
+            .unwrap()
+            .get_polled_evset()
+            .contains(EventSet::OUT)
+        {
+            ctx.init_data_tx_pkt(local_port, peer_port, data.as_slice());
+            ctx.send();
+            sends += 1;
+            assert!(sends < 1024, "TX buffer never filled up");
+        }
+
+        // The host end goes away while data is still buffered.
+        drop(stream);
+
+        // The failing flush kills the connection, which must drop its listener.
+        ctx.muxer.notify(EventSet::IN);
+        assert_eq!(
+            ctx.muxer.conn_map.get(&key).unwrap().state(),
+            ConnState::Killed
+        );
+        assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 0);
+    }
+
+    #[test]
     fn test_starvation_drops_epoll_listener_on_host_eof() {
         // Same as `test_starvation_drops_and_rearms_epoll_listener`, but the host closes
         // its end (EOF) instead of writing data. No host-side entity can break the loop,

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -1175,6 +1175,69 @@ mod tests {
     }
 
     #[test]
+    fn test_starvation_drops_and_rearms_epoll_listener() {
+        // End-to-end regression test for the guest-RX-starvation busy-spin at the muxer
+        // layer. When a connection has host data pending but the guest provides no RX
+        // buffer to drain it, the muxer must drop the connection's epoll listener (so the
+        // nested epoll fd goes quiet instead of re-firing IN forever), and re-arm it once
+        // the pending packet is delivered on RX-queue refill.
+        let mut ctx = MuxerTestContext::new("starvation_data");
+        let peer_port = 1025;
+        let (mut stream, local_port) = ctx.local_connect(peer_port);
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        let conn_fd = ctx.muxer.conn_map.get(&key).unwrap().as_raw_fd();
+
+        // Established connection is registered with an epoll listener.
+        assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 1);
+
+        // Host writes data; drive the muxer without providing a guest RX buffer.
+        stream.write_all(&[1, 2, 3, 4]).unwrap();
+        ctx.notify_muxer();
+
+        // The connection now has an undeliverable pending RX, so its epoll listener
+        // must have been dropped - the nested epoll fd goes quiet.
+        assert!(ctx.muxer.has_pending_rx());
+        assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 0);
+
+        // The guest posts an RX buffer: recv drains the packet, clearing the pending RX
+        // and re-arming the epoll listener.
+        ctx.recv();
+        assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 1);
+    }
+
+    #[test]
+    fn test_starvation_drops_epoll_listener_on_host_eof() {
+        // Same as `test_starvation_drops_and_rearms_epoll_listener`, but the host closes
+        // its end (EOF) instead of writing data. No host-side entity can break the loop,
+        // so dropping the listener is what makes the nested epoll fd quiet.
+        let mut ctx = MuxerTestContext::new("starvation_eof");
+        let peer_port = 1025;
+        let (stream, local_port) = ctx.local_connect(peer_port);
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        let conn_fd = ctx.muxer.conn_map.get(&key).unwrap().as_raw_fd();
+        assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
+
+        // Close the host end and drive the muxer without a guest RX buffer.
+        drop(stream);
+        ctx.notify_muxer();
+
+        // The pending EOF (SHUTDOWN) is undeliverable, so the listener must be dropped.
+        assert!(ctx.muxer.has_pending_rx());
+        assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
+        assert_eq!(ctx.count_epoll_listeners().1, 0);
+    }
+
+    #[test]
     fn test_local_close() {
         let peer_port = 1025;
         let mut ctx = MuxerTestContext::new("local_close");

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -1137,6 +1137,8 @@ mod tests {
         let buf = test_utils::read_packet_data(&ctx.tx_pkt, 4);
         assert_eq!(&buf, &data);
 
+        // The connection stays scheduled until the stream drains, then has no more pending RX.
+        ctx.muxer.recv_pkt(&mut ctx.rx_pkt).unwrap_err();
         assert!(!ctx.muxer.has_pending_rx());
     }
 
@@ -1204,10 +1206,14 @@ mod tests {
         assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
         assert_eq!(ctx.count_epoll_listeners().1, 0);
 
-        // The guest posts an RX buffer: recv drains the packet, clearing the pending RX
-        // and re-arming the epoll listener.
+        // The guest posts an RX buffer: recv delivers the packet, but the connection stays
+        // scheduled (and its listener dropped) while the stream may still hold data.
         ctx.recv();
         assert_eq!(ctx.rx_pkt.hdr.op(), uapi::VSOCK_OP_RW);
+        assert!(!ctx.muxer.listener_map.contains_key(&conn_fd));
+
+        // Draining the stream clears the pending RX and re-arms the epoll listener.
+        ctx.muxer.recv_pkt(&mut ctx.rx_pkt).unwrap_err();
         assert!(ctx.muxer.listener_map.contains_key(&conn_fd));
         assert_eq!(ctx.count_epoll_listeners().1, 1);
     }

--- a/src/vmm/src/logger/logging.rs
+++ b/src/vmm/src/logger/logging.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{OnceLock, RwLock};
 use std::thread;
 
 use log::{Log, Metadata, Record};
@@ -26,7 +26,7 @@ pub static INSTANCE_ID: OnceLock<String> = OnceLock::new();
 /// The logger.
 ///
 /// Default values matching the swagger specification (`src/firecracker/swagger/firecracker.yaml`).
-pub static LOGGER: Logger = Logger(Mutex::new(LoggerConfiguration {
+pub static LOGGER: Logger = Logger(RwLock::new(LoggerConfiguration {
     target: None,
     filter: LogFilter { module: None },
     format: LogFormat {
@@ -62,7 +62,7 @@ impl Logger {
             .transpose()
             .map_err(LoggerUpdateError)?;
 
-        let mut guard = self.0.lock().unwrap();
+        let mut guard = self.0.write().unwrap();
         log::set_max_level(
             config
                 .level
@@ -86,10 +86,6 @@ impl Logger {
             guard.filter.module = Some(module);
         }
 
-        // Ensure we drop the guard before attempting to log, otherwise this
-        // would deadlock.
-        drop(guard);
-
         Ok(())
     }
 }
@@ -109,8 +105,13 @@ pub struct LoggerConfiguration {
     pub filter: LogFilter,
     pub format: LogFormat,
 }
+/// An RwLock lets log() take a read lock, which a signal handler that logs can
+/// re-acquire as a nested read. Only update() takes the write lock, and it runs
+/// pre-boot (the API rejects ConfigureLogger once the VM starts), so at runtime
+/// no writer blocks a read and a running VM cannot hang. A signal during a
+/// pre-boot update() can still block.
 #[derive(Debug)]
-pub struct Logger(pub Mutex<LoggerConfiguration>);
+pub struct Logger(pub RwLock<LoggerConfiguration>);
 
 impl Log for Logger {
     // No additional filters to <https://docs.rs/log/latest/log/fn.max_level.html>.
@@ -119,8 +120,7 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &Record) {
-        // Lock the logger.
-        let mut guard = self.0.lock().unwrap();
+        let guard = self.0.read().unwrap();
 
         // Check if the log message is enabled
         {
@@ -165,7 +165,10 @@ impl Log for Logger {
                 record.args()
             );
 
-            let result = if let Some(file) = &mut guard.target {
+            // Write through a shared &File so a read lock suffices; write_all
+            // needs &mut on the reference, not the File. One write_all per line
+            // keeps output atomic.
+            let result = if let Some(mut file) = guard.target.as_ref() {
                 file.write_all(message.as_bytes())
             } else {
                 std::io::stdout().write_all(message.as_bytes())
@@ -366,7 +369,7 @@ mod tests {
             .unwrap();
 
         // Create logger.
-        let logger = Logger(Mutex::new(LoggerConfiguration {
+        let logger = Logger(RwLock::new(LoggerConfiguration {
             target: Some(target),
             filter: LogFilter {
                 module: Some(String::from("module")),
@@ -409,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_logger_update_with_log_path() {
-        let logger = Logger(Mutex::new(LoggerConfiguration {
+        let logger = Logger(RwLock::new(LoggerConfiguration {
             target: None,
             filter: LogFilter { module: None },
             format: LogFormat {
@@ -428,6 +431,6 @@ mod tests {
                 module: None,
             })
             .unwrap();
-        assert!(logger.0.lock().unwrap().target.is_some());
+        assert!(logger.0.read().unwrap().target.is_some());
     }
 }

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -145,9 +145,9 @@ extern "C" fn sigpipe_handler(num: c_int, info: *mut siginfo_t, _unused: *mut c_
         return;
     }
 
+    // Do not log here: the write that raised SIGPIPE is usually a log write, so
+    // logging would re-enter the logger mid-write on this same thread.
     METRICS.signals.sigpipe.inc();
-
-    error_unrestricted!("Received signal {}, code {}.", si_signo, si_code);
 }
 
 /// Registers all the required signal handlers.

--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -7,8 +7,9 @@
 
 use std::os::fd::AsRawFd;
 use std::sync::atomic::{Ordering, fence};
-use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, TryRecvError, channel};
 use std::sync::{Arc, Barrier};
+use std::time::Duration;
 use std::{fmt, io, thread};
 
 use kvm_bindings::{KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN};
@@ -31,6 +32,9 @@ use crate::vstate::vm::KvmVm;
 
 /// Signal number (SIGRTMIN) used to kick Vcpus.
 pub const VCPU_RTSIG_OFFSET: i32 = 0;
+
+/// Maximum time to wait for a vCPU thread to exit when dropping its handle.
+const VCPU_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Errors associated with the wrappers over KVM ioctls.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
@@ -624,14 +628,28 @@ impl VcpuHandle {
 // Wait for the Vcpu thread to finish execution
 impl Drop for VcpuHandle {
     fn drop(&mut self) {
-        // We assume that by the time a VcpuHandle is dropped, other code has run to
-        // get the state machine loop to finish so the thread is ready to join.
-        // The strategy of avoiding more complex messaging protocols during the Drop
-        // helps avoid cycles which were preventing a truly clean shutdown.
-        //
-        // If the code hangs at this point, that means that a Finish event was not
-        // sent by Vmm.
-        self.vcpu_thread.take().unwrap().join().unwrap();
+        // The vCPU thread owns the response sender, so the channel disconnects
+        // once it exits. Wait for that disconnect (draining any stale responses)
+        // with a timeout rather than joining unconditionally, so a thread that
+        // never finished (e.g. a missed Finish event) fails fast instead of
+        // hanging teardown forever.
+        let thread = self.vcpu_thread.take().unwrap();
+        loop {
+            match self.response_receiver.recv_timeout(VCPU_JOIN_TIMEOUT) {
+                // Sender dropped: the thread has exited.
+                Err(RecvTimeoutError::Disconnected) => break,
+                Err(RecvTimeoutError::Timeout) => {
+                    let name = thread.thread().name().unwrap_or("<unnamed>");
+                    panic!("Timed out waiting for vCPU thread '{name}' to exit")
+                }
+                // Unexpected: a response was still queued at teardown. Discard
+                // it and keep waiting for the thread to exit.
+                Ok(response) => {
+                    warn!("Discarding unexpected vCPU response during teardown: {response:?}");
+                }
+            }
+        }
+        thread.join().unwrap();
     }
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,23 @@ if _libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
     raise OSError(ctypes.get_errno(), "prctl(PR_SET_CHILD_SUBREAPER) failed")
 
 
+def reap_orphaned_children():
+    """Reap descendants that have reparented to this subreaper session.
+
+    Non-blocking; safe to call repeatedly. Returns the number reaped.
+    """
+    reaped = 0
+    while True:
+        try:
+            pid, _status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            break
+        if pid == 0:
+            break
+        reaped += 1
+    return reaped
+
+
 METRICS = get_metrics_logger()
 PHASE_REPORT_KEY = pytest.StashKey[dict[str, pytest.CollectReport]]()
 
@@ -128,6 +145,17 @@ def record_props(request, record_property):
     # Extract attributes from the docstrings
     function_docstring = inspect.getdoc(request.function)
     record_property("description", function_docstring)
+
+
+@pytest.fixture(scope="function")
+def reap_orphans():
+    """Reap orphaned descendants after each test.
+
+    Teardown runs after the microVM is killed because `microvm_factory`
+    depends on this fixture (fixtures finalize in reverse setup order).
+    """
+    yield
+    reap_orphaned_children()
 
 
 def pytest_runtest_logreport(report):
@@ -378,8 +406,14 @@ def netns_factory(worker_id):
 
 
 @pytest.fixture()
-def microvm_factory(request, record_property, results_dir, netns_factory):
-    """Fixture to create microvms simply."""
+# pylint: disable=unused-argument
+def microvm_factory(request, record_property, results_dir, netns_factory, reap_orphans):
+    """Fixture to create microvms simply.
+
+    `reap_orphans` is requested only for teardown ordering (reaping runs
+    after the VMs are killed), so it is intentionally not referenced in
+    the body.
+    """
 
     binary_dir = request.config.getoption("--binary-dir") or DEFAULT_BINARY_DIR
     if isinstance(binary_dir, str):

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -27,6 +27,7 @@ def cargo(
     env: dict = None,
     cwd: str = None,
     nightly: bool = False,
+    timeout: int = None,
 ):
     """Executes the specified cargo subcommand"""
     toolchain = f"+{nightly_toolchain()}" if nightly else ""
@@ -35,7 +36,7 @@ def cargo(
     cmd = (
         f"{env_string} cargo {toolchain} {subcommand} {cargo_args} -- {subcommand_args}"
     )
-    return utils.check_output(cmd, cwd=cwd)
+    return utils.check_output(cmd, cwd=cwd, timeout=timeout)
 
 
 def get_rustflags():
@@ -50,10 +51,18 @@ def cargo_test(path, extra_args=""):
     env = {
         "CARGO_TARGET_DIR": os.path.join(path, "unit-tests"),
         "RUST_TEST_THREADS": 1,
-        "RUST_BACKTRACE": 1,
+        "RUST_BACKTRACE": "1",
         "RUSTFLAGS": get_rustflags(),
     }
-    cargo("test", extra_args + " --all --no-fail-fast", env=env)
+    cargo(
+        "test",
+        extra_args + " --all --no-fail-fast",
+        subcommand_args="--nocapture",
+        env=env,
+        # Kill cargo test 60s before pytest's 600s timeout, so pytest can report
+        # the failure and upload artifacts cleanly instead of being killed itself.
+        timeout=540,
+    )
 
 
 def get_binary(name, *, binary_dir=DEFAULT_BINARY_DIR, example=None):

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -5,10 +5,14 @@
 import json
 import os
 import resource as res
+import subprocess
+import urllib.parse
 from signal import SIGBUS, SIGHUP, SIGILL, SIGPIPE, SIGSEGV, SIGSYS, SIGXCPU, SIGXFSZ
 from time import sleep
 
 import pytest
+
+from framework.http_api import Session
 
 signum_str = {
     SIGBUS: "sigbus",
@@ -45,9 +49,8 @@ def test_generic_signal_handler(uvm_plain, signum):
     assert len(line_metrics) == 1
 
     os.kill(microvm.firecracker_pid, signum)
-    # Firecracker gracefully handles SIGPIPE (doesn't terminate).
+    # Firecracker gracefully handles SIGPIPE (doesn't terminate) and logs nothing.
     if signum == int(SIGPIPE):
-        msg = "Received signal 13"
         # Flush metrics to file, so we can see the SIGPIPE at bottom assert.
         # This is going to fail if process has exited.
         microvm.api.actions.put(action_type="FlushMetrics")
@@ -56,11 +59,50 @@ def test_generic_signal_handler(uvm_plain, signum):
 
         microvm.mark_killed()
 
-    microvm.check_log_message(msg)
+        microvm.check_log_message(msg)
 
     if signum != SIGSYS:
         metric_line = json.loads(metrics_fd.readlines()[0])
         assert metric_line["signals"][signum_str[signum]] == 1
+
+
+def test_sigpipe_from_log_write(microvm_factory, tmp_path):
+    """
+    Test that a SIGPIPE raised by Firecracker's own log write is survivable.
+
+    With no log path configured the log target is stdout, so putting stdout on a
+    pipe and dropping the read end makes the next request log, and so raise
+    SIGPIPE on the thread that is already inside the log write.
+    """
+    sock = tmp_path / "fc.sock"
+    url = f"http+unix://{urllib.parse.quote(str(sock), safe='')}/"
+    read_fd, write_fd = os.pipe()
+    proc = subprocess.Popen(
+        [str(microvm_factory.fc_binary_path), "--api-sock", str(sock)],
+        stdout=write_fd,
+        stderr=write_fd,
+    )
+    os.close(write_fd)
+    try:
+        for _ in range(100):
+            if sock.exists():
+                break
+            sleep(0.05)
+
+        session = Session()
+        assert session.get(url, timeout=5).status_code == 200
+
+        # Drop the read end, so the log write of the next request gets EPIPE.
+        os.close(read_fd)
+        read_fd = None
+
+        assert session.get(url, timeout=5).status_code == 200
+        assert proc.poll() is None, f"Firecracker exited with {proc.poll()}"
+    finally:
+        if read_fd is not None:
+            os.close(read_fd)
+        proc.kill()
+        proc.wait()
 
 
 def test_sigxfsz_handler(uvm_plain_rw):


### PR DESCRIPTION
## Changes

Backport to `firecracker-v1.16` of the fixes I have in the `Unreleased` →
`Fixed` section of `main`'s changelog, preceded by the CI hang fix they need in
order to be testable on this branch. The series are independent of each other,
and each changelog-visible one ends with its own changelog commit:

**[#5943](https://github.com/firecracker-microvm/firecracker/pull/5943) — CI
hang on unit-test teardown (prerequisite, no changelog entry upstream)**

- `fix(tests): add timeout and nocapture to cargo unit tests` (`d3c354a32`)
- `fix(tests): reap orphaned descendants after each test` (`63ec4ba71`)
- `fix(vcpu): bound vCPU thread join on handle drop` (`a6e2026d8`)

All three are clean cherry-picks. See the *Reason* section for why this is in
here: the first revision of this PR hit exactly the hang these fix.

**[#5956](https://github.com/firecracker-microvm/firecracker/pull/5956) — jailer
aarch64 cache-info ownership TOCTOU**

- `fix(jailer): harden aarch64 cache-info file ownership` (clean cherry-pick of
  `b3f4f4c81`)
- `docs(changelog): note aarch64 jailer cache-info ownership fix`

**[#6031](https://github.com/firecracker-microvm/firecracker/pull/6031),
[#6041](https://github.com/firecracker-microvm/firecracker/pull/6041),
[#6077](https://github.com/firecracker-microvm/firecracker/pull/6077) — vsock
event-thread busy-spin**

- `fix(vsock): stop busy-spinning the event thread on guest RX starvation`
  (`dde124627`)
- `test(vsock): add muxer-level RX-starvation regression test` (`2469b2549`)
- `fix(vsock): drain host stream fully on RX` (`048128270`)
- `fix(vsock): stop treating backend RX errors as end-of-data` (`17ff6a038`)
- `fix(vsock): forfeit a killed connection's TX buffer` (`65c2ec472`)
- `docs(changelog): note the vsock event-thread busy-spin fixes`

All five are clean cherry-picks. They depend on `refactor(vsock): make
VsockChannel::send_pkt infallible`, which is already on this branch.

**[#6086](https://github.com/firecracker-microvm/firecracker/pull/6086),
[#6143](https://github.com/firecracker-microvm/firecracker/pull/6143) — logger
signal-handler deadlock**

- `fix(logger): use an RwLock so a signal handler can log without deadlock`
  (`1d9929fdf`, clean)
- `fix(seccomp): allow rt_sigreturn on the API thread` (`84e6dd47a`, clean)
- `fix(logger): do not log from the SIGPIPE handler` (`40f2ed2d3`) — the only
  commit needing adaptation, noted in its commit message: its `CHANGELOG.md`
  hunk is dropped (the entry lives in the series' changelog commit), and the new
  `test_sigpipe_from_log_write` test plus `test_sigxfsz_handler` keep this
  branch's `uvm_plain` / `uvm_plain_rw` fixtures instead of the
  `pin_guest_kernel` / `pin_rootfs_mode` decorators, which only exist on `main`.
  `framework.http_api.Session` and `MicroVMFactory.fc_binary_path`, used by the
  new test, are both already present on this branch.
- `docs(changelog): note the logger signal-handler deadlock fix`

The changelog commits are authored rather than cherry-picked, since this branch
has no pending section: the first one opens `## [1.16.2]`, and each entry is
copied verbatim from `main` so the wording stays identical.

## Reason

**#5943** is here because the first revision of this PR — which did not include
it — failed CI in exactly the way it fixes. Three `build-*` jobs
(`m5n.metal-al2-linux_5.10`, `m5n.metal-al2023-linux_6.18`,
`m6i.metal-al2-linux_5.10`) timed out in
`integration_tests/build/test_unittests.py::test_unittests`, all hung in
`src/vmm/tests/integration_tests.rs`'s `test_build_and_boot_microvm` right after
the guest printed `Hello, world!`, i.e. in teardown. On this branch
`VcpuHandle::drop` still does `self.vcpu_thread.take().unwrap().join().unwrap()`
under a comment that reads "If the code hangs at this point, that means that a
Finish event was not sent by Vmm" — and a `Finish` event can indeed go missing,
because the test framework only `waitpid()`s the firecracker pid while
`screen`/`ssh`/vhost-user/socat descendants linger as zombies whose queued
signals stay charged against the `RLIMIT_SIGPENDING` pool, so later signal sends
get dropped. `#5943` bounds that join so teardown fails fast instead of hanging,
reaps the orphaned descendants so the signals are not dropped in the first
place, and caps `cargo test` at 540s with `--nocapture` so a hang is reported by
pytest rather than killing it. The hang is pre-existing on `firecracker-v1.16`
and unrelated to the vsock/logger/jailer changes below, but without these three
commits it makes CI on this branch unreliable and hard to diagnose.

The remaining three series are bug fixes already on `main` that apply to a
supported release branch:

- **#5956** — `copy_cache_info` / `copy_midr_el1_info` wrote each aarch64 CPU
  cache and `MIDR_EL1` file into the chroot and then set ownership with a
  separate, path-based `libc::chown`, leaving a TOCTOU window. The files are now
  created with `O_CREAT | O_EXCL | O_NOFOLLOW` and owned via `fchown` on that
  descriptor.
- **#6031/#6041/#6077** — the vsock device re-armed its host-stream `EPOLLIN`
  interest while received data was still waiting for a guest RX buffer, so the
  event thread could busy-spin until the guest posted buffers; terminating a
  connection also kept its TX buffer, leaving the device advertising `EPOLLOUT`
  for a stream it would never write to again, another indefinite spin. Both burn
  host CPU on an otherwise idle microVM.
- **#6086/#6143** — a signal handler that logs while the interrupted thread is
  already logging hangs the VMM and its API socket. This is reachable in normal
  operation, whenever a `SIGPIPE` is raised by Firecracker's own log write (e.g.
  logging to `stdout` when the reader of that pipe exits).

Two consequences to be aware of when taking this into a patch release, both
already described in the changelog entries:

- The vsock RX drain change is also a performance change: host-side CPU cost per
  gigabit of host-to-guest traffic drops by up to ~50% and host-to-guest
  throughput improves by ~44% (median) in most configurations, but on
  single-vcpu microVMs on the newest Intel hosts (m7i, m8i) host-to-guest
  throughput may instead decrease by ~15% (median), where the single guest vCPU
  rather than the host becomes the bottleneck.
- Firecracker no longer emits a `Received signal 13, code 0.` log line on
  `SIGPIPE`; the `signals.sigpipe` metric is still incremented.

## Testing

- `tools/devtool checkbuild --all` passes (x86_64 and aarch64).
- `tools/devtool checkstyle` passes.
- `cargo test -p vmm -p jailer` passes. Note that `test_muxer_killq` and
  `test_vsock_basic_metrics` fail when the suite runs multi-threaded, because
  they assert deltas on the process-global `METRICS` static; pristine
  `firecracker-v1.16` fails those same two tests the same way, so this is
  pre-existing and unrelated to the backport.
- `git range-diff` against the original `main` commits shows no code drift — the
  only differences are the cherry-pick annotations and the two adaptations
  documented above.
- The unit-test step that failed on the first revision was re-run locally with
  the exact CI invocation (`RUST_TEST_THREADS=1`, musl target, `--all
  --no-fail-fast -- --nocapture`, 540s cap) to confirm it completes with #5943
  applied.
- The integration tests were not run locally; they ran on the original PRs
  against `main`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
