### PR TITLE
fix(virtio): Drain activation events after reset

### DIFF
--- a/src/vmm/src/devices/virtio/balloon/event_handler.rs
+++ b/src/vmm/src/devices/virtio/balloon/event_handler.rs
@@ -143,7 +143,11 @@ impl MutEventSubscriber for Balloon {
                 "Balloon: The device is not yet activated. Spurious event received: {:?}",
                 source
             );
-            self.drain_queue_events();
+            if source == Self::PROCESS_ACTIVATE {
+                let _ = self.activate_evt.read();
+            } else {
+                self.drain_queue_events();
+            }
         }
     }
 

--- a/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/event_handler.rs
@@ -96,6 +96,9 @@ impl MutEventSubscriber for VirtioBlock {
                 source
             );
             match source {
+                Self::PROCESS_ACTIVATE => {
+                    let _ = self.activate_evt.read();
+                }
                 Self::PROCESS_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
                     let _ = self.rate_limiter.event_handler();

--- a/src/vmm/src/devices/virtio/mem/event_handler.rs
+++ b/src/vmm/src/devices/virtio/mem/event_handler.rs
@@ -76,7 +76,11 @@ impl MutEventSubscriber for VirtioMem {
 
         if !self.is_activated() {
             warn!("virtio-mem: The device is not activated yet. Spurious event received: {source}");
-            self.drain_queue_events();
+            if source == Self::PROCESS_ACTIVATE {
+                let _ = self.activate_event().read();
+            } else {
+                self.drain_queue_events();
+            }
             return;
         }
 

--- a/src/vmm/src/devices/virtio/net/event_handler.rs
+++ b/src/vmm/src/devices/virtio/net/event_handler.rs
@@ -115,6 +115,9 @@ impl MutEventSubscriber for Net {
                 source
             );
             match source {
+                Self::PROCESS_ACTIVATE => {
+                    let _ = self.activate_evt.read();
+                }
                 Self::PROCESS_VIRTQ_RX | Self::PROCESS_VIRTQ_TX => self.drain_queue_events(),
                 Self::PROCESS_RX_RATE_LIMITER => {
                     let _ = self.rx_rate_limiter.event_handler();

--- a/src/vmm/src/devices/virtio/pmem/event_handler.rs
+++ b/src/vmm/src/devices/virtio/pmem/event_handler.rs
@@ -79,6 +79,9 @@ impl MutEventSubscriber for Pmem {
         if !self.is_activated() {
             warn!("pmem: The device is not activated yet. Spurious event received from {source}");
             match source {
+                Self::PROCESS_ACTIVATE => {
+                    let _ = self.activate_event.read();
+                }
                 Self::PROCESS_PMEM_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
                     let _ = self.rate_limiter.event_handler();

--- a/src/vmm/src/devices/virtio/rng/event_handler.rs
+++ b/src/vmm/src/devices/virtio/rng/event_handler.rs
@@ -84,6 +84,9 @@ impl MutEventSubscriber for Entropy {
         if !self.is_activated() {
             warn!("entropy: The device is not activated yet. Spurious event received: {source}");
             match source {
+                Self::PROCESS_ACTIVATE => {
+                    let _ = self.activate_event().read();
+                }
                 Self::PROCESS_ENTROPY_QUEUE => self.drain_queue_events(),
                 Self::PROCESS_RATE_LIMITER => {
                     let _ = self.rate_limiter.event_handler();

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -221,7 +221,11 @@ where
                 "Vsock: The device is not yet activated. Spurious event received: {:?}",
                 source
             );
-            self.drain_queue_events();
+            if source == Self::PROCESS_ACTIVATE {
+                let _ = self.activate_evt.read();
+            } else {
+                self.drain_queue_events();
+            }
         }
     }
 


### PR DESCRIPTION
## Changes

Drain pending activation events for inactive virtio devices that support
reset.

This extends the existing inactive event handling for balloon, block, mem,
net, pmem, rng, and vsock devices. Vhost-user block is unchanged because it
does not support reset.

## Reason

Linux may reset a virtio device after setting `DRIVER_OK`, for example when
driver probing fails or the device is removed.

If Firecracker has not yet consumed `activate_evt`, the reset leaves the device
inactive while its level-triggered eventfd remains readable. The inactive event
handler did not drain the activation event, so `epoll_wait()` could return
repeatedly and cause the event thread to consume an entire host CPU core.

This change fills a gap left by commit [9f6c3b802]. That commit drained queue
and other device events while devices were inactive, but not activation events.

[9f6c3b802]: https://github.com/firecracker-microvm/firecracker/commit/9f6c3b802

Validation:

- `tools/devtool checkstyle`: 20 passed, 4 skipped.
- `tools/devtool checkbuild --all`: passed for x86_64 and aarch64.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
