### PR TITLE
pci: Drop the dead ACPI PCI hot-plug AML

### DIFF
--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -167,97 +167,6 @@ impl PciSegment {
 }
 
 #[cfg(target_arch = "x86_64")]
-struct PciDevSlot {
-    device_id: u8,
-}
-
-#[cfg(target_arch = "x86_64")]
-impl Aml for PciDevSlot {
-    fn append_aml_bytes(&self, v: &mut Vec<u8>) -> Result<(), aml::AmlError> {
-        let sun = self.device_id;
-        let adr: u32 = (self.device_id as u32) << 16;
-        aml::Device::new(
-            format!("S{:03}", self.device_id).as_str().try_into()?,
-            vec![
-                &aml::Name::new("_SUN".try_into()?, &sun)?,
-                &aml::Name::new("_ADR".try_into()?, &adr)?,
-                &aml::Method::new(
-                    "_EJ0".try_into()?,
-                    1,
-                    true,
-                    vec![&aml::MethodCall::new(
-                        "\\_SB_.PHPR.PCEJ".try_into()?,
-                        vec![&aml::Path::new("_SUN")?, &aml::Path::new("_SEG")?],
-                    )],
-                ),
-            ],
-        )
-        .append_aml_bytes(v)
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
-struct PciDevSlotNotify {
-    device_id: u8,
-}
-
-#[cfg(target_arch = "x86_64")]
-impl Aml for PciDevSlotNotify {
-    fn append_aml_bytes(&self, v: &mut Vec<u8>) -> Result<(), aml::AmlError> {
-        let device_id_mask: u32 = 1 << self.device_id;
-        let object = aml::Path::new(&format!("S{:03}", self.device_id))?;
-        aml::And::new(&aml::Local(0), &aml::Arg(0), &device_id_mask).append_aml_bytes(v)?;
-        aml::If::new(
-            &aml::Equal::new(&aml::Local(0), &device_id_mask),
-            vec![&aml::Notify::new(&object, &aml::Arg(1))],
-        )
-        .append_aml_bytes(v)
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
-struct PciDevSlotMethods {}
-
-#[cfg(target_arch = "x86_64")]
-impl Aml for PciDevSlotMethods {
-    fn append_aml_bytes(&self, v: &mut Vec<u8>) -> Result<(), aml::AmlError> {
-        let mut device_notifies = Vec::new();
-        for device_id in 0..32 {
-            device_notifies.push(PciDevSlotNotify { device_id });
-        }
-
-        let mut device_notifies_refs: Vec<&dyn Aml> = Vec::new();
-        for device_notify in device_notifies.iter() {
-            device_notifies_refs.push(device_notify);
-        }
-
-        aml::Method::new("DVNT".try_into()?, 2, true, device_notifies_refs).append_aml_bytes(v)?;
-        aml::Method::new(
-            "PCNT".try_into()?,
-            0,
-            true,
-            vec![
-                &aml::Acquire::new("\\_SB_.PHPR.BLCK".try_into()?, 0xffff),
-                &aml::Store::new(
-                    &aml::Path::new("\\_SB_.PHPR.PSEG")?,
-                    &aml::Path::new("_SEG")?,
-                ),
-                &aml::MethodCall::new(
-                    "DVNT".try_into()?,
-                    vec![&aml::Path::new("\\_SB_.PHPR.PCIU")?, &aml::ONE],
-                ),
-                &aml::MethodCall::new(
-                    "DVNT".try_into()?,
-                    vec![&aml::Path::new("\\_SB_.PHPR.PCID")?, &3usize],
-                ),
-                &aml::Release::new("\\_SB_.PHPR.BLCK".try_into()?),
-            ],
-        )
-        .append_aml_bytes(v)
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
 struct PciDsmMethod {}
 
 #[cfg(target_arch = "x86_64")]
@@ -405,18 +314,6 @@ impl Aml for PciSegment {
             )?
         };
         pci_dsdt_inner_data.push(&crs);
-
-        let mut pci_devices = Vec::new();
-        for device_id in 0..32 {
-            let pci_device = PciDevSlot { device_id };
-            pci_devices.push(pci_device);
-        }
-        for pci_device in pci_devices.iter() {
-            pci_dsdt_inner_data.push(pci_device);
-        }
-
-        let pci_device_methods = PciDevSlotMethods {};
-        pci_dsdt_inner_data.push(&pci_device_methods);
 
         // Build PCI routing table, listing IRQs assigned to PCI devices.
         let prt_package_list: Vec<(u32, u32)> = self


### PR DESCRIPTION
Firecracker's ACPI tables describe an ACPI-based PCI hot-plug interface for all 32 slots of the root bus: an eject method per slot, plus two methods for telling the guest that a slot changed. All of them call into a helper device (\_SB_.PHPR) that Firecracker never puts in the tables, so the eject path could only ever fail, and nothing on the Firecracker side ever triggers a notification anyway. This came from Cloud Hypervisor, which does emit that helper device; we never did. Commit 06a88bf94 ("pci: Remove unused pci_devices_up/down fields") already removed the Firecracker state these methods were meant to report.

An eject method makes Linux treat the slots as ACPI-ejectable, so a guest kernel built with CONFIG_HOTPLUG_PCI_ACPI gets entries under /sys/bus/pci/slots/ whose eject path runs the broken code. Drop the tables to remove the broken path.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
