### PR TITLE
devtool: Fix get_newest_s3_artifacts() selecting incomplete revisions

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -146,23 +146,46 @@ AWS_S3_MAX_ATTEMPTS=5
 # Lockfile used while modifying KVM modules
 KVM_MODULE_LOCKFILE="/tmp/.kvm_module_lock"
 
-# Query default S3 bucket with artifacts and return the most recient path
+# Query default S3 bucket and return the newest revision that is fully
+# uploaded, meaning it has a rootfs for every architecture we build for.
 get_newest_s3_artifacts() {
   local bucket="spec.ccfc.min"
   local base_prefix="firecracker-ci/"
 
-  # Query all files in the `firecracker-ci` directory, check files contianing "vmlinux",
-  # sort them by the `LastModified` date, and return the last one (newest).
-  # We need to do it this way as S3 doesn't store `LastModified`` date for directories,
-  # so we need to list all files.
-  local newest_dir=$(AWS_MAX_ATTEMPTS=$AWS_S3_MAX_ATTEMPTS aws s3api list-objects-v2 \
+  # A revision is uploaded one architecture at a time, and within an
+  # architecture the kernels land before the rootfs, so a revision that
+  # exists is not necessarily usable. Require a rootfs for both
+  # architectures before picking one, so that every job of a CI run tests
+  # against the same artifacts no matter which host it runs on.
+  #
+  # S3 does not store LastModified for "directories", so list every object
+  # under the prefix in one API call and group them here. A revision is
+  # dated by its newest rootfs, which is when it became complete.
+  local newest_dir
+  newest_dir=$(AWS_MAX_ATTEMPTS=$AWS_S3_MAX_ATTEMPTS aws s3api list-objects-v2 \
         --bucket "$bucket" --prefix "$base_prefix" --no-sign-request \
-        --query 'sort_by(Contents[?contains(Key, `vmlinux`)], &LastModified)[-1].Key' |
-        tr -d '"' |
-        sed "s|^$base_prefix||" |
-        cut -d'/' -f1
+        --query 'Contents[?contains(Key, `.squashfs`)].[LastModified,Key]' \
+        --output text |
+        awk '{
+            split($2, path, "/")
+            rev = path[2]
+            seen[rev "/" path[3]] = 1
+            if ($1 > date[rev])
+                date[rev] = $1
+        }
+        END {
+            for (rev in date)
+                if ((rev "/x86_64") in seen && (rev "/aarch64") in seen &&
+                    date[rev] > newest_date) {
+                    newest_date = date[rev]
+                    newest = rev
+                }
+            print newest
+        }'
   )
-  [ -z "$newest_dir" ] && die "Could not find newest artifacts in S3."
+  if [ -z "$newest_dir" ] || [ "$newest_dir" = "None" ]; then
+    die "Could not find a complete set of artifacts in S3."
+  fi
 
   echo "$DEFAULT_ARTIFACTS_S3_BUCKET/$newest_dir"
 }


### PR DESCRIPTION
A revision of the CI artifacts is uploaded one architecture at a time, and within an architecture the kernels land before the rootfs. The old code picked a revision by finding the newest object whose key contained "vmlinux" across all architectures, and download_ci_artifacts() then appended the host architecture to it and synced. So as soon as the aarch64 half of a new revision appeared, x86_64 jobs selected that revision too, synced an empty directory, and setup-ci-artifacts.sh died globbing *.squashfs.

Filtering by architecture alone would not be enough, because a revision whose kernels have uploaded but whose rootfs has not would pass such a check and still leave the glob empty.

Require a rootfs for both architectures before accepting a revision. Until a new revision has fully uploaded, every job keeps using the previous one, so a CI run tests against the same artifacts no matter which host each job lands on. Fail loudly if no revision qualifies, instead of returning a path that cannot be used.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
