### PR TITLE
fix(vmm): correct virtio-mem memory discard on snapshot restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ and this project adheres to
   new host-initiated connection made after the resume hung forever. The gate is
   now part of the persisted device state and the resume kick respects it instead
   of arming it.
+- [#6174](https://github.com/firecracker-microvm/firecracker/pull/6174): Fixed
+  `virtio-mem` leaving unplugged memory writable by the VMM, and potentially
+  unmapped, on microVMs restored from a snapshot memory file. Firecracker now
+  maps each slot straight to the protection it should have, with the
+  `MAP_NORESERVE` flag, and aborts if the re-map fails.
+- [#6174](https://github.com/firecracker-microvm/firecracker/pull/6174): Fixed
+  `virtio-mem` discarding the whole hotpluggable region on every `UNPLUG_ALL`
+  request, even when nothing was plugged. The discard is now skipped when the
+  range has no plugged blocks.
 - [#5956](https://github.com/firecracker-microvm/firecracker/pull/5956): Fixed a
   TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
   `MIDR_EL1` information files copied into the chroot.

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -234,14 +234,14 @@
             },
             {
                 "syscall": "mmap",
-                "comment": "Used by the VirtIO balloon device",
+                "comment": "Used by discard_range for the VirtIO balloon and memory (virtio-mem) devices",
                 "args": [
                     {
                         "index": 3,
                         "type": "dword",
                         "op": "eq",
-                        "val": 50,
-                        "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                        "val": 16434,
+                        "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE | libc::MAP_NORESERVE"
                     },
                     {
                         "index": 2,

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -234,14 +234,14 @@
             },
             {
                 "syscall": "mmap",
-                "comment": "Used by the VirtIO balloon device",
+                "comment": "Used by discard_range for the VirtIO balloon and memory (virtio-mem) devices",
                 "args": [
                     {
                         "index": 3,
                         "type": "dword",
                         "op": "eq",
-                        "val": 50,
-                        "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                        "val": 16434,
+                        "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE | libc::MAP_NORESERVE"
                     },
                     {
                         "index": 2,

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -529,6 +529,11 @@ impl VirtioMem {
         let block_range = self.unchecked_block_range(range);
         let plugged_blocks_slice = &mut self.plugged_blocks[block_range];
         let plugged_before = plugged_blocks_slice.count_ones();
+        // Nothing is plugged in this range, so there is nothing to discard. UNPLUG_ALL covers the
+        // whole region, so this skip avoids repeatedly re-discarding an already-unplugged region.
+        if !plug && plugged_before == 0 {
+            return Ok(());
+        }
         plugged_blocks_slice.fill(plug);
         let plugged_after = plugged_blocks_slice.count_ones();
         self.config.plugged_size -= usize_to_u64(self.nb_blocks_to_len(plugged_before));
@@ -1193,6 +1198,31 @@ mod tests {
         assert_eq!(th.device().plugged_size_mib(), 0);
 
         assert_eq!(METRICS.unplug_all_count.count(), unplug_all_count + 1);
+        assert_eq!(METRICS.unplug_all_fails.count(), unplug_all_fails);
+    }
+
+    #[test]
+    fn test_repeated_unplug_all_is_noop() {
+        let mem_dev = default_virtio_mem();
+        let guest_mem = mem_dev.vm.guest_memory().clone();
+        let mut th = test_helper(mem_dev, &guest_mem);
+        th.device().update_requested_size(1024).unwrap();
+        let addr = th.device().guest_address();
+
+        let resp = emulate_request(
+            &mut th,
+            &guest_mem,
+            Request::Plug(RequestedRange { addr, nb_blocks: 2 }),
+        );
+        assert!(resp.is_ack());
+        let resp = emulate_request(&mut th, &guest_mem, Request::UnplugAll);
+        assert!(resp.is_ack());
+        assert_eq!(th.device().plugged_size_mib(), 0);
+
+        let unplug_all_fails = METRICS.unplug_all_fails.count();
+        let resp = emulate_request(&mut th, &guest_mem, Request::UnplugAll);
+        assert!(resp.is_ack());
+        assert_eq!(th.device().plugged_size_mib(), 0);
         assert_eq!(METRICS.unplug_all_fails.count(), unplug_all_fails);
     }
 

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -734,13 +734,22 @@ impl GuestRegionMmapExt {
                 // file only drops any anonymous pages in range, but subsequent accesses would read
                 // whatever page is stored on the backing file. Mmapping anonymous pages ensures
                 // it's zeroed.
+                // Keep MAP_NORESERVE to match the flags the region was created with (see `create`).
+                // Without it the replacement is subject to overcommit accounting and can fail with
+                // ENOMEM, by which point MAP_FIXED has already unmapped the range.
+                // TODO: this does not re-apply the region's madvise flags, so it would drop the
+                // MADV_HUGEPAGE hint on a THP + file-restore VM. That combination is unsupported
+                // today; revisit if it becomes supported.
                 // SAFETY: The address and length are known to be valid.
                 let ret = unsafe {
                     libc::mmap(
                         phys_address.cast(),
                         len,
                         libc::PROT_READ | libc::PROT_WRITE,
-                        libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+                        libc::MAP_FIXED
+                            | libc::MAP_ANONYMOUS
+                            | libc::MAP_PRIVATE
+                            | libc::MAP_NORESERVE,
                         -1,
                         0,
                     )

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -721,8 +721,6 @@ impl GuestRegionMmapExt {
         caddr: MemoryRegionAddress,
         len: usize,
     ) -> Result<(), GuestMemoryError> {
-        let phys_address = self.get_host_address(caddr)?;
-
         match (self.inner.file_offset(), self.inner.flags()) {
             // If and only if we are resuming from a snapshot file, we have a file and it's mapped
             // private
@@ -740,27 +738,53 @@ impl GuestRegionMmapExt {
                 // TODO: this does not re-apply the region's madvise flags, so it would drop the
                 // MADV_HUGEPAGE hint on a THP + file-restore VM. That combination is unsupported
                 // today; revisit if it becomes supported.
-                // SAFETY: The address and length are known to be valid.
-                let ret = unsafe {
-                    libc::mmap(
-                        phys_address.cast(),
-                        len,
-                        libc::PROT_READ | libc::PROT_WRITE,
-                        libc::MAP_FIXED
-                            | libc::MAP_ANONYMOUS
-                            | libc::MAP_PRIVATE
-                            | libc::MAP_NORESERVE,
-                        -1,
-                        0,
-                    )
-                };
-                if ret == libc::MAP_FAILED {
-                    let os_error = std::io::Error::last_os_error();
-                    error!("discard_range: mmap failed: {:?}", os_error);
-                    Err(GuestMemoryError::IOError(os_error))
-                } else {
-                    Ok(())
+                //
+                // Map each intersecting slot directly to its final protection: fully unplugged
+                // slots get PROT_NONE, plugged (or mixed) slots stay PROT_READ | PROT_WRITE. This
+                // avoids mapping the whole range PROT_READ | PROT_WRITE and then reprotecting the
+                // unplugged slots.
+                let base = self.start_addr().raw_value();
+                let from = base
+                    .checked_add(caddr.raw_value())
+                    .expect("caddr should be within the region");
+                let to = from
+                    .checked_add(len as u64)
+                    .expect("range should be within the region");
+                for (slot, plugged) in self.slots_intersecting_range(GuestAddress(from), len) {
+                    let slot_start = slot.guest_addr.raw_value();
+                    let slot_end = slot_start
+                        .checked_add(slot.slice.len() as u64)
+                        .expect("slot should be within the region");
+                    let start = slot_start.max(from);
+                    let end = slot_end.min(to);
+                    let host = self.get_host_address(MemoryRegionAddress(start - base))?;
+                    let prot = if plugged {
+                        libc::PROT_READ | libc::PROT_WRITE
+                    } else {
+                        libc::PROT_NONE
+                    };
+                    // SAFETY: [start, end) is clamped to this slot, so `host` and the length are
+                    // within the region's existing mapping. MAP_FIXED replaces exactly that range.
+                    let ret = unsafe {
+                        libc::mmap(
+                            host.cast(),
+                            u64_to_usize(end - start),
+                            prot,
+                            libc::MAP_FIXED
+                                | libc::MAP_ANONYMOUS
+                                | libc::MAP_PRIVATE
+                                | libc::MAP_NORESERVE,
+                            -1,
+                            0,
+                        )
+                    };
+                    if ret == libc::MAP_FAILED {
+                        let os_error = std::io::Error::last_os_error();
+                        error!("discard_range: mmap failed: {:?}", os_error);
+                        return Err(GuestMemoryError::IOError(os_error));
+                    }
                 }
+                Ok(())
             }
             // Match either the case of an anonymous mapping, or the case
             // of a shared file mapping.
@@ -770,8 +794,9 @@ impl GuestRegionMmapExt {
             // We keep falling to the madvise branch to keep the previous behaviour.
             _ => {
                 // Madvise the region in order to mark it as not used.
+                let host_addr = self.get_host_address(caddr)?;
                 // SAFETY: The address and length are known to be valid.
-                let ret = unsafe { libc::madvise(phys_address.cast(), len, libc::MADV_DONTNEED) };
+                let ret = unsafe { libc::madvise(host_addr.cast(), len, libc::MADV_DONTNEED) };
                 if ret < 0 {
                     let os_error = std::io::Error::last_os_error();
                     error!("discard_range: madvise failed: {:?}", os_error);

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -721,6 +721,15 @@ impl GuestRegionMmapExt {
         caddr: MemoryRegionAddress,
         len: usize,
     ) -> Result<(), GuestMemoryError> {
+        // The address and length can come straight from a guest descriptor (balloon), so reject
+        // unaligned input here rather than letting the mmap/madvise below fail on it.
+        let page_size = host_page_size() as u64;
+        if !caddr.raw_value().is_multiple_of(page_size) || !(len as u64).is_multiple_of(page_size) {
+            return Err(GuestMemoryError::InvalidGuestAddress(
+                self.start_addr().unchecked_add(caddr.raw_value()),
+            ));
+        }
+
         match (self.inner.file_offset(), self.inner.flags()) {
             // If and only if we are resuming from a snapshot file, we have a file and it's mapped
             // private
@@ -778,10 +787,13 @@ impl GuestRegionMmapExt {
                             0,
                         )
                     };
+                    // MAP_FIXED has already unmapped the old range, so a failure here cannot be
+                    // recovered from.
                     if ret == libc::MAP_FAILED {
-                        let os_error = std::io::Error::last_os_error();
-                        error!("discard_range: mmap failed: {:?}", os_error);
-                        return Err(GuestMemoryError::IOError(os_error));
+                        panic!(
+                            "discard_range: mmap failed: {:?}",
+                            std::io::Error::last_os_error()
+                        );
                     }
                 }
                 Ok(())
@@ -1799,11 +1811,11 @@ mod tests {
             GuestMemoryError::InvalidGuestAddress(_)
         );
 
-        // Madvise fail: the guest address is not aligned to the page size.
+        // Unaligned address is rejected.
         assert_match!(
             mem.discard_range(GuestAddress(0x20), page_size)
                 .unwrap_err(),
-            GuestMemoryError::IOError(_)
+            GuestMemoryError::InvalidGuestAddress(_)
         );
     }
 
@@ -1852,11 +1864,11 @@ mod tests {
             GuestMemoryError::InvalidGuestAddress(_)
         );
 
-        // Mmap fail: the guest address is not aligned to the page size.
+        // Unaligned address is rejected, so the file-backed branch never sees a failing mmap.
         assert_match!(
             mem.discard_range(GuestAddress(0x20), page_size)
                 .unwrap_err(),
-            GuestMemoryError::IOError(_)
+            GuestMemoryError::InvalidGuestAddress(_)
         );
     }
 

--- a/tests/integration_tests/performance/test_hotplug_memory.py
+++ b/tests/integration_tests/performance/test_hotplug_memory.py
@@ -262,6 +262,24 @@ def check_hotunplug(uvm, requested_size_mib):
         assert rss_after < rss_before, "RSS didn't decrease"
 
 
+def writable_anon_vmas(uvm, min_size):
+    """Address ranges of writable anonymous VMAs of at least `min_size` bytes in the VMM process"""
+    ranges = set()
+    # /proc/<pid>/maps lists host virtual addresses, so we can't find the guest region by its guest
+    # physical address; callers diff this set across a plug/unplug cycle instead.
+    with open(f"/proc/{uvm.firecracker_pid}/maps", encoding="utf-8") as f:
+        for line in f:
+            fields = line.split()
+            addr_range, perms = fields[0], fields[1]
+            pathname = fields[5] if len(fields) >= 6 else ""
+            if perms != "rw-p" or pathname:
+                continue
+            start, end = (int(x, 16) for x in addr_range.split("-"))
+            if end - start >= min_size:
+                ranges.add(addr_range)
+    return ranges
+
+
 def test_virtio_mem_hotplug_hotunplug(uvm_any_memhp):
     """
     Check that memory can be hotplugged into the VM.
@@ -277,6 +295,27 @@ def test_virtio_mem_hotplug_hotunplug(uvm_any_memhp):
     # Check it works again
     check_hotplug(uvm, 1024)
     check_memory_usable(uvm)
+
+    validate_metrics(uvm)
+
+
+def test_unplug_keeps_region_protected(uvm_any_memhp):
+    """
+    Check that a plug/unplug cycle leaves unplugged memory PROT_NONE, not writable anonymous.
+    """
+    uvm = uvm_any_memhp
+    total_mib = uvm.api.memory_hotplug.get().json()["total_size_mib"]
+    slot_bytes = uvm.api.memory_hotplug.get().json()["slot_size_mib"] << 20
+
+    before = writable_anon_vmas(uvm, slot_bytes)
+    uvm.hotplug_memory(total_mib)
+    uvm.hotplug_memory(0)
+    after = writable_anon_vmas(uvm, slot_bytes)
+
+    assert after <= before, (
+        f"plug/unplug left new writable anonymous mapping(s): {after - before}; "
+        "PROT_NONE was not restored on unplugged slots"
+    )
 
     validate_metrics(uvm)
 


### PR DESCRIPTION
## Changes

GuestRegionMmapExt::discard_range, snapshot-restore (file-backed):
- Add MAP_NORESERVE to the replacement mmap so it matches the flags the region was created with.
- Map each intersecting slot directly to its final protection in one pass: fully unplugged slots get PROT_NONE, plugged (or mixed) slots stay PROT_READ | PROT_WRITE.
- Treat a failed mmap on this branch as unrecoverable (abort), since MAP_FIXED has already unmapped the range.
- VirtioMem::update_range: skip the discard when unplugging a range that has no plugged block, so a repeated UNPLUG_ALL doesn't re-discard an already-empty region.
- Update the discard_range mmap rule in resources/seccomp/{x86_64,aarch64}-unknown-linux-musl.json to match the new flags.
- Add integration test test_unplug_keeps_region_protected covering the file-backed path.

## Reason

On restore, guest memory is file-backed MAP_PRIVATE, so discard_range reclaims a range by mapping anonymous zero pages over it with mmap(MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE). 

Two issues:

1. The replacement dropped MAP_NORESERVE, which the region was created with (see create). Without it the mapping is charged against overcommit accounting and can fail with ENOMEM; because MAP_FIXED unmaps before that check (kernels < 6.9), the range is left unmapped while still treated as valid guest memory. Matching the original flags removes the failure at source. If the mmap fails anyway, the range is already unmapped and the mismatch is unrecoverable, so it now aborts rather than returning.

2. The replacement re-mapped PROT_READ | PROT_WRITE, clearing the PROT_NONE that update_slot applies to unplugged slots. Mapping each slot straight to its intended protection preserves it, and keeps plugged slots (e.g. balloon on DRAM) accessible. Doing it in discard_range covers all callers.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
