### PR TITLE
Gate clidr overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ and this project adheres to
   to 1. This lets guest kernels recognize that the `VERW` instruction clears
   fill buffers, including on host kernels before v6.4 that cannot expose
   `FLUSH_L1D`.
+- [#6172](https://github.com/firecracker-microvm/firecracker/pull/6172): Gate
+  CLIRD_EL1 override to only happen on host kernels equal or newer than 6.10
+  release. This aliviates the guest performance regression seen on host kernels
+  in range \[6.3..6.10) correlated to incorrect cpu cache topology presented to
+  the guest.
 
 ### Deprecated
 

--- a/src/vmm/src/arch/aarch64/mod.rs
+++ b/src/vmm/src/arch/aarch64/mod.rs
@@ -23,15 +23,14 @@ use std::fs::File;
 use linux_loader::loader::pe::PE as Loader;
 use linux_loader::loader::{Cmdline, KernelLoader};
 use vm_memory::{GuestMemoryBackend, GuestMemoryError, GuestMemoryRegion};
+use zerocopy::IntoBytes;
 
-use crate::arch::{BootProtocol, EntryPoint, arch_memory_regions_with_gap};
+use crate::arch::{BootProtocol, EntryPoint, arch_memory_regions_with_gap, host_kernel_version};
 use crate::cpu_config::aarch64::{CpuConfiguration, CpuConfigurationError};
 use crate::cpu_config::templates::CustomCpuTemplate;
 use crate::initrd::InitrdConfig;
-use zerocopy::IntoBytes;
-
 use crate::logger::warn;
-use crate::utils::{u64_to_usize, usize_to_u64};
+use crate::utils::{Version, u64_to_usize, usize_to_u64};
 use crate::vmm_config::machine_config::MachineConfig;
 use crate::vstate::memory::{Address, Bytes, GuestAddress, GuestMemoryMmap, GuestRegionType};
 use crate::vstate::vcpu::KvmVcpuError;
@@ -123,9 +122,21 @@ pub fn configure_system_for_boot(
         )?;
     }
 
-    // Override CLIDR_EL1 ctype/LoC fields on each vCPU to match the host's
-    // real cache topology. See `override_clidr` for details.
-    override_clidr(vcpus)?;
+    // Override CLIDR_EL1 ctype/LoC fields on each vCPU to match the host's real cache topology.
+    // See `override_clidr` for details.
+    //
+    // Gate the overwrite to only kernels 6.10 and newer. Before 6.10 version, KVM is
+    // unconditionally resetting ID registers on secondary vcpus on PSCI bootup. This causes
+    // secondary vcpus to have default CLIDR_EL1 value, different from the vcpu0 (which never goes
+    // through the PSCI boot up process). This difference causes the guest kernel to misconfigure
+    // its scheduling which significantly affects the performance inside the guest.
+    //
+    // Commit in 6.10 that resolves this issue:
+    // "e016333745c70c960e02b4a9b123c807669d2b22"("KVM: arm64: Only reset vCPU-scoped feature ID
+    // regs once").
+    if Version::new(6, 10, 0) <= host_kernel_version() {
+        override_clidr(vcpus)?;
+    }
 
     let vcpu_mpidr = vcpus
         .iter_mut()

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use vm_memory::GuestAddress;
 
 use crate::logger::warn;
+use crate::utils::Version;
 
 /// Module for aarch64 related functionality.
 #[cfg(target_arch = "aarch64")]
@@ -73,6 +74,48 @@ pub fn host_page_size() -> usize {
     });
 
     *PAGE_SIZE
