### PR TITLE
virtio: balloon: Don't arm the stats timer of an inactive device

### DIFF
--- a/src/vmm/src/devices/virtio/balloon/device.rs
+++ b/src/vmm/src/devices/virtio/balloon/device.rs
@@ -768,10 +768,13 @@ impl Balloon {
             return Err(BalloonError::StatisticsStateChange);
         }
 
-        self.trigger_stats_update()?;
-
         self.stats_polling_interval_s = interval_s;
-        self.update_timer_state();
+
+        if self.is_activated() {
+            self.trigger_stats_update()?;
+            self.update_timer_state();
+        }
+
         Ok(())
     }
 
@@ -1921,6 +1924,37 @@ pub(crate) mod tests {
         );
         balloon.update_stats_polling_interval(1).unwrap();
         balloon.update_stats_polling_interval(2).unwrap();
+    }
+
+    #[test]
+    fn test_update_stats_interval_after_reset() {
+        let mut balloon = Balloon::new(0, true, 1, false, false).unwrap();
+        let mem = default_mem();
+        let q = VirtQueue::new(GuestAddress(0), &mem, 16);
+        balloon.set_queue(INFLATE_INDEX, q.create_queue());
+        balloon.set_queue(DEFLATE_INDEX, q.create_queue());
+        balloon.set_queue(STATS_INDEX, q.create_queue());
+        balloon.activate(mem.clone(), default_interrupt()).unwrap();
+        assert!(balloon.stats_timer.is_armed());
+
+        // A guest reset leaves the stats timerfd registered with the event
+        // loop while the device is inactive, so an interval update must not
+        // arm it.
+        assert!(balloon.reset());
+        assert!(!balloon.is_activated());
+        assert!(!balloon.stats_timer.is_armed());
+
+        balloon.update_stats_polling_interval(2).unwrap();
+        assert_eq!(balloon.stats_polling_interval_s(), 2);
+        assert!(!balloon.stats_timer.is_armed());
+
+        // The guest re-programs the queues and activates the device again,
+        // which picks up the interval set while it was inactive.
+        balloon.set_queue(INFLATE_INDEX, q.create_queue());
+        balloon.set_queue(DEFLATE_INDEX, q.create_queue());
+        balloon.set_queue(STATS_INDEX, q.create_queue());
+        balloon.activate(mem, default_interrupt()).unwrap();
+        assert!(balloon.stats_timer.is_armed());
     }
 
     #[test]


### PR DESCRIPTION
The update_stats_polling_interval() function arms the periodic timerfd unconditionally. A PATCH /balloon/statistics after a device reset will arm the timer. Given that there's nothing that consumes the event when the timer fires, this can cause the main thread to spin unnecessarily. Fix this by only arming the timer and notifying the guest when the device is activated.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
