### PR TITLE
[v1.16] chore(deps): update rand and chacha20

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,15 +7,6 @@ ignore = [
     # See https://github.com/daniel5151/gdbstub/issues/168
     "RUSTSEC-2024-0436",
 
-    # `rand` unsoundness when a custom logger re-enters `rand::rng()`/`thread_rng()`
-    # during ThreadRng reseeding. Firecracker is not affected:
-    # - uuid (1.23.0): does not enable `fast-rng` or `rng-rand` features, so it uses
-    #   `getrandom` directly and never calls into rand.
-    # - proptest: uses rand 0.9 with `default-features = false` and does not enable
-    #   the `thread_rng` feature, so the affected functions are not compiled in.
-    # See https://rustsec.org/advisories/RUSTSEC-2026-0097.html
-    "RUSTSEC-2026-0097",
-
     # `anyhow` is not directly used by any of our crates. It is a transitive
     # dependency of build-time WASM tooling (wit-bindgen).
     # See https://rustsec.org/advisories/RUSTSEC-2026-0190.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1143,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.1",
@@ -1565,7 +1565,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.2",
  "wasm-bindgen",
 ]
 


### PR DESCRIPTION
## Changes

- Update `rand` from 0.10.0 to 0.10.2 and `chacha20` from 0.10.0 to 0.10.2 by running `cargo update --package rand@0.10.0`.
- Remove the obsolete `RUSTSEC-2026-0097` exception from `.cargo/audit.toml`.

## Reason

This backports the applicable dependency updates from [PR #6160](https://github.com/firecracker-microvm/firecracker/pull/6160) to the v1.16 branch.

`rand` 0.10.0 is affected by `RUSTSEC-2026-0097`; version 0.10.2 contains the fix. Updating `rand` also allows the obsolete cargo-audit exception to be removed.

`chacha20` 0.10.0 was yanked after a CPU feature mismatch was found in a path enabled for SSE2 hosts. Version 0.10.2 fixes that mismatch.

## Testing

- `tools/devtool --unattended test --no-build --no-kvm-check --no-artifacts-check -- integration_tests/security/test_sec_audit.py::test_cargo_audit`
- `tools/devtool --unattended checkstyle`
- `tools/devtool --unattended checkbuild --all`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the automated style checks.
- [x] I have clearly described the change and why it is needed.
- [x] Relevant documentation: not applicable.
- [x] `CHANGELOG.md`: not applicable; no user-facing changes.
- [x] Firecracker issue: not applicable.
- [x] API change runbook: not applicable; no API changes.
- [x] I have tested all changed functionality.
- [x] New `TODO` entries: none.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1] (not applicable; no functionality is added).

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
