### PR TITLE
fix(vmm): commit virtio-mem block state after the KVM slot update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,12 @@ and this project adheres to
   `virtio-mem` discarding the whole hotpluggable region on every `UNPLUG_ALL`
   request, even when nothing was plugged. The discard is now skipped when the
   range has no plugged blocks.
+- [#6176](https://github.com/firecracker-microvm/firecracker/pull/6176): Fixed
+  `virtio-mem` leaving its block accounting inconsistent with the KVM memory
+  slots if a plug or unplug request failed part way through. Firecracker now
+  commits each slot's state only after its KVM update succeeds, so a partial
+  failure leaves the block state and the KVM slots reflecting exactly the slots
+  that were updated.
 - [#5956](https://github.com/firecracker-microvm/firecracker/pull/5956): Fixed a
   TOCTOU race in the aarch64 jailer when setting ownership of the CPU cache and
   `MIDR_EL1` information files copied into the chroot.

--- a/src/vmm/src/devices/virtio/mem/device.rs
+++ b/src/vmm/src/devices/virtio/mem/device.rs
@@ -494,65 +494,103 @@ impl VirtioMem {
         &self.activate_event
     }
 
-    fn update_kvm_slots(&self, updated_range: &RequestedRange) -> Result<(), VirtioMemError> {
+    /// Applies the request to a single KVM slot: updates KVM first and, only if that succeeds,
+    /// commits the block state for the blocks the request touches and (when unplugging) discards
+    /// them. Committing after the KVM update keeps the block state consistent with KVM on a partial
+    /// failure, and a block is never discarded before it is committed as unplugged.
+    ///
+    /// Returns `true` if the slot's discard failed. That is not fatal and is not reported to the
+    /// driver; the caller aggregates it into a single metric per request.
+    fn apply_range_to_slot(
+        &mut self,
+        slot_num: u32,
+        slot_first_block: usize,
+        slot_nb_blocks: usize,
+        req_blocks: &Range<usize>,
+        plug: bool,
+    ) -> Result<bool, VirtioMemError> {
+        let slot_blocks = slot_first_block..(slot_first_block + slot_nb_blocks);
+        let touched = slot_blocks.start.max(req_blocks.start)..slot_blocks.end.min(req_blocks.end);
+        // The slot stays plugged into KVM if any of its blocks is plugged once the request applies.
+        let keep_plugged = slot_blocks.clone().any(|b| {
+            if touched.contains(&b) {
+                plug
+            } else {
+                self.plugged_blocks[b]
+            }
+        });
+
         let hp_region = self
             .guest_memory()
             .iter()
             .find(|r| r.region_type == GuestRegionType::Hotpluggable)
             .expect("there should be one and only one hotpluggable region");
         hp_region
-            .slots_intersecting_range(
-                updated_range.addr,
-                self.nb_blocks_to_len(updated_range.nb_blocks),
-            )
-            .try_for_each(|(slot, _)| {
-                let slot_range = RequestedRange {
-                    addr: slot.guest_addr,
-                    nb_blocks: slot.slice.len() / u64_to_usize(self.config.block_size),
-                };
-                match self.range_state(&slot_range) {
-                    BlockRangeState::Mixed | BlockRangeState::Plugged => {
-                        hp_region.update_slot(&self.vm, &slot, true)
-                    }
-                    BlockRangeState::Unplugged => hp_region.update_slot(&self.vm, &slot, false),
-                }
-                .map_err(VirtioMemError::UpdateKvmSlot)
-            })
+            .update_slot(&self.vm, &hp_region.mem_slot(slot_num), keep_plugged)
+            .map_err(VirtioMemError::UpdateKvmSlot)?;
+
+        let plugged_before = self.plugged_blocks[touched.clone()].count_ones();
+        self.plugged_blocks[touched.clone()].fill(plug);
+        let plugged_after = self.plugged_blocks[touched.clone()].count_ones();
+        self.config.plugged_size -= usize_to_u64(self.nb_blocks_to_len(plugged_before));
+        self.config.plugged_size += usize_to_u64(self.nb_blocks_to_len(plugged_after));
+
+        if !plug {
+            let addr =
+                GuestAddress(self.config.addr + touched.start as u64 * self.config.block_size);
+            if let Err(err) = self
+                .guest_memory()
+                .discard_range(addr, self.nb_blocks_to_len(touched.len()))
+            {
+                error!("virtio-mem: Failed to discard memory range: {}", err);
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
-    /// Plugs/unplugs the given range
+    /// Plugs/unplugs the given range, one KVM slot at a time.
     ///
     /// Note: the range passed to this function must be within the device memory to avoid
     /// out-of-bound panics.
     fn update_range(&mut self, range: &RequestedRange, plug: bool) -> Result<(), VirtioMemError> {
-        // Update internal state
-        let block_range = self.unchecked_block_range(range);
-        let plugged_blocks_slice = &mut self.plugged_blocks[block_range];
-        let plugged_before = plugged_blocks_slice.count_ones();
+        let block_size = self.config.block_size;
+        let req_blocks = self.unchecked_block_range(range);
+
         // Nothing is plugged in this range, so there is nothing to discard. UNPLUG_ALL covers the
         // whole region, so this skip avoids repeatedly re-discarding an already-unplugged region.
-        if !plug && plugged_before == 0 {
+        if !plug && self.plugged_blocks[req_blocks.clone()].count_ones() == 0 {
             return Ok(());
         }
-        plugged_blocks_slice.fill(plug);
-        let plugged_after = plugged_blocks_slice.count_ones();
-        self.config.plugged_size -= usize_to_u64(self.nb_blocks_to_len(plugged_before));
-        self.config.plugged_size += usize_to_u64(self.nb_blocks_to_len(plugged_after));
 
-        // Update kvm slots before doing any discards to prevent guest from re-faulting just
-        // discarded memory.
-        self.update_kvm_slots(range)?;
-
-        // If unplugging, discard the range
-        if !plug
-            && let Err(err) = self
+        // Snapshot the intersecting slots so the loop can borrow `self` mutably to commit state.
+        let slots: Vec<(u32, usize, usize)> = {
+            let hp_region = self
                 .guest_memory()
-                .discard_range(range.addr, self.nb_blocks_to_len(range.nb_blocks))
-        {
-            // Failure to discard is not fatal and is not reported to the driver. It only
-            // gets logged.
+                .iter()
+                .find(|r| r.region_type == GuestRegionType::Hotpluggable)
+                .expect("there should be one and only one hotpluggable region");
+            hp_region
+                .slots_intersecting_range(range.addr, self.nb_blocks_to_len(range.nb_blocks))
+                .map(|(slot, _)| {
+                    let first_block =
+                        u64_to_usize((slot.guest_addr.0 - self.config.addr) / block_size);
+                    (
+                        slot.slot,
+                        first_block,
+                        slot.slice.len() / u64_to_usize(block_size),
+                    )
+                })
+                .collect()
+        };
+
+        let mut discard_failed = false;
+        for (slot_num, first_block, block_count) in slots {
+            discard_failed |=
+                self.apply_range_to_slot(slot_num, first_block, block_count, &req_blocks, plug)?;
+        }
+        if discard_failed {
             METRICS.unplug_discard_fails.inc();
-            error!("virtio-mem: Failed to discard memory range: {}", err);
         }
         Ok(())
     }
@@ -1199,6 +1237,35 @@ mod tests {
 
         assert_eq!(METRICS.unplug_all_count.count(), unplug_all_count + 1);
         assert_eq!(METRICS.unplug_all_fails.count(), unplug_all_fails);
+    }
+
+    /// A plug spanning two slots where the second slot's KVM update fails must leave only the first
+    /// slot's block committed, not the whole request.
+    #[test]
+    fn test_plug_partial_kvm_failure_keeps_state_consistent() {
+        let mem_dev = default_virtio_mem();
+        let guest_mem = mem_dev.vm.guest_memory().clone();
+        let mut th = test_helper(mem_dev, &guest_mem);
+        th.device().update_requested_size(1024).unwrap();
+        let block_size = th.device().config.block_size;
+        // Last block of slot 0 and first block of slot 1.
+        let addr = th.device().guest_address().unchecked_add(63 * block_size);
+
+        th.device().vm.fail_next_set_user_memory_region(2);
+
+        let resp = emulate_request(
+            &mut th,
+            &guest_mem,
+            Request::Plug(RequestedRange { addr, nb_blocks: 2 }),
+        );
+        assert!(resp.is_error());
+
+        assert_eq!(th.device().plugged_size_mib(), 2);
+        let block_range = th
+            .device()
+            .unchecked_block_range(&RequestedRange { addr, nb_blocks: 2 });
+        assert!(th.device().plugged_blocks[block_range.start]);
+        assert!(!th.device().plugged_blocks[block_range.start + 1]);
     }
 
     #[test]

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -695,23 +695,36 @@ impl GuestRegionMmapExt {
         assert!(self.region_type == GuestRegionType::Hotpluggable);
 
         let mut bitmap_guard = self.plugged.lock().unwrap();
-        let prev = bitmap_guard.replace((mem_slot.slot - self.slot_from) as usize, plug);
-        // do not do anything if the state is what we're trying to set
-        if prev == plug {
+        let idx = (mem_slot.slot - self.slot_from) as usize;
+        if bitmap_guard[idx] == plug {
             return Ok(());
         }
 
-        let mut kvm_region = kvm_userspace_memory_region::from(mem_slot);
+        // Commit the bitmap only once the protection and the KVM slot have both changed, rolling
+        // back the first step if the second fails. A failed rollback has no way back, so it panics.
+        let kvm_region = kvm_userspace_memory_region::from(mem_slot);
         if plug {
             // make it accessible _before_ adding it to KVM
             mem_slot.protect(false)?;
-            vm.set_user_memory_region(kvm_region)?;
+            if let Err(err) = vm.set_user_memory_region(kvm_region) {
+                mem_slot
+                    .protect(true)
+                    .expect("cannot roll back the virtio-mem slot protection");
+                return Err(err);
+            }
+            bitmap_guard.set(idx, true);
         } else {
             // to remove it we need to pass a size of zero
-            kvm_region.memory_size = 0;
-            vm.set_user_memory_region(kvm_region)?;
+            let mut removed_region = kvm_region;
+            removed_region.memory_size = 0;
+            vm.set_user_memory_region(removed_region)?;
             // make it protected _after_ removing it from KVM
-            mem_slot.protect(true)?;
+            if let Err(err) = mem_slot.protect(true) {
+                vm.set_user_memory_region(kvm_region)
+                    .expect("cannot roll back the virtio-mem slot in KVM");
+                return Err(err.into());
+            }
+            bitmap_guard.set(idx, false);
         }
         Ok(())
     }

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -83,6 +83,10 @@ pub struct VmCommon {
     pub vcpus_handles: Mutex<Vec<VcpuHandle>>,
     /// Event fd written to by vCPUs on exit.
     pub vcpus_exit_evt: EventFd,
+    /// Test-only countdown that forces the Nth-next `set_user_memory_region` call to fail, used
+    /// to exercise partial-failure handling. 0 means never fail.
+    #[cfg(test)]
+    fail_set_user_memory_region_in: AtomicU32,
 }
 
 /// Errors associated with the wrappers over KVM ioctls.
@@ -191,6 +195,8 @@ impl KvmVm {
             uffd: None,
             vcpus_handles: Mutex::new(Vec::new()),
             vcpus_exit_evt,
+            #[cfg(test)]
+            fail_set_user_memory_region_in: AtomicU32::new(0),
         })
     }
 
@@ -421,12 +427,32 @@ impl KvmVm {
         &self,
         region: kvm_userspace_memory_region,
     ) -> Result<(), VmError> {
+        #[cfg(test)]
+        if self.common.fail_set_user_memory_region_in.fetch_update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            |n| (n > 0).then(|| n - 1),
+        ) == Ok(1)
+        {
+            return Err(VmError::SetUserMemoryRegion(kvm_ioctls::Error::new(
+                libc::ENOMEM,
+            )));
+        }
         // SAFETY: Safe because the fd is a valid KVM file descriptor.
         unsafe {
             self.fd()
                 .set_user_memory_region(region)
                 .map_err(VmError::SetUserMemoryRegion)
         }
+    }
+
+    /// Test-only: arm the fault injector so the `n`th subsequent call to
+    /// [`Self::set_user_memory_region`] fails (n == 1 fails the very next call).
+    #[cfg(test)]
+    pub(crate) fn fail_next_set_user_memory_region(&self, n: u32) {
+        self.common
+            .fail_set_user_memory_region_in
+            .store(n, Ordering::Relaxed);
     }
 
     fn register_memory_region(&mut self, region: Arc<GuestRegionMmapExt>) -> Result<(), VmError> {


### PR DESCRIPTION
## Changes

- VirtioMem::update_range now applies a plug/unplug request one KVM slot at a time. For each slot it updates KVM first and only then commits that slot's block state (plugged_blocks, plugged_size), discarding an unplugged slot after it is committed.
- GuestRegionMmapExt::update_slot commits its per-slot bitmap only after the KVM_SET_USER_MEMORY_REGION update succeeds (and restores the slot's protection if the update fails).
- Added a unit test that plugs a range spanning two KVM slots with the second slot's memory-region update forced to fail, asserting only the first slot's block stays committed. A test-only fault injector on set_user_memory_region drives the failure.


## Reason

update_range committed the block state for the whole request up front and only then updated the KVM slots, and update_slot flipped its per-slot bitmap before issuing the KVM ioctl. On a multi-slot plug/unplug that failed part way through (e.g. a slot update returning an error), the committed block state covered the entire range while KVM reflected only the slots that had actually been updated. 

Committing each slot's state only after its KVM update succeeds keeps the block state and the KVM slots consistent on a partial failure: the operation stops with both reflecting exactly the slots that were updated, and a block is never discarded before it is committed as unplugged. The whole-range discard is now done per slot as each commits, which issues one discard per intersecting slot instead of one for the range.

1. Why not rollback:
- On a partial failure the operation stops and returns an error, leaving the block state and the KVM slots consistent with each other, rather than rolling back the slots that already succeeded. Rolling back would require re-issuing KVM slot updates, which allocate per-slot metadata and can themselves fail, most likely under the same resource pressure that caused the original failure, with no reliable way to recover if the unwind fails. Committing each slot's state only after its KVM update succeeds keeps the two consistent by construction.

2. Scope/spec note:
- The virtio-mem specification does not define behavior for a request that fails mid-execution, so this is a robustness fix. A slot update only fails under resource pressure (for example, hitting the KVM memory-slot limit), not on a normal request.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
