### PR TITLE
test: split seccomp filter validation per thread

### DIFF
--- a/tests/integration_tests/security/test_seccomp_validate.py
+++ b/tests/integration_tests/security/test_seccomp_validate.py
@@ -15,6 +15,9 @@ from framework import utils
 
 ARCH = platform.machine()
 
+FC_FILTER_PATH = Path(f"../resources/seccomp/{ARCH}-unknown-linux-musl.json")
+FILTER_THREADS = list(json.loads(FC_FILTER_PATH.read_text(encoding="ascii")))
+
 
 @pytest.fixture
 def bin_test_syscall(tmp_path):
@@ -26,11 +29,11 @@ def bin_test_syscall(tmp_path):
     yield test_syscall_bin.resolve()
 
 
-def test_validate_filter(seccompiler, bin_test_syscall, monkeypatch, tmp_path):
-    """Assert that the seccomp filter matches the JSON description."""
+@pytest.mark.parametrize("thread", FILTER_THREADS)
+def test_validate_filter(seccompiler, bin_test_syscall, monkeypatch, tmp_path, thread):
+    """Assert that the seccomp filter for one thread matches the JSON description."""
 
-    fc_filter_path = Path(f"../resources/seccomp/{ARCH}-unknown-linux-musl.json")
-    fc_filter = json.loads(fc_filter_path.read_text(encoding="ascii"))
+    fc_filter = json.loads(FC_FILTER_PATH.read_text(encoding="ascii"))
 
     # cd to a tmp dir because we may generate a bunch of intermediate files
     monkeypatch.chdir(tmp_path)
@@ -41,47 +44,42 @@ def test_validate_filter(seccompiler, bin_test_syscall, monkeypatch, tmp_path):
 
     # With split_output=True, individual .bpf files are created for each thread
     arch = seccomp.Arch.X86_64 if ARCH == "x86_64" else seccomp.Arch.AARCH64
-    for thread, filter_data in fc_filter.items():
-        filter_path = Path(f"{thread}.bpf")
-        # The individual files should already exist from the split output
-        assert (
-            filter_path.exists()
-        ), f"Expected {filter_path} to be created by seccompiler"
+    filter_data = fc_filter[thread]
+    filter_path = Path(f"{thread}.bpf")
+    assert filter_path.exists(), f"Expected {filter_path} to be created by seccompiler"
 
-        # for each rule, run the helper program and execute a syscall
-        for rule in filter_data["filter"]:
-            print(filter_path, rule)
-            syscall = rule["syscall"]
-            # this one cannot be called directly
-            if syscall in ["rt_sigreturn"]:
-                continue
-            syscall_id = seccomp.resolve_syscall(arch, syscall)
-            cmd = f"{bin_test_syscall} {filter_path} {syscall_id}"
-            if "args" not in rule:
-                # syscall should be allowed with any arguments and exit 0
-                assert utils.run_cmd(cmd).returncode == 0
-            else:
-                allowed_args = [0] * 4
-                # if we call it with allowed args, it should exit 0
-                for arg in rule["args"]:
-                    allowed_args[arg["index"]] = arg["val"]
-                allowed_str = " ".join(str(x) for x in allowed_args)
-                assert utils.run_cmd(f"{cmd} {allowed_str}").returncode == 0
-                # for each allowed arg try a different number
-                for arg in rule["args"]:
-                    bad_args = allowed_args.copy()
-                    if isinstance(arg["op"], dict) and "masked_eq" in arg["op"]:
-                        # For masked_eq, flip the mask bit to violate the check
-                        bad_args[arg["index"]] = str(
-                            arg["val"] ^ arg["op"]["masked_eq"]
-                        )
-                    else:
-                        # We just add 1000000 to the allowed arg and assume it
-                        # is not something we allow in another rule. While not
-                        # perfect it works in practice.
-                        bad_args[arg["index"]] = str(arg["val"] + 1_000_000)
-                    unallowed_str = " ".join(str(x) for x in bad_args)
-                    outcome = utils.run_cmd(f"{cmd} {unallowed_str}")
-                    # if we call it with unallowed args, it should exit 159
-                    # 159 = 128 (abnormal termination) + 31 (SIGSYS)
-                    assert outcome.returncode == 159
+    # for each rule, run the helper program and execute a syscall
+    for rule in filter_data["filter"]:
+        print(filter_path, rule)
+        syscall = rule["syscall"]
+        # this one cannot be called directly
+        if syscall in ["rt_sigreturn"]:
+            continue
+        syscall_id = seccomp.resolve_syscall(arch, syscall)
+        cmd = f"{bin_test_syscall} {filter_path} {syscall_id}"
+        if "args" not in rule:
+            # syscall should be allowed with any arguments and exit 0
+            assert utils.run_cmd(cmd).returncode == 0
+        else:
+            allowed_args = [0] * 4
+            # if we call it with allowed args, it should exit 0
+            for arg in rule["args"]:
+                allowed_args[arg["index"]] = arg["val"]
+            allowed_str = " ".join(str(x) for x in allowed_args)
+            assert utils.run_cmd(f"{cmd} {allowed_str}").returncode == 0
+            # for each allowed arg try a different number
+            for arg in rule["args"]:
+                bad_args = allowed_args.copy()
+                if isinstance(arg["op"], dict) and "masked_eq" in arg["op"]:
+                    # For masked_eq, flip the mask bit to violate the check
+                    bad_args[arg["index"]] = str(arg["val"] ^ arg["op"]["masked_eq"])
+                else:
+                    # We just add 1000000 to the allowed arg and assume it
+                    # is not something we allow in another rule. While not
+                    # perfect it works in practice.
+                    bad_args[arg["index"]] = str(arg["val"] + 1_000_000)
+                unallowed_str = " ".join(str(x) for x in bad_args)
+                outcome = utils.run_cmd(f"{cmd} {unallowed_str}")
+                # if we call it with unallowed args, it should exit 159
+                # 159 = 128 (abnormal termination) + 31 (SIGSYS)
+                assert outcome.returncode == 159


### PR DESCRIPTION
## Changes

Parametrize test_validate_filter per seccomp thread filter instead of testing all three in one serial run. Thread ids come from the filter JSON, so a new thread is picked up automatically.


## Reason

The test forks the test_syscall helper once per rule/arg (~262 times on x86) across all three filters in a single test item. On wide CI hosts (m8i.metal-96xl) the per-fork cost pushes the serial run past the default 300s pytest timeout, while it passes on narrower hosts.
\
Splitting per thread gives each filter its own timeout budget and lets xdist run them in parallel, so the per-fork cost no longer piles into one item. Preferred over raising the timeout, which just defers the failure to the next wider host.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
