### PR TITLE
Define a prefetchable memory window and allocate virtio BARs from mmio32 instead of mmio64

### DIFF
--- a/src/vmm/src/arch/aarch64/fdt.rs
+++ b/src/vmm/src/arch/aarch64/fdt.rs
@@ -488,19 +488,23 @@ fn create_pci_nodes(fdt: &mut FdtWriter, segment: &PciSegment) -> Result<(), Fdt
     let pci_node_name = format!("pci@{:x}", segment.mmio_config_address);
     // Each range here is a thruple of `(PCI address, CPU address, PCI size)`.
     //
+    // The first cell encodes the address space: bits 25-24 hold the space code
+    // (0b10 for 32-bit memory, 0b11 for 64-bit memory) and bit 30 marks the
+    // range prefetchable.
+    //
     // More info about the format can be found here:
     // https://elinux.org/Device_Tree_Usage#PCI_Address_Translation
     let ranges = [
-        // 32bit addresses
-        0x200_0000u32,
+        // 32 bit memory space, non-prefetchable
+        0b0000_0010_0000_0000_0000_0000_0000_0000u32,
         (MEM_32BIT_DEVICES_START >> 32) as u32, // PCI address
         (MEM_32BIT_DEVICES_START & 0xffff_ffff) as u32,
         (MEM_32BIT_DEVICES_START >> 32) as u32, // CPU address
         (MEM_32BIT_DEVICES_START & 0xffff_ffff) as u32,
         (MEM_32BIT_DEVICES_SIZE >> 32) as u32, // Range size
         (MEM_32BIT_DEVICES_SIZE & 0xffff_ffff) as u32,
-        // 64bit addresses
-        0x300_0000u32,
+        // 64 bit memory space, prefetchable
+        0b0100_0011_0000_0000_0000_0000_0000_0000u32,
         // PCI address
         (MEM_64BIT_DEVICES_START >> 32) as u32, // PCI address
         (MEM_64BIT_DEVICES_START & 0xffff_ffff) as u32,

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -144,7 +144,7 @@ impl PciDevices {
         // Don't hold the resource allocator lock across attach_common()
         // below: a device access holds the bus lock and can take the allocator
         // lock, so the reverse order can deadlock.
-        virtio_device.allocate_bars(&mut vm.resource_allocator().mmio64_memory);
+        virtio_device.allocate_bars(&mut vm.resource_allocator().mmio32_memory);
 
         let virtio_device = Arc::new(Mutex::new(virtio_device));
 
@@ -213,7 +213,7 @@ impl PciDevices {
         pci_device_arc
             .lock()
             .expect("Poisoned lock")
-            .free_bars(&mut vm.resource_allocator().mmio64_memory);
+            .free_bars(&mut vm.resource_allocator().mmio32_memory);
 
         // Ensure no other references to the device remain, so it is freed when
         // this function returns.

--- a/src/vmm/src/device_manager/pci_mngr.rs
+++ b/src/vmm/src/device_manager/pci_mngr.rs
@@ -34,7 +34,7 @@ use crate::devices::virtio::vsock::persist::{
 use crate::devices::virtio::vsock::{Vsock, VsockUnixBackend};
 use crate::logger::{debug, warn};
 use crate::pci::PciSBDF;
-use crate::pci::bus::PciRootError;
+use crate::pci::bus::PciBusError;
 use crate::resources::VmResources;
 use crate::snapshot::Persist;
 use crate::vmm_config::memory_hotplug::MemoryHotplugConfig;
@@ -57,8 +57,8 @@ pub enum PciManagerError {
     ResourceAllocation(#[from] vm_allocator::Error),
     /// Bus error: {0}
     Bus(#[from] BusError),
-    /// PCI root error: {0}
-    PciRoot(#[from] PciRootError),
+    /// PCI bus error: {0}
+    PciBus(#[from] PciBusError),
     /// MSI error: {0}
     Msi(#[from] InterruptError),
     /// VirtIO PCI device error: {0}

--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -279,7 +279,7 @@ impl Aml for PciSegment {
                         self.end_of_mem32_area,
                     )?,
                     &aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCacheable::NotCacheable,
+                        aml::AddressSpaceCacheable::PreFetchable,
                         true,
                         self.start_of_mem64_area,
                         self.end_of_mem64_area,
@@ -305,7 +305,7 @@ impl Aml for PciSegment {
                         self.end_of_mem32_area,
                     )?,
                     &aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCacheable::NotCacheable,
+                        aml::AddressSpaceCacheable::PreFetchable,
                         true,
                         self.start_of_mem64_area,
                         self.end_of_mem64_area,

--- a/src/vmm/src/devices/pci/pci_segment.rs
+++ b/src/vmm/src/devices/pci/pci_segment.rs
@@ -21,7 +21,7 @@ use crate::logger::info;
 use crate::pci::PciSBDF;
 #[cfg(target_arch = "x86_64")]
 use crate::pci::bus::{PCI_CONFIG_IO_PORT, PCI_CONFIG_IO_PORT_SIZE, PciConfigIo};
-use crate::pci::bus::{PciBus, PciConfigMmio, PciRoot, PciRootError};
+use crate::pci::bus::{PciBus, PciBusError, PciConfigMmio, PciHostBridge};
 use crate::vstate::bus::BusError;
 use crate::vstate::vm::KvmVm;
 
@@ -65,8 +65,8 @@ impl std::fmt::Debug for PciSegment {
 
 impl PciSegment {
     fn build(id: u16, vm: &Arc<KvmVm>, pci_irq_slots: &[u8; 32]) -> Result<PciSegment, BusError> {
-        let pci_root = PciRoot::new(None);
-        let pci_bus = Arc::new(Mutex::new(PciBus::new(pci_root)));
+        let host_bridge = PciHostBridge::new(None);
+        let pci_bus = Arc::new(Mutex::new(PciBus::new(host_bridge)));
 
         let pci_config_mmio = Arc::new(Mutex::new(PciConfigMmio::new(Arc::clone(&pci_bus))));
         let mmio_config_address = PCI_MMCONFIG_START + PCI_MMIO_CONFIG_SIZE_PER_SEGMENT * id as u64;
@@ -156,7 +156,7 @@ impl PciSegment {
         Ok(segment)
     }
 
-    pub(crate) fn next_device_sbdf(&self) -> Result<PciSBDF, PciRootError> {
+    pub(crate) fn next_device_sbdf(&self) -> Result<PciSBDF, PciBusError> {
         Ok(PciSBDF::new(
             self.id,
             0,

--- a/src/vmm/src/devices/virtio/transport/pci/device.rs
+++ b/src/vmm/src/devices/virtio/transport/pci/device.rs
@@ -351,10 +351,10 @@ impl VirtioPciDevice {
     /// This must happen only during the creation of a brand new VM. When a VM is restored from a
     /// known state, the BARs are already created with the right content, therefore we don't need
     /// to go through this codepath.
-    pub fn allocate_bars(&mut self, mmio64_allocator: &mut AddressAllocator) {
+    pub fn allocate_bars(&mut self, allocator: &mut AddressAllocator) {
         // Allocate the virtio-pci capability BAR.
         // See http://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html#x1-740004
-        self.bar_address = mmio64_allocator
+        self.bar_address = allocator
             .allocate(
                 CAPABILITY_BAR_SIZE,
                 CAPABILITY_BAR_SIZE,
@@ -372,14 +372,14 @@ impl VirtioPciDevice {
     }
 
     /// Free the PCI BAR of the VirtIO device.
-    pub fn free_bars(&mut self, mmio64_allocator: &mut AddressAllocator) {
+    pub fn free_bars(&mut self, allocator: &mut AddressAllocator) {
         let bar_end = self
             .bar_address
             .checked_add(CAPABILITY_BAR_SIZE - 1)
             .expect("virtio-pci BAR end address overflows");
         let range =
             RangeInclusive::new(self.bar_address, bar_end).expect("Invalid virtio-pci BAR range");
-        mmio64_allocator
+        allocator
             .free(&range)
             .expect("virtio-pci BAR is not allocated");
         self.bar_address = 0;
@@ -720,7 +720,7 @@ impl VirtioPciDevice {
         }
 
         // Try to allocate the new range from the resource allocator.
-        let new_range = match self.vm.resource_allocator().mmio64_memory.allocate(
+        let new_range = match self.vm.resource_allocator().mmio32_memory.allocate(
             CAPABILITY_BAR_SIZE,
             CAPABILITY_BAR_SIZE,
             AllocPolicy::ExactMatch(new_base),
@@ -738,7 +738,7 @@ impl VirtioPciDevice {
             error!("Failed to add notification ioeventfds at {new_base:#x}: {err:?}");
             // set_notification_ioevents() might leave some ioeventfds
             // registered in case of failure. Do not return the possibly
-            // "poisoned" address range to the mmio64_allocator.
+            // "poisoned" address range to the memory allocator.
             return;
         }
 
@@ -753,7 +753,7 @@ impl VirtioPciDevice {
                 error!("Failed to remove notification ioeventfds at {new_base:#x}: {err:?}");
                 // As above, only release the old range if it has no ioeventfds left.
             } else {
-                let _ = self.vm.resource_allocator().mmio64_memory.free(&new_range);
+                let _ = self.vm.resource_allocator().mmio32_memory.free(&new_range);
             }
             return;
         }
@@ -769,7 +769,7 @@ impl VirtioPciDevice {
                 .checked_add(CAPABILITY_BAR_SIZE - 1)
                 .expect("BAR end address overflows");
             let old_range = RangeInclusive::new(old_base, old_end).expect("Invalid BAR range");
-            let _ = self.vm.resource_allocator().mmio64_memory.free(&old_range);
+            let _ = self.vm.resource_allocator().mmio32_memory.free(&old_range);
         }
 
         self.bar_address = new_base;
@@ -1233,7 +1233,7 @@ mod tests {
 
     use super::{EventFd, IoEventAddress, KvmVm, NoDatamatch, PciCapabilityType, VirtioPciDevice};
     use crate::Vmm;
-    use crate::arch::{MEM_64BIT_DEVICES_SIZE, MEM_64BIT_DEVICES_START};
+    use crate::arch::{MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START};
     use crate::builder::tests::default_vmm_with_pci;
     use crate::device_manager::tests::pci_devices;
     use crate::devices::virtio::device::VirtioDeviceType;
@@ -1253,6 +1253,11 @@ mod tests {
     use crate::pci::msix::MsixCap;
     use crate::pci::{PciCapabilityId, PciClassCode, PciDevice};
     use crate::rate_limiter::RateLimiter;
+
+    /// The address the single virtio-pci BAR of a freshly booted VM ends up
+    /// at: the first CAPABILITY_BAR_SIZE-aligned address of the 32-bit MMIO
+    /// window.
+    const FIRST_BAR_BASE: u64 = MEM_32BIT_DEVICES_START.next_multiple_of(CAPABILITY_BAR_SIZE);
 
     fn create_vmm_with_virtio_pci_device() -> Vmm {
         let mut vmm = default_vmm_with_pci();
@@ -1410,9 +1415,9 @@ mod tests {
         assert_eq!(bar_addr & 0x1, 0);
         // Type is 0x2 meaning 64-bit BAR
         assert_eq!((bar_addr & 0x6) >> 1, 2);
-        // The actual address of the BAR should be the first available address of our 64-bit MMIO
-        // region
-        assert_eq!(bar_addr & 0xffff_ffff_ffff_fff0, MEM_64BIT_DEVICES_START);
+        // The BAR is 64-bit wide but lives in the 32-bit MMIO region, because it is
+        // non-prefetchable
+        assert_eq!(bar_addr & 0xffff_ffff_ffff_fff0, FIRST_BAR_BASE);
 
         // Reading the BAR size is a bit more convoluted. According to OSDev wiki:
         //
@@ -1452,7 +1457,7 @@ mod tests {
     }
 
     fn allocate_bar_range(vmm: &Vmm, base: u64) -> Result<RangeInclusive, vm_allocator::Error> {
-        kvm_vm(vmm).resource_allocator().mmio64_memory.allocate(
+        kvm_vm(vmm).resource_allocator().mmio32_memory.allocate(
             CAPABILITY_BAR_SIZE,
             CAPABILITY_BAR_SIZE,
             AllocPolicy::ExactMatch(base),
@@ -1475,7 +1480,7 @@ mod tests {
     fn test_bar_relocation() {
         let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
-        let old_base = MEM_64BIT_DEVICES_START;
+        let old_base = FIRST_BAR_BASE;
         let new_base = old_base + CAPABILITY_BAR_SIZE;
 
         {
@@ -1520,7 +1525,7 @@ mod tests {
         let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
         let mut device = device.lock().unwrap();
-        let old_base = MEM_64BIT_DEVICES_START;
+        let old_base = FIRST_BAR_BASE;
         let new_base = old_base + CAPABILITY_BAR_SIZE;
 
         // Enabling memory space decoding with an unchanged BAR is a no-op.
@@ -1543,13 +1548,13 @@ mod tests {
     fn test_bar_relocation_refused() {
         let vmm = create_vmm_with_virtio_pci_device();
         let device = get_virtio_device(&vmm);
-        let old_base = MEM_64BIT_DEVICES_START;
+        let old_base = FIRST_BAR_BASE;
 
         // A range that is already allocated to someone else.
         let taken_base = old_base + CAPABILITY_BAR_SIZE;
         allocate_bar_range(&vmm, taken_base).unwrap();
-        // A range outside the 64-bit MMIO window.
-        let outside_base = MEM_64BIT_DEVICES_START + MEM_64BIT_DEVICES_SIZE;
+        // A range outside the 32-bit MMIO window.
+        let outside_base = MEM_32BIT_DEVICES_START + MEM_32BIT_DEVICES_SIZE;
 
         for base in [taken_base, outside_base] {
             let mut device = device.lock().unwrap();

--- a/src/vmm/src/pci/bus.rs
+++ b/src/vmm/src/pci/bus.rs
@@ -15,9 +15,9 @@ use crate::pci::{PciBridgeSubclass, PciClassCode, PciDevice};
 use crate::utils::u64_to_usize;
 use crate::vstate::bus::BusDevice;
 
-/// Errors for device manager.
+/// Errors for the PCI bus.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub enum PciRootError {
+pub enum PciBusError {
     /// Could not find an available device slot on the PCI bus.
     NoPciDeviceSlotAvailable,
     /// PCI device ID {0} is already in use.
@@ -29,19 +29,19 @@ const DEVICE_ID_INTEL_VIRT_PCIE_HOST: u16 = 0x0d57;
 const NUM_DEVICE_IDS: usize = 32;
 
 #[derive(Debug)]
-/// Emulates the PCI Root bridge device.
-pub struct PciRoot {
+/// Emulates the PCI host bridge device.
+pub struct PciHostBridge {
     /// Configuration space.
     config: PciConfiguration,
 }
 
-impl PciRoot {
-    /// Create an empty PCI root bridge.
+impl PciHostBridge {
+    /// Create an empty PCI host bridge.
     pub fn new(config: Option<PciConfiguration>) -> Self {
         if let Some(config) = config {
-            PciRoot { config }
+            PciHostBridge { config }
         } else {
-            PciRoot {
+            PciHostBridge {
                 config: PciConfiguration::new_type0(
                     VENDOR_ID_INTEL,
                     DEVICE_ID_INTEL_VIRT_PCIE_HOST,
@@ -56,9 +56,9 @@ impl PciRoot {
     }
 }
 
-impl BusDevice for PciRoot {}
+impl BusDevice for PciHostBridge {}
 
-impl PciDevice for PciRoot {
+impl PciDevice for PciHostBridge {
     fn write_config_register(
         &mut self,
         reg_idx: u16,
@@ -92,9 +92,9 @@ impl Debug for PciBus {
 
 impl PciBus {
     /// Create a new PCI bus
-    pub fn new(pci_root: PciRoot) -> Self {
+    pub fn new(host_bridge: PciHostBridge) -> Self {
         let mut bus: Self = Default::default();
-        bus.devices[0] = Some(Arc::new(Mutex::new(pci_root)));
+        bus.devices[0] = Some(Arc::new(Mutex::new(host_bridge)));
         bus
     }
 
@@ -108,10 +108,10 @@ impl PciBus {
         &mut self,
         device_id: u8,
         device: Arc<Mutex<dyn PciDevice>>,
-    ) -> Result<(), PciRootError> {
+    ) -> Result<(), PciBusError> {
         let slot = &mut self.devices[device_id as usize];
         if slot.is_some() {
-            return Err(PciRootError::DuplicateDeviceId(device_id));
+            return Err(PciBusError::DuplicateDeviceId(device_id));
         }
         *slot = Some(device);
         Ok(())
@@ -127,11 +127,11 @@ impl PciBus {
     /// Note: this is non-reserving — repeated calls without an intervening `add_device` will
     /// return the same ID.
     #[allow(clippy::cast_possible_truncation)]
-    pub fn next_device_id(&self) -> Result<u8, PciRootError> {
+    pub fn next_device_id(&self) -> Result<u8, PciBusError> {
         if let Some(position) = self.devices.iter().position(Option::is_none) {
             Ok(position as u8)
         } else {
-            Err(PciRootError::NoPciDeviceSlotAvailable)
+            Err(PciBusError::NoPciDeviceSlotAvailable)
         }
     }
 }
@@ -447,7 +447,7 @@ fn parse_io_config_address(config_address: u32) -> (u8, u8, u8, u16) {
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use super::{PciBus, PciConfigIo, PciConfigMmio, PciRoot};
+    use super::{PciBus, PciConfigIo, PciConfigMmio, PciHostBridge};
     use crate::pci::bus::{DEVICE_ID_INTEL_VIRT_PCIE_HOST, VENDOR_ID_INTEL};
     use crate::pci::configuration::PciConfiguration;
     use crate::pci::{PciClassCode, PciDevice, PciMassStorageSubclass};
@@ -488,8 +488,8 @@ mod tests {
 
     #[test]
     fn test_writing_io_config_address() {
-        let root = PciRoot::new(None);
-        let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(root))));
+        let host_bridge = PciHostBridge::new(None);
+        let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(host_bridge))));
 
         assert_eq!(bus.config_address, 0);
         // Writing more than 32 bits will should fail
@@ -529,8 +529,8 @@ mod tests {
 
     #[test]
     fn test_reading_io_config_address() {
-        let root = PciRoot::new(None);
-        let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(root))));
+        let host_bridge = PciHostBridge::new(None);
+        let mut bus = PciConfigIo::new(Arc::new(Mutex::new(PciBus::new(host_bridge))));
 
         let mut buffer = [0u8; 4];
 
@@ -576,8 +576,8 @@ mod tests {
     }
 
     fn initialize_bus() -> (PciConfigMmio, PciConfigIo) {
-        let root = PciRoot::new(None);
-        let mut bus = PciBus::new(root);
+        let host_bridge = PciHostBridge::new(None);
+        let mut bus = PciBus::new(host_bridge);
         bus.add_device(1, Arc::new(Mutex::new(PciDevMock::new())))
             .unwrap();
 

--- a/tests/integration_tests/functional/test_pci.py
+++ b/tests/integration_tests/functional/test_pci.py
@@ -81,7 +81,7 @@ def _find_virtio_blk_bar(vm):
     Example (BAR0 line)::
 
         # cat /sys/bus/pci/devices/0000:00:01.0/resource | head -1
-        0x0000004000000000 0x000000400007ffff 0x0000000000140204
+        0x00000000c0080000 0x00000000c00fffff 0x0000000000140204
     """
     stdout = vm.ssh.check_output("lspci -n").stdout.strip()
     slot = None
@@ -224,10 +224,10 @@ def test_bar_relocation(uvm_configured, devmem_bin):
     vm = uvm_configured
     slot, old_base, num_queues = _setup_scratch_blk_vm(vm, devmem_bin)
 
-    # Relocate the BAR 4 GiB higher. This stays inside the 64-bit MMIO aperture
-    # ([256 GiB, 512 GiB)) and is naturally aligned to the BAR size, so it does
-    # not collide with any other device.
-    new_base = old_base + 0x1_0000_0000
+    # Relocate the BAR 16 MiB higher. This stays inside the 32-bit MMIO
+    # aperture and is naturally aligned to the BAR size, so it does not collide
+    # with any other device.
+    new_base = old_base + (16 << 20)
     assert new_base % CAPABILITY_BAR_SIZE == 0
 
     # Nothing is mapped at the new base yet: an unmapped MMIO read returns 0.
@@ -263,15 +263,16 @@ def test_bar_relocation(uvm_configured, devmem_bin):
 @pin_guest_kernel(GUEST_KERNEL_DEFAULT)
 def test_bar_relocation_refused(uvm_configured, devmem_bin):
     """
-    Test that Firecracker refuses to relocate a BAR outside the 64-bit MMIO
+    Test that Firecracker refuses to relocate a BAR outside the 32-bit MMIO
     aperture and leaves the device where it is.
     """
     vm = uvm_configured
     slot, base, num_queues = _setup_scratch_blk_vm(vm, devmem_bin)
 
-    # The 64-bit MMIO aperture is [256 GiB, 512 GiB), so the resource
-    # allocator has no range to give us at 1 TiB.
-    invalid_base = 0x100_0000_0000  # 1 TiB
+    # The capability BAR is non-prefetchable so it must live within the 32-bit
+    # MMIO aperture. Relocating to 256 GiB (which falls within the prefetchable
+    # window) must fail.
+    invalid_base = 256 << 30
     assert invalid_base % CAPABILITY_BAR_SIZE == 0
 
     _reprogram_bar(vm, slot, invalid_base)
@@ -298,7 +299,7 @@ def test_bar_relocation_snapshot(uvm_configured, microvm_factory, devmem_bin):
     vm = uvm_configured
     slot, old_base, num_queues = _setup_scratch_blk_vm(vm, devmem_bin)
 
-    new_base = old_base + 0x1_0000_0000
+    new_base = old_base + (16 << 20)
     assert new_base % CAPABILITY_BAR_SIZE == 0
     _reprogram_bar(vm, slot, new_base)
 


### PR DESCRIPTION
    The virtio-pci capability BAR is a non-prefetchable BAR currently
    allocated from the [256 GiB, 512 GiB) range managed by the mmio64
    allocator.
    
    Future patches will add PCIe root ports to the bus topology. Each root
    port defines its own prefetchable and non-prefetchable memory windows
    and all resources behind a root port must be within that window. The
    non-prefetchable memory registers of root ports can only describe memory
    below 4GiB (there is no restriction for prefetchable memory). Therefore
    non-prefetchable BARs must be allocated from the mmio32 allocator.
    
    Use the mmio32 allocator instead of the mmio64 allocator for virtio-pci
    non-prefetchable BARs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
