### PR TITLE
ci: type-check the fuzzer against Firecracker PRs

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -4,6 +4,8 @@
 
 """Generate Buildkite pipelines dynamically"""
 
+import os
+
 from common import (
     BKPipeline,
     ci_artifacts_change_mode,
@@ -36,6 +38,25 @@ pipeline.add_step(
     },
     depends_on_build=False,
 )
+
+# Type-check the out-of-tree fuzzer against this PR to catch API breaks pre-merge.
+if not changed_files or any(
+    x.suffix in [".rs", ".toml", ".lock"] for x in changed_files
+):
+    FC_REF = "main"
+    pr_number = os.environ.get("BUILDKITE_PULL_REQUEST", "false")
+    if pr_number != "false":
+        FC_REF = f"pull/{pr_number}/head"
+    pipeline.add_step(
+        {
+            "command": [
+                "git clone https://github.com/firecracker-microvm/fuzzer.git",
+                f"cd fuzzer && ./tools/devtool -y check -b {FC_REF}",
+            ],
+            "label": "fuzzer-compat",
+        },
+        depends_on_build=False,
+    )
 
 # run sanity build of devtool if Dockerfile is changed
 if any(x.parent.name == "devctr" for x in changed_files):


### PR DESCRIPTION
## Changes

Add a fuzzer-compat step to the PR pipeline that clones the out-of-tree fuzzer (https://github.com/firecracker-microvm/fuzzer) and runs its devtool check against this PR's HEAD (pull/<n>/head). It type-checks all fuzz targets (cargo check) without building AFL binaries or fuzzing, and only runs when .rs, .toml, or .lock files change.

https://github.com/firecracker-microvm/fuzzer/pull/246

## Reason

The fuzzer builds against Firecracker's device and config types, so a change to those types can break the fuzzer's compilation with no change in the fuzzer repo. Until now that only surfaced in the fuzzer's daily run, hours after the PR merged, and failed every fuzz target at once.

This step catches the break on the PR that causes it, so the author updates the fuzzer in the same change. It runs independently of the Firecracker build (no depends_on_build) and is a type-check only, so it stays cheap.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