+}
+
+/// Parses the `major.minor.patch` prefix of a kernel release string
+/// Missing components are treated as 0.
+fn parse_kernel_release(release: &str) -> Version {
+    let mut components = release.split(|c: char| !c.is_ascii_digit());
+
+    let major: u8 = components
+        .next()
+        .and_then(|component| component.parse().ok())
+        .unwrap_or(0);
+    let minor: u8 = components
+        .next()
+        .and_then(|component| component.parse().ok())
+        .unwrap_or(0);
+    let patch: u16 = components
+        .next()
+        .and_then(|component| component.parse().ok())
+        .unwrap_or(0);
+    Version::new(major, minor, patch)
+}
+
+/// Returns the [`Version`] of the kernel running on the host.
+pub fn host_kernel_version() -> Version {
+    static KERNEL_VERSION: LazyLock<Version> = LazyLock::new(|| {
+        // SAFETY: zeroed `libc::utsname` is valid.
+        let mut utsname: libc::utsname = unsafe { std::mem::zeroed() };
+        // SAFETY: Argument is correct.
+        let ret = unsafe { libc::uname(&mut utsname) };
+        if ret < 0 {
+            warn!("Could not get host kernel version. Defaulting to 0.0.0");
+            return Version::default();
+        }
+
+        // SAFETY: `release` is a null terminated ASCII string.
+        let release = unsafe { std::ffi::CStr::from_ptr(utsname.release.as_ptr()) };
+        let release = release.to_str().unwrap_or_default();
+
+        parse_kernel_release(release)
+    });
+
+    *KERNEL_VERSION
 }
 
 impl fmt::Display for DeviceType {
@@ -142,5 +185,23 @@ fn arch_memory_regions_with_gap(
         }
         // case2: region starts past the gap
         Some(_) => Some((first_addr_past_gap.max(region_start), region_size)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_kernel_release() {
+        assert_eq!(parse_kernel_release("1"), Version::new(1, 0, 0));
+        assert_eq!(parse_kernel_release("1.2"), Version::new(1, 2, 0));
+        assert_eq!(parse_kernel_release("1.2.3"), Version::new(1, 2, 3));
+        assert_eq!(parse_kernel_release("1.2.300"), Version::new(1, 2, 300));
+        assert_eq!(
+            parse_kernel_release("1.2.3-69-something"),
+            Version::new(1, 2, 3)
+        );
+        assert_eq!(parse_kernel_release("invalid"), Version::default());
     }
 }

--- a/src/vmm/src/utils/mod.rs
+++ b/src/vmm/src/utils/mod.rs
@@ -107,6 +107,39 @@ pub fn open_file_nonblock(path: &Path) -> Result<File, std::io::Error> {
         .open(path)
 }
 
+/// Simple compact version type encoded as `major << 24 | minor << 16 | patch`
+/// Encoding as `u32` allows for trivial comparison.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version(pub u32);
+
+impl Version {
+    /// Create new version
+    pub const fn new(major: u8, minor: u8, patch: u16) -> Self {
+        Self(((major as u32) << 24) | ((minor as u32) << 16) | (patch as u32))
+    }
+
+    /// Get the `major` part.
+    pub const fn major(self) -> u8 {
+        ((self.0 >> 24) & 0xff) as u8
+    }
+
+    /// Get the `minor` part.
+    pub const fn minor(self) -> u8 {
+        ((self.0 >> 16) & 0xff) as u8
+    }
+
+    /// Get the `patch` part.
+    pub const fn patch(self) -> u16 {
+        (self.0 & 0xffff) as u16
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major(), self.minor(), self.patch())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,5 +277,18 @@ mod tests {
                 assert_eq!(align_up!(addr, align), align * 2);
             }
         }
+    }
+
+    #[test]
+    fn test_version() {
+        let v = Version::new(42, 69, 1234);
+        assert_eq!(v.major(), 42);
+        assert_eq!(v.minor(), 69);
+        assert_eq!(v.patch(), 1234);
+        assert_eq!(v.to_string(), "42.69.1234");
+
+        assert!(Version::new(0, 2, 3) < Version::new(1, 2, 3));
+        assert!(Version::new(1, 0, 3) < Version::new(1, 2, 3));
+        assert!(Version::new(1, 2, 0) < Version::new(1, 2, 3));
     }
 }

--- a/tests/integration_tests/functional/test_topology.py
+++ b/tests/integration_tests/functional/test_topology.py
@@ -217,6 +217,15 @@ def test_cpu_topology(uvm, num_vcpus, htt):
     )
 
 
+@pytest.mark.skipif(
+    (6, 3) <= global_props.host_linux_version_tpl
+    and global_props.host_linux_version_tpl < (6, 10)
+    and PLATFORM == "aarch64",
+    reason="""On the range [6.3..6.10) of host kernels on aarch64 platform, the
+    cache topology provided by DT and CRIDR_EL1 register do not match. In that
+    case guest uses values from CLIDR_EL1 which will not contain info about L1$
+    and so this test will fail.""",
+)
 @pytest.mark.parametrize("num_vcpus", [1, 2, 16])
 @pytest.mark.parametrize("htt", [True, False], ids=["HTT_ON", "HTT_OFF"])
 def test_cache_topology(uvm, num_vcpus, htt):


### PR DESCRIPTION
## Changes
Gate CLIDR_EL1 register overwrite to only happen on [6.3..6.10) range of host kernels. 
```
    Original CLIDR_EL1 overwrite was done in the
    "587e8f18b0d96ae74a820e7622a1327743e53b12"(fix(aarch64): override
    fabricated CLIDR_EL1 to match host cache topology) commit to fix the
    change in behaviour in the kernel 6.3 from the commit "7af0c2534f4c" which
    started fabricating CLIDR_EL1 register.

    The issue here is that for secondary vcpus on aarch64 the PSCI boot up
    process resets vcpu registers (including ID registers like CLIDR_EL1).
    This in creates a situation where the vcpu0 has correct CLIDR_EL1 while
    all secondary vcpus have KVM default CLIDR_EL1. This combination affects
    guest kernel scheduling behaviour significantly affecting the
    performance.

    6.10 kernel contains a fix for this issue
    "e016333745c70c960e02b4a9b123c807669d2b22"(KVM: arm64: Only reset
    vCPU-scoped feature ID regs once). This commit (as the title suggests)
    prevents resetting of ID registers for already initialized vcpus (all
    vcpus are initialized by Firecracker before VM starts). This fixes the
    issue of CLIDR_EL1.

    All of this creates an unfortunate situation where [6.3..6.10) range of
    kernels is affected and have a degraded performance.

    One fix for it is to make secondary vcpu threads to wait until they are
    booted by the vcpu0 and only then enter the `KVM_RUN` syscall. This way
    there is a window of time where CLIDR_EL1 can be set again to the
    correct value. We decide to not use this option since it can potentially
    introduce boot time regression and in general adds unwanted complexity.

    This leaves the option of gating the CLIDR_EL1 overwrite to only kernels
    past 6.10 release. This is not ideal either since cache topology in
    affecter range of kernels will encounter the original problem the
    CLIDR_EL1 override was solving, but at least it does not introduce
    performance regressions in the guest.

    In the future we will investigate if removing CLIRD_EL1 overwrite and
    any cache information from the DT is reasonable to alleviate this problem
    once and for all.
```

## Reason
Fixes performance regression for kernels in [6.3..6.10) range, but re-introduces the issue of incorrect cpu cache being provided to guest userspace by the guest kernel.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
