### PR TITLE
docs: fix typo succesive -> successive

### DIFF
--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -27,8 +27,8 @@ Firecracker binary.
 
 This process is performed automatically, when building the executable.
 
-To minimise the overhead of succesive builds, the compiled filter file is cached
-in the build folder and is only recompiled if modified.
+To minimise the overhead of successive builds, the compiled filter file is
+cached in the build folder and is only recompiled if modified.
 
 You can find the default seccomp filters under `resources/seccomp`.
 


### PR DESCRIPTION
Corrects the misspelling `succesive` -> `successive` in `docs/seccomp.md`.

Documentation only, no behaviour change.